### PR TITLE
fix(suite): hide trading header back arrow on form pages

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/useTradingPageHeader.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/useTradingPageHeader.tsx
@@ -28,6 +28,11 @@ const TradingPageHeader = ({ fallbackTitle }: TradingPageHeaderProps) => {
     const currentRouteName = useSelector(selectRouteName);
     const activeSection = useSelector(selectTradingActiveSection);
 
+    const isFormRoute =
+        currentRouteName === 'wallet-trading-buy' ||
+        currentRouteName === 'wallet-trading-sell' ||
+        currentRouteName === 'wallet-trading-exchange';
+
     const goToRoute = (route: Route['name']) => () => {
         dispatch(goto({ routeName: route, preserveParams: true }));
     };
@@ -35,15 +40,17 @@ const TradingPageHeader = ({ fallbackTitle }: TradingPageHeaderProps) => {
     return (
         <PageHeader>
             <Row width="100%" gap={spacings.md}>
-                <IconButton
-                    icon="caretLeft"
-                    intent="neutral"
-                    priority="secondary"
-                    size="large"
-                    onClick={goToRoute(getBackRoute(currentRouteName, activeSection))}
-                    data-testid="@account-subpage/back"
-                    tooltip={{ content: <Translation id="TR_BACK" /> }}
-                />
+                {!isFormRoute && (
+                    <IconButton
+                        icon="caretLeft"
+                        intent="neutral"
+                        priority="secondary"
+                        size="large"
+                        onClick={goToRoute(getBackRoute(currentRouteName, activeSection))}
+                        data-testid="@account-subpage/back"
+                        tooltip={{ content: <Translation id="TR_BACK" /> }}
+                    />
+                )}
                 <BasicName>
                     <Translation id={fallbackTitle} />
                 </BasicName>


### PR DESCRIPTION
## Description

Hides the back arrow in the trading page header on the base form routes (`wallet-trading-buy`, `wallet-trading-sell`, `wallet-trading-exchange`), where there is no meaningful back target (it previously fell back to `suite-index`). The arrow remains on detail, confirm and transactions subpages.

## Related Issue

n/a

## Screenshots

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change modifies `useTradingPageHeader.tsx`, a React hook within the common TradingLayout used across all trading views (Buy, Sell, Swap). This hook likely controls page header content such as titles, breadcrumbs, or navigation elements on trading pages. The highest risk is to trading page navigation and rendering — tests that verify the correct asset/cryptocurrency name is displayed on trading forms and that trading pages render correctly after navigation are most critical. The recommended strategy focuses on trading-related tests, with the navigation test and a representative buy test at high priority, and additional sell/swap/input tests at medium priority to ensure the header hook works correctly across all trading verticals.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingLayout/useTradingPageHeader.tsx`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test exercises navigation to Buy, Sell, and Swap forms from multiple entry points (dashboard, account, global header, tokens). The `useTradingPageHeader` hook likely controls the header/title displayed on trading pages, and this test verifies the correct cryptocurrency name is shown in those forms (e.g., /Bitcoin/, /Ethereum/, /TrueUSD/), which is directly tied to page header behavior.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test covers the full buy flow for Bitcoin through the trading page, including form display, quote viewing, and transaction confirmation. The `useTradingPageHeader` hook is part of the TradingLayout used by buy pages, so any regression in header rendering or page layout would be caught here.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests the buy flow for Ethereum including asset selection and trading page rendering. The trading page header hook is part of the common TradingLayout, and this test verifies the form opens correctly with the right asset name displayed.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests negative/validation scenarios on the buy form including loading state and form interactions. If the page header hook affects form rendering or layout initialization, validation behavior could be impacted.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Tests buying a Solana SPL token (Jupiter/JUP) through the trading page. The trading page header hook is shared across all trading views, and this test verifies the form correctly displays the selected token asset.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Tests the full sell BTC flow through the trading page. The `useTradingPageHeader` hook is part of the common TradingLayout used by sell pages, so any regression in header/layout would affect this flow.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests selling Solana through the trading/sell flow including form filling, offer display, and transaction completion. The trading layout header hook is shared across all sell pages.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Tests swapping SOL for BTC through the full swap flow. The `useTradingPageHeader` hook is part of the common TradingLayout shared by swap pages, and this test verifies form rendering and transaction details.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests swapping SOL to USDC token through the trading/swap feature. Uses the same TradingLayout with the page header hook, verifying the swap form renders correctly.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation, percentage buttons, and fee settings. The trading page header hook is part of the layout wrapper for sell pages, and form rendering depends on correct layout initialization.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form inputs including asset selection, fraction buttons, and validation. The `useTradingPageHeader` hook affects the TradingLayout used by swap pages.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Tests initiating a buy action from the dashboard assets section which navigates to the trading page. The trading page header hook could affect the landing state of the buy form after navigation from the dashboard.

</details>

_Updated: 2026-06-17T23:43:03.430Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-hide-back-arrow-on-form&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-hide-back-arrow-on-form&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Remembered device > google provider | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-17T23:48:08.073Z • 14 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-17T23:46:23.768Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->