### PR TITLE
fix(suite-native): prevent translation clipping in NoNetworksConfigured card

### DIFF
--- a/suite-native/module-home/src/screens/HomeScreen/components/NoNetworksConfigured.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/NoNetworksConfigured.tsx
@@ -32,6 +32,7 @@ export const NoNetworksConfigured = () => {
                 <CenteredTitleHeader
                     title={<Translation id="moduleHome.emptyState.initializedDevice.title" />}
                     subtitle={<Translation id="moduleHome.emptyState.initializedDevice.subtitle" />}
+                    alignSelf="stretch"
                 />
                 <Button onPress={navigateToNetworkConfiguration} testID="@home/get-started-button">
                     <Translation id="moduleHome.emptyState.initializedDevice.button" />


### PR DESCRIPTION
## Screenshots:

| Before | After |
| --- | --- |
| <img width="1080" height="2340" alt="Screenshot_20260617_115508" src="https://github.com/user-attachments/assets/6da996f4-3543-4e40-adf3-186c0c245153" /> | <img width="1080" height="2340" alt="Screenshot_20260617_115518" src="https://github.com/user-attachments/assets/65797c65-2e41-4451-aa49-5803f49b7b77" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/wallet-is-ready-clipped&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->