### PR TITLE
refactor(suite-common): model yield redeem as a first-class flow type

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts
@@ -5,7 +5,7 @@ import { getNetwork } from '@suite-common/wallet-config';
 import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import {
     type YieldFlowResolvedData,
-    type YieldWithdrawInputUnit,
+    type YieldWithdrawFlowType,
     buildYieldUnsignedTransaction,
     buildYieldWithdrawCalldata,
     selectRawNetworkFeeInfo,
@@ -21,7 +21,7 @@ export type ComposeYieldWithdrawTransactionParams = {
     account: Account & { networkType: 'ethereum' };
     flowData: YieldFlowResolvedData;
     amount: string;
-    withdrawInputUnit: YieldWithdrawInputUnit;
+    flowType: YieldWithdrawFlowType;
     dispatch: Dispatch;
     getState: () => AppState;
 };
@@ -30,7 +30,7 @@ export const composeYieldWithdrawTransaction = async ({
     account,
     flowData,
     amount,
-    withdrawInputUnit,
+    flowType,
     dispatch,
     getState,
 }: ComposeYieldWithdrawTransactionParams): Promise<string> => {
@@ -60,7 +60,7 @@ export const composeYieldWithdrawTransaction = async ({
         flowData,
         ownerAddress,
         receiverAddress: ownerAddress,
-        withdrawInputUnit,
+        flowType,
     });
 
     const nonceTask = dispatch(ethereumGetCurrentNonceThunk({ selectedAccount: account })).unwrap();

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
@@ -6,7 +6,7 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     STABLECOIN_YIELD_PREFIX,
     type YieldFlowResolvedData,
-    type YieldWithdrawInputUnit,
+    type YieldWithdrawFlowType,
     setYieldGenericError,
     stablecoinYieldActions,
 } from '@suite-common/wallet-core';
@@ -18,17 +18,15 @@ type SubmitYieldWithdrawPayload = {
     flowKey: string;
     flowData: YieldFlowResolvedData;
     amount: string;
-    withdrawInputUnit?: YieldWithdrawInputUnit;
+    flowType: YieldWithdrawFlowType;
 };
 
 export const submitYieldWithdrawThunk = createThunk(
     `${STABLECOIN_YIELD_PREFIX}/thunk/submitWithdraw`,
     async (
-        { flowKey, flowData, amount, withdrawInputUnit = 'asset' }: SubmitYieldWithdrawPayload,
+        { flowKey, flowData, amount, flowType }: SubmitYieldWithdrawPayload,
         { dispatch, getState, extra },
     ) => {
-        const flowType = 'withdraw' as const;
-
         try {
             if (flowData.account.networkType !== 'ethereum') {
                 throw new Error('Yield actions currently support only EVM accounts.');
@@ -42,7 +40,7 @@ export const submitYieldWithdrawThunk = createThunk(
                 account,
                 flowData,
                 amount,
-                withdrawInputUnit,
+                flowType,
                 dispatch,
                 getState,
             });
@@ -62,6 +60,7 @@ export const submitYieldWithdrawThunk = createThunk(
                 type: events.yieldWithdrawEvent.name,
                 payload: {
                     type: 'tx-simulation-modal',
+                    operation: flowType,
                     action: userAcceptedTxSimulation?.value === false ? 'cancel' : 'continue',
                     networkSymbol: account.symbol,
                     vaultId: flowData.vault.id,
@@ -73,8 +72,7 @@ export const submitYieldWithdrawThunk = createThunk(
             }
 
             const selectedFee = userAcceptedTxSimulation?.selectedFee ?? null;
-            const isSharesInput = withdrawInputUnit === 'shares';
-            const reviewToken = isSharesInput ? flowData.receiptToken : flowData.token;
+            const reviewToken = flowType === 'redeem' ? flowData.receiptToken : flowData.token;
 
             const result = await sendYieldTransaction({
                 account,
@@ -93,6 +91,7 @@ export const submitYieldWithdrawThunk = createThunk(
                     type: events.yieldWithdrawEvent.name,
                     payload: {
                         type: 'error',
+                        operation: flowType,
                         action: 'continue',
                         networkSymbol: account.symbol,
                         vaultId: flowData.vault.id,
@@ -129,6 +128,7 @@ export const submitYieldWithdrawThunk = createThunk(
                 type: events.yieldWithdrawEvent.name,
                 payload: {
                     type: 'error',
+                    operation: flowType,
                     action: 'continue',
                     networkSymbol: flowData.account.symbol,
                     vaultId: flowData.vault.id,

--- a/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
@@ -2,9 +2,9 @@ import type { ReactNode } from 'react';
 
 import { Translation } from '@suite/intl';
 import type {
-    YieldActionFlowType,
     YieldFlowDisplayToken,
     YieldPendingTransactionState,
+    YieldPositionFlowType,
 } from '@suite-common/wallet-core';
 import { Button, Column } from '@trezor/components';
 
@@ -22,10 +22,15 @@ const actionStepTranslationMap = {
         submitTranslationId: 'TR_EARN_YIELD_WITHDRAW',
         balanceLabelTranslationId: 'TR_EARN_YIELD_DEPOSITED',
     },
+    redeem: {
+        amountLabelTranslationId: 'TR_EARN_YIELD_AMOUNT_TO_WITHDRAW',
+        submitTranslationId: 'TR_EARN_YIELD_WITHDRAW',
+        balanceLabelTranslationId: 'TR_EARN_YIELD_DEPOSITED',
+    },
 } as const;
 
 export type YieldActionStepProps = {
-    flowType: YieldActionFlowType;
+    flowType: YieldPositionFlowType;
     token: YieldFlowDisplayToken;
     summaryValue: ReactNode;
     isDisabled?: boolean;

--- a/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
@@ -2,9 +2,9 @@ import type { ReactNode } from 'react';
 
 import { Translation } from '@suite/intl';
 import type {
-    YieldActionFlowType,
     YieldFlowDisplayToken,
     YieldPendingTransactionState,
+    YieldPositionFlowType,
 } from '@suite-common/wallet-core';
 import { Banner, Button, Column } from '@trezor/components';
 
@@ -19,6 +19,10 @@ const approveStepTranslationMap = {
         balanceLabelTranslationId: 'TR_BALANCE',
     },
     withdraw: {
+        amountLabelTranslationId: 'TR_EARN_YIELD_AMOUNT_TO_WITHDRAW',
+        balanceLabelTranslationId: 'TR_EARN_YIELD_DEPOSITED',
+    },
+    redeem: {
         amountLabelTranslationId: 'TR_EARN_YIELD_AMOUNT_TO_WITHDRAW',
         balanceLabelTranslationId: 'TR_EARN_YIELD_DEPOSITED',
     },
@@ -58,7 +62,7 @@ const getApproveButtonTranslationId = ({
 };
 
 export type YieldApproveStepProps = {
-    flowType: YieldActionFlowType;
+    flowType: YieldPositionFlowType;
     token: YieldFlowDisplayToken;
     variant: 'active' | 'done';
     summaryValue: ReactNode;

--- a/packages/suite/src/components/earn/yield/common/YieldDisabledBanner.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldDisabledBanner.tsx
@@ -14,6 +14,7 @@ type YieldDisabledBannerProps = {
 const yieldDisabledMessageMap = {
     deposit: 'TR_EARN_YIELD_DEPOSIT_DISABLED',
     withdraw: 'TR_EARN_YIELD_WITHDRAW_DISABLED',
+    redeem: 'TR_EARN_YIELD_WITHDRAW_DISABLED',
     claim: 'TR_EARN_YIELD_CLAIM_DISABLED',
 } as const;
 

--- a/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
@@ -19,6 +19,7 @@ const getPendingTransactionLabel = (kind: YieldPendingTransactionState['type']):
         case 'deposit':
             return 'TR_EARN_YIELD_PENDING_DEPOSIT';
         case 'withdraw':
+        case 'redeem':
             return 'TR_EARN_YIELD_PENDING_WITHDRAW';
         case 'claim':
             return 'TR_EARN_YIELD_PENDING_CLAIM';

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -9,7 +9,6 @@ import { type EarnParams } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { type YieldDto } from '@suite-common/earn-stablecoin-api';
 import {
-    type YieldActionFlowType,
     type YieldAllowanceStatus,
     type YieldApproveModalState,
     type YieldFlowDisplayToken,
@@ -17,10 +16,11 @@ import {
     type YieldFlowStepId,
     type YieldFlowToken,
     type YieldPendingTransactionState,
-    type YieldWithdrawInputUnit,
+    type YieldPositionFlowType,
     handleYieldApproveCancelThunk,
     handleYieldApproveSuccessTxidThunk,
     initYieldAllowanceThunk,
+    isYieldWithdrawFlow,
     selectStablecoinYieldSession,
     stablecoinYieldActions,
     submitYieldApproveThunk,
@@ -51,7 +51,7 @@ type UseYieldFlowProps = {
     account: Account;
     routeParams: EarnParams;
     vault: YieldDto;
-    flowType: YieldActionFlowType;
+    flowType: YieldPositionFlowType;
 };
 
 type UseYieldFlowStepsResult = {
@@ -70,7 +70,7 @@ export type UseYieldFlowResult = {
     depositedSharesAmount: string;
     flowKey: string;
     maxAmount: string;
-    withdrawInputUnit: YieldWithdrawInputUnit;
+    flowType: YieldPositionFlowType;
     inputTokenSymbol: string;
     otherUnitTokenSymbol: string;
     canToggleWithdrawUnit: boolean;
@@ -92,7 +92,6 @@ export type UseYieldFlowResult = {
     isSubmittingApprove: boolean;
     isSubmittingAction: boolean;
     setAmountInput: (amount: string) => void;
-    toggleWithdrawInputUnit: () => void;
     submitApprovalAction: () => void;
     submitAction: () => void;
     revokeAllowance: () => void;
@@ -128,7 +127,6 @@ export const useYieldFlow = ({
         mode: 'onChange',
         defaultValues: {
             amountInput: '',
-            withdrawInputUnit: 'asset',
         },
     });
     const methodsRef = useCurrentRef(methods);
@@ -150,9 +148,8 @@ export const useYieldFlow = ({
     const session = useSelector(state => selectStablecoinYieldSession(state, flowType, flowKey));
     const sessionRef = useCurrentRef(session);
 
-    const withdrawInputUnit = methods.watch('withdrawInputUnit');
-    const isSharesInput = flowType === 'withdraw' && withdrawInputUnit === 'shares';
-    const canToggleWithdrawUnit = flowType === 'withdraw' && !!token && !!receiptToken;
+    const isSharesInput = flowType === 'redeem';
+    const canToggleWithdrawUnit = isYieldWithdrawFlow(flowType) && !!token && !!receiptToken;
 
     const getMaxAmount = () => {
         if (flowType === 'deposit') {
@@ -179,11 +176,11 @@ export const useYieldFlow = ({
         dispatch(stablecoinYieldActions.initSession({ flowType, flowKey }));
         dispatch(stablecoinYieldActions.resetSession({ flowType, flowKey }));
 
-        if (flowType === 'withdraw') {
+        if (isYieldWithdrawFlow(flowType)) {
             dispatch(stablecoinYieldActions.skipApprovalStep({ flowType, flowKey }));
         }
 
-        methodsRef.current.reset({ amountInput: '', withdrawInputUnit: 'asset' });
+        methodsRef.current.reset({ amountInput: '' });
 
         return () => {
             dispatch(stablecoinYieldActions.disposeSession({ flowType, flowKey }));
@@ -271,7 +268,6 @@ export const useYieldFlow = ({
                     : actionAmount;
                 methodsRef.current.reset({
                     amountInput: cappedAmount,
-                    withdrawInputUnit: methodsRef.current.getValues('withdrawInputUnit'),
                 });
             }
 
@@ -282,7 +278,6 @@ export const useYieldFlow = ({
                         actionAmount: session.action.amount,
                         maxAmount,
                     }),
-                    withdrawInputUnit: methodsRef.current.getValues('withdrawInputUnit'),
                 });
             }
         }
@@ -354,19 +349,6 @@ export const useYieldFlow = ({
     }, [device, dispatch]);
 
     const isDeviceConnected = !!device?.connected && !!device?.available;
-
-    const toggleWithdrawInputUnit = useCallback(() => {
-        if (!token || !receiptToken || flowType !== 'withdraw') {
-            return;
-        }
-
-        const currentUnit = methodsRef.current.getValues('withdrawInputUnit');
-        const nextUnit: YieldWithdrawInputUnit = currentUnit === 'shares' ? 'asset' : 'shares';
-
-        methodsRef.current.setValue('withdrawInputUnit', nextUnit);
-        methodsRef.current.setValue('amountInput', '');
-        methodsRef.current.clearErrors('amountInput');
-    }, [flowType, methodsRef, receiptToken, token]);
 
     const submitApprove = useCallback(() => {
         if (!isDeviceConnected) {
@@ -496,15 +478,13 @@ export const useYieldFlow = ({
 
         const amount = methodsRef.current.getValues('amountInput');
 
-        if (flowType === 'withdraw') {
-            const currentInputUnit = methodsRef.current.getValues('withdrawInputUnit');
-
+        if (isYieldWithdrawFlow(flowType)) {
             void dispatch(
                 submitYieldWithdrawThunk({
                     flowKey,
                     flowData: { account, vault, token, receiptToken },
                     amount,
-                    withdrawInputUnit: currentInputUnit,
+                    flowType,
                 }),
             );
 
@@ -571,7 +551,7 @@ export const useYieldFlow = ({
         depositedSharesAmount,
         flowKey,
         maxAmount,
-        withdrawInputUnit,
+        flowType,
         inputTokenSymbol,
         otherUnitTokenSymbol,
         canToggleWithdrawUnit,
@@ -596,7 +576,6 @@ export const useYieldFlow = ({
             session.approval.modalState !== null,
         isSubmittingAction: session.action.isSubmitting,
         setAmountInput,
-        toggleWithdrawInputUnit,
         submitApprovalAction,
         submitAction,
         revokeAllowance,

--- a/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
@@ -6,6 +6,7 @@ import { type YieldDto } from '@suite-common/earn-stablecoin-api';
 import {
     type YieldFlowType,
     type YieldPendingTransactionState,
+    type YieldWithdrawFlowType,
     fetchAndUpdateAccountThunk,
     selectConvertedNetworkFeeInfo,
     selectStablecoinYieldSession,
@@ -36,7 +37,7 @@ const getPollIntervalMs = (blockTime: number | undefined): number => {
 
 type ResolutionEventType =
     | { type: 'deposit'; successType: 'approve-success' | 'revoke-success' | 'success' }
-    | { type: 'withdraw'; successType: 'success' }
+    | { type: 'withdraw'; operation: YieldWithdrawFlowType; successType: 'success' }
     | { type: 'claim'; successType: 'success' };
 
 const getResolutionEventType = (
@@ -52,7 +53,9 @@ const getResolutionEventType = (
         case 'deposit':
             return { type: 'deposit', successType: 'success' };
         case 'withdraw':
-            return { type: 'withdraw', successType: 'success' };
+            return { type: 'withdraw', operation: 'withdraw', successType: 'success' };
+        case 'redeem':
+            return { type: 'withdraw', operation: 'redeem', successType: 'success' };
         case 'claim':
             return flowType === 'claim' ? { type: 'claim', successType: 'success' } : null;
         default:
@@ -116,6 +119,7 @@ const reportResolution = (
             payload: {
                 action: 'continue',
                 type: resolveReportedType(outcome, resolution.successType),
+                operation: resolution.operation,
                 networkSymbol: context.networkSymbol,
                 vaultId: context.vault?.id,
                 durationMs: context.durationMs,

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -31,11 +31,11 @@ export const YieldWithdrawForm = () => {
         inputTokenSymbol,
         otherUnitTokenSymbol,
         canToggleWithdrawUnit,
-        withdrawInputUnit,
+        flowType,
         completedInput,
         completedOutput,
         setAmountInput,
-        toggleWithdrawInputUnit,
+        toggleWithdrawFlowType,
         submitAction,
         openPendingTransaction,
         flow,
@@ -43,8 +43,9 @@ export const YieldWithdrawForm = () => {
 
     const { actionPendingTransaction: withdrawPendingTransaction } = splitYieldPendingTransaction(
         pendingTransaction,
-        'withdraw',
+        flowType,
     );
+    const withdrawInputUnit = flowType === 'redeem' ? 'shares' : 'asset';
 
     const handleOnWithdraw = () => {
         const apyBreakdown = getApyBreakdown(vault.rewardRate?.components);
@@ -52,6 +53,7 @@ export const YieldWithdrawForm = () => {
             type: events.yieldWithdrawEvent.name,
             payload: {
                 type: 'withdraw',
+                operation: flowType,
                 action: 'continue',
                 networkSymbol: token.networkSymbol,
                 vaultId: vault.id,
@@ -75,7 +77,7 @@ export const YieldWithdrawForm = () => {
             },
         });
 
-        toggleWithdrawInputUnit();
+        toggleWithdrawFlowType();
     };
 
     // Fire once per form mount when the user first hits the insufficient-funds banner
@@ -136,8 +138,8 @@ export const YieldWithdrawForm = () => {
                         )}
 
                         <YieldActionStep
-                            flowType="withdraw"
-                            token={withdrawInputUnit === 'shares' ? receiptToken : token}
+                            flowType={flowType}
+                            token={flowType === 'redeem' ? receiptToken : token}
                             summaryValue={
                                 <FormattedCryptoAmount
                                     value={maxAmount}

--- a/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
+++ b/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
@@ -1,7 +1,10 @@
+import { useCallback, useState } from 'react';
+
 import { type EarnParams } from '@suite/router';
 import { type YieldDto } from '@suite-common/earn-stablecoin-api';
 import {
     type YieldFlowCompleteValue,
+    type YieldWithdrawFlowType,
     getConvertedOutputTokenBalanceToInputTokenAmount,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
@@ -14,9 +17,11 @@ type UseYieldWithdrawProps = {
     vault: YieldDto;
 };
 
-export type YieldWithdrawContextValues = YieldFlowContextValues & {
+export type YieldWithdrawContextValues = Omit<YieldFlowContextValues, 'flowType'> & {
+    flowType: YieldWithdrawFlowType;
     completedInput: YieldFlowCompleteValue;
     completedOutput?: YieldFlowCompleteValue;
+    toggleWithdrawFlowType: () => void;
 };
 
 export const useYieldWithdraw = ({
@@ -24,20 +29,26 @@ export const useYieldWithdraw = ({
     routeParams,
     vault,
 }: UseYieldWithdrawProps): YieldWithdrawContextValues | null => {
+    const [flowType, setFlowType] = useState<YieldWithdrawFlowType>('withdraw');
+
     const flowResult = useYieldFlow({
         account,
         routeParams,
         vault,
-        flowType: 'withdraw',
+        flowType,
     });
     const { token, receiptToken } = flowResult;
+
+    const toggleWithdrawFlowType = useCallback(() => {
+        setFlowType(prev => (prev === 'redeem' ? 'withdraw' : 'redeem'));
+    }, []);
 
     if (!token || !receiptToken) {
         return null;
     }
 
-    const { completedAmount, withdrawInputUnit } = flowResult;
-    const isSharesInput = withdrawInputUnit === 'shares';
+    const { completedAmount } = flowResult;
+    const isSharesInput = flowType === 'redeem';
     const pricePerShareState = vault.state?.pricePerShareState;
     const completedInput = {
         token: isSharesInput ? receiptToken : token,
@@ -60,10 +71,12 @@ export const useYieldWithdraw = ({
 
     return {
         ...flowResult,
+        flowType,
         token,
         receiptToken,
         vault,
         completedInput,
         completedOutput,
+        toggleWithdrawFlowType,
     };
 };

--- a/packages/suite/src/views/earn/yield/useEarnLayout.tsx
+++ b/packages/suite/src/views/earn/yield/useEarnLayout.tsx
@@ -8,7 +8,7 @@ import { useYieldOpportunity } from '@suite-common/earn-stablecoin-api';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { type EarnAnalyticsStep } from '@suite-common/suite-types/src/staking';
 import { getNetworkByYieldXyzId } from '@suite-common/wallet-config';
-import { type YieldActionFlowType, isStablecoinYieldSupported } from '@suite-common/wallet-core';
+import { type YieldPositionFlowType, isStablecoinYieldSupported } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 
@@ -20,7 +20,7 @@ import { type EarnLayoutState } from 'src/types/earn/earnLayout';
 type EarnYieldAnalyticsStep = Extract<EarnAnalyticsStep, 'yield-deposit' | 'yield-withdraw'>;
 
 type UseEarnLayoutParams = {
-    type: YieldActionFlowType;
+    type: YieldPositionFlowType;
     fallbackTitleId: TranslationKey;
 };
 
@@ -29,7 +29,7 @@ type GetEarnLayoutResultParams = {
     device?: TrezorDevice;
     routeParams?: EarnParams;
     vault?: YieldDto;
-    type: YieldActionFlowType;
+    type: YieldPositionFlowType;
     isYieldOpportunitiesLoading: boolean;
     isYieldOpportunitiesSuccess: boolean;
     isYieldOpportunitiesError: boolean;
@@ -44,11 +44,12 @@ type VaultTokenValidationParams = VaultValidationParams & {
     routeParams: EarnParams;
 };
 
-const getAnalyticsStep = (type: YieldActionFlowType): EarnYieldAnalyticsStep => {
+const getAnalyticsStep = (type: YieldPositionFlowType): EarnYieldAnalyticsStep => {
     switch (type) {
         case 'deposit':
             return 'yield-deposit';
         case 'withdraw':
+        case 'redeem':
             return 'yield-withdraw';
     }
 };

--- a/suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.ts
+++ b/suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.ts
@@ -28,7 +28,7 @@ const claimUnsignedTxBase = {
 
 const stablecoinYieldTxSimulationParams = z.discriminatedUnion('flow', [
     z.strictObject({
-        flow: z.union([z.literal('deposit'), z.literal('withdraw')]),
+        flow: z.union([z.literal('deposit'), z.literal('withdraw'), z.literal('redeem')]),
         account: partialAccount,
         unsignedTx: z.string(),
     }),
@@ -56,6 +56,7 @@ function composeUnsignedEvmTx(
 ): EthereumSignTransaction['transaction'] {
     switch (params.flow) {
         case 'deposit':
+        case 'redeem':
         case 'withdraw': {
             const {
                 to,

--- a/suite-common/message-system/schema/config.schema.v1.json
+++ b/suite-common/message-system/schema/config.schema.v1.json
@@ -791,7 +791,7 @@
         },
         "yieldFlowType": {
             "type": "string",
-            "enum": ["deposit", "withdraw", "claim"]
+            "enum": ["deposit", "withdraw", "redeem", "claim"]
         }
     }
 }

--- a/suite-common/message-system/src/__tests__/messageSystemTypes.test.ts
+++ b/suite-common/message-system/src/__tests__/messageSystemTypes.test.ts
@@ -72,6 +72,7 @@ describe('Message system types', () => {
             it.each([
                 ['deposit', 'earn.yield.deposit'],
                 ['withdraw', 'earn.yield.withdraw'],
+                ['redeem', 'earn.yield.redeem'],
                 ['claim', 'earn.yield.claim'],
             ] as const)('getEarnYield(%s) → %s', (type, expected) => {
                 expect(Context.getEarnYield(type)).toBe(expected);

--- a/suite-common/message-system/src/messageSystemConstants.ts
+++ b/suite-common/message-system/src/messageSystemConstants.ts
@@ -69,7 +69,7 @@ export const CONTEXT_PATTERNS = {
     },
     getEarnYield: {
         pattern: 'earn.yield.{type}',
-        regex: /^earn\.yield\.(deposit|withdraw|claim)$/,
+        regex: /^earn\.yield\.(deposit|withdraw|redeem|claim)$/,
     },
     getSettings: {
         pattern: 'settings.{category}',

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -100,6 +100,7 @@ export const Feature = {
         yield: {
             deposit: 'earn.yield.deposit',
             withdraw: 'earn.yield.withdraw',
+            redeem: 'earn.yield.redeem',
             claim: 'earn.yield.claim',
         } as const satisfies Record<YieldFlowType, string>,
     },

--- a/suite-common/suite-types/src/messageSystem.ts
+++ b/suite-common/suite-types/src/messageSystem.ts
@@ -307,7 +307,7 @@ export type TradingType = 'buy' | 'sell' | 'exchange' | 'concierge';
  * This interface was referenced by `MessageSystem`'s JSON-Schema
  * via the `definition` "yieldFlowType".
  */
-export type YieldFlowType = 'deposit' | 'withdraw' | 'claim';
+export type YieldFlowType = 'deposit' | 'withdraw' | 'redeem' | 'claim';
 
 /**
  * JSON schema of the Trezor Suite messaging system.

--- a/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts
@@ -1,10 +1,12 @@
 import { Calldata, asEvmAddress } from '@suite-common/calldata';
 
+import type { YieldPendingTransactionState } from '../stablecoinYieldTypes';
 import {
     buildEvmSelectedFee,
     buildYieldDepositCalldata,
     buildYieldUnsignedTransaction,
     buildYieldWithdrawCalldata,
+    splitYieldPendingTransaction,
 } from '../stablecoinYieldUtils';
 
 const ACCOUNT_DESCRIPTOR = asEvmAddress('0x9ea3721b5bf3b64b4418c38b603154d2d597fae3');
@@ -44,7 +46,7 @@ describe('stablecoinYieldUtils', () => {
                 flowData,
                 ownerAddress: ACCOUNT_DESCRIPTOR,
                 receiverAddress: ACCOUNT_DESCRIPTOR,
-                withdrawInputUnit: 'asset',
+                flowType: 'withdraw',
             });
 
             expect(Calldata.evm.erc4626.withdraw.decode(calldata)).toEqual({
@@ -60,7 +62,7 @@ describe('stablecoinYieldUtils', () => {
                 flowData,
                 ownerAddress: ACCOUNT_DESCRIPTOR,
                 receiverAddress: ACCOUNT_DESCRIPTOR,
-                withdrawInputUnit: 'shares',
+                flowType: 'redeem',
             });
 
             expect(Calldata.evm.erc4626.redeem.decode(calldata)).toEqual({
@@ -79,9 +81,62 @@ describe('stablecoinYieldUtils', () => {
                         typeof buildYieldWithdrawCalldata
                     >[0]['ownerAddress'],
                     receiverAddress: ACCOUNT_DESCRIPTOR,
-                    withdrawInputUnit: 'asset',
+                    flowType: 'withdraw',
                 }),
             ).toThrow('Failed to encode withdraw calldata');
+        });
+    });
+
+    describe('splitYieldPendingTransaction', () => {
+        const mockPendingTx = (
+            type: YieldPendingTransactionState['type'],
+        ): YieldPendingTransactionState => ({
+            type,
+            txid: '0xabc',
+            amount: '10',
+        });
+
+        it('matches a redeem tx only for the redeem flow', () => {
+            const redeemTx = mockPendingTx('redeem');
+
+            expect(splitYieldPendingTransaction(redeemTx, 'redeem')).toEqual({
+                approvalPendingTransaction: undefined,
+                actionPendingTransaction: redeemTx,
+            });
+        });
+
+        it('does not treat a redeem tx as a withdraw action', () => {
+            expect(splitYieldPendingTransaction(mockPendingTx('redeem'), 'withdraw')).toEqual({
+                approvalPendingTransaction: undefined,
+                actionPendingTransaction: undefined,
+            });
+        });
+
+        it('matches a withdraw tx only for the withdraw flow', () => {
+            const withdrawTx = mockPendingTx('withdraw');
+
+            expect(splitYieldPendingTransaction(withdrawTx, 'withdraw')).toEqual({
+                approvalPendingTransaction: undefined,
+                actionPendingTransaction: withdrawTx,
+            });
+        });
+
+        it('matches a deposit tx only for the deposit flow', () => {
+            const depositTx = mockPendingTx('deposit');
+
+            expect(splitYieldPendingTransaction(depositTx, 'deposit')).toEqual({
+                approvalPendingTransaction: undefined,
+                actionPendingTransaction: depositTx,
+            });
+        });
+
+        it('classifies an approve tx as the approval tx', () => {
+            const approveTx = mockPendingTx('approve');
+
+            expect(splitYieldPendingTransaction(approveTx, 'withdraw')).toEqual({
+                approvalPendingTransaction: approveTx,
+                actionPendingTransaction: undefined,
+            });
         });
     });
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
@@ -11,7 +11,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { STABLECOIN_YIELD_PREFIX, stablecoinYieldActions } from './stablecoinYieldReducer';
 import { selectStablecoinYieldSession } from './stablecoinYieldSelectors';
-import type { YieldActionFlowType, YieldFlowResolvedData } from './stablecoinYieldTypes';
+import type { YieldFlowResolvedData, YieldPositionFlowType } from './stablecoinYieldTypes';
 import { getAllowanceSpender, getWithdrawRequestAmount } from './stablecoinYieldUtils';
 import { fetchAllowance } from '../allowance/fetchAllowance';
 
@@ -19,7 +19,7 @@ const YIELD_THUNK_PREFIX = `${STABLECOIN_YIELD_PREFIX}/thunk`;
 const YIELD_GENERIC_ERROR = 'TR_EARN_YIELD_ERROR_GENERIC';
 
 export type YieldSessionPayload = {
-    flowType: YieldActionFlowType;
+    flowType: YieldPositionFlowType;
     flowKey: string;
 };
 
@@ -41,7 +41,7 @@ type SetYieldGenericErrorParams = YieldSessionPayload & {
 };
 
 type GetApprovalContractAddressParams = {
-    flowType: YieldActionFlowType;
+    flowType: YieldPositionFlowType;
     flowData: YieldFlowResolvedData;
 };
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -11,12 +11,12 @@ import { isSafeObjectKey } from '@trezor/utils';
 
 import type {
     StablecoinYieldClaimUnsignedTransaction,
-    YieldActionFlowType,
     YieldApproveModalState,
     YieldFlowCompleteRewardItem,
     YieldFlowStepId,
     YieldFlowType,
     YieldPendingTransactionState,
+    YieldPositionFlowType,
 } from './stablecoinYieldTypes';
 import { transactionsActions } from '../transactions/transactionsActions';
 
@@ -29,7 +29,7 @@ type StablecoinYieldSerializedTx = {
 
 export type StablecoinYieldActionReviewState =
     | {
-          type: YieldActionFlowType;
+          type: YieldPositionFlowType;
           amount: string;
           receiptAmount: string;
           unsignedTransaction: string;
@@ -42,7 +42,7 @@ export type StablecoinYieldActionReviewState =
 
 type StablecoinYieldStoreActionReviewDataPayload =
     | (StablecoinYieldSessionActionPayload & {
-          flowType: YieldActionFlowType;
+          flowType: YieldPositionFlowType;
           amount: string;
           receiptAmount: string;
           unsignedTransaction: string;
@@ -145,6 +145,7 @@ export const initialStablecoinYieldTxReviewState: StablecoinYieldTxReviewState =
 export const initialStablecoinYieldState: StablecoinYieldState = {
     deposit: Object.create(null),
     withdraw: Object.create(null),
+    redeem: Object.create(null),
     claim: Object.create(null),
     txReview: initialStablecoinYieldTxReviewState,
 };
@@ -499,7 +500,7 @@ export const stablecoinYieldSlice = createSlice({
     extraReducers: builder => {
         builder.addCase(transactionsActions.replaceTransaction, (state, { payload }) => {
             const { txid: prevTxid, tx } = payload;
-            (['deposit', 'withdraw', 'claim'] as const).forEach(flowType => {
+            (['deposit', 'withdraw', 'redeem', 'claim'] as const).forEach(flowType => {
                 const bucket = state[flowType];
                 Object.values(bucket).forEach(session => {
                     if (session.action.pendingTransaction?.txid === prevTxid) {

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
@@ -3,18 +3,16 @@ import type { EvmHexString } from '@suite-common/schemas/src/evm';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { Account } from '@suite-common/wallet-types';
 
-export const YIELD_FLOW_TYPES = ['deposit', 'withdraw', 'claim'] as const;
+export const YIELD_FLOW_TYPES = ['deposit', 'withdraw', 'redeem', 'claim'] as const;
 export const YIELD_FLOW_STEPS = ['approve', 'action', 'complete'] as const;
-export const YIELD_WITHDRAW_INPUT_UNITS = ['asset', 'shares'] as const;
 
 export type YieldFlowType = (typeof YIELD_FLOW_TYPES)[number];
-export type YieldActionFlowType = Exclude<YieldFlowType, 'claim'>;
+export type YieldPositionFlowType = Exclude<YieldFlowType, 'claim'>;
+export type YieldWithdrawFlowType = Extract<YieldFlowType, 'withdraw' | 'redeem'>;
 export type YieldFlowStepId = (typeof YIELD_FLOW_STEPS)[number];
-export type YieldWithdrawInputUnit = (typeof YIELD_WITHDRAW_INPUT_UNITS)[number];
 
 export type YieldFlowFormValues = {
     amountInput: string;
-    withdrawInputUnit: YieldWithdrawInputUnit;
 };
 
 export type YieldFlowDisplayToken = {
@@ -70,7 +68,7 @@ export type YieldApproveModalState = {
 };
 
 export type YieldPendingTransactionState = {
-    type: 'approve' | 'revoke' | 'revoke-only' | 'deposit' | 'withdraw' | 'claim';
+    type: 'approve' | 'revoke' | 'revoke-only' | 'deposit' | 'withdraw' | 'redeem' | 'claim';
     txid: string;
     amount: string;
     fee?: string;

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -16,7 +16,7 @@ import type {
     YieldFlowResolvedData,
     YieldFlowType,
     YieldPendingTransactionState,
-    YieldWithdrawInputUnit,
+    YieldWithdrawFlowType,
 } from './stablecoinYieldTypes';
 
 type TokenLike = {
@@ -74,7 +74,7 @@ type BuildYieldWithdrawCalldataParams = {
     flowData: YieldFlowResolvedData;
     ownerAddress: EvmAddress;
     receiverAddress: EvmAddress;
-    withdrawInputUnit: YieldWithdrawInputUnit;
+    flowType: YieldWithdrawFlowType;
 };
 
 type BuildYieldDepositCalldataParams = {
@@ -106,30 +106,32 @@ export const getStablecoinYieldFlowKey = ({
 }: GetStablecoinYieldFlowKeyParams) =>
     `${accountKey}:${yieldId}:${tokenContract?.toLowerCase() ?? ''}`;
 
+export const isYieldWithdrawFlow = (flowType: YieldFlowType): flowType is YieldWithdrawFlowType =>
+    flowType === 'withdraw' || flowType === 'redeem';
+
 export const getYieldWithdrawInputToken = ({
     flowData,
-    withdrawInputUnit,
+    flowType,
 }: {
     flowData: YieldFlowResolvedData;
-    withdrawInputUnit: YieldWithdrawInputUnit;
-}): YieldFlowDisplayToken =>
-    withdrawInputUnit === 'shares' ? flowData.receiptToken : flowData.token;
+    flowType: YieldWithdrawFlowType;
+}): YieldFlowDisplayToken => (flowType === 'redeem' ? flowData.receiptToken : flowData.token);
 
 export const buildYieldWithdrawCalldata = ({
     amount,
     flowData,
     ownerAddress,
     receiverAddress,
-    withdrawInputUnit,
+    flowType,
 }: BuildYieldWithdrawCalldataParams) => {
-    const isSharesInput = withdrawInputUnit === 'shares';
-    const inputToken = getYieldWithdrawInputToken({ flowData, withdrawInputUnit });
+    const isRedeem = flowType === 'redeem';
+    const inputToken = getYieldWithdrawInputToken({ flowData, flowType });
     const amountSubunits = unitsToSubunits({
         value: asAmountUnit(new BigNumber(amount)),
         decimals: inputToken.decimals,
     });
 
-    const builderResult = isSharesInput
+    const builderResult = isRedeem
         ? Calldata.evm.erc4626.redeem.encode(
               {
                   shares: amountSubunits,

--- a/suite-native/module-earn/src/components/YieldWithdrawReviewContent.tsx
+++ b/suite-native/module-earn/src/components/YieldWithdrawReviewContent.tsx
@@ -1,4 +1,8 @@
-import { type YieldFlowDisplayToken, type YieldFlowResolvedData } from '@suite-common/wallet-core';
+import {
+    type YieldFlowDisplayToken,
+    type YieldFlowResolvedData,
+    type YieldWithdrawFlowType,
+} from '@suite-common/wallet-core';
 
 import { EarnReviewSubmittedCard } from './EarnReviewSubmittedCard';
 import { YieldReviewScreenLayout } from './YieldReviewScreenLayout';
@@ -14,6 +18,7 @@ import { type YieldReviewPreview } from '../utils/yieldReviewOutputUtils';
 type YieldWithdrawReviewContentProps = {
     flowData: YieldFlowResolvedData;
     flowKey: string;
+    flowType: YieldWithdrawFlowType;
     preview: YieldReviewPreview;
     reviewToken: YieldFlowDisplayToken;
 };
@@ -21,6 +26,7 @@ type YieldWithdrawReviewContentProps = {
 export const YieldWithdrawReviewContent = ({
     flowData,
     flowKey,
+    flowType,
     preview,
     reviewToken,
 }: YieldWithdrawReviewContentProps) => {
@@ -39,6 +45,7 @@ export const YieldWithdrawReviewContent = ({
     } = useYieldWithdrawReview({
         flowData,
         flowKey,
+        flowType,
         onReviewLeave: markReviewLeave,
         reviewToken,
     });

--- a/suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts
+++ b/suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts
@@ -8,12 +8,13 @@ import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constan
 import {
     type FeesRootState,
     type FormDraftRootState,
-    type YieldWithdrawInputUnit,
+    type YieldWithdrawFlowType,
     buildEvmSelectedFee,
     buildYieldUnsignedTransaction,
     buildYieldWithdrawCalldata,
     ethereumGetCurrentNonceThunk,
     formDraftActions,
+    getYieldWithdrawInputToken,
     selectConvertedNetworkFeeInfo,
     selectFormDraft,
 } from '@suite-common/wallet-core';
@@ -36,21 +37,18 @@ import { useDebounce } from '@trezor/react-utils';
 
 import { updateEarnSelectedFeeLevelThunk } from './useComposeEarnFees';
 import { type ResolvedYieldFlowData } from './useResolvedYieldFlowData';
-import {
-    getYieldWithdrawFormDraftKey,
-    getYieldWithdrawInputToken,
-} from '../utils/yieldWithdrawUtils';
+import { getYieldWithdrawFormDraftKey } from '../utils/yieldWithdrawUtils';
 
 type UseYieldWithdrawFeesParams = Pick<ResolvedYieldFlowData, 'flowData' | 'flowKey'> & {
     amount: string;
+    flowType: YieldWithdrawFlowType;
     isEnabled: boolean;
-    withdrawInputUnit: YieldWithdrawInputUnit;
 };
 
 type PreparedYieldWithdrawAction = {
     amount: string;
+    flowType: YieldWithdrawFlowType;
     unsignedTransaction: string;
-    withdrawInputUnit: YieldWithdrawInputUnit;
 };
 
 type WithdrawFlowData = NonNullable<ResolvedYieldFlowData['flowData']>;
@@ -71,8 +69,8 @@ type UseYieldWithdrawFeesResult = {
 // re-trigger the effect — most importantly the fee draft that the compose itself writes.
 type ComposeWithdrawFeeParams = {
     amount: string;
+    flowType: YieldWithdrawFlowType;
     formDraftKey: string;
-    withdrawInputUnit: YieldWithdrawInputUnit;
 };
 
 type ComposeYieldWithdrawTransactionParams = {
@@ -80,7 +78,7 @@ type ComposeYieldWithdrawTransactionParams = {
     dispatch: ReturnType<typeof useDispatch>;
     feeInfo: FeeInfo;
     flowData: WithdrawFlowData;
-    withdrawInputUnit: YieldWithdrawInputUnit;
+    flowType: YieldWithdrawFlowType;
 };
 
 type BuildYieldWithdrawFeeLevelsParams = {
@@ -142,7 +140,7 @@ const composeYieldWithdrawTransaction = async ({
     dispatch,
     feeInfo,
     flowData,
-    withdrawInputUnit,
+    flowType,
 }: ComposeYieldWithdrawTransactionParams) => {
     const { account, receiptToken, vault } = flowData;
 
@@ -163,7 +161,7 @@ const composeYieldWithdrawTransaction = async ({
         flowData,
         ownerAddress,
         receiverAddress: ownerAddress,
-        withdrawInputUnit,
+        flowType,
     });
 
     const [{ nonce }, estimatedFee] = await Promise.all([
@@ -230,10 +228,10 @@ const buildYieldWithdrawFeeLevels = ({
 
 export const useYieldWithdrawFees = ({
     amount,
+    flowType,
     flowData,
     flowKey,
     isEnabled,
-    withdrawInputUnit,
 }: UseYieldWithdrawFeesParams): UseYieldWithdrawFeesResult => {
     const dispatch = useDispatch();
     const debounce = useDebounce();
@@ -283,7 +281,7 @@ export const useYieldWithdrawFees = ({
             const { amount: withdrawAmount, formDraftKey: withdrawFormDraftKey } = params;
             const withdrawFlowData = flowDataRef.current;
             const withdrawFeeInfo = feeInfoRef.current;
-            const currentWithdrawInputUnit = params.withdrawInputUnit;
+            const currentFlowType = params.flowType;
             const { customFee: withdrawCustomFee, selectedFee: withdrawSelectedFee } =
                 feeStateRef.current;
 
@@ -307,7 +305,7 @@ export const useYieldWithdrawFees = ({
                     dispatch,
                     feeInfo: withdrawFeeInfo,
                     flowData: withdrawFlowData,
-                    withdrawInputUnit: currentWithdrawInputUnit,
+                    flowType: currentFlowType,
                 });
 
                 if (requestId !== requestIdRef.current) {
@@ -316,7 +314,7 @@ export const useYieldWithdrawFees = ({
 
                 const reviewToken = getYieldWithdrawInputToken({
                     flowData: withdrawFlowData,
-                    withdrawInputUnit: currentWithdrawInputUnit,
+                    flowType: currentFlowType,
                 });
                 const { formState: baseFormState } = buildStablecoinYieldTransactionReview({
                     amount: withdrawAmount,
@@ -381,8 +379,8 @@ export const useYieldWithdrawFees = ({
                 );
                 setPreparedAction({
                     amount: withdrawAmount,
+                    flowType: currentFlowType,
                     unsignedTransaction,
-                    withdrawInputUnit: currentWithdrawInputUnit,
                 });
             } catch {
                 if (requestId === requestIdRef.current) {
@@ -419,8 +417,8 @@ export const useYieldWithdrawFees = ({
                 void composeWithdrawFee(
                     {
                         amount,
+                        flowType,
                         formDraftKey,
-                        withdrawInputUnit,
                     },
                     requestId,
                 ),
@@ -431,10 +429,10 @@ export const useYieldWithdrawFees = ({
         debounce,
         dispatch,
         feeInfoRevision,
+        flowType,
         formDraftKey,
         hasFeeInfo,
         isEnabled,
-        withdrawInputUnit,
     ]);
 
     return {

--- a/suite-native/module-earn/src/hooks/useYieldWithdrawReview.ts
+++ b/suite-native/module-earn/src/hooks/useYieldWithdrawReview.ts
@@ -9,6 +9,7 @@ import {
     type StablecoinYieldRootState,
     type YieldFlowDisplayToken,
     type YieldFlowResolvedData,
+    type YieldWithdrawFlowType,
     selectFormDraft,
     selectStablecoinYieldTxReview,
 } from '@suite-common/wallet-core';
@@ -36,6 +37,7 @@ import { pushYieldActionReviewThunk, signYieldActionReviewThunk } from '../yield
 type UseYieldWithdrawReviewParams = {
     flowData: YieldFlowResolvedData;
     flowKey: string;
+    flowType: YieldWithdrawFlowType;
     onReviewLeave?: () => void;
     reviewToken: YieldFlowDisplayToken;
 };
@@ -55,6 +57,7 @@ type NavigationProps = StackNavigationProps<
 export const useYieldWithdrawReview = ({
     flowData,
     flowKey,
+    flowType,
     onReviewLeave,
     reviewToken,
 }: UseYieldWithdrawReviewParams): UseYieldWithdrawReviewResult => {
@@ -117,7 +120,7 @@ export const useYieldWithdrawReview = ({
                 signYieldActionReviewThunk({
                     flowData,
                     flowKey,
-                    flowType: 'withdraw',
+                    flowType,
                     reviewToken,
                     selectedFee,
                 }),
@@ -150,6 +153,7 @@ export const useYieldWithdrawReview = ({
         dispatch,
         flowData,
         flowKey,
+        flowType,
         reviewToken,
         selectedFee,
         showSignTransactionFailedAlert,
@@ -167,7 +171,7 @@ export const useYieldWithdrawReview = ({
             pushYieldActionReviewThunk({
                 flowData,
                 flowKey,
-                flowType: 'withdraw',
+                flowType,
             }),
         );
 
@@ -192,6 +196,7 @@ export const useYieldWithdrawReview = ({
         dispatch,
         flowData,
         flowKey,
+        flowType,
         markReviewNavigationSuccess,
         navigation,
         showPendingTransactionConflictAlert,

--- a/suite-native/module-earn/src/screens/YieldWithdrawCompleteScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawCompleteScreen.tsx
@@ -39,18 +39,19 @@ export const YieldWithdrawCompleteScreen = () => {
     const { account, apy, flowKey, resolutionStatus, vault } = useResolvedYieldFlowData(
         route.params,
     );
+    const flowType = route.params.withdrawFlowType ?? 'withdraw';
     const session = useSelector((state: StablecoinYieldRootState) =>
-        selectStablecoinYieldSessionByFlowKey(state, 'withdraw', flowKey),
+        selectStablecoinYieldSessionByFlowKey(state, flowType, flowKey),
     );
-    const isSharesInput = route.params.withdrawInputUnit === 'shares';
+    const isSharesInput = flowType === 'redeem';
 
     const handleExit = useCallback(() => {
         if (flowKey) {
-            dispatch(stablecoinYieldActions.disposeSession({ flowType: 'withdraw', flowKey }));
+            dispatch(stablecoinYieldActions.disposeSession({ flowType, flowKey }));
         }
 
         navigateToInitialScreen();
-    }, [dispatch, flowKey, navigateToInitialScreen]);
+    }, [dispatch, flowKey, flowType, navigateToInitialScreen]);
 
     useEffect(() => {
         if (resolutionStatus !== 'resolved') {

--- a/suite-native/module-earn/src/screens/YieldWithdrawReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawReviewScreen.tsx
@@ -7,6 +7,7 @@ import { selectSelectedDevice } from '@suite-common/device';
 import {
     type FormDraftRootState,
     type StablecoinYieldRootState,
+    getYieldWithdrawInputToken,
     selectFormDraft,
     selectStablecoinYieldSessionByFlowKey,
 } from '@suite-common/wallet-core';
@@ -22,10 +23,7 @@ import { YieldWithdrawReviewContent } from '../components/YieldWithdrawReviewCon
 import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
 import { buildYieldReviewPreview } from '../utils/yieldReviewOutputUtils';
 import { getSelectedEvmFeeFromPrecomposedTransaction } from '../utils/yieldSelectedFeeUtils';
-import {
-    getYieldWithdrawFormDraftKey,
-    getYieldWithdrawInputToken,
-} from '../utils/yieldWithdrawUtils';
+import { getYieldWithdrawFormDraftKey } from '../utils/yieldWithdrawUtils';
 
 type RouteProps = RouteProp<YieldStackParamList, YieldStackRoutes.YieldWithdrawReview>;
 type NavigationProps = StackNavigationProps<
@@ -38,8 +36,9 @@ export const YieldWithdrawReviewScreen = () => {
     const navigation = useNavigation<NavigationProps>();
     const { flowData, flowKey, resolutionStatus } = useResolvedYieldFlowData(route.params);
     const device = useSelector(selectSelectedDevice);
+    const flowType = route.params.withdrawFlowType ?? 'withdraw';
     const session = useSelector((state: StablecoinYieldRootState) =>
-        selectStablecoinYieldSessionByFlowKey(state, 'withdraw', flowKey),
+        selectStablecoinYieldSessionByFlowKey(state, flowType, flowKey),
     );
     const formDraftKey = flowKey ? getYieldWithdrawFormDraftKey(flowKey) : '';
     const formDraft = useSelector((state: FormDraftRootState) =>
@@ -57,14 +56,13 @@ export const YieldWithdrawReviewScreen = () => {
                 : null,
         [actionReview],
     );
-    const withdrawInputUnit = route.params.withdrawInputUnit ?? 'asset';
     const reviewToken = useMemo(() => {
         if (!flowData) {
             return null;
         }
 
-        return getYieldWithdrawInputToken({ flowData, withdrawInputUnit });
-    }, [flowData, withdrawInputUnit]);
+        return getYieldWithdrawInputToken({ flowData, flowType });
+    }, [flowData, flowType]);
     const selectedFeePreview = formDraft?.selectedFee
         ? feeLevels[formDraft.selectedFee]
         : undefined;
@@ -114,6 +112,7 @@ export const YieldWithdrawReviewScreen = () => {
         <YieldWithdrawReviewContent
             flowData={flowData}
             flowKey={flowKey}
+            flowType={flowType}
             preview={preview}
             reviewToken={reviewToken}
         />

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -6,9 +6,10 @@ import { type RouteProp, useIsFocused, useNavigation, useRoute } from '@react-na
 import { useFormatters } from '@suite-common/formatters';
 import { getNetwork } from '@suite-common/wallet-config';
 import {
-    type YieldWithdrawInputUnit,
+    type YieldWithdrawFlowType,
     getConvertedOutputTokenBalanceToInputTokenAmount,
     getWithdrawRequestAmount,
+    getYieldWithdrawInputToken,
     splitYieldPendingTransaction,
     stablecoinYieldActions,
 } from '@suite-common/wallet-core';
@@ -49,7 +50,6 @@ import { useShowYieldTransactionFailureAlert } from '../hooks/useShowYieldTransa
 import { useYieldPendingTransactionTracking } from '../hooks/useYieldPendingTransactionTracking';
 import { useYieldSession } from '../hooks/useYieldSession';
 import { useYieldWithdrawFees } from '../hooks/useYieldWithdrawFees';
-import { getYieldWithdrawInputToken } from '../utils/yieldWithdrawUtils';
 
 type RouteProps = RouteProp<YieldStackParamList, YieldStackRoutes.YieldWithdraw>;
 type NavigationProps = StackNavigationProps<YieldStackParamList, YieldStackRoutes.YieldWithdraw>;
@@ -65,6 +65,10 @@ const screenFooterStyle = prepareNativeStyle(utils => ({
     paddingHorizontal: utils.spacings.sp16,
 }));
 
+const getYieldWithdrawFlowTypeByInputView = (
+    activeView: 'primary' | 'secondary',
+): YieldWithdrawFlowType => (activeView === 'secondary' ? 'redeem' : 'withdraw');
+
 export const YieldWithdrawScreen = () => {
     const route = useRoute<RouteProps>();
     const navigation = useNavigation<NavigationProps>();
@@ -77,8 +81,10 @@ export const YieldWithdrawScreen = () => {
     const [assetAmount, setAssetAmount] = useState('');
     const [sharesAmount, setSharesAmount] = useState('');
     const [isMaxSelected, setIsMaxSelected] = useState(false);
-    const [withdrawInputUnit, setWithdrawInputUnit] = useState<YieldWithdrawInputUnit>('asset');
-    const isSharesInput = withdrawInputUnit === 'shares';
+    const [flowType, setFlowType] = useState<YieldWithdrawFlowType>(
+        route.params.withdrawFlowType ?? 'withdraw',
+    );
+    const isSharesInput = flowType === 'redeem';
     const amount = isSharesInput ? sharesAmount : assetAmount;
     const {
         bottomSheetRef: infoBottomSheetRef,
@@ -139,10 +145,10 @@ export const YieldWithdrawScreen = () => {
         updateFeeLevelThunk: updateWithdrawFeeLevelThunk,
     } = useYieldWithdrawFees({
         amount,
+        flowType,
         flowData,
         flowKey,
         isEnabled: resolutionStatus === 'resolved' && !!amount && !isAmountTooHigh,
-        withdrawInputUnit,
     });
     const feeFiatConverters = useCryptoFiatConverters({
         symbol: account?.symbol ?? null,
@@ -152,10 +158,10 @@ export const YieldWithdrawScreen = () => {
             return undefined;
         }
 
-        const inputToken = getYieldWithdrawInputToken({ flowData, withdrawInputUnit });
+        const inputToken = getYieldWithdrawInputToken({ flowData, flowType });
 
         return inputToken.contractAddress ? toTokenAddress(inputToken.contractAddress) : undefined;
-    }, [flowData, withdrawInputUnit]);
+    }, [flowData, flowType]);
 
     const amountFiatConverters = useCryptoFiatConverters({
         symbol: account?.symbol ?? null,
@@ -168,7 +174,7 @@ export const YieldWithdrawScreen = () => {
             !withdrawFee ||
             resolutionStatus !== 'resolved' ||
             preparedAction?.amount !== amount ||
-            preparedAction.withdrawInputUnit !== withdrawInputUnit
+            preparedAction.flowType !== flowType
         ) {
             return false;
         }
@@ -189,25 +195,22 @@ export const YieldWithdrawScreen = () => {
         preparedAction,
         resolutionStatus,
         withdrawFee,
-        withdrawInputUnit,
+        flowType,
     ]);
 
     const isWithdrawReviewReady =
         !!amount &&
         preparedAction?.amount === amount &&
-        preparedAction.withdrawInputUnit === withdrawInputUnit &&
+        preparedAction.flowType === flowType &&
         !!withdrawFeeFormDraft;
 
     const session = useYieldSession({
         flowKey,
-        flowType: 'withdraw',
+        flowType,
         shouldDisposeOnGoBack: true,
     });
     const pendingTransaction = session?.action.pendingTransaction ?? null;
-    const { actionPendingTransaction } = splitYieldPendingTransaction(
-        pendingTransaction,
-        'withdraw',
-    );
+    const { actionPendingTransaction } = splitYieldPendingTransaction(pendingTransaction, flowType);
     const isWithdrawPending = !!actionPendingTransaction;
     const { explorerUrl, openInBlockchain } = useTransactionDetails({
         accountKey: account?.key ?? null,
@@ -224,14 +227,14 @@ export const YieldWithdrawScreen = () => {
     useShowYieldTransactionFailureAlert({
         error: session?.error,
         flowKey,
-        flowType: 'withdraw',
+        flowType,
         isEnabled: isFocused,
     });
 
     useYieldPendingTransactionTracking({
         account,
         flowKey,
-        flowType: 'withdraw',
+        flowType,
         pendingTransaction: actionPendingTransaction,
     });
 
@@ -250,17 +253,17 @@ export const YieldWithdrawScreen = () => {
             return;
         }
 
-        dispatch(stablecoinYieldActions.skipApprovalStep({ flowType: 'withdraw', flowKey }));
-    }, [dispatch, flowKey, resolutionStatus, session?.step]);
+        dispatch(stablecoinYieldActions.skipApprovalStep({ flowType, flowKey }));
+    }, [dispatch, flowKey, flowType, resolutionStatus, session?.step]);
 
     useEffect(() => {
         if (session?.step === 'complete') {
             navigation.replace(YieldStackRoutes.YieldWithdrawComplete, {
                 ...route.params,
-                withdrawInputUnit,
+                withdrawFlowType: flowType,
             });
         }
-    }, [navigation, route.params, session?.step, withdrawInputUnit]);
+    }, [flowType, navigation, route.params, session?.step]);
 
     const getSharesAmountFromAssetAmount = useCallback(
         (value: string) => {
@@ -349,7 +352,7 @@ export const YieldWithdrawScreen = () => {
     }, [closeInfoBottomSheet, isWithdrawPending, openPendingBottomSheet]);
 
     const handleInputSwitch = useCallback((activeView: 'primary' | 'secondary') => {
-        setWithdrawInputUnit(activeView === 'secondary' ? 'shares' : 'asset');
+        setFlowType(getYieldWithdrawFlowTypeByInputView(activeView));
     }, []);
 
     const handleContinue = useCallback(() => {
@@ -362,23 +365,23 @@ export const YieldWithdrawScreen = () => {
             stablecoinYieldActions.storeActionReviewData({
                 amount: preparedAction.amount,
                 flowKey,
-                flowType: 'withdraw',
+                flowType,
                 receiptAmount: preparedAction.amount,
                 unsignedTransaction: preparedAction.unsignedTransaction,
             }),
         );
         navigation.navigate(YieldStackRoutes.YieldWithdrawReview, {
             ...route.params,
-            withdrawInputUnit,
+            withdrawFlowType: flowType,
         });
     }, [
         dispatch,
+        flowType,
         flowKey,
         isWithdrawReviewReady,
         navigation,
         preparedAction,
         route.params,
-        withdrawInputUnit,
     ]);
 
     if (resolutionStatus !== 'resolved') {
@@ -388,7 +391,7 @@ export const YieldWithdrawScreen = () => {
     const underlyingTokenSymbol = toTokenSymbol(flowData.token.symbol.toUpperCase());
     const vaultTokenSymbol = toTokenSymbol(flowData.receiptToken.symbol.toUpperCase());
 
-    const activeInputToken = getYieldWithdrawInputToken({ flowData, withdrawInputUnit });
+    const activeInputToken = getYieldWithdrawInputToken({ flowData, flowType });
     const activeUnitSymbol = toTokenSymbol(activeInputToken.symbol.toUpperCase());
     const activeUnitTokenContract = activeInputToken.contractAddress
         ? toTokenAddress(activeInputToken.contractAddress)

--- a/suite-native/module-earn/src/utils/yieldReviewOutputUtils.ts
+++ b/suite-native/module-earn/src/utils/yieldReviewOutputUtils.ts
@@ -28,7 +28,7 @@ import { buildYieldClaimRewards } from './yieldClaimReviewUtils';
 
 type YieldActionReview = Extract<
     StablecoinYieldActionReviewState,
-    { type: 'deposit' | 'withdraw' }
+    { type: 'deposit' | 'withdraw' | 'redeem' }
 >;
 type YieldDepositReview = YieldActionReview & { type: 'deposit' };
 type YieldWithdrawReview = YieldActionReview & { type: 'withdraw' };

--- a/suite-native/module-earn/src/utils/yieldWithdrawUtils.ts
+++ b/suite-native/module-earn/src/utils/yieldWithdrawUtils.ts
@@ -1,5 +1,3 @@
-export { getYieldWithdrawInputToken } from '@suite-common/wallet-core';
-
 import { EARN_MODULE_PREFIX } from '../constants';
 
 export const getYieldWithdrawFormDraftKey = (flowKey: string) =>

--- a/suite-native/module-earn/src/yieldTransactionThunks.ts
+++ b/suite-native/module-earn/src/yieldTransactionThunks.ts
@@ -4,7 +4,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import {
     type YieldFlowDisplayToken,
     type YieldFlowResolvedData,
-    type YieldFlowType,
+    type YieldPositionFlowType,
     selectAddressDisplayType,
     selectStablecoinYieldSession,
     selectStablecoinYieldTxReview,
@@ -22,7 +22,7 @@ const YIELD_TRANSACTION_THUNK_PREFIX = `${EARN_MODULE_PREFIX}/yield-transaction`
 type YieldActionReviewThunkPayload = {
     flowData: YieldFlowResolvedData;
     flowKey: string;
-    flowType: Extract<YieldFlowType, 'deposit' | 'withdraw'>;
+    flowType: YieldPositionFlowType;
     reviewToken?: YieldFlowDisplayToken;
     selectedFee?: EvmSelectedFee | null;
 };

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -117,7 +117,7 @@ export type YieldDepositRevokeReviewParams = YieldFlowParams & {
 };
 
 export type YieldWithdrawParams = YieldFlowParams & {
-    withdrawInputUnit?: 'asset' | 'shares';
+    withdrawFlowType?: 'withdraw' | 'redeem';
 };
 
 export type YieldStackParamList = {

--- a/suite/analytics/src/events/yieldWithdrawEvent.ts
+++ b/suite/analytics/src/events/yieldWithdrawEvent.ts
@@ -13,6 +13,7 @@ type Attributes = {
         | 'leftPending'
         | 'firmware-upgrade-needed-modal'
     >;
+    operation?: AttributeDef<'withdraw' | 'redeem'>;
     networkSymbol?: AttributeDef<string>;
     vaultId?: AttributeDef<string>;
     durationMs?: AttributeDef<number>;
@@ -37,6 +38,11 @@ export const yieldWithdrawEvent: EventDef<Attributes, EventType.YieldWithdraw> =
                     notes: 'added `leftPending`, `tx-simulation-modal`, `firmware-upgrade-needed-modal` values',
                 },
             ],
+        },
+        operation: {
+            description:
+                'Which ERC-4626 vault-exit operation the withdraw flow performed: `withdraw` (by underlying assets) or `redeem` (by vault shares). Reported on submit and resolution.',
+            changelog: [{ version: '26.6.2', notes: 'added' }],
         },
         networkSymbol: {
             changelog: [{ version: '26.5.0', notes: 'added' }],


### PR DESCRIPTION
## Description

Model the ERC-4626 `redeem` operation as a first-class yield flow type instead of hiding it behind the withdraw form's input unit. Previously `redeem` lived only implicitly in `withdrawInputUnit === 'shares'`, so it was invisible to `YieldFlowType`, pending state, analytics and the pending/completion screens.

- `'redeem'` is now a peer of `'withdraw'` in `YieldFlowType` / `YIELD_FLOW_TYPES` / `YieldPendingTransactionState`, with its own Redux session bucket.
- The withdraw page owns the flow type and toggles `withdraw` ↔ `redeem` at page level (session resets on toggle); the form-level `withdrawInputUnit` is gone. The submit thunk and calldata builder pick the ERC-4626 operation from `flowType`.
- Renamed `YieldActionFlowType` → `YieldPositionFlowType`; added `YieldWithdrawFlowType` and the `isYieldWithdrawFlow` type guard.
- `redeem` is now surfaced in the yield-withdraw analytics (`operation` attribute), pending state and labels — on desktop and suite-native.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28837

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily affects the stablecoin yield/earn withdraw feature (forms, thunks, reducers, hooks, UI components) and message system types/schema. The yield withdraw functionality is a relatively self-contained feature with no dedicated E2E tests in the candidate suite. The message system changes are type-level modifications to constants and types that map to 121+ tests via broad transitive imports but are unlikely to affect runtime behavior for any specific test. The suite-native changes are for the mobile app and have no web E2E coverage. The only concrete E2E risk is that the earn/yield route pages still render correctly, which the check-links test partially validates.

<details><summary><b>Changed files (33)</b></summary>

- `packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts`
- `packages/suite/src/components/earn/yield/common/YieldActionStep.tsx`
- `packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx`
- `packages/suite/src/components/earn/yield/common/YieldDisabledBanner.tsx`
- `packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts`
- `packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx`
- `packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts`
- `packages/suite/src/views/earn/yield/useEarnLayout.tsx`
- `suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.ts`
- `suite-common/message-system/schema/config.schema.v1.json`
- `suite-common/message-system/src/__tests__/messageSystemTypes.test.ts`
- `suite-common/message-system/src/messageSystemConstants.ts`
- `suite-common/message-system/src/messageSystemTypes.ts`
- `suite-common/suite-types/src/messageSystem.ts`
- `suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts`
- `suite-native/module-earn/src/components/YieldWithdrawReviewContent.tsx`
- `suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts`
- `suite-native/module-earn/src/hooks/useYieldWithdrawReview.ts`
- `suite-native/module-earn/src/screens/YieldWithdrawCompleteScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawReviewScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx`
- `suite-native/module-earn/src/utils/yieldReviewOutputUtils.ts`
- `suite-native/module-earn/src/utils/yieldWithdrawUtils.ts`
- `suite-native/module-earn/src/yieldTransactionThunks.ts`
- `suite-native/navigation/src/navigators.ts`
- `suite/analytics/src/events/yieldWithdrawEvent.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test navigates to /earn/yield/withdraw among other earn routes. Changes to YieldWithdrawForm.tsx, useEarnLayout.tsx, and YieldDisabledBanner.tsx could cause rendering failures or broken pages at these routes, which this test would catch by verifying page content loads correctly.

</details>

⚠️ **Changes with no test coverage (30)**
- `packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts`
- `packages/suite/src/components/earn/yield/common/YieldDisabledBanner.tsx`
- `packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts`
- `packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts`
- `packages/suite/src/views/earn/yield/useEarnLayout.tsx`
- `suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.ts`
- `suite-common/message-system/schema/config.schema.v1.json`
- `suite-common/message-system/src/__tests__/messageSystemTypes.test.ts`
- `suite-common/message-system/src/messageSystemConstants.ts`
- `suite-common/message-system/src/messageSystemTypes.ts`
- `suite-common/suite-types/src/messageSystem.ts`
- `suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts`
- `suite-native/module-earn/src/components/YieldWithdrawReviewContent.tsx`
- `suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts`
- `suite-native/module-earn/src/hooks/useYieldWithdrawReview.ts`
- `suite-native/module-earn/src/screens/YieldWithdrawCompleteScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawReviewScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx`
- `suite-native/module-earn/src/utils/yieldReviewOutputUtils.ts`
- `suite-native/module-earn/src/utils/yieldWithdrawUtils.ts`
- `suite-native/module-earn/src/yieldTransactionThunks.ts`
- `suite-native/navigation/src/navigators.ts`
- `suite/analytics/src/events/yieldWithdrawEvent.ts`

_Updated: 2026-06-19T17:42:38.204Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/earn-yield-redeem-flow-type&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/earn-yield-redeem-flow-type&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/earn-yield-redeem-flow-type&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-19T17:46:50.921Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-19T17:45:44.532Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/earn-yield-redeem-flow-type/web/](https://dev.suite.sldev.cz/suite-web/refactor/earn-yield-redeem-flow-type/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->