### PR TITLE
Open Solana staking dashboard from earn entry

### DIFF
--- a/suite-native/module-earn/src/utils/__tests__/navigateByAccountState.test.ts
+++ b/suite-native/module-earn/src/utils/__tests__/navigateByAccountState.test.ts
@@ -68,6 +68,29 @@ describe('navigateByAccountState', () => {
         });
     });
 
+    it('navigates to StakingManagement when a Solana account has a balance but no stake', () => {
+        const account = createMockAccount({ symbol: 'sol' });
+        mockGetAccountTotalStakingBalance.mockReturnValue('0');
+
+        navigateByAccountState(account, mockNavigate);
+
+        // Solana onboards through its dashboard, not the stake form.
+        expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.StakingManagement, {
+            accountKey: account.key,
+        });
+    });
+
+    it('navigates to StakingManagement when a Solana account has insufficient balance and no stake', () => {
+        const account = createMockAccount({ symbol: 'sol', availableBalance: '100' });
+        mockGetAccountTotalStakingBalance.mockReturnValue(null);
+
+        navigateByAccountState(account, mockNavigate);
+
+        expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.StakingManagement, {
+            accountKey: account.key,
+        });
+    });
+
     it('navigates to StakingDetail when a Cardano account has staked balance', () => {
         const account = createMockAccount({ symbol: 'ada' });
         mockGetAccountTotalStakingBalance.mockReturnValue('1000000');

--- a/suite-native/module-earn/src/utils/navigateByAccountState.ts
+++ b/suite-native/module-earn/src/utils/navigateByAccountState.ts
@@ -3,6 +3,7 @@ import {
     formatNetworkAmount,
     getAccountTotalStakingBalance,
     getStakingLimitsByNetworkSymbol,
+    isSupportedSolStakingNetworkSymbol,
 } from '@suite-common/wallet-utils';
 import {
     type RootStackParamList,
@@ -20,8 +21,9 @@ type StakingNavigateFn = StackNavigationProps<
 
 export const navigateByAccountState = (account: Account, navigate: StakingNavigateFn) => {
     const stakedBalance = getAccountTotalStakingBalance(account);
+    const hasStakedBalance = !!stakedBalance && stakedBalance !== '0';
 
-    if (stakedBalance && stakedBalance !== '0') {
+    if (isSupportedSolStakingNetworkSymbol(account.symbol) || hasStakedBalance) {
         navigate(resolveStakingTargetRoute(account.symbol), {
             accountKey: account.key,
         });


### PR DESCRIPTION
## Description

Selecting a Solana account from the Earn screen routed not-yet-staked accounts to the stake onboarding form instead of the Solana staking dashboard. Solana's dashboard is its staking entry point and hosts its own stake call-to-action, so this routes Solana accounts there regardless of stake status, matching the "Your stakes" entry. Ethereum and Cardano keep their form-first onboarding for accounts without a stake. The change lives in the shared navigation helper, so it also corrects the add-coin discovery flow started from Earn.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28883
