### PR TITLE
chore(trading): remove dead trading constants and assets-hook code

### DIFF
--- a/suite-common/trading/src/constants.ts
+++ b/suite-common/trading/src/constants.ts
@@ -16,7 +16,6 @@ export const TRADING_SELL_THUNK_PREFIX = `${TRADING_SELL_PREFIX}/thunk`;
 
 export const TRADING_DEFAULT_CRYPTO_CURRENCY = 'btc' satisfies NetworkSymbol;
 export const TRADING_DEFAULT_PAYMENT_METHOD = 'creditCard' as const;
-export const TRADING_DEFAULT_FIAT_CURRENCY = 'eur' as const;
 export const TRADING_DEFAULT_SELL_FLOWS: SellFiatFlowType[] = ['BANK_ACCOUNT', 'PAYMENT_GATE'];
 
 export const TRADING_EXCHANGE_RATE = 'rateType';
@@ -73,14 +72,3 @@ export const CRYPTO_PLATFORM_SEPARATOR = '--';
  * Used for L2 networks (e.g. base, op)
  */
 export const CONTRACT_ADDRESS_FOR_NATIVE_TOKEN = '0x0000000000000000000000000000000000000000';
-
-export const TOKEN_SELECT_SELECTABLE_NETWORKS: NetworkSymbol[] = [
-    'eth',
-    'sol',
-    'pol',
-    'bsc',
-    'base',
-    'op',
-    'avax',
-    'arb',
-];

--- a/suite-common/trading/src/hooks/useTradingAssets.ts
+++ b/suite-common/trading/src/hooks/useTradingAssets.ts
@@ -316,5 +316,3 @@ export function useTradingAssets() {
 
     return { buildAssetOptions, createAssetOptionFromCryptoId, resolveAssetTokenOption };
 }
-
-export type UseTradingAssets = ReturnType<typeof useTradingAssets>;

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -18,18 +18,13 @@ import {
     getNetwork,
     getNetworkByCoingeckoId,
     getNetworkByTradeCryptoId,
-    networksCollection,
 } from '@suite-common/wallet-config';
 import type { Account, AccountKey, FormStateTrading } from '@suite-common/wallet-types';
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { type TokenInfo } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
 
-import {
-    CONTRACT_ADDRESS_FOR_NATIVE_TOKEN,
-    CRYPTO_PLATFORM_SEPARATOR,
-    TOKEN_SELECT_SELECTABLE_NETWORKS,
-} from './constants';
+import { CONTRACT_ADDRESS_FOR_NATIVE_TOKEN, CRYPTO_PLATFORM_SEPARATOR } from './constants';
 import { regional } from './regional';
 import {
     type TradingCountryCode,
@@ -379,18 +374,6 @@ export const getTradingFormState = ({
             return exhaustive(activeSection);
     }
 };
-
-export const getTokenSelectableNetworks = (
-    isDebugMode = false,
-    allNetworks = networksCollection,
-): NetworkSymbol[] =>
-    allNetworks
-        .filter(
-            n =>
-                (!n.isDebugOnlyNetwork || isDebugMode) &&
-                TOKEN_SELECT_SELECTABLE_NETWORKS.includes(n.symbol),
-        )
-        .map(n => n.symbol);
 
 export const getTradingPrefilledFromAccountData = (
     { symbol, key }: Account,


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into a small isolated PR for easy, low-risk review.

**Deletion-only** — removes dead definitions/code with no export-surface-only changes.

<!-- BLAME-AUTHORS -->
**Author(s) of the removed code** (via `git blame`): @matusbalascak @cermakjiri — please confirm this code is genuinely dead and safe to delete, and not intentional preparation. 🙏

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files (constants.ts, useTradingAssets.ts, utils.ts) are core trading infrastructure in suite-common/trading. While they statically map to all 121 tests due to broad transitive imports, only the trading-specific tests directly exercise this functionality. The highest risk is in buy/sell/swap flows where asset resolution, crypto ID lookup, and trading constants are actively used. Tests outside the trading domain (analytics, backup, onboarding, metadata, etc.) are extremely unlikely to be affected since they don't exercise any trading UI or logic. The recommended strategy focuses on comprehensive coverage of all trading flow variants (buy, sell, swap) across different asset types (coins, tokens, cross-chain).

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/trading/src/constants.ts`
- `suite-common/trading/src/hooks/useTradingAssets.ts`
- `suite-common/trading/src/utils.ts`

</details>

**Recommended tests (18)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Directly exercises the trading buy flow including asset selection, quotes, and trade confirmation. Changes to trading constants, utils, and useTradingAssets hook directly affect how buy assets are resolved, displayed, and processed.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests buying Ethereum including asset picker search/selection and quote display. The useTradingAssets hook and trading utils are core to how assets are listed and filtered in the buy flow.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Tests buying a Solana SPL token (Jupiter/JUP) via asset picker with network filtering and search. Changes to useTradingAssets and trading utils directly affect token asset resolution and display in the buy form.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation to Buy/Sell/Swap forms from multiple entry points and verifies correct asset preselection. Trading constants and asset hooks determine which assets are available and how they're resolved across navigation paths.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Tests the full swap flow (SOL→BTC) including asset selection, quote display, device confirmation, and transaction status polling. Trading utils (e.g., getCryptoId) and constants are directly used in swap asset resolution.

</details>

<details><summary>🟡 <b>Medium priority (12)</b></summary>

- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests buy form validation including amount limits and empty quote handling. Trading constants may define validation thresholds, and trading utils handle quote processing that determines error states.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Tests the full sell BTC flow including best offer display and trade confirmation. Trading utils and constants affect how sell quotes and trade payloads are processed.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token (USDC) through the trading flow. Token asset resolution via useTradingAssets and trading utils is critical for token-based sell flows.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests selling ETH with custom gas fees. Trading utils and constants are used in the sell flow for asset identification and trade processing.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation including decimal limits, insufficient funds, and fraction buttons. Trading constants may affect validation rules and the trading utils handle amount calculations.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests selling SOL including best offer display, trade confirmation, and transaction status updates. Trading utils are used for asset resolution and localizeNumber formatting.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests swapping SOL to USDC token including asset selection and receive account. useTradingAssets hook and getCryptoId from trading utils are directly referenced in the test source hints.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests swap with custom BTC fees. While focused on fee calculation, the swap form setup depends on trading utils for asset resolution and swap quote handling.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests swap with custom ETH gas parameters. The swap form initialization depends on trading utils (getCryptoId) and asset hooks for proper asset resolution.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping USDT token to BTC. getCryptoId from trading utils and the useTradingAssets hook are critical for token-to-coin asset resolution in the swap form.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swapping to an asset on a disabled network, which specifically exercises how trading assets are resolved when the target network isn't enabled. Trading utils getCryptoId is explicitly referenced.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests swapping SPL tokens (USDT→USDC). Token asset identification via trading utils and the useTradingAssets hook is essential for token-to-token swap flows.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Tests buy action from the dashboard assets section which navigates to trading page. Changes to trading asset hooks could affect whether the buy button correctly resolves the asset to trade.

</details>

_Updated: 2026-06-19T11:21:51.955Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-common-trading-utils&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-common-trading-utils&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-common-trading-utils&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-common-trading-utils/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-common-trading-utils/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-19T11:25:14.022Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-19T11:24:54.458Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->