### PR TITLE
fix(e2e): Fixed Jest not exiting properly

### DIFF
--- a/packages/websocket-client/src/client.ts
+++ b/packages/websocket-client/src/client.ts
@@ -87,9 +87,13 @@ export class WebsocketClient<Events extends Record<string, any>> extends TypedEm
             }
         };
 
-        this.pingTimeout = this.isConnected()
-            ? setTimeout(doPing, this.options.pingTimeout || DEFAULT_PING_TIMEOUT)
-            : undefined;
+        if (this.isConnected()) {
+            const t = setTimeout(doPing, this.options.pingTimeout || DEFAULT_PING_TIMEOUT);
+            (t as any).unref?.();
+            this.pingTimeout = t;
+        } else {
+            this.pingTimeout = undefined;
+        }
     }
 
     protected onPing() {
@@ -207,6 +211,7 @@ export class WebsocketClient<Events extends Record<string, any>> extends TypedEm
             },
             this.options.connectionTimeout || this.options.timeout || DEFAULT_TIMEOUT,
         );
+        (connectionTimeout as any).unref?.();
 
         ws.once('error', error => {
             clearTimeout(connectionTimeout);

--- a/suite-native/app/e2e/jest.config.js
+++ b/suite-native/app/e2e/jest.config.js
@@ -39,7 +39,12 @@ const reporters =
 module.exports = {
     ...nativeJestConfig,
     setupFiles: ['<rootDir>/e2e/jest.setup.js', ...(nativeJestConfig.setupFiles ?? [])],
-    moduleNameMapper: restModuleNameMapper,
+    moduleNameMapper: {
+        ...restModuleNameMapper,
+        // Prevent @sentry/react-native from loading in the Jest worker — its AsyncExpiringMap
+        // creates a module-level setInterval that keeps Jest from exiting after tests complete.
+        '^@sentry/react-native$': '<rootDir>/e2e/support/mocks/sentry.js',
+    },
     rootDir: process.cwd(),
     testTimeout: 120000,
     globalSetup: 'detox/runners/jest/globalSetup',

--- a/suite-native/app/e2e/support/mocks/sentry.js
+++ b/suite-native/app/e2e/support/mocks/sentry.js
@@ -1,0 +1,14 @@
+'use strict';
+
+// The Jest worker process doesn't need a real Sentry SDK — the actual SDK runs
+// inside the React Native app on the device. This stub prevents @sentry/react-native
+// from creating its module-level setInterval (AsyncExpiringMap) which would keep
+// Jest from exiting after the test run.
+const noop = () => {};
+
+const sentryMock = new Proxy(
+    { __esModule: true },
+    { get: (target, prop) => (prop in target ? target[prop] : noop) },
+);
+
+module.exports = sentryMock;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The two changed files have minimal overlap with the E2E test suite. `packages/websocket-client/src/client.ts` is a low-level WebSocket client library that could theoretically be used by various features (WalletConnect, blockbook backends, Evolu relay, etc.), but none of the 97 candidate E2E tests have static coverage mapping to it, and the LLM analysis of test behaviors does not reveal any test that directly exercises or closely depends on the raw WebSocket client implementation. `suite-native/app/e2e/support/mocks/sentry.js` is a Sentry mock for the React Native (mobile) app's own E2E tests, which are not part of this candidate test suite at all. Given the lack of direct or inferrable coverage, no E2E tests are recommended. If the WebSocket client change is significant (e.g., connection handling, reconnection logic), manual or integration-level testing of features that rely on WebSocket connections (WalletConnect, custom backends, Suite Sync relay) would be advisable outside this E2E suite.

<details><summary><b>Changed files (2)</b></summary>

- `packages/websocket-client/src/client.ts`
- `suite-native/app/e2e/support/mocks/sentry.js`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/websocket-client/src/client.ts`
- `suite-native/app/e2e/support/mocks/sentry.js`

_Updated: 2026-06-16T17:20:59.898Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-jest-exit&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-jest-exit&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-e2e-jest-exit&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-16T17:24:28.329Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-16T17:23:08.586Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-e2e-jest-exit/web/](https://dev.suite.sldev.cz/suite-web/fix-e2e-jest-exit/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->