### PR TITLE
Tron withdrawal flow

### DIFF
--- a/packages/connect/src/api/tron/__tests__/tronEncode.test.ts
+++ b/packages/connect/src/api/tron/__tests__/tronEncode.test.ts
@@ -75,6 +75,26 @@ const UNFREEZE = {
     },
 } as const;
 
+const WITHDRAW_CONTRACT: TronContracts = {
+    type: 'WithdrawExpireUnfreezeContract',
+    parameter: {
+        value: {
+            owner_address: OWNER_ADDRESS,
+        },
+    },
+};
+
+const WITHDRAW = {
+    signature:
+        'a7f8602b02413e9dded0170daa5b4ada9a2679198af276be456f4faea1bc326f5070789bec5e6471de3f726f4fe0c9daced8df183e4a62804db26d5650c59a521c',
+    blockParams: {
+        ref_block_bytes: 'e942',
+        ref_block_hash: '6394747da9fee421',
+        expiration: 1752562632000,
+        timestamp: 1752562572000,
+    },
+} as const;
+
 const VOTE_CONTRACT: TronContracts = {
     type: 'VoteWitnessContract',
     parameter: {
@@ -144,6 +164,21 @@ describe('tron/encodeBroadcastTransaction', () => {
         // @ts-expect-error: indexing with noUncheckedIndexedAccess
         const firstSignature: (typeof signature)[number] = signature[0];
         expect(bytesToHex(firstSignature)).toBe(UNFREEZE.signature);
+    });
+
+    it('embeds rawData and signature for a withdraw', () => {
+        const rawDataHex = bytesToHex(
+            encodeTronContractRawData(WITHDRAW_CONTRACT, WITHDRAW.blockParams),
+        );
+        const result = encodeBroadcastTransaction(rawDataHex, WITHDRAW.signature);
+
+        const decoded = decodeBroadcastTransaction(result);
+        expect(bytesToHex(decoded.rawData)).toBe(rawDataHex);
+        expect(decoded.signature).toHaveLength(1);
+        const { signature } = decoded;
+        // @ts-expect-error: indexing with noUncheckedIndexedAccess
+        const firstSignature: (typeof signature)[number] = signature[0];
+        expect(bytesToHex(firstSignature)).toBe(WITHDRAW.signature);
     });
 
     it('embeds rawData and signature for a vote', () => {

--- a/packages/connect/src/api/tron/tronEncode.ts
+++ b/packages/connect/src/api/tron/tronEncode.ts
@@ -91,6 +91,20 @@ const encodeInnerContract = (contract: TronContracts): InnerContract => {
                 ),
             };
         }
+        case 'WithdrawExpireUnfreezeContract': {
+            const { owner_address } = contract.parameter.value;
+            const schema = getSchema('TronWithdrawUnfreeze');
+
+            return {
+                type: TronRawContractType.WithdrawExpireUnfreezeContract,
+                bytes: toBinary(
+                    schema,
+                    create(schema, {
+                        ownerAddress: hexToBytes(owner_address ?? ''),
+                    }),
+                ),
+            };
+        }
         case 'VoteWitnessContract': {
             const { owner_address, votes } = contract.parameter.value;
             const schema = getSchema('TronVoteWitnessContract');

--- a/packages/suite-desktop-ui/src/support/desktopComponents.ts
+++ b/packages/suite-desktop-ui/src/support/desktopComponents.ts
@@ -10,6 +10,7 @@ import {
     EarnTronStake,
     EarnTronUnstake,
     EarnTronVote,
+    EarnTronWithdraw,
 } from 'src/views/earn/tron';
 import { EarnClaim } from 'src/views/earn/yield/claim';
 import { EarnDeposit } from 'src/views/earn/yield/deposit';
@@ -53,6 +54,7 @@ export const desktopComponents: Record<PageName, ComponentType> = {
     'earn-tron-stake': EarnTronStake,
     'earn-tron-vote': EarnTronVote,
     'earn-tron-unstake': EarnTronUnstake,
+    'earn-tron-withdraw': EarnTronWithdraw,
     'suite-connect-popup': ConnectPopup,
     'notifications-index': Notification,
 

--- a/packages/suite-web/src/support/webComponents.ts
+++ b/packages/suite-web/src/support/webComponents.ts
@@ -62,6 +62,13 @@ export const webComponents: Record<PageName, LazyExoticComponent<ComponentType>>
             }),
         ),
     ),
+    'earn-tron-withdraw': lazy(() =>
+        import(/* webpackChunkName: "earn" */ 'src/views/earn/tron/index').then(
+            ({ EarnTronWithdraw }) => ({
+                default: EarnTronWithdraw,
+            }),
+        ),
+    ),
     'suite-connect-popup': lazy(() =>
         import(/* webpackChunkName: "connect-popup" */ 'src/views/connect-popup/index').then(
             ({ ConnectPopup }) => ({ default: ConnectPopup }),

--- a/packages/suite/src/components/earn/index.ts
+++ b/packages/suite/src/components/earn/index.ts
@@ -21,6 +21,7 @@ export { TronStakePageHeader } from './staking/tron/TronStakePageHeader';
 export { TronStake } from './staking/tron/TronStake';
 export { TronUnstake } from './staking/tron/TronUnstake';
 export { TronVote } from './staking/tron/TronVote';
+export { TronWithdraw } from './staking/tron/TronWithdraw';
 export { YieldDeposit } from './yield/deposit/YieldDeposit';
 export { YieldWithdraw } from './yield/withdraw/YieldWithdraw';
 export { EarnStakingInfo } from './modals/EarnInANutshell/components/EarnStakingInfo';

--- a/packages/suite/src/components/earn/staking/tron/TronWithdraw.tsx
+++ b/packages/suite/src/components/earn/staking/tron/TronWithdraw.tsx
@@ -1,7 +1,10 @@
+import { Translation } from '@suite/intl';
 import { type Account } from '@suite-common/wallet-types';
 import { Column } from '@trezor/components';
 
 import { TronStakeContext } from './TronStakeContext';
+import { TronStakeComplete } from './complete/TronStakeComplete';
+import { TronWithdrawSummaryCard } from './complete/TronWithdrawSummaryCard';
 import { useTronStakeFlow } from './hooks/useTronStakeFlow';
 import { TronWithdrawForm } from './withdraw/TronWithdrawForm';
 
@@ -11,12 +14,22 @@ interface TronWithdrawProps {
 
 export const TronWithdraw = ({ account }: TronWithdrawProps) => {
     const context = useTronStakeFlow({ account, flow: 'withdraw' });
+    const { step } = context.actions;
 
     return (
         <TronStakeContext.Provider value={context}>
             <Column alignItems="center">
                 <Column gap={24} width="100%" maxWidth={500}>
-                    <TronWithdrawForm />
+                    {step === 'complete' ? (
+                        <TronStakeComplete
+                            heading={<Translation id="TR_EARN_TRON_WITHDRAW_COMPLETE" />}
+                            description={<Translation id="TR_EARN_TRON_WITHDRAW_DESCRIPTION" />}
+                        >
+                            <TronWithdrawSummaryCard />
+                        </TronStakeComplete>
+                    ) : (
+                        <TronWithdrawForm />
+                    )}
                 </Column>
             </Column>
         </TronStakeContext.Provider>

--- a/packages/suite/src/components/earn/staking/tron/TronWithdraw.tsx
+++ b/packages/suite/src/components/earn/staking/tron/TronWithdraw.tsx
@@ -1,0 +1,24 @@
+import { type Account } from '@suite-common/wallet-types';
+import { Column } from '@trezor/components';
+
+import { TronStakeContext } from './TronStakeContext';
+import { useTronStakeFlow } from './hooks/useTronStakeFlow';
+import { TronWithdrawForm } from './withdraw/TronWithdrawForm';
+
+interface TronWithdrawProps {
+    account: Account;
+}
+
+export const TronWithdraw = ({ account }: TronWithdrawProps) => {
+    const context = useTronStakeFlow({ account, flow: 'withdraw' });
+
+    return (
+        <TronStakeContext.Provider value={context}>
+            <Column alignItems="center">
+                <Column gap={24} width="100%" maxWidth={500}>
+                    <TronWithdrawForm />
+                </Column>
+            </Column>
+        </TronStakeContext.Provider>
+    );
+};

--- a/packages/suite/src/components/earn/staking/tron/complete/TronWithdrawSummaryCard.tsx
+++ b/packages/suite/src/components/earn/staking/tron/complete/TronWithdrawSummaryCard.tsx
@@ -1,0 +1,49 @@
+import { Translation } from '@suite/intl';
+import { Card, Column, Divider, Icon, Row, Text } from '@trezor/components';
+import { CoinLogo } from '@trezor/product-components';
+
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+
+import { useTronStakeContext } from '../TronStakeContext';
+import { TronStakeInfoRow } from '../TronStakeInfoRow';
+
+export const TronWithdrawSummaryCard = () => {
+    const { account, form } = useTronStakeContext();
+    const { amount } = form.methods.getValues();
+
+    return (
+        <Card fillType="flat" paddingType="none">
+            <Column gap={0}>
+                <TronStakeInfoRow label={<Translation id="TR_EARN_YIELD_STATUS" />}>
+                    <Row alignItems="center" gap={8}>
+                        <Icon name="checkCircleFilled" intent="brand" />
+                        <Text typographyStyle="body-md" intent="brand">
+                            <Translation id="TR_EARN_YIELD_COMPLETED" />
+                        </Text>
+                    </Row>
+                </TronStakeInfoRow>
+
+                <Divider color="borderNeutral" margin={0} />
+
+                <TronStakeInfoRow label={<Translation id="TR_EARN_TRON_WITHDRAWN" />}>
+                    <Row alignItems="center" gap={8}>
+                        <CoinLogo symbol={account.symbol} size={24} />
+                        <Column gap={2} alignItems="flex-end">
+                            <Text typographyStyle="body-md-strong">
+                                <FormattedCryptoAmount value={amount} symbol={account.symbol} />
+                            </Text>
+                            <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                                <BaseCurrencyValue
+                                    amount={amount}
+                                    symbol={account.symbol}
+                                    showApproximationIndicator
+                                />
+                            </Text>
+                        </Column>
+                    </Row>
+                </TronStakeInfoRow>
+            </Column>
+        </Card>
+    );
+};

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
@@ -5,6 +5,7 @@ import {
     type TronStakeError,
     type TronStakeStepId,
     composeTronFreezeFeeLevelsThunk,
+    getWithdrawableAmount,
     selectTronStakeSession,
     submitTronFreezeThunk,
     submitTronUnstakeThunk,
@@ -13,7 +14,7 @@ import {
     tronStakeActions,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
-import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
+import { asAmountSubunit, formatNetworkAmount, subunitsToUnits } from '@suite-common/wallet-utils';
 import { exhaustive } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils';
 
@@ -152,6 +153,10 @@ export const useTronStakeActions = ({
                 break;
             }
             case 'withdraw':
+                form.methods.setValue(
+                    'amount',
+                    formatNetworkAmount(getWithdrawableAmount(account), account.symbol),
+                );
                 dispatch(
                     submitTronWithdrawThunk({
                         account,

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
@@ -9,6 +9,7 @@ import {
     submitTronFreezeThunk,
     submitTronUnstakeThunk,
     submitTronVoteThunk,
+    submitTronWithdrawThunk,
     tronStakeActions,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
@@ -151,6 +152,19 @@ export const useTronStakeActions = ({
                 break;
             }
             case 'withdraw':
+                dispatch(
+                    submitTronWithdrawThunk({
+                        account,
+                        device,
+                        requestPushApproval: async () =>
+                            Boolean(
+                                await dispatch(openDeferredModal({ type: 'review-transaction' })),
+                            ),
+                        onSigningStart: () => dispatch(preserveModal()),
+                        onSettled: () => dispatch(closeModal()),
+                    }),
+                );
+                break;
             case 'complete':
                 break;
             default:

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
@@ -150,6 +150,7 @@ export const useTronStakeActions = ({
                 );
                 break;
             }
+            case 'withdraw':
             case 'complete':
                 break;
             default:

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFees.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFees.ts
@@ -60,6 +60,7 @@ export const useTronStakeFees = (): TronStakeFees => {
                     dispatch(composeTronUnstakeFeeLevelsThunk({ account, amount, resourceType }))
                         .unwrap()
                         .catch(() => undefined);
+            case 'withdraw':
             case 'complete':
                 return undefined;
             default:

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFees.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFees.ts
@@ -4,6 +4,7 @@ import {
     composeTronFreezeFeeLevelsThunk,
     composeTronUnstakeFeeLevelsThunk,
     composeTronVoteFeeLevelsThunk,
+    composeTronWithdrawFeeLevelsThunk,
     selectRawNetworkFeeInfo,
 } from '@suite-common/wallet-core';
 import { type FeeInfo, type PrecomposedLevels } from '@suite-common/wallet-types';
@@ -61,6 +62,10 @@ export const useTronStakeFees = (): TronStakeFees => {
                         .unwrap()
                         .catch(() => undefined);
             case 'withdraw':
+                return () =>
+                    dispatch(composeTronWithdrawFeeLevelsThunk({ account }))
+                        .unwrap()
+                        .catch(() => undefined);
             case 'complete':
                 return undefined;
             default:

--- a/packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawAmount.tsx
+++ b/packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawAmount.tsx
@@ -1,0 +1,38 @@
+import { Translation } from '@suite/intl';
+import { getWithdrawableAmount } from '@suite-common/wallet-core';
+import { formatNetworkAmount } from '@suite-common/wallet-utils';
+import { Card, Column, Row, Text } from '@trezor/components';
+import { CoinLogo } from '@trezor/product-components';
+
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+
+import { useTronStakeContext } from '../TronStakeContext';
+import { TronStakeInfoRow } from '../TronStakeInfoRow';
+
+export const TronWithdrawAmount = () => {
+    const { account } = useTronStakeContext();
+    const amount = formatNetworkAmount(getWithdrawableAmount(account), account.symbol);
+
+    return (
+        <Card paddingType="none">
+            <TronStakeInfoRow label={<Translation id="AMOUNT" />}>
+                <Row alignItems="center" gap={8}>
+                    <CoinLogo symbol={account.symbol} size={24} />
+                    <Column gap={2} alignItems="flex-end">
+                        <Text typographyStyle="body-md-strong">
+                            <FormattedCryptoAmount value={amount} symbol={account.symbol} />
+                        </Text>
+                        <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                            <BaseCurrencyValue
+                                amount={amount}
+                                symbol={account.symbol}
+                                showApproximationIndicator
+                            />
+                        </Text>
+                    </Column>
+                </Row>
+            </TronStakeInfoRow>
+        </Card>
+    );
+};

--- a/packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawForm.tsx
@@ -1,0 +1,42 @@
+import { FormProvider } from 'react-hook-form';
+
+import { Translation } from '@suite/intl';
+import { Banner, Column, Text } from '@trezor/components';
+
+import { useTronStakeContext } from '../TronStakeContext';
+import { TronStakeFees } from '../TronStakeFees';
+import { TronStakePendingTransaction } from '../TronStakePendingTransaction';
+import { TronWithdrawAmount } from './TronWithdrawAmount';
+import { TronWithdrawSubmitButton } from './TronWithdrawSubmitButton';
+
+export const TronWithdrawForm = () => {
+    const { form, actions } = useTronStakeContext();
+    const { error } = actions;
+
+    return (
+        <FormProvider {...form.methods}>
+            <Column gap={16}>
+                <Text typographyStyle="headline-md">
+                    <Translation id="TR_EARN_TRON_WITHDRAW_TITLE" />
+                </Text>
+
+                <TronWithdrawAmount />
+
+                <TronStakeFees />
+
+                {error && (
+                    <Banner
+                        intent="warning"
+                        description={<Translation id="TR_EARN_TRON_SUBMIT_ERROR" />}
+                    />
+                )}
+
+                <TronWithdrawSubmitButton />
+
+                <TronStakePendingTransaction
+                    title={<Translation id="TR_EARN_TRON_PENDING_WITHDRAW" />}
+                />
+            </Column>
+        </FormProvider>
+    );
+};

--- a/packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawSubmitButton.tsx
+++ b/packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawSubmitButton.tsx
@@ -1,0 +1,33 @@
+import { useDevice } from '@suite/device';
+import { Translation } from '@suite/intl';
+import { getWithdrawableAmount, selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { Button } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { useSelector } from 'src/hooks/suite';
+
+import { useTronStakeContext } from '../TronStakeContext';
+
+export const TronWithdrawSubmitButton = () => {
+    const { device, isLocked } = useDevice();
+    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
+    const { account, actions } = useTronStakeContext();
+    const { isSubmitting, pendingTxid, submitAction } = actions;
+
+    const hasWithdrawableAmount = new BigNumber(getWithdrawableAmount(account)).gt(0);
+    const isDeviceUnavailable = !!device?.connected && !!device?.available && isLocked();
+
+    return (
+        <Button
+            size="large"
+            width="100%"
+            onClick={submitAction}
+            isDisabled={
+                !hasWithdrawableAmount || isSubmitting || isDeviceUnavailable || !!pendingTxid
+            }
+            isLoading={isSubmitting || isDiscoveryRunning}
+        >
+            <Translation id="TR_CONTINUE" />
+        </Button>
+    );
+};

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
@@ -61,6 +61,7 @@ export const Navigation = ({ children }: NavigationProps) => {
                                   'earn-tron-stake',
                                   'earn-tron-vote',
                                   'earn-tron-unstake',
+                                  'earn-tron-withdraw',
                               ],
                           } as NavigationItemProps,
                       ]

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
@@ -188,7 +188,10 @@ export const TransactionReviewModalBodyInner = ({
     };
 
     const isCancelRbfAction = isRbfCancelTransaction(precomposedTx);
-    const isTronStakeFreeze = networkType === 'tron' && Boolean(precomposedForm.tronStakeResource);
+    const isTronStakeFreeze =
+        networkType === 'tron' &&
+        (precomposedForm.tronStaking?.kind === 'freeze' ||
+            precomposedForm.tronStaking?.kind === 'unstake');
     const showSummary =
         !(isBumpFeeRbfAction && networkType === 'bitcoin') &&
         (networkType !== 'tron' || isTronStakeFreeze);

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -264,6 +264,8 @@ const getOutputTitle = (
             return <Translation id="TR_REWARD_TOKENS" />;
         case 'tron-vote':
             return <Translation id="TR_SUMMARY" />;
+        case 'tron-withdraw':
+            return <Translation id="TR_SUMMARY" />;
         default:
             return exhaustive(type);
     }
@@ -576,6 +578,15 @@ const getOutputLines = ({
                     type: 'default',
                     label: <Translation id="TR_TRON_VOTES" />,
                     value: value2,
+                },
+            ];
+        case 'tron-withdraw':
+            return [
+                {
+                    id: 'address',
+                    type: 'safe-address',
+                    label: <Translation id="TR_EARN_TRON_CLAIM_ADDRESS" />,
+                    value,
                 },
             ];
         default:

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -116,7 +116,10 @@ export const TransactionReviewOutputList = ({
         ({ type }) => !['address', 'amount', 'opreturn'].includes(type),
     );
 
-    const isTronStakeFreeze = networkType === 'tron' && Boolean(precomposedForm.tronStakeResource);
+    const isTronStakeFreeze =
+        networkType === 'tron' &&
+        (precomposedForm.tronStaking?.kind === 'freeze' ||
+            precomposedForm.tronStaking?.kind === 'unstake');
 
     const nativeToken =
         account.accountType === 'placeholder' && 'nativeToken' in precomposedTx

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
@@ -201,9 +201,13 @@ export const TransactionReviewTotalOutput = ({
     }
 
     const { networkType } = account;
-    const isTronStakeFreeze = networkType === 'tron' && Boolean(precomposedForm.tronStakeResource);
+    const { tronStaking } = precomposedForm;
+    const isTronStakeFreeze =
+        networkType === 'tron' &&
+        (tronStaking?.kind === 'freeze' || tronStaking?.kind === 'unstake');
     const tronResourceLabel =
-        precomposedForm.tronStakeResource === 'energy'
+        (tronStaking?.kind === 'freeze' || tronStaking?.kind === 'unstake') &&
+        tronStaking.resource === 'energy'
             ? translationString('TR_TRON_ENERGY')
             : translationString('TR_TRON_BANDWIDTH');
     const nativeToken =

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -20,6 +20,7 @@ const SIGN_TX_ROUTES = [
     'earn-tron-stake',
     'earn-tron-vote',
     'earn-tron-unstake',
+    'earn-tron-withdraw',
 ] as const;
 
 const SIGN_TX_CONNECT_METHODS = [

--- a/packages/suite/src/utils/suite/transactionReview.ts
+++ b/packages/suite/src/utils/suite/transactionReview.ts
@@ -114,16 +114,19 @@ export const getTransactionReviewModalActionTranslation = ({
         return { id: 'TR_EARN_TRON_WITHDRAW_TITLE' };
     }
 
-    if (precomposedForm.tronStakeResource) {
+    if (
+        precomposedForm.tronStaking?.kind === 'freeze' ||
+        precomposedForm.tronStaking?.kind === 'unstake'
+    ) {
         return {
             id:
-                routeName === 'earn-tron-unstake'
+                precomposedForm.tronStaking.kind === 'unstake'
                     ? 'TR_EARN_TRON_UNSTAKE_TITLE'
                     : 'TR_EARN_TRON_FREEZE',
         };
     }
 
-    if (precomposedForm.tronStakeVotes !== undefined) {
+    if (precomposedForm.tronStaking?.kind === 'vote') {
         return { id: 'TR_EARN_TRON_VOTE' };
     }
 

--- a/packages/suite/src/utils/suite/transactionReview.ts
+++ b/packages/suite/src/utils/suite/transactionReview.ts
@@ -110,6 +110,10 @@ export const getTransactionReviewModalActionTranslation = ({
         return { id: source === 'heading' ? 'TR_EARN_CLAIM_REWARDS' : 'TR_EARN_YIELD_CLAIM' };
     }
 
+    if (routeName === 'earn-tron-withdraw') {
+        return { id: 'TR_EARN_TRON_WITHDRAW_TITLE' };
+    }
+
     if (precomposedForm.tronStakeResource) {
         return {
             id:

--- a/packages/suite/src/views/earn/tron/EarnTronWithdraw.tsx
+++ b/packages/suite/src/views/earn/tron/EarnTronWithdraw.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+
+import { goto } from '@suite/router';
+import { selectIsDebugModeActive } from '@suite/settings';
+
+import { TronStakePageHeader } from 'src/components/earn';
+import { useEarnRouteAccount } from 'src/components/earn/utils/useEarnRouteAccount';
+import { AccountNotExists } from 'src/components/wallet/WalletLayout/AccountException/AccountNotExists';
+import { useDispatch, useLayout, useSelector } from 'src/hooks/suite';
+
+export const EarnTronWithdraw = () => {
+    const dispatch = useDispatch();
+    const isDebugModeActive = useSelector(selectIsDebugModeActive);
+    const { account } = useEarnRouteAccount();
+
+    useLayout('Earn', <TronStakePageHeader account={account} />);
+
+    useEffect(() => {
+        if (!isDebugModeActive) {
+            dispatch(goto({ routeName: 'suite-earn' }));
+        }
+    }, [isDebugModeActive, dispatch]);
+
+    if (!isDebugModeActive) {
+        return null;
+    }
+
+    if (!account) {
+        return <AccountNotExists />;
+    }
+
+    return null;
+};

--- a/packages/suite/src/views/earn/tron/EarnTronWithdraw.tsx
+++ b/packages/suite/src/views/earn/tron/EarnTronWithdraw.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { goto } from '@suite/router';
 import { selectIsDebugModeActive } from '@suite/settings';
 
-import { TronStakePageHeader } from 'src/components/earn';
+import { TronStakePageHeader, TronWithdraw } from 'src/components/earn';
 import { useEarnRouteAccount } from 'src/components/earn/utils/useEarnRouteAccount';
 import { AccountNotExists } from 'src/components/wallet/WalletLayout/AccountException/AccountNotExists';
 import { useDispatch, useLayout, useSelector } from 'src/hooks/suite';
@@ -29,5 +29,5 @@ export const EarnTronWithdraw = () => {
         return <AccountNotExists />;
     }
 
-    return null;
+    return <TronWithdraw account={account} />;
 };

--- a/packages/suite/src/views/earn/tron/index.ts
+++ b/packages/suite/src/views/earn/tron/index.ts
@@ -1,4 +1,5 @@
 export { EarnTronStake } from './EarnTronStake';
 export { EarnTronVote } from './EarnTronVote';
 export { EarnTronUnstake } from './EarnTronUnstake';
+export { EarnTronWithdraw } from './EarnTronWithdraw';
 export { EarnTronRedirect } from './EarnTronRedirect';

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -76,6 +76,8 @@ export { composeTronVoteFeeLevelsThunk } from './stake/tron/actions/vote/compose
 export { submitTronVoteThunk } from './stake/tron/actions/vote/submitVote';
 export { composeTronUnstakeFeeLevelsThunk } from './stake/tron/actions/unstake/composeUnstake';
 export { submitTronUnstakeThunk } from './stake/tron/actions/unstake/submitUnstake';
+export { composeTronWithdrawFeeLevelsThunk } from './stake/tron/actions/withdraw/composeWithdraw';
+export { submitTronWithdrawThunk } from './stake/tron/actions/withdraw/submitWithdraw';
 export * from './stake/tron/tronStakeTypes';
 export * from './stake/tron/tronStakeUtils';
 export * from './token/stellarTokenThunks';

--- a/suite-common/wallet-core/src/stake/tron/actions/freeze/freezeContract.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/freeze/freezeContract.ts
@@ -59,7 +59,7 @@ export const buildFreezeReviewForm = (resourceType: TronResourceType): FormState
     feePerUnit: '0',
     feeLimit: '',
     options: ['broadcast'],
-    tronStakeResource: resourceType,
+    tronStaking: { kind: 'freeze', resource: resourceType },
     isCoinControlEnabled: false,
     hasCoinControlBeenOpened: false,
     selectedUtxos: [],

--- a/suite-common/wallet-core/src/stake/tron/actions/unstake/unstakeContract.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/unstake/unstakeContract.ts
@@ -59,7 +59,7 @@ export const buildUnstakeReviewForm = (resourceType: TronResourceType): FormStat
     feePerUnit: '0',
     feeLimit: '',
     options: ['broadcast'],
-    tronStakeResource: resourceType,
+    tronStaking: { kind: 'unstake', resource: resourceType },
     isCoinControlEnabled: false,
     hasCoinControlBeenOpened: false,
     selectedUtxos: [],

--- a/suite-common/wallet-core/src/stake/tron/actions/vote/voteContract.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/vote/voteContract.ts
@@ -54,7 +54,7 @@ export const buildVoteReviewForm = (votes: number): FormState => ({
     feePerUnit: '0',
     feeLimit: '',
     options: ['broadcast'],
-    tronStakeVotes: String(votes),
+    tronStaking: { kind: 'vote', votes: String(votes) },
     isCoinControlEnabled: false,
     hasCoinControlBeenOpened: false,
     selectedUtxos: [],

--- a/suite-common/wallet-core/src/stake/tron/actions/withdraw/composeWithdraw.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/withdraw/composeWithdraw.ts
@@ -1,0 +1,72 @@
+import { createThunk } from '@suite-common/redux-utils';
+import {
+    type Account,
+    type PrecomposedLevels,
+    type PrecomposedTransactionFinal,
+} from '@suite-common/wallet-types';
+import { computeBandwidthFeeLevel } from '@suite-common/wallet-utils';
+import TrezorConnect from '@trezor/connect';
+
+import { buildWithdrawContract } from './withdrawContract';
+import {
+    TRON_DUMMY_BLOCK_HASH,
+    TRON_DUMMY_BLOCK_HEIGHT,
+    TRON_STAKE_MODULE,
+} from '../../shared/constants';
+import { type TronStakeError } from '../../tronStakeTypes';
+
+export interface WithdrawThunkArguments {
+    account: Account;
+}
+
+export const composeTronWithdrawFeeLevelsThunk = createThunk<
+    PrecomposedLevels,
+    WithdrawThunkArguments,
+    { rejectValue: TronStakeError }
+>(
+    `${TRON_STAKE_MODULE}/composeTronWithdrawFeeLevelsThunk`,
+    async ({ account }, { rejectWithValue }) => {
+        if (account.networkType !== 'tron') {
+            return rejectWithValue({ kind: 'compose-failed', message: 'Invalid network type.' });
+        }
+
+        const contract = buildWithdrawContract(account);
+
+        if (!contract) {
+            return rejectWithValue({ kind: 'compose-failed', message: 'Invalid owner address.' });
+        }
+
+        const estimate = await TrezorConnect.tronComposeTransaction({
+            contract,
+            blockHash: TRON_DUMMY_BLOCK_HASH,
+            blockHeight: TRON_DUMMY_BLOCK_HEIGHT,
+        });
+
+        if (!estimate.success) {
+            return rejectWithValue({ kind: 'compose-failed', message: estimate.error.message });
+        }
+
+        const bytes = estimate.payload.bandwidth;
+
+        const feeLevel = computeBandwidthFeeLevel({
+            availableStakedBandwidth: account.misc.tronResources?.availableStakedBandwidth ?? 0,
+            availableFreeBandwidth: account.misc.tronResources?.availableFreeBandwidth ?? 0,
+            bytes,
+        });
+
+        const feeInSun = feeLevel.feePerTx || '0';
+
+        const tx: PrecomposedTransactionFinal = {
+            type: 'final',
+            totalSpent: feeInSun,
+            fee: feeInSun,
+            feePerByte: feeLevel.feePerUnit ?? '0',
+            bytes,
+            inputs: [],
+            outputs: [{ address: account.descriptor, amount: '0' }],
+            outputsPermutation: [0],
+        };
+
+        return { normal: tx };
+    },
+);

--- a/suite-common/wallet-core/src/stake/tron/actions/withdraw/submitWithdraw.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/withdraw/submitWithdraw.ts
@@ -1,0 +1,162 @@
+import { createThunk } from '@suite-common/redux-utils';
+import { type TrezorDevice } from '@suite-common/suite-types';
+import { getAccountIdentity } from '@suite-common/wallet-utils';
+import TrezorConnect from '@trezor/connect';
+import { BigNumber } from '@trezor/utils';
+
+import { type WithdrawThunkArguments, composeTronWithdrawFeeLevelsThunk } from './composeWithdraw';
+import { buildWithdrawContract, buildWithdrawReviewForm } from './withdrawContract';
+import { addFakePendingTronTxThunk } from '../../../../transactions/transactionsThunks';
+import { TRON_STAKE_MODULE } from '../../shared/constants';
+import { signTronContract } from '../../shared/signTronContract';
+import { tronStakeActions } from '../../tronStakeReducer';
+import { type TronFlow } from '../../tronStakeTypes';
+import { getWithdrawableAmount } from '../../tronStakeUtils';
+
+interface SubmitWithdrawThunkArguments extends WithdrawThunkArguments {
+    device: TrezorDevice;
+    requestPushApproval: () => Promise<boolean>;
+    onSigningStart?: () => void;
+    onSettled?: () => void;
+}
+
+export const submitTronWithdrawThunk = createThunk<void, SubmitWithdrawThunkArguments>(
+    `${TRON_STAKE_MODULE}/submitTronWithdrawThunk`,
+    async ({ account, device, requestPushApproval, onSigningStart, onSettled }, { dispatch }) => {
+        const { key: accountKey } = account;
+        const flow: TronFlow = 'withdraw';
+
+        if (account.networkType !== 'tron') {
+            dispatch(
+                tronStakeActions.submitFinished({
+                    accountKey,
+                    flow,
+                    error: { kind: 'compose-failed', message: 'Invalid network type.' },
+                }),
+            );
+
+            return;
+        }
+
+        const contract = buildWithdrawContract(account);
+
+        if (!contract) {
+            dispatch(
+                tronStakeActions.submitFinished({
+                    accountKey,
+                    flow,
+                    error: { kind: 'compose-failed', message: 'Invalid owner address.' },
+                }),
+            );
+
+            return;
+        }
+
+        dispatch(tronStakeActions.submitStarted({ accountKey, flow }));
+
+        try {
+            const composed = await dispatch(composeTronWithdrawFeeLevelsThunk({ account }))
+                .unwrap()
+                .catch(() => undefined);
+            const precomposedTx = composed?.normal?.type === 'final' ? composed.normal : undefined;
+
+            if (!precomposedTx) {
+                dispatch(
+                    tronStakeActions.submitFinished({
+                        accountKey,
+                        flow,
+                        error: { kind: 'compose-failed' },
+                    }),
+                );
+
+                return;
+            }
+
+            dispatch(
+                tronStakeActions.storePrecomposedTransaction({
+                    precomposedTx,
+                    precomposedForm: buildWithdrawReviewForm(),
+                    accountKey,
+                }),
+            );
+
+            onSigningStart?.();
+
+            const signResult = await signTronContract({ account, device, contract });
+
+            if ('error' in signResult) {
+                dispatch(
+                    tronStakeActions.submitFinished({ accountKey, flow, error: signResult.error }),
+                );
+
+                return;
+            }
+
+            dispatch(
+                tronStakeActions.storeSignedTransaction({
+                    serializedTx: { tx: signResult.serializedTx, symbol: account.symbol },
+                }),
+            );
+
+            const isPushApproved = await requestPushApproval();
+
+            if (!isPushApproved) {
+                dispatch(
+                    tronStakeActions.submitFinished({
+                        accountKey,
+                        flow,
+                        error: { kind: 'cancelled' },
+                    }),
+                );
+
+                return;
+            }
+
+            const pushResult = await TrezorConnect.pushTransaction({
+                tx: signResult.serializedTx,
+                coin: account.symbol,
+                identity: getAccountIdentity(account),
+            });
+
+            if (!pushResult.success) {
+                dispatch(
+                    tronStakeActions.submitFinished({
+                        accountKey,
+                        flow,
+                        error: { kind: 'broadcast-failed', message: pushResult.error.message },
+                    }),
+                );
+
+                return;
+            }
+
+            const { txid } = pushResult.payload;
+
+            dispatch(
+                addFakePendingTronTxThunk({
+                    account,
+                    txid,
+                    amount: '0',
+                    fee: precomposedTx.fee ?? '0',
+                    type: 'self',
+                    target: {
+                        addresses: [account.descriptor],
+                        amount: getWithdrawableAmount(account),
+                    },
+                    tronSpecific: {
+                        contractType: 'WithdrawExpireUnfreezeContract',
+                        operation: 'withdraw',
+                        bandwidthUsage: new BigNumber(precomposedTx.fee).isZero()
+                            ? String(precomposedTx.bytes)
+                            : undefined,
+                    },
+                }),
+            );
+
+            dispatch(tronStakeActions.submitFinished({ accountKey, flow, txid }));
+        } finally {
+            onSettled?.();
+            dispatch(tronStakeActions.discardTransaction());
+        }
+    },
+);

--- a/suite-common/wallet-core/src/stake/tron/actions/withdraw/withdrawContract.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/withdraw/withdrawContract.ts
@@ -1,0 +1,34 @@
+import { type Account, type FormState } from '@suite-common/wallet-types';
+import { tronUtils } from '@trezor/blockchain-link-utils';
+
+export const buildWithdrawExpireUnfreezeContract = ({ ownerHex }: { ownerHex: string }) =>
+    ({
+        type: 'WithdrawExpireUnfreezeContract' as const,
+        parameter: {
+            value: {
+                owner_address: ownerHex,
+            },
+        },
+    }) as const;
+
+export type TronWithdrawContract = ReturnType<typeof buildWithdrawExpireUnfreezeContract>;
+
+export const buildWithdrawContract = (account: Account) => {
+    const ownerHex = tronUtils.tronAddressToHex(account.descriptor);
+
+    if (!ownerHex) {
+        return null;
+    }
+
+    return buildWithdrawExpireUnfreezeContract({ ownerHex });
+};
+
+export const buildWithdrawReviewForm = (): FormState => ({
+    outputs: [],
+    feePerUnit: '0',
+    feeLimit: '',
+    options: ['broadcast'],
+    isCoinControlEnabled: false,
+    hasCoinControlBeenOpened: false,
+    selectedUtxos: [],
+});

--- a/suite-common/wallet-core/src/stake/tron/actions/withdraw/withdrawContract.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/withdraw/withdrawContract.ts
@@ -28,6 +28,7 @@ export const buildWithdrawReviewForm = (): FormState => ({
     feePerUnit: '0',
     feeLimit: '',
     options: ['broadcast'],
+    tronStakeWithdraw: true,
     isCoinControlEnabled: false,
     hasCoinControlBeenOpened: false,
     selectedUtxos: [],

--- a/suite-common/wallet-core/src/stake/tron/actions/withdraw/withdrawContract.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/withdraw/withdrawContract.ts
@@ -28,7 +28,7 @@ export const buildWithdrawReviewForm = (): FormState => ({
     feePerUnit: '0',
     feeLimit: '',
     options: ['broadcast'],
-    tronStakeWithdraw: true,
+    tronStaking: { kind: 'withdraw' },
     isCoinControlEnabled: false,
     hasCoinControlBeenOpened: false,
     selectedUtxos: [],

--- a/suite-common/wallet-core/src/stake/tron/shared/signTronContract.ts
+++ b/suite-common/wallet-core/src/stake/tron/shared/signTronContract.ts
@@ -6,9 +6,14 @@ import TrezorConnect from '@trezor/connect';
 import { type TronFreezeContract } from '../actions/freeze/freezeContract';
 import { type TronUnstakeContract } from '../actions/unstake/unstakeContract';
 import { type TronVoteContract } from '../actions/vote/voteContract';
+import { type TronWithdrawContract } from '../actions/withdraw/withdrawContract';
 import { type TronStakeError } from '../tronStakeTypes';
 
-type TronStakeContract = TronFreezeContract | TronUnstakeContract | TronVoteContract;
+type TronStakeContract =
+    | TronFreezeContract
+    | TronUnstakeContract
+    | TronVoteContract
+    | TronWithdrawContract;
 
 type SignTronContractResult = { serializedTx: string } | { error: TronStakeError };
 

--- a/suite-common/wallet-core/src/stake/tron/tronStakeTypes.ts
+++ b/suite-common/wallet-core/src/stake/tron/tronStakeTypes.ts
@@ -1,13 +1,14 @@
 export const TRON_RESOURCE_TYPES = ['bandwidth', 'energy'] as const;
 export type TronResourceType = (typeof TRON_RESOURCE_TYPES)[number];
 
-export const TRON_FLOWS = ['stake', 'vote', 'unstake'] as const;
+export const TRON_FLOWS = ['stake', 'vote', 'unstake', 'withdraw'] as const;
 export type TronFlow = (typeof TRON_FLOWS)[number];
 
 export const TRON_FLOW_STEPS = {
     stake: ['freeze', 'vote', 'complete'],
     vote: ['vote', 'complete'],
     unstake: ['unstake', 'complete'],
+    withdraw: ['withdraw', 'complete'],
 } as const satisfies Record<TronFlow, readonly string[]>;
 
 export type TronStakeStepId = (typeof TRON_FLOW_STEPS)[TronFlow][number];

--- a/suite-common/wallet-core/src/stake/tron/tronStakeUtils.ts
+++ b/suite-common/wallet-core/src/stake/tron/tronStakeUtils.ts
@@ -1,7 +1,22 @@
+import { type Account } from '@suite-common/wallet-types';
 import { type TronAccountExtraData } from '@trezor/blockchain-link-types';
 import { BigNumber } from '@trezor/utils';
 
 import { type TronResourceType } from './tronStakeTypes';
+
+export const getWithdrawableAmount = (account: Account): string => {
+    const stakingInfo =
+        account.networkType === 'tron' ? account.misc.tronResources?.stakingInfo : undefined;
+
+    const nowSeconds = Date.now() / 1000;
+
+    return (stakingInfo?.unstakingBatches ?? [])
+        .reduce(
+            (total, batch) => (batch.expireTime <= nowSeconds ? total.plus(batch.amount) : total),
+            new BigNumber(0),
+        )
+        .toString();
+};
 
 export const getResourceGain = (
     amount: string,

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -16,6 +16,11 @@ export type FormOptions =
 
 export type UtxoSorting = 'newestFirst' | 'oldestFirst' | 'smallestFirst' | 'largestFirst';
 
+export type TronStakingFormState =
+    | { kind: 'freeze' | 'unstake'; resource: 'bandwidth' | 'energy' }
+    | { kind: 'vote'; votes: string }
+    | { kind: 'withdraw' };
+
 export type FormStateTradingCryptoCurrency = {
     cryptoId: CryptoId | undefined;
     accountKey: AccountKey | undefined;
@@ -83,9 +88,7 @@ export interface FormState {
     ethereumAdjustGasLimit?: string; // if used, final gas limit = estimated limit * ethereumAdjustGasLimit
     transactionData?: string; // used for solana serialized txn from trading api, ethereum or tron txn hex data
     destinationTag?: string; // For Ripple, Stellar, Solana, and Tron
-    tronStakeResource?: 'bandwidth' | 'energy';
-    tronStakeVotes?: string;
-    tronStakeWithdraw?: boolean;
+    tronStaking?: TronStakingFormState;
     rbfParams?: RbfTransactionParams;
     isCoinControlEnabled: boolean;
     hasCoinControlBeenOpened: boolean;

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -85,6 +85,7 @@ export interface FormState {
     destinationTag?: string; // For Ripple, Stellar, Solana, and Tron
     tronStakeResource?: 'bandwidth' | 'energy';
     tronStakeVotes?: string;
+    tronStakeWithdraw?: boolean;
     rbfParams?: RbfTransactionParams;
     isCoinControlEnabled: boolean;
     hasCoinControlBeenOpened: boolean;

--- a/suite-common/wallet-types/src/transactionReviewOutput.ts
+++ b/suite-common/wallet-types/src/transactionReviewOutput.ts
@@ -25,6 +25,7 @@ export type ReviewOutput =
               | 'recipient_name'
               | 'swap_intent'
               | 'tron-vote'
+              | 'tron-withdraw'
               | 'fee-limit';
           label?: string;
           value: string;

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -344,9 +344,8 @@ const constructNewFlow = ({
     const isSolana = account.networkType === 'solana';
     const isStellar = account.networkType === 'stellar';
     const isTron = account.networkType === 'tron';
-    const isTronStakeFreeze = isTron && Boolean(precomposedForm.tronStakeResource);
-    const isTronStakeVote = isTron && precomposedForm.tronStakeVotes !== undefined;
-    const isTronStakeWithdraw = isTron && Boolean(precomposedForm.tronStakeWithdraw);
+    const tronStaking = isTron ? precomposedForm.tronStaking : undefined;
+    const isTronStakeFreeze = tronStaking?.kind === 'freeze' || tronStaking?.kind === 'unstake';
     const evmApprovalTxData = Calldata.evm.erc20.approve.decode(precomposedForm.transactionData);
     const isEvmApproval = isEvmApprovalTx(precomposedForm.transactionData);
     const stakeType = getStakeType(precomposedForm, outputs);
@@ -392,13 +391,13 @@ const constructNewFlow = ({
         return outputs;
     }
 
-    if (isTronStakeVote) {
+    if (tronStaking?.kind === 'vote') {
         precomposedTx.outputs.forEach(o => {
             if ('address' in o && typeof o.address === 'string') {
                 outputs.push({
                     type: 'tron-vote',
                     value: o.address,
-                    value2: precomposedForm.tronStakeVotes,
+                    value2: tronStaking.votes,
                 });
             }
         });
@@ -406,7 +405,7 @@ const constructNewFlow = ({
         return outputs;
     }
 
-    if (isTronStakeWithdraw) {
+    if (tronStaking?.kind === 'withdraw') {
         outputs.push({ type: 'tron-withdraw', value: account.descriptor });
 
         return outputs;

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -346,6 +346,7 @@ const constructNewFlow = ({
     const isTron = account.networkType === 'tron';
     const isTronStakeFreeze = isTron && Boolean(precomposedForm.tronStakeResource);
     const isTronStakeVote = isTron && precomposedForm.tronStakeVotes !== undefined;
+    const isTronStakeWithdraw = isTron && Boolean(precomposedForm.tronStakeWithdraw);
     const evmApprovalTxData = Calldata.evm.erc20.approve.decode(precomposedForm.transactionData);
     const isEvmApproval = isEvmApprovalTx(precomposedForm.transactionData);
     const stakeType = getStakeType(precomposedForm, outputs);
@@ -401,6 +402,12 @@ const constructNewFlow = ({
                 });
             }
         });
+
+        return outputs;
+    }
+
+    if (isTronStakeWithdraw) {
+        outputs.push({ type: 'tron-withdraw', value: account.descriptor });
 
         return outputs;
     }

--- a/suite/e2e/tests/general/check-links.test.ts
+++ b/suite/e2e/tests/general/check-links.test.ts
@@ -173,6 +173,7 @@ const SECTIONS = {
         '/earn/tron/stake',
         '/earn/tron/vote',
         '/earn/tron/unstake',
+        '/earn/tron/withdraw',
     ],
 } as const satisfies Record<string, string[]>;
 

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10266,6 +10266,14 @@ export const messages = defineMessages({
         id: 'TR_EARN_TRON_PENDING_UNSTAKE',
         defaultMessage: 'Confirming unstake…',
     },
+    TR_EARN_TRON_PENDING_WITHDRAW: {
+        id: 'TR_EARN_TRON_PENDING_WITHDRAW',
+        defaultMessage: 'Confirming withdrawal…',
+    },
+    TR_EARN_TRON_WITHDRAW_TITLE: {
+        id: 'TR_EARN_TRON_WITHDRAW_TITLE',
+        defaultMessage: 'Withdraw',
+    },
     TR_EARN_TRON_UNSTAKE_TITLE: {
         id: 'TR_EARN_TRON_UNSTAKE_TITLE',
         defaultMessage: 'Unstake',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10278,6 +10278,18 @@ export const messages = defineMessages({
         id: 'TR_EARN_TRON_CLAIM_ADDRESS',
         defaultMessage: 'Claim address',
     },
+    TR_EARN_TRON_WITHDRAW_COMPLETE: {
+        id: 'TR_EARN_TRON_WITHDRAW_COMPLETE',
+        defaultMessage: 'Withdrawal complete',
+    },
+    TR_EARN_TRON_WITHDRAW_DESCRIPTION: {
+        id: 'TR_EARN_TRON_WITHDRAW_DESCRIPTION',
+        defaultMessage: 'The withdrawn amount was added to your balance.',
+    },
+    TR_EARN_TRON_WITHDRAWN: {
+        id: 'TR_EARN_TRON_WITHDRAWN',
+        defaultMessage: 'Withdrawn',
+    },
     TR_EARN_TRON_UNSTAKE_TITLE: {
         id: 'TR_EARN_TRON_UNSTAKE_TITLE',
         defaultMessage: 'Unstake',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10274,6 +10274,10 @@ export const messages = defineMessages({
         id: 'TR_EARN_TRON_WITHDRAW_TITLE',
         defaultMessage: 'Withdraw',
     },
+    TR_EARN_TRON_CLAIM_ADDRESS: {
+        id: 'TR_EARN_TRON_CLAIM_ADDRESS',
+        defaultMessage: 'Claim address',
+    },
     TR_EARN_TRON_UNSTAKE_TITLE: {
         id: 'TR_EARN_TRON_UNSTAKE_TITLE',
         defaultMessage: 'Unstake',

--- a/suite/router-config/src/routeConfig.ts
+++ b/suite/router-config/src/routeConfig.ts
@@ -77,6 +77,12 @@ export const routes = [
         params: earnParams,
     },
     {
+        name: 'earn-tron-withdraw',
+        pattern: '/earn/tron/withdraw',
+        app: 'earn-staking',
+        params: earnParams,
+    },
+    {
         name: 'suite-version',
         pattern: '/version',
         app: 'version',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds the **Tron withdraw flow**.

Key changes:
- **connect** — encode `WithdrawExpireUnfreezeContract`
- **suite-common** — withdraw compose / sign / submit thunks
- **suite** — withdraw route scaffold, form UI, submit wiring, review-modal title, success screen
- **Refactor**: the per-flow `FormState` fields (tronStakeResource / tronStakeVotes / tronStakeWithdraw) are consolidated into a single `tronStaking` discriminated union, so the already-large send-form type stops growing

## Notes for QA

Flow available on the `/earn/tron/withdraw#{trx,ttrx}/<account_index>/<account_type>`.

I suggest you test it on testnet where the withdrawal period is just one day instead of 14


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28670

## Screenshots:

### Form
<img width="528" height="296" alt="Screenshot 2026-06-15 at 13 04 23" src="https://github.com/user-attachments/assets/7346d7a9-7b9e-4ca3-8c01-d37d2ca6ef17" />

### tx review modal
<img width="633" height="457" alt="Screenshot 2026-06-15 at 13 04 31" src="https://github.com/user-attachments/assets/89e15cc2-6f6a-45ff-bb8e-668405dc8dfa" />

### In-progress submit
<img width="551" height="364" alt="Screenshot 2026-06-15 at 13 04 46" src="https://github.com/user-attachments/assets/43052ddf-d461-4415-8105-72305d300c7d" />

 ### fake tx detail
<img width="776" height="435" alt="Screenshot 2026-06-15 at 13 05 54" src="https://github.com/user-attachments/assets/0aedd930-8cbf-443f-9f2e-83840b049356" />

### Success
<img width="556" height="417" alt="image" src="https://github.com/user-attachments/assets/02310b09-9134-4472-baae-1209b3b583e2" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-withdraw-flow/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-withdraw-flow/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-withdraw-flow&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-withdraw-flow&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-withdraw-flow&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-17T12:06:29.475Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-17T12:04:11.549Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->