### PR TITLE
Replace hardcoded strings with `getTranslation` 

### DIFF
--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/__tests__/FeeOptionErrorMessage.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/__tests__/FeeOptionErrorMessage.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { FeeOptionErrorMessage } from '../FeeOptionErrorMessage';
@@ -9,8 +10,8 @@ describe('FeeOptionErrorMessage', () => {
     it('should render error message when visible', () => {
         const { getByText, queryByTestId } = renderFeeOptionErrorMessage(true);
 
-        expect(getByText('You don’t have enough balance to use this fee.')).toBeTruthy();
-        expect(queryByTestId('@transactionManagement/fee-option-error-message')).toBeTruthy();
+        expect(getByText(getTranslation('transactionManagement.fees.error'))).toBeOnTheScreen();
+        expect(queryByTestId('@transactionManagement/fee-option-error-message')).toBeOnTheScreen();
     });
 
     it('should have height 0 when not visible', () => {


### PR DESCRIPTION
Replace hardcoded strings with `getTranslation`  utility in FeeOptionErrorMessage tests.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

Nothing to test. Just fix of a test.
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-translations-transaction-management&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->