### PR TITLE
fix(connect): make _updateCurrentRelease await

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -668,14 +668,14 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
             payload,
         );
         this._updateFeatures(message);
-        this._updateCurrentRelease(message);
+        await this._updateCurrentRelease(message);
         this.setState({ deriveCardano: payload?.derive_cardano });
     }
 
     async getFeatures() {
         const { message } = await this.getCurrentSession().typedCall('GetFeatures', 'Features', {});
         this._updateFeatures(message);
-        this._updateCurrentRelease(message);
+        await this._updateCurrentRelease(message);
     }
 
     getAuthenticityChecks() {
@@ -788,14 +788,18 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
                 feat,
                 getFirmwareType(feat),
             );
-            // Here we update `currentRelease` in case of a release JSON that was bundled.
-            // In case it was not bundled it will be fetched after `_updateFeatures` by `_updateCurrentRelease`.
-            this._currentRelease = getReleaseAsset(
-                feat.internal_model,
-                newVersion,
-                getFirmwareType(feat),
-            );
-            this.availableTranslations = this._currentRelease?.translations ?? {};
+            // Bundled release JSONs are production assets, so only seed `currentRelease`
+            // from them on production-like channels. On other channels the
+            // channel-appropriate release is fetched from remote immediately after,
+            // by the awaited `_updateCurrentRelease`.
+            if (isProductionFirmwareChannel(settingsStore.get('firmwareChannel'))) {
+                this._currentRelease = getReleaseAsset(
+                    feat.internal_model,
+                    newVersion,
+                    getFirmwareType(feat),
+                );
+                this.availableTranslations = this._currentRelease?.translations ?? {};
+            }
         }
 
         this._features = feat;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

We had the metod _updateCurrentRelease that was called without await even if it was async method

Here we are awaiting it and also not trying to get _currentRelease from the bundled assets when it is not production.


Follow-up to https://github.com/trezor/trezor-suite/pull/28807

## Notes for QA

Make sure firmware updated and language change works properly in all FW channels.


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Device.ts is a core infrastructure file in @trezor/connect that manages device sessions, connection state, passphrase handling, and communication with Trezor hardware. It maps to all 121 E2E tests, indicating it's a fundamental dependency. The recommended strategy focuses on tests that directly exercise device lifecycle events (connect/disconnect/reconnect), session management (multi-session, bridge stealing), passphrase state, and recovery/backup flows where device state transitions are critical. Tests involving simple UI navigation or analytics without device state changes are omitted despite the static mapping.

<details><summary><b>Changed files (1)</b></summary>

- `packages/connect/src/device/Device.ts`

</details>

**Recommended tests (21)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test directly validates DeviceConnect and DeviceDisconnect events which depend on Device.ts for device state (mode, firmware, backup_type, pin_protection, passphrase_protection, model, optiga_sec). Changes to Device.ts could alter device metadata reported in these events.
- `suite/e2e/tests/backup/t2t1-fail.test.ts` — Tests device disconnect/reconnect during backup, directly exercising Device.ts power-off/power-on lifecycle, device state transitions, and error handling when the device connection is interrupted mid-operation.
- `suite/e2e/tests/backup/t2t1-success.test.ts` — Tests the full backup flow requiring device communication (confirmation prompts, seed backup). Device.ts handles the device session and command dispatching that this flow depends on.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — Tests device disconnect/reconnect persistence during recovery mode, including IndexedDB reset and page reload. Device.ts manages recovery mode state and session persistence that this test directly exercises.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Directly tests Bridge session acquire/steal/reclaim behavior between multiple tabs. Device.ts manages session acquisition and the 'use here' state that this test validates.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Tests device disconnect and reconnect with passphrase caching. Device.ts manages passphrase state and session resumption after reconnection, which is the core behavior being tested.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Tests wallet discovery after device ejection and re-addition. Device.ts manages the device state during eject/add cycles and is critical to discovery initialization.

</details>

<details><summary>🟡 <b>Medium priority (12)</b></summary>

- `suite/e2e/tests/backup/t2t1-misc.test.ts` — Tests backup behavior when device is disconnected (remembered device scenario). Device.ts handles the remembered device state and the 'no-device' detection during backup.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts` — Tests device disconnection during recovery flow and retry. Device.ts manages device connection state transitions that trigger the connect/disconnect prompts tested here.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts` — Tests T1B1 device disconnect during recovery and retry flow. Device.ts handles device reconnection logic that enables the retry mechanism.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — Tests entropy check failure handling including device compromised detection. Device.ts likely participates in entropy check validation and the simulated failure dispatch path.
- `suite/e2e/tests/recovery/dry-run.test.ts` — Tests recovery dry run with device disconnect (bridge stop/start) and page reload persistence. Device.ts manages session state during bridge interruptions.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — Tests passphrase entry after device restart for Cardano address reveal. Device.ts manages passphrase state and device reconnection flow that triggers re-entry.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Tests passphrase mismatch detection, caching, and wallet switching. Device.ts manages passphrase state and device communication for hidden wallet creation.
- `suite/e2e/tests/suite/initial-run.test.ts` — Tests THP pairing flow and device connection state persistence across reloads. Device.ts handles THP protocol negotiation and connection state management.
- `suite/e2e/tests/wallet/discovery.test.ts` — Tests discovery with page reload interruption across multiple coin networks. Device.ts manages the device session that discovery depends on, and reload recovery exercises session reacquisition.
- `suite/e2e/tests/wallet/without-device.test.ts` — Tests UI behavior when device is disconnected mid-flow (connection modal, disconnected banner). Device.ts state changes drive the disconnected status indicators validated here.
- `suite/e2e/tests/settings/passphrase.test.ts` — Tests enabling passphrase protection via device settings with on-device confirmation. Device.ts handles the passphrase enable command dispatching to the device.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts` — Tests device disconnect during advanced recovery and retry with different word count. Device.ts manages reconnection and recovery mode state transitions.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-cancel.test.ts` — Tests canceling passphrase confirmation on device prompt. Device.ts handles the device confirmation cancel flow, though this is a simpler path than reconnection scenarios.
- `suite/e2e/tests/firmware/custom-firmware.test.ts` — Tests custom firmware installation requiring device reconnection afterwards. Device.ts manages the device state during firmware update and reconnection.

</details>

_Updated: 2026-06-18T14:38:15.864Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/update-current-release-fix/web/](https://dev.suite.sldev.cz/suite-web/update-current-release-fix/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=update-current-release-fix&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=update-current-release-fix&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=update-current-release-fix&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-18T14:43:42.266Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-18T14:41:30.475Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->