### PR TITLE
test: pass jest suites in packages with no test files

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -16,6 +16,7 @@ const babelConfig = {
 
 module.exports = {
     rootDir: process.cwd(),
+    passWithNoTests: true,
     // An array of file extensions your modules use
     moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx'],
 

--- a/jest.config.native.js
+++ b/jest.config.native.js
@@ -14,6 +14,7 @@ const swcConfig = require('./jest.config.swc-transform');
 
 module.exports = {
     rootDir: process.cwd(),
+    passWithNoTests: true,
     moduleFileExtensions,
     testMatch,
     testPathIgnorePatterns,


### PR DESCRIPTION
## Description

Adds `passWithNoTests: true` to the shared Jest configs so packages with no test files pass instead of failing the suite — without needing `--passWithNoTests` in each package's `test:unit` script.

- `jest.config.base.js` — covers all packages whose config spreads `baseConfig`.
- `jest.config.native.js` — set directly, since the native config only destructures selected fields from base and would not otherwise inherit it.

Note: this only applies when Jest finds **zero** test files. An empty test file still fails with "Your test suite must contain at least one test."

## Related Issue

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to Jest unit-test configuration files (jest.config.base.js and jest.config.native.js), which are not used by Playwright E2E tests at all. These files govern how Jest unit tests are discovered and executed, not how the application behaves at runtime. There is no risk of E2E regression from these changes, and no Playwright tests need to be run.

<details><summary><b>Changed files (2)</b></summary>

- `jest.config.base.js`
- `jest.config.native.js`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `jest.config.base.js`
- `jest.config.native.js`

_Updated: 2026-06-17T09:51:44.481Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/jest-pass-with-no-tests/web/](https://dev.suite.sldev.cz/suite-web/jest-pass-with-no-tests/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=jest-pass-with-no-tests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=jest-pass-with-no-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-17T09:56:54.696Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-17T09:55:52.505Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->