### PR TITLE
feat(ci): add npm provenance to connect package publishing

### DIFF
--- a/.github/actions/release-connect-npm/action.yml
+++ b/.github/actions/release-connect-npm/action.yml
@@ -81,4 +81,4 @@ runs:
           cd ./packages/${{ inputs.packageName }}
         fi
         yarn build:lib
-        yarn npm publish --tag ${{ inputs.deploymentType }} --access public
+        yarn npm publish --tag ${{ inputs.deploymentType }} --access public --provenance


### PR DESCRIPTION
## Description

Adds `--provenance` flag to the `yarn npm publish` command in the `release-connect-npm` composite action. This generates a provenance statement for every Connect package published to npm, linking each release to the exact GitHub Actions run and source commit that produced it. The calling workflow already has the required `id-token: write` permission and Yarn 4.14.1 supports `--provenance` natively.

## Notes for QA

No functional code changes — this only affects the CI publish step. Provenance attestations will be visible on the npm package pages after the next release.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/8195