### PR TITLE
test(suite): add new watcher for any error or warn toast during test run

### DIFF
--- a/packages/components/src/components/Toast/Toast.tsx
+++ b/packages/components/src/components/Toast/Toast.tsx
@@ -92,7 +92,7 @@ export const Toast = ({
     );
 
     return (
-        <Container data-testid={dataTestBase} $variant={intent}>
+        <Container data-testid={dataTestBase} data-toast-intent={intent} $variant={intent}>
             <Row gap={spacings.sm} justifyContent="space-between" flex="1">
                 {showIcon && (
                     <Icon

--- a/suite/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/suite/e2e/support/testExtends/suiteBaseFixture.ts
@@ -1,7 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
 import { ElectronApplication, Page, test as base } from '@playwright/test';
-import { inspect } from 'node:util';
 
 import { TestAnnotationType } from '@trezor/e2e-utils';
 import { SetupEmu, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
@@ -11,6 +10,7 @@ import { getUrl, isDesktopProject } from '../common';
 import { currentsTest } from './currentsFixture';
 import { enhancePage } from './enhancePage';
 import { PlaywrightTarget, SuiteTestOptions } from './suiteTestOptions';
+import { jsExceptionWatcher, toastErrorWatcher } from './watchers';
 import { DeviceFixture } from '../device';
 import { wipeAndRestartEvoluServer } from '../helpers/evoluClient';
 import { electronSetup, electronTeardown, trezorUserEnvStuckProtection, webSetup } from '../setup';
@@ -24,12 +24,14 @@ type SuiteBaseFixture = {
     deviceSetup: SetupEmu;
     electronConf: ElectronConf;
     ignoreJSExceptions: Array<string>;
+    ignoreToastErrors: string[];
     device: DeviceFixture;
     url: string;
     trezorUserEnv: TrezorUserEnv;
     electronApp: ElectronApplication | undefined;
     page: Page;
-    exceptionLogger: void;
+    jsExceptionWatcher: void;
+    toastErrorWatcher: void;
     coverageMapCollector: void;
 };
 
@@ -143,6 +145,7 @@ const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
     ],
     electronConf: {},
     ignoreJSExceptions: [],
+    ignoreToastErrors: [],
 
     url: async ({ target }, use, testInfo) => {
         await use(getUrl(testInfo, target));
@@ -170,77 +173,9 @@ const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
         }
     },
 
-    exceptionLogger: [
-        async ({ page, ignoreJSExceptions }, use, testInfo) => {
-            const errors: Error[] = [];
-            const ignored: Error[] = [];
+    jsExceptionWatcher: [jsExceptionWatcher, { auto: true }],
 
-            // Listener handler
-            const handlePageError = (error: Error) => {
-                const message = error?.message || '';
-                const isIgnored = ignoreJSExceptions.some(exception =>
-                    message.toLowerCase().includes(exception.toLowerCase()),
-                );
-
-                if (isIgnored) {
-                    ignored.push(error);
-                } else {
-                    errors.push(error);
-                }
-            };
-
-            // Start listening
-            page.on('pageerror', handlePageError);
-
-            // Error format handler
-            const formatError = (error: unknown): string => {
-                if (error instanceof Error) {
-                    let output = error.stack || `${error.name}: ${error.message}`;
-
-                    if (error.cause) {
-                        output += `\nCaused by: ${formatError(error.cause)}`;
-                    }
-
-                    return output;
-                }
-
-                /*
-                 * Fallback for non-Error objects.
-                 * Use Node's `util.inspect` to safely handle circular references
-                 * without crashes during test teardown.
-                 */
-                if (typeof error === 'object' && error !== null) {
-                    return inspect(error, {
-                        showHidden: false,
-                        depth: 3, // How deep to look inside the object
-                        colors: false,
-                        getters: true, // Catch hidden error properties
-                    });
-                }
-
-                return String(error);
-            };
-
-            // Run the actual test
-            await use();
-
-            // Handle annotations
-            if (ignored.length > 0) {
-                testInfo.annotations.push({
-                    type: 'Warning, Ignored JS exceptions',
-                    description: `\n${ignored.map(formatError).join('\n-----\n')}`,
-                });
-            }
-
-            if (errors.length > 0) {
-                throw new Error(
-                    `There was a JS exception during test run.
-                    \n${errors.map(formatError).join('\n-----\n')}`,
-                );
-            }
-        },
-        { auto: true },
-    ],
+    toastErrorWatcher: [toastErrorWatcher, { auto: true }],
 
     coverageMapCollector: [
         async ({ page }, use, testInfo) => {

--- a/suite/e2e/support/testExtends/watchers.ts
+++ b/suite/e2e/support/testExtends/watchers.ts
@@ -1,0 +1,130 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+
+import { type Page, type TestInfo } from '@playwright/test';
+import { inspect } from 'node:util';
+
+export type CapturedToast = { testId: string; intent: string; text: string };
+
+const formatError = (error: unknown): string => {
+    if (error instanceof Error) {
+        let output = error.stack || `${error.name}: ${error.message}`;
+
+        if (error.cause) {
+            output += `\nCaused by: ${formatError(error.cause)}`;
+        }
+
+        return output;
+    }
+
+    if (typeof error === 'object' && error !== null) {
+        /*
+         * Fallback for non-Error objects.
+         * Use Node's `util.inspect` to safely handle circular references
+         * without crashes during test teardown.
+         */
+        return inspect(error, { showHidden: false, depth: 3, colors: false, getters: true });
+    }
+
+    return String(error);
+};
+
+const formatToast = (toast: CapturedToast): string =>
+    `[${toast.intent}] ${toast.testId}: ${toast.text}`;
+
+const installToastObserver = () => {
+    const observer = new MutationObserver(mutations => {
+        for (const mutation of mutations) {
+            for (const node of mutation.addedNodes) {
+                if (!(node instanceof Element)) continue;
+
+                const toastElements = [
+                    ...(node.matches('[data-toast-intent]') ? [node] : []),
+                    ...node.querySelectorAll('[data-toast-intent]'),
+                ];
+
+                for (const el of toastElements) {
+                    const intent = el.getAttribute('data-toast-intent');
+
+                    if (intent === 'critical' || intent === 'warning') {
+                        (window as any).__reportToast({
+                            testId: el.getAttribute('data-testid') ?? '',
+                            intent,
+                            text: el.textContent?.trim() ?? '',
+                        });
+                    }
+                }
+            }
+        }
+    });
+
+    observer.observe(document, { childList: true, subtree: true });
+};
+
+const isExceptionIgnored = (message: string, ignoreJSExceptions: string[]): boolean =>
+    ignoreJSExceptions.some(pattern => message.toLowerCase().includes(pattern.toLowerCase()));
+
+const isToastIgnored = (toast: CapturedToast, ignoreToastErrors: string[]): boolean =>
+    ignoreToastErrors.some(pattern => toast.text.toLowerCase().includes(pattern.toLowerCase()));
+
+export const jsExceptionWatcher = async (
+    { page, ignoreJSExceptions }: { page: Page; ignoreJSExceptions: string[] },
+    use: () => Promise<void>,
+    testInfo: TestInfo,
+) => {
+    const errors: Error[] = [];
+    const ignored: Error[] = [];
+
+    page.on('pageerror', (error: Error) => {
+        const message = error?.message || '';
+
+        if (isExceptionIgnored(message, ignoreJSExceptions)) {
+            ignored.push(error);
+        } else {
+            errors.push(error);
+        }
+    });
+
+    await use();
+
+    if (ignored.length > 0) {
+        testInfo.annotations.push({
+            type: 'Warning, Ignored JS exceptions',
+            description: `\n${ignored.map(formatError).join('\n-----\n')}`,
+        });
+    }
+
+    if (errors.length > 0) {
+        throw new Error(
+            `There was a JS exception during test run.\n${errors.map(formatError).join('\n-----\n')}`,
+        );
+    }
+};
+
+export const toastErrorWatcher = async (
+    { page, ignoreToastErrors }: { page: Page; ignoreToastErrors: string[] },
+    use: () => Promise<void>,
+    testInfo: TestInfo,
+) => {
+    const captured: CapturedToast[] = [];
+
+    await page.exposeFunction('__reportToast', (toast: CapturedToast) => {
+        captured.push(toast);
+    });
+
+    // Inject into the already-loaded page so the observer is active for the whole test.
+    await page.evaluate(installToastObserver);
+    // Register for any subsequent full navigations within the test.
+    await page.addInitScript(installToastObserver);
+
+    await use();
+
+    const unexpected = captured.filter(toast => !isToastIgnored(toast, ignoreToastErrors));
+
+    if (unexpected.length > 0) {
+        const description = unexpected.map(formatToast).join('\n');
+        testInfo.annotations.push({ type: 'Unexpected toast notifications', description });
+        throw new Error(
+            `Unexpected error/warning toast notification(s) appeared during test:\n${description}`,
+        );
+    }
+};

--- a/suite/e2e/tests/backup/t2t1-fail.test.ts
+++ b/suite/e2e/tests/backup/t2t1-fail.test.ts
@@ -1,5 +1,6 @@
 import { escapeRegExp } from 'lodash';
 
+import { messages } from '@suite/intl';
 import { HELP_CENTER_RECOVERY_ISSUES_URL } from '@trezor/urls';
 
 import { expect, test } from '../../support/fixtures';
@@ -7,6 +8,7 @@ import { expect, test } from '../../support/fixtures';
 test.describe('Backup errors', { tag: ['@T2T1'] }, () => {
     test.use({
         deviceSetup: { needs_backup: true },
+        ignoreToastErrors: [messages.TOAST_BACKUP_FAILED.defaultMessage],
     });
 
     test.beforeEach(async ({ onboardingPage }) => {

--- a/suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
+++ b/suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
@@ -8,7 +8,7 @@ import { launchSuite, launchSuiteElectronApp } from '../../support/electron';
 import { expect, test } from '../../support/fixtures';
 
 test.describe('Bridge', { tag: ['@desktopOnly', '@T3W1', '@T3T1'] }, () => {
-    test.use({ exceptionLogger: skipFixture, startEmulator: false, setupEmulator: false });
+    test.use({ jsExceptionWatcher: skipFixture, startEmulator: false, setupEmulator: false });
 
     test.beforeEach(async ({ trezorUserEnv, page }) => {
         await page.close();

--- a/suite/e2e/tests/bridge-tor/spawn-bridge.test.ts
+++ b/suite/e2e/tests/bridge-tor/spawn-bridge.test.ts
@@ -15,7 +15,7 @@ import { SettingsPage } from '../../support/pageObjects/settings/settingsPage';
 import { enhancePage } from '../../support/testExtends/enhancePage';
 
 test.describe('Bridge', { tag: ['@desktopOnly', '@T3W1', '@T3T1'] }, () => {
-    test.use({ exceptionLogger: skipFixture, startEmulator: false, setupEmulator: false });
+    test.use({ jsExceptionWatcher: skipFixture, startEmulator: false, setupEmulator: false });
 
     test.beforeEach(async ({ page, trezorUserEnv }) => {
         await page.close();

--- a/suite/e2e/tests/browser/safari.test.ts
+++ b/suite/e2e/tests/browser/safari.test.ts
@@ -20,7 +20,7 @@ test.use({
     startEmulator: false,
     ...devices['Desktop Safari'],
     channel: 'webkit',
-    exceptionLogger: skipFixture,
+    jsExceptionWatcher: skipFixture,
 });
 
 test.describe('Safari', { tag: ['@webOnly', '@noDevice'] }, () => {

--- a/suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts
+++ b/suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts
@@ -6,6 +6,9 @@ import { createTestAnnotation } from '../../../support/reporters/annotations';
 test.describe('Dropbox API errors', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
     test.use({
         deviceSetup: { mnemonic: 'mnemonic_all' },
+        ignoreToastErrors: [
+            'Failed to save labeling data: Error in call to API function "files/upload": The given OAuth 2 access token is malformed.',
+        ],
     });
 
     test.beforeEach(async ({ metadataMock }) => {

--- a/suite/e2e/tests/metadata/legacy/google-api-errors.test.ts
+++ b/suite/e2e/tests/metadata/legacy/google-api-errors.test.ts
@@ -5,6 +5,7 @@ import { createTestAnnotation } from '../../../support/reporters/annotations';
 test.describe('Google API errors', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
     test.use({
         deviceSetup: { mnemonic: 'mnemonic_all' },
+        ignoreToastErrors: ['Failed to connect to labeling provider: Invalid Credentials'],
     });
 
     test.beforeEach(async ({ metadataMock }) => {

--- a/suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts
@@ -1,3 +1,4 @@
+import { messages } from '@suite/intl';
 import {
     createAccountRowId,
     createOwnerIdFromSecret,
@@ -73,7 +74,11 @@ const expectedWalletTwoLabel = {
 
 test.describe('Suite Sync - Passphrase wallets', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.slow();
-    test.use({ wipeEvoluRelay: true, deviceSetup: { passphrase_protection: true } });
+    test.use({
+        wipeEvoluRelay: true,
+        deviceSetup: { passphrase_protection: true },
+        ignoreToastErrors: [messages.TR_SUITE_SYNC_ERROR_DEVICE_CANCELLED.defaultMessage],
+    });
 
     test.beforeEach(async ({ onboardingPage, metadataPage, settingsPage }) => {
         await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });

--- a/suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts
+++ b/suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts
@@ -6,6 +6,7 @@ import { expect, test } from '../../../support/fixtures';
 test.describe('Onboarding - simulated entropy check failure', { tag: ['@T2T1'] }, () => {
     test.use({
         setupEmulator: false,
+        ignoreToastErrors: ['SIMULATED ERROR', 'device disconnected during action'],
     });
 
     test.beforeEach(async ({ onboardingPage, analyticsSection }) => {

--- a/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts
+++ b/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts
@@ -1,3 +1,4 @@
+import { messages } from '@suite/intl';
 import { TestCategory, TestPriority } from '@trezor/e2e-utils';
 
 import { expect, test } from '../../../support/fixtures';
@@ -7,6 +8,7 @@ test.describe('Onboarding - create wallet', { tag: ['@desktopOnly', '@T3T1', '@s
     test.use({
         setupEmulator: false,
         electronConf: { offlineMode: true },
+        ignoreToastErrors: [messages.TR_FIRMWARE_REVISION_CHECK_OTHER_ERROR.defaultMessage],
     });
 
     test.beforeEach(async ({ onboardingPage }) => {

--- a/suite/e2e/tests/staking/eth/unstake.test.ts
+++ b/suite/e2e/tests/staking/eth/unstake.test.ts
@@ -13,7 +13,7 @@ test.describe('ETH unstaking and claim', { tag: ['@T3W1', '@T3T1'] }, () => {
             mnemonic: 'access juice claim special truth ugly swarm rabbit hair man error bar',
         },
         //TODO: Mock is not handling request for instant unstake information. Fix me
-        exceptionLogger: skipFixture,
+        jsExceptionWatcher: skipFixture,
     });
 
     test.beforeEach(

--- a/suite/e2e/tests/wallet/send-doge.test.ts
+++ b/suite/e2e/tests/wallet/send-doge.test.ts
@@ -9,6 +9,7 @@ test.describe('Doge Send', { tag: ['@T3W1', '@T3T1'] }, () => {
             mnemonic:
                 'fantasy auto fancy access ring spring patrol expect common tape talent annual',
         },
+        ignoreToastErrors: ['Invalid amount specified'],
     });
 
     const recipientAddress = 'DJk8vtoEuNGtT4YRNoqVxWyRh6kM3s8bzc';


### PR DESCRIPTION
Implements idea we had with Ondra Zig.
Same format as is our JS Exception logger.
This new fixture watches during the test run for any toast elements with warning or error intent. And if it collects any -> it throws in the teardown of the test. 

This can help us find hidden problems and debug easily our tests.
Moved to separate .ts file to not clutter our main fixture file.
Renamed to watchers.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set includes 4 directly modified test files (bridge-tor tests, safari browser test, ETH unstake test), infrastructure changes to the base test fixture and watchers, a Toast UI component change, and a new toast-error-logger test. The directly changed tests are highest priority. The Toast.tsx change maps to 121+ tests but only tests that explicitly assert on toast visibility/content are at meaningful risk. The test infrastructure changes (suiteBaseFixture.ts, watchers.ts) could theoretically affect all tests but are best validated by running the directly changed tests first.

<details><summary><b>Changed files (8)</b></summary>

- `packages/components/src/components/Toast/Toast.tsx`
- `suite/e2e/support/testExtends/suiteBaseFixture.ts`
- `suite/e2e/support/testExtends/watchers.ts`
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts`
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts`
- `suite/e2e/tests/browser/safari.test.ts`
- `suite/e2e/tests/general/toast-error-logger.test.ts`
- `suite/e2e/tests/staking/eth/unstake.test.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test file itself was directly changed, so it must be run to verify the modifications are correct and the test still passes.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test file itself was directly changed, so it must be run to verify the modifications are correct and the test still passes.
- `suite/e2e/tests/browser/safari.test.ts` — This test file itself was directly changed, so it must be run to verify the modifications are correct and the test still passes.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test file itself was directly changed, so it must be run to verify the modifications are correct and the test still passes.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test explicitly asserts on toast notifications (backup-failed toast) which directly exercise the changed Toast.tsx component. Changes to Toast rendering could break this test's assertions.
- `suite/e2e/tests/backup/t2t1-success.test.ts` — This test tracks analytics events related to backup creation, and the backup flow involves toast-like confirmation UI. The Toast component change could affect the backup completion feedback.
- `suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts` — This test explicitly asserts on error toast notifications (@toast/error) with specific text content. Changes to the Toast component could affect how error toasts render or display their messages.
- `suite/e2e/tests/metadata/legacy/google-api-errors.test.ts` — This test explicitly asserts on error toast notifications (@toast/error) with specific error text. Toast rendering changes could break these assertions.
- `suite/e2e/tests/settings/passphrase.test.ts` — This test asserts that a '@toast/settings-applied' toast becomes visible and then is detached from the DOM. Changes to Toast.tsx lifecycle or rendering could directly affect this assertion.
- `suite/e2e/tests/settings/t1b1-device-settings.test.ts` — This test asserts on '@toast/pin-changed' and '@pin-mismatch' toast notifications. Changes to the Toast component could affect visibility and content of these toasts.
- `suite/e2e/tests/suite/bug-report-form.test.ts` — This test asserts that a '@toast/user-feedback-send-success' toast becomes visible after submitting a bug report. Toast rendering changes could break this assertion.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — This test asserts on '@toast/sign-message-success' and '@toast/verify-message-success' toast notifications. Changes to Toast.tsx could affect these toast visibility assertions.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — This test asserts on '@toast/verify-message-success' toast notification visibility. Toast component changes could break this specific assertion.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite/e2e/support/testExtends/suiteBaseFixture.ts`
- `suite/e2e/support/testExtends/watchers.ts`
- `suite/e2e/tests/general/toast-error-logger.test.ts`

_Updated: 2026-06-18T12:13:29.095Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/toast-watcher/web/](https://dev.suite.sldev.cz/suite-web/toast-watcher/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=toast-watcher&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=toast-watcher&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-18T18:31:17.018Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-18T18:29:34.153Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->