### PR TITLE
feat(connect): selectAccount method with in-Suite account picker

### DIFF
--- a/packages/connect-common/src/callableMethods.ts
+++ b/packages/connect-common/src/callableMethods.ts
@@ -95,6 +95,7 @@ const connectCallableMethodGroups = {
         'getPublicKey',
         'getAccountInfo',
         'discoverAccounts',
+        'selectAccount',
         'signMessage',
         'verifyMessage',
         'getCoinInfo',

--- a/packages/connect-common/src/types/api/account/index.ts
+++ b/packages/connect-common/src/types/api/account/index.ts
@@ -8,6 +8,7 @@ import type { getCoinInfo } from './getCoinInfo';
 import type { getPublicKey } from './getPublicKey';
 import type { signMessage } from './signMessage';
 import type { verifyMessage } from './verifyMessage';
+import type { selectAccount } from '../selectAccount';
 
 // Generic account and address operations (multi-coin)
 export const TrezorConnectAccount = Type.Object({
@@ -15,6 +16,7 @@ export const TrezorConnectAccount = Type.Object({
     getPublicKey: Type.Unsafe<typeof getPublicKey>(),
     getAccountInfo: Type.Unsafe<typeof getAccountInfo>(),
     discoverAccounts: Type.Unsafe<typeof discoverAccounts>(),
+    selectAccount: Type.Unsafe<typeof selectAccount>(),
     signMessage: Type.Unsafe<typeof signMessage>(),
     verifyMessage: Type.Unsafe<typeof verifyMessage>(),
     getCoinInfo: Type.Unsafe<typeof getCoinInfo>(),

--- a/packages/connect-common/src/types/api/selectAccount.ts
+++ b/packages/connect-common/src/types/api/selectAccount.ts
@@ -1,0 +1,96 @@
+import type { Static } from '@trezor/schema-utils';
+import { Type } from '@trezor/schema-utils';
+
+import type { Params, Response } from '../params';
+
+// Account derivation variant. Mirrors the `type` values in `ACCOUNT_TYPES`
+// (see discoverAccounts.ts). For account-based networks (EVM) the relevant
+// variants are 'normal' | 'ledger' | 'legacy'; bitcoin-likes add 'taproot' | 'segwit'.
+export type AccountType = Static<typeof AccountType>;
+export const AccountType = Type.Union([
+    Type.Literal('normal'),
+    Type.Literal('taproot'),
+    Type.Literal('segwit'),
+    Type.Literal('legacy'),
+    Type.Literal('ledger'),
+]);
+
+// A derivation path template not covered by the network's built-in account types (see
+// networksConfig `AccountType`), identified in the UI by `label` instead of a translated name.
+// `bip43Path` uses `i` as a placeholder for the account index (e.g. `m/44'/60'/i'/0/0`) — the same
+// template format as `NetworkAccount.bip43Path` in `@suite-common/wallet-config`.
+export type CustomAccountType = Static<typeof CustomAccountType>;
+export const CustomAccountType = Type.Object({
+    bip43Path: Type.String(),
+    label: Type.String(),
+});
+
+// Bounds for a 'multi'-style selection. minCount defaults to 1; maxCount defaults to unbounded.
+export type MultiSelectBounds = Static<typeof MultiSelectBounds>;
+export const MultiSelectBounds = Type.Object({
+    minCount: Type.Optional(Type.Number({ minimum: 1 })),
+    maxCount: Type.Optional(Type.Number({ minimum: 1 })),
+});
+
+export type SelectionType = Static<typeof SelectionType>;
+export const SelectionType = Type.Union([
+    // One account (e.g. an exchange). Default.
+    Type.Literal('single'),
+    // Several accounts, unbounded.
+    Type.Literal('multi'),
+    // Several accounts, bounded by minCount/maxCount.
+    MultiSelectBounds,
+]);
+
+export type SelectAccount = Static<typeof SelectAccount>;
+export const SelectAccount = Type.Object({
+    // Network to select an account for, e.g. 'eth' | 'btc' | 'ada'.
+    coin: Type.String(),
+    selectionType: Type.Optional(SelectionType),
+    // Allowed account types, each shown as its own tab in the picker. Entries are either one of
+    // the network's built-in types, or a custom derivation path with its own label. If omitted,
+    // all of the network's publicly available types are allowed.
+    accountType: Type.Optional(Type.Array(Type.Union([AccountType, CustomAccountType]))),
+    // UTXO-only; ignored for account-based networks (EVM, Solana, …), which always export an
+    // individual address. Controls which of two separate flows a UTXO account is shared through:
+    // - 'fullAccount' (default when omitted): the whole account is shared as an xpub, like a
+    //   watch-only wallet import. No individual address is picked or verified as part of this
+    //   call. Requires `read_xpub`.
+    // - 'firstFresh' | 'manual': only the individual address(es) the user picks are exported —
+    //   'firstFresh' auto-selects the next unused receive address, 'manual' lets the user pick a
+    //   used one. The xpub is never exported here; requires the narrower `read_address` instead.
+    addressSelection: Type.Optional(
+        Type.Union([
+            Type.Literal('fullAccount'),
+            Type.Literal('firstFresh'),
+            Type.Literal('manual'),
+        ]),
+    ),
+    // Require the selected address(es) to be confirmed on the device. Default true.
+    requireOnDeviceVerification: Type.Optional(Type.Boolean()),
+});
+
+export type SelectedAccount = Static<typeof SelectedAccount>;
+export const SelectedAccount = Type.Object({
+    // Network symbol, e.g. 'eth'.
+    symbol: Type.String(),
+    // Serialized derivation path of the selected account (and, for the address-selection flow, the
+    // selected address within it).
+    path: Type.String(),
+    // The selected address (checksummed for EVM). Set for account-based networks, and for UTXO
+    // accounts selected via `addressSelection: 'firstFresh' | 'manual'`. Mutually exclusive with
+    // `xpub`.
+    address: Type.Optional(Type.String()),
+    // The account's extended public key. Set only for UTXO accounts shared via
+    // `addressSelection: 'fullAccount'` (or omitted) — mutually exclusive with `address`.
+    xpub: Type.Optional(Type.String()),
+    accountType: Type.Optional(AccountType),
+    // SLIP-0019 address MAC from the on-device verification, when available. Only applies to the
+    // `address` case — lets the integrator later re-prove the address belongs to the device
+    // without an xpub.
+    mac: Type.Optional(Type.String()),
+});
+
+// Always returns an array, even for a 'single' selection — mirrors eth_requestAccounts, and keeps
+// the response shape independent of what selectionType numerically resolves to.
+export declare function selectAccount(params: Params<SelectAccount>): Response<SelectedAccount[]>;

--- a/packages/connect-explorer/src/data/methods/common/selectAccount.ts
+++ b/packages/connect-explorer/src/data/methods/common/selectAccount.ts
@@ -1,0 +1,56 @@
+import { allCoinsSelect } from '../../../constants/coins';
+
+const name = 'selectAccount';
+
+const coin = {
+    name: 'coin',
+    type: 'select',
+    value: 'eth',
+    data: allCoinsSelect,
+};
+
+const selectionTypeOptions = [
+    { value: 'single', label: 'single' },
+    { value: 'multi', label: 'multi' },
+];
+
+const addressSelection = {
+    name: 'addressSelection',
+    type: 'select',
+    optional: true,
+    value: 'fullAccount',
+    data: [
+        { value: 'fullAccount', label: 'fullAccount' },
+        { value: 'firstFresh', label: 'firstFresh' },
+        { value: 'manual', label: 'manual' },
+    ],
+};
+
+const requireOnDeviceVerification = {
+    name: 'requireOnDeviceVerification',
+    type: 'checkbox',
+    value: true,
+};
+
+export default [
+    {
+        name,
+        submitButton: 'Select account',
+        fields: [
+            coin,
+            { name: 'selectionType', type: 'select', value: 'single', data: selectionTypeOptions },
+            addressSelection,
+            requireOnDeviceVerification,
+        ],
+    },
+    {
+        name,
+        submitButton: 'Select multiple accounts',
+        fields: [
+            coin,
+            { name: 'selectionType', type: 'select', value: 'multi', data: selectionTypeOptions },
+            addressSelection,
+            requireOnDeviceVerification,
+        ],
+    },
+];

--- a/packages/connect-explorer/src/pages/methods/common/selectAccount.mdx
+++ b/packages/connect-explorer/src/pages/methods/common/selectAccount.mdx
@@ -1,0 +1,170 @@
+import { SelectAccount } from '@trezor/connect-common/src/types/api/selectAccount';
+
+import { ApiPlayground } from '../../../components/ApiPlayground';
+import { CommonParamsLink } from '../../../components/CommonParamsLink';
+import { ParamsTable } from '../../../components/ParamsTable';
+import selectAccount from '../../../data/methods/common/selectAccount.ts';
+
+<ApiPlayground
+    options={[
+        { title: 'Select account', legacyConfig: selectAccount[0] },
+        { title: 'Select multiple accounts', legacyConfig: selectAccount[1] },
+        { title: 'Advanced schema', method: 'selectAccount', schema: SelectAccount },
+    ]}
+/>
+
+export const paramDescriptions = {
+    coin: 'network to select an account for, e.g. `eth`',
+    selectionType:
+        '`single` (default) selects one account, `multi` selects any number, or an object bounds how many',
+    accountType:
+        "allowed account types; either built-in names (e.g. `segwit`) or custom `{ bip43Path, label }` entries. If omitted, all of the network's account types are allowed",
+    bip43Path:
+        "derivation path template for a custom account type, with `i` standing in for the account index, e.g. `m/44'/60'/i'/0/0`",
+    label: "label shown on the custom account type's tab in the picker",
+    addressSelection:
+        'UTXO networks only — `fullAccount` (default) shares the whole account as an xpub; `firstFresh` or `manual` switch to exporting an individual address instead. Ignored for account-based networks',
+    requireOnDeviceVerification:
+        'require the selected address(es) to be confirmed on the device. Default `true`',
+    minCount:
+        'minimum number of accounts to select, when `selectionType` is an object. Default `1`',
+    maxCount: 'maximum number of accounts to select, when `selectionType` is an object',
+};
+
+## Select account
+
+Opens Trezor Suite's account picker so the user chooses which account(s) to share with the
+connecting app. The picker is rendered by Suite — addresses can be verified on the Trezor before
+they are shared.
+
+```javascript
+const result = await TrezorConnect.selectAccount(params);
+```
+
+### Selection mode
+
+`selectionType` controls how many accounts the user can pick, before any coin-specific behavior
+(UTXO flows, custom account types) comes into play:
+
+- **`single`** (default) — the user picks exactly one account.
+- **`multi`** — the user picks any number of accounts.
+- **An object (`{ minCount, maxCount }`)** — the user picks a bounded number of accounts;
+  `minCount` defaults to `1`, `maxCount` defaults to unbounded.
+
+The result is always an array, even for a `single` selection (mirrors `eth_requestAccounts`), so
+the response shape doesn't depend on what `selectionType` resolves to.
+
+Let the user pick a single Ethereum account:
+
+```javascript
+TrezorConnect.selectAccount({
+    coin: 'eth',
+});
+```
+
+Let the user pick several accounts:
+
+```javascript
+TrezorConnect.selectAccount({
+    coin: 'eth',
+    selectionType: 'multi',
+});
+```
+
+Let the user pick between 2 and 5 accounts:
+
+```javascript
+TrezorConnect.selectAccount({
+    coin: 'eth',
+    selectionType: { minCount: 2, maxCount: 5 },
+});
+```
+
+### UTXO coins
+
+For account-based networks (e.g. Ethereum and its L2s), `selectAccount` always exports an
+individual address per selected account. UTXO networks (Bitcoin, Litecoin, …), where one account
+holds many addresses, support two separate flows, chosen with `addressSelection`:
+
+- **Whole-account flow (`addressSelection: 'fullAccount'`, the default when omitted)** — the
+  account is shared as an extended public key (xpub), the same way a watch-only wallet import
+  works. The integrator derives every address of the account on its own; no individual address is
+  picked or verified as part of this call. This requests the broader `read_xpub` permission.
+- **Address-selection flow (`addressSelection: 'firstFresh' | 'manual'`)** — only the individual
+  address(es) the user picks are exported, exactly like the account-based flow above.
+  `'firstFresh'` auto-selects the next unused receive address for each picked account. `'manual'`
+  adds an extra step: the user first picks which account to browse (same account-index list as
+  `'firstFresh'`, but nothing is exported by picking one), then picks one of that account's
+  previously-used addresses from a second list. The xpub is never exported, and only the narrower
+  `read_address` permission is requested.
+
+These two flows are mutually exclusive per call: pass `addressSelection: 'firstFresh' | 'manual'`
+to get individual address(es), or `'fullAccount'`/omit it to get the account xpub — not both.
+
+### Custom account types
+
+Each entry in `accountType` becomes its own tab in the picker. An entry is either the name of one of
+the network's built-in types (`normal`, `segwit`, `taproot`, `legacy`, `ledger` — availability
+depends on the coin), or a custom derivation path not covered by any of them, given as
+`{ bip43Path, label }`. A custom entry's tab is labeled with `label` instead of a translated
+account-type name.
+
+`bip43Path` is a [BIP-43](https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki)
+derivation path template, written with `i` as a placeholder for the account index, e.g.:
+
+```
+m/44'/60'/i'/0/0
+m/84'/0'/i'
+```
+
+When deriving account `N`, `i` is replaced with `N` — account `0` of the first template above
+resolves to `m/44'/60'/0'/0/0`, account `1` to `m/44'/60'/1'/0/0`, and so on. An apostrophe (`'`)
+marks a hardened level; keep the same hardening as the levels around `i` unless you have a reason
+to deviate from the coin's usual derivation scheme.
+
+```javascript
+TrezorConnect.selectAccount({
+    coin: 'eth',
+    accountType: [{ bip43Path: "m/44'/60'/i'/0/1", label: 'Address #1' }],
+});
+```
+
+### Params
+
+<CommonParamsLink />
+
+#### SelectAccount
+
+<ParamsTable schema={SelectAccount} descriptions={paramDescriptions} />
+
+### Result
+
+Each entry carries either `address` (account-based networks, and UTXO with `addressSelection:
+'firstFresh' | 'manual'`) or `xpub` (UTXO, `addressSelection: 'fullAccount'`/omitted) — never both:
+
+```javascript
+{
+    success: true,
+    payload: [
+        {
+            symbol: string,
+            path: string,         // serialized path, e.g. "m/44'/60'/0'/0/0"
+            address?: string,     // address-selection flow
+            xpub?: string,        // UTXO whole-account flow
+            accountType?: string,
+            mac?: string,         // only set alongside `address`
+        },
+    ]
+}
+```
+
+Error
+
+```javascript
+{
+    success: false,
+    error: {
+        message: string // error message
+    }
+}
+```

--- a/packages/connect/src/api/index.ts
+++ b/packages/connect/src/api/index.ts
@@ -49,6 +49,7 @@ export { default as recoveryDevice } from './recoveryDevice';
 export { default as requestLogin } from './requestLogin';
 export { default as resetDevice } from './resetDevice';
 export { default as loadDevice } from './loadDevice';
+export { default as selectAccount } from './selectAccount';
 export { default as setBrightness } from './setBrightness';
 export { default as setBusy } from './setBusy';
 export { default as signMessage } from './signMessage';

--- a/packages/connect/src/api/selectAccount.ts
+++ b/packages/connect/src/api/selectAccount.ts
@@ -1,0 +1,63 @@
+import { type CoinInfo, type PermissionRequest } from '@trezor/connect-common';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+import { SelectAccount as SelectAccountSchema } from '@trezor/connect-common/src/types/api/selectAccount';
+import { Assert } from '@trezor/schema-utils';
+
+import type { MethodMessage, MethodReturnType } from '../core/AbstractMethod';
+import { AbstractMethod } from '../core/AbstractMethod';
+import { getCoinInfo } from '../data/coinInfo';
+import { isUtxoBased } from '../utils/accountUtils';
+import { getLabel } from '../utils/pathUtils';
+
+type Params = {
+    coinInfo: CoinInfo;
+    addressSelection?: 'fullAccount' | 'firstFresh' | 'manual';
+};
+
+export default class SelectAccount extends AbstractMethod<'selectAccount', Params> {
+    constructor(message: MethodMessage<'selectAccount'>) {
+        const { payload } = message;
+
+        Assert(SelectAccountSchema, payload);
+
+        const coinInfo = getCoinInfo(payload.coin);
+        if (!coinInfo) {
+            throw ERRORS.TypedError('Method_UnknownCoin');
+        }
+
+        super(message, { coinInfo, addressSelection: payload.addressSelection });
+
+        // The picker UI, account derivation and on-device verification are handled entirely by the
+        // host (Suite) via a methodHook. This method neither uses the device nor blocks: it returns
+        // immediately so its call is freed, letting the host make its own nested device calls
+        // (derive/verify) while the picker is open. The host overrides the response with the user's
+        // selection once they confirm — the value returned here is only a placeholder.
+        this.useDevice = false;
+        this.useDeviceState = false;
+        this.useUi = true;
+        this.requiredFirmwareCoins = [coinInfo];
+    }
+
+    get requiredPermissions(): PermissionRequest[] {
+        // UTXO coins have two separate flows: sharing the whole account as an xpub (omitted or
+        // `addressSelection: 'fullAccount'`) needs the broader `read_xpub`, while picking
+        // individual address(es) (`addressSelection: 'firstFresh' | 'manual'`) only needs
+        // `read_address`, same as EVM/other account-based networks, which always export an
+        // individual address.
+        const isFullAccount =
+            this.params.addressSelection === undefined ||
+            this.params.addressSelection === 'fullAccount';
+        const permission =
+            isUtxoBased(this.params.coinInfo) && isFullAccount ? 'read_xpub' : 'read_address';
+
+        return this.coinPerms(permission, this.requiredFirmwareCoins);
+    }
+
+    get info() {
+        return getLabel('Select #NETWORK account', this.params.coinInfo);
+    }
+
+    run(): Promise<MethodReturnType<'selectAccount'>> {
+        return Promise.resolve([]);
+    }
+}

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
@@ -15,6 +15,7 @@ import {
 import { useSelector } from 'src/hooks/suite';
 
 import { ConnectAddressConfirmation } from './UserContextModal/ConnectAddressConfirmation';
+import { ConnectSelectAccount } from './UserContextModal/ConnectSelectAccount/ConnectSelectAccount';
 
 interface ConfirmAddressModalProps extends Pick<
     ConfirmValueModalProps,
@@ -26,16 +27,15 @@ interface ConfirmAddressModalProps extends Pick<
 export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAddressModalProps) => {
     const device = useSelector(selectSelectedDevice);
     const account = useSelector(selectAccountIncludingChosenInTrading);
-    const isConnectPopup = useSelector(
-        state => selectConnectPopupCall(state)?.state === 'address-confirmation',
-    );
+    const popupCallState = useSelector(state => selectConnectPopupCall(state)?.state);
 
     const validateAddress = useCallback(
         () => showAddressThunk({ path: addressPath, address: value }),
         [addressPath, value],
     );
 
-    if (isConnectPopup) return <ConnectAddressConfirmation />;
+    if (popupCallState === 'address-confirmation') return <ConnectAddressConfirmation />;
+    if (popupCallState === 'select-account') return <ConnectSelectAccount />;
     if (!device) return null;
 
     const getHeading = () => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectSelectAccount/ConnectSelectAccount.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectSelectAccount/ConnectSelectAccount.tsx
@@ -1,0 +1,337 @@
+import { useEffect } from 'react';
+
+import { useDevice } from '@suite/device';
+import { Translation, type TranslationKey } from '@suite/intl';
+import {
+    SELECT_ACCOUNT_PAGE_SIZE,
+    type SelectAccountCandidate,
+    type SelectAccountTypeTab,
+    connectPopupActions,
+    connectPopupBackToManualAccountsThunk,
+    connectPopupLoadSelectAccountPageThunk,
+    connectPopupResolveSelectAccountThunk,
+    connectPopupSelectManualAccountThunk,
+    connectPopupVerifySelectAccountThunk,
+    selectConnectPopupCall,
+} from '@suite-common/connect-popup';
+import { type AccountType } from '@suite-common/wallet-config';
+import { Column, H3, Icon, Modal, Paragraph, Row, SubTabs, Text } from '@trezor/components';
+import { ConfirmOnDevicePill } from '@trezor/product-components';
+import { spacings } from '@trezor/theme';
+
+import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
+import { ConnectModalBackdrop } from 'src/components/suite/ConnectModalBackdrop';
+import { Pagination } from 'src/components/wallet/Pagination';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+import { SelectAccountRow } from './SelectAccountRow';
+
+// Labels for the network's built-in account types; custom tabs carry their own `customLabel`.
+const ACCOUNT_TYPE_LABELS: Partial<Record<AccountType, TranslationKey>> = {
+    normal: 'TR_ACCOUNT_TYPE_DEFAULT',
+    taproot: 'TR_ACCOUNT_TYPE_TAPROOT',
+    segwit: 'TR_ACCOUNT_TYPE_SEGWIT',
+    legacy: 'TR_ACCOUNT_TYPE_LEGACY',
+    ledger: 'TR_ACCOUNT_TYPE_LEDGER',
+};
+
+export const ConnectSelectAccount = () => {
+    const dispatch = useDispatch();
+    const { device } = useDevice();
+    const popupCall = useSelector(selectConnectPopupCall);
+
+    // Load the first page once the picker opens (the Connect method only sets up the state).
+    const isSelectAccount = popupCall?.state === 'select-account';
+    const isEmpty = isSelectAccount && popupCall.candidates.length === 0;
+    useEffect(() => {
+        if (isEmpty) {
+            dispatch(connectPopupLoadSelectAccountPageThunk({ page: 0 }));
+        }
+    }, [isEmpty, dispatch]);
+
+    if (popupCall?.state !== 'select-account') return null;
+
+    const {
+        options,
+        candidates,
+        selectedAccountTypeKey,
+        page,
+        exported,
+        totalCandidates,
+        manualPhase,
+        manualAccountIndex,
+    } = popupCall;
+    const { selectionType, minCount, maxCount, accountTypeTabs, addressSelection } = options;
+    // 'manual' is a two-phase flow: pick an account (drill-in, no export), then pick one of its
+    // used addresses (the actual export). Every other mode has a single, flat account-index list.
+    const isManualAccountPickPhase = addressSelection === 'manual' && manualPhase !== 'address';
+    const isManualAddressPhase = addressSelection === 'manual' && manualPhase === 'address';
+    const isMulti = selectionType === 'multi';
+    const activeTab =
+        accountTypeTabs.find(tab => tab.key === selectedAccountTypeKey) ?? accountTypeTabs[0]!;
+
+    const startIndex = page * SELECT_ACCOUNT_PAGE_SIZE;
+    const pageCandidates = candidates
+        .filter(
+            c =>
+                c.accountTypeKey === activeTab.key &&
+                c.accountIndex >= startIndex &&
+                c.accountIndex < startIndex + SELECT_ACCOUNT_PAGE_SIZE,
+        )
+        .sort((a, b) => a.accountIndex - b.accountIndex);
+
+    const selectedCandidates = candidates.filter(c => c.selected);
+    const selectedCount = selectedCandidates.length;
+    const isVerifying = candidates.some(c => c.verifying);
+    // Deriving accounts issues sequential getAccountInfo calls on the device. Any competing device
+    // call fired mid-discovery (verify, retry, or a fresh page/tab load) would contend for the same
+    // device and get cancelled — so those actions are blocked until the visible page has settled.
+    // Selection stays live: it's pure Redux state and touches no device.
+    const isDiscovering = pageCandidates.some(c => c.loading);
+
+    // Verification is always available but optional (mirrors ConnectAddressConfirmation) — connecting
+    // only requires a valid selection.
+    const canConfirm =
+        selectedCount >= minCount &&
+        (maxCount === undefined || selectedCount <= maxCount) &&
+        !isVerifying;
+
+    const toggle = (target: SelectAccountCandidate) => {
+        const isTarget = (c: SelectAccountCandidate) =>
+            c.accountIndex === target.accountIndex && c.accountTypeKey === target.accountTypeKey;
+
+        const next = candidates.map(c => {
+            if (selectionType === 'single') {
+                return { ...c, selected: isTarget(c) ? !c.selected : false };
+            }
+            if (!isTarget(c)) return c;
+            // respect maxCount when selecting a new one
+            if (!c.selected && maxCount !== undefined && selectedCount >= maxCount) return c;
+
+            return { ...c, selected: !c.selected };
+        });
+
+        dispatch(connectPopupActions.updateSelectAccount({ candidates: next }));
+    };
+
+    const verify = (candidate: SelectAccountCandidate) =>
+        dispatch(
+            connectPopupVerifySelectAccountThunk({
+                accountIndex: candidate.accountIndex,
+                accountTypeKey: candidate.accountTypeKey,
+            }),
+        );
+
+    // Manual account-pick phase: clicking a row drills in, it doesn't toggle a selection.
+    const selectManualAccount = (candidate: SelectAccountCandidate) =>
+        dispatch(connectPopupSelectManualAccountThunk({ accountIndex: candidate.accountIndex }));
+
+    const backToManualAccounts = () => dispatch(connectPopupBackToManualAccountsThunk());
+
+    const retry = () => dispatch(connectPopupLoadSelectAccountPageThunk({ page }));
+
+    const goToPage = (nextPage: number) => {
+        if (nextPage < 0 || isVerifying || isDiscovering) return;
+        dispatch(connectPopupLoadSelectAccountPageThunk({ page: nextPage }));
+    };
+
+    const selectAccountType = (tab: SelectAccountTypeTab) => {
+        if (tab.key === activeTab.key || isVerifying || isDiscovering) return;
+        dispatch(
+            connectPopupActions.updateSelectAccount({
+                selectedAccountTypeKey: tab.key,
+                page: 0,
+                // switching account type invalidates any account chosen in the manual address phase
+                manualPhase: addressSelection === 'manual' ? 'account' : undefined,
+                manualAccountIndex: undefined,
+            }),
+        );
+        dispatch(connectPopupLoadSelectAccountPageThunk({ page: 0 }));
+    };
+
+    // Accounts can always be derived further, so there's no last page — except in the UTXO
+    // `addressSelection: 'manual'` flow, where `totalCandidates` bounds the used-address list.
+    const paginationTotalItems = totalCandidates ?? (page + 2) * SELECT_ACCOUNT_PAGE_SIZE;
+
+    const onConnect = () => dispatch(connectPopupResolveSelectAccountThunk({ confirmed: true }));
+    // Cancel (select phase) or close (exported phase) — the thunk routes based on `exported`.
+    const onFinish = () => dispatch(connectPopupResolveSelectAccountThunk({ confirmed: false }));
+
+    const rows = exported ? selectedCandidates : pageCandidates;
+
+    let descriptionKey: TranslationKey = 'TR_CONNECT_SELECT_ACCOUNT_DESCRIPTION';
+    if (exported) {
+        descriptionKey = 'TR_CONNECT_SELECT_ACCOUNT_EXPORTED_DESCRIPTION';
+    } else if (isManualAccountPickPhase) {
+        descriptionKey = 'TR_CONNECT_SELECT_ACCOUNT_PICK_ACCOUNT_DESCRIPTION';
+    }
+
+    let rowInteractionMode: 'toggle' | 'drillIn' | 'readOnly' = 'toggle';
+    if (exported) {
+        rowInteractionMode = 'readOnly';
+    } else if (isManualAccountPickPhase) {
+        rowInteractionMode = 'drillIn';
+    }
+
+    return (
+        <ConnectModalBackdrop onClick={onFinish} canSwitchDevice={false}>
+            {isVerifying && (
+                <ConfirmOnDevicePill
+                    title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
+                    deviceModelInternal={device?.features?.internal_model}
+                    deviceUnitColor={device?.features?.unit_color}
+                />
+            )}
+            <Modal.ModalBase
+                intent="brand"
+                onBackClick={
+                    isManualAddressPhase && !exported && !isVerifying
+                        ? backToManualAccounts
+                        : undefined
+                }
+                backButtonTooltip={<Translation id="TR_BACK" />}
+                bottomContent={
+                    exported ? (
+                        <Modal.Button
+                            onClick={onFinish}
+                            size="medium"
+                            isDisabled={isVerifying}
+                            data-testid="@connect-select-account/close-button"
+                        >
+                            <Translation id="TR_CLOSE" />
+                        </Modal.Button>
+                    ) : (
+                        <>
+                            {!isManualAccountPickPhase && (
+                                <Modal.Button
+                                    onClick={onConnect}
+                                    size="medium"
+                                    isDisabled={!canConfirm}
+                                    data-testid="@connect-select-account/confirm-button"
+                                >
+                                    <Translation id="TR_CONNECT_SELECT_ACCOUNT_CONFIRM" />
+                                </Modal.Button>
+                            )}
+                            <Modal.Button
+                                intent="neutral"
+                                priority="secondary"
+                                onClick={onFinish}
+                                size="medium"
+                                isDisabled={isVerifying}
+                                data-testid="@connect-select-account/cancel-button"
+                            >
+                                <Translation id="TR_CANCEL" />
+                            </Modal.Button>
+                        </>
+                    )
+                }
+            >
+                <Column gap={spacings.md}>
+                    <Column gap={spacings.xs}>
+                        {exported ? (
+                            <Row alignItems="center" gap={spacings.sm}>
+                                <Icon name="checkCircle" size={32} intent="brand" />
+                                <H3 intent="brand">
+                                    <Translation id="TR_CONNECT_SELECT_ACCOUNT_EXPORTED" />
+                                </H3>
+                            </Row>
+                        ) : (
+                            <H3>
+                                <Translation id="TR_CONNECT_SELECT_ACCOUNT" />
+                            </H3>
+                        )}
+                        <ConnectCallSource />
+                        <Paragraph>
+                            <Translation id={descriptionKey} />
+                        </Paragraph>
+                        {isManualAddressPhase && (
+                            <Text typographyStyle="body-xs" color="contentSecondary">
+                                <Translation
+                                    id="TR_CONNECT_SELECT_ACCOUNT_LABEL"
+                                    values={{ index: (manualAccountIndex ?? 0) + 1 }}
+                                />
+                            </Text>
+                        )}
+                    </Column>
+
+                    <Column gap={spacings.sm}>
+                        {accountTypeTabs.length > 1 && !exported && !isManualAddressPhase && (
+                            <SubTabs activeItemId={activeTab.key}>
+                                {accountTypeTabs.map(tab => (
+                                    <SubTabs.Item
+                                        key={tab.key}
+                                        id={tab.key}
+                                        onClick={() => selectAccountType(tab)}
+                                        data-testid={`@connect-select-account/type-tab/${tab.key}`}
+                                    >
+                                        {tab.accountType && ACCOUNT_TYPE_LABELS[tab.accountType] ? (
+                                            <Translation
+                                                id={ACCOUNT_TYPE_LABELS[tab.accountType]!}
+                                            />
+                                        ) : (
+                                            tab.customLabel
+                                        )}
+                                    </SubTabs.Item>
+                                ))}
+                            </SubTabs>
+                        )}
+
+                        {isMulti && !exported && !isManualAccountPickPhase && (
+                            <Text typographyStyle="body-xs">
+                                <Translation
+                                    id="TR_CONNECT_SELECT_ACCOUNT_SELECTED"
+                                    values={{
+                                        count: maxCount
+                                            ? `${selectedCount}/${maxCount}`
+                                            : selectedCount,
+                                    }}
+                                />
+                            </Text>
+                        )}
+
+                        <Column gap={spacings.xs}>
+                            {rows.map(candidate => (
+                                <SelectAccountRow
+                                    key={`${candidate.accountTypeKey}-${candidate.accountIndex}`}
+                                    candidate={candidate}
+                                    label={
+                                        <Translation
+                                            id={
+                                                isManualAddressPhase
+                                                    ? 'TR_CONNECT_SELECT_ACCOUNT_ADDRESS_LABEL'
+                                                    : 'TR_CONNECT_SELECT_ACCOUNT_LABEL'
+                                            }
+                                            values={{ index: candidate.accountIndex + 1 }}
+                                        />
+                                    }
+                                    interactionMode={rowInteractionMode}
+                                    disabled={isVerifying}
+                                    discovering={isDiscovering}
+                                    deviceModelInternal={device?.features?.internal_model}
+                                    onToggle={() =>
+                                        isManualAccountPickPhase
+                                            ? selectManualAccount(candidate)
+                                            : toggle(candidate)
+                                    }
+                                    onVerify={() => verify(candidate)}
+                                    onRetry={retry}
+                                />
+                            ))}
+                        </Column>
+
+                        {!exported && (
+                            <Pagination
+                                currentPage={page + 1}
+                                perPage={SELECT_ACCOUNT_PAGE_SIZE}
+                                totalItems={paginationTotalItems}
+                                explicitNavigation
+                                noUpperBound={totalCandidates === undefined}
+                                onPageSelected={p => goToPage(p - 1)}
+                            />
+                        )}
+                    </Column>
+                </Column>
+            </Modal.ModalBase>
+        </ConnectModalBackdrop>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectSelectAccount/SelectAccountRow.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectSelectAccount/SelectAccountRow.tsx
@@ -1,0 +1,220 @@
+import { type MouseEvent, type ReactNode } from 'react';
+
+import { Translation } from '@suite/intl';
+import { type SelectAccountCandidate } from '@suite-common/connect-popup';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config/src/utils';
+import {
+    Badge,
+    Button,
+    Card,
+    Checkbox,
+    Column,
+    Icon,
+    Row,
+    Skeleton,
+    Text,
+} from '@trezor/components';
+import { type DeviceModelInternal } from '@trezor/device-utils';
+import {
+    NetworkIcon,
+    isNetworkSymbolWithIcon,
+    mapTrezorModelToIcon,
+} from '@trezor/product-components';
+import { borders, spacings } from '@trezor/theme';
+
+interface SelectAccountRowProps {
+    candidate: SelectAccountCandidate;
+    // "Account #N" (account-index list) or "Address #N" (UTXO addressSelection: 'manual')
+    label: ReactNode;
+    // 'toggle': checkbox-driven select/export (needs a value to be interactive).
+    // 'drillIn': the whole row navigates onward (e.g. pick account -> view its addresses); no
+    //            value needed since nothing is exported at this step.
+    // 'readOnly': exported/read-only display, not clickable.
+    interactionMode: 'toggle' | 'drillIn' | 'readOnly';
+    disabled: boolean;
+    // Set while the picker is still deriving accounts on the device. Verifying or retrying now would
+    // fire a second, competing device call, so both buttons are disabled until discovery settles.
+    discovering: boolean;
+    deviceModelInternal?: DeviceModelInternal;
+    onToggle: () => void;
+    onVerify: () => void;
+    onRetry: () => void;
+}
+
+const truncateAddress = (address: string) =>
+    address.length > 24 ? `${address.slice(0, 12)}…${address.slice(-8)}` : address;
+
+const stop = (e: MouseEvent) => e.stopPropagation();
+
+export const SelectAccountRow = ({
+    candidate,
+    label,
+    interactionMode,
+    disabled,
+    discovering,
+    deviceModelInternal,
+    onToggle,
+    onVerify,
+    onRetry,
+}: SelectAccountRowProps) => {
+    const {
+        accountIndex,
+        address,
+        xpub,
+        balance,
+        symbol,
+        loading,
+        loadFailed,
+        verifying,
+        validated,
+        selected,
+    } = candidate;
+    // `address` (individual address) and `xpub` (whole-account, UTXO only) are mutually exclusive.
+    const displayValue = address ?? xpub;
+    const showCheckbox = interactionMode === 'toggle';
+    // 'drillIn' rows don't export a value, so they're interactive as soon as they've loaded.
+    const interactive =
+        interactionMode !== 'readOnly' &&
+        !disabled &&
+        !loading &&
+        !loadFailed &&
+        (interactionMode === 'toggle' ? !!displayValue : true);
+
+    const renderRightColumn = () => {
+        if (loading) {
+            return (
+                <>
+                    <Skeleton width={48} height={16} />
+                    <Skeleton width={80} height={32} borderRadius={borders.radii.full} />
+                </>
+            );
+        }
+        if (loadFailed) {
+            return (
+                <Row onClick={stop}>
+                    <Button
+                        intent="neutral"
+                        priority="secondary"
+                        size="small"
+                        iconLeft="arrowsClockwise"
+                        isDisabled={disabled || discovering}
+                        onClick={onRetry}
+                        data-testid={`@connect-select-account/retry-button/${accountIndex}`}
+                    >
+                        <Translation id="TR_RETRY" />
+                    </Button>
+                </Row>
+            );
+        }
+
+        if (interactionMode === 'drillIn') {
+            return (
+                <Row alignItems="center" gap={spacings.xs}>
+                    <Text typographyStyle="body-sm">
+                        {balance ?? '0'} {getNetworkDisplaySymbol(symbol)}
+                    </Text>
+                    <Icon name="caretRight" size={16} intent="neutral" />
+                </Row>
+            );
+        }
+
+        return (
+            <>
+                <Text typographyStyle="body-sm">
+                    {balance ?? '0'} {getNetworkDisplaySymbol(symbol)}
+                </Text>
+                {displayValue && (
+                    <Row alignItems="center" gap={spacings.xs} onClick={stop}>
+                        {validated === 'valid' && (
+                            <Badge
+                                intent="brand"
+                                iconLeft="check"
+                                size="small"
+                                data-testid={`@connect-select-account/verified-badge/${accountIndex}`}
+                            >
+                                <Translation id="TR_VERIFIED" />
+                            </Badge>
+                        )}
+                        {validated === 'failed' && (
+                            <Badge
+                                intent="warning"
+                                iconLeft="warning"
+                                size="small"
+                                data-testid={`@connect-select-account/error-badge/${accountIndex}`}
+                            >
+                                <Translation id="TR_VERIFICATION_CANCELED" />
+                            </Badge>
+                        )}
+                        <Button
+                            intent="neutral"
+                            priority="secondary"
+                            size="small"
+                            iconLeft={
+                                deviceModelInternal
+                                    ? mapTrezorModelToIcon[deviceModelInternal]
+                                    : undefined
+                            }
+                            isLoading={verifying}
+                            isDisabled={disabled || discovering}
+                            onClick={onVerify}
+                            data-testid={`@connect-select-account/verify-button/${accountIndex}`}
+                        >
+                            {verifying ? (
+                                <Translation id="TR_VERIFYING" />
+                            ) : (
+                                <Translation id="TR_VERIFY" />
+                            )}
+                        </Button>
+                    </Row>
+                )}
+            </>
+        );
+    };
+
+    // The second line under the label: the address/xpub value, or nothing while loading or for
+    // 'drillIn' rows (which have no value — the chevron in the right column signals the action).
+    const renderSecondaryLine = () => {
+        if (loading) return <Skeleton width={140} height={16} />;
+        if (interactionMode === 'drillIn') return null;
+
+        return (
+            <Text typographyStyle="body-xs" isMonospaced color="contentSecondary">
+                {displayValue ? truncateAddress(displayValue) : '—'}
+            </Text>
+        );
+    };
+
+    return (
+        <Card
+            paddingType="tiny"
+            onClick={interactive ? onToggle : undefined}
+            data-testid={`@connect-select-account/account/${accountIndex}`}
+        >
+            <Row alignItems="center" gap={spacings.sm}>
+                {showCheckbox && (
+                    <div onClick={stop} role="presentation">
+                        <Checkbox
+                            isChecked={selected}
+                            isDisabled={!interactive}
+                            onChange={onToggle}
+                            data-testid={`@connect-select-account/checkbox/${accountIndex}`}
+                        />
+                    </div>
+                )}
+
+                {isNetworkSymbolWithIcon(symbol) && (
+                    <NetworkIcon networkSymbol={symbol} size={24} />
+                )}
+
+                <Column gap={spacings.xxxs} flex="1" minWidth={0} alignItems="flex-start">
+                    <Text typographyStyle="body-sm-strong">{label}</Text>
+                    {renderSecondaryLine()}
+                </Column>
+
+                <Column alignItems="flex-end" gap={spacings.xs}>
+                    {renderRightColumn()}
+                </Column>
+            </Row>
+        </Card>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -40,6 +40,7 @@ import { ConnectAddressConfirmation } from './ConnectAddressConfirmation';
 import { ConnectErrorModal } from './ConnectErrorModal';
 import { ConnectLoadingModal } from './ConnectLoadingModal';
 import { ConnectPermissionsModal } from './ConnectPermissionsModal';
+import { ConnectSelectAccount } from './ConnectSelectAccount/ConnectSelectAccount';
 import { CriticalCoinjoinPhaseModal } from './CriticalCoinjoinPhaseModal/CriticalCoinjoinPhaseModal';
 import { DeviceAuthenticityOptOutModal } from './DeviceAuthenticityOptOutModal';
 import { DisableTorModal } from './DisableTorModal';
@@ -184,6 +185,8 @@ export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL_CONTE
             return <WalletConnectSwitchAccountModal sessionTopic={payload.sessionTopic} />;
         case 'connect-address-confirmation':
             return <ConnectAddressConfirmation />;
+        case 'connect-select-account':
+            return <ConnectSelectAccount />;
         case 'connect-error':
             return <ConnectErrorModal />;
         case 'connect-loading':

--- a/packages/suite/src/components/wallet/Pagination.tsx
+++ b/packages/suite/src/components/wallet/Pagination.tsx
@@ -95,6 +95,9 @@ interface PaginationProps {
     perPage: number;
     totalItems: number;
     explicitNavigation?: boolean;
+    // `totalItems` is a lower-bound estimate rather than a true count (e.g. accounts that can
+    // always be derived further), so the page-input shouldn't reject pages beyond it.
+    noUpperBound?: boolean;
     onPageSelected: (page: number) => void;
 }
 
@@ -106,13 +109,14 @@ export const Pagination = ({
     perPage,
     totalItems,
     explicitNavigation = false,
+    noUpperBound = false,
     ...rest
 }: PaginationProps) => {
     const locale = useSelector(selectLanguage);
 
     const totalPages = Math.ceil(totalItems / perPage);
     const showPrev = currentPage > 1;
-    const showNext = currentPage < totalPages;
+    const showNext = noUpperBound || currentPage < totalPages;
 
     const { control, watch } = useForm({
         defaultValues: {
@@ -125,7 +129,7 @@ export const Pagination = ({
     const isPageInputInvalid =
         !Number.isInteger(Number(pageInput)) ||
         Number(pageInput) < 1 ||
-        Number(pageInput) > totalPages;
+        (!noUpperBound && Number(pageInput) > totalPages);
 
     const pageNumbers = getPages({ currentPage, totalPages });
 

--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -195,6 +195,7 @@ export const useConnectPopupDesktop = () => {
                 case 'switch-device':
                 case 'permission-request':
                 case 'address-confirmation':
+                case 'select-account':
                 case 'tx-simulation':
                     return true;
                 case 'ongoing': {

--- a/packages/suite/src/support/suite/useConnectPopupModals.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupModals.tsx
@@ -42,6 +42,7 @@ export const useConnectPopupModals = () => {
                 'connect-popup',
                 'connect-loading',
                 'connect-address-confirmation',
+                'connect-select-account',
                 'connect-error',
                 'connect-popup-tx-simulation',
             ].includes(modalType);
@@ -63,6 +64,7 @@ export const useConnectPopupModals = () => {
                 | 'connect-popup'
                 | 'connect-loading'
                 | 'connect-address-confirmation'
+                | 'connect-select-account'
                 | 'connect-error'
                 | 'connect-popup-tx-simulation',
         ) => {
@@ -99,6 +101,18 @@ export const useConnectPopupModals = () => {
             }
             case 'address-confirmation': {
                 return openIfNeeded('connect-address-confirmation');
+            }
+            case 'select-account': {
+                // The picker itself triggers nested device calls (derive/verify) that
+                // open MODAL_CONTEXT_DEVICE modals; don't replace those with the picker.
+                if (
+                    modalContext === MODAL_CONTEXT_DEVICE ||
+                    modalContext === MODAL_CONTEXT_DEVICE_CONFIRMATION
+                ) {
+                    return;
+                }
+
+                return openIfNeeded('connect-select-account');
             }
             case 'tx-simulation': {
                 return openIfNeeded('connect-popup-tx-simulation');

--- a/suite-common/connect-popup/package.json
+++ b/suite-common/connect-popup/package.json
@@ -19,6 +19,7 @@
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
+        "@suite-common/wallet-utils": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/connect-common": "workspace:^",
         "@trezor/type-utils": "workspace:^",

--- a/suite-common/connect-popup/src/connectPopupActions.ts
+++ b/suite-common/connect-popup/src/connectPopupActions.ts
@@ -47,6 +47,43 @@ const confirmAddresses = createAction(
     }),
 );
 
+const selectAccount = createAction(
+    `${ACTION_PREFIX}/selectAccount`,
+    (
+        payload: Pick<
+            ConnectPopupCallWithState<'select-account'>,
+            | 'options'
+            | 'selectedAccountTypeKey'
+            | 'candidates'
+            | 'page'
+            | 'exported'
+            | 'manualPhase'
+        >,
+    ) => ({
+        payload,
+    }),
+);
+
+const updateSelectAccount = createAction(
+    `${ACTION_PREFIX}/updateSelectAccount`,
+    (
+        payload: Partial<
+            Pick<
+                ConnectPopupCallWithState<'select-account'>,
+                | 'selectedAccountTypeKey'
+                | 'candidates'
+                | 'page'
+                | 'exported'
+                | 'totalCandidates'
+                | 'manualPhase'
+                | 'manualAccountIndex'
+            >
+        >,
+    ) => ({
+        payload,
+    }),
+);
+
 const setSelectedAccountKey = createAction(
     `${ACTION_PREFIX}/setSelectedAccountKey`,
     (payload: Pick<ConnectPopupCall & { state: 'ongoing' }, 'selectedAccountKey'>) => ({
@@ -116,6 +153,8 @@ export const connectPopupActions = {
     rejectPermissions,
     finishCall,
     confirmAddresses,
+    selectAccount,
+    updateSelectAccount,
     setSelectedAccountKey,
     deeplinkCallback,
     setError,

--- a/suite-common/connect-popup/src/connectPopupPromiseManager.ts
+++ b/suite-common/connect-popup/src/connectPopupPromiseManager.ts
@@ -8,10 +8,14 @@ const createDeferredWrapper = <Resolve = void>(id: string) => {
     const getDeferred = (clear: boolean = false) => {
         if (!_deferred || clear) {
             _deferred = createDeferred(id);
-            _deferred.promise.finally(() => {
-                // Reset when the call is finished
-                _deferred = undefined;
-            });
+            // Reset when the call is finished. Swallow here — this internal cleanup chain has no
+            // consumer of its own; without the catch, a rejection (e.g. Method_Cancel) becomes an
+            // unhandled promise rejection even though callers of `.promise` handle it themselves.
+            _deferred.promise
+                .finally(() => {
+                    _deferred = undefined;
+                })
+                .catch(() => {});
         }
 
         return _deferred;

--- a/suite-common/connect-popup/src/connectPopupReducer.ts
+++ b/suite-common/connect-popup/src/connectPopupReducer.ts
@@ -109,6 +109,26 @@ export const prepareConnectPopupReducer = createReducerWithExtraDeps(
                     };
                 }
             })
+            .addCase(connectPopupActions.selectAccount, (state, { payload }) => {
+                if (
+                    state.activeCall?.state === 'ongoing' ||
+                    state.activeCall?.state === 'select-account'
+                ) {
+                    state.activeCall = {
+                        ...state.activeCall,
+                        state: 'select-account',
+                        ...payload,
+                    };
+                }
+            })
+            .addCase(connectPopupActions.updateSelectAccount, (state, { payload }) => {
+                if (state.activeCall?.state === 'select-account') {
+                    state.activeCall = {
+                        ...state.activeCall,
+                        ...payload,
+                    };
+                }
+            })
             .addCase(connectPopupActions.setSelectedAccountKey, (state, { payload }) => {
                 if (state.activeCall?.state === 'ongoing') {
                     state.activeCall = {

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -4,8 +4,23 @@ import { events } from '@suite-common/analytics';
 import { deviceActions, selectSelectedDevice } from '@suite-common/device';
 import { type CustomThunkAPI, createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
+import { type Bip43PathTemplate, getNetwork } from '@suite-common/wallet-config';
+import {
+    getAddressForNetworkType,
+    getPublicKeyForNetworkType,
+    selectDeviceAccountsByNetworkSymbol,
+} from '@suite-common/wallet-core';
 import { type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import {
+    formatNetworkAmount,
+    getAddressParameters,
+    getDerivationType,
+    getNetworkId,
+    getProtocolMagic,
+    prepareNewAccountPayload,
+} from '@suite-common/wallet-utils';
 import TrezorConnect, {
+    type CallMethodAnyResponse,
     type CallMethodKeys,
     type CallMethodParams,
     type CallMethodPayload,
@@ -23,6 +38,9 @@ import {
     CALL_SOURCE_DEEPLINK,
     CALL_SOURCE_WALLETCONNECT,
     type ConnectCallSource,
+    SELECT_ACCOUNT_PAGE_SIZE,
+    type SelectAccountCandidate,
+    isUtxoNetwork,
 } from './connectPopupTypes';
 import { deriveCardanoEnabledNetworks } from './deriveEnabledNetworks';
 import { postCallHooks, preCallHooks } from './methodHooks';
@@ -384,6 +402,527 @@ export const connectPopupVerifyAddressThunk = createThunk<void, { index: number 
                 }),
             );
         }
+    },
+);
+
+// Resolves what a picker row actually exports, given the picker's mode:
+// - 'xpub' (UTXO, addressSelection 'fullAccount'): the whole account, via its extended public key.
+// - 'address' + UTXO ('firstFresh'): the account's next unused receive address, not the account
+//   itself.
+// - 'address' + non-UTXO (account-based networks): the account descriptor IS the address.
+const resolveCandidateValue = (
+    mode: 'xpub' | 'address',
+    isUtxo: boolean,
+    account: {
+        path: string;
+        descriptor: string;
+        addresses?: { unused: { path: string; address: string }[] };
+    },
+): Pick<SelectAccountCandidate, 'path' | 'address' | 'xpub'> => {
+    if (mode === 'xpub') return { path: account.path, xpub: account.descriptor };
+    if (isUtxo) {
+        // NOTE: can be undefined if the account has exhausted its unused-address gap limit.
+        const fresh = account.addresses?.unused[0];
+
+        return { path: fresh?.path ?? account.path, address: fresh?.address };
+    }
+
+    return { path: account.path, address: account.descriptor };
+};
+
+export const connectPopupLoadSelectAccountPageThunk = createThunk<void, { page: number }>(
+    `${CONNECT_POPUP_MODULE}/loadSelectAccountPageThunk`,
+    async ({ page }, { dispatch, getState, extra }) => {
+        // release any device lock held by the (still pending) selectAccount call
+        dispatch(extra.actions.lockDevice(false));
+
+        const device = selectSelectedDevice(getState());
+        const call = selectConnectPopupCall(getState());
+        if (!device || call?.state !== 'select-account') return;
+
+        // Populates one page of the picker's account-index list. Used for every mode except UTXO
+        // `addressSelection: 'manual'`'s address phase (see loadManualAddressPage below), which
+        // browses one chosen account's existing addresses instead of paging through BIP44 account
+        // indices. `manual`'s own account phase reuses this same list to let the user pick which
+        // account to drill into — `includeValue: false` skips deriving address/xpub for those rows,
+        // since picking one just navigates onward rather than exporting it.
+        // Existing accounts are read from Redux discovery; indices without a discovered account
+        // are derived on demand (sequentially — concurrent getAccountInfo calls would contend for
+        // the same device).
+        async function loadAccountIndexPage(
+            activeDevice: NonNullable<ReturnType<typeof selectSelectedDevice>>,
+            includeValue: boolean,
+        ) {
+            const initialCall = selectConnectPopupCall(getState());
+            if (initialCall?.state !== 'select-account') return;
+
+            const { options, candidates: prevCandidates, selectedAccountTypeKey } = initialCall;
+            const { symbol, accountTypeTabs, mode } = options;
+            const isUtxo = isUtxoNetwork(symbol);
+            // accountTypeTabs is guaranteed non-empty by the methodHook that builds it
+            const activeTab =
+                accountTypeTabs.find(tab => tab.key === selectedAccountTypeKey) ??
+                accountTypeTabs[0]!;
+
+            // Redux discovery only knows about the network's built-in types — a custom bip43Path
+            // tab has no existing accounts to reuse, everything is derived fresh.
+            const existingAccounts = activeTab.accountType
+                ? selectDeviceAccountsByNetworkSymbol(getState(), symbol).filter(
+                      a => a.backendType !== 'coinjoin' && a.accountType === activeTab.accountType,
+                  )
+                : [];
+
+            const startIndex = page * SELECT_ACCOUNT_PAGE_SIZE;
+            const accountIndices = Array.from(
+                { length: SELECT_ACCOUNT_PAGE_SIZE },
+                (_, i) => startIndex + i,
+            );
+
+            // Build the page rows: reuse already-loaded candidates and Redux accounts; show a
+            // skeleton (loading) for indices that still need on-device derivation.
+            const rows: SelectAccountCandidate[] = accountIndices.map(accountIndex => {
+                const cached = prevCandidates.find(
+                    c => c.accountIndex === accountIndex && c.accountTypeKey === activeTab.key,
+                );
+                if (cached && !cached.loading) return cached;
+
+                const existing = existingAccounts.find(a => a.index === accountIndex);
+                if (existing) {
+                    return {
+                        symbol,
+                        accountIndex,
+                        accountTypeKey: activeTab.key,
+                        ...(includeValue
+                            ? resolveCandidateValue(mode, isUtxo, existing)
+                            : { path: existing.path }),
+                        balance: existing.formattedBalance,
+                        used: !existing.empty,
+                        selected: cached?.selected ?? false,
+                        loading: false,
+                        loadFailed: false,
+                        verifying: false,
+                        validated: cached?.validated ?? 'not-started',
+                        mac: cached?.mac,
+                    };
+                }
+
+                return {
+                    symbol,
+                    accountIndex,
+                    accountTypeKey: activeTab.key,
+                    path: '',
+                    used: false,
+                    selected: cached?.selected ?? false,
+                    loading: true,
+                    loadFailed: false,
+                    verifying: false,
+                    validated: 'not-started',
+                };
+            });
+
+            // Merge the page rows into the full candidate list (keeping selections made on other
+            // pages and other tabs) so multi-selection survives pagination and tab switches.
+            const otherCandidates = prevCandidates.filter(
+                c =>
+                    !(
+                        c.accountTypeKey === activeTab.key &&
+                        accountIndices.includes(c.accountIndex)
+                    ),
+            );
+            const merged = [...otherCandidates, ...rows].sort(
+                (a, b) => a.accountIndex - b.accountIndex,
+            );
+            dispatch(
+                connectPopupActions.updateSelectAccount({
+                    candidates: merged,
+                    page,
+                    totalCandidates: undefined,
+                }),
+            );
+
+            for (const row of rows) {
+                if (!row.loading) continue;
+
+                const result = await prepareNewAccountPayload({
+                    accountType: activeTab.accountType ?? 'normal',
+                    networkSymbol: symbol,
+                    index: row.accountIndex,
+                    selectedAccount: {
+                        accountType: activeTab.accountType ?? 'normal',
+                        bip43Path: activeTab.bip43Path as Bip43PathTemplate,
+                    },
+                    device: activeDevice,
+                });
+
+                // bail if the user navigated to another page/tab or closed the picker meanwhile
+                const current = selectConnectPopupCall(getState());
+                if (
+                    current?.state !== 'select-account' ||
+                    current.page !== page ||
+                    current.selectedAccountTypeKey !== selectedAccountTypeKey
+                )
+                    return;
+
+                const resolved: SelectAccountCandidate =
+                    result instanceof Error
+                        ? { ...row, loading: false, loadFailed: true }
+                        : {
+                              ...row,
+                              ...(includeValue
+                                  ? resolveCandidateValue(mode, isUtxo, {
+                                        path: result.path,
+                                        descriptor: result.accountInfo.descriptor,
+                                        addresses: result.accountInfo.addresses,
+                                    })
+                                  : { path: result.path }),
+                              balance: formatNetworkAmount(result.accountInfo.balance, symbol),
+                              used: !result.accountInfo.empty,
+                              loading: false,
+                              loadFailed: false,
+                          };
+
+                dispatch(
+                    connectPopupActions.updateSelectAccount({
+                        candidates: current.candidates.map(c =>
+                            c.accountIndex === resolved.accountIndex &&
+                            c.accountTypeKey === resolved.accountTypeKey
+                                ? resolved
+                                : c,
+                        ),
+                    }),
+                );
+            }
+        }
+
+        // Populates one page of the UTXO `addressSelection: 'manual'` picker's address phase: it
+        // browses the previously-used addresses of the account chosen in the account phase (see
+        // connectPopupSelectManualAccountThunk), instead of paging through BIP44 account indices.
+        async function loadManualAddressPage(
+            activeDevice: NonNullable<ReturnType<typeof selectSelectedDevice>>,
+            manualAccountIndex: number,
+        ) {
+            const initialCall = selectConnectPopupCall(getState());
+            if (initialCall?.state !== 'select-account') return;
+
+            const { options, selectedAccountTypeKey } = initialCall;
+            const { symbol, accountTypeTabs } = options;
+            const activeTab =
+                accountTypeTabs.find(tab => tab.key === selectedAccountTypeKey) ??
+                accountTypeTabs[0]!;
+
+            const isStillOnThisAccount = () => {
+                const current = selectConnectPopupCall(getState());
+
+                return (
+                    current?.state === 'select-account' &&
+                    current.selectedAccountTypeKey === selectedAccountTypeKey &&
+                    current.manualAccountIndex === manualAccountIndex
+                );
+            };
+
+            const paintPage = (
+                usedAddresses: { path: string; address: string; balance: string }[],
+            ) => {
+                const current = selectConnectPopupCall(getState());
+                if (current?.state !== 'select-account') return;
+
+                const startIndex = page * SELECT_ACCOUNT_PAGE_SIZE;
+                const pageAddresses = usedAddresses.slice(
+                    startIndex,
+                    startIndex + SELECT_ACCOUNT_PAGE_SIZE,
+                );
+
+                const rows: SelectAccountCandidate[] = pageAddresses.map((addr, i) => {
+                    const accountIndex = startIndex + i;
+                    const cached = current.candidates.find(
+                        c => c.accountIndex === accountIndex && c.accountTypeKey === activeTab.key,
+                    );
+
+                    return {
+                        symbol,
+                        accountIndex,
+                        accountTypeKey: activeTab.key,
+                        path: addr.path,
+                        address: addr.address,
+                        balance: formatNetworkAmount(addr.balance, symbol),
+                        used: true,
+                        selected: cached?.selected ?? false,
+                        loading: false,
+                        loadFailed: false,
+                        verifying: false,
+                        validated: cached?.validated ?? 'not-started',
+                        mac: cached?.mac,
+                    };
+                });
+
+                const otherCandidates = current.candidates.filter(
+                    c => c.accountTypeKey !== activeTab.key,
+                );
+                dispatch(
+                    connectPopupActions.updateSelectAccount({
+                        candidates: [...otherCandidates, ...rows],
+                        page,
+                        totalCandidates: usedAddresses.length,
+                    }),
+                );
+            };
+
+            // Redux is an optimistic cache, not a source of truth: an account discovered earlier
+            // (or with a coarser detail level) can have a stale or plain incomplete `addresses`
+            // list — including a wrongly-empty `used` array for an account that does have history.
+            // Paint it immediately (avoids a blank page while the device round-trip below is in
+            // flight) but always reconcile with a fresh, authoritative getAccountInfo call.
+            const existingAccount = activeTab.accountType
+                ? selectDeviceAccountsByNetworkSymbol(getState(), symbol).find(
+                      a =>
+                          a.backendType !== 'coinjoin' &&
+                          a.accountType === activeTab.accountType &&
+                          a.index === manualAccountIndex,
+                  )
+                : undefined;
+            if (existingAccount?.addresses?.used) {
+                paintPage(existingAccount.addresses.used);
+            }
+
+            const result = await prepareNewAccountPayload({
+                accountType: activeTab.accountType ?? 'normal',
+                networkSymbol: symbol,
+                index: manualAccountIndex,
+                selectedAccount: {
+                    accountType: activeTab.accountType ?? 'normal',
+                    bip43Path: activeTab.bip43Path as Bip43PathTemplate,
+                },
+                device: activeDevice,
+            });
+
+            // bail if the user navigated to another tab/account or closed the picker meanwhile
+            if (!isStillOnThisAccount()) return;
+
+            if (result instanceof Error) {
+                // Only clobber an optimistic paint with an empty state if we never had one.
+                if (!existingAccount?.addresses?.used) {
+                    dispatch(
+                        connectPopupActions.updateSelectAccount({
+                            candidates: [],
+                            page,
+                            totalCandidates: 0,
+                        }),
+                    );
+                }
+
+                return;
+            }
+
+            paintPage(result.accountInfo.addresses?.used ?? []);
+        }
+
+        if (call.options.addressSelection === 'manual' && call.manualPhase === 'address') {
+            await loadManualAddressPage(device, call.manualAccountIndex ?? 0);
+        } else if (call.options.addressSelection === 'manual') {
+            await loadAccountIndexPage(device, false);
+        } else {
+            await loadAccountIndexPage(device, true);
+        }
+    },
+);
+
+// UTXO `addressSelection: 'manual'` only: the user picked an account in the account phase — drill
+// into it by switching to the address phase and loading its used addresses from page 0.
+export const connectPopupSelectManualAccountThunk = createThunk<void, { accountIndex: number }>(
+    `${CONNECT_POPUP_MODULE}/selectManualAccountThunk`,
+    ({ accountIndex }, { dispatch, getState }) => {
+        const call = selectConnectPopupCall(getState());
+        if (call?.state !== 'select-account' || call.options.addressSelection !== 'manual') return;
+
+        dispatch(
+            connectPopupActions.updateSelectAccount({
+                manualPhase: 'address',
+                manualAccountIndex: accountIndex,
+                candidates: [],
+                page: 0,
+            }),
+        );
+        dispatch(connectPopupLoadSelectAccountPageThunk({ page: 0 }));
+    },
+);
+
+// UTXO `addressSelection: 'manual'` only: back out of the address phase to the account list.
+export const connectPopupBackToManualAccountsThunk = createThunk<void, void>(
+    `${CONNECT_POPUP_MODULE}/backToManualAccountsThunk`,
+    (_, { dispatch, getState }) => {
+        const call = selectConnectPopupCall(getState());
+        if (call?.state !== 'select-account' || call.options.addressSelection !== 'manual') return;
+
+        dispatch(
+            connectPopupActions.updateSelectAccount({
+                manualPhase: 'account',
+                manualAccountIndex: undefined,
+                candidates: [],
+                page: 0,
+                totalCandidates: undefined,
+            }),
+        );
+        dispatch(connectPopupLoadSelectAccountPageThunk({ page: 0 }));
+    },
+);
+
+// Verifies a single candidate address on the device. Safe to run while the selectAccount call is
+// pending because that method holds no device session (useDevice = false).
+export const connectPopupVerifySelectAccountThunk = createThunk<
+    void,
+    { accountIndex: number; accountTypeKey: string }
+>(
+    `${CONNECT_POPUP_MODULE}/verifySelectAccountThunk`,
+    async ({ accountIndex, accountTypeKey }, { dispatch, getState, extra }) => {
+        dispatch(extra.actions.lockDevice(false));
+
+        const isTarget = (c: SelectAccountCandidate) =>
+            c.accountIndex === accountIndex && c.accountTypeKey === accountTypeKey;
+
+        const device = selectSelectedDevice(getState());
+        const call = selectConnectPopupCall(getState());
+        if (!device || call?.state !== 'select-account') return;
+        const candidate = call.candidates.find(isTarget);
+        if (!candidate?.address && !candidate?.xpub) return;
+
+        const patchCandidate = (patch: Partial<SelectAccountCandidate>) => {
+            const cur = selectConnectPopupCall(getState());
+            if (cur?.state !== 'select-account') return;
+            dispatch(
+                connectPopupActions.updateSelectAccount({
+                    candidates: cur.candidates.map(c => (isTarget(c) ? { ...c, ...patch } : c)),
+                }),
+            );
+        };
+
+        patchCandidate({ verifying: true });
+
+        const deviceParams = {
+            path: device.path,
+            instance: device.instance,
+            state: device.state,
+            useEmptyPassphrase: device.useEmptyPassphrase,
+        };
+
+        const { networkType } = getNetwork(candidate.symbol);
+        const accountType =
+            call.options.accountTypeTabs.find(tab => tab.key === candidate.accountTypeKey)
+                ?.accountType ?? 'normal';
+
+        try {
+            // The `xpub` flow has no on-screen address to compare — verification just confirms the
+            // export on-device, same call as the initial account derivation (see getPublicKey.ts).
+            if (candidate.xpub) {
+                const res = await getPublicKeyForNetworkType({
+                    device: deviceParams,
+                    networkType,
+                    path: candidate.path,
+                    coin: candidate.symbol,
+                    showOnTrezor: true,
+                    derivationType: getDerivationType(accountType),
+                });
+                if (!res.success) {
+                    console.error('connectPopupVerifySelectAccountThunk (xpub)', res.error);
+                }
+                patchCandidate({ verifying: false, validated: res.success ? 'valid' : 'failed' });
+
+                return;
+            }
+
+            // Cardano's stakingPath is keyed by the BIP44 account index. In the UTXO 'manual'
+            // address phase, `candidate.accountIndex` is repurposed as the used-address list index
+            // (see SelectAccountCandidate) — the real account index is `call.manualAccountIndex`.
+            const cardanoAccountIndex =
+                call.manualPhase === 'address'
+                    ? (call.manualAccountIndex ?? candidate.accountIndex)
+                    : candidate.accountIndex;
+
+            const res = await getAddressForNetworkType({
+                device: deviceParams,
+                networkType,
+                path: candidate.path,
+                coin: candidate.symbol,
+                showOnTrezor: true,
+                cardano:
+                    networkType === 'cardano'
+                        ? {
+                              addressParameters: getAddressParameters(
+                                  { index: cardanoAccountIndex },
+                                  candidate.path,
+                              ),
+                              protocolMagic: getProtocolMagic(candidate.symbol),
+                              networkId: getNetworkId(),
+                              derivationType: getDerivationType(accountType),
+                          }
+                        : undefined,
+            });
+
+            if (!res.success) {
+                console.error('connectPopupVerifySelectAccountThunk', res.error);
+            }
+            patchCandidate({
+                verifying: false,
+                validated: res.success ? 'valid' : 'failed',
+                mac: res.success ? res.payload.mac : undefined,
+            });
+        } catch (error) {
+            console.error('connectPopupVerifySelectAccountThunk', error);
+            patchCandidate({ verifying: false, validated: 'failed' });
+        }
+    },
+);
+
+// Finalizes the picker. The selectAccount methodHook is awaiting `getPermissionDeferred`; on cancel
+// we reject it (the call thunk's catch maps Method_Cancel to the final error response), on confirm
+// we override the placeholder method response with the user's selection via `getPopupCallDeferred`
+// and unblock the hook (which then flips the picker into its `exported` phase). Mirrors
+// ConnectAddressConfirmation: after export the modal stays open so the user can keep verifying the
+// exported addresses on device, and only `finishCall` (Close) actually closes it.
+export const connectPopupResolveSelectAccountThunk = createThunk<void, { confirmed: boolean }>(
+    `${CONNECT_POPUP_MODULE}/resolveSelectAccountThunk`,
+    ({ confirmed }, { dispatch, getState }) => {
+        const call = selectConnectPopupCall(getState());
+        if (call?.state !== 'select-account') return;
+
+        // Already exported -> this is a "Close": the response was sent on confirm, just close.
+        if (call.exported) {
+            dispatch(connectPopupActions.finishCall());
+
+            return;
+        }
+
+        // Not exported + not confirmed -> "Cancel": reject the pending method call.
+        if (!confirmed) {
+            getPermissionDeferred().reject(TypedError('Method_Cancel'));
+            dispatch(connectPopupActions.finishCall());
+
+            return;
+        }
+
+        // Always an array, even for a 'single' selection — mirrors eth_requestAccounts. `address`
+        // and `xpub` are mutually exclusive per candidate (see SelectAccountCandidate).
+        const payload = call.candidates
+            .filter(c => c.selected && (c.address || c.xpub))
+            .map(c => ({
+                symbol: c.symbol,
+                path: c.path,
+                address: c.address,
+                xpub: c.xpub,
+                // undefined for custom (non-built-in) account-type tabs — no real AccountType to report
+                accountType: call.options.accountTypeTabs.find(tab => tab.key === c.accountTypeKey)
+                    ?.accountType,
+                mac: c.mac,
+            }));
+
+        // Export: deliver the selection to the 3rd-party app and flip the picker into its `exported`
+        // phase, then unblock the methodHook. Do NOT finishCall — keep the modal open so the user can
+        // keep verifying the exported addresses on device (mirrors ConnectAddressConfirmation).
+        getPopupCallDeferred().resolve({
+            success: true,
+            payload,
+        } as Awaited<CallMethodAnyResponse>);
+        dispatch(connectPopupActions.updateSelectAccount({ exported: true }));
+        getPermissionDeferred().resolve();
     },
 );
 

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -1,6 +1,16 @@
+import { type AccountType, type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { type AccountKey, type TxSimulationAction } from '@suite-common/wallet-types';
 import { type CallMethodKeys, type PermissionRequest } from '@trezor/connect';
 import { type SerializedError } from '@trezor/connect-common/src/constants/errors';
+
+// UTXO coins have accounts with many addresses (mirrors `isUtxoBased` in
+// wallet-utils/accountUtils, which operates on an already-loaded `Account` instead of a symbol) —
+// `selectAccount`'s `addressSelection`/xpub-vs-address distinction only applies to them.
+export const isUtxoNetwork = (symbol: NetworkSymbol) => {
+    const { networkType } = getNetwork(symbol);
+
+    return networkType === 'bitcoin' || networkType === 'cardano';
+};
 
 export type ManifestPartial = {
     appName: string;
@@ -67,6 +77,63 @@ type SelectedFee =
           gasLimit: string;
       };
 
+// One account-type tab offered by the `selectAccount` picker. `accountType` is set when the tab
+// is one of the network's built-in types (see networksConfig); custom tabs (arbitrary bip43Path
+// requested by the app) have no `accountType` and carry their own display label instead.
+export type SelectAccountTypeTab = {
+    key: string;
+    bip43Path: string;
+    accountType?: AccountType;
+    customLabel?: string;
+};
+
+// A single row in the `selectAccount` picker. The host (Suite) owns this list: existing accounts
+// come from Redux discovery, new/arbitrary indices are derived on demand.
+//
+// In `options.mode === 'xpub'` (UTXO, `addressSelection` omitted or 'fullAccount') a row is one
+// BIP44 account, identified by `xpub`. In `options.mode === 'address'` a row is one individual
+// address (`address`) — either the account itself (account-based networks, and UTXO
+// `addressSelection: 'firstFresh'`, one row per BIP44 account index) or one of the chosen
+// account's previously-used addresses (UTXO `addressSelection: 'manual'`, `manualPhase ===
+// 'address'` — one row per used address, and `accountIndex` is then the index into that
+// used-address list, not a BIP44 account index). `addressSelection: 'manual'`'s account-picking
+// phase (`manualPhase === 'account'`) reuses the same account-index rows as
+// `mode === 'address'`/`'firstFresh'`, but never populates `address`/`xpub` on them — picking one
+// is a drill-in, not an export.
+export type SelectAccountCandidate = {
+    symbol: NetworkSymbol;
+    accountIndex: number;
+    accountTypeKey: string; // SelectAccountTypeTab.key of the tab this row belongs to
+    path: string; // serialized derivation path of the address/account
+    address?: string; // mutually exclusive with `xpub`
+    xpub?: string; // mutually exclusive with `address` — set only in `options.mode === 'xpub'`
+    balance?: string; // formatted crypto amount
+    used: boolean; // has on-chain history
+    selected: boolean;
+    loading: boolean; // deriving address/xpub/balance
+    loadFailed: boolean; // derivation failed
+    verifying: boolean; // on-device verification in progress
+    validated: 'valid' | 'failed' | 'not-started';
+    mac?: string; // SLIP-0019 address MAC captured during verification (`address` rows only)
+};
+
+export const SELECT_ACCOUNT_PAGE_SIZE = 5;
+
+// Picker options derived from the `selectAccount` method params (by its methodHook).
+export type SelectAccountOptions = {
+    symbol: NetworkSymbol;
+    selectionType: 'single' | 'multi';
+    accountTypeTabs: SelectAccountTypeTab[]; // at least one
+    // Resolved once from `addressSelection` + the coin's network type (see SelectAccountCandidate).
+    mode: 'xpub' | 'address';
+    // Normalized: 'fullAccount' when the coin is UTXO-based and the param was omitted or explicit;
+    // undefined only for account-based networks, where `addressSelection` is ignored entirely.
+    addressSelection?: 'fullAccount' | 'firstFresh' | 'manual';
+    requireOnDeviceVerification: boolean;
+    minCount: number;
+    maxCount?: number;
+};
+
 type TxSimulationConnectPopupCallLoaded = {
     state: 'tx-simulation';
     selectedAccountKey?: AccountKey;
@@ -116,6 +183,28 @@ type ConnectPopupCallLoaded = {
               validatePayload: any;
           }[];
           payload: any;
+      }
+    | {
+          method: CallMethodKeys;
+          state: 'select-account';
+          payload: any;
+          options: SelectAccountOptions;
+          selectedAccountTypeKey: string; // options.accountTypeTabs[n].key of the active tab
+          page: number;
+          candidates: SelectAccountCandidate[];
+          // Total number of candidates, when finite (UTXO `addressSelection: 'manual'`, bounded by
+          // the account's used-address count). Undefined elsewhere — accounts can always be
+          // derived further, so there's no last page.
+          totalCandidates?: number;
+          // UTXO `addressSelection: 'manual'` only: a two-phase flow — pick an account, then pick
+          // one of its addresses. Undefined for every other mode (no account-drill-in phase).
+          manualPhase?: 'account' | 'address';
+          // Set once `manualPhase === 'address'`: the BIP44 index of the account chosen in the
+          // 'account' phase, whose used addresses are now being listed.
+          manualAccountIndex?: number;
+          // false while selecting, true once the selection has been sent to the app; in the
+          // exported phase the modal stays open so the user can keep verifying on device.
+          exported: boolean;
       }
     | {
           method: CallMethodKeys;

--- a/suite-common/connect-popup/src/methodHooks/index.ts
+++ b/suite-common/connect-popup/src/methodHooks/index.ts
@@ -4,6 +4,7 @@ import { addressConfirmationModalHooks } from './addressConfirmation';
 import { bitcoinSignTransaction } from './bitcoinSignTransaction';
 import { ethereumSignTransaction } from './ethereumSignTransaction';
 import { requestLoginHooks } from './requestLogin';
+import { selectAccountHooks } from './selectAccount';
 import { solanaSignTransaction } from './solanaSignTransaction';
 import { type PostCallHookParams, type PreCallHookParams } from './types';
 
@@ -29,6 +30,7 @@ export async function postCallHooks<M extends CallMethodKeys>(params: PostCallHo
         await ethereumSignTransaction.postCallHook(params),
         await solanaSignTransaction.postCallHook(params),
         await addressConfirmationModalHooks.postCallHook(params),
+        await selectAccountHooks.postCallHook(params),
     ];
 
     return hooks.some(Boolean);

--- a/suite-common/connect-popup/src/methodHooks/selectAccount.ts
+++ b/suite-common/connect-popup/src/methodHooks/selectAccount.ts
@@ -1,0 +1,135 @@
+import { type AccountType, type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { getAvailableAccountTypes } from '@suite-common/wallet-utils';
+import { type CallMethodKeys } from '@trezor/connect';
+import { type SelectionType } from '@trezor/connect-common/src/types/api/selectAccount';
+
+import { connectPopupActions } from '../connectPopupActions';
+import { getPermissionDeferred } from '../connectPopupPromiseManager';
+import {
+    type SelectAccountOptions,
+    type SelectAccountTypeTab,
+    isUtxoNetwork,
+} from '../connectPopupTypes';
+import { type PostCallHookParams } from './types';
+
+// Resolves one of the network's built-in types (bypassing the "publicly available" filter that
+// getAvailableAccountTypes applies) — an app explicitly requesting a debug-only type, e.g.
+// 'ledger' on eth, should still get it.
+const resolveKnownAccountType = (symbol: NetworkSymbol, accountType: AccountType) => {
+    const network = getNetwork(symbol);
+    if (accountType === 'normal') return { accountType, bip43Path: network.bip43Path };
+
+    return network.accountTypes[accountType];
+};
+
+// Builds the picker's account-type tabs. Requested entries are either a built-in AccountType name
+// or a custom { bip43Path, label } descriptor; unknown/unsupported names are dropped. Falls back
+// to the network's full publicly available list when unrequested or nothing requested survives.
+const buildAccountTypeTabs = (
+    symbol: NetworkSymbol,
+    requested: Array<AccountType | { bip43Path: string; label: string }> | undefined,
+): SelectAccountTypeTab[] => {
+    const defaultTabs = () =>
+        getAvailableAccountTypes(symbol).map(({ accountType, bip43Path }) => ({
+            key: accountType,
+            accountType,
+            bip43Path,
+        }));
+
+    if (!requested?.length) return defaultTabs();
+
+    const tabs = requested
+        .map((entry, index): SelectAccountTypeTab | undefined => {
+            if (typeof entry === 'string') {
+                const known = resolveKnownAccountType(symbol, entry);
+
+                return (
+                    known && {
+                        key: known.accountType,
+                        accountType: known.accountType,
+                        bip43Path: known.bip43Path,
+                    }
+                );
+            }
+
+            return { key: `custom-${index}`, bip43Path: entry.bip43Path, customLabel: entry.label };
+        })
+        .filter((tab): tab is SelectAccountTypeTab => !!tab);
+
+    return tabs.length ? tabs : defaultTabs();
+};
+
+// 'single' -> exactly one; 'multi' -> unbounded; an object carries explicit minCount/maxCount.
+const resolveSelectionType = (selectionType: SelectionType | undefined) => {
+    if (selectionType === undefined || selectionType === 'single') {
+        return { selectionType: 'single' as const, minCount: 1, maxCount: 1 };
+    }
+    const bounds = selectionType === 'multi' ? {} : selectionType;
+
+    return {
+        selectionType: 'multi' as const,
+        minCount: bounds.minCount ?? 1,
+        maxCount: bounds.maxCount,
+    };
+};
+
+const buildOptions = (payload: Record<string, any>): SelectAccountOptions => {
+    const symbol = String(payload.coin).toLowerCase() as NetworkSymbol;
+    const { selectionType, minCount, maxCount } = resolveSelectionType(payload.selectionType);
+    // Normalize the default so every downstream check compares against a concrete literal instead
+    // of `undefined` — irrelevant (and left undefined) for account-based networks.
+    const addressSelection = isUtxoNetwork(symbol)
+        ? (payload.addressSelection ?? 'fullAccount')
+        : undefined;
+
+    return {
+        symbol,
+        selectionType,
+        minCount,
+        maxCount,
+        accountTypeTabs: buildAccountTypeTabs(symbol, payload.accountType),
+        mode: addressSelection === 'fullAccount' ? 'xpub' : 'address',
+        addressSelection,
+        requireOnDeviceVerification: payload.requireOnDeviceVerification ?? true,
+    };
+};
+
+// Drives the `selectAccount` picker. The Connect method itself is a no-op that returns immediately,
+// so by the time this runs the call has already returned — which is what makes it safe for the
+// picker to fire nested Connect calls (deriving new indices, verifying addresses on device) without
+// colliding with an in-flight call. We keep the call "ongoing" by blocking on getPermissionDeferred,
+// which connectPopupResolveSelectAccountThunk resolves (confirm) or rejects (cancel).
+async function postCallHook<M extends CallMethodKeys>({
+    method,
+    originalPayload,
+    response,
+    dispatch,
+}: PostCallHookParams<M>) {
+    if (method !== 'selectAccount' || !response.success) return false;
+
+    const options = buildOptions(originalPayload);
+
+    dispatch(
+        connectPopupActions.selectAccount({
+            options,
+            // accountTypeTabs is guaranteed non-empty by buildAccountTypeTabs
+            selectedAccountTypeKey: options.accountTypeTabs[0]!.key,
+            candidates: [],
+            page: 0,
+            // 'manual' starts by picking which account to browse; every other mode has no such
+            // drill-in step.
+            manualPhase: options.addressSelection === 'manual' ? 'account' : undefined,
+            exported: false,
+        }),
+    );
+
+    // Block until the user connects. connectPopupResolveSelectAccountThunk delivers the selection to
+    // the app, flips the picker into its `exported` phase (keeping the modal open so the user can
+    // still verify the exported addresses on device, like ConnectAddressConfirmation), and resolves
+    // this deferred. A cancel rejects it instead, which the call thunk maps to Method_Cancel.
+    await getPermissionDeferred(true).promise;
+
+    return true;
+}
+
+export const selectAccountHooks = { postCallHook };

--- a/suite-common/connect-popup/tsconfig.json
+++ b/suite-common/connect-popup/tsconfig.json
@@ -9,6 +9,7 @@
         { "path": "../wallet-config" },
         { "path": "../wallet-core" },
         { "path": "../wallet-types" },
+        { "path": "../wallet-utils" },
         { "path": "../../packages/connect" },
         {
             "path": "../../packages/connect-common"

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -223,6 +223,9 @@ export type UserContextPayload =
           type: 'connect-address-confirmation';
       }
     | {
+          type: 'connect-select-account';
+      }
+    | {
           type: 'connect-error';
       }
     | {

--- a/suite-common/wallet-core/src/device/deviceAddressUtils.ts
+++ b/suite-common/wallet-core/src/device/deviceAddressUtils.ts
@@ -1,0 +1,113 @@
+import { type NetworkSymbol, type NetworkType } from '@suite-common/wallet-config';
+import TrezorConnect, { type PROTO } from '@trezor/connect';
+import { type SerializedError } from '@trezor/connect-common/src/constants/errors';
+import { type DeviceIdentity } from '@trezor/connect-common/src/types/params';
+import { type Result } from '@trezor/type-utils';
+
+type DeviceParam = DeviceIdentity & { useEmptyPassphrase?: boolean };
+
+const methodNotDefinedError = (method: string): Result<never, SerializedError> => ({
+    success: false,
+    error: {
+        message: `Method for ${method} not defined`,
+        code: 'Failure_UnknownCode',
+    },
+});
+
+type GetPublicKeyForNetworkTypeParams = {
+    device: DeviceParam;
+    networkType: NetworkType;
+    path: string;
+    coin?: NetworkSymbol;
+    showOnTrezor?: boolean;
+    // Only meaningful for `cardano`.
+    derivationType?: PROTO.CardanoDerivationType;
+};
+
+// Single entry point for "show/derive the public key on-device", used both by regular account
+// discovery (showXpubOnDevice) and by any other caller that only has a bare device+path+coin,
+// without a full Account (e.g. the connect-popup selectAccount picker, verifying a not-yet-added
+// candidate). Not every network exposes a public key on-device (see the `default` case).
+export const getPublicKeyForNetworkType = ({
+    device,
+    networkType,
+    path,
+    coin,
+    showOnTrezor = true,
+    derivationType,
+}: GetPublicKeyForNetworkTypeParams) => {
+    const params = { device, path, coin, showOnTrezor };
+
+    switch (networkType) {
+        case 'bitcoin':
+            return TrezorConnect.getPublicKey(params);
+        case 'cardano':
+            return TrezorConnect.cardanoGetPublicKey({ ...params, derivationType });
+        case 'solana':
+            return TrezorConnect.solanaGetPublicKey(params);
+        default:
+            return methodNotDefinedError('getPublicKey');
+    }
+};
+
+type CardanoAddressForNetworkTypeParams = {
+    addressParameters: {
+        path: string;
+        addressType: PROTO.CardanoAddressType;
+        stakingPath: string;
+    };
+    protocolMagic: number;
+    networkId: number;
+    derivationType: PROTO.CardanoDerivationType;
+};
+
+type GetAddressForNetworkTypeParams = {
+    device: DeviceParam;
+    networkType: NetworkType;
+    path: string;
+    coin?: NetworkSymbol;
+    showOnTrezor?: boolean;
+    chunkify?: boolean;
+    unlockPath?: PROTO.UnlockPath;
+    // Required to resolve `cardano` — omitted callers (e.g. a bare candidate with no derived
+    // Account) get the same "not defined" error as a genuinely unsupported network.
+    cardano?: CardanoAddressForNetworkTypeParams;
+};
+
+// Single entry point for "show/derive an address on-device". `getAddress` only understands
+// Bitcoin-like coins — every other network has its own dedicated GetAddress method.
+export const getAddressForNetworkType = ({
+    device,
+    networkType,
+    path,
+    coin,
+    showOnTrezor = true,
+    chunkify = false,
+    unlockPath,
+    cardano,
+}: GetAddressForNetworkTypeParams) => {
+    const params = { device, path, unlockPath, coin, chunkify, showOnTrezor };
+
+    switch (networkType) {
+        case 'tron':
+            return TrezorConnect.tronGetAddress(params);
+        case 'ethereum':
+            return TrezorConnect.ethereumGetAddress(params);
+        case 'cardano':
+            if (!cardano) {
+                return methodNotDefinedError('getAddress');
+            }
+
+            return TrezorConnect.cardanoGetAddress({ device, chunkify, ...cardano });
+        case 'ripple':
+            return TrezorConnect.rippleGetAddress(params);
+        case 'bitcoin':
+            return TrezorConnect.getAddress(params);
+        case 'solana':
+            return TrezorConnect.solanaGetAddress(params);
+        case 'stellar':
+            return TrezorConnect.stellarGetAddress(params);
+        default:
+            return methodNotDefinedError('getAddress');
+    }
+};

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -25,11 +25,10 @@ import { removeThpCredentialsThunk } from '@suite-common/thp';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { type AccountKey } from '@suite-common/wallet-types';
 import {
-    getAddressType,
+    getAddressParameters,
     getDerivationType,
     getNetworkId,
     getProtocolMagic,
-    getStakingPath,
 } from '@suite-common/wallet-utils';
 import TrezorConnect, {
     type Address,
@@ -42,6 +41,7 @@ import TrezorConnect, {
 import { exhaustive } from '@trezor/type-utils';
 import { isChanged } from '@trezor/utils';
 
+import { getAddressForNetworkType } from './deviceAddressUtils';
 import { selectAccountByKey } from '../accounts/accountsSelectors';
 import { startDiscoveryThunk } from '../discovery/discoveryThunks';
 import { selectDeviceThunk, selectNewlyConnectedDeviceThunk } from '../discovery/selectDeviceThunk';
@@ -232,61 +232,21 @@ export const confirmAddressOnDeviceThunk = createThunk(
                 },
             };
 
-        const params = {
+        return await getAddressForNetworkType({
             device,
+            networkType: account.networkType,
             path: addressPath,
             unlockPath: account.unlockPath,
             coin: account.symbol,
             chunkify,
             showOnTrezor,
-        };
-
-        let response;
-
-        switch (account.networkType) {
-            case 'tron':
-                response = await TrezorConnect.tronGetAddress(params);
-                break;
-            case 'ethereum':
-                response = await TrezorConnect.ethereumGetAddress(params);
-                break;
-            case 'cardano':
-                response = TrezorConnect.cardanoGetAddress({
-                    device,
-                    addressParameters: {
-                        stakingPath: getStakingPath(account),
-                        addressType: getAddressType(),
-                        path: addressPath,
-                    },
-                    protocolMagic: getProtocolMagic(account.symbol),
-                    networkId: getNetworkId(),
-                    derivationType: getDerivationType(account.accountType),
-                    chunkify,
-                });
-                break;
-            case 'ripple':
-                response = TrezorConnect.rippleGetAddress(params);
-                break;
-            case 'bitcoin':
-                response = TrezorConnect.getAddress(params);
-                break;
-            case 'solana':
-                response = TrezorConnect.solanaGetAddress(params);
-                break;
-            case 'stellar':
-                response = TrezorConnect.stellarGetAddress(params);
-                break;
-            default:
-                response = {
-                    success: false,
-                    error: {
-                        message: 'Method for getAddress not defined',
-                        code: 'Failure_UnknownCode',
-                    },
-                } as const;
-        }
-
-        return response;
+            cardano: {
+                addressParameters: getAddressParameters(account, addressPath),
+                protocolMagic: getProtocolMagic(account.symbol),
+                networkId: getNetworkId(),
+                derivationType: getDerivationType(account.accountType),
+            },
+        });
     },
 );
 

--- a/suite-common/wallet-core/src/device/publicKeyActions.ts
+++ b/suite-common/wallet-core/src/device/publicKeyActions.ts
@@ -1,39 +1,15 @@
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { type Account } from '@suite-common/wallet-types';
 import { getDerivationType } from '@suite-common/wallet-utils';
-import TrezorConnect from '@trezor/connect';
-import { type SerializedError } from '@trezor/connect-common/src/constants/errors';
-import { type Result } from '@trezor/type-utils';
 
-export const showXpubOnDevice = async (device: TrezorDevice, account: Account) => {
-    const params = {
+import { getPublicKeyForNetworkType } from './deviceAddressUtils';
+
+export const showXpubOnDevice = (device: TrezorDevice, account: Account) =>
+    getPublicKeyForNetworkType({
         device,
+        networkType: account.networkType,
         path: account.path,
+        coin: account.symbol,
         showOnTrezor: true,
         derivationType: getDerivationType(account.accountType),
-        coin: account.symbol,
-    };
-
-    let response: Result<unknown, SerializedError>;
-    switch (account.networkType) {
-        case 'bitcoin':
-            response = await TrezorConnect.getPublicKey(params);
-            break;
-        case 'cardano':
-            response = await TrezorConnect.cardanoGetPublicKey(params);
-            break;
-        case 'solana':
-            response = await TrezorConnect.solanaGetPublicKey(params);
-            break;
-        default:
-            response = {
-                success: false,
-                error: {
-                    message: 'Method for getPublicKey not defined',
-                    code: 'Failure_UnknownCode',
-                },
-            };
-    }
-
-    return response;
-};
+    });

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -14,6 +14,7 @@ export * from './blockchain/blockchainMiddleware';
 export * from './blockchain/blockchainReducer';
 export * from './blockchain/blockchainSelectors';
 export * from './blockchain/blockchainThunks';
+export * from './device/deviceAddressUtils';
 export * from './device/deviceSelectors';
 export * from './device/deviceThunks';
 export * from './device/preparePushNotificationMiddleware';

--- a/suite-common/wallet-utils/src/__tests__/cardanoUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/cardanoUtils.test.ts
@@ -61,7 +61,6 @@ describe('cardano utils', () => {
             const address = getUnusedChangeAddress(f.account);
             const res = address && {
                 address: address.address,
-                // @ts-expect-error params are partial
                 addressParameters: getAddressParameters(f.account, address.path),
             };
             expect(res).toMatchObject(f.result);

--- a/suite-common/wallet-utils/src/cardanoUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoUtils.ts
@@ -27,7 +27,8 @@ export const getDerivationType = (accountType: AccountType) => {
     }
 };
 
-export const getStakingPath = (account: Account) => `m/1852'/1815'/${account.index}'/2/0`;
+export const getStakingPath = (account: Pick<Account, 'index'>) =>
+    `m/1852'/1815'/${account.index}'/2/0`;
 
 export const getProtocolMagic = (accountSymbol: Account['symbol']) =>
     // TODO: use testnet magic from connect once this PR is merged https://github.com/trezor/connect/pull/1046
@@ -48,7 +49,7 @@ export const getUnusedChangeAddress = (account: Pick<Account, 'addresses'>) => {
     return changeAddress;
 };
 
-export const getAddressParameters = (account: Account, path: string) => ({
+export const getAddressParameters = (account: Pick<Account, 'index'>, path: string) => ({
     path,
     addressType: getAddressType(),
     stakingPath: getStakingPath(account),

--- a/suite/e2e/support/fixtures.ts
+++ b/suite/e2e/support/fixtures.ts
@@ -11,6 +11,7 @@ import { TradingMock } from './mocks/tradingMock';
 import { AnalyticsSection } from './pageObjects/analyticsSection';
 import { AssetsSection } from './pageObjects/assetsSection';
 import { ConnectPermissionsModal } from './pageObjects/connectPermissionsModal';
+import { ConnectSelectAccountModal } from './pageObjects/connectSelectAccountModal';
 import { DashboardPage } from './pageObjects/dashboardPage';
 import { DevicePrompt } from './pageObjects/devicePrompt';
 import { GuidePanel } from './pageObjects/guidePanel';
@@ -50,6 +51,7 @@ type Fixtures = {
     solanaStakingMock: SolanaStakingMock;
     tradingMock: TradingMock;
     connectPermissionsModal: ConnectPermissionsModal;
+    connectSelectAccountModal: ConnectSelectAccountModal;
     stakingSection: StakingSection;
     paginationControl: PaginationControl;
     evoluClient: EvoluClient;
@@ -122,6 +124,9 @@ const test = suiteBaseTest.extend<Fixtures>({
     },
     tradingMock: async ({ page }, use) => {
         await use(new TradingMock(page));
+    },
+    connectSelectAccountModal: async ({ page }, use) => {
+        await use(new ConnectSelectAccountModal(page));
     },
     connectPermissionsModal: async ({ page }, use) => {
         await use(new ConnectPermissionsModal(page));

--- a/suite/e2e/support/pageObjects/connectSelectAccountModal.ts
+++ b/suite/e2e/support/pageObjects/connectSelectAccountModal.ts
@@ -1,0 +1,39 @@
+import { Locator, Page } from '@playwright/test';
+
+export class ConnectSelectAccountModal {
+    readonly confirmButton: Locator;
+    readonly cancelButton: Locator;
+    readonly closeButton: Locator;
+    readonly prevPage: Locator;
+    readonly nextPage: Locator;
+    readonly pageInput: Locator;
+
+    constructor(private readonly page: Page) {
+        this.confirmButton = page.getByTestId('@connect-select-account/confirm-button');
+        this.cancelButton = page.getByTestId('@connect-select-account/cancel-button');
+        this.closeButton = page.getByTestId('@connect-select-account/close-button');
+        this.prevPage = page.getByTestId('@connect-select-account/prev-page');
+        this.nextPage = page.getByTestId('@connect-select-account/next-page');
+        this.pageInput = page.getByTestId('@connect-select-account/page-input');
+    }
+
+    account(index: number): Locator {
+        return this.page.getByTestId(`@connect-select-account/account/${index}`);
+    }
+
+    checkbox(index: number): Locator {
+        return this.page.getByTestId(`@connect-select-account/checkbox/${index}`);
+    }
+
+    verifyButton(index: number): Locator {
+        return this.page.getByTestId(`@connect-select-account/verify-button/${index}`);
+    }
+
+    verifiedBadge(index: number): Locator {
+        return this.page.getByTestId(`@connect-select-account/verified-badge/${index}`);
+    }
+
+    errorBadge(index: number): Locator {
+        return this.page.getByTestId(`@connect-select-account/error-badge/${index}`);
+    }
+}

--- a/suite/e2e/tests/trezor-connect/selectAccount.test.ts
+++ b/suite/e2e/tests/trezor-connect/selectAccount.test.ts
@@ -1,0 +1,119 @@
+import TrezorConnect from '@trezor/connect-web';
+
+import { expect, test } from '../../support/fixtures';
+
+test.describe('TrezorConnect.selectAccount', { tag: ['@T3T1', '@T3W1', '@desktopOnly'] }, () => {
+    test.use({ electronConf: { exposeConnectWs: true } });
+
+    test.beforeEach(async ({ onboardingPage }) => {
+        await onboardingPage.completeOnboarding();
+
+        await test.step('Initialize TrezorConnect', async () => {
+            await TrezorConnect.init({
+                manifest: {
+                    appUrl: 'http://localhost:8080',
+                    email: '',
+                    appName: 'Tester',
+                },
+                coreMode: 'suite-desktop',
+                debug: true,
+            });
+        });
+    });
+
+    test('selects and verifies an account (multi)', async ({
+        page,
+        device,
+        connectPermissionsModal,
+        connectSelectAccountModal,
+    }) => {
+        const res = TrezorConnect.selectAccount({
+            coin: 'eth',
+            selectionType: 'multi',
+        });
+
+        await connectPermissionsModal.confirmButton.click();
+
+        // picker opens and shows the first account
+        await expect(connectSelectAccountModal.account(0)).toBeVisible();
+
+        // select account #0
+        await connectSelectAccountModal.checkbox(0).click();
+
+        // verify it on the device
+        await connectSelectAccountModal.verifyButton(0).click();
+        await expect(connectSelectAccountModal.verifyButton(0)).toHaveTranslation('TR_VERIFYING');
+        // TODO: 'verifying' is not enough to ensure the device call is already in progress, it is
+        // only set right after clicking the button (see getAddress.test.ts for the same caveat).
+        await page.waitForTimeout(1000);
+        await device.pressYes();
+        await expect(connectSelectAccountModal.verifiedBadge(0)).toBeVisible();
+
+        // connect: delivers the selection to the app
+        await connectSelectAccountModal.confirmButton.click();
+
+        const response = await res;
+        expect(response.success).toBe(true);
+        if (!response.success) return;
+
+        const accounts = response.payload;
+        expect(accounts).toHaveLength(1);
+        const [account] = accounts;
+        if (!account) return;
+        expect(account.address).toMatch(/^0x[0-9a-fA-F]{40}$/);
+        expect(account.path).toContain("m/44'/60'/0'/0/0");
+        // privacy: never expose an xpub / public key
+        expect(account).not.toHaveProperty('xpub');
+        expect(account).not.toHaveProperty('publicKey');
+
+        // the modal stays open after export so the user can double-check the shared addresses
+        await expect(connectSelectAccountModal.closeButton).toBeVisible();
+        await connectSelectAccountModal.closeButton.click();
+    });
+
+    test('returns a single account (single)', async ({
+        connectPermissionsModal,
+        connectSelectAccountModal,
+    }) => {
+        const res = TrezorConnect.selectAccount({
+            coin: 'eth',
+            selectionType: 'single',
+            requireOnDeviceVerification: false,
+        });
+
+        await connectPermissionsModal.confirmButton.click();
+
+        await expect(connectSelectAccountModal.account(0)).toBeVisible();
+        await connectSelectAccountModal.checkbox(0).click();
+        await connectSelectAccountModal.confirmButton.click();
+
+        const response = await res;
+        expect(response.success).toBe(true);
+        if (!response.success) return;
+
+        expect(response.payload).toHaveLength(1);
+        const [account] = response.payload;
+        if (!account) return;
+        expect(account.address).toMatch(/^0x[0-9a-fA-F]{40}$/);
+
+        // modal stays open after export; close it
+        await connectSelectAccountModal.closeButton.click();
+    });
+
+    test('cancelling returns a Method_Cancel error', async ({
+        connectPermissionsModal,
+        connectSelectAccountModal,
+    }) => {
+        const res = TrezorConnect.selectAccount({ coin: 'eth' });
+
+        await connectPermissionsModal.confirmButton.click();
+        await expect(connectSelectAccountModal.account(0)).toBeVisible();
+        await connectSelectAccountModal.cancelButton.click();
+
+        const response = await res;
+        expect(response.success).toBe(false);
+        if (response.success) return;
+
+        expect(response.error.code).toBe('Method_Cancel');
+    });
+});

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -12479,6 +12479,44 @@ export const messages = defineMessages({
         defaultMessage:
             'The following accounts from {passphraseWalletLabel} on {deviceLabel} will be shared with {thirdParty}. Your private keys stay secure and are never exposed.',
     },
+    TR_CONNECT_SELECT_ACCOUNT: {
+        id: 'TR_CONNECT_SELECT_ACCOUNT',
+        defaultMessage: 'Select account',
+    },
+    TR_CONNECT_SELECT_ACCOUNT_DESCRIPTION: {
+        id: 'TR_CONNECT_SELECT_ACCOUNT_DESCRIPTION',
+        defaultMessage:
+            'Only the accounts you select are shared. Verify an address on your Trezor to confirm it before connecting.',
+    },
+    TR_CONNECT_SELECT_ACCOUNT_PICK_ACCOUNT_DESCRIPTION: {
+        id: 'TR_CONNECT_SELECT_ACCOUNT_PICK_ACCOUNT_DESCRIPTION',
+        defaultMessage: 'Choose which account to pick an address from.',
+    },
+    TR_CONNECT_SELECT_ACCOUNT_CONFIRM: {
+        id: 'TR_CONNECT_SELECT_ACCOUNT_CONFIRM',
+        defaultMessage: 'Connect',
+    },
+    TR_CONNECT_SELECT_ACCOUNT_LABEL: {
+        id: 'TR_CONNECT_SELECT_ACCOUNT_LABEL',
+        defaultMessage: 'Account #{index}',
+    },
+    TR_CONNECT_SELECT_ACCOUNT_ADDRESS_LABEL: {
+        id: 'TR_CONNECT_SELECT_ACCOUNT_ADDRESS_LABEL',
+        defaultMessage: 'Address #{index}',
+    },
+    TR_CONNECT_SELECT_ACCOUNT_SELECTED: {
+        id: 'TR_CONNECT_SELECT_ACCOUNT_SELECTED',
+        defaultMessage: '{count} selected',
+    },
+    TR_CONNECT_SELECT_ACCOUNT_EXPORTED: {
+        id: 'TR_CONNECT_SELECT_ACCOUNT_EXPORTED',
+        defaultMessage: 'Accounts shared',
+    },
+    TR_CONNECT_SELECT_ACCOUNT_EXPORTED_DESCRIPTION: {
+        id: 'TR_CONNECT_SELECT_ACCOUNT_EXPORTED_DESCRIPTION',
+        defaultMessage:
+            'You can verify the shared addresses on your Trezor to make sure they are correct.',
+    },
     TR_DYK_TITLE: {
         id: 'TR_DYK_TITLE',
         defaultMessage: 'Did you know?',

--- a/yarn.lock
+++ b/yarn.lock
@@ -10573,6 +10573,7 @@ __metadata:
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
+    "@suite-common/wallet-utils": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/connect-common": "workspace:^"
     "@trezor/type-utils": "workspace:^"


### PR DESCRIPTION
## Description

Adds a new `selectAccount` Connect method that moves the "connect / choose accounts" flow used by 3rd-party apps (MetaMask, Rabby, exchanges) into Trezor Suite's own UI, so addresses are verified on-device and the full xpub is never exported. The Connect method is intentionally thin and event-driven (no device session, `useUi: true`); a Suite `methodHook` renders the picker and returns the selection, which keeps the nested derive/verify calls safe. The picker supports single and multi selection, existing accounts plus arbitrary indices via pagination, and per-account on-device verification that stays available even after exporting — mirroring `ConnectAddressConfirmation`, the modal stays open after "Connect" so the user can double-check the shared addresses. It also ships a connect-explorer playground/docs page (`methods/common/selectAccount`) and an e2e test.

## Notes for QA

Run Suite desktop against trezor-user-env and trigger `selectAccount` (via connect-explorer → Common → selectAccount, or a 3rd-party app over the desktop WS). Verify: the picker opens; single and multi (`selectionType`) selection works; pagination + "go to page" loads arbitrary account indices; the per-row "Verify on Trezor" button shows the address on the device (before and after connecting); clicking Connect returns the selection to the caller and keeps the modal open with a Close button; Cancel / closing returns a `Method_Cancel` error. The returned payload must contain only address + path (+ optional MAC) — never an xpub or public key.

## Related Issue

Resolve #23799

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-select-account-method&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-select-account-method&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-08T14:24:27.425Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T14:20:54.106Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/connect-select-account-method/web/](https://dev.suite.sldev.cz/suite-web/connect-select-account-method/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->