### PR TITLE
fix(trading): unify picker modal max heights

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySelectModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySelectModal.tsx
@@ -38,7 +38,7 @@ export const CountrySelectModal = ({ heading, onClose }: CountrySelectModalProps
     return (
         <Modal
             width={400}
-            height="85vh"
+            maxHeight={680}
             onCancel={onClose}
             heading={heading ? <Translation id={heading} /> : undefined}
         >

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySubdivisionSelectModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySubdivisionSelectModal.tsx
@@ -39,7 +39,7 @@ export const CountrySubdivisionSelectModal = ({
         <Modal
             heading={<Translation id="TR_TRADING_COUNTRY_SUBDIVISION" />}
             onCancel={onClose}
-            height="85vh"
+            maxHeight={680}
             width={400}
         >
             <Column gap={12} height="100%">

--- a/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersModal.tsx
@@ -39,7 +39,7 @@ export const TradingOffersModal = ({ onClose, onSelect }: TradingOffersModalProp
             heading={<Translation id="TR_TRADING_SHOW_OFFERS" />}
             data-testid="@trading/offers/modal"
             width={600}
-            height={680}
+            maxHeight={680}
         >
             <Box padding={{ bottom: 16 }}>
                 {isTradingExchangeContext(context) ? (

--- a/suite/trading/src/ui/Country/CountrySelectModal.tsx
+++ b/suite/trading/src/ui/Country/CountrySelectModal.tsx
@@ -26,7 +26,7 @@ export const CountrySelectModal = ({
     return (
         <Modal
             width={400}
-            height="85vh"
+            maxHeight={680}
             onCancel={onClose}
             heading={heading ? <Translation id={heading} /> : undefined}
         >

--- a/suite/trading/src/ui/currency-picker/CurrencyPickerModal.tsx
+++ b/suite/trading/src/ui/currency-picker/CurrencyPickerModal.tsx
@@ -36,7 +36,7 @@ export const CurrencyPickerModal = ({
     };
 
     return (
-        <Modal {...props} width={400} heading={<Translation id="TR_CURRENCY" />} height="85vh">
+        <Modal {...props} width={400} heading={<Translation id="TR_CURRENCY" />} maxHeight={680}>
             <Column gap={16} height="100%">
                 <Input
                     onChange={ev => setFilterValue(ev.target.value)}


### PR DESCRIPTION
## Description

- replace fixed picker modal heights with `maxHeight={680}` in trading country, country subdivision, and currency pickers
- 
## Notes for QA

- Verify modal heights matching specification 

## Related Issue

Resolve #28597

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect modal components in the trading/coinmarket UI: country selection modals (CountrySelectModal, CountrySubdivisionSelectModal), a currency picker modal (CurrencyPickerModal), and the trading offers comparison modal (TradingOffersModal). These are UI-layer components used across buy and sell flows. The highest risk is in tests that directly interact with country selection or offer comparison, while buy/sell flow tests that render these modals without direct interaction carry medium risk. Three of the five changed files have no static test coverage mapping, suggesting possible gaps in test infrastructure coverage for the shared trading UI library.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySelectModal.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySubdivisionSelectModal.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersModal.tsx`
- `suite/trading/src/ui/Country/CountrySelectModal.tsx`
- `suite/trading/src/ui/currency-picker/CurrencyPickerModal.tsx`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test directly exercises the country selector in the sell form ('Country selector does not default to Worldwide option') and validates country-related UI behavior, which is directly affected by changes to CountrySelectModal and CountrySubdivisionSelectModal.
- `suite/e2e/tests/trading/buy-negative.test.ts` — This test validates buy form behavior including selecting fiat currency via the currency picker and interacting with the trading form inputs. Changes to CurrencyPickerModal and the country select modals could affect the form loading and interaction flow tested here.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test exercises the full buy flow including the trading form where the country selector and currency picker modals are rendered. Changes to these modal components could cause regressions in the buy quote flow, offer comparison modal (TradingOffersModal), or form submission.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Covers the buy flow for Ethereum which uses the same trading form components including country and currency selection modals. A regression in these modals could break the form initialization or quote retrieval.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test covers the sell flow for Solana including offer comparison via TradingOffersModal and uses the trading form where country selection modals are rendered. Changes to TradingOffersModal directly affect the offer comparison behavior tested here.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — The sell-bitcoin test exercises the full sell flow including the trading offers/quotes UI where TradingOffersModal is used for offer display and confirmation. Although not statically mapped, TradingOffersModal is clearly part of the sell offer flow.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Tests the buy flow for a Solana SPL token which uses the same trading form with country selection. The form initialization and quote display could be affected by modal component changes.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test verifies that buy/sell/swap forms open correctly with the right cryptocurrency pre-selected. While it renders the trading forms containing the changed country select modals, it only checks form opening behavior rather than interacting with the modals directly.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Exercises the ETH sell flow which renders TradingOffersModal for offer confirmation. Not statically mapped but inferred from the shared offer confirmation pattern across sell flows.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite/trading/src/ui/Country/CountrySelectModal.tsx`
- `suite/trading/src/ui/currency-picker/CurrencyPickerModal.tsx`

_Updated: 2026-06-16T11:59:55.427Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/28597-trading-picker-modal-heights&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/28597-trading-picker-modal-heights&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-16T12:04:26.236Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-16T12:02:56.917Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->