### PR TITLE
feat(eslint): enforce typedObject* casts in suite/metadata/connect-explorer

### DIFF
--- a/packages/connect-explorer/eslint.config.mjs
+++ b/packages/connect-explorer/eslint.config.mjs
@@ -1,6 +1,10 @@
 import * as mdx from 'eslint-plugin-mdx';
 
-import { eslint, globalNoExtraneousDependenciesDevDependencies } from '@trezor/eslint';
+import {
+    eslint,
+    globalNoExtraneousDependenciesDevDependencies,
+    noCastedObjectHelpersSyntax,
+} from '@trezor/eslint';
 
 export default [
     ...eslint,
@@ -30,7 +34,8 @@ export default [
         rules: {
             'no-console': 'off',
             'import/no-default-export': 'off', // Todo: shall be fixed
-            'no-restricted-syntax': 'off', // Todo: shall be fixed
+            // keep the casted-Object-helper ban active; the rest of no-restricted-syntax stays off (legacy getState/state-as-any debt)
+            'no-restricted-syntax': ['error', ...noCastedObjectHelpersSyntax],
             '@typescript-eslint/no-restricted-imports': 'off',
             '@typescript-eslint/no-shadow': 'off', // Todo: shall be fixed
             'react/jsx-filename-extension': [
@@ -48,6 +53,14 @@ export default [
                     ],
                 },
             ],
+        },
+    },
+    {
+        // the catch-all override above has no `files` key, so it re-enables no-restricted-syntax
+        // for .mdx too; keep MDX exempt (it intentionally disables the whole rule)
+        files: ['**/*.mdx'],
+        rules: {
+            'no-restricted-syntax': 'off',
         },
     },
 ];

--- a/packages/eslint/src/index.mjs
+++ b/packages/eslint/src/index.mjs
@@ -3,7 +3,7 @@ import playwright from 'eslint-plugin-playwright';
 import globals from 'globals';
 
 import { globalNoExtraneousDependenciesDevDependencies, importConfig } from './importConfig.mjs';
-import { javascriptConfig } from './javascriptConfig.mjs';
+import { javascriptConfig, noCastedObjectHelpersSyntax } from './javascriptConfig.mjs';
 import { javascriptNodejsConfig } from './javascriptNodejsConfig.mjs';
 import { jestConfig } from './jestConfig.mjs';
 import { localRulesConfig } from './localRulesConfig.mjs';
@@ -13,7 +13,11 @@ import { restrictedImportsPatterns, typescriptConfig } from './typescriptConfig.
  * @typedef {import('eslint').Linter.Config} Config
  */
 
-export { globalNoExtraneousDependenciesDevDependencies, restrictedImportsPatterns };
+export {
+    globalNoExtraneousDependenciesDevDependencies,
+    noCastedObjectHelpersSyntax,
+    restrictedImportsPatterns,
+};
 
 /** @type {Config[]} */
 export const eslint = [

--- a/packages/eslint/src/javascriptConfig.mjs
+++ b/packages/eslint/src/javascriptConfig.mjs
@@ -3,6 +3,32 @@ import pluginJs from '@eslint/js';
  * @typedef {import('eslint').Linter.Config} Config
  */
 
+/**
+ * Cast bans for the result of `Object.keys/entries/values(...) as …` — steer them to the
+ * typedObject* helpers. Exported separately so packages that switch the rest of
+ * `no-restricted-syntax` off can still opt back into just these selectors.
+ */
+export const noCastedObjectHelpersSyntax = [
+    {
+        selector:
+            "TSAsExpression[expression.type='CallExpression'][expression.callee.type='MemberExpression'][expression.callee.object.name='Object'][expression.callee.property.name='keys']",
+        message:
+            'Use typedObjectKeys from @trezor/utils instead of casting the result of Object.keys(). The `as` assertion just re-spells `keyof typeof`, which typedObjectKeys provides safely.',
+    },
+    {
+        selector:
+            "TSAsExpression[expression.type='CallExpression'][expression.callee.type='MemberExpression'][expression.callee.object.name='Object'][expression.callee.property.name='entries']",
+        message:
+            'Use typedObjectEntries from @trezor/utils instead of casting the result of Object.entries(). The `as` assertion just re-spells the entry tuple type, which typedObjectEntries provides safely.',
+    },
+    {
+        selector:
+            "TSAsExpression[expression.type='CallExpression'][expression.callee.type='MemberExpression'][expression.callee.object.name='Object'][expression.callee.property.name='values']",
+        message:
+            'Use typedObjectValues from @trezor/utils instead of casting the result of Object.values(). The `as` assertion just re-spells the value type, which typedObjectValues provides safely.',
+    },
+];
+
 /** @type {Config[]} */
 export const javascriptConfig = [
     pluginJs.configs.recommended,
@@ -67,24 +93,7 @@ export const javascriptConfig = [
                     message:
                         'Use `undefined` (or `never` in discriminated unions) instead of `typeof undefined` in type position.',
                 },
-                {
-                    selector:
-                        "TSAsExpression[expression.type='CallExpression'][expression.callee.type='MemberExpression'][expression.callee.object.name='Object'][expression.callee.property.name='keys']",
-                    message:
-                        'Use typedObjectKeys from @trezor/utils instead of casting the result of Object.keys(). The `as` assertion just re-spells `keyof typeof`, which typedObjectKeys provides safely.',
-                },
-                {
-                    selector:
-                        "TSAsExpression[expression.type='CallExpression'][expression.callee.type='MemberExpression'][expression.callee.object.name='Object'][expression.callee.property.name='entries']",
-                    message:
-                        'Use typedObjectEntries from @trezor/utils instead of casting the result of Object.entries(). The `as` assertion just re-spells the entry tuple type, which typedObjectEntries provides safely.',
-                },
-                {
-                    selector:
-                        "TSAsExpression[expression.type='CallExpression'][expression.callee.type='MemberExpression'][expression.callee.object.name='Object'][expression.callee.property.name='values']",
-                    message:
-                        'Use typedObjectValues from @trezor/utils instead of casting the result of Object.values(). The `as` assertion just re-spells the value type, which typedObjectValues provides safely.',
-                },
+                ...noCastedObjectHelpersSyntax,
             ],
             'object-shorthand': [
                 'error',

--- a/packages/suite/eslint.config.mjs
+++ b/packages/suite/eslint.config.mjs
@@ -1,4 +1,8 @@
-import { eslint, globalNoExtraneousDependenciesDevDependencies } from '@trezor/eslint';
+import {
+    eslint,
+    globalNoExtraneousDependenciesDevDependencies,
+    noCastedObjectHelpersSyntax,
+} from '@trezor/eslint';
 
 export default [
     ...eslint,
@@ -10,7 +14,8 @@ export default [
                     allow: ['FormattedNumber'],
                 },
             ],
-            'no-restricted-syntax': 'off', // Todo: this should be fixed in codebase and this line removed
+            // keep the casted-Object-helper ban active; the rest of no-restricted-syntax stays off (legacy getState/state-as-any debt)
+            'no-restricted-syntax': ['error', ...noCastedObjectHelpersSyntax],
             'import/no-default-export': 'off', // Todo: shall be solved one day, usually its legacy Components
             'no-console': 'off', // Todo: we use it a lot, shall be disabled more granulary I think
             '@typescript-eslint/no-shadow': 'off', // Todo: shall be fixed

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -271,7 +271,7 @@ export const useSendFormCompose = ({
             !selectedFee || (typeof setMaxOutputId === 'number' && selectedFee !== 'custom');
         if (shouldSwitch && composed.type === 'error') {
             // find nearest possible tx
-            // composedLevels is keyed by fee labels but typed as Record<string, …>, so assert the keys back to FeeLevel['label']
+            // eslint-disable-next-line no-restricted-syntax -- composedLevels is keyed by fee labels but typed as Record<string, …>, so assert the keys back to FeeLevel['label']
             const nearest = (Object.keys(composedLevels) as FeeLevel['label'][]).find(
                 key => composedLevels[key]?.type !== 'error',
             );

--- a/suite/metadata/eslint.config.mjs
+++ b/suite/metadata/eslint.config.mjs
@@ -1,4 +1,4 @@
-import { eslint } from '@trezor/eslint';
+import { eslint, noCastedObjectHelpersSyntax } from '@trezor/eslint';
 
 export default [
     ...eslint,
@@ -6,7 +6,8 @@ export default [
         rules: {
             'no-console': 'off',
             '@typescript-eslint/no-shadow': 'off', // Todo: shall be fixed
-            'no-restricted-syntax': 'off', // Todo: this should be fixed in codebase and this line removed
+            // keep the casted-Object-helper ban active; the rest of no-restricted-syntax stays off (legacy getState/state-as-any debt)
+            'no-restricted-syntax': ['error', ...noCastedObjectHelpersSyntax],
             'import/no-default-export': 'off', // Todo: shall be solved one day, usually its legacy Components
         },
     },


### PR DESCRIPTION
## Description

Stacked on #28896. That PR adds the `no-restricted-syntax` selectors that ban casting the result of `Object.keys/entries/values(...)` (use the `typedObject*` helpers instead), but three packages — `packages/suite`, `suite/metadata`, `packages/connect-explorer` — blanket-disable `no-restricted-syntax` for unrelated legacy reasons (`getState` / `state-as-any` debt). In ESLint flat config a later `'no-restricted-syntax': 'off'` clobbers the whole rule, so the cast ban does **not** enforce in those packages — and `packages/suite` is where most call sites live.

This PR re-enables just the cast ban there, DRY: the three selectors are extracted into `noCastedObjectHelpersSyntax`, exported from `@trezor/eslint`, and re-added on top of the blanket `off` in each package as `'no-restricted-syntax': ['error', ...noCastedObjectHelpersSyntax]`. The legacy `getState` / `state-as-any` selectors stay deferred — that cleanup is ~222 violations across ~134 files, a separate effort.

The only casted `Object.keys/entries/values` across the three packages is `useSendFormCompose.ts`, which gets its `eslint-disable` back now that the rule is live in `packages/suite` (exactly the transition #28896's description predicted).

### Verified locally

- Base config still enforces the cast ban in normal packages (the `DeviceAnimation.stories.tsx` disable stays "used", no unused-directive).
- `packages/suite` now enforces the cast ban (the `useSendFormCompose` disable is "used", not unused).
- The legacy selectors stay off in all three packages — e.g. `storageActions.ts`, which has 25 `getState` hits, still lints clean.
- `.mdx` files in `connect-explorer` stay exempt: the catch-all override block has no `files` key, so it would re-enable the rule for `.mdx` too — a trailing `files: ['**/*.mdx']` override turns `no-restricted-syntax` back off there (verified with `eslint --print-config`: `.mdx` resolves to `off`, `.ts`/`.tsx` keep the cast ban). Caught in Copilot review.

## Related

- #28896 — adds the cast-ban rule this PR extends to the opted-out packages (this PR is stacked on top of it).

## Notes for QA

No QA needed. ESLint-config-only change with zero runtime impact — it turns the existing cast-ban lint rule on in three more packages and re-adds one `eslint-disable`. No product code behaviour changes.
