### PR TITLE
chore(icons): remove dead code from downloadCryptoIcons script

### DIFF
--- a/suite-common/icons/scripts/downloadCryptoIcons.ts
+++ b/suite-common/icons/scripts/downloadCryptoIcons.ts
@@ -11,12 +11,7 @@ import {
     UPDATED_ICONS_LIST_FILE,
 } from './constants';
 import { CoinListData } from './types';
-import {
-    COIN_IMAGE_SIZES,
-    LEGACY_COIN_IMAGE_SIZES,
-    createCoinImageName,
-    createCoinImageNameLegacy,
-} from '../src/coinImages';
+import { COIN_IMAGE_SIZES, createCoinImageName } from '../src/coinImages';
 import { getCoinData, getCoinList, getUpdatedIconsList } from './utils/fetchCoins';
 import { sleep } from './utils/sleep';
 
@@ -85,26 +80,6 @@ const updateIcon = async (coin: CoinListData) => {
             ([platform, contract]) => platform && contract,
         );
 
-        // Legacy naming – Make sure it's backwards compatible for older versions of the Trezor Suite
-        for (const size of LEGACY_COIN_IMAGE_SIZES) {
-            const finalImageBuffer = await resizeImage(originImageBuffer, size);
-
-            const fileNameLegacy = createCoinImageNameLegacy({ coingeckoId: coinData.id, size });
-            console.log(`[legacy] Writing image (${coin.id}):`, fileNameLegacy);
-            await writeImage(fileNameLegacy, finalImageBuffer);
-
-            for (const [coingeckoId, contractAddress] of platforms) {
-                const fileNameLegacyPlatform = createCoinImageNameLegacy({
-                    coingeckoId,
-                    contractAddress,
-                    size,
-                });
-                console.log(`[legacy] Writing image (${coin.id}):`, fileNameLegacyPlatform);
-                await writeImage(fileNameLegacyPlatform, finalImageBuffer);
-            }
-        }
-
-        // New naming
         for (const size of COIN_IMAGE_SIZES) {
             const finalImageBuffer = await resizeImage(originImageBuffer, size);
 


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into a small isolated PR for easy, low-risk review.

**Deletion-only** — removes dead definitions/code with no export-surface-only changes.

<!-- BLAME-AUTHORS -->
**Author(s) of the removed code** (via `git blame`): @cermakjiri — please confirm this code is genuinely dead and safe to delete, and not intentional preparation. 🙏

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `suite-common/icons/scripts/downloadCryptoIcons.ts`, which is a build-time script for downloading cryptocurrency icons. It is not runtime application code — it runs during the build/asset pipeline and does not affect any application logic, UI components, state management, or user-facing flows exercised by the E2E tests. No static coverage mapping exists for this file, and none of the 92 candidate tests reference or interact with icon download scripts. There is no meaningful risk of E2E regression from this change, so no tests are recommended.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/icons/scripts/downloadCryptoIcons.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-common/icons/scripts/downloadCryptoIcons.ts`

_Updated: 2026-06-19T10:55:54.203Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-icons-script/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-icons-script/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-icons-script&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-icons-script&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-icons-script&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-19T11:01:05.046Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-19T11:00:02.915Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->