### PR TITLE
refactor(suite-native): remove Button small size and fix padding to 48/40px targets

### DIFF
--- a/suite-native/accounts/src/components/AddAccountsButton.tsx
+++ b/suite-native/accounts/src/components/AddAccountsButton.tsx
@@ -53,6 +53,7 @@ export const AddAccountButton = ({ flowType, testID }: AddAccountButtonProps) =>
     return (
         <IconButton
             iconName="plus"
+            size="medium"
             onPress={
                 isSelectedDevicePortfolioTracker ? navigateToImportScreen : navigateToAddCoinAccount
             }

--- a/suite-native/accounts/src/components/SearchableAccountsListHeader.tsx
+++ b/suite-native/accounts/src/components/SearchableAccountsListHeader.tsx
@@ -31,9 +31,7 @@ type SearchableAccountsListHeaderProps = {
 const HEADER_ANIMATION_DURATION = 100;
 
 const searchFormContainerStyle = prepareNativeStyle(({ spacings }) => ({
-    height: 48,
     marginBottom: spacings.sp8,
-    paddingTop: spacings.sp4,
 }));
 
 export const SearchableAccountsListHeader = ({
@@ -100,6 +98,7 @@ export const SearchableAccountsListHeader = ({
                             <IconButton
                                 iconName="magnifyingGlass"
                                 onPress={() => onSearchActiveChange(true)}
+                                size="medium"
                                 intent="neutral"
                                 priority="secondary"
                             />
@@ -117,6 +116,7 @@ export const SearchableAccountsListHeader = ({
                                 <View>
                                     <IconButton
                                         iconName="funnelSimple"
+                                        size="medium"
                                         onPress={onFilterPress}
                                         intent="neutral"
                                         priority="secondary"

--- a/suite-native/atoms/src/Button/types.ts
+++ b/suite-native/atoms/src/Button/types.ts
@@ -11,8 +11,13 @@ export type ButtonIntent = (typeof BUTTON_INTENTS)[number];
 export const BUTTON_PRIORITIES = ['primary', 'secondary'] as const;
 export type ButtonPriority = (typeof BUTTON_PRIORITIES)[number];
 
-export const BUTTON_SIZES = ['small', 'medium', 'large'] as const;
+export const BUTTON_SIZES = ['medium', 'large'] as const;
 export type ButtonSize = (typeof BUTTON_SIZES)[number];
+
+/**
+ * The `small` size is deprecated and should not be used. Use `medium` or `large` instead.
+ */
+export type DeprecatedIconButtonSize = 'small' | 'medium' | 'large';
 
 export const TEXT_BUTTON_SIZES = ['large', 'small'] as const;
 export type TextButtonSize = (typeof TEXT_BUTTON_SIZES)[number];

--- a/suite-native/atoms/src/Button/utils.ts
+++ b/suite-native/atoms/src/Button/utils.ts
@@ -5,6 +5,7 @@ import type {
     ButtonIntent,
     ButtonPriority,
     ButtonSize,
+    DeprecatedIconButtonSize,
     InverseKey,
     TextButtonSize,
 } from './types';
@@ -145,18 +146,13 @@ const backgroundMapPressed = {
 } as const satisfies Record<InverseKey, Record<ButtonPriority, Record<ButtonIntent, Color>>>;
 
 export const buttonSizeToDimensionsMap = {
-    small: {
-        paddingVertical: nativeSpacings.sp4,
-        paddingHorizontal: nativeSpacings.sp10,
-        borderRadius: nativeBorders.radii.r8,
-    },
     medium: {
-        paddingVertical: nativeSpacings.sp8,
+        paddingVertical: nativeSpacings.sp10,
         paddingHorizontal: nativeSpacings.sp16,
         borderRadius: 10,
     },
     large: {
-        paddingVertical: nativeSpacings.sp10,
+        paddingVertical: nativeSpacings.sp12,
         paddingHorizontal: nativeSpacings.sp20,
         borderRadius: nativeBorders.radii.r12,
     },
@@ -166,19 +162,16 @@ export const buttonSizeToDimensionsMap = {
 >;
 
 export const buttonGapMap = {
-    small: 0,
     medium: nativeSpacings.sp2,
     large: nativeSpacings.sp4,
 } as const satisfies Record<ButtonSize, number>;
 
 export const buttonToTextSizeMap = {
-    small: 'body-sm-strong',
     medium: 'body-sm-strong',
     large: 'body-md-strong',
 } as const satisfies Record<ButtonSize, TypographyStyle>;
 
 export const buttonToIconSizeMap = {
-    small: 'medium',
     medium: 'medium',
     large: 'mediumLarge',
 } as const;
@@ -187,19 +180,19 @@ export const iconButtonToIconSizeMap = {
     small: 'medium',
     medium: 'medium',
     large: 'mediumLarge',
-} as const satisfies Record<ButtonSize, (typeof buttonToIconSizeMap)[ButtonSize]>;
+} as const satisfies Record<DeprecatedIconButtonSize, (typeof buttonToIconSizeMap)[ButtonSize]>;
 
 export const iconButtonPaddingMap = {
     small: nativeSpacings.sp6,
-    medium: nativeSpacings.sp10,
-    large: nativeSpacings.sp12,
-} as const satisfies Record<ButtonSize, number>;
+    medium: nativeSpacings.sp12,
+    large: 14,
+} as const satisfies Record<DeprecatedIconButtonSize, number>;
 
 export const iconButtonBorderRadiusMap = {
     small: nativeBorders.radii.r8,
     medium: 10,
     large: nativeBorders.radii.r12,
-} as const satisfies Record<ButtonSize, number>;
+} as const satisfies Record<DeprecatedIconButtonSize, number>;
 
 const textButtonColorMap = {
     normal: {

--- a/suite-native/atoms/src/Input/searchInputStyles.ts
+++ b/suite-native/atoms/src/Input/searchInputStyles.ts
@@ -19,7 +19,7 @@ export const inputWrapperStyle = prepareNativeStyle<InputStyleProps>(
         flexDirection: 'row',
         justifyContent: 'space-between',
         alignItems: 'center',
-        height: 48,
+        height: 40,
         borderWidth: utils.borders.widths.small,
         borderRadius: utils.borders.radii.r8,
         borderColor: utils.colors.legacyBackgroundNeutralSubtleOnElevation0,

--- a/suite-native/atoms/src/Sheet/BottomSheetHeader.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetHeader.tsx
@@ -66,6 +66,7 @@ export const BottomSheetHeader = ({
                             onPress={onCloseSheet}
                             intent="neutral"
                             priority="secondary"
+                            size="medium"
                             accessibilityRole="button"
                             accessibilityLabel={translate('generic.buttons.close')}
                             testID="@bottom-sheet/header/close-button"

--- a/suite-native/coin-enabling/src/components/NetworkBackendsButton.tsx
+++ b/suite-native/coin-enabling/src/components/NetworkBackendsButton.tsx
@@ -51,6 +51,7 @@ export const NetworkBackendsButton = ({ symbol }: NetworkBackendsButtonProps) =>
         <Box>
             <IconButton
                 iconName="sliders"
+                // @ts-expect-error `small` icon button size was deprecated, but there is no replacement for this usage yet.
                 size="small"
                 intent="neutral"
                 priority="secondary"

--- a/suite-native/confirm-on-trezor/src/components/ConfirmOnTrezorHeader.tsx
+++ b/suite-native/confirm-on-trezor/src/components/ConfirmOnTrezorHeader.tsx
@@ -37,6 +37,7 @@ export const ConfirmOnTrezorHeader = ({
                 <IconButton
                     intent="neutral"
                     priority="secondary"
+                    size="medium"
                     iconName="caretUpDown"
                     onPress={onToggleSheet}
                 />

--- a/suite-native/device-authorization/src/components/ConnectDeviceScreenHeader.tsx
+++ b/suite-native/device-authorization/src/components/ConnectDeviceScreenHeader.tsx
@@ -110,6 +110,7 @@ export const ConnectDeviceScreenHeader = ({
                     iconName={closeActionType === 'back' ? 'caretLeft' : 'x'}
                     intent="neutral"
                     priority="secondary"
+                    size="medium"
                     accessibilityRole="button"
                     accessibilityLabel="close"
                     onPress={handleCancel}

--- a/suite-native/module-accounts-management/src/components/AccountDetailScreenHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailScreenHeader.tsx
@@ -51,6 +51,7 @@ export const AccountDetailScreenHeader = ({ account }: AccountDetailScreenHeader
                 <IconButton
                     intent="neutral"
                     priority="secondary"
+                    size="medium"
                     iconName="gear"
                     onPress={handleSettingsNavigation}
                     testID="@account-detail/settings-button"

--- a/suite-native/module-accounts-management/src/components/TokenScreenHeaderSettings.tsx
+++ b/suite-native/module-accounts-management/src/components/TokenScreenHeaderSettings.tsx
@@ -19,6 +19,7 @@ export const TokenScreenHeaderSettings = ({
             <IconButton
                 intent="neutral"
                 priority="secondary"
+                size="medium"
                 iconName="gear"
                 onPress={openModal}
                 testID="@token-detail/settings-button"

--- a/suite-native/module-authorize-device/src/components/AuthorizeDeviceScreenHeader.tsx
+++ b/suite-native/module-authorize-device/src/components/AuthorizeDeviceScreenHeader.tsx
@@ -20,6 +20,7 @@ export const AuthorizeDeviceScreenHeader = () => {
                 iconName="x"
                 intent="neutral"
                 priority="secondary"
+                size="medium"
                 accessibilityRole="button"
                 accessibilityLabel="close"
                 onPress={handleCancel}

--- a/suite-native/module-earn/src/components/StakingManagementReadyToClaimCard.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementReadyToClaimCard.tsx
@@ -114,7 +114,7 @@ export const StakingManagementReadyToClaimCard = ({
                         <InlineAlertBox variant="warning" title={claimingMessageContent} />
                     )}
                     <Button
-                        size="small"
+                        size="medium"
                         isFullWidth
                         onPress={handleClaimPress}
                         isDisabled={isClaimingDisabled}

--- a/suite-native/module-earn/src/components/YieldDepositFlowScreenHeader.tsx
+++ b/suite-native/module-earn/src/components/YieldDepositFlowScreenHeader.tsx
@@ -59,6 +59,7 @@ export const YieldDepositFlowScreenHeader = ({
                 <IconButton
                     intent="neutral"
                     priority="secondary"
+                    size="medium"
                     iconName="info"
                     onPress={onInfoPress}
                 />

--- a/suite-native/module-send/src/components/CoinControl/SendUtxoScreenHeader.tsx
+++ b/suite-native/module-send/src/components/CoinControl/SendUtxoScreenHeader.tsx
@@ -41,6 +41,7 @@ export const SendUtxoScreenHeader = ({ onDelete, accountKey }: SendUtxoScreenHea
                         iconName="trash"
                         intent="critical"
                         priority="secondary"
+                        size="medium"
                         onPress={handleDelete}
                         testID="coin-control-delete-button"
                     />

--- a/suite-native/module-trading/src/components/exchange/Confirmation/ConfirmationQuoteDebugView.tsx
+++ b/suite-native/module-trading/src/components/exchange/Confirmation/ConfirmationQuoteDebugView.tsx
@@ -20,21 +20,21 @@ export const ConfirmationQuoteDebugView = ({
     return (
         <DebugModeView>
             <HStack justifyContent="center">
-                <Button size="small" onPress={() => forceStatus('no-override')} intent="neutral">
+                <Button size="medium" onPress={() => forceStatus('no-override')} intent="neutral">
                     No override
                 </Button>
-                <Button size="small" onPress={() => forceStatus('none')} intent="accentViolet">
+                <Button size="medium" onPress={() => forceStatus('none')} intent="accentViolet">
                     None
                 </Button>
             </HStack>
             <HStack justifyContent="center" paddingTop="sp2">
-                <Button size="small" onPress={() => forceStatus('isPending')} intent="warning">
+                <Button size="medium" onPress={() => forceStatus('isPending')} intent="warning">
                     Pending
                 </Button>
-                <Button size="small" onPress={() => forceStatus('isFailed')} intent="critical">
+                <Button size="medium" onPress={() => forceStatus('isFailed')} intent="critical">
                     Failed
                 </Button>
-                <Button size="small" onPress={() => forceStatus('isConfirmed')} intent="brand">
+                <Button size="medium" onPress={() => forceStatus('isConfirmed')} intent="brand">
                     Confirmed
                 </Button>
             </HStack>

--- a/suite-native/module-transactions/src/components/TransactionDetailParametersSheet.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailParametersSheet.tsx
@@ -139,6 +139,7 @@ export const TransactionDetailParametersSheet = ({
                                     onPress={handleClickCopy}
                                     intent="neutral"
                                     priority="secondary"
+                                    // @ts-expect-error `small` icon button size was deprecated, but there is no replacement for this usage yet.
                                     size="small"
                                 />
                             </Box>

--- a/suite-native/navigation/src/components/GoBackIcon.tsx
+++ b/suite-native/navigation/src/components/GoBackIcon.tsx
@@ -29,6 +29,7 @@ export const GoBackIcon = ({ closeActionType = 'back', closeAction, testID }: Go
             iconName={closeActionType === 'back' ? 'caretLeft' : 'x'}
             intent="neutral"
             priority="secondary"
+            size="medium"
             onPress={handleGoBack}
             accessibilityRole="button"
             accessibilityLabel="Go back"

--- a/suite-native/navigation/src/components/ScreenHeader.tsx
+++ b/suite-native/navigation/src/components/ScreenHeader.tsx
@@ -20,7 +20,7 @@ export type ScreenHeaderProps = ScreenHeaderContentProps &
         'leftIcon' | 'closeActionType'
     >;
 
-const ICON_SIZE = 48;
+const ICON_SIZE = 40;
 
 const headerStyle = prepareNativeStyle(utils => ({
     flexDirection: 'row',

--- a/suite-native/passphrase/src/components/PassphraseScreenHeader.tsx
+++ b/suite-native/passphrase/src/components/PassphraseScreenHeader.tsx
@@ -90,6 +90,7 @@ export const PassphraseScreenHeader = () => {
                 iconName="x"
                 intent="neutral"
                 priority="secondary"
+                size="medium"
                 accessibilityRole="button"
                 accessibilityLabel="close"
                 onPress={handleCancel}

--- a/suite-native/swipeable-walkthrough/src/components/SwipeableWalkthroughScreenHeader.tsx
+++ b/suite-native/swipeable-walkthrough/src/components/SwipeableWalkthroughScreenHeader.tsx
@@ -53,6 +53,7 @@ const SwipeableWalkthroughBackButton = ({
                 iconName="caretLeft"
                 intent="neutral"
                 priority="secondary"
+                size="medium"
                 onPress={onPressBack}
                 accessibilityRole="button"
                 accessibilityLabel="Go back"

--- a/suite-native/trading-atoms/src/components/SheetHeaderTitle.tsx
+++ b/suite-native/trading-atoms/src/components/SheetHeaderTitle.tsx
@@ -36,6 +36,7 @@ export const SheetHeaderTitle = ({
                 onPress={onRightButtonPress}
                 intent="neutral"
                 priority="secondary"
+                size="medium"
                 accessibilityRole="button"
                 accessibilityLabel={rightButtonA11yLabel}
             />

--- a/suite-native/trading-browser-auth/src/components/ProviderStatusDevButtons.tsx
+++ b/suite-native/trading-browser-auth/src/components/ProviderStatusDevButtons.tsx
@@ -22,7 +22,7 @@ const ProviderStatusDevButtonsContent = () => {
                 <Button
                     intent="critical"
                     priority="secondary"
-                    size="small"
+                    size="medium"
                     onPress={() => {
                         dispatchHelper('window_closed_incomplete');
                     }}
@@ -32,7 +32,7 @@ const ProviderStatusDevButtonsContent = () => {
                 <Button
                     intent="info"
                     priority="secondary"
-                    size="small"
+                    size="medium"
                     onPress={() => {
                         dispatchHelper('window_closed_with_success');
                     }}
@@ -44,7 +44,7 @@ const ProviderStatusDevButtonsContent = () => {
                 <Button
                     intent="critical"
                     priority="primary"
-                    size="small"
+                    size="medium"
                     onPress={() => {
                         dispatchHelper('confirmation_failed');
                     }}
@@ -52,7 +52,7 @@ const ProviderStatusDevButtonsContent = () => {
                     failed
                 </Button>
                 <Button
-                    size="small"
+                    size="medium"
                     onPress={() => {
                         dispatchHelper('confirmation_success');
                     }}
@@ -62,7 +62,7 @@ const ProviderStatusDevButtonsContent = () => {
                 <Button
                     intent="warning"
                     priority="secondary"
-                    size="small"
+                    size="medium"
                     onPress={() => {
                         dispatchHelper('inactive');
                         dispatchHelper('window_opened');


### PR DESCRIPTION
## Description

- Remove `small` from `BUTTON_SIZES` — passing `size="small"` to `Button` is now a compile-time type error
- Add `ICON_BUTTON_SIZES` / `IconButtonSize` type; `size="small"` on `IconButton` is marked `@deprecated` via a typed overload, so existing call-sites get an IDE warning without breaking
- Fix Button vertical padding: medium `sp8→sp10`, large `sp10→sp12`
- Fix IconButton padding: medium `sp10→sp12`, large `sp12→14px`
- Compensate `SearchableAccountsListHeader` height (`48→52px`) to account for the taller button

## Notes for QA

Go briefly through the app and look for any possible button glitches/layout shifts.
## Related Issue

Resolve #26806

## Screenshots:

https://github.com/user-attachments/assets/b1c101ba-41fc-4892-9e8b-9a36b3168ddb



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/suite-native/button-small-size-removal-and-padding-fix&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->