### PR TITLE
feat: Add flags editor in debug settings

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/Flags.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Flags.tsx
@@ -1,0 +1,37 @@
+import { type FlagsState, selectFlags, setFlag } from '@suite/flags';
+import { Switch } from '@trezor/components';
+import { ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
+
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+type FlagKey = keyof FlagsState;
+
+export const Flags = () => {
+    const dispatch = useDispatch();
+    const flags = useSelector(selectFlags);
+
+    const entries = Object.entries(flags) as [FlagKey, FlagsState[FlagKey]][];
+
+    return (
+        <>
+            {entries.map(([key, value]) => {
+                if (typeof value !== 'boolean') {
+                    return null;
+                }
+
+                const handleChange = () => {
+                    dispatch(setFlag({ key, value: !value }));
+                };
+
+                return (
+                    <SectionItem key={key}>
+                        <TextColumn title={key} />
+                        <ActionColumn>
+                            <Switch isChecked={value} onChange={handleChange} />
+                        </ActionColumn>
+                    </SectionItem>
+                );
+            })}
+        </>
+    );
+};

--- a/packages/suite/src/views/settings/SettingsDebug/PreField.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/PreField.tsx
@@ -1,8 +1,0 @@
-import styled from 'styled-components';
-
-const Pre = styled.pre`
-    line-break: anywhere;
-    white-space: break-spaces;
-`;
-
-export const PreField = ({ children }: { children: string }) => <Pre>{children}</Pre>;

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -1,4 +1,3 @@
-import { selectFlags } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { SuiteSyncSettings, suiteSyncErrorHandler } from '@suite/suite-sync';
 import { Context } from '@suite-common/message-system';
@@ -11,7 +10,7 @@ import { breakpoints } from '@trezor/theme';
 
 import { SettingsLayout } from 'src/components/settings/SettingsLayout';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
-import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 
 import { AnalyticsLogging } from './AnalyticsLogging';
@@ -24,6 +23,7 @@ import { DeviceAuthenticity } from './DeviceAuthenticity';
 import { Devkit } from './Devkit';
 import { EarnApi } from './EarnApi';
 import { FirmwareUpdateEnvironmentSelect } from './FirmwareUpdateEnvironmentSelect';
+import { Flags } from './Flags';
 import { ForgetAllDevicesButton } from './ForgetBluetoothDevices';
 import { GithubIssue } from './GithubIssue';
 import { MessageSystemConfigSourceSelect } from './MessageSystem/MessageSystemConfigSourceSelect';
@@ -33,7 +33,6 @@ import { N4w1Backup } from './N4w1Backup';
 import { OAuthApi } from './OAuthApi';
 import { PingDevice } from './PingDevice';
 import { PlatformEncryption } from './PlatformEncryption';
-import { PreField } from './PreField';
 import { QuotaManagerSettings } from './QuotaManagerSettings';
 import { ResetThpCredentials } from './ResetThpCredentials';
 import { ShowBluetoothDebugInfo } from './ShowBluetoothDebugInfo';
@@ -50,7 +49,6 @@ import { WipeData } from './WipeData';
 export const SettingsDebug = () => {
     const dispatch = useDispatch();
     const hasContentBelowTabletWidth = useIsContentBelowBreakpoint(breakpoints.laptop);
-    const flags = useSelector(selectFlags);
 
     const handleWipeSuiteSyncLabelsError = ({
         error,
@@ -124,8 +122,8 @@ export const SettingsDebug = () => {
             <SettingsSection hasVerticalLayout={hasContentBelowTabletWidth} title="Backends">
                 <Backends />
             </SettingsSection>
-            <SettingsSection hasVerticalLayout={hasContentBelowTabletWidth} title="Flags JSON">
-                <PreField>{JSON.stringify(flags)}</PreField>
+            <SettingsSection hasVerticalLayout={hasContentBelowTabletWidth} title="Flags">
+                <Flags />
             </SettingsSection>
             <SettingsSection hasVerticalLayout={hasContentBelowTabletWidth} title="Metadata">
                 <Metadata />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In debug menu we can easily switch values for debugging purposes.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before

<img width="1484" height="1083" alt="image" src="https://github.com/user-attachments/assets/c5bc7635-84fa-4ad0-90ee-9bf237f7c514" />

after

<img width="1498" height="1096" alt="image" src="https://github.com/user-attachments/assets/fb3c8389-8287-4b5b-b9b3-252bc73805df" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to the Settings Debug view (SettingsDebug.tsx, PreField.tsx, and a new/modified Flags.tsx component). The promo-banner-events test is the highest risk since it directly interacts with the debug tab UI to add banners. The Suite Sync metadata tests are medium risk as they use debug mode during onboarding and are statically linked to the changed files. Flags.tsx has no static test coverage, so any new functionality it introduces is uncovered by existing E2E tests.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/views/settings/SettingsDebug/Flags.tsx`
- `packages/suite/src/views/settings/SettingsDebug/PreField.tsx`
- `packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — This test directly interacts with the Settings Debug tab to add promo banners (settingsPage.debugTab.addBanner), which is rendered by the changed SettingsDebug.tsx component. Changes to the debug settings view could break the banner-adding functionality used in this test.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test completes onboarding with debug mode and interacts with metadata/labeling features that may be configured through the debug settings page. The static mapping links it to both SettingsDebug.tsx and PreField.tsx, suggesting the debug settings UI is part of its flow.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test uses completeOnboarding with debug mode and is statically mapped to both changed files. The debug settings page may be involved in enabling Suite Sync or metadata features during the test setup.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — Statically mapped to SettingsDebug.tsx and PreField.tsx. This test uses debug mode during onboarding and exercises Suite Sync setup, which may rely on debug settings flags or UI elements rendered by the changed components.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — Statically mapped to both changed files. Uses debug mode during onboarding and exercises Suite Sync label removal, which may depend on debug settings configuration rendered by the changed components.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — Statically mapped to both changed files. Tests Suite Sync label syncing from the Evolu relay, which may use debug settings for configuration. Changes to the debug settings view could affect the setup flow.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/views/settings/SettingsDebug/Flags.tsx`

_Updated: 2026-06-18T13:59:34.540Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=add-flags-editor-in-debug&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=add-flags-editor-in-debug&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-18T14:05:26.987Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-18T14:03:20.222Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/add-flags-editor-in-debug/web/](https://dev.suite.sldev.cz/suite-web/add-flags-editor-in-debug/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->