### PR TITLE
Experiment: enable Sentry profiling for web e2e tests

### DIFF
--- a/packages/suite-web/src/MainWeb.tsx
+++ b/packages/suite-web/src/MainWeb.tsx
@@ -23,7 +23,7 @@ import { useConnectPopupWebextension } from 'src/support/suite/useConnectPopupWe
 import { useTor } from 'src/support/suite/useTor';
 
 import { createSuiteWebCompositionRoot } from './createSuiteWebCompositionRoot';
-import { initSentry } from './sentry';
+import { initSentry, initSentryE2E } from './sentry';
 import { usePlaywright } from './support/usePlaywright';
 import { webComponents } from './support/webComponents';
 
@@ -48,7 +48,11 @@ const MainWeb = () => {
 };
 
 export const init = async (container: HTMLElement) => {
-    if (!window.Playwright) {
+    if (window.__SENTRY_E2E_PROFILING__) {
+        // Playwright e2e profiling run: init Sentry with the dedicated e2e config and expose
+        // window.uiProfiler for the harness to drive. See suite/sentry SENTRY_E2E_CONFIG.
+        initSentryE2E();
+    } else if (!window.Playwright) {
         initSentry();
     }
 

--- a/packages/suite-web/src/global.d.ts
+++ b/packages/suite-web/src/global.d.ts
@@ -3,4 +3,11 @@ interface Window {
     Playwright?: any;
     TrezorConnect?: any;
     store?: any;
+    // Set by the Playwright e2e harness to init Sentry with the dedicated e2e profiling config.
+    __SENTRY_E2E_PROFILING__?: boolean;
+    // Exposed by initSentryE2E so the e2e harness can profile each test flow.
+    uiProfiler?: {
+        startProfiler: (meta?: { test?: string; file?: string }) => void;
+        stopProfiler: () => void;
+    };
 }

--- a/packages/suite-web/src/sentry.ts
+++ b/packages/suite-web/src/sentry.ts
@@ -1,6 +1,14 @@
-import { type BrowserOptions, init } from '@sentry/browser';
+import {
+    type BrowserOptions,
+    type Span,
+    init,
+    setContext,
+    setTag,
+    startInactiveSpan,
+    uiProfiler,
+} from '@sentry/browser';
 
-import { SENTRY_BROWSER_CONFIG } from '@suite/sentry';
+import { SENTRY_BROWSER_CONFIG, SENTRY_E2E_CONFIG } from '@suite/sentry';
 
 const BROWSER_SENTRY_CONFIG: BrowserOptions = {
     ...SENTRY_BROWSER_CONFIG,
@@ -12,4 +20,51 @@ const BROWSER_SENTRY_CONFIG: BrowserOptions = {
 
 export const initSentry = () => {
     init(BROWSER_SENTRY_CONFIG);
+};
+
+const E2E_SENTRY_CONFIG: BrowserOptions = {
+    ...SENTRY_E2E_CONFIG,
+    integrations: defaults => [
+        ...defaults.filter(i => i.name !== 'BrowserSession'),
+        ...SENTRY_E2E_CONFIG.integrations,
+    ],
+};
+
+/**
+ * Initializes Sentry for Playwright e2e profiling runs and exposes a `window.uiProfiler` handle that
+ * the e2e harness drives via page.evaluate. Called from MainWeb only when the harness sets
+ * `window.__SENTRY_E2E_PROFILING__`, so normal e2e runs stay Sentry-free.
+ *
+ * Each flow is wrapped in a named root transaction (`e2e: <test>`) so the standalone profile chunk —
+ * which only carries a per-session profiler_id — correlates to a uniquely named transaction in the
+ * Sentry UI, and is tagged with the test name/file for filtering.
+ */
+export const initSentryE2E = () => {
+    init(E2E_SENTRY_CONFIG);
+
+    let flowSpan: Span | undefined;
+
+    window.uiProfiler = {
+        startProfiler: meta => {
+            if (meta?.test) {
+                setTag('e2e.test', meta.test);
+            }
+            if (meta?.file) {
+                setTag('e2e.file', meta.file);
+            }
+            setContext('e2e', meta ?? null);
+
+            uiProfiler.startProfiler();
+            flowSpan = startInactiveSpan({
+                name: `e2e: ${meta?.test ?? 'flow'}`,
+                op: 'e2e.flow',
+                forceTransaction: true,
+            });
+        },
+        stopProfiler: () => {
+            flowSpan?.end();
+            flowSpan = undefined;
+            uiProfiler.stopProfiler();
+        },
+    };
 };

--- a/suite/e2e/support/setup.ts
+++ b/suite/e2e/support/setup.ts
@@ -82,7 +82,10 @@ export const electronTeardown = async (
     await closePromise;
 };
 
-export const webSetup = async (browserContext: BrowserContext) => {
+export const webSetup = async (
+    browserContext: BrowserContext,
+    options?: { sentryProfiling?: boolean },
+) => {
     await TrezorUserEnvLink.startBridge(BRIDGE_VERSION);
 
     // Need to allow this to be able to access bridge on localhost
@@ -98,6 +101,13 @@ export const webSetup = async (browserContext: BrowserContext) => {
     await page.context().addInitScript(() => {
         window.Playwright = true;
     });
+    // Must run before navigation: the app reads this flag at bootstrap to init Sentry with the
+    // dedicated e2e profiling config and expose window.uiProfiler.
+    if (options?.sentryProfiling) {
+        await page.context().addInitScript(() => {
+            window.__SENTRY_E2E_PROFILING__ = true;
+        });
+    }
     await page.goto('./');
     await mockRemoteMessageSystem(page);
 

--- a/suite/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/suite/e2e/support/testExtends/suiteBaseFixture.ts
@@ -33,6 +33,7 @@ type SuiteBaseFixture = {
     jsExceptionWatcher: void;
     toastErrorWatcher: void;
     coverageMapCollector: void;
+    sentryProfiler: void;
 };
 
 // This is the base Suite text fixture containing all the necessary setup and core page object
@@ -54,6 +55,7 @@ const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
     target: [PlaywrightTarget.Web, { option: true }],
     model: [undefined, { option: true }],
     firmwareVersion: [undefined, { option: true }],
+    sentryProfiling: [true, { option: true }],
     startEmulator: true,
     setupEmulator: true,
     deviceSetup: {},
@@ -161,13 +163,13 @@ const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
         }
     },
 
-    page: async ({ target, context, electronApp }, use) => {
+    page: async ({ target, context, electronApp, sentryProfiling }, use) => {
         if (isDesktopProject(target)) {
             const window = await electronApp!.firstWindow();
             enhancePage(window);
             await use(window);
         } else {
-            const page = await webSetup(context);
+            const page = await webSetup(context, { sentryProfiling });
             enhancePage(page);
             await use(page);
         }
@@ -181,6 +183,40 @@ const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
         async ({ page }, use, testInfo) => {
             await use();
             await collectCoverageMap(page, testInfo);
+        },
+        { auto: true },
+    ],
+
+    // Profiles the whole test (incl. beforeEach setup) via Sentry's manual uiProfiler, wrapping it in
+    // a named transaction tagged with the test name so each flow is filterable in Sentry. Enabled for
+    // all web tests by default (sentryProfiling); disabled for desktop (no window.uiProfiler there).
+    // Best-effort: profiling must never fail a test, so every profiler interaction is defensive — if
+    // window.uiProfiler never appears (e.g. app built without the change), profiling is skipped.
+    sentryProfiler: [
+        async ({ target, page, sentryProfiling }, use, testInfo) => {
+            if (!sentryProfiling || isDesktopProject(target)) {
+                await use();
+
+                return;
+            }
+
+            const meta = { test: testInfo.title, file: testInfo.titlePath.join(' › ') };
+            // window.uiProfiler is exposed by the app's initSentryE2E once Sentry has initialized.
+            const profiling = await page
+                .waitForFunction(() => Boolean((window as any).uiProfiler), undefined, {
+                    timeout: 5_000,
+                })
+                .then(() => page.evaluate(m => (window as any).uiProfiler.startProfiler(m), meta))
+                .then(() => true)
+                .catch(() => false);
+
+            await use();
+
+            if (profiling) {
+                await page
+                    .evaluate(() => (window as any).uiProfiler?.stopProfiler())
+                    .catch(() => undefined);
+            }
         },
         { auto: true },
     ],

--- a/suite/e2e/support/testExtends/suiteTestOptions.ts
+++ b/suite/e2e/support/testExtends/suiteTestOptions.ts
@@ -9,4 +9,7 @@ export type SuiteTestOptions = {
     target: PlaywrightTarget;
     model: Model | undefined;
     firmwareVersion: string | undefined;
+    // Profiles the test flow via the dedicated Sentry e2e config. Defaults to true for web tests
+    // (set in suiteBaseFixture) and is ignored for desktop. Set false per test to opt out.
+    sentryProfiling: boolean;
 };

--- a/suite/e2e/support/types/index.ts
+++ b/suite/e2e/support/types/index.ts
@@ -42,6 +42,8 @@ declare global {
         // Needed for Cypress and Playwright
         Playwright?: any;
         store?: any;
+        // Set before navigation to make the app init Sentry with the dedicated e2e profiling config.
+        __SENTRY_E2E_PROFILING__?: boolean;
     }
 }
 

--- a/suite/sentry/src/config.ts
+++ b/suite/sentry/src/config.ts
@@ -102,6 +102,7 @@ export const SENTRY_BROWSER_CONFIG = {
     ...SENTRY_CONFIG,
     profileSessionSampleRate: isCodesignBuild() ? 0.1 : 1,
     tracesSampleRate: isCodesignBuild() ? 0.1 : 1,
+    // 'trace' = real user sessions are profiled automatically around sampled transactions.
     profileLifecycle: 'trace',
     integrations: [
         captureConsoleIntegration({ levels: ['error'] }),
@@ -109,4 +110,22 @@ export const SENTRY_BROWSER_CONFIG = {
         browserTracingIntegration(),
         elementTimingIntegration(),
     ],
+} satisfies BrowserOptions;
+
+/**
+ * Dedicated Sentry config for Playwright e2e profiling runs. See `initSentryE2E` in
+ * packages/suite-web/src/sentry.ts and the `sentryProfiling` fixture in suite/e2e.
+ *
+ * Differences from SENTRY_BROWSER_CONFIG:
+ * - `enabled: true` so profiles are sent even when the app is not a production build.
+ * - `environment: 'e2e-web'` so e2e data can be filtered out from real user data in Sentry
+ *   (a future desktop e2e PoC would use 'e2e-desktop').
+ * - `profileLifecycle: 'manual'` so each test explicitly starts/stops the profiler around its own
+ *   user flow via uiProfiler.startProfiler()/stopProfiler().
+ */
+export const SENTRY_E2E_CONFIG = {
+    ...SENTRY_BROWSER_CONFIG,
+    enabled: true,
+    environment: 'e2e-web',
+    profileLifecycle: 'manual',
 } satisfies BrowserOptions;

--- a/suite/sentry/src/index.ts
+++ b/suite/sentry/src/index.ts
@@ -1,1 +1,1 @@
-export { SENTRY_CONFIG, SENTRY_BROWSER_CONFIG } from './config';
+export { SENTRY_CONFIG, SENTRY_BROWSER_CONFIG, SENTRY_E2E_CONFIG } from './config';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description



## Related Issue

Resolve #28874

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/experiment/e2e-sentry-profiling/web/](https://dev.suite.sldev.cz/suite-web/experiment/e2e-sentry-profiling/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=experiment/e2e-sentry-profiling&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=experiment/e2e-sentry-profiling&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-19T11:01:31.190Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-19T10:59:56.837Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->