### PR TITLE
feat(suite-desktop): display nonce warning on transaction list item

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/EvmBumpFeeTooltip.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/EvmBumpFeeTooltip.tsx
@@ -1,0 +1,26 @@
+import { Translation } from '@suite/intl';
+import { Link } from '@trezor/components';
+import { HELP_CENTER_REPLACE_BY_FEE_ETHEREUM } from '@trezor/urls';
+
+type EvmBumpFeeTooltipProps = {
+    isDisabled?: boolean;
+    nonce?: number;
+};
+
+export const EvmBumpFeeTooltip = ({ isDisabled, nonce }: EvmBumpFeeTooltipProps) => {
+    if (isDisabled)
+        return (
+            <Translation
+                id="TR_BUMP_FEE_DISABLED_TOOLTIP"
+                values={{
+                    nonce,
+                    a: chunks => <Link href={HELP_CENTER_REPLACE_BY_FEE_ETHEREUM}>{chunks}</Link>,
+                }}
+            />
+        );
+
+    if (nonce !== undefined)
+        return <Translation id="TR_TRANSACTION_NONCE_TOOLTIP" values={{ nonce }} />;
+
+    return null;
+};

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -9,12 +9,18 @@ import { AccountTransactionBaseAnchor, useAnchor } from '@suite/router';
 import { type AccountType, type Network } from '@suite-common/wallet-config';
 import {
     createTargets,
+    selectAccountTransactions,
     selectIsPhishingTransaction,
     useDisplayBaseCurrency,
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { formatNetworkAmount, isTxFeePaid } from '@suite-common/wallet-utils';
-import { Button, Link, Row, Tooltip } from '@trezor/components';
+import {
+    formatNetworkAmount,
+    isPending as getIsPending,
+    isSentTransaction,
+    isTxFeePaid,
+} from '@suite-common/wallet-utils';
+import { Button, Icon, Link, Row, Tooltip } from '@trezor/components';
 import { OutlineHighlight } from '@trezor/product-components';
 import { HELP_CENTER_REPLACE_BY_FEE_ETHEREUM } from '@trezor/urls';
 
@@ -89,6 +95,39 @@ export const TransactionItem = memo(
             networkFeatures?.includes('rbf') &&
             !transaction?.deadline;
 
+        // Nonce bounds are derived once per account (memoized) and shared by every pending
+        // TransactionItem, instead of each item subscribing to the full tx list and recomputing.
+        const { confirmedNonce, nextNonce } = useSelector(state =>
+            selectAccountEvmNonceInfo(state, accountKey),
+        );
+
+        // A pending EVM tx can be stuck two ways: its nonce is above the next free nonce (a lower
+        // nonce is missing — a gap), or below the confirmed nonce (that slot was already mined by
+        // another tx — superseded). Either way it won't confirm; `nextNonce` is the nonce to
+        // re-send with to unblock it.
+        const pendingEvmNonce =
+            isPending && network.networkType === 'ethereum'
+                ? transaction.ethereumSpecific?.nonce
+                : undefined;
+
+        const isSuperseded = pendingEvmNonce !== undefined && pendingEvmNonce < confirmedNonce;
+        const hasNonceGap = pendingEvmNonce !== undefined && pendingEvmNonce > nextNonce;
+
+        const renderNonceWarning = () => {
+            if (isSuperseded)
+                return (
+                    <Translation
+                        id="TR_PENDING_NONCE_SUPERSEDED_WARNING"
+                        values={{ nonce: nextNonce }}
+                    />
+                );
+            if (hasNonceGap)
+                return <Translation id="TR_BUMP_FEE_NONCE_GAP_WARNING" values={{ nonce: nextNonce }} />;
+
+            return null;
+        };
+        const nonceWarning = renderNonceWarning();
+
         const openTxDetailsModal = ({ flow }: OpenModalParams) => {
             if (isActionDisabled) return; // open explorer
             dispatch(
@@ -115,7 +154,16 @@ export const TransactionItem = memo(
                 <OutlineHighlight shouldHighlight={shouldHighlight}>
                     <TransactionLayout
                         onClick={() => openTxDetailsModal({ flow: 'detail' })}
-                        timestamp={<TransactionTimestamp transaction={transaction} />}
+                        timestamp={
+                            <Row gap={4}>
+                                <TransactionTimestamp transaction={transaction} />
+                                {nonceWarning && (
+                                    <Tooltip content={nonceWarning}>
+                                        <Icon name="warning" size={16} intent="warning" />
+                                    </Tooltip>
+                                )}
+                            </Row>
+                        }
                         heading={
                             <TransactionHeading
                                 transaction={transaction}

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -9,17 +9,12 @@ import { AccountTransactionBaseAnchor, useAnchor } from '@suite/router';
 import { type AccountType, type Network } from '@suite-common/wallet-config';
 import {
     createTargets,
-    selectAccountTransactions,
+    selectAccountEvmNonceInfo,
     selectIsPhishingTransaction,
     useDisplayBaseCurrency,
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import {
-    formatNetworkAmount,
-    isPending as getIsPending,
-    isSentTransaction,
-    isTxFeePaid,
-} from '@suite-common/wallet-utils';
+import { formatNetworkAmount, isTxFeePaid } from '@suite-common/wallet-utils';
 import { Button, Icon, Link, Row, Tooltip } from '@trezor/components';
 import { OutlineHighlight } from '@trezor/product-components';
 import { HELP_CENTER_REPLACE_BY_FEE_ETHEREUM } from '@trezor/urls';
@@ -101,14 +96,14 @@ export const TransactionItem = memo(
             selectAccountEvmNonceInfo(state, accountKey),
         );
 
+        const evmNonce =
+            network.networkType === 'ethereum' ? transaction.ethereumSpecific?.nonce : undefined;
+
         // A pending EVM tx can be stuck two ways: its nonce is above the next free nonce (a lower
         // nonce is missing — a gap), or below the confirmed nonce (that slot was already mined by
         // another tx — superseded). Either way it won't confirm; `nextNonce` is the nonce to
         // re-send with to unblock it.
-        const pendingEvmNonce =
-            isPending && network.networkType === 'ethereum'
-                ? transaction.ethereumSpecific?.nonce
-                : undefined;
+        const pendingEvmNonce = isPending ? evmNonce : undefined;
 
         const isSuperseded = pendingEvmNonce !== undefined && pendingEvmNonce < confirmedNonce;
         const hasNonceGap = pendingEvmNonce !== undefined && pendingEvmNonce > nextNonce;
@@ -122,11 +117,38 @@ export const TransactionItem = memo(
                     />
                 );
             if (hasNonceGap)
-                return <Translation id="TR_BUMP_FEE_NONCE_GAP_WARNING" values={{ nonce: nextNonce }} />;
+                return (
+                    <Translation id="TR_BUMP_FEE_NONCE_GAP_WARNING" values={{ nonce: nextNonce }} />
+                );
 
             return null;
         };
         const nonceWarning = renderNonceWarning();
+
+        // The speed-up button's tooltip surfaces the EVM nonce so the user can tell which
+        // transaction in the queue this is, and when bumping is disabled it also explains why
+        // (the nonce is woven into the disabled message itself).
+        const renderBumpFeeTooltip = () => {
+            if (disableBumpFee)
+                return (
+                    <Translation
+                        id="TR_BUMP_FEE_DISABLED_TOOLTIP"
+                        values={{
+                            nonce: evmNonce,
+                            a: chunks => (
+                                <Link href={HELP_CENTER_REPLACE_BY_FEE_ETHEREUM}>{chunks}</Link>
+                            ),
+                        }}
+                    />
+                );
+            if (evmNonce !== undefined)
+                return (
+                    <Translation id="TR_TRANSACTION_NONCE_TOOLTIP" values={{ nonce: evmNonce }} />
+                );
+
+            return null;
+        };
+        const bumpFeeTooltip = renderBumpFeeTooltip();
 
         const openTxDetailsModal = ({ flow }: OpenModalParams) => {
             if (isActionDisabled) return; // open explorer
@@ -185,22 +207,12 @@ export const TransactionItem = memo(
                                 <Row gap={12}>
                                     <Tooltip
                                         content={
-                                            <Translation
-                                                id="TR_BUMP_FEE_DISABLED_TOOLTIP"
-                                                values={{
-                                                    a: chunks => (
-                                                        <Link
-                                                            href={
-                                                                HELP_CENTER_REPLACE_BY_FEE_ETHEREUM
-                                                            }
-                                                        >
-                                                            {chunks}
-                                                        </Link>
-                                                    ),
-                                                }}
+                                            <EvmBumpFeeTooltip
+                                                isDisabled={disableBumpFee}
+                                                nonce={evmNonce}
                                             />
                                         }
-                                        isActive={disableBumpFee}
+                                        isActive={disableBumpFee || evmNonce !== undefined}
                                     >
                                         <Button
                                             intent="neutral"

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -15,14 +15,14 @@ import {
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { formatNetworkAmount, isTxFeePaid } from '@suite-common/wallet-utils';
-import { Button, Icon, Link, Row, Tooltip } from '@trezor/components';
+import { Button, Icon, Row, Tooltip } from '@trezor/components';
 import { OutlineHighlight } from '@trezor/product-components';
-import { HELP_CENTER_REPLACE_BY_FEE_ETHEREUM } from '@trezor/urls';
 
 import { SUBPAGE_NAV_HEIGHT } from 'src/constants/suite/layout';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { type WalletAccountTransaction } from 'src/types/wallet';
 
+import { EvmBumpFeeTooltip } from './EvmBumpFeeTooltip';
 import { TransactionHeading } from './TransactionHeading';
 import { TransactionLayout } from './TransactionLayout';
 import { CoinjoinRow, DepositRow, FeeRow, WithdrawalRow } from './TransactionRow';
@@ -124,31 +124,6 @@ export const TransactionItem = memo(
             return null;
         };
         const nonceWarning = renderNonceWarning();
-
-        // The speed-up button's tooltip surfaces the EVM nonce so the user can tell which
-        // transaction in the queue this is, and when bumping is disabled it also explains why
-        // (the nonce is woven into the disabled message itself).
-        const renderBumpFeeTooltip = () => {
-            if (disableBumpFee)
-                return (
-                    <Translation
-                        id="TR_BUMP_FEE_DISABLED_TOOLTIP"
-                        values={{
-                            nonce: evmNonce,
-                            a: chunks => (
-                                <Link href={HELP_CENTER_REPLACE_BY_FEE_ETHEREUM}>{chunks}</Link>
-                            ),
-                        }}
-                    />
-                );
-            if (evmNonce !== undefined)
-                return (
-                    <Translation id="TR_TRANSACTION_NONCE_TOOLTIP" values={{ nonce: evmNonce }} />
-                );
-
-            return null;
-        };
-        const bumpFeeTooltip = renderBumpFeeTooltip();
 
         const openTxDetailsModal = ({ flow }: OpenModalParams) => {
             if (isActionDisabled) return; // open explorer

--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
@@ -17,11 +17,13 @@ import type {
 } from '@suite-common/wallet-types';
 import {
     getConfirmations,
+    getEvmNonceInfo,
     getFiatRateKey,
     isCardanoStakingTx,
     isClaimTx,
     isNftTokenTransfer,
     isPending,
+    isSentTransaction,
     isStakeTx,
     isStakeTypeTx,
     isUnstakeTx,
@@ -86,6 +88,36 @@ export const selectAccountTransactionsWithNulls = (
 export const selectAccountTransactions = createMemoizedSelector(
     [selectAccountTransactionsWithNulls],
     transactions => returnStableArrayIfEmpty(transactions.filter(isNotNullOrUndefined)),
+);
+
+/**
+ * EVM nonce bounds for an account, derived once from its local tx list. Memoized per account so
+ * every pending `TransactionItem` can read the shared `{ confirmedNonce, nextNonce }` instead of
+ * each one subscribing to the full tx list and recomputing it. See `getEvmNonceInfo`.
+ */
+export const selectAccountEvmNonceInfo = createMemoizedSelector(
+    [selectAccountTransactions],
+    transactions => {
+        // Derive the confirmed nonce from the local tx list (heuristic for display; signing uses the
+        // authoritative backend nonce via fetchConfirmedNonce). Using max confirmed nonce + 1 avoids
+        // a dependency on account.misc.nonce so this selector stays tx-list-only.
+        const confirmedNonces = transactions
+            .filter(tx => !isPending(tx))
+            .filter(isSentTransaction)
+            .map(tx => tx.ethereumSpecific?.nonce)
+            .filter((n): n is number => typeof n === 'number');
+        const accountNonce = confirmedNonces.length ? Math.max(...confirmedNonces) + 1 : 0;
+        const pendingTxs = transactions.filter(isPending);
+
+        // accountNonce here is derived from the local confirmed-tx list, so it's already
+        // ground truth — unlike getEvmNonceInfo's other caller (resolveEthereumNonce), which
+        // feeds it a backend nonce that may overstate reality and needs clamping. Only reuse
+        // nextNonce from getEvmNonceInfo; keep confirmedNonce as the local ground truth so a
+        // stale pending tx below it is correctly flagged as superseded.
+        const { nextNonce } = getEvmNonceInfo(accountNonce, pendingTxs);
+
+        return { confirmedNonce: accountNonce, nextNonce };
+    },
 );
 
 export const selectPendingAccountAddresses = createMemoizedSelector(

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11413,6 +11413,16 @@ export const messages = defineMessages({
         defaultMessage:
             'To speed up your transactions, increase the fee on the oldest pending transaction in the queue (by nonce), as transactions must be confirmed in order. If you want to speed up this transaction specifically, open its detail and use the "Speed up" option. <a>Learn more</a>',
     },
+    TR_BUMP_FEE_NONCE_GAP_WARNING: {
+        id: 'TR_BUMP_FEE_NONCE_GAP_WARNING',
+        defaultMessage:
+            "There is a gap before this nonce, so it won't confirm. Re-send the transaction with nonce {nonce} to unblock it.",
+    },
+    TR_PENDING_NONCE_SUPERSEDED_WARNING: {
+        id: 'TR_PENDING_NONCE_SUPERSEDED_WARNING',
+        defaultMessage:
+            "This transaction's nonce was already used by a confirmed transaction, so it can't confirm. Re-send it with nonce {nonce}.",
+    },
     TR_TREZOR_CONNECT: {
         id: 'TR_TREZOR_CONNECT',
         defaultMessage: 'Trezor Connect',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11411,7 +11411,7 @@ export const messages = defineMessages({
     TR_BUMP_FEE_DISABLED_TOOLTIP: {
         id: 'TR_BUMP_FEE_DISABLED_TOOLTIP',
         defaultMessage:
-            'To speed up your transactions, increase the fee on the oldest pending transaction in the queue (by nonce), as transactions must be confirmed in order. If you want to speed up this transaction specifically, open its detail and use the "Speed up" option. <a>Learn more</a>',
+            'Nonce: {nonce}. To speed up your transactions, increase the fee on the oldest pending transaction in the queue (by nonce), as transactions must be confirmed in order. If you want to speed up this transaction specifically, open its detail and use the "Speed up" option. <a>Learn more</a>',
     },
     TR_BUMP_FEE_NONCE_GAP_WARNING: {
         id: 'TR_BUMP_FEE_NONCE_GAP_WARNING',
@@ -11422,6 +11422,10 @@ export const messages = defineMessages({
         id: 'TR_PENDING_NONCE_SUPERSEDED_WARNING',
         defaultMessage:
             "This transaction's nonce was already used by a confirmed transaction, so it can't confirm. Re-send it with nonce {nonce}.",
+    },
+    TR_TRANSACTION_NONCE_TOOLTIP: {
+        id: 'TR_TRANSACTION_NONCE_TOOLTIP',
+        defaultMessage: 'Nonce: {nonce}',
     },
     TR_TREZOR_CONNECT: {
         id: 'TR_TREZOR_CONNECT',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds tooltips related to nonce gap to the transaction list item

## Notes for QA

Use custom nonce on the send form to introduce the gap

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19136

## Screenshots:

<img width="1180" height="266" alt="Screenshot 2026-06-17 at 11 54 39" src="https://github.com/user-attachments/assets/137e87c3-cc1d-441a-af8b-6eff9af2f271" />

<img width="983" height="241" alt="Screenshot 2026-06-17 at 12 37 00" src="https://github.com/user-attachments/assets/7e0e2651-5f2d-49f3-814f-2ef45bf7ff6d" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/evm-pending-nonce-tooltip&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->