### PR TITLE
feat: draft to ontroduce conenct logged as dependency

### DIFF
--- a/packages/connect-common/src/types/settings.ts
+++ b/packages/connect-common/src/types/settings.ts
@@ -42,6 +42,7 @@ export type ConnectSettingsTransport =
     | (new (...args: any[]) => Transport);
 
 export type CreateLogger = (prefix: string) => Logger;
+export type CreateLoggerDep = { createLogger: CreateLogger};
 
 export interface ConnectSettingsPublic {
     manifest?: Manifest;

--- a/packages/utils/src/logsManager.ts
+++ b/packages/utils/src/logsManager.ts
@@ -8,7 +8,7 @@ export class LogsManager {
         this.colors = colors;
     }
 
-    initLog(prefix: string, enabled?: boolean, logWriter?: LogWriter) {
+    initLog(prefix: string, enabled?: () => boolean, logWriter?: LogWriter) {
         const instanceWriter = logWriter || this.writer;
         const instance = new Log(prefix, !!enabled, instanceWriter);
         if (this.colors) {

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -20,6 +20,7 @@ import {
     type ConnectSettings,
     type Manifest,
     type StaticSessionId,
+    type CreateLoggetDeps,
 } from '@trezor/connect';
 
 import { type ConnectInitHooks } from './connectInitHooksType';
@@ -42,7 +43,8 @@ export type CommonServices = SuiteSyncDep &
         connectInitSettings: ConnectInitSettings;
         connectInitHooks: ConnectInitHooks;
     } & ReportSecurityCheckDep &
-    MigrateSuiteSyncLabelsForRbfTransactionDep;
+    MigrateSuiteSyncLabelsForRbfTransactionDep &
+    CreateLoggetDeps;
 
 export type ExtraDependenciesStatic = {
     /** @deprecated Do not add any thunks here, this is antipattern. */

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -23,8 +23,16 @@ import { type NativeServices } from '@suite-native/services';
 import type { EnsureEncryptionKeyDep, MMKVStorageDep } from '@suite-native/storage';
 import { createSuiteSyncNativeCompositionRoot } from '@suite-native/suite-sync';
 import { selectTradingEnvironment } from '@suite-native/trading-state';
+<<<<<<< Updated upstream
 import TrezorConnect from '@trezor/connect';
 import { BridgeTransport } from '@trezor/transport';
+=======
+import TrezorConnect, { initLog, type ConnectSettings } from '@trezor/connect';
+// Deep import bypasses the `@trezor/transport` barrel so Metro does not
+// resolve sibling node-only modules (`UdpTransport`/`dgram`,
+// `NodeUsbTransport`/`usb`).
+import { BridgeTransport } from '@trezor/transport/src/transports/bridge';
+>>>>>>> Stashed changes
 import { NativeBluetoothTransport } from '@trezor/transport-native-bluetooth';
 import { NativeUsbTransport } from '@trezor/transport-native-usb';
 import { ok } from '@trezor/type-utils';
@@ -97,7 +105,8 @@ export const createNativeCompositionRoot = (deps: NativeAppDeps): NativeServices
                 appUrl: '@trezor/suite',
             },
         },
-        connectInitHooks: { deviceEvent: {}, uiEvent: {} },
+      connectInitHooks: { deviceEvent: {}, uiEvent: {} },
+      createLogger: (prefix: string) => initLog(prefix, toGetter(deps.getState, selectorForIsDebugEnabled)),
         migrateSuiteSyncLabelsForRbfTransaction:
             createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot({
                 dispatch: deps.dispatch,


### PR DESCRIPTION
gift to @mroz22 

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies four files: a TypeScript type definition for connect settings, the logs manager utility, a Redux extra dependencies type definition, and a React Native state module. The logsManager.ts change has the broadest potential impact but maps to 121 tests, indicating it's a broadly imported utility — most tests won't exercise logging-specific behavior. The application log test is the most directly relevant since it explicitly tests log display and export. The other three files are type definitions or native-only code with no web E2E test coverage. Overall risk is low since type-level changes rarely cause runtime regressions and logsManager changes would primarily affect log output rather than core functionality.

<details><summary><b>Changed files (4)</b></summary>

- `packages/connect-common/src/types/settings.ts`
- `packages/utils/src/logsManager.ts`
- `suite-common/redux-utils/src/extraDependenciesType.ts`
- `suite-native/state/src/extraDependencies.ts`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/settings/application-log.test.ts` — This test directly exercises application log viewing and export functionality. Changes to packages/utils/src/logsManager.ts could affect how logs are collected, formatted, and displayed in the application log modal, potentially causing empty logs or export failures.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/suite/guide.test.ts` — The guide panel includes a bug report/feedback form that may attach or reference application logs. Changes to logsManager.ts could affect log data included in feedback submissions, though this is a secondary concern.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/connect-common/src/types/settings.ts`
- `suite-common/redux-utils/src/extraDependenciesType.ts`
- `suite-native/state/src/extraDependencies.ts`

_Updated: 2026-06-17T15:22:36.993Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/connectLogger/web/](https://dev.suite.sldev.cz/suite-web/connectLogger/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connectLogger&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connectLogger&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-17T15:27:40.948Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-17T15:26:56.721Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->