### PR TITLE
chore(suite-native): remove dead residence-check trading fixture

### DIFF
--- a/suite-native/trading-fixtures/src/__fixtures__/residenceCheckState.ts
+++ b/suite-native/trading-fixtures/src/__fixtures__/residenceCheckState.ts
@@ -6,10 +6,3 @@ export const residenceCheckDisabledState = {
         [FeatureFlag.IsTradingResidenceCheckEnabled]: false,
     },
 };
-
-export const residenceCheckEnabledState = {
-    featureFlags: {
-        ...featureFlagsInitialState,
-        [FeatureFlag.IsTradingResidenceCheckEnabled]: true,
-    },
-};


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into a small isolated PR for easy, low-risk review.

**Deletion-only** — removes dead definitions/code with no export-surface-only changes.

<!-- BLAME-AUTHORS -->
**Author(s) of the removed code** (via `git blame`): @jbazant — please confirm this code is genuinely dead and safe to delete, and not intentional preparation. 🙏

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-trading-fixtures-residence&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->