### PR TITLE
chore(connect): get rid of cross-fetch for native fetch

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -104,7 +104,6 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
-        "cross-fetch": "^4.1.0",
         "jws": "^4.0.1",
         "viem": "^2.48.1"
     },

--- a/packages/connect/src/api/ethereum/ethereumDefinitions.ts
+++ b/packages/connect/src/api/ethereum/ethereumDefinitions.ts
@@ -1,5 +1,3 @@
-import fetch from 'cross-fetch';
-
 import type { EthereumNetworkInfoDefinitionValues } from '@trezor/connect-common';
 import type { MessagesSchema } from '@trezor/protobuf';
 import { protobufManager } from '@trezor/protobuf';

--- a/packages/connect/src/api/solana/__tests__/solanaDefinitions.test.ts
+++ b/packages/connect/src/api/solana/__tests__/solanaDefinitions.test.ts
@@ -1,14 +1,15 @@
-import fetch from 'cross-fetch';
-
 import { loadProtobufModules } from '../../../data/protobufLoader';
 import { decodeSolanaTokenDefinition, getSolanaTokenDefinition } from '../solanaDefinitions';
 
-jest.mock('cross-fetch');
-
-const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;
+const mockedFetch = jest.fn();
+global.fetch = mockedFetch as unknown as typeof fetch;
 
 describe('getSolanaTokenDefinition', () => {
     const mintAddress = 'fakeMintAddress';
+
+    beforeEach(() => {
+        mockedFetch.mockReset();
+    });
 
     it('should return ArrayBuffer when fetch is successful', async () => {
         const mockArrayBuffer = new ArrayBuffer(10);

--- a/packages/connect/src/api/solana/solanaDefinitions.ts
+++ b/packages/connect/src/api/solana/solanaDefinitions.ts
@@ -1,5 +1,3 @@
-import fetch from 'cross-fetch';
-
 import { MessagesSchema, protobufManager } from '@trezor/protobuf';
 import { trzd } from '@trezor/protocol';
 import { Assert } from '@trezor/schema-utils';

--- a/packages/connect/src/utils/assetUtils.ts
+++ b/packages/connect/src/utils/assetUtils.ts
@@ -1,5 +1,3 @@
-import fetch from 'cross-fetch';
-
 import { firmwareAssets } from '@trezor/connect-data';
 import connectDataCoinsEth from '@trezor/connect-data/files/coins-eth.json';
 import connectDataCoins from '@trezor/connect-data/files/coins.json';

--- a/packages/connect/src/utils/assets.ts
+++ b/packages/connect/src/utils/assets.ts
@@ -1,12 +1,7 @@
-import fetch from 'cross-fetch';
 import { promises as fs } from 'fs';
 
 import { httpRequest as browserHttpRequest, tryLocalAssetRequire } from './assetUtils';
 import type { HttpRequestOptions, HttpRequestReturnType, HttpRequestType } from './assetsTypes';
-
-if (global && typeof global.fetch !== 'function') {
-    global.fetch = fetch;
-}
 
 /**
  * Http request wrapper for Suite Web & Desktop, that first tries to read files locally (unless forced to skip),

--- a/packages/connect/tsconfig.lib.json
+++ b/packages/connect/tsconfig.lib.json
@@ -3,7 +3,7 @@
     "include": ["./src"],
     "compilerOptions": {
         "outDir": "./lib",
-        "lib": ["webworker", "ES2022"],
+        "lib": ["webworker", "dom", "ES2022"],
         "types": ["w3c-web-usb"]
     },
     "references": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -16085,7 +16085,6 @@ __metadata:
     "@types/node": "npm:22.13.10"
     "@types/w3c-web-usb": "npm:^1.0.14"
     "@vitest/browser-playwright": "npm:^4.1.6"
-    cross-fetch: "npm:^4.1.0"
     crypto-browserify: "npm:3.12.1"
     jest: "npm:29.7.0"
     jws: "npm:^4.0.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Getting rid of `cross-fetch` in connect in favor of native `fetch`.

## Notes for QA

Nothing to test.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in the @trezor/connect package, specifically in Ethereum and Solana definition resolution logic (ethereumDefinitions.ts, solanaDefinitions.ts) and shared asset utilities (assetUtils.ts, assets.ts). These files control how token/network definitions are fetched and applied during transaction signing flows. The highest risk is in tests that perform actual transaction signing on Ethereum or Solana networks, as broken definitions could cause transaction construction failures or incorrect data displayed on the hardware device. The solanaDefinitions.ts and assetUtils.ts files map to 121 tests each, indicating they are broad dependencies — only tests that directly exercise Ethereum/Solana transaction or token resolution flows should be prioritized.

<details><summary><b>Changed files (7)</b></summary>

- `packages/connect/package.json`
- `packages/connect/src/api/ethereum/ethereumDefinitions.ts`
- `packages/connect/src/api/solana/__tests__/solanaDefinitions.test.ts`
- `packages/connect/src/api/solana/solanaDefinitions.ts`
- `packages/connect/src/utils/assetUtils.ts`
- `packages/connect/src/utils/assets.ts`
- `packages/connect/tsconfig.lib.json`

</details>

**Recommended tests (18)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — This test exercises the Ethereum send flow end-to-end including gas fee display on the device prompt. Changes to ethereumDefinitions.ts directly affect how Ethereum transaction parameters are resolved, which could break the send confirmation flow.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — This test signs and verifies Ethereum messages via TrezorConnect. ethereumDefinitions.ts changes could affect how Ethereum network/token definitions are resolved during signMessage/verifyMessage API calls, potentially breaking signature generation.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test performs a full Solana staking transaction including device confirmation. solanaDefinitions.ts changes directly affect Solana token/asset resolution which is exercised during stake transaction construction and signing.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test sends max SOL from a passphrase wallet with full device confirmation. solanaDefinitions.ts changes could affect how Solana transaction parameters and token definitions are resolved during the send flow.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This test directly calls TrezorConnect.ethereumSignTransaction. Changes to ethereumDefinitions.ts affect how Ethereum definitions (network info, token data) are fetched and applied during transaction signing, which is the core path this test validates.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — This test calls TrezorConnect.ethereumSignMessage which depends on Ethereum definitions resolution. Changes to ethereumDefinitions.ts could break the message signing flow.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking involves signing an Ethereum transaction to the Everstake contract. ethereumDefinitions.ts changes affect how Ethereum network/token definitions are resolved during the staking transaction construction.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Solana unstaking and claiming involves signing Solana transactions. solanaDefinitions.ts changes could affect how Solana token definitions are resolved during unstake/claim transaction flows.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — This test performs additional SOL staking which involves Solana transaction signing. Changes to solanaDefinitions.ts affect how Solana program/token definitions are resolved.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Selling ETH involves constructing and signing an Ethereum transaction with custom gas fees. ethereumDefinitions.ts changes could affect how the Ethereum transaction parameters are resolved.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Selling an ERC-20 token (USDC) involves Ethereum token definition resolution. ethereumDefinitions.ts changes directly affect how token metadata is fetched for ERC-20 transactions.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Swapping SOL to USDC involves Solana token definitions for the SPL token. solanaDefinitions.ts changes could affect how the swap transaction handles token metadata resolution.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swapping USDT (Solana SPL token) to BTC involves Solana token definition resolution during transaction construction. solanaDefinitions.ts changes are directly relevant.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test validates Ethereum custom fee parameters during a swap. ethereumDefinitions.ts changes affect the Ethereum transaction definition resolution used in fee calculation and display.
- `suite/e2e/tests/wallet/send-base.test.ts` — Sending on the Base EVM L2 network uses Ethereum definitions for transaction signing. ethereumDefinitions.ts changes could affect how Base network transaction parameters are resolved.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Swapping Solana SPL tokens (USDT to USDC) requires Solana token definition resolution for both tokens. solanaDefinitions.ts changes directly affect this flow.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — Receiving addresses for ETH and SOL involves definition resolution for address derivation. While primarily a display test, changes to definitions could affect address generation paths.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstaking and claiming involves Ethereum transaction signing. ethereumDefinitions.ts changes could theoretically affect how the unstake contract call is constructed.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/connect/package.json`
- `packages/connect/src/api/solana/__tests__/solanaDefinitions.test.ts`
- `packages/connect/src/utils/assets.ts`
- `packages/connect/tsconfig.lib.json`

_Updated: 2026-06-19T10:32:54.051Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=get-rid-cross-fetch-connect&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=get-rid-cross-fetch-connect&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=get-rid-cross-fetch-connect&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-19T10:37:13.569Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-19T10:36:31.860Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/get-rid-cross-fetch-connect/web/](https://dev.suite.sldev.cz/suite-web/get-rid-cross-fetch-connect/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->