### PR TITLE
feat(protobuf): strict wire direction types for typedCall

### DIFF
--- a/packages/connect/src/api/cardano/cardanoUtils.ts
+++ b/packages/connect/src/api/cardano/cardanoUtils.ts
@@ -122,8 +122,8 @@ export const sendChunkedHexString = async (
     typedCall: PROTO.TypedCall,
     data: string,
     chunkSize: number,
-    messageType: PROTO.MessageKey,
-    responseType: PROTO.MessageKey = 'CardanoTxItemAck',
+    messageType: PROTO.WireInMessage,
+    responseType: PROTO.WireOutMessage = 'CardanoTxItemAck',
 ) => {
     let processedSize = 0;
     while (processedSize < data.length) {

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -103,9 +103,9 @@ export class DeviceCurrentSession implements TypedCallProvider {
     }
 
     async typedCall(
-        type: Messages.MessageKey,
-        expectedType: Messages.MessageKey | Messages.MessageKey[],
-        msg: Messages.MessagePayload = {},
+        type: Messages.WireInMessage,
+        expectedType: Messages.WireOutMessage | Messages.WireOutMessage[],
+        msg: Messages.MessagePayload<Messages.WireInMessage> = {},
     ) {
         const deviceSessionId =
             this.device.getThpState()?.sessionId || this.device?.features?.session_id;

--- a/packages/connect/tests/typedCall.type-test.ts
+++ b/packages/connect/tests/typedCall.type-test.ts
@@ -1,0 +1,45 @@
+// Type-level regression test for the wire-direction strictness of `typedCall` (see #5298).
+//
+// `typedCall` must accept only host -> device requests (`WireInMessage`) and only device -> host
+// expected responses (`WireOutMessage`). This is enforced purely at the type level; the actual
+// encode/decode is string-keyed and direction-agnostic.
+//
+// This file is part of `type-check` (tsc --build) but is NOT run by jest (no `spec`/`test`
+// filename suffix). It exercises the real call-site chain — `DeviceCommands(provider).typedCall`,
+// the same `typedCall` the per-coin `api/*.ts` modules consume — so if a future change breaks the
+// `TypedCallProvider` -> bound `typedCall` resolution, the `@ts-expect-error` directives below
+// become unused and type-check fails (TS2578).
+
+import type { MessagesSchema as Messages } from '@trezor/protobuf';
+
+import { DeviceCommands } from '../src/device/DeviceCommands';
+import type { TypedCallProvider } from '../src/types/typed-call-provider';
+
+declare const provider: TypedCallProvider;
+declare const wireOut: Messages.WireOutMessage;
+
+const { typedCall } = DeviceCommands(provider);
+
+// Valid: GetFeatures (wire_in) request -> Features (wire_out) response.
+export const valid = typedCall('GetFeatures', 'Features');
+
+// Valid: the Monero stateful signing requests are sent host -> device and are tagged wire_in.
+export const validMoneroRequest = typedCall(
+    'MoneroTransactionInitRequest',
+    'MoneroTransactionInitAck',
+);
+
+// @ts-expect-error request must be a host -> device message; 'PublicKey' is wire_out.
+export const badRequestDirection = typedCall('PublicKey', wireOut);
+
+// @ts-expect-error expected response must be a device -> host message; 'GetPublicKey' is wire_in.
+export const badResponseDirection = typedCall('GetPublicKey', 'GetPublicKey');
+
+// Valid: the array-response overload (R extends WireOutMessage[]) accepts a list of wire_out messages.
+export const validArrayResponse = typedCall('SignTx', ['TxRequest', 'ButtonRequest']);
+
+// @ts-expect-error every array response must be a device -> host message; 'GetPublicKey' is wire_in.
+export const badArrayResponseDirection = typedCall('SignTx', ['TxRequest', 'GetPublicKey']);
+
+// @ts-expect-error 'NotAMessage' is not a known protobuf message.
+export const badMessageName = typedCall('NotAMessage', wireOut);

--- a/packages/protobuf/scripts/protobuf-patches/MessageType.ts
+++ b/packages/protobuf/scripts/protobuf-patches/MessageType.ts
@@ -13,12 +13,12 @@ export type MessageResponse<T extends MessageKey = MessageKey> = T extends any
     : never;
 
 export type TypedCall = {
-    <T extends MessageKey, R extends MessageKey[]>(
+    <T extends WireInMessage, R extends WireOutMessage[]>(
         type: T,
         resType: R,
         message?: MessagePayload<T>,
     ): Promise<MessageResponse<R[number]>>;
-    <T extends MessageKey, R extends MessageKey>(
+    <T extends WireInMessage, R extends WireOutMessage>(
         type: T,
         resType: R,
         message?: MessagePayload<T>,

--- a/packages/protobuf/src/definitions/index.ts
+++ b/packages/protobuf/src/definitions/index.ts
@@ -907,12 +907,12 @@ export type MessageResponse<T extends MessageKey = MessageKey> = T extends any
     : never;
 
 export type TypedCall = {
-    <T extends MessageKey, R extends MessageKey[]>(
+    <T extends WireInMessage, R extends WireOutMessage[]>(
         type: T,
         resType: R,
         message?: MessagePayload<T>,
     ): Promise<MessageResponse<R[number]>>;
-    <T extends MessageKey, R extends MessageKey>(
+    <T extends WireInMessage, R extends WireOutMessage>(
         type: T,
         resType: R,
         message?: MessagePayload<T>,


### PR DESCRIPTION
## Description

Issue #5298 asked the protobuf build script to split messages into in/out categories using the `wire_in`/`wire_out` proto options. That split already exists — the `@bufbuild` generator emits `WireInMessage` and `WireOutMessage` unions into `@trezor/protobuf` — but the unions were not consumed anywhere. This PR puts them to use at the `typedCall` layer: requests must be a `WireInMessage`, expected responses must be a `WireOutMessage`, and wrong-direction calls now fail to compile.

### Monero

The 11 stateful Monero `*Request` messages (transaction signing and key-image sync) used to be tagged `(wire_out)` in trezor-firmware even though connect sends them host → device, which earlier revisions of this PR worked around with a temporary `TypedCallRequest` escape hatch. [trezor-firmware#7137](https://github.com/trezor/trezor-firmware/pull/7137) corrected the wire direction to `(wire_in)`, and `develop` already carries the regenerated protobuf definitions, so the Monero requests are now part of `WireInMessage` and the escape hatch is gone — `TypedCall` constrains requests to `WireInMessage` directly.

### Scope

This covers the `typedCall` layer only. The transport-level API (`AbstractTransport.call/send/receive`) is intentionally left untouched: that raw path also carries THP handshake messages and debug-link messages that are not part of `WireInMessage`/`WireOutMessage`, so tightening it would require a union rather than a restriction and is a separate, riskier change.

## Notes for QA

No QA needed. This is a compile-time-only change: it tightens TypeScript types and adds zero runtime behavior. Verified with `@trezor/protobuf` and `@trezor/connect` type-checks (no new errors against the branch baseline), ESLint, and Prettier. All ~142 `typedCall` call sites were audited — every request is a `WireInMessage` and every response is a `WireOutMessage`.

## Related Issue

Part of #5298 (implements the `typedCall` layer; transport-level strictness deferred — see Scope above, so this PR does not auto-close the issue).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies Cardano utility functions (cardanoUtils.ts), the device session layer (DeviceCurrentSession.ts), protobuf definitions, and a type test file. The highest risk is in the Cardano-specific changes since cardanoUtils.ts directly affects address derivation, staking transactions, and account handling for ADA. DeviceCurrentSession.ts maps to 121 tests, indicating it's a broad shared infrastructure file—without evidence of behavioral changes visible at the E2E level, tests mapped only through this file are omitted. The protobuf and type-test files have no direct E2E coverage. The recommended strategy focuses on comprehensive Cardano functionality testing.

<details><summary><b>Changed files (5)</b></summary>

- `packages/connect/src/api/cardano/cardanoUtils.ts`
- `packages/connect/src/device/DeviceCurrentSession.ts`
- `packages/connect/tests/typedCall.type-test.ts`
- `packages/protobuf/scripts/protobuf-patches/MessageType.ts`
- `packages/protobuf/src/definitions/index.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — Directly exercises Cardano account operations (account details, public key reveal, send form, receive address) which depend on cardanoUtils.ts for address derivation and transaction handling. Changes to cardanoUtils.ts could break address generation or account display.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — Tests Cardano receive address derivation with passphrase protection, which directly uses cardanoUtils.ts for address computation. The test asserts a specific Cardano address format and value, making it highly sensitive to changes in Cardano utility functions.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Tests the full Cardano staking flow including stake key registration, delegation, and transaction signing—all of which rely on cardanoUtils.ts for constructing Cardano-specific transaction parameters and certificate handling.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Tests Cardano reward claiming with withdrawal details (reward address, account path, amount), which depends on cardanoUtils.ts for constructing withdrawal parameters and address derivation.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Tests Cardano unstaking with stake key deregistration and deposit reclaim. The transaction construction relies on cardanoUtils.ts for certificate handling and address derivation.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/public-keys.test.ts` — Tests public key export for ADA (among BTC and LTC), asserting a specific expected XPUB value. Changes to cardanoUtils.ts could affect how the Cardano public key is derived or formatted.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/connect/tests/typedCall.type-test.ts`
- `packages/protobuf/scripts/protobuf-patches/MessageType.ts`
- `packages/protobuf/src/definitions/index.ts`

_Updated: 2026-06-22T10:09:03.950Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/issue-5298/web/](https://dev.suite.sldev.cz/suite-web/mroz22/issue-5298/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/issue-5298&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/issue-5298&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/issue-5298&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-22T10:14:03.972Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-22T10:11:51.937Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->