### PR TITLE
ci(connect): add license-compliance gate for connect packages

### DIFF
--- a/.github/workflows/test-connect-misc.yml
+++ b/.github/workflows/test-connect-misc.yml
@@ -92,3 +92,67 @@ jobs:
 
       - name: Test local install
         run: ./packages/connect/e2e/test-connect-local.sh
+
+  check-licenses:
+    name: License compliance
+    runs-on: ubuntu-latest
+    if: github.repository == 'trezor/trezor-suite'
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Setup node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
+        continue-on-error: true
+        with:
+          version: v0.19.1
+      - name: Install dependencies
+        run: yarn install
+
+      # @trezor/connect (the core package) and its thin wrappers
+      # (connect-web / connect-mobile / connect-webextension) are the packages
+      # 3rd parties install. A copyleft license (GPL/AGPL/SSPL/...) anywhere in
+      # their production closure would impose obligations on every downstream
+      # consumer, so it must never be pulled in.
+      #
+      # We start the scan at the hoisted package directory under the root
+      # node_modules (not packages/<pkg>): in a Yarn workspace the package's
+      # production dependencies are hoisted to the root node_modules, so that is
+      # the only start point from which license-checker resolves and walks the
+      # full transitive closure. Starting at packages/<pkg> would only see the
+      # package itself. Internal @trezor/ packages are filtered from the report
+      # (they ship under the repo's own non-copyleft reference-source license),
+      # but the scan still walks through them into their third-party
+      # dependencies. Only the @trezor/ scope appears in these closures — the
+      # lower package layers cannot import from @suite*, so no other first-party
+      # scope needs filtering. Note --excludePackagesStartingWith takes a single
+      # prefix; a comma-separated list is silently treated as one literal prefix
+      # and matches nothing.
+      - name: Check public closure licenses (no copyleft)
+        run: |
+          # license-checker is run via `yarn dlx` (version-pinned) rather than a
+          # repo devDependency on purpose: it is a CI-only tool with a large
+          # transitive tree, and vendoring it would add ~90 packages to the
+          # lockfile and the project's supply-chain surface for no runtime gain.
+          LICENSE_CHECKER="license-checker-rseidelsohn@5.0.1"
+          FORBIDDEN="GPL-2.0;GPL-3.0;AGPL-1.0;AGPL-3.0;SSPL-1.0;OSL-3.0;EUPL-1.1;EUPL-1.2;CPAL-1.0"
+          for pkg in connect connect-web connect-mobile connect-webextension; do
+            echo "::group::License summary for @trezor/$pkg"
+            yarn dlx "$LICENSE_CHECKER" \
+              --start "node_modules/@trezor/$pkg" \
+              --production \
+              --excludePackagesStartingWith "@trezor/" \
+              --summary
+            echo "::endgroup::"
+            yarn dlx "$LICENSE_CHECKER" \
+              --start "node_modules/@trezor/$pkg" \
+              --production \
+              --excludePackagesStartingWith "@trezor/" \
+              --failOn "$FORBIDDEN"
+          done


### PR DESCRIPTION
## Description

Adds a `check-licenses` job to `test-connect-misc.yml` that scans the production dependency closure of `@trezor/connect` (the core package) and its three thin entry points — `@trezor/connect-web`, `@trezor/connect-mobile`, `@trezor/connect-webextension` — and fails on any copyleft license (GPL/AGPL/SSPL/OSL/EUPL/CPAL).

These are the most-installed packages by 3rd parties and they publish under MIT. A copyleft license anywhere in their closure would impose obligations on every downstream consumer, and nothing currently guards against one being pulled in. This complements the existing `@trezor/requirements` `connect-public-dependencies` snapshots (which track *which* packages are in the closure) by checking *under which license* that closure ships.

Implementation notes:
- Uses `license-checker-rseidelsohn`, run via version-pinned `yarn dlx` rather than a repo devDependency. It is a CI-only tool with a large transitive tree (~90 packages); vendoring it would grow the lockfile and the project's supply-chain surface for no runtime gain. Yarn 4 has no built-in `yarn licenses` command, and `nodeLinker: node-modules` makes this tool a natural fit.
- The scan starts at the hoisted package dir under the root `node_modules` (`node_modules/@trezor/<pkg>`), not `packages/<pkg>`. In a Yarn workspace the production dependencies are hoisted to the root `node_modules`, so that is the only start point from which license-checker resolves and walks the full **transitive** closure; starting at the workspace source dir only sees the package itself. Verified against a synthetic hoisted workspace that the start path catches both direct and transitively-nested copyleft deps.
- Blocklist (copyleft) rather than allowlist — targets real legal risk with low noise and no clarifications file. LGPL is intentionally omitted for now; it is a policy decision (dynamic-linking exception) and can be added.
- Internal `@trezor/` packages are filtered from the report via `--excludePackagesStartingWith "@trezor/"` (they ship under the repo's own non-copyleft reference-source license), but the scan still walks through them into their third-party dependencies. Only the `@trezor/` scope appears in these closures — the package layering forbids the lower layers from importing `@suite*`, so no other first-party scope needs filtering. (`--excludePackagesStartingWith` takes a single prefix; a comma-separated list is silently treated as one literal prefix and matches nothing.)
- A per-package `--summary` is printed before the failing check so the closure's license breakdown is visible in the job log.

Current result (job green): the third-party closures are fully permissive, no copyleft. Per-package breakdown (verified locally against the rebased tree):
- `@trezor/connect` — 35×MIT, 8×Apache-2.0, 1×(Apache-2.0 AND BSD-3-Clause), 1×0BSD, 1×BSD-2-Clause, 1×ISC
- `@trezor/connect-web` — 4×MIT, 1×(Apache-2.0 AND BSD-3-Clause), 1×0BSD
- `@trezor/connect-mobile` — 3×MIT, 1×(Apache-2.0 AND BSD-3-Clause), 1×0BSD
- `@trezor/connect-webextension` — 4×MIT, 1×(Apache-2.0 AND BSD-3-Clause), 1×0BSD

Gate verified to actually reject copyleft, in two scenarios (both throwaway commits, since removed; branch is clean):
- Direct dependency — `pm2` (`AGPL-3.0`) added directly to `@trezor/connect-web`. Failed run: https://github.com/trezor/trezor-suite/actions/runs/27907334670/job/82578221280
- Nested dependency — `pm2` added to `@trezor/utils`, a (report-excluded) `@trezor/` dependency of `@trezor/connect-web`, so the copyleft sits behind a first-party package. Still caught, confirming the report exclusion is display-only and the scan walks through excluded first-party packages into their third-party deps. Failed run: https://github.com/trezor/trezor-suite/actions/runs/27907857804/job/82579614659

In both cases the job printed `AGPL-3.0: 1` in the summary and failed with `Found license defined by the --failOn flag: "AGPL-3.0". Exiting.`

Scope/strictness (allowlist mode, LGPL, broader package set) can be tuned in follow-ups.

## Related Issue

N/A

## Screenshots

N/A

## Notes for QA

No runtime/product impact — this only adds a CI job and a devDependency; no shipped code changes. Nothing to test on device or in the app. The only thing to verify is the new `License compliance` job in the `[Test] connect misc` workflow: it runs on this PR (the PR touches the workflow file, which is in the trigger paths) and passes, with the `--summary` groups in the log showing the scanned closure. If it ever fails, the job output names the offending package and its license.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-license-gate&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-license-gate&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T11:40:49.402Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T11:40:14.424Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-license-gate/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-license-gate/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->
