### PR TITLE
fix(e2e): Android API level 35

### DIFF
--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -72,7 +72,6 @@ jobs:
           path: |
             node_modules
             suite-native/app/node_modules
-            .yarn/install-state.gz
           key: node_modules-native-full-${{ hashFiles('yarn.lock') }}
 
       - name: Install Socket Firewall
@@ -146,14 +145,14 @@ jobs:
           CURRENTS_TAG: ${{ inputs.currents_tags }}
           COMMIT_INFO_BRANCH: ${{ github.head_ref }}
         with:
-          api-level: 34
+          api-level: 35
           profile: pixel_6
           arch: x86_64
           working-directory: suite-native/app
           ram-size: 4096M
           force-avd-creation: true
           avd-name: ${{ steps.device.outputs.AVD_NAME }}
-          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot-load -no-snapshot-save -noaudio -no-boot-anim -grpc 8554 -memory 4096
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot-load -no-snapshot-save -noaudio -no-boot-anim -camera-back none -camera-front none -grpc 8554 -memory 4096
           disable-animations: true
           cores: 4
           heap-size: 512M

--- a/.nix/android.nix
+++ b/.nix/android.nix
@@ -62,16 +62,16 @@ rec {
     export GRADLE_OPTS="-Dorg.gradle.project.android.aapt2FromMavenOverride=${pkgs.aapt}/bin/aapt2"
 
     # Setup Android emulator device if it doesn't exist
-    if [ ! -d "$HOME/.android/avd/Pixel_6_API_34.avd" ]; then
-      avdmanager create avd -n Pixel_6_API_34 -d pixel_6 --package "system-images;android-34;google_apis;x86_64"
+    if [ ! -d "$HOME/.android/avd/Pixel_6_API_35.avd" ]; then
+      avdmanager create avd -n Pixel_6_API_35 -d pixel_6 --package "system-images;android-35;google_apis;x86_64"
 
       # enable GPU acceleration, this option is not available in avdmanager
       sed -i \
         -e 's/^hw\.gpu\.enabled=no$/hw.gpu.enabled=yes/' \
         -e 's/^hw\.gpu\.mode=auto$/hw.gpu.mode=host/' \
-        $HOME/.android/avd/Pixel_6_API_34.avd/config.ini
+        $HOME/.android/avd/Pixel_6_API_35.avd/config.ini
 
-      echo "✓ Created Android emulator device: Pixel_6_API_34"
+      echo "✓ Created Android emulator device: Pixel_6_API_35"
     fi
 
     echo "- Java $(java -version 2>&1 | head -n1)"

--- a/docs/misc/development-on-nix.md
+++ b/docs/misc/development-on-nix.md
@@ -67,13 +67,13 @@ nix develop .#android
 # list available AVDs with:
 avdmanager list avd
 emulator -avd <avd-name>
-emulator -avd Pixel_6_API_34
+emulator -avd Pixel_6_API_35
 ```
 
 If you have troubles with your GPU acceleration you can disable it when running emulator like:
 
 ```bash
-emulator -avd Pixel_6_API_34 -gpu swiftshader_indirect
+emulator -avd Pixel_6_API_35 -gpu swiftshader_indirect
 ```
 
 ### Running tests

--- a/suite-native/app/.detoxrc.js
+++ b/suite-native/app/.detoxrc.js
@@ -46,7 +46,7 @@ module.exports = {
         emulator: {
             type: 'android.emulator',
             device: {
-                avdName: 'Pixel_6_API_34',
+                avdName: 'Pixel_6_API_35',
             },
             bootArgs: '-no-metrics',
         },

--- a/suite-native/app/e2e/README.md
+++ b/suite-native/app/e2e/README.md
@@ -14,7 +14,7 @@ To run the tests locally, you need to have the following installed:
     - Installed Xcode with iPhone 11 simulator created
     - Installed applesimutils with `brew tap wix/brew && brew install applesimutils`
 
-- for **Android** build: Installed Android Studio with existing emulator device named `Pixel_6_API_34`. You can do it via Android Studio UI. If you want to do it via the command line, please follow [this guide](https://wix.github.io/Detox/docs/guide/android-dev-env#heres-how-to-install-them-using-the-command-line). You can also use another emulator device, but you have to map its name to the `devices.emulator.device.avdName` value in the `.detoxrc.js` config file.
+- for **Android** build: Installed Android Studio with existing emulator device named `Pixel_6_API_35`. You can do it via Android Studio UI. If you want to do it via the command line, please follow [this guide](https://wix.github.io/Detox/docs/guide/android-dev-env#heres-how-to-install-them-using-the-command-line). You can also use another emulator device, but you have to map its name to the `devices.emulator.device.avdName` value in the `.detoxrc.js` config file.
 
 ### Debug build
 

--- a/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
@@ -37,8 +37,7 @@ describe('Trade Exchange [@androidOnly]', () => {
         });
     });
 
-    // Skipping due to emulator crash
-    describe.skip('with device disconnected [@T3T1]', () => {
+    describe('with device disconnected [@T3T1]', () => {
         beforeAll(() => {
             if (!passphrase) {
                 throw new Error(
@@ -78,8 +77,7 @@ describe('Trade Exchange [@androidOnly]', () => {
         });
     });
 
-    // Skipping due to emulator crash
-    describe.skip('with device connected [@T3T1]', () => {
+    describe('with device connected [@T3T1]', () => {
         beforeAll(() => {
             if (!passphrase) {
                 throw new Error(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All 24 changed files are under the `suite-native/` directory, which is the React Native mobile app codebase. The 117 candidate E2E tests are all Playwright-based tests for the desktop/web Trezor Suite application (`suite/e2e/tests/`). There is no overlap between the changed native mobile code (Detox tests, native atoms, native icons, native trading module components) and the web/desktop E2E test suite. None of the candidate tests exercise any of the changed mobile-specific components, and no static coverage mapping exists. Therefore, no web/desktop E2E tests need to be run for this change set. The appropriate tests would be the suite-native Detox tests (e.g., `bitcoinAccountsImport.test.ts`, `tradingExchangeFlow.test.ts`, etc.), which are not among the 117 candidate Playwright tests.

<details><summary><b>Changed files (24)</b></summary>

- `suite-native/app/.detoxrc.js`
- `suite-native/app/e2e/tests/bitcoinAccountsImport.test.ts`
- `suite-native/app/e2e/tests/importAdaAccount.test.ts`
- `suite-native/app/e2e/tests/importDogeAccount.test.ts`
- `suite-native/app/e2e/tests/importEthAccount.test.ts`
- `suite-native/app/e2e/tests/importLtcAccount.test.ts`
- `suite-native/app/e2e/tests/importXrpAccount.test.ts`
- `suite-native/app/e2e/tests/importZecAccount.test.ts`
- `suite-native/app/e2e/tests/invalidAccountsImport.test.ts`
- `suite-native/app/e2e/tests/tradingExchangeFlow.test.ts`
- `suite-native/atoms/src/AnimatedView.e2e.tsx`
- `suite-native/atoms/src/AnimatedView.tsx`
- `suite-native/atoms/src/Image.e2e.tsx`
- `suite-native/atoms/src/index.ts`
- `suite-native/icons/src/CryptoIcon.e2e.tsx`
- `suite-native/icons/src/CryptoIcon.tsx`
- `suite-native/icons/src/PaymentMethodLogo.e2e.tsx`
- `suite-native/module-accounts-import/src/components/QRWithLaser.tsx`
- `suite-native/module-trading/src/components/exchange/Approval/ApprovalButton.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewContinueButton.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx`
- `suite-native/module-trading/src/components/general/ProviderReceiveAddress.tsx`
- `suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsFooter.tsx`
- `suite-native/trading-atoms/src/components/SearchableSheetHeader.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (24)**
- `suite-native/app/.detoxrc.js`
- `suite-native/app/e2e/tests/bitcoinAccountsImport.test.ts`
- `suite-native/app/e2e/tests/importAdaAccount.test.ts`
- `suite-native/app/e2e/tests/importDogeAccount.test.ts`
- `suite-native/app/e2e/tests/importEthAccount.test.ts`
- `suite-native/app/e2e/tests/importLtcAccount.test.ts`
- `suite-native/app/e2e/tests/importXrpAccount.test.ts`
- `suite-native/app/e2e/tests/importZecAccount.test.ts`
- `suite-native/app/e2e/tests/invalidAccountsImport.test.ts`
- `suite-native/app/e2e/tests/tradingExchangeFlow.test.ts`
- `suite-native/atoms/src/AnimatedView.e2e.tsx`
- `suite-native/atoms/src/AnimatedView.tsx`
- `suite-native/atoms/src/Image.e2e.tsx`
- `suite-native/atoms/src/index.ts`
- `suite-native/icons/src/CryptoIcon.e2e.tsx`
- `suite-native/icons/src/CryptoIcon.tsx`
- `suite-native/icons/src/PaymentMethodLogo.e2e.tsx`
- `suite-native/module-accounts-import/src/components/QRWithLaser.tsx`
- `suite-native/module-trading/src/components/exchange/Approval/ApprovalButton.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewContinueButton.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx`
- `suite-native/module-trading/src/components/general/ProviderReceiveAddress.tsx`
- `suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsFooter.tsx`
- `suite-native/trading-atoms/src/components/SearchableSheetHeader.tsx`

_Updated: 2026-06-18T11:36:21.684Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-e2e-android-api-35&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-e2e-android-api-35&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat-e2e-android-api-35&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-24T08:39:29.162Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-24T08:38:17.767Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat-e2e-android-api-35/web/](https://dev.suite.sldev.cz/suite-web/feat-e2e-android-api-35/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->