### PR TITLE
feat(trading): add buy preview confirm step before partner redirect

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/__tests__/useTradingBuyConfirm.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/__tests__/useTradingBuyConfirm.test.tsx
@@ -1,0 +1,181 @@
+import type { BuyTrade, CryptoId, FiatCurrencyCode } from 'invity-api';
+
+import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { type Account, type AccountKey } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+
+import { useTradingBuyConfirm } from '../useTradingBuyConfirm';
+
+jest.mock('@suite/router', () => ({
+    ...jest.requireActual('@suite/router'),
+    goto: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
+}));
+
+jest.mock('@suite-common/dependency-injection', () => ({
+    ...jest.requireActual('@suite-common/dependency-injection'),
+    useServices: () => ({ analytics: { report: jest.fn() } }),
+}));
+
+const mockConfirmTradeThunk = jest.fn((args: unknown) => {
+    const thunk = () => ({ unwrap: () => Promise.resolve({ paymentId: 'payment-1' }) });
+
+    return Object.assign(thunk, { args });
+});
+
+jest.mock('@suite-common/trading', () => {
+    const actual = jest.requireActual('@suite-common/trading');
+
+    return {
+        ...actual,
+        buyThunks: {
+            ...actual.buyThunks,
+            confirmTradeThunk: (args: unknown) => mockConfirmTradeThunk(args),
+        },
+    };
+});
+
+const ACCOUNT = mockWalletAccount({ symbol: 'btc' });
+const BITCOIN_CRYPTO_ID = 'bitcoin' as CryptoId;
+const EURO_FIAT_CURRENCY = 'EUR' as FiatCurrencyCode;
+
+const SELECTED_QUOTE: BuyTrade = {
+    fiatStringAmount: '47.12',
+    fiatCurrency: EURO_FIAT_CURRENCY,
+    receiveCurrency: BITCOIN_CRYPTO_ID,
+    receiveStringAmount: '0.004705020432603938',
+    rate: 10014.834297738,
+    quoteId: 'd369ba9e-7370-4a6e-87dc-aefd3851c735',
+    exchange: 'paybis',
+    minFiat: 20.03,
+    maxFiat: 2000.05,
+    minCrypto: 0.002,
+    maxCrypto: 0.19952,
+    paymentMethod: 'creditCard',
+    paymentId: 'payment-1',
+};
+
+type StateOverrides = {
+    selectedQuote?: BuyTrade;
+    receiveAddress?: string;
+    isLoading?: boolean;
+    accountKey?: AccountKey;
+    accounts?: Account[];
+};
+
+const DEFAULTS: Required<StateOverrides> = {
+    selectedQuote: SELECTED_QUOTE,
+    receiveAddress: 'bc1qreceive',
+    isLoading: false,
+    accountKey: ACCOUNT.key,
+    accounts: [ACCOUNT],
+};
+
+const buildState = (overrides: StateOverrides = {}) => {
+    const { selectedQuote, receiveAddress, isLoading, accountKey, accounts } = {
+        ...DEFAULTS,
+        ...overrides,
+    };
+
+    return {
+        wallet: {
+            accounts,
+            trading: {
+                buy: {
+                    selectedQuote,
+                    receiveAddress,
+                    isLoading,
+                    tradingAccountKey: accountKey,
+                    receiveAccountKey: undefined,
+                    buyInfo: undefined,
+                },
+                sell: {
+                    tradingAccountKey: undefined,
+                },
+                exchange: {
+                    tradingAccountKey: undefined,
+                },
+            },
+        },
+    };
+};
+
+const renderConfirm = (overrides?: StateOverrides) => {
+    const store = configureMockStore({ preloadedState: buildState(overrides) });
+    const { result } = renderHookWithStoreProvider(() => useTradingBuyConfirm(), { store });
+
+    return { store, result };
+};
+
+const gotoActions = (store: ReturnType<typeof renderConfirm>['store']) =>
+    store.getActions().filter(action => action.type === '@router/goto');
+
+describe('useTradingBuyConfirm', () => {
+    beforeEach(() => {
+        mockConfirmTradeThunk.mockClear();
+    });
+
+    describe('isConfirmDisabled', () => {
+        it('is false when quote, receive address and account are all present', () => {
+            const { result } = renderConfirm();
+
+            expect(result.current.isConfirmDisabled).toBe(false);
+        });
+
+        it('is true while loading', () => {
+            const { result } = renderConfirm({ isLoading: true });
+
+            expect(result.current.isConfirmDisabled).toBe(true);
+        });
+
+        it.each<[string, StateOverrides]>([
+            ['the selected quote', { selectedQuote: undefined }],
+            ['the receive address', { receiveAddress: undefined }],
+            ['the active account', { accountKey: undefined, accounts: [] }],
+        ])('is true when %s is missing', (_, overrides) => {
+            const { result } = renderConfirm(overrides);
+
+            expect(result.current.isConfirmDisabled).toBe(true);
+        });
+    });
+
+    describe('readiness guard', () => {
+        it('does not redirect when every requirement is satisfied', () => {
+            const { store } = renderConfirm();
+
+            expect(gotoActions(store)).toHaveLength(0);
+        });
+
+        it('redirects to the buy form when a requirement is missing', () => {
+            const { store } = renderConfirm({ selectedQuote: undefined });
+
+            expect(gotoActions(store)).toEqual([
+                { type: '@router/goto', payload: { routeName: 'wallet-trading-buy' } },
+            ]);
+        });
+    });
+
+    describe('confirmTrade', () => {
+        it('dispatches confirmTradeThunk with the persisted address and active account', async () => {
+            const { result } = renderConfirm();
+
+            await result.current.confirmTrade();
+
+            expect(mockConfirmTradeThunk).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    quote: SELECTED_QUOTE,
+                    address: 'bc1qreceive',
+                    account: ACCOUNT,
+                    returnUrl: expect.any(String),
+                }),
+            );
+        });
+
+        it('does nothing when the receive address is missing', async () => {
+            const { result } = renderConfirm({ receiveAddress: undefined });
+
+            await result.current.confirmTrade();
+
+            expect(mockConfirmTradeThunk).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 
-import type { BuyTrade, BuyTradeResponse } from 'invity-api';
+import type { BuyTrade } from 'invity-api';
 import useDebounce from 'react-use/lib/useDebounce';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
@@ -31,7 +31,6 @@ import {
 } from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
-import { isDesktop } from '@trezor/env-utils';
 import { isChanged } from '@trezor/utils';
 
 import { submitRequestForm } from 'src/actions/wallet/trading/tradingCommonActions';
@@ -43,11 +42,8 @@ import { useTradingBuyFormRedirectValues } from 'src/hooks/wallet/trading/form/u
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { type Dispatch } from 'src/types/suite';
 import { type UseTradingFormCommonProps } from 'src/types/trading/trading';
-import {
-    type TradingBuyConfirmTradeProps,
-    type TradingBuyFormContextProps,
-} from 'src/types/trading/tradingForm';
-import { createQuoteLink, createTxLink } from 'src/utils/wallet/trading/buyUtils';
+import { type TradingBuyFormContextProps } from 'src/types/trading/tradingForm';
+import { createQuoteLink } from 'src/utils/wallet/trading/buyUtils';
 
 import { useTradingClearStaleQuotes } from './common/useTradingClearStaleQuotes';
 import { useTradingFiatValues } from './common/useTradingFiatValues';
@@ -159,47 +155,6 @@ export const useTradingBuyForm = ({
         setValue,
     });
 
-    const confirmTrade = async ({
-        trade,
-        receiveAddress,
-    }: TradingBuyConfirmTradeProps): Promise<BuyTrade | undefined> => {
-        const buyTrade = trade ?? selectedQuote;
-
-        if (!buyTrade) return;
-
-        const returnUrl = await createTxLink(buyTrade, account);
-
-        const processResponseData = (response: BuyTradeResponse) => {
-            if (response.tradeForm) {
-                dispatch(submitRequestForm(response.tradeForm.form));
-            }
-            if (isDesktop()) {
-                if (response.trade.paymentId) {
-                    dispatch(tradingBuyActions.saveTransactionId(response.trade.paymentId));
-                }
-                dispatch(goto({ routeName: 'wallet-trading-buy-detail' }));
-            }
-        };
-
-        const triggerAnalyticsTradeConfirmation = () => {
-            analytics.report({
-                type: events.tradeConfirmTradeEvent.name,
-                payload: { action: type },
-            });
-        };
-
-        return await dispatch(
-            buyThunks.confirmTradeThunk({
-                quote: buyTrade,
-                address: receiveAddress,
-                returnUrl,
-                account,
-                processResponseData,
-                triggerAnalyticsTradeConfirmation,
-            }),
-        ).unwrap();
-    };
-
     const selectQuote = async (quote: BuyTrade) => {
         const provider = buyInfo && quote.exchange ? buyInfo.providerInfos[quote.exchange] : null;
 
@@ -233,7 +188,7 @@ export const useTradingBuyForm = ({
                     dispatch(submitRequestForm(form));
                 },
                 nextStep: () => {
-                    confirmTrade({ trade: quote, receiveAddress });
+                    dispatch(goto({ routeName: 'wallet-trading-buy-confirm' }));
                 },
             }),
         );
@@ -405,7 +360,6 @@ export const useTradingBuyForm = ({
         isAmountEmpty,
         selectQuote,
         onQuoteSelected,
-        confirmTrade,
         verifyAddress,
         setAmountLimits: (limits: TradingAmountLimitProps | undefined) => {
             dispatch(tradingBuyActions.setAmountLimits(limits));

--- a/packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.ts
@@ -1,0 +1,79 @@
+import { useEffect } from 'react';
+
+import type { BuyTrade, BuyTradeResponse } from 'invity-api';
+
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
+import { goto } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
+import {
+    buyThunks,
+    selectTradingAccountKeyByTradeType,
+    selectTradingBuyIsLoading,
+    selectTradingBuyReceiveAddress,
+    selectTradingBuySelectedQuote,
+    tradingBuyActions,
+} from '@suite-common/trading';
+import { selectAccountByKey } from '@suite-common/wallet-core';
+import { isDesktop } from '@trezor/env-utils';
+
+import { submitRequestForm } from 'src/actions/wallet/trading/tradingCommonActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { createTxLink } from 'src/utils/wallet/trading/buyUtils';
+
+export const useTradingBuyConfirm = () => {
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const dispatch = useDispatch();
+
+    const selectedQuote = useSelector(selectTradingBuySelectedQuote);
+    const receiveAddress = useSelector(selectTradingBuyReceiveAddress);
+    const isLoading = useSelector(selectTradingBuyIsLoading);
+    const accountKey = useSelector(state => selectTradingAccountKeyByTradeType(state, 'buy'));
+    const account = useSelector(state => selectAccountByKey(state, accountKey) ?? undefined);
+
+    const isReady = !!selectedQuote && !!receiveAddress && !!account;
+    const isConfirmDisabled = isLoading || !selectedQuote || !receiveAddress || !account;
+
+    useEffect(() => {
+        if (!isReady) {
+            dispatch(goto({ routeName: 'wallet-trading-buy' }));
+        }
+    }, [isReady, dispatch]);
+
+    const confirmTrade = async (): Promise<BuyTrade | undefined> => {
+        if (!account || !receiveAddress || !selectedQuote) return;
+
+        const returnUrl = await createTxLink(selectedQuote, account);
+
+        const processResponseData = (response: BuyTradeResponse) => {
+            if (response.tradeForm) {
+                dispatch(submitRequestForm(response.tradeForm.form));
+            }
+            if (isDesktop()) {
+                if (response.trade.paymentId) {
+                    dispatch(tradingBuyActions.saveTransactionId(response.trade.paymentId));
+                }
+                dispatch(goto({ routeName: 'wallet-trading-buy-detail' }));
+            }
+        };
+
+        const triggerAnalyticsTradeConfirmation = () => {
+            analytics.report({
+                type: events.tradeConfirmTradeEvent.name,
+                payload: { action: 'buy' },
+            });
+        };
+
+        return await dispatch(
+            buyThunks.confirmTradeThunk({
+                quote: selectedQuote,
+                address: receiveAddress,
+                returnUrl,
+                account,
+                processResponseData,
+                triggerAnalyticsTradeConfirmation,
+            }),
+        ).unwrap();
+    };
+
+    return { confirmTrade, isConfirmDisabled };
+};

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -119,11 +119,6 @@ type TradingVerifyAccountProps = (
     path?: string,
 ) => (dispatch: Dispatch, getState: GetState) => Promise<void>;
 
-export type TradingBuyConfirmTradeProps = {
-    trade?: BuyTrade;
-    receiveAddress: string;
-};
-
 export interface TradingBuyFormContextProps
     extends
         UseFormReturn<TradingBuyFormProps>,
@@ -146,9 +141,6 @@ export interface TradingBuyFormContextProps
 
     selectQuote: (quote: BuyTrade) => Promise<void>;
     onQuoteSelected: (quote: BuyTrade) => void;
-    confirmTrade: ({
-        receiveAddress,
-    }: TradingBuyConfirmTradeProps) => Promise<BuyTrade | undefined>;
     verifyAddress: TradingVerifyAccountProps;
     setAmountLimits: (limits?: AmountLimitProps) => void;
     methods: UseFormReturn<TradingBuyFormProps>;
@@ -387,8 +379,10 @@ export interface TradingOfferCommonProps {
     paymentMethodName?: string;
 }
 
-export interface TradingOfferBuyProps extends TradingOfferCommonProps {
+export interface TradingOfferBuyProps {
     selectedQuote: BuyTrade;
+    isConfirmDisabled: boolean;
+    confirmTrade: () => Promise<BuyTrade | undefined>;
 }
 
 export interface TradingOfferSellProps extends TradingOfferCommonProps {
@@ -404,5 +398,6 @@ export interface TradingOfferExchangeProps extends Omit<
 
 export interface TradingSelectedOfferInfoProps extends TradingOfferCommonProps {
     selectedAccount?: Account;
+    receiveAddress?: string;
     transactionId?: string;
 }

--- a/packages/suite/src/views/wallet/trading/buy/TradingBuyConfirm.tsx
+++ b/packages/suite/src/views/wallet/trading/buy/TradingBuyConfirm.tsx
@@ -1,27 +1,43 @@
-import { FormProvider } from 'react-hook-form';
+import {
+    selectTradingBuySelectedQuote,
+    selectTradingProviderByNameAndTradeType,
+} from '@suite-common/trading';
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { Column } from '@trezor/components';
 
-import { useTradingBuyForm } from 'src/hooks/wallet/trading/form/useTradingBuyForm';
-import { TradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
-import { getProvidersInfoProps } from 'src/utils/wallet/trading/tradingTypingUtils';
-import { getTradeProvider } from 'src/utils/wallet/trading/tradingUtils';
-import { TradingContainer } from 'src/views/wallet/trading/common/TradingContainer';
-import { TradingSelectedOffer } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOffer';
+import { useSelector } from 'src/hooks/suite';
+import { useTradingBuyConfirm } from 'src/hooks/wallet/trading/useTradingBuyConfirm';
+import { DiscoveryWarning } from 'src/views/wallet/staking/components/StakingDashboard/components/DiscoveryWarning';
+import { TradingFooter } from 'src/views/wallet/trading/common/TradingFooter/TradingFooter';
+import { useTradingPageHeader } from 'src/views/wallet/trading/common/TradingLayout/useTradingPageHeader';
+import { TradingOfferBuy } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferBuy/TradingOfferBuy';
 
 export const TradingBuyConfirm = () => {
-    const tradingBuyContextValues = useTradingBuyForm({
-        pageType: 'confirm',
-    });
+    const { confirmTrade, isConfirmDisabled } = useTradingBuyConfirm();
+    const selectedQuote = useSelector(selectTradingBuySelectedQuote);
+    const provider = useSelector(state =>
+        selectTradingProviderByNameAndTradeType(state, selectedQuote?.exchange, 'buy'),
+    );
+    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
+    useTradingPageHeader();
 
-    const provider = getTradeProvider({
-        trade: tradingBuyContextValues.selectedQuote,
-        providerInfo: getProvidersInfoProps(tradingBuyContextValues),
-    });
+    if (!selectedQuote) {
+        return null;
+    }
 
     return (
-        <TradingFormContext.Provider value={tradingBuyContextValues}>
-            <FormProvider {...tradingBuyContextValues.methods}>
-                <TradingContainer SectionComponent={TradingSelectedOffer} provider={provider} />
-            </FormProvider>
-        </TradingFormContext.Provider>
+        <>
+            {isDiscoveryRunning && (
+                <Column margin={{ bottom: 16 }}>
+                    <DiscoveryWarning />
+                </Column>
+            )}
+            <TradingOfferBuy
+                selectedQuote={selectedQuote}
+                confirmTrade={confirmTrade}
+                isConfirmDisabled={isConfirmDisabled}
+            />
+            <TradingFooter provider={provider} />
+        </>
     );
 };

--- a/packages/suite/src/views/wallet/trading/buy/TradingFormOfferBuyActions.tsx
+++ b/packages/suite/src/views/wallet/trading/buy/TradingFormOfferBuyActions.tsx
@@ -10,7 +10,6 @@ import { useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingStellarActivation } from 'src/hooks/wallet/trading/useTradingStellarActivation';
 import { TradingFormOfferConfirmButton } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferConfirmButton';
-import { TradingFormOfferKYCWarning } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferKYCWarning';
 import { TradingFormOfferOTC } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC';
 import { useTradingFormOfferCommon } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffer/hooks/useTradingFormOfferCommon';
 import { useReceiveAddressModalControls } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/useReceiveAddressModalControls';
@@ -76,7 +75,8 @@ export const TradingFormOfferBuyActions = () => {
 
         return (
             <TradingFormOfferConfirmButton
-                {...confirmButtonData}
+                translationId="TR_CONTINUE"
+                isLoading={confirmButtonData.isLoading}
                 onClick={onSelectQuote}
                 isDisabled={isButtonDisabled}
                 testId="@trading/form/buy-button"
@@ -87,7 +87,6 @@ export const TradingFormOfferBuyActions = () => {
     return (
         <>
             {renderActionButton()}
-            {quote && <TradingFormOfferKYCWarning />}
             {stellarActivateModal}
             <TradingFormOfferOTC />
         </>

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuySidebar.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuySidebar.tsx
@@ -25,7 +25,6 @@ export const TradingDetailBuySidebar = ({
         <Column gap={24} padding={24}>
             <TradingInfoItem
                 account={receiveAccount}
-                type="buy"
                 label="TR_TRADING_YOU_GET"
                 currency={quoteAmounts.receiveCurrency}
                 amount={quoteAmounts.receiveAmount}

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchangeSidebar.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchangeSidebar.tsx
@@ -62,7 +62,6 @@ export const TradingDetailExchangeSidebar = ({
             <Column gap={24} padding={24}>
                 <TradingInfoItem
                     account={sendAccount}
-                    type="exchange"
                     label="TR_TRADING_YOU_PAY"
                     currency={trade.send}
                     amount={trade.sendStringAmount}
@@ -72,7 +71,6 @@ export const TradingDetailExchangeSidebar = ({
 
                 <TradingInfoItem
                     account={receiveAccount}
-                    type="exchange"
                     label="TR_TRADING_YOU_GET"
                     currency={trade.receive}
                     amount={trade.receiveStringAmount}

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSellSidebar.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSellSidebar.tsx
@@ -25,7 +25,6 @@ export const TradingDetailSellSidebar = ({
         <Column gap={24} padding={24}>
             <TradingInfoItem
                 account={sendAccount}
-                type="sell"
                 label="TR_TRADING_YOU_PAY"
                 currency={quoteAmounts.receiveCurrency}
                 amount={quoteAmounts.receiveAmount}

--- a/packages/suite/src/views/wallet/trading/common/TradingKYCWarning.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingKYCWarning.tsx
@@ -1,7 +1,7 @@
 import { Translation } from '@suite/intl';
 import { Banner } from '@trezor/components';
 
-export const TradingFormOfferKYCWarning = () => (
+export const TradingKYCWarning = () => (
     <Banner
         intent="warning"
         icon="identificationCard"

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
@@ -3,11 +3,7 @@ import { type CryptoId } from 'invity-api';
 import { AccountLabel } from '@suite/account';
 import { Address } from '@suite/address';
 import { Translation, useTranslation } from '@suite/intl';
-import {
-    type TradingType,
-    cryptoIdToNetworkSymbolAndContractAddress,
-    useTradingAssets,
-} from '@suite-common/trading';
+import { cryptoIdToNetworkSymbolAndContractAddress, useTradingAssets } from '@suite-common/trading';
 import { type NetworkSymbol, getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { type Account, type TokenAddress } from '@suite-common/wallet-types';
 import { Box, Column, Row, SkeletonRectangle, Text } from '@trezor/components';
@@ -20,7 +16,6 @@ import { TradingCryptoAmount } from 'src/views/wallet/trading/common/TradingCryp
 
 interface TradingInfoItemProps {
     account?: Account;
-    type: TradingType;
     label: TradingPayGetLabelType;
     currency?: CryptoId;
     amount?: string;
@@ -32,7 +27,6 @@ interface TradingInfoItemProps {
 
 export const TradingInfoItem = ({
     account,
-    type,
     isReceive,
     label,
     currency,
@@ -47,7 +41,7 @@ export const TradingInfoItem = ({
     const accountLabelPrefix = translationString(isReceive ? 'TR_TO' : 'TR_FROM').toLowerCase();
 
     const showAccountLabel = !!account;
-    const isExternalExchange = type === 'exchange' && !account && !!receiveAddress;
+    const isExternalAddress = !account && !!receiveAddress;
     const testIdPrefix = `@trading/detail/${isReceive ? 'receive' : 'send'}`;
 
     const {
@@ -73,7 +67,7 @@ export const TradingInfoItem = ({
                 <Text intent="neutral" priority="secondary" typographyStyle="body-sm">
                     <Translation id={label} />
                 </Text>
-                {(showAccountLabel || isExternalExchange) && (
+                {(showAccountLabel || isExternalAddress) && (
                     <Text
                         intent="neutral"
                         priority="secondary"
@@ -83,10 +77,10 @@ export const TradingInfoItem = ({
                     >
                         <Row>
                             {accountLabelPrefix}&nbsp;
-                            {isExternalExchange && (
+                            {isExternalAddress && (
                                 <Address isCopyAllowed isTruncated value={receiveAddress} />
                             )}
-                            {!isExternalExchange && account && (
+                            {!isExternalAddress && account && (
                                 <Text maxWidth={200} as="div">
                                     <AccountLabel
                                         account={account}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferBuy/TradingOfferBuy.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferBuy/TradingOfferBuy.tsx
@@ -1,0 +1,87 @@
+import { Translation } from '@suite/intl';
+import {
+    selectTradingBuyInfo,
+    selectTradingBuyReceiveAccountKey,
+    selectTradingBuyReceiveAddress,
+    selectTradingProviderCompanyName,
+} from '@suite-common/trading';
+import { selectAccountByKey } from '@suite-common/wallet-core';
+import { Card, Column, H2, Text } from '@trezor/components';
+import { useAsyncClickHandler } from '@trezor/react-utils';
+
+import { useSelector } from 'src/hooks/suite';
+import { type TradingGetCryptoQuoteAmountProps } from 'src/types/trading/trading';
+import { type TradingOfferBuyProps } from 'src/types/trading/tradingForm';
+import { TradingFormOfferConfirmButton } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferConfirmButton';
+import { TradingKYCWarning } from 'src/views/wallet/trading/common/TradingKYCWarning';
+import { TradingSelectedOfferInfo } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo';
+
+export const TradingOfferBuy = ({
+    selectedQuote,
+    isConfirmDisabled,
+    confirmTrade,
+}: TradingOfferBuyProps) => {
+    const { handleClick, disabled } = useAsyncClickHandler();
+
+    const buyInfo = useSelector(selectTradingBuyInfo);
+    const receiveAddress = useSelector(selectTradingBuyReceiveAddress);
+    const receiveAccountKey = useSelector(selectTradingBuyReceiveAccountKey);
+    const receiveAccount = useSelector(
+        state => selectAccountByKey(state, receiveAccountKey) ?? undefined,
+    );
+    const providerName = useSelector(state =>
+        selectTradingProviderCompanyName(state, selectedQuote.exchange, 'buy'),
+    );
+
+    const quoteAmounts: TradingGetCryptoQuoteAmountProps = {
+        amountInCrypto: selectedQuote?.wantCrypto,
+        sendAmount: selectedQuote.fiatStringAmount ?? '',
+        sendCurrency: selectedQuote.fiatCurrency,
+        receiveAmount: selectedQuote.receiveStringAmount ?? '',
+        receiveCurrency: selectedQuote.receiveCurrency,
+    };
+
+    return (
+        <Column width="100%" alignItems="center">
+            <Card maxWidth="440px" data-testid="@trading/selected-offer">
+                <Column gap={12}>
+                    <Column margin={{ bottom: 16 }}>
+                        <H2 typographyStyle="headline-sm">
+                            <Translation
+                                id="TR_TRADING_BUY_CONFIRM_TITLE"
+                                values={{ providerName: providerName ?? '' }}
+                            />
+                        </H2>
+                        <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                            <Translation id="TR_TRADING_BUY_CONFIRM_DESCRIPTION" />
+                        </Text>
+                    </Column>
+
+                    <TradingSelectedOfferInfo
+                        type="buy"
+                        selectedQuote={selectedQuote}
+                        providers={buyInfo?.providerInfos}
+                        quoteAmounts={quoteAmounts}
+                        paymentMethod={selectedQuote.paymentMethod}
+                        paymentMethodName={selectedQuote.paymentMethodName}
+                        selectedAccount={receiveAccount}
+                        receiveAddress={receiveAddress}
+                    />
+                    <Column gap={12}>
+                        <TradingFormOfferConfirmButton
+                            translationId="TR_TRADING_BUY_VIA"
+                            translationValues={{ providerName: providerName ?? '' }}
+                            iconRight="arrowSquareOut"
+                            testId="@trading/offer/buy-button"
+                            isDisabled={isConfirmDisabled || disabled}
+                            isLoading={disabled}
+                            onClick={() => handleClick(confirmTrade)}
+                        />
+
+                        <TradingKYCWarning />
+                    </Column>
+                </Column>
+            </Card>
+        </Column>
+    );
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
@@ -83,7 +83,6 @@ export const TradingOfferExchange = ({
             <TradingInfoItem
                 key={amountLabels.sendLabel}
                 account={sendAccount}
-                type={type}
                 label={amountLabels.sendLabel}
                 currency={quoteAmounts?.sendCurrency as CryptoId}
                 amount={quoteAmounts?.sendAmount}
@@ -92,7 +91,6 @@ export const TradingOfferExchange = ({
             <TradingInfoItem
                 key={amountLabels.receiveLabel}
                 account={receiveAccount}
-                type={type}
                 label={amountLabels.receiveLabel}
                 currency={quoteAmounts?.receiveCurrency}
                 amount={quoteAmounts?.receiveAmount}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo.tsx
@@ -2,8 +2,7 @@ import { Translation } from '@suite/intl';
 import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import type { TradingOfferSellProps } from 'src/types/trading/tradingForm';
-import type { Account } from 'src/types/wallet';
+import type { TradingSelectedOfferInfoProps } from 'src/types/trading/tradingForm';
 import { tradingGetAmountLabels } from 'src/utils/wallet/trading/tradingUtils';
 
 import { TradingFiatAmountInfoItem } from './TradingInfo/TradingFiatAmountInfoItem';
@@ -11,31 +10,30 @@ import { TradingInfoItem } from './TradingInfo/TradingInfoItem';
 import { TradingPaymentMethodInfoItem } from './TradingInfo/TradingPaymentMethodInfoItem';
 import { TradingProviderInfoItem } from './TradingInfo/TradingProviderInfoItem';
 
-type TradingSelectedOfferInfoProps = TradingOfferSellProps & {
-    selectedAccount?: Account;
-};
-
 export const TradingSelectedOfferInfo = ({
+    type,
     selectedQuote,
     providers,
     quoteAmounts,
     selectedAccount,
+    receiveAddress,
     paymentMethod,
     paymentMethodName,
 }: TradingSelectedOfferInfoProps) => {
     const { exchange } = selectedQuote;
 
     const amountInCrypto = quoteAmounts?.amountInCrypto ?? true;
-    const amountLabels = tradingGetAmountLabels({ type: 'sell', amountInCrypto });
+    const amountLabels = tradingGetAmountLabels({ type, amountInCrypto });
 
     return (
         <Column gap={spacings.lg} data-testid="@trading/form/info">
             <TradingInfoItem
                 account={selectedAccount}
-                type="sell"
                 label={amountLabels.receiveLabel}
                 currency={quoteAmounts?.receiveCurrency}
                 amount={quoteAmounts?.receiveAmount}
+                receiveAddress={receiveAddress}
+                isReceive={type === 'buy'}
             />
 
             <Column gap={spacings.xs}>
@@ -45,14 +43,14 @@ export const TradingSelectedOfferInfo = ({
                     label={<Translation id={amountLabels.sendLabel} />}
                 />
 
-                <TradingProviderInfoItem providers={providers} exchange={exchange} />
-
                 {paymentMethod && (
                     <TradingPaymentMethodInfoItem
                         paymentMethod={paymentMethod}
                         paymentMethodName={paymentMethodName}
                     />
                 )}
+
+                <TradingProviderInfoItem providers={providers} exchange={exchange} />
             </Column>
         </Column>
     );

--- a/packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.tsx
@@ -5,9 +5,9 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { getTradingFirstOutput } from 'src/utils/wallet/trading/tradingUtils';
 import { TradingFormOfferConfirmButton } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferConfirmButton';
-import { TradingFormOfferKYCWarning } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferKYCWarning';
 import { TradingFormOfferOTC } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC';
 import { useTradingFormOfferCommon } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffer/hooks/useTradingFormOfferCommon';
+import { TradingKYCWarning } from 'src/views/wallet/trading/common/TradingKYCWarning';
 
 export const TradingFormOfferSellActions = () => {
     const dispatch = useDispatch();
@@ -68,7 +68,7 @@ export const TradingFormOfferSellActions = () => {
                 testId="@trading/form/sell-button"
             />
 
-            {quote && <TradingFormOfferKYCWarning />}
+            {quote && <TradingKYCWarning />}
 
             <TradingFormOfferOTC />
         </>

--- a/suite/e2e/support/pageObjects/trading/confirmationModal.ts
+++ b/suite/e2e/support/pageObjects/trading/confirmationModal.ts
@@ -20,6 +20,7 @@ export class TradingConfirmationModal {
     readonly copyTransactionIdButton: Locator;
     readonly finishButton: Locator;
     readonly confirmAndSendButton: Locator;
+    readonly buyButton: Locator;
 
     constructor(
         private readonly page: Page,
@@ -44,6 +45,7 @@ export class TradingConfirmationModal {
         this.confirmAndSendButton = this.page.getByTestId(
             '@trading/offer/confirm-on-trezor-and-send',
         );
+        this.buyButton = this.page.getByTestId('@trading/offer/buy-button');
     }
 
     @step()

--- a/suite/e2e/tests/trading/buy-bitcoin.test.ts
+++ b/suite/e2e/tests/trading/buy-bitcoin.test.ts
@@ -46,12 +46,16 @@ test.describe('Trading - Buy BTC', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () =
             await tradingPage.quotes.selectedProvider.click();
         });
 
-        await test.step('Select second offer from modal', async () => {
-            const tradeRequestPromise = page.waitForRequest(invityEndpoint.buyTrade);
+        await test.step('Select second offer from modal and continue to preview', async () => {
             await tradingPage.quotes.selectQuoteByProvider(
                 capitalizeFirstLetter(secondOfferQuote?.exchange ?? ''),
             );
             await tradingPage.buyBestOfferButton.click();
+        });
+
+        await test.step('Confirm the compared offer from the preview', async () => {
+            const tradeRequestPromise = page.waitForRequest(invityEndpoint.buyTrade);
+            await tradingPage.confirmation.buyButton.click();
             await expect(tradeRequestPromise).toHavePayload(
                 { trade: { ...secondOfferQuote, receiveAddress } },
                 { omit: ['returnUrl', 'trade.orderId', 'trade.paymentId'] },
@@ -69,12 +73,24 @@ test.describe('Trading - Buy BTC', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () =
             });
         });
 
-        await test.step('Confirm button shows provider name and KYC warning is visible', async () => {
-            await expect(tradingPage.buyBestOfferButton).toHaveTranslation('TR_TRADING_BUY_VIA', {
-                values: { providerName: bestBuyProviderCompanyName },
-            });
-            await expect(tradingPage.buyBestOfferButton.locator('svg')).toBeVisible();
+        await test.step('Form CTA shows Continue', async () => {
+            await expect(tradingPage.buyBestOfferButton).toHaveTranslation('TR_CONTINUE');
+        });
+
+        await test.step('Continue to the preview showing provider name and KYC warning', async () => {
+            await tradingPage.buyBestOfferButton.click();
+            await expect(tradingPage.confirmation.buyButton).toHaveTranslation(
+                'TR_TRADING_BUY_VIA',
+                {
+                    values: { providerName: bestBuyProviderCompanyName },
+                },
+            );
+            await expect(tradingPage.confirmation.buyButton.locator('svg')).toBeVisible();
             await expect(tradingPage.kycWarning).toBeVisible();
+
+            await expect(tradingPage.confirmation.fiatAmount).toHaveText(formattedFiatAmount);
+            await expect(tradingPage.confirmation.cryptoAmount).toHaveText(bestBuyCryptoAmount);
+            await expect(tradingPage.confirmation.provider).toHaveText(bestBuyProvider);
         });
 
         await page.clock.install();
@@ -84,7 +100,7 @@ test.describe('Trading - Buy BTC', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () =
             const tradeRequestPromise = page.waitForRequest(invityEndpoint.buyTrade);
             const watchRequestPromise = page.waitForRequest(invityEndpoint.buyWatch);
 
-            await tradingPage.buyBestOfferButton.click();
+            await tradingPage.confirmation.buyButton.click();
 
             await expect.soft(tradeRequestPromise).toHavePayload(invityRequest.buyTradeBTCPayload, {
                 omit: ['returnUrl', 'trade.orderId', 'trade.paymentId'],

--- a/suite/e2e/tests/trading/buy-ethereum.test.ts
+++ b/suite/e2e/tests/trading/buy-ethereum.test.ts
@@ -43,10 +43,16 @@ test.describe('Trading - Buy Ethereum', { tag: ['@webOnly', '@T3W1', '@T3T1'] },
             await expect(tradingPage.quotes.bestOfferAmount).toContainText('0.018615 ETH');
         });
 
-        await test.step('Confirm Trade', async () => {
+        await test.step('Continue to preview and confirm the trade', async () => {
             await tradingMock.routeTrade(invityEndpoint.buyTrade, buyTradeEthereum);
 
             await tradingPage.buyBestOfferButton.click();
+
+            await expect(tradingPage.confirmation.fiatAmount).toHaveText(formattedFiatAmount);
+            await expect(tradingPage.confirmation.cryptoAmount).toHaveText(formattedCryptoAmount);
+            await expect(tradingPage.confirmation.provider).toHaveText(provider);
+
+            await tradingPage.confirmation.buyButton.click();
         });
 
         await tradingPage.waitForRedirectCompletion();

--- a/suite/e2e/tests/trading/buy-solana-token.test.ts
+++ b/suite/e2e/tests/trading/buy-solana-token.test.ts
@@ -54,9 +54,17 @@ test.describe('Trading - Buy Solana', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, (
             await expect(tradingPage.quotes.provider).toHaveText(provider);
         });
 
+        await test.step('Continue to the preview', async () => {
+            await tradingPage.buyBestOfferButton.click();
+
+            await expect(tradingPage.confirmation.fiatAmount).toHaveText(formattedFiatAmount);
+            await expect(tradingPage.confirmation.cryptoAmount).toHaveText(formattedCryptoAmount);
+            await expect(tradingPage.confirmation.provider).toHaveText(provider);
+        });
+
         await test.step('Confirm the trade', async () => {
             const tradeRequestPromise = page.waitForRequest(invityEndpoint.buyTrade);
-            await tradingPage.buyBestOfferButton.click();
+            await tradingPage.confirmation.buyButton.click();
 
             await expect
                 .soft(tradeRequestPromise)

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1165,7 +1165,15 @@ export const messages = defineMessages({
     },
     TR_TRADING_BUY_VIA: {
         id: 'TR_TRADING_BUY_VIA',
-        defaultMessage: 'Buy with {providerName}',
+        defaultMessage: 'Buy via {providerName}',
+    },
+    TR_TRADING_BUY_CONFIRM_TITLE: {
+        id: 'TR_TRADING_BUY_CONFIRM_TITLE',
+        defaultMessage: 'Complete your buy with {providerName}',
+    },
+    TR_TRADING_BUY_CONFIRM_DESCRIPTION: {
+        id: 'TR_TRADING_BUY_CONFIRM_DESCRIPTION',
+        defaultMessage: "You'll be redirected to provider's website to finish the payment.",
     },
     TR_TRADING_SELL_VIA: {
         id: 'TR_TRADING_SELL_VIA',
@@ -1173,7 +1181,7 @@ export const messages = defineMessages({
     },
     TR_TRADING_KYC_REQUIRED_WARNING: {
         id: 'TR_TRADING_KYC_REQUIRED_WARNING',
-        defaultMessage: 'KYC is required.',
+        defaultMessage: 'Identity verification will be required.',
     },
     TR_TRADING_RATE: {
         id: 'TR_TRADING_RATE',


### PR DESCRIPTION
## Description

- Add a buy preview step before redirecting to the partner.
- Handle the preview page from Redux state instead of context, and route back to the buy form when required trade data is missing.
- Show provider, amounts, payment method, receive address, and KYC warning on the preview, then submit only from the final confirm button.

## Notes for QA

- In Trading > Buy, fill the form and click Continue; verify the preview opens with provider, amounts, payment method, receive address, and KYC warning.
- On the preview screen, click Buy with <provider>; verify the partner redirect starts only from this button and the flow does not submit directly from the form.
- Reopen the preview with missing quote or receive data; verify the app routes back to the buy form instead of staying on the confirm step.

## Related Issue

Resolve #28527

## Screenshots:

<img width="1149" height="578" alt="image" src="https://github.com/user-attachments/assets/06f4e259-32a3-450a-b2ee-a6c480de914c" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/28527-buy-preview-confirm-step/web/](https://dev.suite.sldev.cz/suite-web/feat/28527-buy-preview-confirm-step/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/28527-buy-preview-confirm-step&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/28527-buy-preview-confirm-step&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Dropbox API errors > Malformed token | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-18T13:42:17.117Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-18T13:41:15.071Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->