### PR TITLE
feat(eslint): enforce typedObject* over casted Object.keys/entries/values

### DIFF
--- a/packages/analytics-docs/scripts/buildData.ts
+++ b/packages/analytics-docs/scripts/buildData.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import type { EventDef } from '@suite-common/analytics';
-import { unique } from '@trezor/utils';
+import { typedObjectValues, unique } from '@trezor/utils';
 
 import type { EventDoc } from '../src/types';
 import {
@@ -52,9 +52,11 @@ const loadEventsFromPackage = async (
 ): Promise<Array<EventDef<unknown, string>>> => {
     const packageRoot = getPackageRoot(packageName);
     const eventsPath = path.join(packageRoot, 'src', 'events', 'index.ts');
-    const module = await import(pathToFileURL(eventsPath).href);
+    const module: Record<string, EventDef<unknown, string>> = await import(
+        pathToFileURL(eventsPath).href
+    );
 
-    return Object.values(module) as Array<EventDef<unknown, string>>;
+    return typedObjectValues(module);
 };
 
 const loadAllEvents = async (): Promise<

--- a/packages/connect-explorer/eslint.config.mjs
+++ b/packages/connect-explorer/eslint.config.mjs
@@ -1,6 +1,10 @@
 import * as mdx from 'eslint-plugin-mdx';
 
-import { eslint, globalNoExtraneousDependenciesDevDependencies } from '@trezor/eslint';
+import {
+    eslint,
+    globalNoExtraneousDependenciesDevDependencies,
+    noCastedObjectHelpersSyntax,
+} from '@trezor/eslint';
 
 export default [
     ...eslint,
@@ -30,7 +34,8 @@ export default [
         rules: {
             'no-console': 'off',
             'import/no-default-export': 'off', // Todo: shall be fixed
-            'no-restricted-syntax': 'off', // Todo: shall be fixed
+            // keep the casted-Object-helper ban active; the rest of no-restricted-syntax stays off (legacy getState/state-as-any debt)
+            'no-restricted-syntax': ['error', ...noCastedObjectHelpersSyntax],
             '@typescript-eslint/no-restricted-imports': 'off',
             '@typescript-eslint/no-shadow': 'off', // Todo: shall be fixed
             'react/jsx-filename-extension': [
@@ -48,6 +53,14 @@ export default [
                     ],
                 },
             ],
+        },
+    },
+    {
+        // the catch-all override above has no `files` key, so it re-enables no-restricted-syntax
+        // for .mdx too; keep MDX exempt (it intentionally disables the whole rule)
+        files: ['**/*.mdx'],
+        rules: {
+            'no-restricted-syntax': 'off',
         },
     },
 ];

--- a/packages/eslint/src/index.mjs
+++ b/packages/eslint/src/index.mjs
@@ -3,7 +3,7 @@ import playwright from 'eslint-plugin-playwright';
 import globals from 'globals';
 
 import { globalNoExtraneousDependenciesDevDependencies, importConfig } from './importConfig.mjs';
-import { javascriptConfig } from './javascriptConfig.mjs';
+import { javascriptConfig, noCastedObjectHelpersSyntax } from './javascriptConfig.mjs';
 import { javascriptNodejsConfig } from './javascriptNodejsConfig.mjs';
 import { jestConfig } from './jestConfig.mjs';
 import { localRulesConfig } from './localRulesConfig.mjs';
@@ -13,7 +13,11 @@ import { restrictedImportsPatterns, typescriptConfig } from './typescriptConfig.
  * @typedef {import('eslint').Linter.Config} Config
  */
 
-export { globalNoExtraneousDependenciesDevDependencies, restrictedImportsPatterns };
+export {
+    globalNoExtraneousDependenciesDevDependencies,
+    noCastedObjectHelpersSyntax,
+    restrictedImportsPatterns,
+};
 
 /** @type {Config[]} */
 export const eslint = [

--- a/packages/eslint/src/javascriptConfig.mjs
+++ b/packages/eslint/src/javascriptConfig.mjs
@@ -67,6 +67,24 @@ export const javascriptConfig = [
                     message:
                         'Use `undefined` (or `never` in discriminated unions) instead of `typeof undefined` in type position.',
                 },
+                {
+                    selector:
+                        "TSAsExpression[expression.type='CallExpression'][expression.callee.type='MemberExpression'][expression.callee.object.name='Object'][expression.callee.property.name='keys']",
+                    message:
+                        'Use typedObjectKeys from @trezor/utils instead of casting the result of Object.keys(). The `as` assertion just re-spells `keyof typeof`, which typedObjectKeys provides safely.',
+                },
+                {
+                    selector:
+                        "TSAsExpression[expression.type='CallExpression'][expression.callee.type='MemberExpression'][expression.callee.object.name='Object'][expression.callee.property.name='entries']",
+                    message:
+                        'Use typedObjectEntries from @trezor/utils instead of casting the result of Object.entries(). The `as` assertion just re-spells the entry tuple type, which typedObjectEntries provides safely.',
+                },
+                {
+                    selector:
+                        "TSAsExpression[expression.type='CallExpression'][expression.callee.type='MemberExpression'][expression.callee.object.name='Object'][expression.callee.property.name='values']",
+                    message:
+                        'Use typedObjectValues from @trezor/utils instead of casting the result of Object.values(). The `as` assertion just re-spells the value type, which typedObjectValues provides safely.',
+                },
             ],
             'object-shorthand': [
                 'error',

--- a/packages/eslint/src/javascriptConfig.mjs
+++ b/packages/eslint/src/javascriptConfig.mjs
@@ -3,6 +3,32 @@ import pluginJs from '@eslint/js';
  * @typedef {import('eslint').Linter.Config} Config
  */
 
+/**
+ * Cast bans for the result of `Object.keys/entries/values(...) as …` — steer them to the
+ * typedObject* helpers. Exported separately so packages that switch the rest of
+ * `no-restricted-syntax` off can still opt back into just these selectors.
+ */
+export const noCastedObjectHelpersSyntax = [
+    {
+        selector:
+            "TSAsExpression[expression.type='CallExpression'][expression.callee.type='MemberExpression'][expression.callee.object.name='Object'][expression.callee.property.name='keys']",
+        message:
+            'Use typedObjectKeys from @trezor/utils instead of casting the result of Object.keys(). The `as` assertion just re-spells `keyof typeof`, which typedObjectKeys provides safely.',
+    },
+    {
+        selector:
+            "TSAsExpression[expression.type='CallExpression'][expression.callee.type='MemberExpression'][expression.callee.object.name='Object'][expression.callee.property.name='entries']",
+        message:
+            'Use typedObjectEntries from @trezor/utils instead of casting the result of Object.entries(). The `as` assertion just re-spells the entry tuple type, which typedObjectEntries provides safely.',
+    },
+    {
+        selector:
+            "TSAsExpression[expression.type='CallExpression'][expression.callee.type='MemberExpression'][expression.callee.object.name='Object'][expression.callee.property.name='values']",
+        message:
+            'Use typedObjectValues from @trezor/utils instead of casting the result of Object.values(). The `as` assertion just re-spells the value type, which typedObjectValues provides safely.',
+    },
+];
+
 /** @type {Config[]} */
 export const javascriptConfig = [
     pluginJs.configs.recommended,
@@ -67,24 +93,7 @@ export const javascriptConfig = [
                     message:
                         'Use `undefined` (or `never` in discriminated unions) instead of `typeof undefined` in type position.',
                 },
-                {
-                    selector:
-                        "TSAsExpression[expression.type='CallExpression'][expression.callee.type='MemberExpression'][expression.callee.object.name='Object'][expression.callee.property.name='keys']",
-                    message:
-                        'Use typedObjectKeys from @trezor/utils instead of casting the result of Object.keys(). The `as` assertion just re-spells `keyof typeof`, which typedObjectKeys provides safely.',
-                },
-                {
-                    selector:
-                        "TSAsExpression[expression.type='CallExpression'][expression.callee.type='MemberExpression'][expression.callee.object.name='Object'][expression.callee.property.name='entries']",
-                    message:
-                        'Use typedObjectEntries from @trezor/utils instead of casting the result of Object.entries(). The `as` assertion just re-spells the entry tuple type, which typedObjectEntries provides safely.',
-                },
-                {
-                    selector:
-                        "TSAsExpression[expression.type='CallExpression'][expression.callee.type='MemberExpression'][expression.callee.object.name='Object'][expression.callee.property.name='values']",
-                    message:
-                        'Use typedObjectValues from @trezor/utils instead of casting the result of Object.values(). The `as` assertion just re-spells the value type, which typedObjectValues provides safely.',
-                },
+                ...noCastedObjectHelpersSyntax,
             ],
             'object-shorthand': [
                 'error',

--- a/packages/product-components/src/components/DeviceAnimation/DeviceAnimation.stories.tsx
+++ b/packages/product-components/src/components/DeviceAnimation/DeviceAnimation.stories.tsx
@@ -11,6 +11,7 @@ const createDeviceAnimationStory = (
 ): StoryObj<typeof DeviceAnimationComponent> => {
     const animationType = DEVICE_ANIMATION_TYPES[type];
     const config = DEVICE_ANIMATION_CONFIG[animationType];
+    // eslint-disable-next-line no-restricted-syntax -- config.models is a union of per-animation shapes, so typedObjectEntries would collapse keyof to `never`; the cast keeps the model key usable
     const modelEntries = Object.entries(config.models) as [DeviceModelInternal, any][];
     const [firstModel, firstModelCfg] = modelEntries[0] ?? [];
     const colors: number[] = (firstModelCfg?.colors as number[]) ?? [1];

--- a/packages/suite/eslint.config.mjs
+++ b/packages/suite/eslint.config.mjs
@@ -1,4 +1,8 @@
-import { eslint, globalNoExtraneousDependenciesDevDependencies } from '@trezor/eslint';
+import {
+    eslint,
+    globalNoExtraneousDependenciesDevDependencies,
+    noCastedObjectHelpersSyntax,
+} from '@trezor/eslint';
 
 export default [
     ...eslint,
@@ -10,7 +14,8 @@ export default [
                     allow: ['FormattedNumber'],
                 },
             ],
-            'no-restricted-syntax': 'off', // Todo: this should be fixed in codebase and this line removed
+            // keep the casted-Object-helper ban active; the rest of no-restricted-syntax stays off (legacy getState/state-as-any debt)
+            'no-restricted-syntax': ['error', ...noCastedObjectHelpersSyntax],
             'import/no-default-export': 'off', // Todo: shall be solved one day, usually its legacy Components
             'no-console': 'off', // Todo: we use it a lot, shall be disabled more granulary I think
             '@typescript-eslint/no-shadow': 'off', // Todo: shall be fixed

--- a/packages/suite/src/components/earn/dashboard/utils/earnYieldUtils.ts
+++ b/packages/suite/src/components/earn/dashboard/utils/earnYieldUtils.ts
@@ -1,6 +1,6 @@
 import { type AccountType, networkSymbolCollection, networks } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
-import { BigNumber } from '@trezor/utils';
+import { BigNumber, typedObjectKeys } from '@trezor/utils';
 
 type YieldRowWithAvailableBalance = {
     additionalDepositAmount: string;
@@ -69,7 +69,11 @@ export const compareYieldRowsByTokenNetworkOrder = (
     }
 
     const network = networks[a.account.symbol];
-    const orderedAccountTypes = Object.keys(network.accountTypes) as AccountType[];
+    // `network` is a union over all networks (some declare `accountTypes: {}`), which would collapse
+    // `keyof` to `never`; widening to the field's declared keyset yields `AccountType[]` soundly.
+    const orderedAccountTypes = typedObjectKeys(
+        network.accountTypes as Partial<Record<AccountType, unknown>>,
+    );
     const aAccountTypeIndex = orderedAccountTypes.indexOf(a.account.accountType);
     const bAccountTypeIndex = orderedAccountTypes.indexOf(b.account.accountType);
     if (aAccountTypeIndex !== bAccountTypeIndex) return aAccountTypeIndex - bAccountTypeIndex;

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -271,6 +271,7 @@ export const useSendFormCompose = ({
             !selectedFee || (typeof setMaxOutputId === 'number' && selectedFee !== 'custom');
         if (shouldSwitch && composed.type === 'error') {
             // find nearest possible tx
+            // composedLevels is keyed by fee labels but typed as Record<string, …>, so assert the keys back to FeeLevel['label']
             const nearest = (Object.keys(composedLevels) as FeeLevel['label'][]).find(
                 key => composedLevels[key]?.type !== 'error',
             );

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -271,7 +271,7 @@ export const useSendFormCompose = ({
             !selectedFee || (typeof setMaxOutputId === 'number' && selectedFee !== 'custom');
         if (shouldSwitch && composed.type === 'error') {
             // find nearest possible tx
-            // composedLevels is keyed by fee labels but typed as Record<string, …>, so assert the keys back to FeeLevel['label']
+            // eslint-disable-next-line no-restricted-syntax -- composedLevels is keyed by fee labels but typed as Record<string, …>, so assert the keys back to FeeLevel['label']
             const nearest = (Object.keys(composedLevels) as FeeLevel['label'][]).find(
                 key => composedLevels[key]?.type !== 'error',
             );

--- a/packages/suite/src/views/settings/SettingsDebug/Flags.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Flags.tsx
@@ -1,16 +1,15 @@
-import { type FlagsState, selectFlags, setFlag } from '@suite/flags';
+import { selectFlags, setFlag } from '@suite/flags';
 import { Switch } from '@trezor/components';
 import { ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
+import { typedObjectEntries } from '@trezor/utils';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
-
-type FlagKey = keyof FlagsState;
 
 export const Flags = () => {
     const dispatch = useDispatch();
     const flags = useSelector(selectFlags);
 
-    const entries = Object.entries(flags) as [FlagKey, FlagsState[FlagKey]][];
+    const entries = typedObjectEntries(flags);
 
     return (
         <>

--- a/packages/transport-bluetooth/src/browser.ts
+++ b/packages/transport-bluetooth/src/browser.ts
@@ -1,4 +1,5 @@
 import { createIpcProxy } from '@trezor/ipc-proxy';
+import { typedObjectKeys } from '@trezor/utils';
 
 import { bluetoothIpc } from './client/bluetooth-ipc-renderer';
 import { type BluetoothIpcApi } from './client/types';
@@ -20,7 +21,7 @@ const proxyState = () => {
 
 // create ipcProxy and wrap each bluetoothIpc method
 const getProxy = proxyState();
-(Object.keys(bluetoothIpc) as (keyof BluetoothIpcApi)[]).forEach(key => {
+typedObjectKeys(bluetoothIpc).forEach(key => {
     (bluetoothIpc[key] as unknown) = (...args: any[]) =>
         getProxy().then(p => (p[key] as any)(...args));
 });

--- a/packages/transport-bluetooth/src/client/types.ts
+++ b/packages/transport-bluetooth/src/client/types.ts
@@ -93,7 +93,7 @@ export interface BluetoothIpcState {
     knownDevices: BluetoothDevice[];
 }
 
-export interface BluetoothIpcApi {
+export type BluetoothIpcApi = {
     init(state?: BluetoothIpcState): Promise<IpcResponse>;
     getInfo(): Promise<IpcResponse<BluetoothInfo>>;
     dispose(): Promise<IpcResponse>;
@@ -108,4 +108,4 @@ export interface BluetoothIpcApi {
     on: TypedManagerEvents['on'];
     off: TypedManagerEvents['off'];
     removeAllListeners: TypedManagerEvents['removeAllListeners'];
-}
+};

--- a/packages/utils/src/typedObject.ts
+++ b/packages/utils/src/typedObject.ts
@@ -1,3 +1,6 @@
+/* eslint-disable no-restricted-syntax -- this file *is* the typed Object.keys/entries/values
+   wrappers, so the very casts the rule warns about live here on purpose — the whole point is
+   that nobody else has to write them. */
 import { type KeysOfUnion, type NarrowObjectWithKey } from '@trezor/type-utils';
 
 export const typedObjectEntries = <T extends Record<string, unknown>>(

--- a/suite-common/calldata/src/builder/createBuilder.ts
+++ b/suite-common/calldata/src/builder/createBuilder.ts
@@ -30,6 +30,7 @@ export const createBuilder = <
     ExtractContext<Config>,
     ExtractEncoderOutput<E>
 > => {
+    // eslint-disable-next-line no-restricted-syntax -- typedObjectKeys can only yield `keyof Config`; the param keys are narrowed to `ExtractParamNames<E>` by the generic constraint, which TS cannot infer on its own
     const paramNames = Object.keys(config.params) as ExtractParamNames<E>[];
 
     return (

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -42,7 +42,7 @@ import TrezorConnect, {
 } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
 import { HELP_CENTER_ADDRESSES_URL, HELP_CENTER_TAPROOT_URL } from '@trezor/urls';
-import { BigNumber, arrayDistinct, bufferUtils } from '@trezor/utils';
+import { BigNumber, arrayDistinct, bufferUtils, typedObjectKeys } from '@trezor/utils';
 
 import { convertAmountSubunitsToUnits, formatNetworkAmount } from './amountUtils';
 import { toFiatCurrency } from './fiatConverterUtils';
@@ -277,7 +277,11 @@ export const sortByCoin = <T extends Account>(accounts: T[]) =>
 
         // when it is sorted by network, sort by order of accountType keys within the same network
         const network = networks[a.symbol];
-        const orderedAccountTypes = Object.keys(network.accountTypes) as AccountType[];
+        // `network` is a union over all networks (some declare `accountTypes: {}`), which would collapse
+        // `keyof` to `never`; widening to the field's declared keyset yields `AccountType[]` soundly.
+        const orderedAccountTypes = typedObjectKeys(
+            network.accountTypes as Partial<Record<AccountType, unknown>>,
+        );
         const aAccountTypeIndex = orderedAccountTypes.indexOf(a.accountType);
         const bAccountTypeIndex = orderedAccountTypes.indexOf(b.accountType);
 

--- a/suite/flags/src/flagsSlice.ts
+++ b/suite/flags/src/flagsSlice.ts
@@ -3,7 +3,7 @@ import { type PayloadAction } from '@reduxjs/toolkit';
 import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
 import { DEVICE } from '@trezor/connect';
 
-export interface FlagsState {
+export type FlagsState = {
     initialRun: boolean;
     taprootBannerClosed: boolean;
     firmwareTypeBannerClosed: boolean;
@@ -30,7 +30,7 @@ export interface FlagsState {
     hasSeenDisconnectTooltip: boolean;
     showNoDeviceEshopSidebarBanner: boolean;
     areNoDeviceEshopBannersDisabled: boolean;
-}
+};
 
 export type FlagsRootState = { flags: FlagsState };
 

--- a/suite/metadata/eslint.config.mjs
+++ b/suite/metadata/eslint.config.mjs
@@ -1,4 +1,4 @@
-import { eslint } from '@trezor/eslint';
+import { eslint, noCastedObjectHelpersSyntax } from '@trezor/eslint';
 
 export default [
     ...eslint,
@@ -6,7 +6,8 @@ export default [
         rules: {
             'no-console': 'off',
             '@typescript-eslint/no-shadow': 'off', // Todo: shall be fixed
-            'no-restricted-syntax': 'off', // Todo: this should be fixed in codebase and this line removed
+            // keep the casted-Object-helper ban active; the rest of no-restricted-syntax stays off (legacy getState/state-as-any debt)
+            'no-restricted-syntax': ['error', ...noCastedObjectHelpersSyntax],
             'import/no-default-export': 'off', // Todo: shall be solved one day, usually its legacy Components
         },
     },


### PR DESCRIPTION
## Description

Adds an ESLint rule (`@trezor/eslint`) enforcing the `typedObjectKeys` / `typedObjectEntries` / `typedObjectValues` helpers from `@trezor/utils` over hand-written casts of `Object.keys/entries/values(...) as …`. The casted form just re-spells `keyof typeof` by hand; the helpers do it safely. The helper file itself carries a single file-level `eslint-disable` — that's where the casts legitimately live so the rest of the codebase doesn't.

The non-controversial code conversions were merged separately in #28920. This PR is the rule itself plus the call sites that the rule forces a decision on.

### Cutting the disables from 7 to 3

An initial pass needed 7 `eslint-disable`s. A deep review (per-site type analysis + two cross-cutting options) reworked 4 of them away; 3 sites keep the hand-written cast — two as documented `eslint-disable`s, and `useSendFormCompose.ts` as a plain comment because the rule is currently off in `packages/suite` (see below).

**4 reworked to need no disable:**

- `buildData.ts` — annotate the dynamic-`import()` result as `Record<string, EventDef<…>>`, so `typedObjectValues` returns the right type. Removes the `any`; the old disable's premise no longer holds.
- `browser.ts` — convert the `BluetoothIpcApi` `interface` to a `type` alias (no declaration merging exists; `implements` still works on the class), so it satisfies the helper's `Record<string, unknown>` constraint; then a bare `typedObjectKeys`. Same precedent as `CoinjoinConfig` / `FlagsState`.
- `accountUtils.ts` / `earnYieldUtils.ts` — `network` is a union over all networks (some declare `accountTypes: {}`), so a bare `keyof` collapses to `never`. Widening to the field's declared keyset `Partial<Record<AccountType, unknown>>` before `typedObjectKeys` yields `AccountType[]` soundly — and replaces the previous unsound `string[] -> AccountType[]` downcast.

**3 keep the hand-written cast.** The helper genuinely cannot reproduce the type here:

- `createBuilder.ts` — keys are narrowed to `ExtractParamNames<E>`, tighter than `keyof Config`, via a generic constraint TS cannot infer. (`eslint-disable`)
- `DeviceAnimation.stories.tsx` — `config.models` is a union of per-animation shapes, so `keyof` collapses to `never` (value stays `any`). (`eslint-disable`)
- `useSendFormCompose.ts` — `composedLevels` is keyed by fee labels but typed `Record<string, …>`, so the keys must be asserted back to `FeeLevel['label']`. Kept as a plain `//` comment rather than an `eslint-disable`, because `no-restricted-syntax` is currently off in `packages/suite`, so a disable directive there would itself be reported as unused (`--max-warnings 0` fails). Once the rule is enabled in `suite` (see the follow-up below) this becomes a real `eslint-disable`, consistent with the other two.

#### Why not make these three disable-free as well?

All three *can* be made to pass the rule without a disable — the rule only flags a cast that directly wraps `Object.keys/entries/values`, so moving the cast off that call dodges it:

```ts
// createBuilder.ts — output-cast on the helper instead of on Object.keys
const paramNames = typedObjectKeys(config.params) as ExtractParamNames<E>[];

// DeviceAnimation.stories.tsx — output-cast on the helper instead of on Object.entries
const modelEntries = typedObjectEntries(config.models) as [DeviceModelInternal, any][];

// useSendFormCompose.ts — a .find() type-guard predicate
const nearest = Object.keys(composedLevels).find(
    (key): key is FeeLevel['label'] => composedLevels[key]?.type !== 'error',
);
```

All compile and satisfy the rule, but they don't make anything safer — the first two purely relocate the same (still-unsound) narrowing off `Object.keys`, and the `useSendFormCompose` type-guard is worse: its predicate (`type !== 'error'`) has nothing to do with whether the key is a fee label, so it's a cast dressed up as a type-guard. We deliberately keep the documented cast with an accurate inline reason instead, because it's the more honest representation. (Worth noting for the rule discussion: a syntactic rule is trivially bypassable by relocating the cast; only a type-aware rule could tell a redundant cast from a legitimate narrowing — see below.) If the team prefers a hard zero-disable policy, the snippets above are the drop-in replacements.

### Cross-cutting options that were considered and rejected

- **Type-aware custom rule** (eslint-local-rules, using the type checker to flag a cast only when it equals the helper's return type) — would eliminate all disables precisely *and* close the relocation bypass above, but it's ~80 lines + tests vs a 3-selector block, and type-aware rules only run under the `**/src/**` projectService glob, so it would stop catching redundant casts in `tests/` / `scripts/` (e.g. the one already fixed in `utxo-lib/tests/compose.test.ts`). Over-engineered for 3 well-documented disables; noted as the principled upgrade if redundant casts recur.
- **Relaxing the helper constraint** `Record<string, unknown>` -> `T extends object` with `keyof T & string` — fixes only `browser.ts` and carries an unprovable numeric-key regression risk for any (currently believed-absent) numeric-key caller. The local `interface -> type` conversion fixes that site without touching a shared helper.

### Follow-up: enable the rule everywhere

Today the rule does not enforce in the packages that blanket-disable `no-restricted-syntax` for legacy reasons — `packages/suite`, `suite/metadata`, and `packages/connect-explorer` each set `'no-restricted-syntax': 'off'` in their own flat config, which in ESLint flat config clobbers the whole rule (all selectors), not just the pre-existing ones. So the cast-ban is currently advisory in `packages/suite`, where most of the migrated call sites live. #28945 (stacked on this PR) turns it on there too: the migration cost is effectively zero (the only casted `Object.keys/entries/values` across those three packages is the `useSendFormCompose.ts` site above, already handled), so it comes down to re-adding the three selectors on top of the blanket `off` — export them from `@trezor/eslint` and set `'no-restricted-syntax': ['error', ...noCastedObjectHelpersSyntax]` in those configs. At that point `useSendFormCompose`'s plain comment becomes a real `eslint-disable`, consistent with the other two kept casts. (The unrelated `getState` / `state-as-any` debt those packages also defer — ~222 violations across ~134 files — stays out of scope.)

## Related

- #28920 — the merged code conversions this rule would enforce.
- #28945 — follow-up (stacked on this PR) that enables the cast ban in `packages/suite` / `suite/metadata` / `connect-explorer`.
- Review comment that started this: https://github.com/trezor/trezor-suite/pull/28838#discussion_r3435605706

## Notes for QA

No QA needed. Lint-rule + type-level change with zero runtime behaviour change — the helpers are `Object.keys/entries/values` at runtime; the `interface -> type` changes (`BluetoothIpcApi`, plus `FlagsState` here) and the widening rewrites are all type-only.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set touches several broadly-used utilities (typedObject, accountUtils, calldata builder, transport-bluetooth browser) that map to 121+ tests each, plus two more targeted files: useSendFormCompose (send transaction composition hook) and earnYieldUtils (earn/staking dashboard utilities). The highest risk is in useSendFormCompose, which directly affects all send, sell, swap, and staking transaction flows — these should be tested thoroughly. The earnYieldUtils change warrants coverage of ETH and SOL staking dashboard tests. The broad utilities (typedObject, calldata builder, bluetooth browser) are unlikely to cause regressions observable in E2E tests unless they introduced breaking API changes. Several files (analytics-docs build script, Storybook stories, SettingsDebug Flags, bluetooth client types, flagsSlice) have no direct test coverage.

<details><summary><b>Changed files (11)</b></summary>

- `packages/analytics-docs/scripts/buildData.ts`
- `packages/product-components/src/components/DeviceAnimation/DeviceAnimation.stories.tsx`
- `packages/suite/src/components/earn/dashboard/utils/earnYieldUtils.ts`
- `packages/suite/src/hooks/wallet/useSendFormCompose.ts`
- `packages/suite/src/views/settings/SettingsDebug/Flags.tsx`
- `packages/transport-bluetooth/src/browser.ts`
- `packages/transport-bluetooth/src/client/types.ts`
- `packages/utils/src/typedObject.ts`
- `suite-common/calldata/src/builder/createBuilder.ts`
- `suite-common/wallet-utils/src/accountUtils.ts`
- `suite/flags/src/flagsSlice.ts`

</details>

**Recommended tests (19)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — useSendFormCompose.ts is the core hook for composing send transactions. This test directly exercises the send form with multiple outputs, locktime options, OP_RETURN, and unit switching — all of which rely on the compose hook's logic.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test exercises Ethereum send form composition with custom gas fees (gas limit, max fee per gas, max priority fee per gas), which directly uses useSendFormCompose. Changes to the compose hook could affect fee calculation and transaction composition.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Tests Solana send-max flow which relies heavily on useSendFormCompose for calculating maximum sendable amount after deducting fees and reserves. A regression in the compose hook would directly break this calculation.
- `suite/e2e/tests/wallet/send-base.test.ts` — Tests sending on Base (EVM L2) with custom Ethereum fees and full transaction confirmation flow. The useSendFormCompose hook is central to composing the transaction, and this test verifies the composed serializedTx Redux state.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Tests sending DOGE amounts exceeding MAX_SAFE_INTEGER via broadcast mode. The compose hook handles amount validation and transaction composition — a change here could affect error handling for large amounts.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Tests LTC send with MimbleWimble peg-out transactions and max amount via broadcast mode. Directly exercises useSendFormCompose for LTC-specific transaction composition.

</details>

<details><summary>🟡 <b>Medium priority (11)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — earnYieldUtils.ts is used in the staking dashboard. This test verifies the full ETH staking flow including staking amounts display and progress indicators, which may consume yield utility outputs.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Tests staking more ETH with dashboard showing staked/pending/rewards amounts. earnYieldUtils.ts provides utility functions for the earn dashboard that this test validates.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Tests ETH unstaking and claiming flow with staking dashboard amount displays. Changes to earnYieldUtils could affect how staked/unstaking/claimable amounts are computed and displayed.
- `suite/e2e/tests/staking/staking-form.test.ts` — Tests ETH staking form validation including min/max amounts, percentage buttons, and crypto/fiat switching. The staking form uses useSendFormCompose for transaction composition, and earnYieldUtils for balance display.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — accountUtils.ts contains account management utilities. This test directly validates adding different account types (normal, taproot, segwit, legacy) and verifying account counts, which likely uses accountUtils functions.
- `suite/e2e/tests/wallet/discovery.test.ts` — accountUtils.ts is core to account discovery and management. This test validates discovery completion across multiple coins and balance visibility, which depends on account utility functions.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation including decimal limits, fraction buttons, and max calculations. The sell form uses useSendFormCompose for transaction composition and fee calculation.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests Bitcoin swap with custom fee settings and verifies composedTransactionInfo Redux state. useSendFormCompose is responsible for composing the transaction that populates this state.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests Ethereum swap with custom gas parameters and verifies composedTransactionInfo. The compose hook directly populates this state when processing the swap transaction.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Tests SOL staking dashboard and initial stake flow. earnYieldUtils may be used for yield/reward calculations in the staking dashboard components.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Tests SOL staking rewards display and updates after epoch advances. earnYieldUtils likely provides utility functions for computing and formatting reward amounts.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/settings/forget-device.test.ts` — The forget-device test includes Bluetooth history/unpairing behavior for TS7 devices. Changes to transport-bluetooth/src/browser.ts could affect Bluetooth state detection, though E2E tests likely mock this layer.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — Tests CSV import into the send form which triggers useSendFormCompose for populating outputs. While the compose hook is changed, CSV import is a distinct entry point that exercises the hook indirectly.

</details>

⚠️ **Changes with no test coverage (5)**
- `packages/analytics-docs/scripts/buildData.ts`
- `packages/product-components/src/components/DeviceAnimation/DeviceAnimation.stories.tsx`
- `packages/suite/src/views/settings/SettingsDebug/Flags.tsx`
- `packages/transport-bluetooth/src/client/types.ts`
- `suite/flags/src/flagsSlice.ts`

_Updated: 2026-06-22T07:28:56.159Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/enforce-typed-object-helpers/web/](https://dev.suite.sldev.cz/suite-web/mroz22/enforce-typed-object-helpers/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/enforce-typed-object-helpers&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/enforce-typed-object-helpers&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-22T07:34:05.681Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-22T07:32:15.355Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

