### PR TITLE
feat(suite-native): animate GetTrezorCard close icon color on press

### DIFF
--- a/suite-native/icons/src/Icon.tsx
+++ b/suite-native/icons/src/Icon.tsx
@@ -9,6 +9,7 @@ import codepoints from '@suite-common/icons/iconFontsMobile/TrezorSuiteIcons.jso
 import { useNativeStyles } from '@trezor/styles-native';
 import { type CSSColor, type Color, type Colors } from '@trezor/theme';
 
+export type { CSSColor };
 export type IconColor = Color | CSSColor;
 export type AnimatedIconColor = Color | CSSColor | SharedValue<CSSColor>;
 

--- a/suite-native/module-home/package.json
+++ b/suite-native/module-home/package.json
@@ -58,6 +58,7 @@
         "jotai": "2.17.1",
         "react": "19.2.4",
         "react-native": "0.83.2",
+        "react-native-gesture-handler": "2.31.1",
         "react-native-reanimated": "~4.2.1",
         "react-native-svg": "15.15.3",
         "react-redux": "9.2.0"

--- a/suite-native/module-home/src/screens/HomeScreen/components/GetTrezorCard.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/GetTrezorCard.tsx
@@ -3,13 +3,14 @@ import { useDispatch } from 'react-redux';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectNativeAnalyticsDep } from '@suite-native/analytics';
-import { Box, Card, HStack, PressableOpacity, Text, TextButton, VStack } from '@suite-native/atoms';
+import { Box, Card, HStack, Text, TextButton, VStack } from '@suite-native/atoms';
 import { setIsGetTrezorBannerClosed } from '@suite-native/banner-flags';
 import { TwoSidedTS7Image } from '@suite-native/device';
-import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { useGetTrezorEshopCta } from '@suite-native/link';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+import { GetTrezorCardCloseIcon } from './GetTrezorCardCloseIcon';
 
 const CONTAINER_SIZE = 80;
 const IMAGE_SIZE = 53;
@@ -61,7 +62,7 @@ export const GetTrezorCard = () => {
                     </Text>
                     <HStack>
                         <TextButton
-                            size="small"
+                            size="large"
                             intent="neutral"
                             priority="secondary"
                             iconRight="arrowLineUpRight"
@@ -73,13 +74,7 @@ export const GetTrezorCard = () => {
                         </TextButton>
                     </HStack>
                 </VStack>
-                <PressableOpacity
-                    onPress={handleClose}
-                    testID="@home/get-trezor-cta/close"
-                    hitSlop={10}
-                >
-                    <Icon name="x" size="mediumLarge" color="contentNeutral" />
-                </PressableOpacity>
+                <GetTrezorCardCloseIcon onPress={handleClose} />
             </HStack>
         </Card>
     );

--- a/suite-native/module-home/src/screens/HomeScreen/components/GetTrezorCardCloseIcon.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/GetTrezorCardCloseIcon.tsx
@@ -1,0 +1,54 @@
+/* eslint-disable react-hooks/immutability */
+import { View } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import {
+    interpolateColor,
+    runOnJS,
+    useDerivedValue,
+    useSharedValue,
+    withTiming,
+} from 'react-native-reanimated';
+
+import { type CSSColor, Icon } from '@suite-native/icons';
+import { useNativeStyles } from '@trezor/styles-native';
+
+const ANIMATION_DURATION = 100;
+
+type GetTrezorCardCloseIconProps = {
+    onPress: () => void;
+};
+
+export const GetTrezorCardCloseIcon = ({ onPress }: GetTrezorCardCloseIconProps) => {
+    const {
+        utils: { colors },
+    } = useNativeStyles();
+
+    const isPressed = useSharedValue(0);
+    const animatedColor = useDerivedValue<CSSColor>(
+        () =>
+            interpolateColor(
+                isPressed.value,
+                [0, 1],
+                [colors.contentNeutral, colors.elementFillNeutralSoftPressed],
+            ) as CSSColor,
+    );
+
+    const tapGesture = Gesture.Tap()
+        .onBegin(() => {
+            isPressed.value = withTiming(1, { duration: ANIMATION_DURATION });
+        })
+        .onFinalize(() => {
+            isPressed.value = withTiming(0, { duration: ANIMATION_DURATION });
+        })
+        .onEnd(() => {
+            runOnJS(onPress)();
+        });
+
+    return (
+        <GestureDetector gesture={tapGesture}>
+            <View collapsable={false} hitSlop={10} testID="@home/get-trezor-cta/close">
+                <Icon.Animated name="x" size="mediumLarge" color={animatedColor} />
+            </View>
+        </GestureDetector>
+    );
+};

--- a/suite-native/module-settings/src/components/GetTrezorCard.tsx
+++ b/suite-native/module-settings/src/components/GetTrezorCard.tsx
@@ -49,7 +49,7 @@ export const GetTrezorCard = () => {
                         <VStack spacing="sp10">
                             {bulletPointValues.map(({ icon, textId }) => (
                                 <HStack key={icon} spacing="sp8" alignItems="center">
-                                    <Icon name={icon} size="medium" color="contentNeutral" />
+                                    <Icon name={icon} size="medium" color="contentSecondary" />
                                     <Text variant="body-xs" color="contentSecondary">
                                         <Translation id={textId} />
                                     </Text>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12980,6 +12980,7 @@ __metadata:
     jotai: "npm:2.17.1"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
+    react-native-gesture-handler: "npm:2.31.1"
     react-native-reanimated: "npm:~4.2.1"
     react-native-svg: "npm:15.15.3"
     react-redux: "npm:9.2.0"


### PR DESCRIPTION
## Description

Fixes [Design QA findings](https://www.figma.com/design/mq0EzN9PldTmHKKPfijEco/Dashboard?node-id=5299-3252&t=PO33GVqUqsLzXW7j-4) from #28460 (feat(suite-native): add Get Trezor eShop CTA for no-device users).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All changed files are in the `suite-native` package scope (suite-native/icons, suite-native/module-home, suite-native/module-settings), which is the React Native mobile app codebase. The 138 candidate E2E tests are all Playwright-based tests targeting the Suite web/desktop application, not the native mobile app. There is no static coverage mapping between the changed files and any of these tests, and the LLM analysis of the tests confirms they exercise web/desktop Suite features (onboarding, settings, trading, staking, wallet, etc.) with no connection to native mobile components like GetTrezorCard or the native Icon component. No E2E tests from this candidate set are relevant to these changes.

<details><summary><b>Changed files (5)</b></summary>

- `suite-native/icons/src/Icon.tsx`
- `suite-native/module-home/package.json`
- `suite-native/module-home/src/screens/HomeScreen/components/GetTrezorCard.tsx`
- `suite-native/module-home/src/screens/HomeScreen/components/GetTrezorCardCloseIcon.tsx`
- `suite-native/module-settings/src/components/GetTrezorCard.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (5)**
- `suite-native/icons/src/Icon.tsx`
- `suite-native/module-home/package.json`
- `suite-native/module-home/src/screens/HomeScreen/components/GetTrezorCard.tsx`
- `suite-native/module-home/src/screens/HomeScreen/components/GetTrezorCardCloseIcon.tsx`
- `suite-native/module-settings/src/components/GetTrezorCard.tsx`

_Updated: 2026-06-17T11:12:37.872Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/suite-native/get-trezor-card-close-icon-animation/web/](https://dev.suite.sldev.cz/suite-web/feat/suite-native/get-trezor-card-close-icon-animation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-native/get-trezor-card-close-icon-animation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-native/get-trezor-card-close-icon-animation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/suite-native/get-trezor-card-close-icon-animation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-17T11:18:11.524Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-17T11:16:36.877Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->