### PR TITLE
refactor: prefer typedObject* helpers over casted Object.keys/entries/values

### DIFF
--- a/packages/analytics-docs/src/utils/normalizeEvents.ts
+++ b/packages/analytics-docs/src/utils/normalizeEvents.ts
@@ -1,4 +1,5 @@
 import type { AttributeDef, EventDef } from '@suite-common/analytics';
+import { typedObjectEntries } from '@trezor/utils';
 
 import type { AttributeDoc, EventDoc } from '../types';
 import { normalizeChangelog } from './normalizeChangelog';
@@ -21,11 +22,8 @@ type NormalizableEvent = (
 ) & { platform?: string; attributes?: Record<string, AttributeDef<unknown>> };
 
 const toEventDoc = (event: NormalizableEvent): [string, EventDoc] => {
-    const attributes = Object.fromEntries(
-        (Object.entries(event.attributes ?? {}) as [string, AttributeDef<unknown>][]).map(
-            toAttributeDoc,
-        ),
-    );
+    const eventAttributes: Record<string, AttributeDef<unknown>> = event.attributes ?? {};
+    const attributes = Object.fromEntries(typedObjectEntries(eventAttributes).map(toAttributeDoc));
 
     const eventChangelogEntries = event.changelog ?? [];
     const attributeChangelogEntries = Object.values(attributes).flatMap(

--- a/packages/components/src/components/IconCircle/IconCircle.stories.tsx
+++ b/packages/components/src/components/IconCircle/IconCircle.stories.tsx
@@ -4,7 +4,8 @@ import { type Meta, type StoryObj } from '@storybook/react';
 
 // TODO: suite-common imports in non-suite packages should not be allowed
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { type IconName, icons } from '@suite-common/icons/src/icons';
+import { icons } from '@suite-common/icons/src/icons';
+import { typedObjectKeys } from '@trezor/utils';
 
 import {
     IconCircle as IconCircleComponent,
@@ -44,7 +45,7 @@ export const IconCircle: StoryObj<typeof meta> = {
             control: {
                 type: 'select',
             },
-            options: Object.keys(icons) as IconName[],
+            options: typedObjectKeys(icons),
         },
         ...getFramePropsStory(allowedIconCircleFrameProps).argTypes,
     },

--- a/packages/product-components/src/components/CoinLogo/CoinLogo.stories.tsx
+++ b/packages/product-components/src/components/CoinLogo/CoinLogo.stories.tsx
@@ -3,6 +3,7 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import { isCryptoIconSymbol, networkIconSymbolMap } from '@suite-common/icons/src/iconUtils';
 import { networksCollection } from '@suite-common/wallet-config';
 import { Column, Grid, H2, Paragraph } from '@trezor/components';
+import { typedObjectKeys } from '@trezor/utils';
 
 import {
     COIN_LOGO_TYPE,
@@ -13,9 +14,7 @@ import {
     allowedCoinLogoSizes,
 } from './CoinLogo';
 
-const NETWORK_ICON_SYMBOLS = Object.keys(
-    networkIconSymbolMap,
-) as (keyof typeof networkIconSymbolMap)[];
+const NETWORK_ICON_SYMBOLS = typedObjectKeys(networkIconSymbolMap);
 const TOKEN_WITH_NETWORK_SYMBOLS = networksCollection
     .filter(network => network.settlementLayer)
     .map(network => network.symbol)

--- a/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
 import { type IconName, Toast, type ToastProps } from '@trezor/components';
+import { typedObjectKeys } from '@trezor/utils';
 
 import {
     TransactionNotification,
@@ -194,9 +195,7 @@ export const InToast: StoryObj<TransactionToastStoryArgs> = {
             control: {
                 type: 'select',
             },
-            options: Object.keys(
-                transactionNotificationConfig,
-            ) as (keyof typeof transactionNotificationConfig)[],
+            options: typedObjectKeys(transactionNotificationConfig),
         },
     },
     render: ({ notificationType }) => {

--- a/packages/suite/src/components/guide/GuideHint.tsx
+++ b/packages/suite/src/components/guide/GuideHint.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react';
 
 import { Banner, type BannerIntent } from '@trezor/components';
+import { typedObjectKeys } from '@trezor/utils';
 
 // The displayed Banner intent is determined by an emoji at the start of the markdown quote.
 // The mapping is exhaustive over BannerIntent so Guide hints support every Banner intent.
@@ -18,7 +19,7 @@ const INTENT_EMOJI = {
     neutral: '📝',
 } as const satisfies Record<BannerIntent, string>;
 
-const HINT_INTENTS = Object.keys(INTENT_EMOJI) as BannerIntent[];
+const HINT_INTENTS = typedObjectKeys(INTENT_EMOJI);
 const EMOJI_REGEX = new RegExp(`^(${Object.values(INTENT_EMOJI).join('|')})\\s*`);
 
 // This is a hack to sneak a bit more complex component into the generated markup.

--- a/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
@@ -21,7 +21,7 @@ import {
 import { type AccountKey } from '@suite-common/wallet-types';
 import { RoundPhase, SessionPhase } from '@trezor/coinjoin';
 import { DEVICE, UI_REQUEST } from '@trezor/connect';
-import { arrayDistinct } from '@trezor/utils';
+import { arrayDistinct, typedObjectKeys } from '@trezor/utils';
 
 import { SUITE } from 'src/actions/suite/constants';
 import * as storageActions from 'src/actions/suite/storageActions';
@@ -41,7 +41,6 @@ import {
 } from 'src/reducers/wallet/coinjoinReducer';
 import { CoinjoinService } from 'src/services/coinjoin';
 import type { Action, AppState, Dispatch } from 'src/types/suite';
-import { type CoinjoinConfig } from 'src/types/wallet/coinjoin';
 import { isCoinjoinSupportedSymbol } from 'src/utils/wallet/coinjoinUtils';
 
 export const coinjoinMiddleware =
@@ -243,7 +242,7 @@ export const coinjoinMiddleware =
                 const updatedConfig: Partial<typeof config> = {};
 
                 // Iterate over existing config and replace the value from remote config only if it's valid number.
-                (Object.keys(config) as Array<keyof CoinjoinConfig>).forEach(key => {
+                typedObjectKeys(config).forEach(key => {
                     const value = incomingConfig[key];
 
                     if (

--- a/packages/suite/src/types/wallet/coinjoin.ts
+++ b/packages/suite/src/types/wallet/coinjoin.ts
@@ -103,11 +103,11 @@ export interface CoinjoinDebugSettings {
     coinjoinConfigOverride?: PartialRecord<NetworkSymbol, Partial<CoinjoinNetworksConfig>>;
 }
 
-export interface CoinjoinConfig {
+export type CoinjoinConfig = {
     averageAnonymityGainPerRound: number;
     roundsFailRateBuffer: number;
     roundsDurationInHours: number;
     maxMiningFeeModifier: number;
     maxFeePerVbyte?: number;
     legalDocumentsVersion: string;
-}
+};

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -12,6 +12,7 @@
     },
     "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
-        "@suite-common/wallet-config": "workspace:*"
+        "@suite-common/wallet-config": "workspace:*",
+        "@trezor/utils": "workspace:*"
     }
 }

--- a/packages/theme/src/spacings.ts
+++ b/packages/theme/src/spacings.ts
@@ -1,3 +1,5 @@
+import { typedObjectKeys } from '@trezor/utils';
+
 /**
  * @deprecated Use numbers directly instead
  */
@@ -49,7 +51,7 @@ export type SpacingPx = { [K in Spacing]: `${Spacings[K]}px` };
 export type NegativeSpacingPx = { [K in Spacing]: `-${Spacings[K]}px` };
 export type SpacingPxValues = SpacingPx[Spacing] | NegativeSpacingPx[Spacing];
 
-export const spacingsPx = (Object.keys(spacings) as Array<Spacing>).reduce((result, key) => {
+export const spacingsPx = typedObjectKeys(spacings).reduce((result, key) => {
     (result as Record<Spacing, string>)[key] = `${spacings[key]}px`;
 
     return result;

--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -4,6 +4,7 @@
     "references": [
         {
             "path": "../../suite-common/wallet-config"
-        }
+        },
+        { "path": "../utils" }
     ]
 }

--- a/packages/utxo-lib/tests/compose.test.ts
+++ b/packages/utxo-lib/tests/compose.test.ts
@@ -1,4 +1,4 @@
-import { getRandomInt } from '@trezor/utils';
+import { getRandomInt, typedObjectKeys } from '@trezor/utils';
 
 import { verifyTxBytes } from './compose.utils';
 import { composeTx } from '../src/compose';
@@ -206,7 +206,7 @@ describe('composeTx addresses cross-check', () => {
         p2wsh: '101500',
     };
 
-    const addrKeys = Object.keys(addrTypes) as Array<keyof typeof addrTypes>;
+    const addrKeys = typedObjectKeys(addrTypes);
 
     fixturesCrossCheck.forEach(f => {
         txTypes.forEach(txType => {

--- a/suite-native/icons/package.json
+++ b/suite-native/icons/package.json
@@ -25,6 +25,7 @@
         "@trezor/device-utils": "workspace:*",
         "@trezor/styles-native": "workspace:*",
         "@trezor/theme": "workspace:*",
+        "@trezor/utils": "workspace:*",
         "expo-image": "~55.0.5",
         "react": "19.2.4",
         "react-native": "0.83.2",

--- a/suite-native/icons/src/Icon.tsx
+++ b/suite-native/icons/src/Icon.tsx
@@ -8,6 +8,7 @@ import { MOBILE_ICON_FONT_NAME } from '@suite-common/icons';
 import codepoints from '@suite-common/icons/iconFontsMobile/TrezorSuiteIcons.json';
 import { useNativeStyles } from '@trezor/styles-native';
 import { type CSSColor, type Color, type Colors } from '@trezor/theme';
+import { typedObjectKeys } from '@trezor/utils';
 
 export type { CSSColor };
 export type IconColor = Color | CSSColor;
@@ -25,7 +26,7 @@ export const MAX_FONT_SIZE_MULTIPLIER = 1.5;
  * 3. Remove app from sim/device and create new build to see the new icons in the app.
  */
 export type IconName = keyof typeof codepoints;
-export const ICON_NAMES = Object.keys(codepoints) as IconName[];
+export const ICON_NAMES = typedObjectKeys(codepoints);
 
 export const iconSizes = {
     extraSmall: 8,
@@ -36,7 +37,7 @@ export const iconSizes = {
     extraLarge: 32,
 } as const;
 
-export const ICON_SIZES = Object.keys(iconSizes) as IconSize[];
+export const ICON_SIZES = typedObjectKeys(iconSizes);
 export type IconSize = keyof typeof iconSizes;
 
 export const getIconSize = (size: IconSize | number) =>

--- a/suite-native/icons/tsconfig.json
+++ b/suite-native/icons/tsconfig.json
@@ -20,6 +20,7 @@
             "path": "../../packages/styles-native"
         },
         { "path": "../../packages/theme" },
+        { "path": "../../packages/utils" },
         { "path": "../test-utils" }
     ]
 }

--- a/suite/e2e/support/helpers/evoluClient.ts
+++ b/suite/e2e/support/helpers/evoluClient.ts
@@ -11,11 +11,12 @@ import {
     wipeAndRestartEvoluRelayServer,
 } from '@suite-common/e2e-evolu-client';
 import { Schema } from '@suite-common/suite-sync-evolu';
+import { typedObjectKeys } from '@trezor/utils';
 
 import { step } from '../common';
 
 type TableName = keyof typeof Schema;
-const allTables = Object.keys(Schema) as TableName[];
+const allTables = typedObjectKeys(Schema);
 
 export class EvoluClient extends BaseEvoluClient {
     @step()

--- a/suite/e2e/tests/general/check-links.test.ts
+++ b/suite/e2e/tests/general/check-links.test.ts
@@ -2,6 +2,7 @@ import { Page, TestInfo } from '@playwright/test';
 
 import { routes } from '@suite/router-config';
 import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+import { typedObjectEntries } from '@trezor/utils';
 
 import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
@@ -196,10 +197,7 @@ test.describe('Check Links', { tag: ['@webOnly', '@nightlyOnly', '@T3T1'] }, () 
         ignoreJSExceptions: ['Aborted by signal', 'Failed to fetch'],
     });
 
-    for (const [section, paths] of Object.entries(SECTIONS) as [
-        keyof typeof SECTIONS,
-        string[],
-    ][]) {
+    for (const [section, paths] of typedObjectEntries(SECTIONS)) {
         test(
             `${section} links return 200`,
             {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12402,6 +12402,7 @@ __metadata:
     "@trezor/device-utils": "workspace:*"
     "@trezor/styles-native": "workspace:*"
     "@trezor/theme": "workspace:*"
+    "@trezor/utils": "workspace:*"
     expo-image: "npm:~55.0.5"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
@@ -16881,6 +16882,7 @@ __metadata:
   dependencies:
     "@mobily/ts-belt": "npm:^3.13.1"
     "@suite-common/wallet-config": "workspace:*"
+    "@trezor/utils": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

Replace `Object.keys/entries/values(x) as …` casts with the `typedObjectKeys` / `typedObjectEntries` / `typedObjectValues` helpers from `@trezor/utils`, wherever the cast was just re-spelling `keyof typeof` by hand. The helpers provide the same typing safely, with zero runtime change (at runtime they are `Object.keys` / `Object.entries` / `Object.values`).

Originally prompted by a review comment on #28838 suggesting `typedObjectKeys` instead of `Object.keys(messages) as Array<keyof typeof messages>`.

### What changed

- Converted the call sites where the cast was a hand-written `keyof typeof` (stories, `spacings`, `GuideHint`, `compose.test`, `Icon`, `evoluClient`, `check-links`, `normalizeEvents`, `coinjoinMiddleware`).
- `CoinjoinConfig` was an `interface` (no implicit index signature → does not satisfy the helpers' `Record<string, unknown>` constraint). It is a plain data shape with no merging / `extends` / `implements`, so it is changed to a `type` alias and its call site now uses the helper.
- `@trezor/utils` added as a dependency to `@trezor/theme` and `@suite-native/icons` (the only affected packages that did not already depend on it); `update-project-references` + `yarn dedupe` applied.

## Related

- Split out of #28896, which adds an ESLint rule to *enforce* these helpers repo-wide. That rule is parked for team discussion because a non-trivial share of existing casts genuinely cannot use the helpers (union types collapsing `keyof` to `never`, generic-constraint narrowing, `any` from dynamic imports, interfaces that are real class contracts) and would need documented `eslint-disable`s. This PR is the non-controversial code-improvement subset that stands on its own.
- Review comment: https://github.com/trezor/trezor-suite/pull/28838#discussion_r3435605706

## Notes for QA

No QA needed. Pure type-level refactor with zero runtime behaviour change — `typedObjectKeys`/`typedObjectEntries`/`typedObjectValues` are `Object.keys`/`Object.entries`/`Object.values` at runtime, and the `interface` → `type` change for `CoinjoinConfig` is type-only. The only non-source changes are two `package.json` dependency additions (`@trezor/utils`, already present transitively) plus the lockfile/tsconfig updates from `update-project-references` + `dedupe`.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/prefer-typed-object-helpers/web/](https://dev.suite.sldev.cz/suite-web/mroz22/prefer-typed-object-helpers/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/prefer-typed-object-helpers&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/prefer-typed-object-helpers&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-19T10:02:29.626Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-19T10:00:53.585Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->