### PR TITLE
chore: bump Node.js to 24.17.0 (June 2026 security release)

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,3 +1,3 @@
-24.11.1
+24.17.0
 
 # This needs to be consistent with node version defined in suite-native/app/eas.json file!

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -20,6 +20,10 @@ npmMinimalAgeGate: 20160
 npmPreapprovedPackages:
   - "@evolu/*"
   - "@types/invity-api@*"
+  # electron 42.5.0 bundles Node 24.17.0 (the June 2026 security release) and ships the
+  # @electron-internal/extract-zip fork that fixes the Node >=24.16 installer break. Whitelisted
+  # to skip the 14-day npmMinimalAgeGate; drop this once 42.5.0 ages out (~2026-07-07).
+  - "electron@42.5.0"
 
 plugins:
   - checksum: 5e73a1acbb9741fce1e8335e243c9480ea2107b9b4b65ed7643785ddea9e3019aee254a92a853b1cd71023b16fff5b7d3afd5256fe57cd35a54f8785b8c30281

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
         "type-fest": "5.5.0",
         "bcrypto": "5.4.0",
         "react": "19.2.4",
-        "electron": "42.2.0",
+        "electron": "42.5.0",
         "@types/node": "22.13.10",
         "bn.js": "5.2.3",
         "### Force buffer >=6 so the browser polyfill has writeBig(U)Int64LE etc. (5.x lacks them, see suite-build)": "1.0.0",

--- a/packages/coinjoin/package.json
+++ b/packages/coinjoin/package.json
@@ -32,7 +32,6 @@
         "@trezor/eslint": "workspace:*",
         "@trezor/utils": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
-        "cross-fetch": "^4.1.0",
         "golomb": "1.2.0",
         "n64": "^0.2.10"
     },

--- a/packages/coinjoin/src/client/coordinatorRequest.ts
+++ b/packages/coinjoin/src/client/coordinatorRequest.ts
@@ -73,12 +73,17 @@ export const coordinatorRequest = async <R = void>(
             // catch errors from:
             // - nodejs http module (by e.code) like "socket hang up" or "socket disconnected before secure TLS connection was established" (see ./node_modules/@types/node/*/http.d.ts)
             // - socks module (by e.type and e.message) like "Socks5 proxy rejected connection" or "Proxy connection timed out" (see ./node_modules/socks/build/common/constants)
+            // native fetch (undici) wraps network failures as `TypeError: fetch failed` and exposes the
+            // underlying error (carrying `code`/`type`/`message`) on `e.cause`; node-fetch put them on `e`.
+            // A reset connection is `ECONNRESET` under node-fetch but `UND_ERR_SOCKET` ("other side
+            // closed") under undici; both should reset the TOR circuit and retry.
+            const err = e.cause ?? e;
             const socksErrors = ['Socks5', 'Proxy'];
             const shouldSwitchIdentity =
-                ('code' in e && e.code === 'ECONNRESET') ||
-                ('type' in e &&
-                    e.type === 'system' &&
-                    socksErrors.some(se => e.message.includes(se)));
+                ('code' in err && (err.code === 'ECONNRESET' || err.code === 'UND_ERR_SOCKET')) ||
+                ('type' in err &&
+                    err.type === 'system' &&
+                    socksErrors.some(se => err.message.includes(se)));
 
             if (shouldSwitchIdentity) {
                 switchIdentity();

--- a/packages/coinjoin/src/utils/http.ts
+++ b/packages/coinjoin/src/utils/http.ts
@@ -1,5 +1,3 @@
-import fetch from 'cross-fetch';
-
 import { type ScheduleActionParams, capitalizeFirstLetter, getWeakRandomId } from '@trezor/utils';
 
 export interface RequestOptions extends ScheduleActionParams {

--- a/packages/coinjoin/tests/client/outputDecomposition.test.ts
+++ b/packages/coinjoin/tests/client/outputDecomposition.test.ts
@@ -90,7 +90,10 @@ describe('outputRegistration', () => {
                 expect(r.outputs.length).toBe(expected.outputs.length);
                 expect(r).toMatchObject(expected);
             });
-            expect(availableVsize).toEqual(f.availableVsize);
+            // per-account requests run concurrently (Promise.all), so their arrival order is not
+            // guaranteed; compare as a multiset rather than a sequence
+            const byValue = (a: number, b: number) => a - b;
+            expect([...availableVsize].sort(byValue)).toEqual([...f.availableVsize].sort(byValue));
             expect(spy).toHaveBeenCalledTimes(f.credentialIssuanceCalls);
         });
     });

--- a/packages/connect-examples/electron-main-process/package.json
+++ b/packages/connect-examples/electron-main-process/package.json
@@ -59,7 +59,7 @@
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
-        "electron": "42.2.0",
+        "electron": "42.5.0",
         "electron-builder": "26.11.1"
     }
 }

--- a/packages/suite-desktop-api/package.json
+++ b/packages/suite-desktop-api/package.json
@@ -23,6 +23,6 @@
         "@suite-common/platform-encryption": "workspace:*",
         "@suite/tor": "workspace:*",
         "@trezor/type-utils": "workspace:*",
-        "electron": "42.2.0"
+        "electron": "42.5.0"
     }
 }

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -53,7 +53,7 @@
         "@sentry/webpack-plugin": "^5.3.0",
         "@trezor/type-utils": "workspace:*",
         "@types/electron-localshortcut": "^3.1.3",
-        "electron": "42.2.0",
+        "electron": "42.5.0",
         "electron-devtools-installer": "^4.0.0",
         "glob": "^13.0.1",
         "lodash": "^4.18.1",

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -32,7 +32,7 @@
         "usb": "^2.17.0"
     },
     "devDependencies": {
-        "electron": "42.2.0",
+        "electron": "42.5.0",
         "electron-builder": "26.11.1"
     }
 }

--- a/suite-native/app/eas.json
+++ b/suite-native/app/eas.json
@@ -6,7 +6,7 @@
     },
     "build": {
         "base": {
-            "node": "24.11.1",
+            "node": "24.17.0",
             "env": {
                 "EAS_NO_FROZEN_LOCKFILE": "1"
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15990,7 +15990,6 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
-    cross-fetch: "npm:^4.1.0"
     golomb: "npm:1.2.0"
     n64: "npm:^0.2.10"
     node-fetch: "npm:^3.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2457,6 +2457,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@electron-internal/extract-zip@npm:^1.0.1":
+  version: 1.0.3
+  resolution: "@electron-internal/extract-zip@npm:1.0.3"
+  checksum: 10/fe4d9f66a852da8b1a156efafd30522880e38fea74172f2d5202e3dcd9ef4ea07000d28a5f89b1de88c6cf89a06614c0b6d00d2305a7d01e4f0fb621441effd4
+  languageName: node
+  linkType: hard
+
 "@electron/asar@npm:3.4.1, @electron/asar@npm:^3.3.1":
   version: 3.4.1
   resolution: "@electron/asar@npm:3.4.1"
@@ -16716,7 +16723,7 @@ __metadata:
     "@suite-common/platform-encryption": "workspace:*"
     "@suite/tor": "workspace:*"
     "@trezor/type-utils": "workspace:*"
-    electron: "npm:42.2.0"
+    electron: "npm:42.5.0"
   languageName: unknown
   linkType: soft
 
@@ -16755,7 +16762,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     "@types/electron-localshortcut": "npm:^3.1.3"
     chalk: "npm:^5.6.2"
-    electron: "npm:42.2.0"
+    electron: "npm:42.5.0"
     electron-devtools-installer: "npm:^4.0.0"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:11.0.2"
@@ -16821,7 +16828,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/suite-desktop@workspace:packages/suite-desktop"
   dependencies:
-    electron: "npm:42.2.0"
+    electron: "npm:42.5.0"
     electron-builder: "npm:26.11.1"
     openpgp: "npm:^6.3.0"
     usb: "npm:^2.17.0"
@@ -18525,15 +18532,6 @@ __metadata:
   dependencies:
     "@types/yargs-parser": "npm:*"
   checksum: 10/16f6681bf4d99fb671bf56029141ed01db2862e3db9df7fc92d8bea494359ac96a1b4b1c35a836d1e95e665fb18ad753ab2015fc0db663454e8fd4e5d5e2ef91
-  languageName: node
-  linkType: hard
-
-"@types/yauzl@npm:^2.9.1":
-  version: 2.10.0
-  resolution: "@types/yauzl@npm:2.10.0"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10/55d27ae5d346ea260e40121675c24e112ef0247649073848e5d4e03182713ae4ec8142b98f61a1c6cbe7d3b72fa99bbadb65d8b01873e5e605cdc30f1ff70ef2
   languageName: node
   linkType: hard
 
@@ -21599,13 +21597,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-crc32@npm:~0.2.3":
-  version: 0.2.13
-  resolution: "buffer-crc32@npm:0.2.13"
-  checksum: 10/06252347ae6daca3453b94e4b2f1d3754a3b146a111d81c68924c22d91889a40623264e95e67955b1cb4a68cbedf317abeabb5140a9766ed248973096db5ce1c
-  languageName: node
-  linkType: hard
-
 "buffer-equal-constant-time@npm:^1.0.1":
   version: 1.0.1
   resolution: "buffer-equal-constant-time@npm:1.0.1"
@@ -22953,7 +22944,7 @@ __metadata:
   dependencies:
     "@trezor/connect": "workspace:*"
     "@trezor/eslint": "workspace:*"
-    electron: "npm:42.2.0"
+    electron: "npm:42.5.0"
     electron-builder: "npm:26.11.1"
   languageName: unknown
   linkType: soft
@@ -25150,17 +25141,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:42.2.0":
-  version: 42.2.0
-  resolution: "electron@npm:42.2.0"
+"electron@npm:42.5.0":
+  version: 42.5.0
+  resolution: "electron@npm:42.5.0"
   dependencies:
+    "@electron-internal/extract-zip": "npm:^1.0.1"
     "@electron/get": "npm:^5.0.0"
     "@types/node": "npm:^24.9.0"
-    extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
     install-electron: install.js
-  checksum: 10/7a1efa469036dc5795884cc0d95e862ce7ee3611396ed85b605187e00c641babd3e1ac734ca78b186cd2a5a070c69e959478ec324249afd4bcdfc35fb0583217
+  checksum: 10/d2d90d9f81fcf825a1fc8fd0ee923ba9820ef73ac70417295675a406fc256c93c0d45afd7a5aa81612a1c76fd3387398da2b73fe8400c7ba0a6891836b64cb4c
   languageName: node
   linkType: hard
 
@@ -27635,23 +27626,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extract-zip@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "extract-zip@npm:2.0.1"
-  dependencies:
-    "@types/yauzl": "npm:^2.9.1"
-    debug: "npm:^4.1.1"
-    get-stream: "npm:^5.1.0"
-    yauzl: "npm:^2.10.0"
-  dependenciesMeta:
-    "@types/yauzl":
-      optional: true
-  bin:
-    extract-zip: cli.js
-  checksum: 10/8cbda9debdd6d6980819cc69734d874ddd71051c9fe5bde1ef307ebcedfe949ba57b004894b585f758b7c9eeeea0e3d87f2dda89b7d25320459c2c9643ebb635
-  languageName: node
-  linkType: hard
-
 "extsprintf@npm:^1.2.0":
   version: 1.4.1
   resolution: "extsprintf@npm:1.4.1"
@@ -27878,15 +27852,6 @@ __metadata:
     setimmediate: "npm:^1.0.5"
     ua-parser-js: "npm:^1.0.35"
   checksum: 10/71252595b00b06fb0475a295c74d81ada1cc499b7e11f2cde51fef04618affa568f5b7f4927f61720c23254b9144be28f8acb2086a5001cf65df8eec87c6ca5c
-  languageName: node
-  linkType: hard
-
-"fd-slicer@npm:~1.1.0":
-  version: 1.1.0
-  resolution: "fd-slicer@npm:1.1.0"
-  dependencies:
-    pend: "npm:~1.2.0"
-  checksum: 10/db3e34fa483b5873b73f248e818f8a8b59a6427fd8b1436cd439c195fdf11e8659419404826059a642b57d18075c856d06d6a50a1413b714f12f833a9341ead3
   languageName: node
   linkType: hard
 
@@ -47606,23 +47571,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yauzl@npm:^2.10.0":
-  version: 2.10.0
-  resolution: "yauzl@npm:2.10.0"
-  dependencies:
-    buffer-crc32: "npm:~0.2.3"
-    fd-slicer: "npm:~1.1.0"
-  checksum: 10/1e4c311050dc0cf2ee3dbe8854fe0a6cde50e420b3e561a8d97042526b4cf7a0718d6c8d89e9e526a152f4a9cec55bcea9c3617264115f48bd6704cf12a04445
-  languageName: node
-  linkType: hard
-
 "yauzl@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "yauzl@npm:3.2.0"
+  version: 3.4.0
+  resolution: "yauzl@npm:3.4.0"
   dependencies:
-    buffer-crc32: "npm:~0.2.3"
     pend: "npm:~1.2.0"
-  checksum: 10/a3cd2bfcf7590673bb35750f2a4e5107e3cc939d32d98a072c0673fe42329e390f471b4a53dbbd72512229099b18aa3b79e6ddb87a73b3a17446080c903a2c4b
+  checksum: 10/76c1ca208478135dcd0b9f8baaa2e40a761652e0ec793c5a6bdeb973118f9720adc487f388e8394b4cfb73ae1976083ff58be4ea0ec60e060ffc9cf232db2c0a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Bumps the repo's Node.js pin from `24.11.1` to `24.17.0`, the June 2026 security release for the 24.x line ([advisory](https://nodejs.org/en/blog/vulnerability/june-2026-security-releases)) which fixes two HIGH severity issues — `CVE-2026-48618` (TLS server identity check) and `CVE-2026-48933` (WebCrypto cipher output length) — plus several medium/low fixes.

Changed pins:
- `.nvmrc`
- `suite-native/app/eas.json` (`build.base.node`)

`engines.node` is `"24"` (major only) and already permits this. Electron is bumped to `42.5.0` so the **shipped desktop app** gets the same Node 24.17.0 (see below).

## Node ≥24.16 compatibility (why this is more than a one-line bump)

Moving the toolchain to Node 24.17.0 exposed two dependency-layer incompatibilities. Both are handled in this PR:

**1. Electron — bumped `42.2.0` → `42.5.0` (installer fix + Node 24.17.0).** Two things:
- `electron@42.2.0` unzips its downloaded binary via `extract-zip` → `yauzl@2.10.0`, which is broken on Node `>=24.16` ([electron/electron#51619](https://github.com/electron/electron/issues/51619)): the binary downloads but never extracts → `node_modules/electron/path.txt` is missing → every desktop e2e test fails at `electron.launch` (reproduced across all 7 shards). Electron `>=42.4.0` replaces the broken `extract-zip` with the `@electron-internal/extract-zip` fork that carries the fix (`extract-zip@2.0.1` leaves the tree entirely).
- Electron `42.5.0` bundles **Node 24.17.0** (42.4.x bundled 24.16.0), so the **shipped desktop app** actually receives the June 2026 Node security fix — not just the build/CI toolchain. Verified locally: electron 42.5.0 installs on Node 24.17.0 and its bundled `process.versions.node` reports `24.17.0` (Chromium 148).

`42.5.0` is younger than the repo's 14-day `npmMinimalAgeGate`, so it is whitelisted in `npmPreapprovedPackages`; that entry can be dropped once 42.5.0 ages out (~2026-07-07). This moves the **shipped desktop runtime** (Electron `42.2.0` → `42.5.0`, bundled Node `24.15.0` → `24.17.0`), so it needs desktop QA.

**2. `cross-fetch` / `node-fetch` "Premature close" — fixed for `@trezor/coinjoin` in this PR.** `node-fetch` (bundled by `cross-fetch`) throws `FetchError: Premature close` (`ERR_STREAM_PREMATURE_CLOSE`) when reading a response body from a Node http server **on Node 24.17.0 specifically** — verified in isolation it passes on 24.15.0 **and 24.16.0** and fails only on 24.17.0; native `fetch` (undici) works on all. The only package this breaks in CI is `@trezor/coinjoin`, whose client unit tests exercise a real local http mock server (others mock `cross-fetch` or run paths that don't hit the broken read, so they stay green on 24.17.0). This PR migrates `coinjoin` to native `fetch` and adapts `coordinatorRequest`'s TOR-circuit-reset detection to undici's error shape (`e.cause.code`, `UND_ERR_SOCKET`). Verified: `coinjoin` `test:unit` is green on both Node 24.11.1 and 24.17.0.

Scope note: `connect` / `transport` / `request-manager` need no change for this PR (their unit tests pass on 24.17.0 and the bug is 24.17.0-only). The broader `cross-fetch` → native-fetch cleanup continues separately (@karliatto's #28538 / #28780 / #28923 / #28935) but is not a prerequisite for this bump.

## Notes for QA

- **Desktop app smoke test** — the shipped Electron runtime moves `42.2.0` → `42.5.0` (same major; Chromium + Node patch bump, bundled Node `24.15.0` → `24.17.0`). Verify the desktop app launches, connects to a device, and runs a basic flow on macOS/Windows/Linux. The desktop build (electron-builder, which also unzips) must pass.
- **Coinjoin** — the HTTP layer switched from `cross-fetch` to native `fetch`; smoke-test a coinjoin session (rounds discovery / registration) on desktop, since this touches the coordinator/middleware request path and TOR-reset retry behaviour.
- **CI on Node 24.17.0** — must be green; desktop e2e was red before the Electron bump and `coinjoin` unit tests were red before the fetch migration.
- Native EAS build node is bumped in lockstep; sanity-check one EAS develop/preview build if a native build runs.

## Related Issue

N/A — routine security maintenance following the June 2026 Node.js release. Upstream/related: electron/electron#51619; broader fetch migration #28538, #28780, #28923, #28935.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set is predominantly dependency/version bumps in package.json files across coinjoin, suite-desktop, suite-desktop-api, suite-desktop-core, connect-examples, and suite-native packages, plus internal coinjoin source changes (coordinatorRequest.ts, http.ts) and a coinjoin unit test update. The coinjoin changes are isolated to the coinjoin package with no E2E test coverage (coinjoin functionality like CoinJoin/anonymize is not directly exercised by any of the 115 candidate E2E tests). The desktop package.json changes carry minor risk of affecting Electron-based tests, particularly bridge spawning tests. Overall risk is low since these are mostly infrastructure/dependency changes with no direct feature-level impact on Suite UI flows.

<details><summary><b>Changed files (10)</b></summary>

- `package.json`
- `packages/coinjoin/package.json`
- `packages/coinjoin/src/client/coordinatorRequest.ts`
- `packages/coinjoin/src/utils/http.ts`
- `packages/coinjoin/tests/client/outputDecomposition.test.ts`
- `packages/connect-examples/electron-main-process/package.json`
- `packages/suite-desktop-api/package.json`
- `packages/suite-desktop-core/package.json`
- `packages/suite-desktop/package.json`
- `suite-native/app/eas.json`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Changes to packages/suite-desktop-core/package.json and packages/suite-desktop/package.json could affect dependency versions used by the Electron desktop app, including the node-bridge spawning logic. This test validates bridge lifecycle management in the desktop app, which is directly tied to suite-desktop-core infrastructure.
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — Similar to spawn-bridge.test.ts, this test exercises the bridge daemon mode in the Electron app. Dependency changes in suite-desktop-core or suite-desktop package.json files could affect bridge daemon spawning behavior.

</details>

⚠️ **Changes with no test coverage (8)**
- `package.json`
- `packages/coinjoin/package.json`
- `packages/coinjoin/src/client/coordinatorRequest.ts`
- `packages/coinjoin/src/utils/http.ts`
- `packages/coinjoin/tests/client/outputDecomposition.test.ts`
- `packages/connect-examples/electron-main-process/package.json`
- `packages/suite-desktop-api/package.json`
- `suite-native/app/eas.json`

_Updated: 2026-06-29T08:50:04.426Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/node-june-2026-security-update&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/node-june-2026-security-update&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/node-june-2026-security-update&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T08:55:07.718Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T08:53:39.817Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/node-june-2026-security-update/web/](https://dev.suite.sldev.cz/suite-web/mroz22/node-june-2026-security-update/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->




