### PR TITLE
feat(suite-desktop): display current nonce info on the account detail page

### DIFF
--- a/packages/suite/src/views/wallet/details/AccountNonce.tsx
+++ b/packages/suite/src/views/wallet/details/AccountNonce.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+
+import { Translation } from '@suite/intl';
+import { ethereumGetCurrentNonceThunk } from '@suite-common/wallet-core/src/send/sendFormEthereumThunks';
+import { type AccountWithNetworkType } from '@suite-common/wallet-types';
+import { Paragraph } from '@trezor/components';
+
+import { useDispatch } from 'src/hooks/suite';
+
+type AccountNonceProps = {
+    account: AccountWithNetworkType<'ethereum'>;
+};
+
+export const AccountNonce = ({ account }: AccountNonceProps) => {
+    const dispatch = useDispatch();
+    const [nonces, setNonces] = useState<{ nonce: string; confirmedNonce: string }>();
+
+    useEffect(() => {
+        const promise = dispatch(
+            ethereumGetCurrentNonceThunk({ selectedAccount: account, fetchConfirmedNonce: true }),
+        );
+
+        void promise
+            .unwrap()
+            .then(setNonces)
+            .catch(() => {});
+
+        return () => {
+            promise.abort();
+        };
+    }, [account, dispatch]);
+
+    if (!nonces) return null;
+
+    return (
+        <>
+            <Paragraph typographyStyle="body-sm">
+                <Translation id="TR_ACCOUNT_DETAILS_NONCE_CONFIRMED" />
+                {': '}
+                {nonces.confirmedNonce}
+            </Paragraph>
+            {nonces.nonce !== nonces.confirmedNonce && (
+                <Paragraph typographyStyle="body-xs" intent="neutral" priority="secondary">
+                    <Translation id="TR_ACCOUNT_DETAILS_NONCE_NEXT" />
+                    {': '}
+                    {nonces.nonce}
+                </Paragraph>
+            )}
+        </>
+    );
+};

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -10,12 +10,7 @@ import { useReceiveDisabled } from '@suite/receive';
 import { getAccountTypeTech } from '@suite-common/wallet-utils';
 import { Button, Card, Column, InfoItem, Paragraph } from '@trezor/components';
 import { typography } from '@trezor/theme';
-import {
-    HELP_CENTER_BIP32_URL,
-    HELP_CENTER_XPUB_URL,
-    TREZOR_GLOSSARY_NONCE_URL,
-    type Url,
-} from '@trezor/urls';
+import { HELP_CENTER_BIP32_URL, HELP_CENTER_XPUB_URL, type Url } from '@trezor/urls';
 
 import { showXpub } from 'src/actions/wallet/publicKeyActions';
 import { AccountTypeDescription } from 'src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription';
@@ -170,7 +165,6 @@ const Details = () => {
                         <DetailsRow
                             title="TR_ACCOUNT_DETAILS_NONCE_HEADER"
                             description={<Translation id="TR_ACCOUNT_DETAILS_NONCE_DESC" />}
-                            learnMoreUrl={TREZOR_GLOSSARY_NONCE_URL}
                         >
                             <AccountNonce account={account} />
                         </DetailsRow>

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -10,7 +10,12 @@ import { useReceiveDisabled } from '@suite/receive';
 import { getAccountTypeTech } from '@suite-common/wallet-utils';
 import { Button, Card, Column, InfoItem, Paragraph } from '@trezor/components';
 import { typography } from '@trezor/theme';
-import { HELP_CENTER_BIP32_URL, HELP_CENTER_XPUB_URL, type Url } from '@trezor/urls';
+import {
+    HELP_CENTER_BIP32_URL,
+    HELP_CENTER_XPUB_URL,
+    TREZOR_GLOSSARY_NONCE_URL,
+    type Url,
+} from '@trezor/urls';
 
 import { showXpub } from 'src/actions/wallet/publicKeyActions';
 import { AccountTypeDescription } from 'src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription';
@@ -18,6 +23,7 @@ import { WalletLayout } from 'src/components/wallet';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { ContentFlex, useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 
+import { AccountNonce } from './AccountNonce';
 import { CoinjoinLogs } from './CoinjoinLogs';
 import { CoinjoinSetup } from './CoinjoinSetup/CoinjoinSetup';
 import { RescanAccount } from './RescanAccount';
@@ -159,6 +165,15 @@ const Details = () => {
                         )
                     ) : (
                         <RescanAccount account={account} />
+                    )}
+                    {account.networkType === 'ethereum' && (
+                        <DetailsRow
+                            title="TR_ACCOUNT_DETAILS_NONCE_HEADER"
+                            description={<Translation id="TR_ACCOUNT_DETAILS_NONCE_DESC" />}
+                            learnMoreUrl={TREZOR_GLOSSARY_NONCE_URL}
+                        >
+                            <AccountNonce account={account} />
+                        </DetailsRow>
                     )}
                     <Bip329Labels account={account} isLoading={locked} />
                 </Column>

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -210,6 +210,9 @@ export const HELP_CENTER_ADVANCED_RECOVERY_URL: Url = withPlatformUtm(
 export const HELP_CENTER_XPUB_URL: Url = withPlatformUtm(
     'https://trezor.io/learn/supported-assets/bitcoin/what-is-a-public-key-xpub',
 );
+export const TREZOR_GLOSSARY_NONCE_URL: Url = withPlatformUtm(
+    'https://trezor.io/learn/supported-assets/ethereum-layer-2-EVM/replace-by-fee-rbf-ethereum',
+);
 export const HELP_CENTER_BIP329_URL: Url = withPlatformUtm(
     'https://trezor.io/learn/advanced/standards-proposals/what-is-bip-329',
 );

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -210,9 +210,6 @@ export const HELP_CENTER_ADVANCED_RECOVERY_URL: Url = withPlatformUtm(
 export const HELP_CENTER_XPUB_URL: Url = withPlatformUtm(
     'https://trezor.io/learn/supported-assets/bitcoin/what-is-a-public-key-xpub',
 );
-export const TREZOR_GLOSSARY_NONCE_URL: Url = withPlatformUtm(
-    'https://trezor.io/learn/supported-assets/ethereum-layer-2-EVM/replace-by-fee-rbf-ethereum',
-);
 export const HELP_CENTER_BIP329_URL: Url = withPlatformUtm(
     'https://trezor.io/learn/advanced/standards-proposals/what-is-bip-329',
 );

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -3874,6 +3874,23 @@ export const messages = defineMessages({
         id: 'TR_ACCOUNT_DETAILS_XPUB_HEADER',
         defaultMessage: 'Public key (XPUB)',
     },
+    TR_ACCOUNT_DETAILS_NONCE_HEADER: {
+        id: 'TR_ACCOUNT_DETAILS_NONCE_HEADER',
+        defaultMessage: 'Nonce',
+    },
+    TR_ACCOUNT_DETAILS_NONCE_DESC: {
+        id: 'TR_ACCOUNT_DETAILS_NONCE_DESC',
+        defaultMessage:
+            'The nonce is the number of confirmed transactions sent from this account. The next transaction will use the next available nonce.',
+    },
+    TR_ACCOUNT_DETAILS_NONCE_CONFIRMED: {
+        id: 'TR_ACCOUNT_DETAILS_NONCE_CONFIRMED',
+        defaultMessage: 'Confirmed',
+    },
+    TR_ACCOUNT_DETAILS_NONCE_NEXT: {
+        id: 'TR_ACCOUNT_DETAILS_NONCE_NEXT',
+        defaultMessage: 'Next',
+    },
     TR_ACCOUNT_DETAILS_EXPORT_LABELS_BUTTON: {
         id: 'TR_ACCOUNT_DETAILS_EXPORT_LABELS_BUTTON',
         defaultMessage: 'Export',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

This option must be displayed for every EVM chain (except Tron). 

Would make sense to test transaction creation from multiple tabs to see how value is incrementing or updating.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19135

## Screenshots:

Fetching of nonce on this page with special parameter that return confirmed nonce

<img width="1145" height="714" alt="Screenshot 2026-06-16 at 13 56 28" src="https://github.com/user-attachments/assets/ecac1138-6588-48af-9442-b7cce539927e" />

Sent transaction from the other window and it **wasn't** instantly included
<img width="917" height="177" alt="Screenshot 2026-06-16 at 13 18 22" src="https://github.com/user-attachments/assets/bf580db3-15cf-4469-9537-ea6d2f89d4d6" />

Sent transaction from the other window and it **was** instantly included
<img width="1155" height="186" alt="Screenshot 2026-06-16 at 13 57 43" src="https://github.com/user-attachments/assets/66ce265f-3837-47a1-b67a-9bc6e61cdcad" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/evm-account-nonce-detail&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/evm-account-nonce-detail&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/evm-account-nonce-detail&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-18T13:08:21.666Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-18T13:07:17.072Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/evm-account-nonce-detail/web/](https://dev.suite.sldev.cz/suite-web/feat/evm-account-nonce-detail/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->