### PR TITLE
fix(connect-explorer): close BroadcastChannel on deeplink re-init

### DIFF
--- a/packages/connect-explorer/src/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/actions/trezorConnectActions.ts
@@ -11,6 +11,8 @@ import {
     ON_INIT_ERROR,
 } from '../types/actions';
 
+let _deeplinkChannel: BroadcastChannel | undefined;
+
 export const onConnectOptionChange = (option: Field<any>, value: any) => ({
     type: ON_CHANGE_CONNECT_OPTION,
     payload: {
@@ -58,6 +60,11 @@ export const init =
             ...options,
         };
 
+        // onSubmitInit re-runs init() on each "Init Connect" click; close the previous
+        // channel so a popup_callback isn't handled once per past init.
+        _deeplinkChannel?.close();
+        _deeplinkChannel = undefined;
+
         try {
             if (connectOptions.coreMode === 'deeplink') {
                 await TrezorConnectMobile.init({
@@ -70,8 +77,8 @@ export const init =
                         (process.env.CONNECT_EXPLORER_FULL_URL || window.location.origin) +
                         '/callback',
                 });
-                const bc = new BroadcastChannel('trezor_connect_callback');
-                bc.onmessage = e => {
+                _deeplinkChannel = new BroadcastChannel('trezor_connect_callback');
+                _deeplinkChannel.onmessage = e => {
                     if (e.data.type === 'popup_callback') {
                         TrezorConnectMobile.handleDeeplink(e.data.url);
                     }


### PR DESCRIPTION
## Description

In deeplink `coreMode`, every `init()` opened a new `BroadcastChannel('trezor_connect_callback')` without closing the previous one. `onSubmitInit()` re-runs `init()` on each "Init Connect" click, so channels piled up — after N inits a single `popup_callback` fired `handleDeeplink()` N times.

**Fix:** track the channel in a module-level reference and close any previous one at the start of `init()`, before opening a new one. This covers every re-init, including switching between deeplink and non-deeplink modes.

## Notes for QA

No QA needed — `@trezor/connect-explorer` is an internal developer playground, not shipped Suite. No user-facing impact.

## Related Issue

Part of the listener-leak audit (#27978), split out for independent review. Siblings: #28242, #28241, #28329, #27982.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to packages/connect-explorer/src/actions/trezorConnectActions.ts, which is the action layer for the Connect Explorer app that dispatches TrezorConnect API calls. No static test mappings exist for this file, so all recommendations are inferred from LLM analysis. The highest risk tests are those that use Connect Explorer directly (connectPopupWeb and connectPopupWebextension), while the suite-desktop core mode tests are medium priority since they exercise similar TrezorConnect methods but through a different integration path. Tests outside the trezor-connect folder are unaffected as they don't interact with Connect Explorer actions.

<details><summary><b>Changed files (1)</b></summary>

- `packages/connect-explorer/src/actions/trezorConnectActions.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises TrezorConnect API calls (getAddress) through the Connect Explorer app, which is the primary consumer of trezorConnectActions.ts. Changes to how TrezorConnect actions are dispatched would directly affect the happy path, cancellation, and popup lifecycle behaviors tested here.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test uses the Connect Explorer webextension build to call TrezorConnect.getAddress, directly exercising the connect explorer action layer. Changes to trezorConnectActions.ts could affect how the extension dispatches API calls and handles responses.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This test calls TrezorConnect.getAddress in suite-desktop core mode with single and bundle exports. While it uses TrezorConnect directly rather than through Connect Explorer's UI, trezorConnectActions.ts defines how getAddress calls are constructed, so changes could affect parameter formatting or call structure.
- `suite/e2e/tests/trezor-connect/error.test.ts` — This test validates TrezorConnect error handling (invalid derivation path) through the Connect Explorer interface. trezorConnectActions.ts likely handles how API call parameters are assembled and dispatched, which directly relates to error path behavior.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — This test calls TrezorConnect.getAccountInfo through the suite-desktop core mode with account selection. trezorConnectActions.ts governs how connect explorer dispatches these API methods, so changes could affect the account info retrieval flow.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — This test exercises TrezorConnect.ethereumSignMessage through the suite-desktop app. trezorConnectActions.ts defines how sign message actions are dispatched in Connect Explorer, and changes could affect the signing flow.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This test exercises TrezorConnect.ethereumSignTransaction. trezorConnectActions.ts handles dispatching connect API calls including transaction signing, so changes could affect how transaction parameters are sent to the device.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — This test calls TrezorConnect.signTransaction for Bitcoin. trezorConnectActions.ts is responsible for constructing and dispatching these API calls in the Connect Explorer context.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — This test validates TrezorConnect permissions granting/revoking flow triggered through Connect Explorer API calls. trezorConnectActions.ts orchestrates how these calls are initiated, so changes could affect the permissions lifecycle.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — This test validates silent mode behavior during TrezorConnect.signMessage calls. trezorConnectActions.ts handles how these API calls are dispatched, and changes could affect silent mode interaction with the connect flow.

</details>

_Updated: 2026-06-19T15:40:26.959Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-explorer-broadcastchannel-leak/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-explorer-broadcastchannel-leak/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-explorer-broadcastchannel-leak&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-explorer-broadcastchannel-leak&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-19T15:44:59.299Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-19T15:43:29.426Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->
