### PR TITLE
Include rent in Solana stake review amount

### DIFF
--- a/suite-native/module-earn/src/components/EarnTransactionDataReviewStepList.tsx
+++ b/suite-native/module-earn/src/components/EarnTransactionDataReviewStepList.tsx
@@ -4,7 +4,11 @@ import { useSelector } from 'react-redux';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { asAmountUnit, unitsToSubunits } from '@suite-common/wallet-utils';
+import {
+    asAmountUnit,
+    isSupportedSolStakingNetworkSymbol,
+    unitsToSubunits,
+} from '@suite-common/wallet-utils';
 import { Button, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -73,6 +77,14 @@ export const EarnTransactionDataReviewStepList = ({
         symbol: accountSymbol,
     }).toString();
 
+    const isSolanaStake = isSupportedSolStakingNetworkSymbol(accountSymbol);
+    const displayedAmountInBaseUnits =
+        isSolanaStake && selectedPrecomposed
+            ? new BigNumber(selectedPrecomposed.totalSpent)
+                  .minus(selectedPrecomposed.fee)
+                  .toFixed(0)
+            : amountInBaseUnits;
+
     return (
         <View>
             <VStack spacing={LIST_VERTICAL_SPACING}>
@@ -84,7 +96,7 @@ export const EarnTransactionDataReviewStepList = ({
 
                 <EarnSummaryOutputItem
                     accountKey={accountKey}
-                    amount={amountInBaseUnits}
+                    amount={displayedAmountInBaseUnits}
                     fee={summaryOutput?.fee ?? selectedPrecomposed?.fee ?? '0'}
                     outputState={summaryOutput?.state ?? (isLastStep ? 'active' : undefined)}
                     onLayout={event => handleReadListItemHeight(event, 1)}


### PR DESCRIPTION
## Description

On mobile, the Solana staking review screen showed only the stake amount, which didn't match the total shown on the Trezor device. The device total also includes the account rent (~0.00228 SOL), so the two figures disagreed. This change makes the Solana stake review display the device amount (total spent minus fee), so the reviewed value matches what the user confirms on-device. Unstake and claim flows, and non-Solana networks, are unchanged.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28919


