### PR TITLE
test(suite): removes label notification handling

### DIFF
--- a/suite/e2e/support/pageObjects/metadata/metadataPage.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataPage.ts
@@ -101,13 +101,6 @@ export class MetadataPage {
             this.settingsPage.metadataSelectInputOption('legacy'),
         );
         await this.passThroughInitMetadata(provider);
-        await this.closeLegacyUpgradeNotification();
-    }
-
-    @step()
-    async closeLegacyUpgradeNotification() {
-        await expect(this.legacyNotification).toBeVisible();
-        await this.closeLegacyNotificationButton.click();
     }
 
     @step()

--- a/suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts
+++ b/suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts
@@ -37,7 +37,6 @@ test.describe('Dropbox API errors', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () 
             );
 
             await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
-            await metadataPage.closeLegacyUpgradeNotification();
 
             await walletPage.openAccount();
 
@@ -165,7 +164,6 @@ test.describe('Dropbox API errors', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () 
             );
 
             await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
-            await metadataPage.closeLegacyUpgradeNotification();
 
             await walletPage.openAccount();
             // just enter some label, this indicates that app did not crash

--- a/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
@@ -66,11 +66,6 @@ test.describe('Suite Sync - Labelling', { tag: ['@T3W1', '@T3T1'] }, () => {
                 .toHaveText(expectedAddress.label);
         });
 
-        await test.step('Close Suite Sync feedback notification', async () => {
-            await expect(metadataPage.suiteSyncNotification).toBeVisible();
-            await metadataPage.closeSuiteSyncNotificationButton.click();
-        });
-
         await test.step('Change output label', async () => {
             await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
             await metadataPage.output.changeLabel({


### PR DESCRIPTION


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-lebales-notificaitons/web/](https://dev.suite.sldev.cz/suite-web/fix-lebales-notificaitons/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-lebales-notificaitons&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-lebales-notificaitons&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 18 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Import a BTC csv file > Go to BTC send form and import a csv | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-18T07:22:56.423Z • 18 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-18T07:20:42.375Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->