### PR TITLE
[tiny nitpick]: chore(types): reuse existing types to remove `any` annotations

### DIFF
--- a/packages/components/src/components/Icon/Icon.tsx
+++ b/packages/components/src/components/Icon/Icon.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent } from 'react';
+import { type KeyboardEvent, type MouseEvent } from 'react';
 import { ReactSVG } from 'react-svg';
 
 import styled, { css } from 'styled-components';
@@ -103,7 +103,7 @@ const SVG = styled(ReactSVG)`
 export type IconProps = AllowedFrameProps & {
     name: IconName;
     size?: IconSize;
-    onClick?: (e: any) => void;
+    onClick?: (e: MouseEvent<HTMLDivElement> | KeyboardEvent<Element>) => void;
     'data-testid'?: string;
 } & ExclusiveColorOrIntent;
 
@@ -130,7 +130,7 @@ export const Icon = ({
         svg.setAttribute('height', '100%');
     };
 
-    const handleClick = (e: MouseEvent<any>) => {
+    const handleClick = (e: MouseEvent<HTMLDivElement>) => {
         onClick?.(e);
 
         // We need to stop default/propagation in case the icon is rendered in popup/modal so it won't close it.

--- a/packages/connect-explorer-theme/src/mdx-components.tsx
+++ b/packages/connect-explorer-theme/src/mdx-components.tsx
@@ -3,6 +3,7 @@ import type { ComponentProps, HTMLProps, PropsWithChildren, ReactElement, ReactN
 import { Children, cloneElement, useEffect, useRef, useState } from 'react';
 
 import cn from 'clsx';
+import type { FrontMatter } from 'nextra';
 import { Code, Pre, Table, Td, Th, Tr } from 'nextra/components';
 import type { Components } from 'nextra/mdx';
 
@@ -186,7 +187,7 @@ export const getComponents = ({
     isRawLayout,
     components,
 }: {
-    frontMatter: any;
+    frontMatter: FrontMatter;
     isRawLayout?: boolean;
     components?: DocsThemeConfig['components'];
 }): Components => {

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -375,8 +375,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                     const checksumAndUsageValidationResult = checkIsAddressNotUsedNotChecksummed(
                         address,
                         payload.history,
-                        inputName,
-                        setValue,
+                        checksummed => setValue(inputName, checksummed, { shouldValidate: true }),
                         setHasAddressChecksummed,
                     );
                     if (checksumAndUsageValidationResult) {

--- a/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
+++ b/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
@@ -8,6 +8,7 @@ import {
     selectPersistentDeviceDataById,
 } from '@suite-common/device';
 import { selectIsProductionFirmwareChannel } from '@suite-common/firmware';
+import { type SuiteCompatibleSelector } from '@suite-common/redux-utils';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { isDeviceKnown as getIsDeviceKnown, isDeviceAcquired } from '@suite-common/suite-utils';
 import { FIRMWARE } from '@trezor/connect';
@@ -20,7 +21,7 @@ import { hashCheckErrorScenarios, revisionCheckErrorScenarios } from './scenario
 // to avoid unnecessary wallet-core import
 type CommonProps = {
     device: TrezorDevice | undefined;
-    selectAllowPrerelease: (state: any) => boolean;
+    selectAllowPrerelease: SuiteCompatibleSelector<boolean>;
 };
 
 const useCommonData = ({ device }: Pick<CommonProps, 'device'>) => {

--- a/suite-common/firmware/src/firmwareReducer.ts
+++ b/suite-common/firmware/src/firmwareReducer.ts
@@ -1,6 +1,9 @@
 import { type PayloadAction, createSelector } from '@reduxjs/toolkit';
 
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import {
+    type SuiteCompatibleSelector,
+    createReducerWithExtraDeps,
+} from '@suite-common/redux-utils';
 import { type FirmwareStatus, type TrezorDevice } from '@suite-common/suite-types';
 import {
     DEVICE,
@@ -135,7 +138,9 @@ export const selectSwitchFirmwareType = (state: RootState) => state.firmware.swi
 export const selectIsFirmwareInstallationRunning = (state: RootState) =>
     state.firmware.status === 'started';
 
-export const selectEffectiveFirmwareChannel = (selectAllowPrerelease: (state: any) => boolean) =>
+export const selectEffectiveFirmwareChannel = (
+    selectAllowPrerelease: SuiteCompatibleSelector<boolean>,
+) =>
     createSelector(
         selectFirmwareChannel,
         selectAllowPrerelease,
@@ -145,7 +150,9 @@ export const selectEffectiveFirmwareChannel = (selectAllowPrerelease: (state: an
             allowPrerelease ? 'production-early-access' : firmwareChannel,
     );
 
-export const selectIsProductionFirmwareChannel = (selectAllowPrerelease: (state: any) => boolean) =>
+export const selectIsProductionFirmwareChannel = (
+    selectAllowPrerelease: SuiteCompatibleSelector<boolean>,
+) =>
     createSelector(
         selectEffectiveFirmwareChannel(selectAllowPrerelease),
         (firmwareChannel): boolean =>

--- a/suite-common/wallet-types/src/transactionSimulation.ts
+++ b/suite-common/wallet-types/src/transactionSimulation.ts
@@ -1,4 +1,8 @@
-import type { EthereumSignTransaction, EthereumSignTypedData } from '@trezor/connect';
+import type {
+    EthereumSignTransaction,
+    EthereumSignTypedData,
+    EthereumSignTypedDataTypes,
+} from '@trezor/connect';
 
 type TxSimulationActionBase = {
     sourceOrigin: string;
@@ -13,7 +17,7 @@ export type TxSimulationAction = TxSimulationActionBase &
           }
         | {
               method: 'ethereumSignTypedData';
-              payload: EthereumSignTypedData<any>;
+              payload: EthereumSignTypedData<EthereumSignTypedDataTypes>;
           }
     );
 

--- a/suite-common/wallet-utils/src/validationUtils.ts
+++ b/suite-common/wallet-utils/src/validationUtils.ts
@@ -1,5 +1,3 @@
-import { type UseFormSetValue } from 'react-hook-form';
-
 import { toChecksumAddress } from 'web3-utils';
 
 import { type AccountInfo } from '@trezor/blockchain-link-types';
@@ -45,14 +43,13 @@ export const isHexValid = (value: string, prefix?: string) => {
 export const checkIsAddressNotUsedNotChecksummed = (
     address: string,
     history: AccountInfo['history'],
-    inputName: string,
-    setValue: UseFormSetValue<any>,
+    setChecksummedAddress: (value: string) => void,
     setHasAddressChecksummed: (value: boolean) => void,
 ) => {
     const hasHistory = history.total !== 0;
 
     if (hasHistory) {
-        setValue(inputName, toChecksumAddress(address), { shouldValidate: true });
+        setChecksummedAddress(toChecksumAddress(address));
         setHasAddressChecksummed(true);
 
         return false;

--- a/suite-common/walletconnect/src/adapters/ethereum.ts
+++ b/suite-common/walletconnect/src/adapters/ethereum.ts
@@ -17,6 +17,7 @@ import { getAccountIdentity, getMevProtectedTxData, sanitizeHex } from '@suite-c
 import TrezorConnect, {
     type CallMethodResponse,
     type EthereumSignTypedData,
+    type EthereumSignTypedDataTypes,
 } from '@trezor/connect';
 import { isAscii, isHex, throwError } from '@trezor/utils';
 
@@ -106,7 +107,7 @@ const ethereumRequestThunk = createThunk<
 
             // EIP-712 hashes for T1B1 are computed by @trezor/connect internally
             // since Connect 10 — pass `data` directly for all device models.
-            const payload: EthereumSignTypedData<any> = {
+            const payload: EthereumSignTypedData<EthereumSignTypedDataTypes> = {
                 path: account.path,
                 data: parsedData,
                 metamask_v4_compat: true,


### PR DESCRIPTION
Split-out from the type-hardening staging branch (#27649). This batch only contains `any` removals that **reuse an existing named type** — no `any → unknown` widening — so each change tightens a real contract rather than just relaxing it.



<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set touches the wallet send form Address component, validation utilities, firmware reducer, device compromise reporting, WalletConnect Ethereum adapter, Icon component, and transaction simulation types. The highest risk areas are the send form (Address.tsx + validationUtils.ts) which directly affect all send-related E2E tests, and the WalletConnect Ethereum adapter which affects WalletConnect event tests. The Icon component, firmwareReducer, useReportDeviceCompromised, and validationUtils are very broadly imported (121 tests each), so only tests with specific behavioral overlap are recommended. The connect-explorer-theme MDX components and transactionSimulation types have no direct test coverage.

<details><summary><b>Changed files (8)</b></summary>

- `packages/components/src/components/Icon/Icon.tsx`
- `packages/connect-explorer-theme/src/mdx-components.tsx`
- `packages/suite/src/views/wallet/send/Outputs/Address.tsx`
- `suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts`
- `suite-common/firmware/src/firmwareReducer.ts`
- `suite-common/wallet-types/src/transactionSimulation.ts`
- `suite-common/wallet-utils/src/validationUtils.ts`
- `suite-common/walletconnect/src/adapters/ethereum.ts`

</details>

**Recommended tests (17)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — Directly exercises the send form Address component (Address.tsx) and validationUtils for Ethereum transactions. Changes to the send address input and validation logic could break address entry, display, and fee rendering in this test.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Tests multiple send form features including adding/removing outputs, locktime, OP_RETURN, and amount unit switching — all of which rely on the Address output component and validation utilities that were changed.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Tests the full Solana send flow including address input, amount validation, and device confirmation. The Address.tsx and validationUtils changes directly affect the send form's address field behavior.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — Imports CSV data into send form outputs populating address fields. Changes to Address.tsx directly affect how imported addresses are rendered and validated in each output row.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Tests sending DOGE with a large amount that exceeds MAX_SAFE_INTEGER. The Address.tsx component is used for recipient input and validationUtils handles amount validation — both changed files are exercised.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Tests LTC send form with MimbleWimble peg-out transaction handling. The send form Address component and validation logic are directly exercised when filling in recipient address.
- `suite/e2e/tests/wallet/send-base.test.ts` — Tests complete ETH send on Base network with custom fees and address display. The Address.tsx component renders the recipient address input and validationUtils validates the form.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/wallet/global-receive-send.test.ts` — Tests the global send flow which opens a send form with address input. Changes to Address.tsx affect the send form header and address display, though the test focuses more on navigation than form validation.
- `suite/e2e/tests/wallet/cardano.test.ts` — Opens the Cardano send form and verifies it displays Cardano-specific content. The Address.tsx change could affect rendering of the send form for Cardano accounts.
- `suite/e2e/tests/wallet/without-device.test.ts` — Tests the send form behavior when device is disconnected, including filling address and amount fields. Address.tsx changes could affect send form rendering in the disconnected state.
- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — Directly exercises WalletConnect proposal approval/rejection flows. The ethereum.ts adapter change in walletconnect could affect how Ethereum WalletConnect sessions are handled during pairing and proposal events.
- `suite/e2e/tests/firmware/custom-firmware.test.ts` — Tests custom firmware installation flow which depends on firmwareReducer state management. Changes to firmwareReducer.ts could affect firmware installation state transitions.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — Tests firmware readiness detection during onboarding which relies on firmwareReducer state. Changes to the reducer could affect how firmware status is tracked and displayed.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — Tests the device compromised modal which is directly related to useReportDeviceCompromised.ts. Changes to how device compromise is reported could affect the modal display behavior.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form validation including decimal limits, insufficient funds errors, and percentage buttons. The validationUtils changes could affect how amounts are validated in the sell form.
- `suite/e2e/tests/staking/staking-form.test.ts` — Tests staking form validation including minimum amounts, decimal limits, and insufficient funds — all validation scenarios that depend on validationUtils.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — Tests sending Bitcoin transactions with multiple outputs using the send form. The Address.tsx component is used for each output's address field.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/connect-explorer-theme/src/mdx-components.tsx`
- `suite-common/wallet-types/src/transactionSimulation.ts`

_Updated: 2026-06-16T14:53:01.584Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/types-reuse-existing&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/types-reuse-existing&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/types-reuse-existing&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-16T14:58:22.823Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-16T14:56:20.564Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/types-reuse-existing/web/](https://dev.suite.sldev.cz/suite-web/mroz22/types-reuse-existing/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->