### PR TITLE
test(agent): adds cron job and minor improvements

### DIFF
--- a/.github/workflows/test-suite-nightly-fix-agent.yml
+++ b/.github/workflows/test-suite-nightly-fix-agent.yml
@@ -1,6 +1,8 @@
 name: "[Test] Nightly Suite Fix Agent"
 
 on:
+  schedule:
+    - cron: "0 3 * * 1-5"
   workflow_dispatch:
 
 permissions:
@@ -265,6 +267,7 @@ jobs:
         env:
           TASK_ID: ${{ matrix.task-id }}
         run: |
+          git fetch origin develop --depth=1
           BRANCH=$(jq -r --arg id "$TASK_ID" \
             'first(.fixTasks[] | select(.id == $id) | .branch) // empty' "report-download/report.json")
           if [ -z "$BRANCH" ]; then echo "Branch not found for task id: $TASK_ID" && exit 1; fi

--- a/packages/e2e-utils/src/fixBot/ANALYSIS_AGENT.md
+++ b/packages/e2e-utils/src/fixBot/ANALYSIS_AGENT.md
@@ -171,7 +171,8 @@ Route each cluster by the **first** rule that applies:
    cluster against every entry's `rootCause` and `validations` (platform/group/spec), not just an
    overlapping spec path — a failure may be specific to a platform or device group (e.g. `T1B1`):
     - **Confident match → skipped**, reusing the entry's `reason`.
-    - **Unsure → treat as new** — skip this rule, continue to rules 2–4.
+    - **rootCause match, but different validations → treat as new** — continue to rules 2–4.
+    - **Unsure → treat as new** — continue to rules 2–4.
 2. **Fixable** — the **entire** remedy fits inside `suite/e2e/` and/or adding `data-testid`
    attributes in product source → **fix_task**.
 3. **Needs a product-logic change** → **skipped**, `reason: "PRODUCT_BUG"`.

--- a/packages/e2e-utils/src/fixBot/FIX_AGENT.md
+++ b/packages/e2e-utils/src/fixBot/FIX_AGENT.md
@@ -184,9 +184,12 @@ Then use `git commit --fixup $FIRST_SHA` for all subsequent iterations.
 
 ---
 
-## Step 4 — Write the PR description and return the result
+## Step 4 — Verify the commit, write the PR description, return the result
 
 _Cost marker: run `echo fixagent-stage-finalize` before starting this step._
+
+Before reporting, reconcile your result with `git log --oneline origin/develop..HEAD` — a
+`pass` or `partial` result requires at least one commit; if the log is empty, commit your fix now.
 
 **`pr-description.md`** — write this file to the repo root (current directory) using the
 Write tool (see the section below for its contents).
@@ -207,8 +210,8 @@ Emit only the JSON object as your final answer, with no surrounding prose or cod
 }
 ```
 
-`pass` — all validations pass after fixes.
-`partial` — at least one passes, at least one fails.
+`pass` — all validations pass and the fix is committed.
+`partial` — at least one passes, at least one fails; the partial fix is committed.
 `fail` — zero validations pass after fixes.
 `not_duplicated` — all validations already passed in pre-flight; failure could not be reproduced.
 

--- a/packages/e2e-utils/src/fixBot/docs.md
+++ b/packages/e2e-utils/src/fixBot/docs.md
@@ -12,7 +12,7 @@ A fully automated system that runs after nightly tests, analyzes failures, imple
 
 ## Overall Architecture
 
-A single GitHub Actions workflow, `.github/workflows/test-suite-nightly-fix-agent.yml`, is the orchestrator:
+Source code in `packages/e2e-utils/src/fixBot`. A single GitHub Actions workflow, `.github/workflows/test-suite-nightly-fix-agent.yml`, is the orchestrator:
 
 ```
 analyze        → downloads ledger.json (S3), harness writes report.json + report.md

--- a/packages/e2e-utils/src/fixBot/fix.ts
+++ b/packages/e2e-utils/src/fixBot/fix.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { prettifyError } from 'zod';
 
@@ -99,6 +99,13 @@ function main(): void {
     }
 
     writeFileSync(join(root, 'fix-result.json'), `${JSON.stringify(fixResult.data, null, 2)}\n`);
+
+    const prDescriptionFile = join(root, 'pr-description.md');
+    if (existsSync(prDescriptionFile)) {
+        log(`PR description:\n\n${readFileSync(prDescriptionFile, 'utf-8')}`);
+    } else {
+        log('No pr-description.md written by the agent.');
+    }
 
     log('Agent done.');
     process.exit(status ?? 1);

--- a/packages/e2e-utils/src/fixBot/notify.ts
+++ b/packages/e2e-utils/src/fixBot/notify.ts
@@ -68,7 +68,21 @@ function buildMessage(
 
     // Header
     lines.push(`🤖 *Nightly Fix Agent — ${report.runDate}*  <${runUrl()}|GHA Run>`);
-    lines.push('');
+
+    // Cost summary
+    const fixCosts = summaries.map(s => s.costUsd).filter((c): c is number => c !== null);
+    const totalFixCost = fixCosts.reduce((a, b) => a + b, 0);
+    const hasCost = analyzeCost !== null || fixCosts.length > 0;
+
+    if (hasCost) {
+        const totalCost = (analyzeCost ?? 0) + totalFixCost;
+        const parts: string[] = [];
+
+        if (analyzeCost !== null) parts.push(`analysis ${formatCost(analyzeCost)}`);
+        if (fixCosts.length > 0) parts.push(`fixes ${formatCost(totalFixCost)}`);
+
+        lines.push(`💰 ~${formatCost(totalCost)} (${parts.join(' · ')})`);
+    }
 
     // Analyzer summary line
     const fixable = report.fixTasks.length;
@@ -125,23 +139,6 @@ function buildMessage(
             lines.push(`⛔ *${skip.reason}* — ${skip.rootCause}`);
             lines.push(formatTestRef(skip.validations));
         }
-    }
-
-    // Cost footer
-    const fixCosts = summaries.map(s => s.costUsd).filter((c): c is number => c !== null);
-    const totalFixCost = fixCosts.reduce((a, b) => a + b, 0);
-    const hasCost = analyzeCost !== null || fixCosts.length > 0;
-
-    if (hasCost) {
-        const totalCost = (analyzeCost ?? 0) + totalFixCost;
-        const parts: string[] = [];
-
-        if (analyzeCost !== null) parts.push(`analysis ${formatCost(analyzeCost)}`);
-        if (fixCosts.length > 0) parts.push(`fixes ${formatCost(totalFixCost)}`);
-
-        lines.push('');
-        lines.push(DIVIDER);
-        lines.push(`💰 ~${formatCost(totalCost)} (${parts.join(' · ')})`);
     }
 
     return lines.join('\n');


### PR DESCRIPTION
- enforce commits on passed/partial fixes
- pr description logging on wf
- moved cost in report to header
- started logging pr-description in terminal

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files (packages/e2e-utils/src/fixBot/fix.ts and packages/e2e-utils/src/fixBot/notify.ts) are part of a "fixBot" utility within the e2e-utils package. Based on the naming convention, these appear to be internal tooling/infrastructure files related to automated fix suggestions or notifications for the E2E test framework itself, not production application code exercised by any of the 41 candidate E2E tests. No static coverage mapping exists for these files, and none of the analyzed tests reference fixBot functionality in their source hints, behaviors, or entry points. This is a very low-risk change from a user-facing regression perspective, and no E2E tests need to be run.

<details><summary><b>Changed files (2)</b></summary>

- `packages/e2e-utils/src/fixBot/fix.ts`
- `packages/e2e-utils/src/fixBot/notify.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/e2e-utils/src/fixBot/fix.ts`
- `packages/e2e-utils/src/fixBot/notify.ts`

_Updated: 2026-06-17T08:11:53.057Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/nightly-fix-agent-cron/web/](https://dev.suite.sldev.cz/suite-web/nightly-fix-agent-cron/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=nightly-fix-agent-cron&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=nightly-fix-agent-cron&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-17T13:22:06.698Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-17T13:20:32.262Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->