### PR TITLE
feat(suite-desktop): add lightweight HTTP server status page

### DIFF
--- a/packages/suite-desktop-core/src/__fixtures__/http.ts
+++ b/packages/suite-desktop-core/src/__fixtures__/http.ts
@@ -1,6 +1,16 @@
 export const fixtures = [
     {
         method: 'GET',
+        path: '/status',
+        search: '',
+        result: {
+            response: {
+                status: 200,
+            },
+        },
+    },
+    {
+        method: 'GET',
         path: '/oauth',
         search: '?code=meow',
         result: {

--- a/packages/suite-desktop-core/src/libs/http-receiver.ts
+++ b/packages/suite-desktop-core/src/libs/http-receiver.ts
@@ -9,6 +9,16 @@ type TemplateOptions = {
     title?: string;
     script?: string;
 };
+
+/**
+ * Lightweight runtime status of the built-in HTTP server, rendered on `/status`.
+ */
+export type HttpReceiverStatus = {
+    /** Application version, e.g. `25.6.1`. */
+    appVersion?: string;
+    /** Whether the connect-popup WebSocket transport (`/connect-ws`) is enabled. */
+    connectPopupWsEnabled: boolean;
+};
 /**
  * Events that may be emitted or listened to by HttpReceiver
  */
@@ -63,7 +73,99 @@ const applyTemplate = (content = 'You may now close this window.', options?: Tem
     return template;
 };
 
-export const createHttpReceiver = (options?: { port?: number }) => {
+/**
+ * Standalone, dependency-free status page. Intentionally minimal: no logo, no
+ * scripts, no external assets – just plain HTML/CSS describing the server state.
+ */
+const renderStatusPage = (status?: HttpReceiverStatus) => {
+    const wsEnabled = status?.connectPopupWsEnabled ?? false;
+    const version = status?.appVersion;
+
+    const row = (label: string, on: boolean) => `
+        <div class="row">
+            <span class="label">${label}</span>
+            <span class="value ${on ? 'on' : 'off'}">${on ? 'Enabled' : 'Disabled'}</span>
+        </div>
+    `;
+
+    return `<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Trezor Suite – Status</title>
+        <style>
+            body {
+                margin: 0;
+                min-height: 100vh;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                font-family: system-ui, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+                color: #171717;
+                background: #f7f7f7;
+            }
+            main {
+                width: 320px;
+                padding: 24px;
+                background: #fff;
+                border: 1px solid #ebebeb;
+                border-radius: 12px;
+            }
+            h1 {
+                margin: 0 0 4px;
+                font-size: 16px;
+                font-weight: 600;
+            }
+            p {
+                margin: 0 0 20px;
+                font-size: 13px;
+                color: #757575;
+            }
+            .row {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                padding: 10px 0;
+                border-top: 1px solid #ebebeb;
+                font-size: 14px;
+            }
+            .value {
+                display: inline-flex;
+                align-items: center;
+                gap: 8px;
+                font-weight: 500;
+            }
+            .value::before {
+                content: "";
+                width: 8px;
+                height: 8px;
+                border-radius: 50%;
+                background: currentColor;
+            }
+            .value.on {
+                color: #21963b;
+            }
+            .value.off {
+                color: #b0b0b0;
+            }
+        </style>
+    </head>
+    <body>
+        <main>
+            <h1>Trezor Suite</h1>
+            <p>Local HTTP server is running${version ? ` · v${xssFilters.inHTML(version)}` : ''}.</p>
+            ${row('Connect popup WebSocket', wsEnabled)}
+        </main>
+    </body>
+</html>`;
+};
+
+export const createHttpReceiver = (options?: {
+    port?: number;
+    /** Provides the current status rendered on the `/status` page. */
+    getStatus?: () => HttpReceiverStatus;
+}) => {
     // Note that if we override the `address` to something else than 127.0.0.1 or localhost, it might break google oauth
     const httpReceiver = new HttpServer<Events>({
         logger: convertILoggerToLog(global.logger, { serviceName: 'http-receiver' }),
@@ -74,6 +176,16 @@ export const createHttpReceiver = (options?: { port?: number }) => {
         (request, response, next) => {
             response.setHeader('Content-Type', 'text/html; charset=UTF-8');
             next(request, response);
+        },
+    ]);
+
+    // Lightweight status page. Unlike the other routes it stays active so it can
+    // always be reached to inspect the server while it is running. The server is
+    // bound to 127.0.0.1 and sets no CORS headers, so a cross-origin page can't
+    // read this (trivial) response anyway.
+    httpReceiver.get('/status', [
+        (_request, response) => {
+            response.end(renderStatusPage(options?.getStatus?.()));
         },
     ]);
 

--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -34,9 +34,16 @@ export const initBackground: ModuleInitBackground = ({
         if (httpReceiver) {
             return httpReceiver.getInfo();
         }
+        const connectPopupEnabled = () => !store.getConnectSettings().disableWs;
+
         // External request handler.
         // Note that if we override the `port` to something else than 21335, it might break google oauth
-        const receiver = createHttpReceiver();
+        const receiver = createHttpReceiver({
+            getStatus: () => ({
+                appVersion: app.getVersion(),
+                connectPopupWsEnabled: connectPopupEnabled(),
+            }),
+        });
         httpReceiver = receiver;
 
         // wait for httpReceiver to start accepting connections then register event handlers
@@ -91,7 +98,6 @@ export const initBackground: ModuleInitBackground = ({
             }
         });
 
-        const connectPopupEnabled = () => !store.getConnectSettings().disableWs;
         ipcMain.handle('connect-popup/enabled', ipcEvent => {
             validateIpcMessage({ ipcEvent });
 


### PR DESCRIPTION
## Description

Adds a lightweight `/status` page to the built-in HTTP receiver in suite-desktop. The page is a standalone, dependency-free HTML/CSS card (no logo, scripts, or external assets) that shows the app version and whether the Connect Popup WebSocket transport is enabled. The route stays active while the server runs; no extra access guard is added since the server binds to `127.0.0.1` and sets no CORS headers, so cross-origin pages can't read the response.

The goal is so support can troubleshoot the HTTP receiver in cases the Connect Popup WS is seemingly not working.

## Notes for QA

Open `http://127.0.0.1:21335/status` in a browser while Suite desktop is running and verify the page renders, shows the correct version, and reflects the Connect Popup WebSocket status

## Screenshots

<img width="405" height="188" alt="Screenshot 2026-06-16 at 16 48 24" src="https://github.com/user-attachments/assets/a425e0f0-6934-416d-bd67-f5c5e34ee8a3" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are in the suite-desktop-core HTTP receiver infrastructure, which handles incoming HTTP requests in the Electron desktop app — primarily used for OAuth callback redirects (metadata provider authentication with Google/Dropbox) and trading/coinmarket provider return URLs. There is no static test coverage mapping for these files, so recommendations are inferred. The risk is moderate: regressions would primarily affect desktop-only OAuth flows and trading redirect handling. The fixture file change suggests test data updates, which lowers regression risk but warrants validation of the flows that consume this module.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite-desktop-core/src/__fixtures__/http.ts`
- `packages/suite-desktop-core/src/libs/http-receiver.ts`
- `packages/suite-desktop-core/src/modules/http-receiver.ts`

</details>

**Recommended tests (4)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — The http-receiver module in suite-desktop-core handles OAuth/trading redirect callbacks (e.g., coinmarket buy/sell flows returning from external providers). The buy-bitcoin test exercises the full buy trade flow including provider redirect and transaction detail status updates, which may use the HTTP receiver for handling return URLs.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Sell flows involve provider redirects that route back through the desktop app's HTTP receiver. Changes to the http-receiver module could affect how sell trade confirmations and redirect callbacks are processed in the desktop app.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Swap flows involve exchange provider redirects that may use the HTTP receiver module for handling return callbacks in the desktop app. This test exercises the full swap lifecycle including provider interaction.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/metadata/legacy/interval-fetching.test.ts` — The http-receiver module handles OAuth callbacks for metadata providers (Google, Dropbox). This test exercises legacy metadata labeling with cloud providers, which relies on OAuth flows that go through the HTTP receiver for authentication.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite-desktop-core/src/__fixtures__/http.ts`
- `packages/suite-desktop-core/src/libs/http-receiver.ts`
- `packages/suite-desktop-core/src/modules/http-receiver.ts`

_Updated: 2026-06-16T14:50:10.349Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/http-server-status-page/web/](https://dev.suite.sldev.cz/suite-web/http-server-status-page/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=http-server-status-page&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=http-server-status-page&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-30T13:53:28.978Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-30T13:51:51.560Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->