### PR TITLE
fix(suite-native): account list rerendering

### DIFF
--- a/suite-common/redux-utils/src/selectorsUtils.ts
+++ b/suite-common/redux-utils/src/selectorsUtils.ts
@@ -1,5 +1,7 @@
 import { createSelectorCreator, weakMapMemoize } from 'reselect';
 
+export { weakMapMemoize };
+
 const EMPTY_STABLE_ARRAY: unknown[] = [];
 
 /**

--- a/suite-common/suite-sync/src/data/account/__tests__/selectAccountsWithSuiteSyncLabel.test.ts
+++ b/suite-common/suite-sync/src/data/account/__tests__/selectAccountsWithSuiteSyncLabel.test.ts
@@ -1,0 +1,139 @@
+import { type SuiteSyncAccount, createSuiteSyncAccountId } from '@suite-common/suite-sync-storage';
+import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { type StaticSessionId, asWalletDescriptor } from '@trezor/device-utils';
+
+import { type SuiteSyncDataRootState } from '../../suiteSyncDataReducer';
+import { selectAccountsWithSuiteSyncLabel } from '../selectAccountsWithSuiteSyncLabel';
+
+const WALLET_DESCRIPTOR = asWalletDescriptor('selectedWallet');
+const DEVICE_STATIC_SESSION_ID: StaticSessionId = 'selectedWallet@deviceId:0';
+
+const btcAccount = mockWalletAccount({
+    symbol: 'btc',
+    descriptor: asAccountDescriptor('btcdefault'),
+    deviceState: DEVICE_STATIC_SESSION_ID,
+    accountType: 'normal',
+    index: 0,
+});
+
+const ethAccount = mockWalletAccount({
+    symbol: 'eth',
+    descriptor: asAccountDescriptor('ethdefault'),
+    deviceState: DEVICE_STATIC_SESSION_ID,
+    accountType: 'normal',
+    index: 0,
+});
+
+const createSuiteSyncAccount = (account: Account, label: string): SuiteSyncAccount => ({
+    id: createSuiteSyncAccountId(account.descriptor, account.symbol),
+    accountDescriptor: account.descriptor,
+    networkSymbol: account.symbol,
+    label,
+});
+
+const createSuiteSyncAccountsRecord = (accounts: SuiteSyncAccount[]) =>
+    accounts.reduce<Record<SuiteSyncAccount['id'], SuiteSyncAccount>>((acc, account) => {
+        acc[account.id] = account;
+
+        return acc;
+    }, {});
+
+const createState = (suiteSyncAccounts: SuiteSyncAccount[]): SuiteSyncDataRootState => ({
+    suiteSyncData: {
+        wallets: {
+            [WALLET_DESCRIPTOR]: {
+                wallet: {
+                    walletDescriptor: WALLET_DESCRIPTOR,
+                    label: null,
+                },
+                accounts: createSuiteSyncAccountsRecord(suiteSyncAccounts),
+                addresses: {},
+                outputs: {},
+            },
+        },
+    },
+});
+
+describe('selectAccountsWithSuiteSyncLabel', () => {
+    it('maps the suite sync label onto each account', () => {
+        const state = createState([createSuiteSyncAccount(btcAccount, 'Daily spending')]);
+
+        const result = selectAccountsWithSuiteSyncLabel(
+            state,
+            [btcAccount, ethAccount],
+            DEVICE_STATIC_SESSION_ID,
+        );
+
+        expect(result).toEqual([
+            { ...btcAccount, label: 'Daily spending' },
+            { ...ethAccount, label: null },
+        ]);
+    });
+
+    it('preserves the wrapped object reference for an account whose data and label are unchanged', () => {
+        const state = createState([createSuiteSyncAccount(btcAccount, 'Daily spending')]);
+
+        const [btcFirst, ethFirst] = selectAccountsWithSuiteSyncLabel(
+            state,
+            [btcAccount, ethAccount],
+            DEVICE_STATIC_SESSION_ID,
+        );
+
+        const [btcSecond, ethSecond] = selectAccountsWithSuiteSyncLabel(
+            state,
+            [btcAccount, ethAccount],
+            DEVICE_STATIC_SESSION_ID,
+        );
+
+        expect(btcSecond).toBe(btcFirst);
+        expect(ethSecond).toBe(ethFirst);
+    });
+
+    it('returns a new wrapped object only for the account whose source object changed', () => {
+        const state = createState([createSuiteSyncAccount(btcAccount, 'Daily spending')]);
+
+        const [btcFirst, ethFirst] = selectAccountsWithSuiteSyncLabel(
+            state,
+            [btcAccount, ethAccount],
+            DEVICE_STATIC_SESSION_ID,
+        );
+
+        const updatedBtcAccount: Account = { ...btcAccount, availableBalance: '123' };
+
+        const [btcSecond, ethSecond] = selectAccountsWithSuiteSyncLabel(
+            state,
+            [updatedBtcAccount, ethAccount],
+            DEVICE_STATIC_SESSION_ID,
+        );
+
+        expect(btcSecond).not.toBe(btcFirst);
+        expect(btcSecond?.availableBalance).toBe('123');
+        expect(btcSecond?.label).toBe('Daily spending');
+        // The untouched account keeps its wrapped object identity.
+        expect(ethSecond).toBe(ethFirst);
+    });
+
+    it('returns a new wrapped object when only the suite sync label changes', () => {
+        const stateWithLabel = createState([createSuiteSyncAccount(btcAccount, 'Daily spending')]);
+
+        const [btcFirst] = selectAccountsWithSuiteSyncLabel(
+            stateWithLabel,
+            [btcAccount],
+            DEVICE_STATIC_SESSION_ID,
+        );
+
+        const stateWithRenamedLabel = createState([
+            createSuiteSyncAccount(btcAccount, 'Renamed label'),
+        ]);
+
+        const [btcSecond] = selectAccountsWithSuiteSyncLabel(
+            stateWithRenamedLabel,
+            [btcAccount],
+            DEVICE_STATIC_SESSION_ID,
+        );
+
+        expect(btcSecond).not.toBe(btcFirst);
+        expect(btcSecond?.label).toBe('Renamed label');
+    });
+});

--- a/suite-common/suite-sync/src/data/account/selectAccountsWithSuiteSyncLabel.ts
+++ b/suite-common/suite-sync/src/data/account/selectAccountsWithSuiteSyncLabel.ts
@@ -1,4 +1,4 @@
-import { createWeakMapSelector } from '@suite-common/redux-utils';
+import { createWeakMapSelector, weakMapMemoize } from '@suite-common/redux-utils';
 import { type SuiteSyncAccount } from '@suite-common/suite-sync-storage';
 import { type Account } from '@suite-common/wallet-types';
 import { type StaticSessionId } from '@trezor/connect';
@@ -13,21 +13,24 @@ export type AccountWithSuiteSyncLabel = Account & {
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<SuiteSyncDataRootState>();
 
+const createAccountWithSuiteSyncLabel = weakMapMemoize(
+    (account: Account, label: string | null): AccountWithSuiteSyncLabel => ({ ...account, label }),
+);
+
 const mapAccountsToSuiteSyncLabel = (
     accounts: readonly Account[],
     suiteSyncAccountLabels: SuiteSyncAccount[],
 ): AccountWithSuiteSyncLabel[] =>
-    accounts.map(account => ({
-        ...account,
-        label:
+    accounts.map(account => {
+        const label =
             findSuiteSyncAccountLabel({
                 accounts: suiteSyncAccountLabels,
                 accountDescriptor: account.descriptor,
                 networkSymbol: account.symbol,
-            })?.label ??
-            // account.accountLabel ??
-            null,
-    }));
+            })?.label ?? null;
+
+        return createAccountWithSuiteSyncLabel(account, label);
+    });
 
 export const selectAccountsWithSuiteSyncLabel = createMemoizedSelector(
     [

--- a/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
@@ -15,15 +15,15 @@ import { Translation } from '@suite-native/intl';
 import { type NativeStakingRootState, selectAccountHasStaking } from '@suite-native/staking';
 import { isNetworkWithTokens } from '@suite-native/tokens';
 
-import { AccountLabel } from '../AccountLabel';
-import { AccountsListItemBase } from './AccountsListItemBase';
-import { StakingBadge } from './StakingBadge';
 import {
     type NativeAccountsRootState,
     selectAccountFiatBalance,
     selectActiveAndDefiTokensCount,
 } from '../../selectors';
 import { type OnSelectAccount } from '../../types';
+import { AccountLabel } from '../AccountLabel';
+import { AccountsListItemBase } from './AccountsListItemBase';
+import { StakingBadge } from './StakingBadge';
 
 type AccountListItemProps = {
     account: Account;
@@ -57,7 +57,7 @@ const TokenBadge = React.memo(({ accountKey }: { accountKey: AccountKey }) => {
     );
 });
 
-export const AccountsListItem = ({
+const AccountsListItemComponent = ({
     account,
     onPress,
     disabled,
@@ -178,3 +178,7 @@ export const AccountsListItem = ({
         />
     );
 };
+
+export const AccountsListItem = React.memo(AccountsListItemComponent);
+
+AccountsListItem.displayName = 'AccountsListItem';

--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -40,6 +40,7 @@ import {
     type RatesByKey,
     type TokenAddress,
     type TokenInfoBranded,
+    asBaseCurrencyAmount,
     createAccountKey,
 } from '@suite-common/wallet-types';
 import {
@@ -57,6 +58,7 @@ import { type CombinedLabelingState, selectIsLabellingAllowed } from '@suite-nat
 import { isNetworkWithTokens, selectAccountTokenInfo } from '@suite-native/tokens';
 import { type StaticSessionId } from '@trezor/connect';
 import { parseStaticSessionId } from '@trezor/device-utils';
+import { BigNumber } from '@trezor/utils';
 
 import { type AccountListSection, type GroupedByTypeAccounts } from './types';
 import {
@@ -181,7 +183,7 @@ export const selectNetworkFilterOptions = createMemoizedSelector(
     },
 );
 
-export const selectAccountFiatBalance = createMemoizedSelector(
+const selectAccountFiatBalanceValue = createMemoizedSelector(
     [
         selectCurrentFiatRates,
         selectAccountByKey,
@@ -197,7 +199,7 @@ export const selectAccountFiatBalance = createMemoizedSelector(
     ],
     (fiatRates, account, localCurrency, shouldIncludeStaking, shouldIncludeTokens) => {
         if (!account) {
-            return BASE_CURRENCY_ZERO;
+            return BASE_CURRENCY_ZERO.toFixed();
         }
 
         const totalBalance = getAccountFiatBalance({
@@ -209,11 +211,16 @@ export const selectAccountFiatBalance = createMemoizedSelector(
         });
 
         if (!totalBalance) {
-            return BASE_CURRENCY_ZERO;
+            return BASE_CURRENCY_ZERO.toFixed();
         }
 
-        return totalBalance;
+        return totalBalance.toFixed();
     },
+);
+
+export const selectAccountFiatBalance = createMemoizedSelector(
+    [selectAccountFiatBalanceValue],
+    fiatBalance => asBaseCurrencyAmount(new BigNumber(fiatBalance)),
 );
 
 export const selectAccountTokenFiatBalance = createMemoizedSelector(


### PR DESCRIPTION
## Description

This PR optimizes (minimizes) the re-rendering of accounts in the `My assets` screen.

### About the Problem

One major issue that I found is that the **account object references** change during discovery due to **Suite Sync labels**. The `mapAccountsToSuiteSyncLabel` function that is used in the `selectAccountsWithSuiteSyncLabel` generates new account object references each time anything changes. This triggers many re-renders, especially during discovery.

Once this is fixed and the references are stable, we can memoize the `AccountsListItem` using `React.memo` to optimize re-renders even further.

### Core Changes

This PR introduces an identity-preserving cache using `weakMapMemoize`, so that when the Suite Sync label is not changed, it preserves the account object reference, returns the cached account, and ultimately makes the references more stable.

Once the references are stabilized, we use `React.memo` for the `AccountsListItem` to further optimize re-renders.

Finally, we introduce a new selector that returns the account fiat balance as string instead of a new `BigNumber` object, which is then memoized and transformed to `BigNumber` only when the string value changes.

## Related Issue

Resolve #28519 

## Screenshots:

https://github.com/user-attachments/assets/e7a7fa3a-1e37-4c5b-88bf-b3a848d3c17d

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes center on two areas: (1) the selectAccountsWithSuiteSyncLabel selector and its supporting selectorsUtils infrastructure, and (2) suite-native mobile account components. The selector changes affect Suite Sync label functionality — how accounts are matched with their synced labels. The selectorsUtils.ts file is a broad utility (121 tests) but the actual behavioral impact is confined to Suite Sync labeling flows. The suite-native changes (AccountsListItem.tsx, selectors.ts) are mobile-only and have no E2E test coverage in this suite. Testing should focus on Suite Sync label creation, syncing, removal, and migration scenarios.

<details><summary><b>Changed files (5)</b></summary>

- `suite-common/redux-utils/src/selectorsUtils.ts`
- `suite-common/suite-sync/src/data/account/__tests__/selectAccountsWithSuiteSyncLabel.test.ts`
- `suite-common/suite-sync/src/data/account/selectAccountsWithSuiteSyncLabel.ts`
- `suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx`
- `suite-native/accounts/src/selectors.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test directly exercises Suite Sync account labeling, which relies on selectAccountsWithSuiteSyncLabel.ts — one of the changed files. It creates account labels and verifies they sync to the Evolu Relay, exercising the exact selector pipeline that was modified.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test syncs account labels from the Evolu relay server and verifies they display correctly. It directly depends on the selectAccountsWithSuiteSyncLabel selector to match accounts with their synced labels.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test removes Suite Sync labels and verifies the relay reflects null values. The removal flow depends on selectAccountsWithSuiteSyncLabel to identify which accounts have labels to remove.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test creates multiple wallets with Suite Sync labels and verifies account-level labels per passphrase wallet. It directly exercises the account label selector across multiple wallet contexts.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test migrates legacy Dropbox labels to Suite Sync, which involves the selectAccountsWithSuiteSyncLabel selector to display the migrated account label. Changes to the selector could affect the migration display.
- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — This test performs a full legacy-to-Suite-Sync migration of account/output/address labels and verifies synced data via the Evolu relay. The account label verification path uses the changed selector.
- `suite/e2e/tests/metadata/suite-sync/unsupported-device.test.ts` — This test enables Suite Sync and checks the unsupported device banner behavior. While primarily about the banner, the Suite Sync setup path involves the account selector infrastructure that was changed.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/suite-sync/src/data/account/__tests__/selectAccountsWithSuiteSyncLabel.test.ts`
- `suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx`
- `suite-native/accounts/src/selectors.ts`

_Updated: 2026-07-02T10:29:13.387Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/account-list-rerendering&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/account-list-rerendering&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/account-list-rerendering&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T10:35:28.117Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |

</details>

_Updated: 2026-07-02T10:31:54.714Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/native/account-list-rerendering/web/](https://dev.suite.sldev.cz/suite-web/fix/native/account-list-rerendering/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->