### PR TITLE
feat(trading): reorder trade form parameters on desktop

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
@@ -7,8 +7,8 @@ import {
     TRADING_FORM_FIAT_INPUT,
     type TradingBuyType,
     isCountrySubdivisionRequired,
+    selectTradingBuyQuotes,
     selectTradingBuySupportedCryptoIds,
-    selectTradingLoadingAndTimestamp,
     tradingActions,
 } from '@suite-common/trading';
 import { type TokenAddress } from '@suite-common/wallet-types';
@@ -25,21 +25,20 @@ import { TradingFormInputPaymentMethod } from 'src/views/wallet/trading/common/T
 
 import { TradingFormCard } from './TradingFormCard';
 import { TradingFormSection } from './TradingFormSection';
-import { TradingReceiveAddress } from '../TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddress';
 import { TradingSelectedOfferProvider } from '../TradingSelectedOffer/TradingSelectedOfferProvider';
 import {
     TradingFormInputBuyAsset,
     type TradingFormInputBuyAssetProps,
 } from './TradingFormInput/TradingFormInputBuyAsset/TradingFormInputBuyAsset';
 import { TradingFormInputCountrySubdivision } from './TradingFormInput/TradingFormInputCountry/TradingFormInputCountrySubdivision';
+import { TradingReceiveAddress } from '../TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddress';
 
 export const TradingBuyFormInputs = () => {
     const context = useTradingFormContext<TradingBuyType>();
-    const { defaultCountry } = context;
+    const buySupportedCryptoIds = useSelector(selectTradingBuySupportedCryptoIds);
+    const quotes = useSelector(selectTradingBuyQuotes);
 
-    const { isLoading } = useSelector(selectTradingLoadingAndTimestamp);
-
-    const { device, setAmountLimits, getValues, setValue, quotes } = context;
+    const { device, setAmountLimits, getValues, defaultCountry, setValue } = context;
     const {
         [TRADING_FORM_CRYPTO_CURRENCY_SELECT]: cryptoSelect,
         [TRADING_FORM_CRYPTO_INPUT]: cryptoInput,
@@ -65,13 +64,11 @@ export const TradingBuyFormInputs = () => {
         [dispatch, setAmountLimitsRef, setValueRef],
     );
 
-    const buySupportedCryptoIds = useSelector(selectTradingBuySupportedCryptoIds);
-
     const selectedCountry = countrySelect ?? defaultCountry;
     const countryRequiresSubdivision = isCountrySubdivisionRequired(selectedCountry?.value);
 
     return (
-        <Column gap={20}>
+        <Column gap={16}>
             <TradingFormCard>
                 <TradingFormSection>
                     <TradingFormInputBuyAsset
@@ -106,20 +103,19 @@ export const TradingBuyFormInputs = () => {
                         )}
                     </Column>
                 </TradingFormSection>
-                {cryptoSelect && !isLoading && <TradingReceiveAddress />}
             </TradingFormCard>
 
             <TradingFormCard>
-                {quotes?.length > 0 && (
-                    <TradingFormInputPaymentMethod label="TR_TRADING_PAYMENT_METHOD" />
-                )}
+                {cryptoSelect && <TradingReceiveAddress />}
                 <TradingFormInputCountry label="TR_TRADING_COUNTRY" />
-
                 {selectedCountry && countryRequiresSubdivision && (
                     <TradingFormInputCountrySubdivision
                         label="TR_TRADING_COUNTRY_SUBDIVISION"
                         country={selectedCountry}
                     />
+                )}
+                {!!quotes.length && (
+                    <TradingFormInputPaymentMethod label="TR_TRADING_PAYMENT_METHOD" />
                 )}
                 <TradingSelectedOfferProvider />
             </TradingFormCard>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -11,14 +11,17 @@ import {
     type TradingExchangeType,
     getDisplayComposedLevels,
     selectTradingExchangeBuyCryptoIds,
+    selectTradingExchangeQuotes,
+    selectTradingExchangeSelectedQuote,
     selectTradingExchangeSellCryptoIds,
     selectTradingLoadingAndTimestamp,
     tradingActions,
 } from '@suite-common/trading';
 import { type TokenAddress } from '@suite-common/wallet-types';
-import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
+import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
 import { Column, Row } from '@trezor/components';
 import { useCurrentRef } from '@trezor/react-utils';
+import { BigNumber } from '@trezor/utils';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingAssetDecimals } from 'src/hooks/wallet/trading/form/common/useTradingAssetDecimals';
@@ -47,6 +50,10 @@ export const TradingExchangeFormInputs = () => {
     const context = useTradingFormContext<TradingExchangeType>();
 
     const { isLoading } = useSelector(selectTradingLoadingAndTimestamp);
+    const exchangeBuySupportedCryptoIds = useSelector(selectTradingExchangeBuyCryptoIds);
+    const exchangeSellSupportedCryptoIds = useSelector(selectTradingExchangeSellCryptoIds);
+    const quotes = useSelector(selectTradingExchangeQuotes);
+    const selectedQuote = useSelector(selectTradingExchangeSelectedQuote);
 
     const {
         feeInfo,
@@ -57,7 +64,6 @@ export const TradingExchangeFormInputs = () => {
         shouldSendInSats,
         showReserveBanner,
         resetSelectedOffer,
-        selectedQuote,
         setAmountLimits,
     } = context;
 
@@ -88,7 +94,10 @@ export const TradingExchangeFormInputs = () => {
     );
     const outputAmount =
         shouldSendInSats && output?.amount
-            ? convertAmountSubunitsToUnits(output.amount, sendAssetDecimals)
+            ? subunitsToUnits({
+                  value: asAmountSubunit(new BigNumber(output.amount)),
+                  decimals: sendAssetDecimals,
+              }).toString()
             : output?.amount;
 
     const dispatch = useDispatch();
@@ -120,9 +129,6 @@ export const TradingExchangeFormInputs = () => {
         },
         [dispatch, setAmountLimitsRef, setValueRef, resetSelectedOfferRef],
     );
-
-    const exchangeBuySupportedCryptoIds = useSelector(selectTradingExchangeBuyCryptoIds);
-    const exchangeSellSupportedCryptoIds = useSelector(selectTradingExchangeSellCryptoIds);
 
     return (
         <Column gap={20}>
@@ -183,12 +189,14 @@ export const TradingExchangeFormInputs = () => {
             </TradingFormCard>
             <TradingFormCard>
                 {receiveCryptoSelect && !isLoading && <TradingReceiveAddress />}
-                <TradingFormFees
-                    feeInfo={feeInfo}
-                    account={account}
-                    composedLevels={displayComposedLevels}
-                    changeFeeLevel={changeFeeLevel}
-                />
+                {!!quotes.length && (
+                    <TradingFormFees
+                        feeInfo={feeInfo}
+                        account={account}
+                        composedLevels={displayComposedLevels}
+                        changeFeeLevel={changeFeeLevel}
+                    />
+                )}
                 <TradingSelectedOfferProvider />
             </TradingFormCard>
         </Column>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
@@ -8,12 +8,14 @@ import {
     type TradingSellFormProps,
     type TradingSellType,
     isCountrySubdivisionRequired,
+    selectTradingSellQuotes,
     selectTradingSellSupportedCryptoIds,
 } from '@suite-common/trading';
 import { type TokenAddress } from '@suite-common/wallet-types';
-import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
+import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
 import { Column, Row } from '@trezor/components';
 import { useCurrentRef } from '@trezor/react-utils';
+import { BigNumber } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
 import { useTradingAssetDecimals } from 'src/hooks/wallet/trading/form/common/useTradingAssetDecimals';
@@ -38,6 +40,8 @@ import { TradingNetworkReserveBanner } from './TradingNetworkReserveBanner';
 
 export const TradingSellFormInputs = () => {
     const context = useTradingFormContext<TradingSellType>();
+    const quotes = useSelector(selectTradingSellQuotes);
+    const sellSupportedCryptoIds = useSelector(selectTradingSellSupportedCryptoIds);
 
     const {
         feeInfo,
@@ -47,10 +51,11 @@ export const TradingSellFormInputs = () => {
         shouldSendInSats,
         changeFeeLevel,
         showReserveBanner,
-        quotes,
         defaultCountry,
     } = context;
+
     const { getValues } = useFormContext<TradingSellFormProps>();
+
     const { outputs, sendCryptoSelect, amountInCrypto, countrySelect } = getValues();
     const output = outputs[0];
     const currencySelect = output?.currency;
@@ -68,7 +73,10 @@ export const TradingSellFormInputs = () => {
 
     const outputAmount =
         shouldSendInSats && output?.amount
-            ? convertAmountSubunitsToUnits(output.amount, sendAssetDecimals)
+            ? subunitsToUnits({
+                  value: asAmountSubunit(new BigNumber(output.amount)),
+                  decimals: sendAssetDecimals,
+              }).toString()
             : output?.amount;
 
     const onCryptoCurrencyChangeRef = useCurrentRef(helpers.onCryptoCurrencyChange);
@@ -78,8 +86,6 @@ export const TradingSellFormInputs = () => {
         },
         [onCryptoCurrencyChangeRef],
     );
-
-    const sellSupportedCryptoIds = useSelector(selectTradingSellSupportedCryptoIds);
 
     const selectedCountry = countrySelect ?? defaultCountry;
     const countryRequiresSubdivision = isCountrySubdivisionRequired(selectedCountry?.value);
@@ -131,22 +137,23 @@ export const TradingSellFormInputs = () => {
                 </TradingFormSection>
             </TradingFormCard>
             <TradingFormCard>
-                <TradingFormFees
-                    feeInfo={feeInfo}
-                    account={account}
-                    composedLevels={composedLevels}
-                    changeFeeLevel={changeFeeLevel}
-                />
-                {!!quotes.length && (
-                    <TradingFormInputPaymentMethod label="TR_TRADING_RECEIVE_METHOD" />
-                )}
-
                 <TradingFormInputCountry label="TR_TRADING_COUNTRY" />
                 {countryRequiresSubdivision && (
                     <TradingFormInputCountrySubdivision
                         label="TR_TRADING_COUNTRY_SUBDIVISION"
                         country={selectedCountry}
                     />
+                )}
+                {!!quotes.length && (
+                    <>
+                        <TradingFormFees
+                            feeInfo={feeInfo}
+                            account={account}
+                            composedLevels={composedLevels}
+                            changeFeeLevel={changeFeeLevel}
+                        />
+                        <TradingFormInputPaymentMethod label="TR_TRADING_RECEIVE_METHOD" />
+                    </>
                 )}
 
                 <TradingSelectedOfferProvider />

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferProvider.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferProvider.tsx
@@ -68,6 +68,7 @@ export const TradingSelectedOfferProvider = () => {
                 cursor="pointer"
                 data-testid="@trading/selected-offer-provider"
                 borderRadius={0}
+                isDisabled={form.state.isFormLoading}
             >
                 <Row alignItems="center" justifyContent="space-between" padding={20}>
                     <Text typographyStyle="body-md" intent="neutral" priority="secondary">
@@ -78,15 +79,22 @@ export const TradingSelectedOfferProvider = () => {
                             {form.state.isFormLoading ? (
                                 <Skeleton animate />
                             ) : (
-                                <Text typographyStyle="body-md" as="div">
-                                    <TradingUtilsProvider
-                                        providers={providers}
-                                        exchange={quote.exchange}
+                                <>
+                                    <Text typographyStyle="body-md" as="div">
+                                        <TradingUtilsProvider
+                                            providers={providers}
+                                            exchange={quote.exchange}
+                                        />
+                                    </Text>
+                                    <Icon
+                                        name="caretRight"
+                                        size={20}
+                                        intent="neutral"
+                                        priority="secondary"
                                     />
-                                </Text>
+                                </>
                             )}
                         </Row>
-                        <Icon name="caretRight" size={20} intent="neutral" priority="secondary" />
                     </Row>
                 </Row>
             </GhostContainer>

--- a/suite/e2e/tests/trading/sell-inputs.test.ts
+++ b/suite/e2e/tests/trading/sell-inputs.test.ts
@@ -84,6 +84,7 @@ test.describe('Trading - Sell inputs', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, 
                     });
                 });
             }
+            await tradingPage.quotes.waitForSync();
             await tradingPage.fees.switchToCustom();
             await tradingPage.fees.customInput.fill(customFeeRate.toString());
 


### PR DESCRIPTION
## Description

Reorder the trade form parameters (buy, sell, exchange) on desktop. Quotes are now read directly from Redux in the form inputs instead of through the form context.

## Notes for QA

Check the buy/sell/exchange forms render fields in the correct order, and that the payment-method picker and fee section still appear once quotes load.

## Related Issue

Resolve #28358

## Screenshots:
<img width="683" height="636" alt="image" src="https://github.com/user-attachments/assets/78c4510b-4b35-4f10-8a6d-6ba43bd53a6b" />
<img width="670" height="675" alt="image" src="https://github.com/user-attachments/assets/7f031774-a531-42f6-8645-7b6ae58e9e99" />
<img width="669" height="721" alt="image" src="https://github.com/user-attachments/assets/37498e3f-243a-4c2f-97f4-968fbae1b165" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change modifies all three trading form input components (Buy, Sell, Exchange/Swap) and the shared TradingSelectedOfferProvider component. The risk is concentrated in the trading/coinmarket flows — buy, sell, and swap forms plus offer selection/confirmation. The sell-inputs test was also directly modified. Testing strategy prioritizes: (1) the directly changed test file, (2) full flow tests for each trading type (buy/sell/swap) that exercise both form inputs and offer provider, (3) additional network/token variations at medium priority. Non-trading tests are omitted since TradingSelectedOfferProvider maps to 17 tests but only trading-specific tests actually exercise the changed code paths.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferProvider.tsx`
- `suite/e2e/tests/trading/sell-inputs.test.ts`

</details>

**Recommended tests (18)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test file was directly modified in the changeset and directly exercises TradingSellFormInputs.tsx. It validates sell form decimal limits, insufficient funds errors, fraction buttons, max button, custom fees, and currency switching — all behaviors that depend on the sell form inputs component.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Directly exercises the buy form inputs (TradingBuyFormInputs.tsx) by filling fiat amount, selecting receive address, and proceeding through quotes to confirmation via TradingSelectedOfferProvider.tsx. Tests the full buy flow including offer selection and trade confirmation.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Directly tests validation behaviors of TradingBuyFormInputs.tsx — max/min limit errors, disabled best offer button, empty quotes state. These are core input validation paths that would break if the buy form inputs component changes.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Exercises the full sell flow on Solana using TradingSellFormInputs.tsx for form filling and TradingSelectedOfferProvider.tsx for offer confirmation, device prompt, and transaction sending. Covers sell form, best offer, confirmation details, and trade payload.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Exercises TradingExchangeFormInputs.tsx by filling in a swap form with send/receive assets and amount, then proceeds through TradingSelectedOfferProvider.tsx for offer confirmation, device prompt, toast, and status updates. Comprehensive swap flow test.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Full BTC sell flow test covering sell form filling (TradingSellFormInputs), best offer display and confirmation (TradingSelectedOfferProvider), trade payload verification, and device prompt. Directly validates the sell form and offer provider components.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests the ETH sell flow including custom gas fees, form filling via TradingSellFormInputs.tsx, and offer confirmation via TradingSelectedOfferProvider.tsx. Covers a different network (ETH) than sell-bitcoin and sell-solana, catching network-specific regressions.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests buy flow for ETH including asset picker search, fiat amount input, and trade confirmation — exercises TradingBuyFormInputs.tsx and TradingSelectedOfferProvider.tsx on a non-BTC network.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Tests buy flow for a Solana SPL token including crypto/fiat toggle in the buy form (TradingBuyFormInputs.tsx) and trade confirmation (TradingSelectedOfferProvider.tsx). Covers token-specific buy paths.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests swap from SOL to USDC token, exercising TradingExchangeFormInputs.tsx for form filling and TradingSelectedOfferProvider.tsx for offer/confirmation. Covers cross-network token swap path.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swap from USDT token to BTC, covering TradingExchangeFormInputs.tsx for token-based sell asset selection and TradingSelectedOfferProvider.tsx for confirmation. Exercises token→coin swap direction.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token (USDC) through the sell flow, exercising TradingSellFormInputs.tsx for token sell form and TradingSelectedOfferProvider.tsx for confirmation. Covers ERC-20 token sell path not covered by other sell tests.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Directly tests swap form input behaviors — asset selection, fraction buttons, max button, validation errors — which exercise TradingExchangeFormInputs.tsx. Also verifies provider display and fee calculation from TradingSelectedOfferProvider.tsx.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests that buy/sell/swap forms open correctly from various navigation entry points, verifying form rendering of TradingBuyFormInputs, TradingSellFormInputs, and TradingExchangeFormInputs. A rendering regression in any form component would cause navigation assertions to fail.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests custom BTC fee settings in swap flow, exercising TradingExchangeFormInputs.tsx for form filling and fee configuration. Validates fee calculation and device prompt display.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests custom ETH gas fee settings in swap flow, exercising TradingExchangeFormInputs.tsx for form filling and custom gas configuration. Covers Ethereum-specific fee path in swap form.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests SPL token-to-token swap (USDT→USDC) which exercises TradingExchangeFormInputs.tsx. Lower priority since token swap paths are partially covered by swap-coin-to-token and swap-token-to-coin tests.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests an edge case where buy asset belongs to a disabled network in swap form. Exercises TradingExchangeFormInputs.tsx but the scenario is narrow and unlikely to regress from typical form input changes.

</details>

_Updated: 2026-06-24T07:23:15.407Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/28358-order-trade-form-parameters-desktop&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/28358-order-trade-form-parameters-desktop&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-24T07:07:29.550Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-24T07:26:04.993Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/28358-order-trade-form-parameters-desktop/web/](https://dev.suite.sldev.cz/suite-web/feat/28358-order-trade-form-parameters-desktop/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->