### PR TITLE
fix(node-utils): settle HttpServer.start() on server start errors

### DIFF
--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -200,7 +200,25 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
                 const portOccupied = errorCode === 'EADDRINUSE' || errorCode === 'EACCES';
 
                 if (this.ports.length) {
-                    return this.stop().then(() => this.start());
+                    // Retry on the next port. The recursive start() settles the
+                    // outer promise; it must always resolve (never reject) because
+                    // callers `await start()` without a try/catch and rely on the
+                    // {success} union (e.g. transport-bridge/src/http.ts). Note that
+                    // stop() calls this.emitter.removeAllListeners(), which also
+                    // drops any consumer server/* subscriptions across this retry.
+                    try {
+                        return resolve(await this.stop().then(() => this.start()));
+                    } catch (retryError) {
+                        const retryMessage =
+                            retryError instanceof Error ? retryError.message : String(retryError);
+                        this.logger.error(retryMessage);
+
+                        return resolve({
+                            success: false,
+                            error: 'other error',
+                            message: retryMessage,
+                        });
+                    }
                 }
 
                 if (portOccupied) {
@@ -220,11 +238,11 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
 
                 this.logger.error(errorMessage);
 
-                return {
+                return resolve({
                     success: false,
                     error: 'other error',
-                    message: `Start error code: ${errorCode}`,
-                };
+                    message: errorMessage,
+                });
             };
             this.server.on('error', this.onError);
 

--- a/packages/node-utils/src/tests/http.test.ts
+++ b/packages/node-utils/src/tests/http.test.ts
@@ -582,6 +582,73 @@ describe('HttpServer', () => {
         expect(newAddress.port).toEqual(address.port);
     });
 
+    // Previously start() never resolved the outer promise on a non-port server
+    // error: the 'other error' branch of onError returned a plain object instead
+    // of calling resolve(), so `await start()` hung forever and the failure never
+    // reached consumers (e.g. the suite-desktop http-receiver Sentry warning).
+    test('start() resolves with "other error" on a non-port server error', async () => {
+        const underlying = (server as any).server;
+        // Force a non-port start failure: emit a synthetic error with a code that
+        // is neither EADDRINUSE nor EACCES while the start() promise is pending.
+        // onError is attached before listen() is called, so this is observed.
+        jest.spyOn(underlying, 'listen').mockImplementation(() => {
+            const error = Object.assign(new Error('synthetic'), { code: 'EOTHER' });
+            underlying.emit('error', error);
+
+            return underlying;
+        });
+
+        await expect(server.start()).resolves.toEqual({
+            success: false,
+            error: 'other error',
+            message: 'Start error code: EOTHER',
+        });
+    });
+
+    // Previously the port-fallback retry branch (`if (this.ports.length) return
+    // this.stop().then(() => this.start())`) returned the retry promise into the
+    // error-event handler without settling the outer promise, so `await start()`
+    // hung whenever the first port was occupied and a fallback port existed.
+    test('start() resolves via the port-fallback retry when the first port is occupied', async () => {
+        const [freePort1, freePort2] = await getFreePort(2);
+
+        const blocker = new HttpServer<Events>({ logger: muteLogger, port: freePort1 ?? 0 });
+        await blocker.start();
+
+        server = new HttpServer<Events>({
+            logger: muteLogger,
+            ports: [freePort1 ?? 0, freePort2 ?? 0],
+        });
+
+        const result = await server.start();
+        expect(result).toMatchObject({ success: true });
+        expect(server.getServerAddress()).toMatchObject({ port: freePort2 });
+
+        await blocker.stop();
+    });
+
+    // The retry chain must always resolve to a {success} value, never reject:
+    // consumers `await start()` without a try/catch. When every fallback port is
+    // occupied, start() resolves with a failure rather than rejecting or hanging.
+    test('start() resolves (never rejects) when every fallback port is occupied', async () => {
+        const [freePort1, freePort2] = await getFreePort(2);
+
+        const blocker1 = new HttpServer<Events>({ logger: muteLogger, port: freePort1 ?? 0 });
+        const blocker2 = new HttpServer<Events>({ logger: muteLogger, port: freePort2 ?? 0 });
+        await blocker1.start();
+        await blocker2.start();
+
+        server = new HttpServer<Events>({
+            logger: muteLogger,
+            ports: [freePort1 ?? 0, freePort2 ?? 0],
+        });
+
+        const result = await server.start();
+        expect(result).toMatchObject({ success: false });
+
+        await Promise.all([blocker1.stop(), blocker2.stop()]);
+    });
+
     describe('route matching logic (express.js-like)', () => {
         test('unregistered route does not match any registered route', async () => {
             const handler1 = jest.fn((_request, response) => {


### PR DESCRIPTION
## Summary

Fixes two branches of `HttpServer.start()`'s `onError` handler that returned a value instead of calling the outer promise's `resolve()`, so `start()` never settled on a server-start error:

- **`'other error'` branch** (codes other than `EADDRINUSE`/`EACCES`) returned a plain object, so `await start()` hung forever — and the failure never reached consumers (the suite-desktop `http-receiver` `captureMessage` Sentry warning never fired; node-bridge `trezordNode.start()` never completed).
- **Port-fallback retry branch** returned the retry promise into the error-event handler without settling the original caller's promise.

Both now `resolve` the outer promise. The retry is wrapped so it always resolves to a `{ success }` value and **never rejects** — callers `await start()` without a try/catch (e.g. `transport-bridge/src/http.ts`), so a rejection would crash `trezordNode.start()`. The duplicated `Start error code:` message string is collapsed to a single `errorMessage`.

## Tests

Three new unit tests in `http.test.ts`, all asserting `start()` settles (no hang):
- non-port server error → resolves to `{ success: false, error: 'other error' }`
- port-occupied (`EADDRINUSE`) with a fallback port → resolves via the retry on the second port
- every fallback port occupied → resolves to `{ success: false }`, never rejects

Verified locally: the pre-fix code hangs the existing `port negotiation, first available port is occupied, second is free` test (the retry branch never resolved); with the fix the full suite is 45/45 green, type-check and lint clean.

Closes #28813

## Team
- **Product owner:** mroz22
- **Reviewer:** marekpolakjr
- **Eng owner:** _not needed — single-file fix, no architectural change_
- **Tester:** _not needed — covered by new unit tests in node-utils_

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to `packages/node-utils/src/http.ts` and its co-located unit test `packages/node-utils/src/tests/http.test.ts`. This is a low-level Node.js HTTP utility package. None of the 45 candidate E2E tests have static coverage mapping to these files, and reviewing the LLM analysis of each test reveals no direct or concrete dependency on `@trezor/node-utils` HTTP utilities — the E2E tests operate at the Playwright/browser level against the Suite web or Electron app, and their HTTP interactions go through browser APIs, Playwright request contexts, or test environment helpers rather than this Node.js utility. The unit test file itself provides direct coverage for the changed code. No E2E tests are recommended; the risk is best mitigated by the co-located unit test.

<details><summary><b>Changed files (2)</b></summary>

- `packages/node-utils/src/http.ts`
- `packages/node-utils/src/tests/http.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/node-utils/src/http.ts`
- `packages/node-utils/src/tests/http.test.ts`

_Updated: 2026-06-16T12:00:19.403Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/http-onerror-no-resolve&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/http-onerror-no-resolve&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/http-onerror-no-resolve/web/](https://dev.suite.sldev.cz/suite-web/mroz22/http-onerror-no-resolve/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-16T12:05:11.723Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-16T12:03:44.300Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->