### PR TITLE
chore(suite): remove dead notification util code

### DIFF
--- a/packages/suite/src/utils/suite/notification.ts
+++ b/packages/suite/src/utils/suite/notification.ts
@@ -1,8 +1,6 @@
 import { type TranslationKey } from '@suite/intl';
 import { type NotificationEntry } from '@suite-common/toast-notifications';
-import { intermediaryTheme } from '@trezor/components';
 
-import type { NotificationViewProps } from 'src/components/suite';
 import { type AppState, type ToastNotificationVariant } from 'src/types/suite';
 
 export const getNotificationIcon = (variant: ToastNotificationVariant) => {
@@ -15,22 +13,6 @@ export const getNotificationIcon = (variant: ToastNotificationVariant) => {
         case 'success':
             return 'check';
         // no default
-    }
-};
-
-export const getVariantColor = (variant: NotificationViewProps['variant']) => {
-    switch (variant) {
-        case 'info':
-            return intermediaryTheme.light.contentInfo;
-        case 'warning':
-            return intermediaryTheme.light.contentWarning;
-        case 'error':
-            return intermediaryTheme.light.contentCritical;
-        case 'success':
-            return intermediaryTheme.light.contentBrand;
-        case 'transparent':
-        default:
-            return 'transparent';
     }
 };
 


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into a small isolated PR for easy, low-risk review.

**Deletion-only** — removes dead definitions/code with no export-surface-only changes.

## Notes for QA

No QA needed — pure dead-code removal; the deleted symbols have no remaining references and there is no runtime effect.

<!-- BLAME-AUTHORS -->
**Author(s) of the removed code** (via `git blame`): @tomasklim @seibei-iguchi — please confirm this code is genuinely dead and safe to delete, and not intentional preparation. 🙏

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file `notification.ts` is a broad utility mapped to 121 tests, indicating it is a shared infrastructure module for toast/notification creation across the entire Suite application. The risk is moderate: if the change alters how notifications are constructed, formatted, or dispatched, it could affect any toast-dependent flow. The recommended strategy focuses on tests that explicitly assert toast notification visibility, content, or lifecycle — these are the tests most likely to catch regressions from notification utility changes. Tests that merely transitively import this module without asserting on notifications are omitted.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/utils/suite/notification.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test explicitly validates toast notifications for backup failures (@toast/backup-failed) and error banners, which are directly generated by the notification utility. Changes to notification.ts could break how these error/warning notifications are created and displayed.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/backup/t2t1-success.test.ts` — This test verifies backup creation analytics events and the backup flow completion, which may involve notification creation for success states. Less direct than the failure case but still exercises notification paths.
- `suite/e2e/tests/settings/passphrase.test.ts` — This test explicitly asserts that a '@toast/settings-applied' notification appears and then auto-dismisses. Changes to notification utility could directly affect toast creation, visibility, and lifecycle.
- `suite/e2e/tests/settings/t1b1-device-settings.test.ts` — This test asserts toast notifications for PIN changes (@toast/pin-changed) and PIN mismatch errors. The notification utility likely handles construction of these toast payloads.
- `suite/e2e/tests/wallet/receive.test.ts` — This test verifies a 'Copied to clipboard' toast notification appears after copying a receive address. Changes to the notification utility could affect how this toast is created or displayed.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test explicitly asserts a '@toast/sign-tx-error' notification with a specific TOAST_SIGN_TX_ERROR message. The notification utility is likely responsible for constructing this error toast.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — This test asserts '@toast/verify-message-success' toast notification visibility after message verification. Changes to notification.ts could affect how success toasts are generated.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — This test asserts both '@toast/sign-message-success' and '@toast/verify-message-success' toast notifications. The notification utility directly governs how these toasts are constructed.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test asserts a specific verify address error toast (TOAST_VERIFY_ADDRESS_ERROR with passphrase mismatch message). The notification utility may be involved in constructing this error notification payload.
- `suite/e2e/tests/suite/bug-report-form.test.ts` — This test asserts a '@toast/user-feedback-send-success' toast after submitting a bug report. The notification utility may handle the creation of this feedback success notification.

</details>

_Updated: 2026-06-29T08:20:47.104Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-suite-notification&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-suite-notification&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T08:25:34.652Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T08:24:00.022Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-notification/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-notification/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->