### PR TITLE
test(suite): stabilize send-base and fix label migration

### DIFF
--- a/suite/e2e/support/device.ts
+++ b/suite/e2e/support/device.ts
@@ -178,36 +178,36 @@ export class DeviceFixture {
         );
     };
 
-    private wrapTextByWords = (text: string, lineCharLimit: number) => {
-        const words = text.split(' ');
+    private wrapTextByWords = (
+        text: string,
+        lineCharLimit: number,
+        options?: { hyphenate?: boolean },
+    ) => {
         const lines: string[] = [];
-        let currentLine = '';
+        let rest = text;
 
-        const wouldExceedLimit = (line: string, word: string): boolean => {
-            const combinedLength = line ? line.length + 1 + word.length : word.length;
+        // Greedily fill each line. Break at the last space that fits; when no
+        // space fits, either hyphenate the word (the dash takes one slot) or,
+        // if hyphenation is off, overflow up to the next space.
+        while (rest.length > lineCharLimit) {
+            const lastWhitespaceIndex = rest.lastIndexOf(' ', lineCharLimit);
+            const hasFittingWhitespace = lastWhitespaceIndex > 0;
 
-            return combinedLength > lineCharLimit;
-        };
-
-        for (const word of words) {
-            if (!currentLine) {
-                // First word on the line
-                currentLine = word;
-            } else if (wouldExceedLimit(currentLine, word)) {
-                // Word doesn't fit, wrap to new line
-                lines.push(currentLine);
-                lines.push('\n');
-                currentLine = word;
+            if (hasFittingWhitespace) {
+                lines.push(rest.slice(0, lastWhitespaceIndex), '\n');
+                rest = rest.slice(lastWhitespaceIndex + 1);
+            } else if (options?.hyphenate) {
+                lines.push(rest.slice(0, lineCharLimit - 1), '-', '\n');
+                rest = rest.slice(lineCharLimit - 1);
             } else {
-                // Word fits, add it with a space
-                currentLine += ' ' + word;
+                const nextSpace = rest.indexOf(' ');
+                if (nextSpace === -1) break;
+                lines.push(rest.slice(0, nextSpace), '\n');
+                rest = rest.slice(nextSpace + 1);
             }
         }
 
-        // Add the final line without trailing newline
-        if (currentLine) {
-            lines.push(currentLine);
-        }
+        lines.push(rest);
 
         return lines;
     };
@@ -218,27 +218,18 @@ export class DeviceFixture {
     ) => {
         const T3W1_EXACT_LINE_LENGTH = options?.lengthOverride ?? 14;
         const T3T1_EXACT_LINE_LENGTH = options?.lengthOverride ?? 18;
-        const T3W1_LINE_LENGTH_MINUS_DASH = T3W1_EXACT_LINE_LENGTH - 1;
 
         if (this.model === Model.T3W1) {
-            //1. Fits on one line without wrap
-            if (text.length === T3W1_EXACT_LINE_LENGTH) {
-                return [text];
+            // Wrap by words with conditional hyphenation for amounts
+            // Amounts have potentially long decimal parts -> hyphenation
+            if (options?.isAmount || options?.wrapByWords) {
+                return this.wrapTextByWords(text, T3W1_EXACT_LINE_LENGTH, {
+                    hyphenate: options?.isAmount,
+                });
             }
 
-            //2. Needs to be wrapped by whole words
-            if (options?.wrapByWords) {
-                return this.wrapTextByWords(text, T3W1_EXACT_LINE_LENGTH);
-            }
-
-            //3. string is split by the size limit
-            //text string will have a dash at the end of separation
-            const lineCharLimit = options?.isAmount
-                ? T3W1_LINE_LENGTH_MINUS_DASH
-                : T3W1_EXACT_LINE_LENGTH;
-            const newline = options?.isAmount ? ['-', '\n'] : ['\n'];
-
-            return this.wrapTextByLineLimit(text, lineCharLimit, newline);
+            // Otherwise wrap by chars at the size limit
+            return this.wrapTextByLineLimit(text, T3W1_EXACT_LINE_LENGTH, ['\n']);
         }
 
         if (options?.wrapByWords) {

--- a/suite/e2e/support/pageObjects/dashboardPage.ts
+++ b/suite/e2e/support/pageObjects/dashboardPage.ts
@@ -197,11 +197,11 @@ export class DashboardPage {
         await this.device.pressYes();
 
         await this.passphraseInput.fill(passphrase);
-        await this.passphraseSubmitButton.click();
-
         // Give Connect time to emit REQUEST_PASSPHRASE before we submit
         // submitting in the ~100ms gap before it drops the response and the device prompt never shows.
         await this.page.waitForTimeout(2_000);
+        await this.passphraseSubmitButton.click();
+
         await this.devicePrompt.confirmOnDevicePromptIsShown();
         await this.device.pressYes();
 

--- a/suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts
+++ b/suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts
@@ -25,7 +25,13 @@ test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] },
         await metadataPage.enableLegacyLabeling(MetadataProvider.LOCAL);
     });
 
-    test('Migration from local file', async ({ page, walletPage, metadataPage, evoluClient }) => {
+    test('Migration from local file', async ({
+        page,
+        devicePrompt,
+        walletPage,
+        metadataPage,
+        evoluClient,
+    }) => {
         await test.step('Set up local file labeling', async () => {
             await walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }).click();
             await expect(
@@ -75,6 +81,7 @@ test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] },
 
         await test.step('Switch to Suite Sync labeling and confirm legacy label is migrated', async () => {
             await metadataPage.enableSuiteSync();
+            await devicePrompt.waitForPromptAndConfirm();
             await expect(
                 page.getByTestId('@toast/legacy-labeling-migration-success'),
             ).toHaveTranslation('TR_LABELING_MIGRATION_SUCCESS', {


### PR DESCRIPTION
- rework wrapbyWord for the device display verification
- add missing device prompt click into label migration
- correct sleep placement from previous fix (/facepalm)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-tests-6-16/web/](https://dev.suite.sldev.cz/suite-web/fix-tests-6-16/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-tests-6-16&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-tests-6-16&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-16T09:39:49.704Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-16T09:38:28.449Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->