### PR TITLE
refactor(connect): move createLogger to host composition roots

### DIFF
--- a/packages/connect-common/src/types/settings.ts
+++ b/packages/connect-common/src/types/settings.ts
@@ -43,6 +43,8 @@ export type ConnectSettingsTransport =
 
 export type CreateLogger = (prefix: string) => Logger;
 
+export type CreateLoggerDep = { createLogger?: CreateLogger };
+
 export interface ConnectSettingsPublic {
     manifest?: Manifest;
     // Enables connect logs. NOTE: connect core no longer uses this to gate its COMPONENT loggers

--- a/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
+++ b/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
@@ -13,5 +13,9 @@ export const createSuiteDesktopCompositionRoot = (
     const history = createMemoryHistory();
     const platformEncryption = createElectronPlatformEncryption({ desktopApi });
 
-    return initStore({ history, platformEncryption }, preloadStoreAction, { statePatch });
+    return initStore(
+        { history, platformEncryption, createConnectLoggerFactory: undefined },
+        preloadStoreAction,
+        { statePatch },
+    );
 };

--- a/packages/suite-web/src/createSuiteWebCompositionRoot.ts
+++ b/packages/suite-web/src/createSuiteWebCompositionRoot.ts
@@ -3,11 +3,15 @@ import { createBrowserHistory } from 'history';
 import { createWebauthnPlatformEncryption } from '@suite/platform-encryption-webauthn';
 
 import { initStore } from 'src/reducers/store';
+import { createConnectLoggerFactory } from 'src/support/createConnectLoggerFactory';
 import { type PreloadStoreAction } from 'src/support/suite/preloadStore';
 
 export const createSuiteWebCompositionRoot = (preloadStoreAction?: PreloadStoreAction) => {
     const history = createBrowserHistory();
     const platformEncryption = createWebauthnPlatformEncryption();
 
-    return initStore({ history, platformEncryption }, preloadStoreAction);
+    return initStore(
+        { history, platformEncryption, createConnectLoggerFactory },
+        preloadStoreAction,
+    );
 };

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -45,6 +45,7 @@ import type { PreloadStoreAction } from 'src/support/suite/preloadStore';
 import { prepareBioAuthReducer } from './bioAuth';
 import { desktopReducer } from './desktop';
 import { bluetoothSlice } from '../actions/bluetooth/desktopBluetoothReducer';
+import { type CreateConnectLoggerFactoryDep } from '../support/createConnectLoggerFactory';
 import {
     createSuiteServicesCompositionRoot,
     extraDependencies,
@@ -128,7 +129,7 @@ type RootReducerShape = typeof rootReducer;
 export type PreloadedState = Partial<AppState>;
 type InferredAction = Parameters<RootReducerShape>[1];
 
-export type SuiteStoreDeps = HistoryDep & PlatformEncryptionDep;
+export type SuiteStoreDeps = HistoryDep & PlatformEncryptionDep & CreateConnectLoggerFactoryDep;
 
 export const initStore = (
     deps: SuiteStoreDeps,
@@ -157,6 +158,7 @@ export const initStore = (
             dispatch: api.dispatch,
             history: deps.history,
             platformEncryption: deps.platformEncryption,
+            createLogger: deps.createConnectLoggerFactory?.({ getState: api.getState }),
         }),
     });
 

--- a/packages/suite/src/support/createConnectLoggerFactory.ts
+++ b/packages/suite/src/support/createConnectLoggerFactory.ts
@@ -1,0 +1,18 @@
+import { selectShowConnectLogs } from '@suite/settings';
+import { type CreateLogger, initLog } from '@trezor/connect';
+
+type CreateConnectLoggerFactoryDeps = {
+    getState: () => any;
+};
+
+export type CreateConnectLoggerFactory = (deps: CreateConnectLoggerFactoryDeps) => CreateLogger;
+
+export type CreateConnectLoggerFactoryDep = {
+    createConnectLoggerFactory?: CreateConnectLoggerFactory;
+};
+
+export const createConnectLoggerFactory: CreateConnectLoggerFactory = ({ getState }) => {
+    const enabled = selectShowConnectLogs(getState());
+
+    return prefix => initLog(prefix, enabled);
+};

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -60,7 +60,7 @@ import {
 } from '@suite-common/wallet-core';
 import { createAccountKey } from '@suite-common/wallet-types';
 import { buildHistoricRatesFromStorage } from '@suite-common/wallet-utils';
-import TrezorConnect, { type StaticSessionId } from '@trezor/connect';
+import TrezorConnect, { type CreateLoggerDep, type StaticSessionId } from '@trezor/connect';
 import { isDesktop } from '@trezor/env-utils';
 
 import { type StorageLoadAction } from 'src/actions/suite/storageActions';
@@ -90,7 +90,7 @@ export type StoreAPIDep = {
     dispatch: Dispatch;
 };
 
-export type SuiteAppDeps = StoreAPIDep & HistoryDep & PlatformEncryptionDep;
+export type SuiteAppDeps = StoreAPIDep & HistoryDep & PlatformEncryptionDep & CreateLoggerDep;
 
 export type SuiteServices = CommonServices &
     DesktopAnalyticsDep &
@@ -165,6 +165,7 @@ export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteSer
         saveAs: (data: Blob, fileName: string) => saveAs(data, fileName),
         connectInitSettings,
         connectInitHooks,
+        createLogger: deps.createLogger,
         migrateSuiteSyncLabelsForRbfTransaction:
             createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot({
                 dispatch: deps.dispatch,

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -24,7 +24,6 @@ import TrezorConnect, {
     DEVICE_EVENT,
     TRANSPORT_EVENT,
     UI_EVENT,
-    initLog,
 } from '@trezor/connect';
 import { isDesktop, isWeb } from '@trezor/env-utils';
 import { DATA_URL } from '@trezor/urls';
@@ -44,7 +43,7 @@ export const connectInitThunk = createThunk<void, void, void>(
         const {
             selectors: { selectDebugSettings, selectThpSettings },
             actions: { lockDevice },
-            services: { connectInitSettings, connectInitHooks, analytics },
+            services: { connectInitSettings, connectInitHooks, analytics, createLogger },
         } = extra;
 
         const getEnabledNetworks = () => selectEnabledNetworks(getState());
@@ -152,14 +151,6 @@ export const connectInitThunk = createThunk<void, void, void>(
         if (isWeb()) {
             thp.hostName = capitalizeFirstLetter(getBrowserName());
         }
-
-        // Logger factory supplied to @trezor/connect from this composition root. On desktop the core
-        // runs in the main process, so the factory (a function) cannot cross the IPC boundary — it is
-        // injected there instead (see suite-desktop-core's trezor-connect.ts), driven by showConnectLogs.
-        // TODO(logger-unification): build the logger from a unified app-wide logger instead of initLog.
-        const createLogger = isDesktop()
-            ? undefined
-            : (prefix: string) => initLog(prefix, showConnectLogs);
 
         try {
             await TrezorConnect.init({

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -18,6 +18,7 @@ import { type Analytics } from '@trezor/analytics-uploader';
 import {
     type BluetoothDeviceId,
     type ConnectSettings,
+    type CreateLoggerDep,
     type Manifest,
     type StaticSessionId,
 } from '@trezor/connect';
@@ -42,7 +43,8 @@ export type CommonServices = SuiteSyncDep &
         connectInitSettings: ConnectInitSettings;
         connectInitHooks: ConnectInitHooks;
     } & ReportSecurityCheckDep &
-    MigrateSuiteSyncLabelsForRbfTransactionDep;
+    MigrateSuiteSyncLabelsForRbfTransactionDep &
+    CreateLoggerDep;
 
 export type ExtraDependenciesStatic = {
     /** @deprecated Do not add any thunks here, this is antipattern. */

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -25,7 +25,7 @@ import { type NativeServices } from '@suite-native/services';
 import type { EnsureEncryptionKeyDep, MMKVStorageDep } from '@suite-native/storage';
 import { createSuiteSyncNativeCompositionRoot } from '@suite-native/suite-sync';
 import { selectTradingEnvironment } from '@suite-native/trading-state';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { initLog } from '@trezor/connect';
 import { BridgeTransport } from '@trezor/transport';
 import { NativeBluetoothTransport } from '@trezor/transport-native-bluetooth';
 import { NativeUsbTransport } from '@trezor/transport-native-usb';
@@ -103,6 +103,7 @@ export const createNativeCompositionRoot = (deps: NativeAppDeps): NativeServices
             },
         },
         connectInitHooks: { deviceEvent: {}, uiEvent: {} },
+        createLogger: (prefix: string) => initLog(prefix, false),
         migrateSuiteSyncLabelsForRbfTransaction:
             createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot({
                 dispatch: deps.dispatch,


### PR DESCRIPTION
## What

Pure code move, no logic change. The `@trezor/connect` `createLogger` factory used to be built inline in the shared `connectInitThunk`, behind an `isDesktop()` branch. It now lives in each host's composition root (web, desktop, native) and is handed to the thunk as an injected dependency, the same way the other services already are. The thunk no longer needs to know which platform it runs on.

## Why

Groundwork for the pure-DI transports work (#28805), where each host builds its own `Transport` instances and needs `createLogger` available in its composition root rather than buried in the init thunk. This PR only relocates the factory; the logger behaviour itself is unchanged.

## Behaviour

Unchanged on every host:
- web: gated by the "TrezorConnect logs" debug switch, exactly as before
- desktop: the renderer provides nothing and the main process keeps injecting its own logger (untouched)
- native: logs stay off

`debug` still flows from `showConnectLogs`, and `suite-desktop-core` is not touched.

## Notes for QA

No QA needed. Nothing functional changed, only where the logger factory is constructed. Connect logging behaves exactly as before on all three platforms. Type-check and the `@suite-common/connect-init` unit tests pass locally.

Prerequisite for #28805, and finishes the #28862 draft.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files span TrezorConnect initialization infrastructure (connectInitThunks, connect settings types, connect logger factory), app composition roots (web, desktop, native), Redux store configuration, and extra dependencies. These are all foundational bootstrapping files that affect how Suite initializes and communicates with Trezor devices. The highest risk is in the TrezorConnect initialization pipeline, so tests that directly exercise TrezorConnect API calls (getAddress, signTransaction, permissions, etc.) should be prioritized. The broad infrastructure files (store.ts, extraDependencies, composition roots) map to 121+ tests each but most tests only transitively depend on them — only tests that specifically exercise initialization, connect flows, or app bootstrap deserve targeted runs.

<details><summary><b>Changed files (9)</b></summary>

- `packages/connect-common/src/types/settings.ts`
- `packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts`
- `packages/suite-web/src/createSuiteWebCompositionRoot.ts`
- `packages/suite/src/reducers/store.ts`
- `packages/suite/src/support/createConnectLoggerFactory.ts`
- `packages/suite/src/support/extraDependencies.ts`
- `suite-common/connect-init/src/connectInitThunks.ts`
- `suite-common/redux-utils/src/extraDependenciesType.ts`
- `suite-native/state/src/extraDependencies.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises TrezorConnect initialization and API calls (getAddress) which directly depend on connectInitThunks.ts, connect settings types, and the connect logger factory. Changes to how TrezorConnect is initialized or configured could break the popup permission flow and address export.
- `suite/e2e/tests/trezor-connect/error.test.ts` — Tests TrezorConnect.init with coreMode 'suite-desktop' and error handling for invalid paths. Directly exercises connectInitThunks, the desktop composition root, and connect settings types. A regression in initialization would surface here.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Tests TrezorConnect.getAddress with single/bundle/showOnTrezor modes after TrezorConnect.init in suite-desktop mode. Directly validates the connect initialization pipeline including connectInitThunks and connect settings.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests TrezorConnect permission granting/revoking flow which depends on TrezorConnect.init and the connect popup infrastructure. Changes to connectInitThunks or extraDependencies could affect permission state management.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Tests TrezorConnect.signTransaction with suite-desktop coreMode, directly exercising the connect initialization and transaction signing pipeline. Changes to connectInitThunks or settings types could break device communication.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Tests TrezorConnect.ethereumSignMessage with suite-desktop coreMode. Validates connect init and Ethereum signing flow. Changes to connect settings or init thunks could affect this signing path.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Tests TrezorConnect.ethereumSignTransaction with suite-desktop coreMode. Exercises connect initialization and the EVM transaction signing flow which depends on the changed settings types and init thunks.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Tests TrezorConnect.getAccountInfo with suite-desktop coreMode including account selection modal. Exercises the connect init pipeline and permissions flow affected by connectInitThunks changes.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests TrezorConnect silent mode and permission management with suite-desktop coreMode. Exercises the connect init pipeline and permission state that depends on extraDependencies and connectInitThunks.
- `suite/e2e/tests/suite/initial-run.test.ts` — Tests the initial run/onboarding flow which is the first user-visible flow after app initialization. Changes to store.ts, composition roots, and extraDependencies affect the app bootstrap that this test validates end-to-end.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Tests TrezorConnect via webextension calling Suite Web. Exercises connect initialization in suite-web mode and permission flows affected by connectInitThunks and composition root changes.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Wallet discovery depends on TrezorConnect being properly initialized to communicate with the device for account enumeration. Changes to connectInitThunks could affect the discovery transport layer.
- `suite/e2e/tests/suite/bridge.test.ts` — Tests bridge page and WebUSB fallback, which involves TrezorConnect transport initialization. Changes to connectInitThunks could affect transport selection behavior.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts`
- `packages/suite/src/support/createConnectLoggerFactory.ts`
- `suite-common/redux-utils/src/extraDependenciesType.ts`
- `suite-native/state/src/extraDependencies.ts`

_Updated: 2026-06-19T16:55:38.792Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mvarmuza/connect-logger-di/web/](https://dev.suite.sldev.cz/suite-web/mvarmuza/connect-logger-di/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mvarmuza/connect-logger-di&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mvarmuza/connect-logger-di&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mvarmuza/connect-logger-di&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-19T17:00:20.227Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-19T16:58:11.279Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->
