### PR TITLE
fix(suite-build): enable sentry tracing

### DIFF
--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -206,7 +206,10 @@ const config: webpack.Configuration = {
             ),
             'process.env.TRANSPORT_BROWSER_PING': JSON.stringify(transportBrowserPing),
             __SENTRY_DEBUG__: isDev,
-            __SENTRY_TRACING__: false, // needs to be removed when we introduce performance monitoring in trezor-suite
+            // Keeps Sentry tracing/performance code in the bundle. Must stay truthy for
+            // browserTracingIntegration (transactions, Web Vitals) and trace-lifecycle profiling
+            // to work; setting it false tree-shakes all of that out at build time.
+            __SENTRY_TRACING__: true,
         }),
         new webpack.ProvidePlugin({
             Buffer: ['buffer', 'Buffer'],

--- a/suite/sentry/src/config.ts
+++ b/suite/sentry/src/config.ts
@@ -3,6 +3,7 @@ import {
     browserProfilingIntegration,
     browserTracingIntegration,
     captureConsoleIntegration,
+    elementTimingIntegration,
 } from '@sentry/browser';
 import type { ErrorEvent, Options } from '@sentry/core';
 
@@ -106,5 +107,6 @@ export const SENTRY_BROWSER_CONFIG = {
         captureConsoleIntegration({ levels: ['error'] }),
         browserProfilingIntegration(),
         browserTracingIntegration(),
+        elementTimingIntegration(),
     ],
 } satisfies BrowserOptions;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Enable sentry tracing (it was forcefully disabled and the tracing / profiling code have never gotten deployed).
- Enable [element tracing integration](https://docs.sentry.io/platforms/javascript/configuration/integrations/elementtiming/)

## Related Issue

Resolve #28874


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `suite/sentry/src/config.ts`, which is the Sentry error-reporting configuration. This file controls error monitoring/reporting setup (DSN, sample rates, integrations, etc.) and is not exercised by any of the 104 candidate E2E tests — none of them test Sentry error reporting behavior, and no static coverage mapping exists. The change is low-risk from an E2E perspective since Sentry config affects observability infrastructure rather than user-facing application behavior. No E2E tests are recommended.

<details><summary><b>Changed files (1)</b></summary>

- `suite/sentry/src/config.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite/sentry/src/config.ts`

_Updated: 2026-06-18T14:11:55.841Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sentry-profiling&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sentry-profiling&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-18T14:17:14.738Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-18T14:15:26.099Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/sentry-profiling/web/](https://dev.suite.sldev.cz/suite-web/fix/sentry-profiling/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->