### PR TITLE
feat(suite-native): tron view-only staking

### DIFF
--- a/packages/suite/src/components/earn/dashboard/staking/hooks/__tests__/useStakingAccountsVisibility.test.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/hooks/__tests__/useStakingAccountsVisibility.test.tsx
@@ -26,7 +26,7 @@ const createMockAccount = (overrides: Partial<Account>): Account =>
     }) as Account;
 
 const defaultProps = {
-    currentRates: { eth: 2000, sol: 100, ada: 0.5, thod: 2000, dsol: 100 },
+    currentRates: { eth: 2000, sol: 100, ada: 0.5, thod: 2000, dsol: 100, trx: 0.3 },
     ethNotActivated: false,
     solNotActivated: false,
     adaNotActivated: false,

--- a/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingTableData.ts
+++ b/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingTableData.ts
@@ -27,6 +27,7 @@ export const useStakingTableData = (): UseStakingTableDataResult => {
     const ethCurrentRate = useCryptoCurrentRate('eth');
     const solCurrentRate = useCryptoCurrentRate('sol');
     const adaCurrentRate = useCryptoCurrentRate('ada');
+    const trxCurrentRate = useCryptoCurrentRate('trx');
 
     const currentRates: Record<StakingNetworkSymbol, number | undefined> = useMemo(
         () => ({
@@ -35,8 +36,9 @@ export const useStakingTableData = (): UseStakingTableDataResult => {
             ada: adaCurrentRate,
             thod: ethCurrentRate,
             dsol: solCurrentRate,
+            trx: trxCurrentRate,
         }),
-        [ethCurrentRate, solCurrentRate, adaCurrentRate],
+        [ethCurrentRate, solCurrentRate, adaCurrentRate, trxCurrentRate],
     );
 
     const accounts = useSelector(selectVisibleDeviceAccounts);

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/TronStakeInANutshellModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/TronStakeInANutshellModal.tsx
@@ -13,6 +13,7 @@ import {
 } from './components/EarnInANutshellProcesses';
 import { EarnInfoRow } from './components/EarnInfoRow';
 
+// TODO: move to constants
 const TRON_UNSTAKING_PERIOD_DAYS = 14;
 
 interface TronStakeInANutshellModalProps {

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnInANutshellWithdrawalBadge.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnInANutshellWithdrawalBadge.tsx
@@ -15,6 +15,8 @@ export const EarnInANutshellWithdrawalBadge = ({
         case 'ethereum':
         case 'solana':
             return <Translation id="TR_TX_FEE_COUNT" values={{ count: 2 }} />;
+        case 'tron':
+            return null;
         default:
             return exhaustive(networkType);
     }

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/StakingEarnInANutshellHighlights.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/StakingEarnInANutshellHighlights.tsx
@@ -113,6 +113,8 @@ export const StakingEarnInANutshellHighlights = ({
                         ),
                     },
                 ];
+            case 'tron':
+                return [];
             default:
                 return exhaustive(networkType);
         }

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/UpdateEarnInANutshellHighlights.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/UpdateEarnInANutshellHighlights.tsx
@@ -61,6 +61,8 @@ export const UpdateEarnInANutshellHighlights = ({
         case 'cardano':
         case 'solana':
             return <EarnInANutshellHighlights items={highlights} />;
+        case 'tron':
+            return null;
         default:
             return exhaustive(networkType);
     }

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/components/StakingProviderConsentBanners.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/components/StakingProviderConsentBanners.tsx
@@ -68,6 +68,8 @@ export const StakingProviderConsentBanners = ({
                     />
                 </>
             );
+        case 'tron':
+            return null;
         default:
             return exhaustive(networkType);
     }

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/components/YieldProviderConsentBanners.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/components/YieldProviderConsentBanners.tsx
@@ -43,6 +43,8 @@ export const YieldProviderConsentBanners = ({
                     />
                 </>
             );
+        case 'tron':
+            return null;
         default:
             return exhaustive(networkType);
     }

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -70,6 +70,8 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
             case 'cardano':
                 dispatch(setFlag({ key: 'stakeCardanoBannerClosed', value: true }));
                 break;
+            case 'tron':
+                break;
             default:
                 if (isSupportedStakingNetworkSymbol(account.symbol)) {
                     exhaustive(
@@ -110,6 +112,8 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
                 return stakeSolBannerClosed;
             case 'cardano':
                 return stakeCardanoBannerClosed;
+            case 'tron':
+                return true;
             default:
                 if (isSupportedStakingNetworkSymbol(account.symbol)) {
                     exhaustive(

--- a/suite-common/earn-staking-api/src/index.ts
+++ b/suite-common/earn-staking-api/src/index.ts
@@ -3,5 +3,6 @@ export type * from './api/types';
 export * from './staking/hooks';
 export * from './staking/reportSolanaRewardsOutOfSync';
 export * from './staking/services';
+export * from './staking/utils';
 export type * from './staking/types';
 export * from './constants';

--- a/suite-common/earn-staking-api/src/staking/hooks/useTronStakingStats.ts
+++ b/suite-common/earn-staking-api/src/staking/hooks/useTronStakingStats.ts
@@ -15,6 +15,7 @@ export function useTronStakingStats(
     });
 
     const maxApr = stats.data?.length ? Math.max(...stats.data.map(({ apr }) => apr)) : null;
+    const formattedMaxApr = maxApr ? Number(maxApr.toFixed(2)) : null;
 
-    return { stats, maxApr };
+    return { stats, maxApr, formattedMaxApr };
 }

--- a/suite-common/earn-staking-api/src/staking/index.ts
+++ b/suite-common/earn-staking-api/src/staking/index.ts
@@ -1,4 +1,5 @@
 export * from './hooks';
 export * from './reportSolanaRewardsOutOfSync';
 export * from './services';
+export * from './utils';
 export type * from './types';

--- a/suite-common/earn-staking-api/src/staking/utils/index.ts
+++ b/suite-common/earn-staking-api/src/staking/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './tronAprUtils';

--- a/suite-common/earn-staking-api/src/staking/utils/tronAprUtils.ts
+++ b/suite-common/earn-staking-api/src/staking/utils/tronAprUtils.ts
@@ -1,0 +1,19 @@
+import { type TrxStats } from '../../api/types';
+
+export const formatTronApr = (apr: number | null | undefined): number | null =>
+    apr != null ? Number(apr.toFixed(2)) : null;
+
+export const getTronVotedApr = (
+    stats: TrxStats | undefined,
+    votedAddresses: string[],
+): number | null => {
+    if (!stats?.length || votedAddresses.length === 0) {
+        return null;
+    }
+
+    const votedAprs = stats
+        .filter(({ address }) => votedAddresses.includes(address))
+        .map(({ apr }) => apr);
+
+    return votedAprs.length ? Math.max(...votedAprs) : null;
+};

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -342,7 +342,7 @@ export const networks = {
         bip43Path: "m/44'/195'/0'/0/i",
         decimals: 6,
         testnet: false,
-        features: ['tokens', 'coin-definitions', 'graph', 'nfts'],
+        features: ['tokens', 'coin-definitions', 'graph', 'nfts', 'staking'],
         explorer: getExplorerUrls('https://tronscan.org/#', 'tron'),
         support: {
             [DeviceModelInternal.T2T1]: '2.11.0',

--- a/suite-common/wallet-types/src/index.ts
+++ b/suite-common/wallet-types/src/index.ts
@@ -2,6 +2,7 @@ export * from './account';
 export type * from './allowance';
 export type * from './backend';
 export * from './cardanoStaking';
+export * from './tronStaking';
 export type * from './discovery';
 export * from './fiatRates';
 export type * from './form';

--- a/suite-common/wallet-types/src/tronStaking.ts
+++ b/suite-common/wallet-types/src/tronStaking.ts
@@ -1,0 +1,3 @@
+export const supportedTronNetworkSymbols = ['trx'] as const;
+
+export type SupportedTronNetworkSymbols = (typeof supportedTronNetworkSymbols)[number];

--- a/suite-common/wallet-utils/src/__tests__/tronStakingUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/tronStakingUtils.test.ts
@@ -1,0 +1,283 @@
+import { type Account } from '@suite-common/wallet-types';
+import {
+    type TronStakingInfo,
+    type TronUnstakingBatch,
+    type TronVote,
+} from '@trezor/blockchain-link-types';
+
+import {
+    getTronAccountTotalStakingBalance,
+    getTronAvailableVotingPower,
+    getTronCryptoBalanceWithStaking,
+    getTronPendingUnstakeBalance,
+    getTronResources,
+    getTronStakingInfo,
+    getTronStakingRewards,
+    getTronTotalVotingPower,
+    getTronUnstakingBalance,
+    getTronVotes,
+    getTronWithdrawableBalance,
+    isSupportedTronStakingNetworkSymbol,
+    isTronStakingActive,
+} from '../tronStakingUtils';
+
+const TRX = 1_000_000;
+const NOW_SECONDS = 1_700_000_000;
+
+const buildStakingInfo = (overrides: Partial<TronStakingInfo> = {}): TronStakingInfo => ({
+    stakedBalance: '0',
+    stakedBalanceEnergy: '0',
+    stakedBalanceBandwidth: '0',
+    unstakingBatches: [],
+    totalVotingPower: '0',
+    availableVotingPower: '0',
+    votes: [],
+    unclaimedReward: '0',
+    delegatedBalanceEnergy: '0',
+    delegatedBalanceBandwidth: '0',
+    ...overrides,
+});
+
+const buildBatch = (amount: string, expireTime: number): TronUnstakingBatch => ({
+    amount,
+    expireTime,
+});
+
+interface TronAccountOverrides {
+    formattedBalance?: string;
+    stakingInfo?: TronStakingInfo;
+}
+
+const buildTronAccount = ({
+    formattedBalance = '0',
+    stakingInfo,
+}: TronAccountOverrides = {}): Account =>
+    ({
+        symbol: 'trx',
+        networkType: 'tron',
+        formattedBalance,
+        misc: {
+            tronResources: {
+                availableStakedBandwidth: 0,
+                totalStakedBandwidth: 0,
+                availableFreeBandwidth: 0,
+                totalFreeBandwidth: 0,
+                availableEnergy: 0,
+                totalEnergy: 0,
+                totalEnergyLimit: 0,
+                totalEnergyWeight: 0,
+                totalBandwidthLimit: 0,
+                totalBandwidthWeight: 0,
+                stakingInfo,
+            },
+        },
+    }) as unknown as Account;
+
+const buildNonTronAccount = (): Account =>
+    ({
+        symbol: 'eth',
+        networkType: 'ethereum',
+        formattedBalance: '0',
+        misc: {},
+    }) as unknown as Account;
+
+describe('isSupportedTronStakingNetworkSymbol', () => {
+    it('returns true for trx', () => {
+        expect(isSupportedTronStakingNetworkSymbol('trx')).toBe(true);
+    });
+
+    it('returns false for non-Tron symbols', () => {
+        expect(isSupportedTronStakingNetworkSymbol('btc')).toBe(false);
+        expect(isSupportedTronStakingNetworkSymbol('eth')).toBe(false);
+        // testnet Tron is not in the supported list
+        expect(isSupportedTronStakingNetworkSymbol('ttrx')).toBe(false);
+    });
+});
+
+describe('getTronResources', () => {
+    it('returns undefined when no account is provided', () => {
+        expect(getTronResources()).toBeUndefined();
+    });
+
+    it('returns undefined for non-Tron accounts', () => {
+        expect(getTronResources(buildNonTronAccount())).toBeUndefined();
+    });
+
+    it('returns the tronResources for Tron accounts', () => {
+        const stakingInfo = buildStakingInfo({ stakedBalance: '1000000' });
+        const account = buildTronAccount({ stakingInfo });
+        expect(getTronResources(account)?.stakingInfo).toBe(stakingInfo);
+    });
+});
+
+describe('getTronStakingInfo', () => {
+    it('returns undefined when no account is provided', () => {
+        expect(getTronStakingInfo()).toBeUndefined();
+    });
+
+    it('returns undefined when the account has no stakingInfo', () => {
+        expect(getTronStakingInfo(buildTronAccount())).toBeUndefined();
+    });
+
+    it('returns the stakingInfo when present', () => {
+        const stakingInfo = buildStakingInfo({ stakedBalance: '1000000' });
+        expect(getTronStakingInfo(buildTronAccount({ stakingInfo }))).toBe(stakingInfo);
+    });
+});
+
+describe('isTronStakingActive', () => {
+    it('returns false for a null account', () => {
+        expect(isTronStakingActive(null)).toBe(false);
+    });
+
+    it('returns false when there is no stakingInfo', () => {
+        expect(isTronStakingActive(buildTronAccount())).toBe(false);
+    });
+
+    it('returns false when the staked balance is zero', () => {
+        const account = buildTronAccount({ stakingInfo: buildStakingInfo({ stakedBalance: '0' }) });
+        expect(isTronStakingActive(account)).toBe(false);
+    });
+
+    it('returns true when the staked balance is greater than zero', () => {
+        const account = buildTronAccount({
+            stakingInfo: buildStakingInfo({ stakedBalance: '1' }),
+        });
+        expect(isTronStakingActive(account)).toBe(true);
+    });
+});
+
+describe('getTronAccountTotalStakingBalance', () => {
+    it('returns null when there is no stakingInfo', () => {
+        expect(getTronAccountTotalStakingBalance(buildTronAccount())).toBeNull();
+    });
+
+    it('converts the staked balance from Sun to TRX', () => {
+        const account = buildTronAccount({
+            stakingInfo: buildStakingInfo({ stakedBalance: String(5 * TRX) }),
+        });
+        expect(getTronAccountTotalStakingBalance(account)).toBe('5');
+    });
+});
+
+describe('getTronCryptoBalanceWithStaking', () => {
+    it('returns the spendable balance when there is no stakingInfo', () => {
+        const account = buildTronAccount({ formattedBalance: '10' });
+        expect(getTronCryptoBalanceWithStaking(account)).toBe('10');
+    });
+
+    it('adds the staked balance (in TRX) to the spendable balance', () => {
+        const account = buildTronAccount({
+            formattedBalance: '10',
+            stakingInfo: buildStakingInfo({ stakedBalance: String(5 * TRX) }),
+        });
+        expect(getTronCryptoBalanceWithStaking(account)).toBe('15');
+    });
+});
+
+describe('getTronStakingRewards', () => {
+    it('returns 0 when there is no stakingInfo', () => {
+        expect(getTronStakingRewards(buildTronAccount())).toBe('0');
+    });
+
+    it('converts the unclaimed reward from Sun to TRX', () => {
+        const account = buildTronAccount({
+            stakingInfo: buildStakingInfo({ unclaimedReward: String(2 * TRX) }),
+        });
+        expect(getTronStakingRewards(account)).toBe('2');
+    });
+});
+
+describe('Tron unstaking balances', () => {
+    beforeEach(() => {
+        jest.spyOn(Date, 'now').mockReturnValue(NOW_SECONDS * 1000);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    const accountWithBatches = buildTronAccount({
+        stakingInfo: buildStakingInfo({
+            unstakingBatches: [
+                // withdrawable
+                buildBatch(String(4 * TRX), NOW_SECONDS - 100),
+                // still pending
+                buildBatch(String(6 * TRX), NOW_SECONDS + 100),
+            ],
+        }),
+    });
+
+    describe('getTronUnstakingBalance', () => {
+        it('returns 0 when there is no stakingInfo', () => {
+            expect(getTronUnstakingBalance(buildTronAccount())).toBe('0');
+        });
+
+        it('sums all unstaking batches regardless of expiry', () => {
+            expect(getTronUnstakingBalance(accountWithBatches)).toBe('10');
+        });
+    });
+
+    describe('getTronWithdrawableBalance', () => {
+        it('sums only batches whose expireTime has passed', () => {
+            expect(getTronWithdrawableBalance(accountWithBatches)).toBe('4');
+        });
+
+        it('treats a batch expiring exactly now as withdrawable', () => {
+            const account = buildTronAccount({
+                stakingInfo: buildStakingInfo({
+                    unstakingBatches: [buildBatch(String(3 * TRX), NOW_SECONDS)],
+                }),
+            });
+            expect(getTronWithdrawableBalance(account)).toBe('3');
+        });
+    });
+
+    describe('getTronPendingUnstakeBalance', () => {
+        it('sums only batches that have not yet expired', () => {
+            expect(getTronPendingUnstakeBalance(accountWithBatches)).toBe('6');
+        });
+    });
+});
+
+describe('getTronVotes', () => {
+    it('returns an empty array when no account is provided', () => {
+        expect(getTronVotes()).toEqual([]);
+    });
+
+    it('returns an empty array when there is no stakingInfo', () => {
+        expect(getTronVotes(buildTronAccount())).toEqual([]);
+    });
+
+    it('returns the votes when present', () => {
+        const votes: TronVote[] = [{ address: 'TSR...', voteCount: '100' }];
+        const account = buildTronAccount({ stakingInfo: buildStakingInfo({ votes }) });
+        expect(getTronVotes(account)).toBe(votes);
+    });
+});
+
+describe('getTronTotalVotingPower', () => {
+    it('returns 0 when there is no stakingInfo', () => {
+        expect(getTronTotalVotingPower(buildTronAccount())).toBe('0');
+    });
+
+    it('returns the total voting power when present', () => {
+        const account = buildTronAccount({
+            stakingInfo: buildStakingInfo({ totalVotingPower: '42' }),
+        });
+        expect(getTronTotalVotingPower(account)).toBe('42');
+    });
+});
+
+describe('getTronAvailableVotingPower', () => {
+    it('returns 0 when there is no stakingInfo', () => {
+        expect(getTronAvailableVotingPower(buildTronAccount())).toBe('0');
+    });
+
+    it('returns the available voting power when present', () => {
+        const account = buildTronAccount({
+            stakingInfo: buildStakingInfo({ availableVotingPower: '7' }),
+        });
+        expect(getTronAvailableVotingPower(account)).toBe('7');
+    });
+});

--- a/suite-common/wallet-utils/src/index.ts
+++ b/suite-common/wallet-utils/src/index.ts
@@ -35,3 +35,4 @@ export * from './bigNumberUtils';
 export * from './feeUnitUtils';
 export * from './stellarTokens';
 export * from './tronUtils';
+export * from './tronStakingUtils';

--- a/suite-common/wallet-utils/src/stakingUtils.ts
+++ b/suite-common/wallet-utils/src/stakingUtils.ts
@@ -59,6 +59,12 @@ import {
     getSolStakingAccountsInfo,
     isSupportedSolStakingNetworkSymbol,
 } from './solanaStakingUtils';
+import {
+    getTronAccountTotalStakingBalance,
+    getTronStakingRewards,
+    getTronUnstakingBalance,
+    isSupportedTronStakingNetworkSymbol,
+} from './tronStakingUtils';
 
 export const secondsToDays = (seconds: number) => Math.round(seconds / 60 / 60 / 24);
 
@@ -72,6 +78,7 @@ const STAKING_BALANCE_BY_TYPE = {
     ethereum: getEthAccountTotalStakingBalance,
     solana: getSolAccountTotalStakingBalance,
     cardano: getAdaAccountTotalStakingBalance,
+    tron: getTronAccountTotalStakingBalance,
 } satisfies Record<StakingNetworkType, (a: Account) => string | null>;
 
 export const getAccountTotalStakingBalance = (account: Account) =>
@@ -82,7 +89,8 @@ export const getAccountTotalStakingBalance = (account: Account) =>
 export const isSupportedStakingNetworkSymbol = (symbol: NetworkSymbol) =>
     isSupportedEthStakingNetworkSymbol(symbol) ||
     isSupportedSolStakingNetworkSymbol(symbol) ||
-    isSupportedAdaStakingNetworkSymbol(symbol);
+    isSupportedAdaStakingNetworkSymbol(symbol) ||
+    isSupportedTronStakingNetworkSymbol(symbol);
 
 export const isSupportedNativeStakingManagementSymbol = (symbol: NetworkSymbol) =>
     isSupportedEthStakingNetworkSymbol(symbol) || isSupportedSolStakingNetworkSymbol(symbol);
@@ -126,6 +134,9 @@ export const getStakingLimitsByNetworkSymbol = (
                 MIN_BALANCE_FOR_FEE_BUFFER: MIN_ETH_BALANCE_FOR_FEE_BUFFER,
                 MIN_BALANCE_FOR_STAKING: MIN_CARDANO_BALANCE_FOR_STAKING,
             };
+
+        case 'trx':
+            return null;
 
         default:
             return exhaustive(symbol);
@@ -195,6 +206,23 @@ export const getStakingDataForNetwork = (
                 canClaim: false,
             };
         }
+
+        case 'tron': {
+            const stakedBalance = getTronAccountTotalStakingBalance(account) ?? '';
+
+            return {
+                autocompoundBalance: stakedBalance,
+                claimableAmount: '',
+                depositedBalance: stakedBalance,
+                pendingBalance: '',
+                pendingDepositedBalance: '',
+                totalPendingStakeBalance: '',
+                restakedReward: getTronStakingRewards(account),
+                withdrawTotalAmount: getTronUnstakingBalance(account),
+                canClaim: false,
+            };
+        }
+
         default:
             return exhaustive(account.networkType);
     }
@@ -215,6 +243,11 @@ export const getUnstakingPeriodInDays = (
 
     if (networkType === 'cardano') {
         return CARDANO_EPOCH_DAYS;
+    }
+
+    if (networkType === 'tron') {
+        // TODO: move to constants
+        return 14;
     }
 
     if (typeof withdrawTime !== 'number' || typeof exitTime !== 'number') {

--- a/suite-common/wallet-utils/src/tronStakingUtils.ts
+++ b/suite-common/wallet-utils/src/tronStakingUtils.ts
@@ -1,0 +1,100 @@
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type Account,
+    type SupportedTronNetworkSymbols,
+    supportedTronNetworkSymbols,
+} from '@suite-common/wallet-types';
+import {
+    type TronAccountExtraData,
+    type TronStakingInfo,
+    type TronUnstakingBatch,
+    type TronVote,
+} from '@trezor/blockchain-link-types';
+import { BigNumber, isArrayMember } from '@trezor/utils';
+
+import { asAmountSubunit } from './AmountTypes';
+import { subunitsToUnits } from './amountUtils';
+
+export function isSupportedTronStakingNetworkSymbol(
+    symbol: NetworkSymbol,
+): symbol is SupportedTronNetworkSymbols {
+    return isArrayMember(symbol, supportedTronNetworkSymbols);
+}
+
+const sunToTrx = (sun: string, symbol: NetworkSymbol) =>
+    subunitsToUnits({
+        value: asAmountSubunit(new BigNumber(sun)),
+        symbol,
+    }).toString();
+
+export const getTronResources = (account?: Account): TronAccountExtraData | undefined =>
+    account?.networkType === 'tron' ? account.misc?.tronResources : undefined;
+
+export const getTronStakingInfo = (account?: Account): TronStakingInfo | undefined =>
+    getTronResources(account)?.stakingInfo;
+
+export const isTronStakingActive = (account: Account | null): boolean => {
+    const stakingInfo = getTronStakingInfo(account ?? undefined);
+    if (!stakingInfo) return false;
+
+    return new BigNumber(stakingInfo.stakedBalance).isGreaterThan(0);
+};
+
+export const getTronAccountTotalStakingBalance = (account: Account): string | null => {
+    const stakingInfo = getTronStakingInfo(account);
+    if (!stakingInfo) return null;
+
+    return sunToTrx(stakingInfo.stakedBalance, account.symbol);
+};
+
+export const getTronCryptoBalanceWithStaking = (account: Account): string => {
+    const stakingBalance = getTronAccountTotalStakingBalance(account) ?? '0';
+
+    return new BigNumber(account.formattedBalance).plus(stakingBalance).toString();
+};
+
+export const getTronStakingRewards = (account: Account): string => {
+    const stakingInfo = getTronStakingInfo(account);
+    if (!stakingInfo) return '0';
+
+    return sunToTrx(stakingInfo.unclaimedReward, account.symbol);
+};
+
+const sumUnstakingBatchesSun = (
+    account: Account,
+    predicate: (batch: TronUnstakingBatch) => boolean,
+): string => {
+    const stakingInfo = getTronStakingInfo(account);
+    if (!stakingInfo) return '0';
+
+    const totalSun = stakingInfo.unstakingBatches.reduce(
+        (acc, batch) => (predicate(batch) ? acc.plus(batch.amount) : acc),
+        new BigNumber(0),
+    );
+
+    return sunToTrx(totalSun.toString(), account.symbol);
+};
+
+export const getTronUnstakingBalance = (account: Account): string =>
+    sumUnstakingBatchesSun(account, () => true);
+
+export const getTronWithdrawableBalance = (account: Account): string => {
+    const nowSeconds = Date.now() / 1000;
+
+    return sumUnstakingBatchesSun(account, batch => batch.expireTime <= nowSeconds);
+};
+
+export const getTronPendingUnstakeBalance = (account: Account): string => {
+    const nowSeconds = Date.now() / 1000;
+
+    return sumUnstakingBatchesSun(account, batch => batch.expireTime > nowSeconds);
+};
+
+export const getTronVotes = (account?: Account): TronVote[] =>
+    getTronStakingInfo(account)?.votes ?? [];
+
+export const getTronTotalVotingPower = (account?: Account): string =>
+    getTronStakingInfo(account)?.totalVotingPower ?? '0';
+
+export const getTronAvailableVotingPower = (account?: Account): string =>
+    getTronStakingInfo(account)?.availableVotingPower ?? '0';

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2994,6 +2994,21 @@ export const messages = {
         rewards: 'Rewards',
         rewardsPerEpoch: 'Next estimated reward',
         apy: 'Annual Percentage Yield',
+        apr: 'Annual Percentage Return',
+        tron: {
+            votes: 'Votes',
+            allVotesUsed: 'All {count} votes used',
+            votesRemaining:
+                '{count, plural, one {1 remaining vote} other {{count} remaining votes}}',
+            votesBottomSheet: {
+                title: 'Assign all votes to earn more rewards.',
+                description: 'Staking can be currently managed only in Trezor Suite for desktop.',
+            },
+            votesAlertText:
+                'Assign {count, plural, one {1 remaining vote} other {{count} remaining votes}} to earn more rewards.',
+            readyToWithdrawAlert: '{amount} TRX unstaked & ready to be withdrawn.',
+            unstakingCardTitle: 'Unstaking (~{days} days)',
+        },
         stakingCanBeManaged: 'Staking is currently only available with',
         trezorDesktop: 'the Trezor Suite desktop and web apps.',
         adaStaysFullyAccessuble: 'Your ADA stays fully accessible while earning rewards.',

--- a/suite-native/module-earn/src/components/EarnAccountCard.tsx
+++ b/suite-native/module-earn/src/components/EarnAccountCard.tsx
@@ -1,6 +1,11 @@
 import { useSelector } from 'react-redux';
 
 import { selectIsPortfolioTrackerDevice } from '@suite-common/device';
+import {
+    formatTronApr,
+    getTronVotedApr,
+    useTronStakingStats,
+} from '@suite-common/earn-staking-api';
 import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import {
     isSupportedSolStakingNetworkSymbol,
@@ -15,6 +20,8 @@ import {
     selectCanClaimByAccountKey,
     selectClaimableAmountByAccountKey,
     selectIsCardanoStakedOutsideEverstake,
+    selectTronAvailableVotingPowerByAccountKey,
+    selectTronVotesByAccountKey,
     useSelector as useStakingSelector,
 } from '@suite-native/staking';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
@@ -24,6 +31,7 @@ import { EarnClaimAlert } from './EarnClaimAlert';
 import { useMessageSystemStaking } from '../hooks/useMessageSystemStaking';
 import { useSolanaStakingFlag } from '../hooks/useSolanaStakingFlag';
 import { type EarnDepositsCardActiveItem } from '../types';
+import { EarnTronVotingAlert } from './EarnTronVotingAlert';
 
 const itemCardStyle = prepareNativeStyle(utils => ({
     marginBottom: utils.spacings.sp16,
@@ -74,13 +82,35 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const isSolanaStakingEnabled = useSolanaStakingFlag();
 
+    const symbol = isStakingItem ? item.symbol : item.networkSymbol;
+
     const apy = useStakingSelector(state =>
         isStakingItem
             ? selectApy(state, { accountKey: item.accountKey, networkSymbol: item.symbol })
             : null,
     );
 
-    const apyValue = isStakingItem ? apy : item.apy;
+    const { stats: tronStats, formattedMaxApr: tronMaxApr } = useTronStakingStats({
+        enabled: isStakingItem && item.symbol === 'trx',
+    });
+
+    const tronVotes = useStakingSelector(state =>
+        selectTronVotesByAccountKey(state, item.accountKey),
+    );
+
+    const votedTronApr = getTronVotedApr(
+        tronStats.data,
+        tronVotes.map(({ address }) => address),
+    );
+
+    const tronApr = formatTronApr(votedTronApr ?? tronMaxApr);
+
+    const resolvedApy = symbol === 'trx' ? tronApr : apy;
+    const apyValue = isStakingItem ? resolvedApy : item.apy;
+
+    const availableTronVotingPower = useStakingSelector(state =>
+        selectTronAvailableVotingPowerByAccountKey(state, item.accountKey),
+    );
 
     const isAdaStakedOutsideEverstake = useStakingSelector(state =>
         selectIsCardanoStakedOutsideEverstake(state, item.accountKey),
@@ -102,7 +132,9 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
     const showClaimAlert =
         canClaim && !isClaimingDisabled && !isPortfolioTrackerDevice && !isSolClaimHidden;
 
-    const symbol = isStakingItem ? item.symbol : item.networkSymbol;
+    const showTronVotingAlert =
+        isStakingItem && item.symbol === 'trx' && availableTronVotingPower !== '0';
+
     const contractAddress = isStablecoinYieldItem ? item.tokenContractAddress : undefined;
     const secondaryDescription = isStablecoinYieldItem
         ? item.accountLabel || getNetworkDisplaySymbolName(item.networkSymbol)
@@ -146,12 +178,17 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
                     <Icon name="caretRight" size="mediumLarge" color="contentSecondary" />
                 </Box>
             </PressableOpacity>
+
             {showClaimAlert && (
                 <EarnClaimAlert
                     claimableAmount={claimableAmount}
                     symbol={symbol}
                     onClaimPress={onClaimPress}
                 />
+            )}
+
+            {showTronVotingAlert && (
+                <EarnTronVotingAlert votesRemaining={availableTronVotingPower} />
             )}
         </Card>
     );

--- a/suite-native/module-earn/src/components/EarnItemOverviewSection.tsx
+++ b/suite-native/module-earn/src/components/EarnItemOverviewSection.tsx
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux';
 
+import { useTronStakingStats } from '@suite-common/earn-staking-api';
 import {
     selectFormattedAccountType,
     selectHasRunningDiscovery,
@@ -81,13 +82,20 @@ export const EarnItemOverviewSection = (item: EarnPromoItem) => {
         }),
     );
 
+    const { formattedMaxApr: tronMaxApr } = useTronStakingStats({
+        enabled: item.type === 'staking' && item.symbol === 'trx',
+    });
+
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     const isAdaStakedOutsideEverstake = useNativeStakingSelector(state =>
         accountKey ? selectIsCardanoStakedOutsideEverstake(state, accountKey) : false,
     );
 
-    const apyValue = item.type === 'staking' ? apy : item.apy;
+    const symbol = item.type === 'staking' ? item.symbol : item.networkSymbol;
+
+    const resolvedApy = symbol === 'trx' ? tronMaxApr : apy;
+    const apyValue = item.type === 'staking' ? resolvedApy : item.apy;
 
     const iconProps =
         item.type === 'staking'

--- a/suite-native/module-earn/src/components/EarnTronVotingAlert.tsx
+++ b/suite-native/module-earn/src/components/EarnTronVotingAlert.tsx
@@ -1,0 +1,27 @@
+import { Box, InlineAlertBox } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+const alertStyle = prepareNativeStyle(utils => ({
+    marginHorizontal: utils.spacings.sp16,
+    marginBottom: utils.spacings.sp12,
+}));
+
+interface EarnTronVotingAlertProps {
+    votesRemaining: string;
+}
+
+export const EarnTronVotingAlert = ({ votesRemaining }: EarnTronVotingAlertProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <Box style={applyStyle(alertStyle)}>
+            <InlineAlertBox
+                variant="warning"
+                title={
+                    <Translation id="earn.tron.votesAlertText" values={{ count: votesRemaining }} />
+                }
+            />
+        </Box>
+    );
+};

--- a/suite-native/module-earn/src/components/ManualStakedBalancesCard.tsx
+++ b/suite-native/module-earn/src/components/ManualStakedBalancesCard.tsx
@@ -1,13 +1,19 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { Box, Card, PressableOpacity, Text } from '@suite-native/atoms';
+import { Box, Card, PressableOpacity, Text, useBottomSheetModal } from '@suite-native/atoms';
 import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import { selectStakedBalanceByAccountKey, useSelector } from '@suite-native/staking';
+import {
+    selectStakedBalanceByAccountKey,
+    selectTronAvailableVotingPowerByAccountKey,
+    selectTronTotalVotingPowerByAccountKey,
+    useSelector,
+} from '@suite-native/staking';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { ApyValue } from './ApyValue';
+import { TronStakingVotesBottomSheet } from './TronStakingVotesBottomSheet';
 
 const stakingItemStyle = prepareNativeStyle(utils => ({
     flexDirection: 'row',
@@ -28,6 +34,17 @@ const separatorStyle = prepareNativeStyle(utils => ({
     borderBottomColor: utils.colors.borderNeutral,
 }));
 
+const votesValueStyle = prepareNativeStyle(utils => ({
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: utils.spacings.sp4,
+}));
+
+const remainingVotesStyle = prepareNativeStyle(utils => ({
+    textDecorationLine: 'underline',
+    marginLeft: utils.spacings.sp4,
+}));
+
 type ManualStakedBalancesCardProps = {
     accountKey: AccountKey;
     symbol: NetworkSymbol | null;
@@ -46,8 +63,18 @@ export const ManualStakedBalancesCard = ({
     handleToggleBottomSheet,
 }: ManualStakedBalancesCardProps) => {
     const { applyStyle } = useNativeStyles();
+    const tronVotesModal = useBottomSheetModal();
 
     const stakedBalance = useSelector(state => selectStakedBalanceByAccountKey(state, accountKey));
+
+    const isTron = symbol === 'trx';
+
+    const totalVotingPower = useSelector(state =>
+        selectTronTotalVotingPowerByAccountKey(state, accountKey),
+    );
+    const availableVotingPower = useSelector(state =>
+        selectTronAvailableVotingPowerByAccountKey(state, accountKey),
+    );
 
     if (!symbol) return null;
 
@@ -58,74 +85,133 @@ export const ManualStakedBalancesCard = ({
     );
 
     return (
-        <PressableOpacity onPress={() => handleToggleBottomSheet(true)}>
-            <Card>
-                <Box style={applyStyle(stakingWrapperStyle)}>
-                    <Box flex={1}>
-                        <Box style={applyStyle(stakingItemStyle)}>
-                            <Icon name="lock" color="contentSecondary" size="medium" />
-                            <Text color="contentSecondary" variant="body-xs">
-                                <Translation id="earn.staked" />
-                            </Text>
-                        </Box>
-                        <CryptoAmountFormatter
-                            value={stakedBalance}
-                            symbol={symbol}
-                            decimals={CRYPTO_BALANCE_DECIMALS}
-                            color="contentPrimary"
-                            variant="headline-sm"
-                        />
-                        <Box flexDirection="row">
-                            <Text color="contentSecondary">≈</Text>
-                            <CryptoToFiatAmountFormatter
+        <>
+            <PressableOpacity onPress={() => handleToggleBottomSheet(true)}>
+                <Card>
+                    <Box style={applyStyle(stakingWrapperStyle)}>
+                        <Box flex={1}>
+                            <Box style={applyStyle(stakingItemStyle)}>
+                                <Icon name="lock" color="contentSecondary" size="medium" />
+                                <Text color="contentSecondary" variant="body-xs">
+                                    <Translation id="earn.staked" />
+                                </Text>
+                            </Box>
+                            <CryptoAmountFormatter
                                 value={stakedBalance}
                                 symbol={symbol}
-                                color="contentSecondary"
-                                isBalance
+                                decimals={CRYPTO_BALANCE_DECIMALS}
+                                color="contentPrimary"
+                                variant="headline-sm"
                             />
+                            <Box flexDirection="row">
+                                <Text color="contentSecondary">≈</Text>
+                                <CryptoToFiatAmountFormatter
+                                    value={stakedBalance}
+                                    symbol={symbol}
+                                    color="contentSecondary"
+                                    isBalance
+                                />
+                            </Box>
                         </Box>
-                    </Box>
-                    <Box flex={1}>
-                        <Box style={applyStyle(stakingItemStyle)}>
-                            <Icon name="plusCircle" color="contentSecondary" size="medium" />
-                            <Text color="contentSecondary" variant="body-xs">
-                                {rewardsTitle}
-                            </Text>
-                        </Box>
-                        <CryptoAmountFormatter
-                            value={rewardsBalance}
-                            symbol={symbol}
-                            decimals={CRYPTO_BALANCE_DECIMALS}
-                            color="contentBrand"
-                            variant="headline-sm"
-                        />
-                        <Box flexDirection="row">
-                            <Text color="contentSecondary">≈</Text>
-                            <CryptoToFiatAmountFormatter
+
+                        <Box flex={1}>
+                            <Box style={applyStyle(stakingItemStyle)}>
+                                <Icon name="plusCircle" color="contentSecondary" size="medium" />
+                                <Text color="contentSecondary" variant="body-xs">
+                                    {rewardsTitle}
+                                </Text>
+                            </Box>
+                            <CryptoAmountFormatter
                                 value={rewardsBalance}
                                 symbol={symbol}
-                                color="contentSecondary"
-                                isBalance
+                                decimals={CRYPTO_BALANCE_DECIMALS}
+                                color="contentBrand"
+                                variant="headline-sm"
                             />
+                            <Box flexDirection="row">
+                                <Text color="contentSecondary">≈</Text>
+                                <CryptoToFiatAmountFormatter
+                                    value={rewardsBalance}
+                                    symbol={symbol}
+                                    color="contentSecondary"
+                                    isBalance
+                                />
+                            </Box>
                         </Box>
                     </Box>
-                </Box>
-                <Box style={applyStyle(separatorStyle)} />
 
-                <Box
-                    flexDirection="row"
-                    alignItems="center"
-                    justifyContent="space-between"
-                    paddingTop="sp16"
-                >
-                    <Text color="contentSecondary">
-                        <Translation id="earn.apy" />
-                    </Text>
-                    <Text>
-                        <ApyValue apy={apy} />
-                    </Text>
-                </Box>
-            </Card>
-        </PressableOpacity>
+                    <Box style={applyStyle(separatorStyle)} />
+
+                    <Box
+                        flexDirection="row"
+                        alignItems="center"
+                        justifyContent="space-between"
+                        paddingTop="sp16"
+                    >
+                        <Text color="contentSecondary">
+                            <Translation id={isTron ? 'earn.apr' : 'earn.apy'} />
+                        </Text>
+
+                        <Text>
+                            <ApyValue apy={apy} />
+                        </Text>
+                    </Box>
+
+                    {isTron && (
+                        <Box paddingTop="sp16">
+                            <Box style={applyStyle(separatorStyle)} />
+
+                            <Box
+                                flexDirection="row"
+                                alignItems="center"
+                                justifyContent="space-between"
+                                paddingTop="sp16"
+                            >
+                                <Text color="contentSecondary">
+                                    <Translation id="earn.tron.votes" />
+                                </Text>
+
+                                <Box style={applyStyle(votesValueStyle)}>
+                                    {availableVotingPower === '0' ? (
+                                        <Text variant="body-sm-strong">
+                                            <Translation
+                                                id="earn.tron.allVotesUsed"
+                                                values={{ count: totalVotingPower }}
+                                            />
+                                        </Text>
+                                    ) : (
+                                        <PressableOpacity onPress={tronVotesModal.openModal}>
+                                            <Box flexDirection="row" alignItems="center">
+                                                <Icon
+                                                    name="warning"
+                                                    color="contentWarning"
+                                                    size="medium"
+                                                />
+
+                                                <Text
+                                                    style={applyStyle(remainingVotesStyle)}
+                                                    variant="body-sm-strong"
+                                                    color="contentWarning"
+                                                >
+                                                    <Translation
+                                                        id="earn.tron.votesRemaining"
+                                                        values={{ count: availableVotingPower }}
+                                                    />
+                                                </Text>
+                                            </Box>
+                                        </PressableOpacity>
+                                    )}
+                                </Box>
+                            </Box>
+                        </Box>
+                    )}
+                </Card>
+            </PressableOpacity>
+
+            <TronStakingVotesBottomSheet
+                ref={tronVotesModal.bottomSheetRef}
+                onClose={tronVotesModal.closeModal}
+            />
+        </>
     );
 };

--- a/suite-native/module-earn/src/components/StakingBalancesOverviewCard.tsx
+++ b/suite-native/module-earn/src/components/StakingBalancesOverviewCard.tsx
@@ -1,9 +1,15 @@
+import {
+    formatTronApr,
+    getTronVotedApr,
+    useTronStakingStats,
+} from '@suite-common/earn-staking-api';
 import { selectAccountNetworkSymbol, useAccountsSelector } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import {
     AUTO_STAKED_SYMBOLS,
     selectApy,
     selectRewardsBalanceByAccountKey,
+    selectTronVotesByAccountKey,
     useSelector as useNativeStakingSelector,
 } from '@suite-native/staking';
 
@@ -25,6 +31,21 @@ export const StakingBalancesOverviewCard = ({
         selectApy(state, { accountKey, networkSymbol: symbol ?? undefined }),
     );
 
+    const { stats: tronStats, formattedMaxApr: tronMaxApr } = useTronStakingStats({
+        enabled: symbol === 'trx',
+    });
+
+    const tronVotes = useNativeStakingSelector(state =>
+        selectTronVotesByAccountKey(state, accountKey),
+    );
+
+    const votedTronApr = getTronVotedApr(
+        tronStats.data,
+        tronVotes.map(({ address }) => address),
+    );
+
+    const tronApr = formatTronApr(votedTronApr ?? tronMaxApr);
+
     const rewardsBalance = useNativeStakingSelector(state =>
         selectRewardsBalanceByAccountKey(state, accountKey),
     );
@@ -32,13 +53,14 @@ export const StakingBalancesOverviewCard = ({
     if (!symbol) return null;
 
     const isAutoStaked = AUTO_STAKED_SYMBOLS.includes(symbol);
+    const apyValue = symbol === 'trx' ? tronApr : apy;
 
     return isAutoStaked ? (
         <AutoStakedBalancesCard
             accountKey={accountKey}
             symbol={symbol}
             rewardsBalance={rewardsBalance}
-            apy={apy}
+            apy={apyValue}
             handleToggleBottomSheet={handleToggleBottomSheet}
         />
     ) : (
@@ -46,7 +68,7 @@ export const StakingBalancesOverviewCard = ({
             accountKey={accountKey}
             symbol={symbol}
             rewardsBalance={rewardsBalance}
-            apy={apy}
+            apy={apyValue}
             handleToggleBottomSheet={handleToggleBottomSheet}
         />
     );

--- a/suite-native/module-earn/src/components/StakingInfo.tsx
+++ b/suite-native/module-earn/src/components/StakingInfo.tsx
@@ -10,6 +10,8 @@ import { StakeClaimableCard } from './StakeClaimableCard';
 import { StakePendingCard } from './StakePendingCard';
 import { StakingBalancesOverviewCard } from './StakingBalancesOverviewCard';
 import { StakingUnavailableBottomSheet } from './StakingUnavailableBottomSheet';
+import { TronStakingUnstakeCard } from './TronStakingUnstakeCard';
+import { TronStakingWithdrawBanner } from './TronStakingWithdrawBanner';
 
 const sectionStyle = prepareNativeStyle(utils => ({
     paddingHorizontal: utils.spacings.sp8,
@@ -42,6 +44,9 @@ export const StakingInfo = ({ accountKey }: StakingInfoProps) => {
             <StakeClaimableCard accountKey={accountKey} />
 
             <CardanoStakingInfoBanner accountKey={accountKey} />
+
+            <TronStakingWithdrawBanner accountKey={accountKey} />
+            <TronStakingUnstakeCard accountKey={accountKey} />
 
             <StakingBalancesOverviewCard
                 accountKey={accountKey}

--- a/suite-native/module-earn/src/components/TronStakingUnstakeCard.tsx
+++ b/suite-native/module-earn/src/components/TronStakingUnstakeCard.tsx
@@ -1,0 +1,61 @@
+import { selectAccountByKey } from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+import { Box, Card, Text } from '@suite-native/atoms';
+import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
+import { Translation } from '@suite-native/intl';
+import {
+    selectTronPendingUnstakeBalanceByAccountKey,
+    selectUnstakingPeriodInDaysByAccountKey,
+    useSelector as useStakingSelector,
+} from '@suite-native/staking';
+
+import { CRYPTO_BALANCE_DECIMALS } from '../constants';
+
+interface TronStakingUnstakeCardProps {
+    accountKey: AccountKey;
+}
+
+export const TronStakingUnstakeCard = ({ accountKey }: TronStakingUnstakeCardProps) => {
+    const account = useStakingSelector(state => selectAccountByKey(state, accountKey));
+
+    const pendingUnstakeBalance = useStakingSelector(state =>
+        selectTronPendingUnstakeBalanceByAccountKey(state, accountKey),
+    );
+    const unstakingPeriodInDays = useStakingSelector(state =>
+        selectUnstakingPeriodInDaysByAccountKey(state, accountKey),
+    );
+
+    if (account?.networkType !== 'tron') return null;
+    if (pendingUnstakeBalance === '0') return null;
+
+    return (
+        <Card>
+            <Box flexDirection="row" alignItems="center" justifyContent="space-between">
+                <Text variant="body-sm-strong">
+                    <Translation
+                        id="earn.tron.unstakingCardTitle"
+                        values={{ days: unstakingPeriodInDays ?? 14 }}
+                    />
+                </Text>
+
+                <Box flexDirection="column" alignItems="flex-end">
+                    <CryptoAmountFormatter
+                        value={pendingUnstakeBalance}
+                        symbol={account.symbol}
+                        decimals={CRYPTO_BALANCE_DECIMALS}
+                        variant="body-sm"
+                        color="contentPrimary"
+                    />
+
+                    <CryptoToFiatAmountFormatter
+                        value={pendingUnstakeBalance}
+                        symbol={account.symbol}
+                        isBalance
+                        variant="body-sm"
+                        color="contentSecondary"
+                    />
+                </Box>
+            </Box>
+        </Card>
+    );
+};

--- a/suite-native/module-earn/src/components/TronStakingVotesBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/TronStakingVotesBottomSheet.tsx
@@ -1,0 +1,40 @@
+import { BottomSheetModal, type BottomSheetModalRef, Button, Text } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+const bottomSheetElementStyle = prepareNativeStyle(utils => ({
+    marginVertical: utils.spacings.sp8,
+}));
+
+interface TronStakingVotesBottomSheetProps {
+    ref: BottomSheetModalRef;
+    onClose: () => void;
+}
+
+export const TronStakingVotesBottomSheet = ({ ref, onClose }: TronStakingVotesBottomSheetProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <BottomSheetModal
+            ref={ref}
+            title={
+                <Text variant="headline-sm" textAlign="center">
+                    <Translation id="earn.tron.votesBottomSheet.title" />
+                </Text>
+            }
+            paddingHorizontal="sp24"
+        >
+            <Text
+                color="contentSecondary"
+                textAlign="center"
+                style={applyStyle(bottomSheetElementStyle)}
+            >
+                <Translation id="earn.stakingBottomSheet.description" />
+            </Text>
+
+            <Button onPress={onClose} style={applyStyle(bottomSheetElementStyle)}>
+                <Translation id="generic.buttons.gotIt" />
+            </Button>
+        </BottomSheetModal>
+    );
+};

--- a/suite-native/module-earn/src/components/TronStakingWithdrawBanner.tsx
+++ b/suite-native/module-earn/src/components/TronStakingWithdrawBanner.tsx
@@ -1,0 +1,34 @@
+import { selectAccountByKey } from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+import { InlineAlertBox } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import {
+    selectUnstakingBalanceByAccountKey,
+    useSelector as useStakingSelector,
+} from '@suite-native/staking';
+
+interface TronStakingWithdrawBannerProps {
+    accountKey: AccountKey;
+}
+
+export const TronStakingWithdrawBanner = ({ accountKey }: TronStakingWithdrawBannerProps) => {
+    const account = useStakingSelector(state => selectAccountByKey(state, accountKey));
+
+    const withdrawableBalance =
+        useStakingSelector(state => selectUnstakingBalanceByAccountKey(state, accountKey)) ?? '0';
+
+    if (account?.networkType !== 'tron') return null;
+    if (withdrawableBalance === '0') return null;
+
+    return (
+        <InlineAlertBox
+            variant="info"
+            title={
+                <Translation
+                    id="earn.tron.readyToWithdrawAlert"
+                    values={{ amount: withdrawableBalance }}
+                />
+            }
+        />
+    );
+};

--- a/suite-native/staking/src/index.ts
+++ b/suite-native/staking/src/index.ts
@@ -22,3 +22,13 @@ export {
     selectIsCardanoStakedOutsideEverstake,
     selectIsCardanoStakedWithFiveBinaries,
 } from './cardanoStakingSelectors';
+export {
+    selectTronAccountHasStaked,
+    selectTronAvailableVotingPowerByAccountKey,
+    selectTronPendingUnstakeBalanceByAccountKey,
+    selectTronRewardsBalanceByAccountKey,
+    selectTronStakedBalanceByAccountKey,
+    selectTronTotalVotingPowerByAccountKey,
+    selectTronUnstakedBalanceByAccountKey,
+    selectTronVotesByAccountKey,
+} from './tronStakingSelectors';

--- a/suite-native/staking/src/selectors.ts
+++ b/suite-native/staking/src/selectors.ts
@@ -10,6 +10,7 @@ import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import {
     getEthereumCryptoBalanceWithStaking,
     getSolanaCryptoBalanceWithStaking,
+    getTronCryptoBalanceWithStaking,
     getUnstakingPeriodInDays,
     isStakingSymbol,
 } from '@suite-common/wallet-utils';
@@ -46,6 +47,13 @@ import {
     selectSolanaUnstakingBalanceByAccountKey,
     selectVisibleDeviceSolanaAccountsWithStakingByNetworkSymbol,
 } from './solanaStakingSelectors';
+import {
+    selectTronAccountHasStaked,
+    selectTronRewardsBalanceByAccountKey,
+    selectTronStakedBalanceByAccountKey,
+    selectTronUnstakedBalanceByAccountKey,
+    selectVisibleDeviceTronAccountsWithStakingByNetworkSymbol,
+} from './tronStakingSelectors';
 import { type NativeStakingRootState } from './types';
 
 // create empty array in advance so it will be always same on shallow comparison
@@ -68,6 +76,8 @@ const selectDeviceAccountsWithStaking = (
             return selectVisibleDeviceSolanaAccountsWithStakingByNetworkSymbol(state, 'sol');
         case 'ada':
             return selectVisibleDeviceCardanoAccountsWithStakingByNetworkSymbol(state, 'ada');
+        case 'trx':
+            return selectVisibleDeviceTronAccountsWithStakingByNetworkSymbol(state, 'trx');
         default:
             return exhaustive(symbol);
     }
@@ -94,6 +104,8 @@ export const getAccountCryptoBalanceWithStaking = (account: Account | null) => {
             return getSolanaCryptoBalanceWithStaking(account);
         case 'ada':
             return account.formattedBalance;
+        case 'trx':
+            return getTronCryptoBalanceWithStaking(account);
         default:
             return exhaustive(account.symbol);
     }
@@ -125,6 +137,8 @@ export const selectAccountHasStaking = (state: NativeStakingRootState, accountKe
             return selectSolAccountHasStaked(state, accountKey);
         case 'ada':
             return selectAdaAccountHasStaked(state, accountKey);
+        case 'trx':
+            return selectTronAccountHasStaked(state, accountKey);
         default:
             return exhaustive(symbol);
     }
@@ -149,6 +163,8 @@ export const selectIsStakePendingByAccountKey = (
             return selectSolanaIsStakePendingByAccountKey(state, accountKey);
         case 'ada':
             return false;
+        case 'trx':
+            return false;
         default:
             return exhaustive(symbol);
     }
@@ -172,6 +188,8 @@ export const selectIsStakeConfirmingByAccountKey = (
         case 'sol':
             return false; // there are no pending txns for solana staking;
         case 'ada':
+            return false;
+        case 'trx':
             return false;
         default:
             return exhaustive(symbol);
@@ -206,6 +224,8 @@ export const selectStakedBalanceByAccountKey = (
             return selectSolanaStakedBalanceByAccountKey(state, accountKey);
         case 'ada':
             return selectCardanoStakedBalanceByAccountKey(state, accountKey);
+        case 'trx':
+            return selectTronStakedBalanceByAccountKey(state, accountKey);
         default:
             return exhaustive(symbol);
     }
@@ -231,6 +251,8 @@ export const selectRewardsBalanceByAccountKey = (
             return selectExpectedRewardsForEpoch(state, accountKey);
         case 'ada':
             return selectCardanoRewardsBalanceByAccountKey(state, accountKey);
+        case 'trx':
+            return selectTronRewardsBalanceByAccountKey(state, accountKey);
         default:
             return exhaustive(symbol);
     }
@@ -255,6 +277,8 @@ export const selectTotalStakePendingByAccountKey = (
             return selectSolanaTotalStakePendingByAccountKey(state, accountKey);
         case 'ada':
             return selectCardanoTotalStakePendingByAccountKey(state, accountKey);
+        case 'trx':
+            return '0';
         default:
             return exhaustive(symbol);
     }
@@ -278,6 +302,8 @@ export const selectClaimableAmountByAccountKey = (
         case 'sol':
             return selectSolanaClaimableAmountByAccountKey(state, accountKey);
         case 'ada':
+            return '0';
+        case 'trx':
             return '0';
         default:
             return exhaustive(symbol);
@@ -303,6 +329,8 @@ export const selectCanClaimByAccountKey = (
             return selectSolanaCanClaimByAccountKey(state, accountKey);
         case 'ada':
             return false;
+        case 'trx':
+            return false;
         default:
             return exhaustive(symbol);
     }
@@ -327,6 +355,8 @@ export const selectUnstakingBalanceByAccountKey = (
             return selectSolanaUnstakingBalanceByAccountKey(state, accountKey);
         case 'ada':
             return '0';
+        case 'trx':
+            return selectTronUnstakedBalanceByAccountKey(state, accountKey);
         default:
             return exhaustive(symbol);
     }
@@ -360,6 +390,8 @@ export const selectEntryPeriodInDaysBySymbol = (
         case 'sol':
             return SOLANA_EPOCH_DAYS;
         case 'ada':
+            return undefined;
+        case 'trx':
             return undefined;
         default:
             return exhaustive(symbol);

--- a/suite-native/staking/src/tronStakingSelectors.ts
+++ b/suite-native/staking/src/tronStakingSelectors.ts
@@ -1,0 +1,112 @@
+import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type AccountsRootState,
+    selectAccountByKey,
+    selectDeviceAccounts,
+} from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+import {
+    getStakingDataForNetwork,
+    getTronAvailableVotingPower,
+    getTronPendingUnstakeBalance,
+    getTronTotalVotingPower,
+    getTronVotes,
+    getTronWithdrawableBalance,
+    isTronStakingActive,
+} from '@suite-common/wallet-utils';
+
+import { type NativeStakingRootState } from './types';
+
+const createMemoizedSelector = createWeakMapSelector.withTypes<NativeStakingRootState>();
+
+export const selectVisibleDeviceTronAccountsWithStakingByNetworkSymbol = createMemoizedSelector(
+    [selectDeviceAccounts, (_state, symbol: NetworkSymbol) => symbol],
+    accounts =>
+        returnStableArrayIfEmpty(
+            accounts.filter(
+                account =>
+                    account.visible && account.symbol === 'trx' && isTronStakingActive(account),
+            ),
+        ),
+);
+
+export const selectTronAccountHasStaked = (state: AccountsRootState, accountKey: AccountKey) => {
+    const account = selectAccountByKey(state, accountKey);
+    if (account?.networkType !== 'tron') return false;
+
+    return isTronStakingActive(account);
+};
+
+export const selectTronStakedBalanceByAccountKey = (
+    state: AccountsRootState,
+    accountKey: AccountKey,
+) => {
+    const account = selectAccountByKey(state, accountKey);
+    if (account?.networkType !== 'tron') return null;
+
+    const stakingData = getStakingDataForNetwork(account);
+
+    return stakingData?.autocompoundBalance ?? '0';
+};
+
+export const selectTronRewardsBalanceByAccountKey = (
+    state: AccountsRootState,
+    accountKey: AccountKey,
+) => {
+    const account = selectAccountByKey(state, accountKey);
+    if (account?.networkType !== 'tron') return null;
+
+    const stakingData = getStakingDataForNetwork(account);
+
+    return stakingData?.restakedReward ?? '0';
+};
+
+/** TRX whose unfreeze window has elapsed and is ready to be withdrawn. */
+export const selectTronUnstakedBalanceByAccountKey = (
+    state: AccountsRootState,
+    accountKey: AccountKey,
+) => {
+    const account = selectAccountByKey(state, accountKey);
+    if (account?.networkType !== 'tron') return '0';
+
+    return getTronWithdrawableBalance(account);
+};
+
+/** TRX still in the unfreeze queue (being unstaked, not yet withdrawable). */
+export const selectTronPendingUnstakeBalanceByAccountKey = (
+    state: AccountsRootState,
+    accountKey: AccountKey,
+) => {
+    const account = selectAccountByKey(state, accountKey);
+    if (account?.networkType !== 'tron') return '0';
+
+    return getTronPendingUnstakeBalance(account);
+};
+
+export const selectTronVotesByAccountKey = (state: AccountsRootState, accountKey: AccountKey) => {
+    const account = selectAccountByKey(state, accountKey);
+    if (account?.networkType !== 'tron') return [];
+
+    return getTronVotes(account);
+};
+
+export const selectTronTotalVotingPowerByAccountKey = (
+    state: AccountsRootState,
+    accountKey: AccountKey,
+) => {
+    const account = selectAccountByKey(state, accountKey);
+    if (account?.networkType !== 'tron') return '0';
+
+    return getTronTotalVotingPower(account);
+};
+
+export const selectTronAvailableVotingPowerByAccountKey = (
+    state: AccountsRootState,
+    accountKey: AccountKey,
+) => {
+    const account = selectAccountByKey(state, accountKey);
+    if (account?.networkType !== 'tron') return '0';
+
+    return getTronAvailableVotingPower(account);
+};


### PR DESCRIPTION
## Description

This PR introduces view-only Tron staking for mobile.

Design: [Figma](https://www.figma.com/design/KmnFwCWdGwd6QrSll7Elx8/Networks--Final-?node-id=3056-16686&t=n0ANW32rgTCd3HBn-0)

## Related Issue

Resolve #26908 

## Screenshots:

<table>
<tr>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-17 at 12 26 24" src="https://github.com/user-attachments/assets/5640bdda-e8a2-4aa5-92d8-53164c680e4e" />
</td>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-17 at 12 26 37" src="https://github.com/user-attachments/assets/280ebc8f-2ab7-475a-8320-724b8160ab6d" />
</td>
</tr>

<tr>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-17 at 12 26 45" src="https://github.com/user-attachments/assets/8c2f1aef-67fa-46f6-8424-acfa897561af" />
</td>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-17 at 12 27 17" src="https://github.com/user-attachments/assets/0b1a698c-405e-4396-96a0-bf209385c0cf" />
</td>
</tr>

<tr>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-17 at 12 27 31" src="https://github.com/user-attachments/assets/c832485c-3e2a-4c4e-b4db-1f57b7b4f85b" />
</td>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-17 at 12 27 34" src="https://github.com/user-attachments/assets/893e3a7c-03d0-41ff-bdb2-3357d2b0bd9a" />
</td>
</tr>

<tr>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-17 at 12 27 50" src="https://github.com/user-attachments/assets/1a1f1749-153e-4795-8a7d-67c8d4f57586" />
</td>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-17 at 12 27 58" src="https://github.com/user-attachments/assets/b9a21324-4717-4edd-9c12-0927411be65b" />
</td>
</tr>
</table>

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/tron-staking-view-only&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/tron-staking-view-only&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/tron-staking-view-only&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 18 test(s)</summary>

| Test | Type |
|------|------|
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Import a BTC csv file > Go to BTC send form and import a csv | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-18T12:09:37.888Z • 18 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-18T12:08:29.471Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native/tron-staking-view-only/web/](https://dev.suite.sldev.cz/suite-web/feat/native/tron-staking-view-only/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->