### PR TITLE
chore(coinjoin): replace node and cross fetch with native fetch

### DIFF
--- a/packages/coinjoin/package.json
+++ b/packages/coinjoin/package.json
@@ -32,14 +32,12 @@
         "@trezor/eslint": "workspace:*",
         "@trezor/utils": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
-        "cross-fetch": "^4.1.0",
         "golomb": "1.2.0",
         "n64": "^0.2.10"
     },
     "devDependencies": {
         "@trezor/node-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*",
-        "node-fetch": "^3.3.2",
         "socks-proxy-agent": "8.0.5",
         "ws": "^8.20.0"
     }

--- a/packages/coinjoin/src/utils/http.ts
+++ b/packages/coinjoin/src/utils/http.ts
@@ -1,5 +1,3 @@
-import fetch from 'cross-fetch';
-
 import { type ScheduleActionParams, capitalizeFirstLetter, getWeakRandomId } from '@trezor/utils';
 
 export interface RequestOptions extends ScheduleActionParams {

--- a/packages/coinjoin/tests/tools/benchmark-test.ts
+++ b/packages/coinjoin/tests/tools/benchmark-test.ts
@@ -4,7 +4,6 @@
 import http from 'http';
 import https from 'https';
 import net from 'net';
-import fetch from 'node-fetch';
 import { SocksProxyAgent } from 'socks-proxy-agent';
 import WebSocket from 'ws';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15696,10 +15696,8 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
-    cross-fetch: "npm:^4.1.0"
     golomb: "npm:1.2.0"
     n64: "npm:^0.2.10"
-    node-fetch: "npm:^3.3.2"
     socks-proxy-agent: "npm:8.0.5"
     ws: "npm:^8.20.0"
   languageName: unknown


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Replacing libraries `node-fetch` and `cross-fetch` with native fetch since now `fetch` is first citizen of all react-native, web and nodejs, so there is not anymore need to have more of those libraries that were needed in the past.

## Notes for QA
Noting to test.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to the `packages/coinjoin` package: a `package.json` update, a modification to an HTTP utility (`http.ts`), and a benchmark test file. None of the 75 candidate E2E tests reference coinjoin functionality, coinjoin HTTP utilities, or any coinjoin-related code paths. The coinjoin package is a relatively isolated module dealing with CoinJoin (privacy mixing) transactions, and none of the analyzed E2E tests exercise CoinJoin flows. There is no static mapping and no inferred connection between these changes and any of the available E2E tests, so no tests are recommended. The risk is low for user-facing regressions detectable by these E2E tests; unit/integration tests within the coinjoin package itself would be the appropriate validation layer.

<details><summary><b>Changed files (3)</b></summary>

- `packages/coinjoin/package.json`
- `packages/coinjoin/src/utils/http.ts`
- `packages/coinjoin/tests/tools/benchmark-test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `packages/coinjoin/package.json`
- `packages/coinjoin/src/utils/http.ts`
- `packages/coinjoin/tests/tools/benchmark-test.ts`

_Updated: 2026-06-19T12:10:10.269Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/get-rid-x-fetch-coinjoin/web/](https://dev.suite.sldev.cz/suite-web/get-rid-x-fetch-coinjoin/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=get-rid-x-fetch-coinjoin&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=get-rid-x-fetch-coinjoin&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-19T12:15:37.794Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-19T12:14:20.828Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->