### PR TITLE
fix(suite): report which account keyPath fields are missing on storag…

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -287,10 +287,34 @@ export const forgetDevice = (device: TrezorDevice) => (_: Dispatch, getState: Ge
     ]);
 };
 
-export const saveAccounts = (accounts: SuccessfulAccount[]) => {
+// The 'accounts' store keys records by these fields (its IndexedDB keyPath). `satisfies` ensures
+// they stay valid account fields, so a rename/typo is a compile error here rather than at runtime.
+const ACCOUNT_KEY_PATH_FIELDS = [
+    'descriptor',
+    'symbol',
+    'deviceState',
+] as const satisfies readonly (keyof SuccessfulAccount)[];
+
+export const saveAccounts = async (accounts: SuccessfulAccount[]) => {
     if (!db.isAccessible()) return;
 
-    return db.addItems('accounts', accounts, true);
+    try {
+        return await db.addItems('accounts', accounts, true);
+    } catch (error) {
+        // IndexedDB throws an opaque "Evaluating the object store's key path did not yield a value"
+        // DataError when a keyPath field is missing. Report only WHICH key fields are missing - never
+        // their values (descriptor / deviceState etc. are sensitive and must not reach Sentry/logs).
+        const missingKeyPathFields = ACCOUNT_KEY_PATH_FIELDS.filter(field =>
+            accounts.some(account => !account[field]),
+        );
+
+        throw new Error(
+            missingKeyPathFields.length
+                ? `Cannot save account(s) to storage, missing keyPath field(s): ${missingKeyPathFields.join(', ')}`
+                : `Cannot save account(s) to storage: ${error?.message ?? ''}`,
+            { cause: error },
+        );
+    }
 };
 
 export const saveTradingTrade = (trade: TradingTransaction) => {


### PR DESCRIPTION
…e save failure

Saving an account whose descriptor/symbol/deviceState is undefined fails the accounts IndexedDB put with an opaque "Failed to execute 'put' on 'IDBObjectStore': Evaluating the object store's key path did not yield a value" DataError - it doesn't say which account or which field caused it.

Wrap the accounts addItems in saveAccounts and rethrow a clear error naming the offending account(s) and the missing keyPath field(s), so the report is actionable.

Refs #28916



## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28916

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to storageActions.ts, which is a broadly-imported module responsible for persisting and loading application state (suite settings, wallet data, device state, metadata, analytics preferences, discovery state) to/from IndexedDB. Since it maps to all 121 tests, the key strategy is to focus on tests that explicitly exercise state persistence across reloads, session management, device remembering, and recovery persistence — scenarios where storageActions behavior is directly observable. The highest-risk tests are those involving page reloads, wallet ejection/re-addition, and cross-session state persistence. Most other tests only transitively depend on storageActions for initial state loading and are unlikely to regress from typical changes to this file.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/actions/suite/storageActions.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/suite/initial-run.test.ts` — storageActions.ts manages persistence of onboarding/initial-run state (e.g., initialRun flag). This test explicitly validates that onboarding state persists across page reloads — analytics toggle visibility, complete-onboarding button persistence, and post-onboarding device status after reload — all of which depend on correct storage save/load behavior.
- `suite/e2e/tests/analytics/toggle.test.ts` — This test validates that analytics toggle state persists across app reloads, that session IDs change but instance IDs remain the same after reload, and that the initialRun flag is correctly managed — all behaviors directly dependent on storageActions persisting and restoring analytics/suite state from IndexedDB.
- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — This test validates metadata/labeling preference persistence across wallet sessions, device resets, and ejection/re-addition of wallets. storageActions is responsible for saving and loading metadata provider settings and device state, making this a direct consumer of the changed code.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — storageActions handles saving/loading wallet and device state. This test ejects a wallet via device switcher and adds a standard wallet, exercising storage operations for wallet management (remembering/forgetting wallets) that storageActions orchestrates.
- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — This test specifically exercises remembered (saved) device behavior — editing labels on a remembered device after the emulator is powered off. storageActions is responsible for persisting device remember state and associated metadata keys, directly impacting this flow.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — This test validates that recovery mode state persists after IndexedDB reset and page reload. It explicitly calls indexedDb reset and verifies recovery session persistence — a flow that depends on storageActions correctly saving and restoring device/recovery state.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test reloads the page during discovery and verifies discovery recovers and completes. storageActions manages persisting discovery state and wallet data to IndexedDB, which is critical for recovery after page reload interruption.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test validates behavior across page reloads and multiple browser tabs, including session state persistence and device status recovery. storageActions manages the persisted state that determines whether a session is reclaimed or remains in 'Use Here' state after reload.
- `suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — This test verifies wallet labels persist across full page reloads (saved to metadata provider like Dropbox). storageActions is involved in persisting wallet/device state that enables label retrieval after reload.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — Passphrase wallet numbering depends on stored wallet state. storageActions manages wallet persistence, and this test validates that numbering continues incrementing after ejecting and re-adding wallets, which involves storage operations for wallet state tracking.
- `suite/e2e/tests/settings/general.test.ts` — Settings changes (fiat currency, theme, language) are persisted via storageActions. While these settings are straightforward key-value stores, a regression in storage save logic could cause settings to not persist, which this test would surface.

</details>

_Updated: 2026-06-19T10:12:12.288Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=28916-failed-to-put-account-index-db-sentry&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=28916-failed-to-put-account-index-db-sentry&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-19T10:16:10.941Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-19T10:15:08.188Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/28916-failed-to-put-account-index-db-sentry/web/](https://dev.suite.sldev.cz/suite-web/28916-failed-to-put-account-index-db-sentry/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->