### PR TITLE
fix(connect): when test firmwareChannel always remote release JSON

### DIFF
--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -38,6 +38,7 @@ import {
     buildLocalReleaseName,
     findBestCompatibleRelease,
     isFirmwareCacheUsedForSelectedSource,
+    isProductionFirmwareChannel,
     isStrictFeatures,
 } from '../utils/firmwareUtils';
 
@@ -164,6 +165,7 @@ export const getReleaseByVersion = async (
     firmwareType: FirmwareType,
 ): Promise<FirmwareRelease | undefined> => {
     const deviceModel = features.internal_model;
+    const firmwareChannel = settingsStore.get('firmwareChannel');
 
     const tryGetRelease = async (
         getter: () => Promise<FirmwareRelease | undefined> | FirmwareRelease | undefined,
@@ -184,7 +186,7 @@ export const getReleaseByVersion = async (
 
     const { firmwareDir, firmwareList } = localFirmwareStore.get();
     if (
-        isFirmwareCacheUsedForSelectedSource(settingsStore.get('firmwareChannel')) &&
+        isFirmwareCacheUsedForSelectedSource(firmwareChannel) &&
         firmwareList.includes(releaseName)
     ) {
         const localReleasePath = `${firmwareDir}${releaseName}`;
@@ -193,9 +195,15 @@ export const getReleaseByVersion = async (
         return JSON.parse(localReleaseBuffer.toString());
     }
 
+    // Bundled assets are production releases, so only use them on production-like channels.
+    // On other channels we must fetch the channel-appropriate release from remote.
+    const useBundledRelease = isProductionFirmwareChannel(firmwareChannel);
+
     const release =
         // Order is important!
-        (await tryGetRelease(() => getReleaseAsset(deviceModel, firmwareVersion, firmwareType))) ||
+        (useBundledRelease
+            ? await tryGetRelease(() => getReleaseAsset(deviceModel, firmwareVersion, firmwareType))
+            : undefined) ||
         (await tryGetRelease(() =>
             getOnlineReleaseByVersion(deviceModel, firmwareVersion, firmwareType),
         ));

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -49,6 +49,7 @@ import {
     getFirmwareStatus,
     getReleaseByVersion,
 } from '../data/firmwareInfo';
+import * as settingsStore from '../data/settingsStore';
 import type { DeviceEvents, DeviceLifecycleEvents, IDevice, RunOptions } from '../types/idevice';
 import { getReleaseAsset } from '../utils/assetUtils';
 import {
@@ -57,7 +58,11 @@ import {
     parseCapabilities,
     parseRevision,
 } from '../utils/deviceFeaturesUtils';
-import { getFirmwareMode, getFirmwareType } from '../utils/firmwareUtils';
+import {
+    getFirmwareMode,
+    getFirmwareType,
+    isProductionFirmwareChannel,
+} from '../utils/firmwareUtils';
 import { changeLanguage } from './workflow/changeLanguage';
 import { checkFirmwareHashWithRetries } from './workflow/checkFirmwareHashWithRetries';
 import { handshakeCancel } from './workflow/handshake';
@@ -736,7 +741,9 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
         if (
             this._currentRelease &&
             newFirmwareType === this.firmwareType &&
-            versionUtils.isEqual(this._currentRelease.version, firmwareVersion)
+            versionUtils.isEqual(this._currentRelease.version, firmwareVersion) &&
+            // When test firmware channel is used, we need to fetch the release from remote.
+            isProductionFirmwareChannel(settingsStore.get('firmwareChannel'))
         ) {
             return;
         }

--- a/packages/connect/src/utils/firmwareUtils.ts
+++ b/packages/connect/src/utils/firmwareUtils.ts
@@ -134,5 +134,11 @@ export const getFirmwareType = (features: Features) => {
     return type;
 };
 
+// Bundled release JSONs are the production assets, valid only for production-like channels.
+export const isProductionFirmwareChannel = (firmwareChannel?: FirmwareChannel) =>
+    firmwareChannel === undefined ||
+    firmwareChannel === 'production' ||
+    firmwareChannel === 'production-early-access';
+
 export const isFirmwareCacheUsedForSelectedSource = (firmwareChannel?: FirmwareChannel) =>
-    firmwareChannel === 'production';
+    isProductionFirmwareChannel(firmwareChannel);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

If it happens that we have bundled the same version that is tested in a testing firmwareChannel that makes confusion and was using local bundled one and then failing for getting translations becuase the path is wrong and translations are not bundled, so this PR makes it that remote firmware releases are always used when in a testing firmware channel.

## Notes for QA
With the current state of signed firmware channel testing there was issue Changing translations only works with the latest 2.12.1 firmware. If I downgrade to 2.12.0 changing translations stops working because an incorrect URL is called by Suite. It might be some problem with logic in Suite working with this channel (or channels in general).

Now it should work fine also for 2.12.0 (the bundled one).


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect core device management and firmware utility code in @trezor/connect (firmwareInfo.ts, firmwareUtils.ts, Device.ts). Since all three files map to all 121 tests via transitive imports, they are clearly global dependencies. The highest risk areas are firmware-specific flows (firmware checks, custom firmware installation, firmware update modals) and device lifecycle management (session handling, connection/disconnection, onboarding device interactions). The recommended strategy focuses on firmware-specific tests as high priority, onboarding and device settings tests as medium priority (since they exercise firmware steps and device state), and a few device reconnection tests as low priority.

<details><summary><b>Changed files (3)</b></summary>

- `packages/connect/src/data/firmwareInfo.ts`
- `packages/connect/src/device/Device.ts`
- `packages/connect/src/utils/firmwareUtils.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/firmware/custom-firmware.test.ts` — This test directly exercises firmware installation on a device, which is the core domain of all three changed files (firmwareInfo.ts, firmwareUtils.ts, Device.ts). Changes to firmware info/utils could break firmware installation detection, validation, or the installation flow itself.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test explicitly validates firmware readiness detection during onboarding across multiple device models. Changes to firmwareInfo.ts and firmwareUtils.ts directly affect how firmware status (ready/outdated/required) is determined, which is the core assertion of this test.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test asserts DeviceConnect event metadata including firmware version, model, and device properties. Changes to Device.ts could affect how device metadata is populated and reported in analytics events, and firmwareInfo.ts changes could alter firmware version reporting.
- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — Wallet creation during onboarding involves firmware steps and device interaction. Changes to Device.ts affect device state management during onboarding, and firmware checks are part of the flow (firmware step is explicitly referenced).
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test exercises entropy check failure handling during wallet creation which involves Device.ts for device state and error handling. The test explicitly passes through firmware checks and interacts with device state management that could be affected by Device.ts changes.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — Recovery onboarding involves firmware continuation steps and device interaction (mnemonic input, PIN setup). Device.ts changes could affect device session management during the multi-step recovery flow.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — T3T1 wallet creation passes through firmware installation, authenticity check, and device interaction steps. All three changed files are relevant as firmware info/utils determine firmware state and Device.ts manages the device session throughout onboarding.
- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` — T1B1 wallet creation involves firmware steps and device interaction including PIN setup and seed backup. Device.ts changes could affect device communication during the multi-step onboarding and backup flow.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — Device settings tests interact directly with Device.ts for changing device name, rotation, and opening firmware update modal. The firmware update modal opening specifically exercises firmware info/utils to determine available updates.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test exercises Bridge session management (acquire/enumerate) which is handled through Device.ts. Changes to device session handling could affect how session stealing, reclaiming, and multi-tab behavior works.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test simulates device disconnect during backup which exercises Device.ts reconnection logic. Changes to device state management could affect how the app detects disconnection and handles backup failure recovery.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — This test validates that device recovery state persists across disconnects and page reloads, exercising Device.ts session persistence logic. Changes could affect how recovery-mode device state is maintained.
- `suite/e2e/tests/recovery/dry-run.test.ts` — Dry run recovery involves device disconnection/reconnection handling which is managed through Device.ts. The test specifically exercises bridge stop/restart scenarios that interact with device session management.

</details>

_Updated: 2026-06-16T08:02:03.299Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/always-remote-firmware-release-when-test-firmware-channel&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/always-remote-firmware-release-when-test-firmware-channel&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/always-remote-firmware-release-when-test-firmware-channel&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-16T08:06:38.870Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-16T08:05:19.168Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/always-remote-firmware-release-when-test-firmware-channel/web/](https://dev.suite.sldev.cz/suite-web/fix/always-remote-firmware-release-when-test-firmware-channel/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->