### PR TITLE
feat(suite): implement tron staking dashboard

### DIFF
--- a/packages/suite/src/views/wallet/staking/WalletStaking.tsx
+++ b/packages/suite/src/views/wallet/staking/WalletStaking.tsx
@@ -7,6 +7,7 @@ import { useSelector } from 'src/hooks/suite';
 import { AdaStakingDashboard } from './components/AdaStakingDashboard/AdaStakingDashboard';
 import { EthStakingDashboard } from './components/EthStakingDashboard/EthStakingDashboard';
 import { SolStakingDashboard } from './components/SolStakingDashboard/SolStakingDashboard';
+import { TronStakingDashboard } from './components/TronStakingDashboard/TronStakingDashboard';
 
 export const WalletStaking = () => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
@@ -23,6 +24,8 @@ export const WalletStaking = () => {
                 return <EthStakingDashboard selectedAccount={selectedAccount} />;
             case 'solana':
                 return <SolStakingDashboard selectedAccount={selectedAccount} />;
+            case 'tron':
+                return <TronStakingDashboard selectedAccount={selectedAccount} />;
             // no default
         }
     }

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourceBreakdownRow.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourceBreakdownRow.tsx
@@ -1,0 +1,37 @@
+import { Translation, type TranslationKey } from '@suite/intl';
+import { Row, Text, Tooltip } from '@trezor/components';
+
+export interface TronResourceBreakdownRowProps {
+    label: TranslationKey;
+    value: number;
+    tooltip?: TranslationKey;
+    isDeduction?: boolean;
+}
+
+export const TronResourceBreakdownRow = ({
+    label,
+    value,
+    tooltip,
+    isDeduction,
+}: TronResourceBreakdownRowProps) => {
+    const labelText = (
+        <Text typographyStyle="body-md" intent="neutral" priority="secondary">
+            <Translation id={label} />
+        </Text>
+    );
+
+    return (
+        <Row justifyContent="space-between">
+            {tooltip ? (
+                <Tooltip hasIcon content={<Translation id={tooltip} />}>
+                    {labelText}
+                </Tooltip>
+            ) : (
+                labelText
+            )}
+            <Text typographyStyle="body-md" intent="neutral" priority="secondary">
+                {isDeduction && value > 0 ? `-${value}` : value}
+            </Text>
+        </Row>
+    );
+};

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourceModal.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourceModal.tsx
@@ -1,0 +1,172 @@
+import { Translation } from '@suite/intl';
+import { goto } from '@suite/router';
+import { type Account, type TronResourceType } from '@suite-common/wallet-types';
+import {
+    getResourceGain,
+    getTronResources,
+    getTronStakingInfo,
+    sunToTrx,
+} from '@suite-common/wallet-utils';
+import { Button, Card, Column, Divider, Icon, Modal, Row, Text } from '@trezor/components';
+
+import { useDispatch } from 'src/hooks/suite';
+
+import {
+    TronResourceBreakdownRow,
+    type TronResourceBreakdownRowProps,
+} from './TronResourceBreakdownRow';
+
+interface TronResourceModalProps {
+    account: Account;
+    resourceType: TronResourceType;
+    onClose: () => void;
+}
+
+export const TronResourceModal = ({ account, resourceType, onClose }: TronResourceModalProps) => {
+    const dispatch = useDispatch();
+    const resources = getTronResources(account);
+    const stakingInfo = getTronStakingInfo(account);
+    const isEnergy = resourceType === 'energy';
+
+    const freeBandwidth = resources?.totalFreeBandwidth ?? 0;
+    const stakedBandwidth = resources?.totalStakedBandwidth ?? 0;
+    const availableFreeBandwidth = resources?.availableFreeBandwidth ?? 0;
+    const availableStakedBandwidth = resources?.availableStakedBandwidth ?? 0;
+
+    const totalEnergy = resources?.totalEnergy ?? 0;
+    const availableEnergy = resources?.availableEnergy ?? 0;
+
+    const delegatedSun = isEnergy
+        ? (stakingInfo?.delegatedBalanceEnergy ?? '0')
+        : (stakingInfo?.delegatedBalanceBandwidth ?? '0');
+    const delegatedTrx = sunToTrx(delegatedSun, account.symbol);
+    const delegatedToOthers = Math.round(
+        getResourceGain(delegatedTrx, resourceType, resources) ?? 0,
+    );
+
+    const rows: TronResourceBreakdownRowProps[] = isEnergy
+        ? [
+              { label: 'TR_EARN_TRON_RESOURCE_FROM_STAKING', value: totalEnergy },
+              {
+                  label: 'TR_EARN_TRON_RESOURCE_DELEGATED_TO_OTHERS',
+                  value: delegatedToOthers,
+                  isDeduction: true,
+              },
+          ]
+        : [
+              {
+                  label: 'TR_EARN_TRON_RESOURCE_FREE',
+                  value: freeBandwidth,
+                  tooltip: 'TR_EARN_TRON_FREE_BANDWIDTH_TOOLTIP',
+              },
+              { label: 'TR_EARN_TRON_RESOURCE_FROM_STAKING', value: stakedBandwidth },
+              {
+                  label: 'TR_EARN_TRON_RESOURCE_DELEGATED_TO_OTHERS',
+                  value: delegatedToOthers,
+                  isDeduction: true,
+              },
+          ];
+
+    const hasStakedBandwidth = stakedBandwidth > 0;
+    const formatBandwidthValue = (free: number, staked: number) =>
+        hasStakedBandwidth ? `${free} + ${staked}` : `${free}`;
+
+    const total = isEnergy
+        ? `${totalEnergy}`
+        : formatBandwidthValue(freeBandwidth, stakedBandwidth);
+    const available = isEnergy
+        ? `${availableEnergy}`
+        : formatBandwidthValue(availableFreeBandwidth, availableStakedBandwidth);
+
+    const goToFreeze = () => {
+        dispatch(
+            goto({
+                routeName: 'earn-tron-stake',
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
+        onClose();
+    };
+
+    return (
+        <Modal
+            width={400}
+            heading={
+                <Translation
+                    id={isEnergy ? 'TR_EARN_TRON_MY_ENERGY' : 'TR_EARN_TRON_MY_BANDWIDTH'}
+                />
+            }
+            onCancel={onClose}
+            bottomContent={
+                <Row gap={8}>
+                    <Button intent="brand" priority="primary" onClick={goToFreeze}>
+                        <Translation id="TR_EARN_TRON_GET_MORE" />
+                    </Button>
+                    <Button intent="neutral" priority="secondary" onClick={onClose}>
+                        <Translation id="TR_CLOSE" />
+                    </Button>
+                </Row>
+            }
+        >
+            <Column gap={12} alignItems="stretch">
+                <Card>
+                    <Column gap={12} alignItems="stretch">
+                        {rows.map(row => (
+                            <TronResourceBreakdownRow key={row.label} {...row} />
+                        ))}
+
+                        <Divider margin={{}} />
+
+                        <Column gap={4} alignItems="stretch">
+                            <Row justifyContent="space-between">
+                                <Text typographyStyle="body-md-strong">
+                                    <Translation
+                                        id={
+                                            isEnergy
+                                                ? 'TR_EARN_TRON_TOTAL_ENERGY'
+                                                : 'TR_EARN_TRON_TOTAL_BANDWIDTH'
+                                        }
+                                    />
+                                </Text>
+                                <Text typographyStyle="body-md-strong">{total}</Text>
+                            </Row>
+                            <Row justifyContent="space-between">
+                                <Text
+                                    typographyStyle="body-sm"
+                                    intent="neutral"
+                                    priority="secondary"
+                                >
+                                    <Translation id="TR_EARN_TRON_AVAILABLE_NOW" />
+                                </Text>
+                                <Text
+                                    typographyStyle="body-sm"
+                                    intent="neutral"
+                                    priority="secondary"
+                                >
+                                    {available}
+                                </Text>
+                            </Row>
+                        </Column>
+                    </Column>
+                </Card>
+
+                <Row gap={8} alignItems="center">
+                    <Icon name="info" size={20} intent="neutral" priority="secondary" />
+                    <Text typographyStyle="body-md" intent="neutral" priority="secondary">
+                        <Translation
+                            id={
+                                isEnergy
+                                    ? 'TR_EARN_TRON_ENERGY_BALANCE_NOTE'
+                                    : 'TR_EARN_TRON_BANDWIDTH_BALANCE_NOTE'
+                            }
+                        />
+                    </Text>
+                </Row>
+            </Column>
+        </Modal>
+    );
+};

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourceRow.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourceRow.tsx
@@ -1,0 +1,40 @@
+import { Translation, type TranslationKey } from '@suite/intl';
+import { Box, ProgressBar, Row, Text, TextButton, Tooltip } from '@trezor/components';
+
+interface TronResourceRowProps {
+    label: TranslationKey;
+    tooltip: TranslationKey;
+    available: number;
+    total: number;
+    onClick: () => void;
+}
+
+export const TronResourceRow = ({
+    label,
+    tooltip,
+    available,
+    total,
+    onClick,
+}: TronResourceRowProps) => (
+    <Row justifyContent="space-between" alignItems="center">
+        <Tooltip hasIcon content={<Translation id={tooltip} />}>
+            <Text typographyStyle="body-sm">
+                <Translation id={label} />
+            </Text>
+        </Tooltip>
+        <Row gap={12} alignItems="center">
+            <TextButton
+                size="small"
+                intent="neutral"
+                priority="primary"
+                isUnderlined
+                onClick={onClick}
+            >
+                {available}/{total}
+            </TextButton>
+            <Box width={120}>
+                <ProgressBar value={available} max={Math.max(total, 1)} />
+            </Box>
+        </Row>
+    </Row>
+);

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+
+import { Translation } from '@suite/intl';
+import { goto } from '@suite/router';
+import { type Account, type TronResourceType } from '@suite-common/wallet-types';
+import { getTronResources } from '@suite-common/wallet-utils';
+import { Button, Card, Column, Icon, Row, Text } from '@trezor/components';
+
+import { useDispatch } from 'src/hooks/suite';
+
+import { TronResourceModal } from '../TronResourceModal';
+import { TronResourceRow } from './TronResourceRow';
+
+interface TronResourcesCardProps {
+    account: Account;
+}
+
+export const TronResourcesCard = ({ account }: TronResourcesCardProps) => {
+    const dispatch = useDispatch();
+    const [openResource, setOpenResource] = useState<TronResourceType | null>(null);
+    const resources = getTronResources(account);
+
+    const bandwidthAvailable =
+        (resources?.availableStakedBandwidth ?? 0) + (resources?.availableFreeBandwidth ?? 0);
+    const bandwidthTotal =
+        (resources?.totalStakedBandwidth ?? 0) + (resources?.totalFreeBandwidth ?? 0);
+    const energyAvailable = resources?.availableEnergy ?? 0;
+    const energyTotal = resources?.totalEnergy ?? 0;
+
+    const goToFreeze = () =>
+        dispatch(
+            goto({
+                routeName: 'earn-tron-stake',
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
+
+    return (
+        <Card
+            paddingType="normal"
+            header={
+                <Row gap={8} alignItems="center">
+                    <Icon name="lightning" size={20} />
+                    <Text typographyStyle="body-md-strong">
+                        <Translation id="TR_EARN_TRON_RESOURCES" />
+                    </Text>
+                </Row>
+            }
+            footer={
+                <Button intent="neutral" priority="secondary" onClick={goToFreeze}>
+                    <Translation id="TR_EARN_TRON_GET_MORE" />
+                </Button>
+            }
+        >
+            <Column gap={16} alignItems="stretch">
+                <TronResourceRow
+                    label="TR_TRON_BANDWIDTH"
+                    tooltip="TR_TRON_BANDWIDTH_TOOLTIP"
+                    available={bandwidthAvailable}
+                    total={bandwidthTotal}
+                    onClick={() => setOpenResource('bandwidth')}
+                />
+                <TronResourceRow
+                    label="TR_TRON_ENERGY"
+                    tooltip="TR_TRON_ENERGY_TOOLTIP"
+                    available={energyAvailable}
+                    total={energyTotal}
+                    onClick={() => setOpenResource('energy')}
+                />
+            </Column>
+
+            {openResource && (
+                <TronResourceModal
+                    account={account}
+                    resourceType={openResource}
+                    onClose={() => setOpenResource(null)}
+                />
+            )}
+        </Card>
+    );
+};

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx
@@ -1,0 +1,144 @@
+import { Translation } from '@suite/intl';
+import { goto } from '@suite/router';
+import { getTronVotedApr, useTronStakingStats } from '@suite-common/earn-staking-api';
+import { type Account } from '@suite-common/wallet-types';
+import {
+    getTronAccountTotalStakingBalance,
+    getTronAvailableVotingPower,
+    getTronTotalVotingPower,
+    getTronVotes,
+} from '@suite-common/wallet-utils';
+import {
+    Button,
+    Card,
+    Column,
+    IconCircle,
+    Row,
+    Text,
+    TextButton,
+    Tooltip,
+} from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { formatApr } from 'src/components/earn/staking/tron/voteUtils';
+import { BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
+import { useDispatch } from 'src/hooks/suite';
+
+interface TronStakedCardProps {
+    account: Account;
+}
+
+export const TronStakedCard = ({ account }: TronStakedCardProps) => {
+    const dispatch = useDispatch();
+    const { stats, maxApr } = useTronStakingStats();
+
+    const stakedBalance = getTronAccountTotalStakingBalance(account) ?? '0';
+    const hasStake = new BigNumber(stakedBalance).gt(0);
+    const votedAddresses = getTronVotes(account).map(vote => vote.address);
+    const apr = votedAddresses.length > 0 ? getTronVotedApr(stats.data, votedAddresses) : maxApr;
+    const remainingVotes = getTronAvailableVotingPower(account);
+    const totalVotes = getTronTotalVotingPower(account);
+    const hasRemainingVotes = new BigNumber(remainingVotes).gt(0);
+
+    const goToFlow = (routeName: 'earn-tron-stake' | 'earn-tron-unstake' | 'earn-tron-vote') =>
+        dispatch(
+            goto({
+                routeName,
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
+
+    return (
+        <Card
+            paddingType="normal"
+            header={
+                <Column gap={2} alignItems="flex-start">
+                    <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                        <Translation id="TR_EARN_TRON_STAKED" />
+                    </Text>
+                    <Text typographyStyle="headline-sm">
+                        <FormattedCryptoAmount value={stakedBalance} symbol={account.symbol} />
+                    </Text>
+                    <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                        <BaseCurrencyValue
+                            amount={stakedBalance}
+                            symbol={account.symbol}
+                            showApproximationIndicator
+                        />
+                    </Text>
+                </Column>
+            }
+            footer={
+                <Row gap={8}>
+                    <Button
+                        intent="brand"
+                        priority="primary"
+                        onClick={() => goToFlow('earn-tron-stake')}
+                    >
+                        <Translation
+                            id={
+                                hasStake
+                                    ? 'TR_EARN_STAKING_DASHBOARD_STAKE_MORE'
+                                    : 'TR_EARN_STAKING_DASHBOARD_STAKE_NOW'
+                            }
+                        />
+                    </Button>
+                    {hasStake && (
+                        <Button
+                            intent="neutral"
+                            priority="secondary"
+                            onClick={() => goToFlow('earn-tron-unstake')}
+                        >
+                            <Translation id="TR_EARN_TRON_UNSTAKE_TITLE" />
+                        </Button>
+                    )}
+                    {hasStake && (
+                        <Button
+                            intent="neutral"
+                            priority="secondary"
+                            onClick={() => goToFlow('earn-tron-vote')}
+                        >
+                            <Translation id="TR_EARN_TRON_VOTE" />
+                        </Button>
+                    )}
+                </Row>
+            }
+        >
+            <Row justifyContent="space-between" alignItems="center">
+                <Text typographyStyle="body-md-strong">
+                    <Translation id="TR_EARN_TRON_APR_LABEL" /> {formatApr(apr ?? undefined)}
+                </Text>
+                {hasRemainingVotes ? (
+                    <Tooltip content={<Translation id="TR_EARN_TRON_ASSIGN_VOTES_TOOLTIP" />}>
+                        <Row gap={4} alignItems="center">
+                            <IconCircle name="warning" size={24} intent="warning" />
+                            <TextButton
+                                size="small"
+                                intent="neutral"
+                                priority="secondary"
+                                isUnderlined
+                                onClick={() => goToFlow('earn-tron-vote')}
+                            >
+                                <Translation
+                                    id="TR_EARN_TRON_VOTES_TO_ALLOCATE"
+                                    values={{ count: remainingVotes }}
+                                />
+                            </TextButton>
+                        </Row>
+                    </Tooltip>
+                ) : (
+                    <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                        <Translation
+                            id="TR_EARN_TRON_REMAINING_VOTES"
+                            values={{ remaining: remainingVotes, total: totalVotes }}
+                        />
+                    </Text>
+                )}
+            </Row>
+        </Card>
+    );
+};

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakingDashboard.tsx
@@ -1,0 +1,42 @@
+import { Translation } from '@suite/intl';
+import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
+import { Column, Row, TextButton } from '@trezor/components';
+
+import { WalletLayout } from 'src/components/wallet';
+
+import { TronResourcesCard } from './TronResourcesCard/TronResourcesCard';
+import { TronStakedCard } from './TronStakedCard';
+import { TronUnstakingCard } from './TronUnstakingCard';
+import { TronVotingRewardsCard } from './TronVotingRewardsCard';
+import { TronWithdrawReadyBanner } from './TronWithdrawReadyBanner';
+
+interface TronStakingDashboardProps {
+    selectedAccount: SelectedAccountLoaded;
+}
+
+export const TronStakingDashboard = ({ selectedAccount }: TronStakingDashboardProps) => {
+    const { account } = selectedAccount;
+
+    return (
+        <WalletLayout title="TR_NAV_STAKING" account={selectedAccount}>
+            <Column
+                gap={12}
+                alignItems="stretch"
+                width="100%"
+                maxWidth={560}
+                margin={{ horizontal: 'auto' }}
+            >
+                <TronWithdrawReadyBanner account={account} />
+                <TronUnstakingCard account={account} />
+                <TronVotingRewardsCard account={account} />
+                <TronStakedCard account={account} />
+                <TronResourcesCard account={account} />
+                <Row justifyContent="center" padding={{ vertical: 20 }}>
+                    <TextButton size="small" iconLeft="question" isUnderlined>
+                        <Translation id="TR_EARN_TRON_HOW_IT_WORKS" />
+                    </TextButton>
+                </Row>
+            </Column>
+        </WalletLayout>
+    );
+};

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronUnstakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronUnstakingCard.tsx
@@ -1,0 +1,46 @@
+import { Translation } from '@suite/intl';
+import { type Account } from '@suite-common/wallet-types';
+import { getTronPendingUnstakeBalance, getUnstakingPeriodInDays } from '@suite-common/wallet-utils';
+import { Box, Card, Column, Row, Text } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
+
+interface TronUnstakingCardProps {
+    account: Account;
+}
+
+export const TronUnstakingCard = ({ account }: TronUnstakingCardProps) => {
+    const pendingAmount = getTronPendingUnstakeBalance(account);
+
+    if (new BigNumber(pendingAmount).lte(0)) {
+        return null;
+    }
+
+    return (
+        <Card paddingType="none">
+            <Box padding={{ vertical: 12, horizontal: 20 }}>
+                <Row justifyContent="space-between" alignItems="center">
+                    <Text typographyStyle="body-sm-strong">
+                        <Translation
+                            id="TR_EARN_TRON_UNSTAKING"
+                            values={{ days: getUnstakingPeriodInDays(account.networkType) }}
+                        />
+                    </Text>
+                    <Column gap={2} alignItems="flex-end">
+                        <Text typographyStyle="body-md-strong">
+                            <FormattedCryptoAmount value={pendingAmount} symbol={account.symbol} />
+                        </Text>
+                        <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                            <BaseCurrencyValue
+                                amount={pendingAmount}
+                                symbol={account.symbol}
+                                showApproximationIndicator
+                            />
+                        </Text>
+                    </Column>
+                </Row>
+            </Box>
+        </Card>
+    );
+};

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx
@@ -1,0 +1,48 @@
+import { Translation } from '@suite/intl';
+import { type Account } from '@suite-common/wallet-types';
+import { getTronStakingRewards } from '@suite-common/wallet-utils';
+import { Box, Button, Card, Column, Row, Text } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
+
+interface TronVotingRewardsCardProps {
+    account: Account;
+}
+
+export const TronVotingRewardsCard = ({ account }: TronVotingRewardsCardProps) => {
+    const rewards = getTronStakingRewards(account);
+
+    if (new BigNumber(rewards).lte(0)) {
+        return null;
+    }
+
+    return (
+        <Card paddingType="none">
+            <Box padding={{ vertical: 12, horizontal: 20 }}>
+                <Row justifyContent="space-between" alignItems="center">
+                    <Text typographyStyle="body-sm-strong">
+                        <Translation id="TR_EARN_TRON_VOTING_REWARDS" />
+                    </Text>
+                    <Row gap={16} alignItems="center">
+                        <Column gap={2} alignItems="flex-end">
+                            <Text typographyStyle="body-md-strong">
+                                <FormattedCryptoAmount value={rewards} symbol={account.symbol} />
+                            </Text>
+                            <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                                <BaseCurrencyValue
+                                    amount={rewards}
+                                    symbol={account.symbol}
+                                    showApproximationIndicator
+                                />
+                            </Text>
+                        </Column>
+                        <Button intent="brand" priority="primary" isDisabled>
+                            <Translation id="TR_STAKE_CLAIM" />
+                        </Button>
+                    </Row>
+                </Row>
+            </Box>
+        </Card>
+    );
+};

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronWithdrawReadyBanner.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronWithdrawReadyBanner.tsx
@@ -1,0 +1,59 @@
+import { Translation } from '@suite/intl';
+import { goto } from '@suite/router';
+import { type Account } from '@suite-common/wallet-types';
+import { getTronWithdrawableBalance } from '@suite-common/wallet-utils';
+import { Banner } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { FormattedCryptoAmount } from 'src/components/suite';
+import { useDispatch } from 'src/hooks/suite';
+
+interface TronWithdrawReadyBannerProps {
+    account: Account;
+}
+
+export const TronWithdrawReadyBanner = ({ account }: TronWithdrawReadyBannerProps) => {
+    const dispatch = useDispatch();
+    const withdrawableAmount = getTronWithdrawableBalance(account);
+
+    if (new BigNumber(withdrawableAmount).lte(0)) {
+        return null;
+    }
+
+    const goToWithdraw = () =>
+        dispatch(
+            goto({
+                routeName: 'earn-tron-withdraw',
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
+
+    return (
+        <Banner
+            icon
+            intent="info"
+            rightContent={
+                <Banner.Button onClick={goToWithdraw}>
+                    <Translation id="TR_EARN_TRON_WITHDRAW_TITLE" />
+                </Banner.Button>
+            }
+            description={
+                <Translation
+                    id="TR_EARN_TRON_WITHDRAW_READY"
+                    values={{
+                        amount: (
+                            <FormattedCryptoAmount
+                                value={withdrawableAmount}
+                                symbol={account.symbol}
+                            />
+                        ),
+                    }}
+                />
+            }
+        />
+    );
+};

--- a/suite-common/wallet-utils/src/tronStakingUtils.ts
+++ b/suite-common/wallet-utils/src/tronStakingUtils.ts
@@ -23,7 +23,7 @@ export function isSupportedTronStakingNetworkSymbol(
     return isArrayMember(symbol, supportedTronNetworkSymbols);
 }
 
-const sunToTrx = (sun: string, symbol: NetworkSymbol) =>
+export const sunToTrx = (sun: string, symbol: NetworkSymbol) =>
     subunitsToUnits({
         value: asAmountSubunit(new BigNumber(sun)),
         symbol,

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10339,6 +10339,87 @@ export const messages = defineMessages({
         id: 'TR_EARN_TRON_STAKED',
         defaultMessage: 'Staked',
     },
+    TR_EARN_TRON_REMAINING_VOTES: {
+        id: 'TR_EARN_TRON_REMAINING_VOTES',
+        defaultMessage: '{remaining}/{total} remaining votes',
+    },
+    TR_EARN_TRON_VOTES_TO_ALLOCATE: {
+        id: 'TR_EARN_TRON_VOTES_TO_ALLOCATE',
+        defaultMessage: '{count} remaining votes',
+    },
+    TR_EARN_TRON_ASSIGN_VOTES_TOOLTIP: {
+        id: 'TR_EARN_TRON_ASSIGN_VOTES_TOOLTIP',
+        defaultMessage: 'Assign all votes to earn more rewards.',
+    },
+    TR_EARN_TRON_UNSTAKING: {
+        id: 'TR_EARN_TRON_UNSTAKING',
+        defaultMessage: 'Unstaking (~{days} days)',
+    },
+    TR_EARN_TRON_VOTING_REWARDS: {
+        id: 'TR_EARN_TRON_VOTING_REWARDS',
+        defaultMessage: 'Voting rewards',
+    },
+    TR_EARN_TRON_WITHDRAW_READY: {
+        id: 'TR_EARN_TRON_WITHDRAW_READY',
+        defaultMessage: '{amount} unstaked & ready to be withdrawn',
+    },
+    TR_EARN_TRON_HOW_IT_WORKS: {
+        id: 'TR_EARN_TRON_HOW_IT_WORKS',
+        defaultMessage: 'How does TRX staking work?',
+    },
+    TR_EARN_TRON_MY_ENERGY: {
+        id: 'TR_EARN_TRON_MY_ENERGY',
+        defaultMessage: 'My energy',
+    },
+    TR_EARN_TRON_MY_BANDWIDTH: {
+        id: 'TR_EARN_TRON_MY_BANDWIDTH',
+        defaultMessage: 'My bandwidth',
+    },
+    TR_EARN_TRON_RESOURCE_FROM_STAKING: {
+        id: 'TR_EARN_TRON_RESOURCE_FROM_STAKING',
+        defaultMessage: 'From staking',
+    },
+    TR_EARN_TRON_RESOURCE_FREE: {
+        id: 'TR_EARN_TRON_RESOURCE_FREE',
+        defaultMessage: 'Free',
+    },
+    TR_EARN_TRON_RESOURCE_DELEGATED_TO_OTHERS: {
+        id: 'TR_EARN_TRON_RESOURCE_DELEGATED_TO_OTHERS',
+        defaultMessage: 'Delegated to others',
+    },
+    TR_EARN_TRON_FREE_BANDWIDTH_TOOLTIP: {
+        id: 'TR_EARN_TRON_FREE_BANDWIDTH_TOOLTIP',
+        defaultMessage:
+            'Each account includes free bandwidth. For any transaction, you can use free or earned bandwidth, not both.',
+    },
+    TR_EARN_TRON_TOTAL_ENERGY: {
+        id: 'TR_EARN_TRON_TOTAL_ENERGY',
+        defaultMessage: 'Total energy',
+    },
+    TR_EARN_TRON_TOTAL_BANDWIDTH: {
+        id: 'TR_EARN_TRON_TOTAL_BANDWIDTH',
+        defaultMessage: 'Total bandwidth',
+    },
+    TR_EARN_TRON_AVAILABLE_NOW: {
+        id: 'TR_EARN_TRON_AVAILABLE_NOW',
+        defaultMessage: 'Available now',
+    },
+    TR_EARN_TRON_ENERGY_BALANCE_NOTE: {
+        id: 'TR_EARN_TRON_ENERGY_BALANCE_NOTE',
+        defaultMessage: 'Energy balances may change with network activity and reward rates.',
+    },
+    TR_EARN_TRON_BANDWIDTH_BALANCE_NOTE: {
+        id: 'TR_EARN_TRON_BANDWIDTH_BALANCE_NOTE',
+        defaultMessage: 'Bandwidth balances may change with network activity and reward rates.',
+    },
+    TR_EARN_TRON_RESOURCES: {
+        id: 'TR_EARN_TRON_RESOURCES',
+        defaultMessage: 'Resources',
+    },
+    TR_EARN_TRON_GET_MORE: {
+        id: 'TR_EARN_TRON_GET_MORE',
+        defaultMessage: 'Get more',
+    },
     TR_EARN_TRON_RESOURCE_REDUCTION: {
         id: 'TR_EARN_TRON_RESOURCE_REDUCTION',
         defaultMessage: 'Resource reduction',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR implements the Tron staking dashboard

- **Withdraw-ready banner** — unstaked TRX past the 14-day window, with a Withdraw CTA
- **Unstaking (~14 days)** — TRX still in the unfreeze queue (hidden when none)
- **Voting rewards** — unclaimed rewards with a (currently disabled) Claim button (hidden when none)
- **Staked** — staked balance, voted-SR APR, remaining-votes nudge, and Stake / Unstake / Vote actions (Stake-only when nothing's staked yet)
- **Resources** — bandwidth & energy usage; each row opens a breakdown modal (sources, total, available)


## Notes for QA

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26910

## Screenshots:

### Dashboard
<img width="896" height="946" alt="Screenshot 2026-06-18 at 17 23 10" src="https://github.com/user-attachments/assets/937e9a2d-30ce-4b42-9788-136e2a682fcd" />

### Bandwidth modal
<img width="411" height="425" alt="Screenshot 2026-06-18 at 17 23 52" src="https://github.com/user-attachments/assets/61f45c10-7101-440d-92af-06deafed7b93" />

### Energy modal
<img width="412" height="391" alt="Screenshot 2026-06-18 at 17 23 59" src="https://github.com/user-attachments/assets/308ea14f-8e7a-43a4-9409-2fbe63a5ea09" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-staking-dashboard/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-staking-dashboard/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-staking-dashboard&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-staking-dashboard&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-staking-dashboard&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-19T10:53:51.050Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-19T10:52:38.503Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->