### PR TITLE
fix(suite-native): display aggregated amounts on tx list item

### DIFF
--- a/suite-native/transactions/src/components/TransactionListItem.tsx
+++ b/suite-native/transactions/src/components/TransactionListItem.tsx
@@ -26,7 +26,7 @@ import { type WalletAccountTransaction } from '@suite-native/tokens';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { selectTransactionFiatRate } from '../selectors';
-import { getTransactionValueSign, groupTargetOutputs, isTokenTransferTransaction } from '../utils';
+import { getTransactionValueSign, groupTargetOutputs } from '../utils';
 import { TokenTransferListItem } from './TokenTransferListItem';
 import { TransactionListItemContainer } from './TransactionListItemContainer';
 import { TransactionTarget } from './TransactionTarget';
@@ -138,8 +138,8 @@ export const TransactionListItem = ({
 
     const stakeOperationType = getTxStakeType(transaction);
 
-    // Self transactions move no net value (only a network fee is paid), so we show an empty amount
-    // instead of the redundant dust/change output. Staking self-transactions keep their amount.
+    // Self transactions don't change the account balance (only a network fee is paid), so we show
+    // an empty amount instead of the redundant/dust output. Staking self-transactions keep theirs.
     if (transaction.type === 'self' && !stakeOperationType)
         return (
             <TransactionListItemContainer
@@ -154,7 +154,10 @@ export const TransactionListItem = ({
             </TransactionListItemContainer>
         );
 
-    if (firstToken !== undefined && isTokenTransferTransaction(transaction))
+    // Any non-self transaction carrying a token transfer is summarized by its token (e.g. an ERC20
+    // transfer, or a swap that also moves native coin). The native amount — rent on Solana, swap
+    // value on EVM — is dropped here; the detail screen still shows the full breakdown.
+    if (firstToken !== undefined)
         return (
             <TokenTransferListItem
                 transaction={transaction}

--- a/suite-native/transactions/src/components/TransactionListItem.tsx
+++ b/suite-native/transactions/src/components/TransactionListItem.tsx
@@ -26,7 +26,7 @@ import { type WalletAccountTransaction } from '@suite-native/tokens';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { selectTransactionFiatRate } from '../selectors';
-import { getTransactionValueSign, groupTargetOutputs } from '../utils';
+import { getTransactionValueSign, groupTargetOutputs, isTokenTransferTransaction } from '../utils';
 import { TokenTransferListItem } from './TokenTransferListItem';
 import { TransactionListItemContainer } from './TransactionListItemContainer';
 import { TransactionTarget } from './TransactionTarget';
@@ -130,14 +130,31 @@ export const TransactionListItem = ({
     const includedCoinsCount = transaction.tokens.length;
 
     const firstToken = transaction.tokens[0];
-    const isTokenOnlyTransaction = transaction.amount === '0' && firstToken !== undefined;
 
     const allOutputs = useMemo(
         () => (account !== null ? groupTargetOutputs(createTargets({ transaction, account })) : []),
         [transaction, account],
     );
 
-    if (isTokenOnlyTransaction)
+    const stakeOperationType = getTxStakeType(transaction);
+
+    // Self transactions move no net value (only a network fee is paid), so we show an empty amount
+    // instead of the redundant dust/change output. Staking self-transactions keep their amount.
+    if (transaction.type === 'self' && !stakeOperationType)
+        return (
+            <TransactionListItemContainer
+                transaction={transaction}
+                transactionType={transaction.type}
+                accountKey={accountKey}
+                includedCoinsCount={includedCoinsCount}
+                isFirst={isFirst}
+                isLast={isLast}
+            >
+                <EmptyAmountText />
+            </TransactionListItemContainer>
+        );
+
+    if (firstToken !== undefined && isTokenTransferTransaction(transaction))
         return (
             <TokenTransferListItem
                 transaction={transaction}
@@ -148,8 +165,6 @@ export const TransactionListItem = ({
                 isLast={isLast}
             />
         );
-
-    const stakeOperationType = getTxStakeType(transaction);
 
     return (
         <TransactionListItemContainer

--- a/suite-native/transactions/src/components/TransactionListItem.tsx
+++ b/suite-native/transactions/src/components/TransactionListItem.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
@@ -25,7 +26,7 @@ import { type WalletAccountTransaction } from '@suite-native/tokens';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { selectTransactionFiatRate } from '../selectors';
-import { getTransactionValueSign } from '../utils';
+import { getTransactionValueSign, groupTargetOutputs } from '../utils';
 import { TokenTransferListItem } from './TokenTransferListItem';
 import { TransactionListItemContainer } from './TransactionListItemContainer';
 import { TransactionTarget } from './TransactionTarget';
@@ -131,7 +132,10 @@ export const TransactionListItem = ({
     const firstToken = transaction.tokens[0];
     const isTokenOnlyTransaction = transaction.amount === '0' && firstToken !== undefined;
 
-    const allOutputs = account !== null ? createTargets({ transaction, account }) : [];
+    const allOutputs = useMemo(
+        () => (account !== null ? groupTargetOutputs(createTargets({ transaction, account })) : []),
+        [transaction, account],
+    );
 
     if (isTokenOnlyTransaction)
         return (

--- a/suite-native/transactions/src/components/TransactionName.tsx
+++ b/suite-native/transactions/src/components/TransactionName.tsx
@@ -166,13 +166,17 @@ export const TransactionName = ({ transaction, isPending, variant }: Transaction
 
     const stakeTranslationId = stakeType ? getStakeTransactionMessage(stakeType, isPending) : null;
 
+    // The contract method name (e.g. "Transfer") must not override the "self" label for
+    // self-transactions, otherwise sending to your own account shows up as a generic transfer.
+    const ethNameToDisplay = transaction.type === 'self' ? undefined : ethName;
+
     return (
         <Text variant={variant}>
             {stakeTranslationId ? (
                 <Translation id={stakeTranslationId} />
             ) : (
                 // use name of eth txns, but not for recv or sent Transfer
-                ethName || <Translation id={getTransactionName(transaction, isPending)} />
+                ethNameToDisplay || <Translation id={getTransactionName(transaction, isPending)} />
             )}
         </Text>
     );

--- a/suite-native/transactions/src/components/TransactionTarget.tsx
+++ b/suite-native/transactions/src/components/TransactionTarget.tsx
@@ -70,7 +70,7 @@ const TransactionListItemValues = ({
                         <SignValueFormatter value={operation} />
                     )}
                     <CryptoToFiatAmountFormatter
-                        value={amount || transaction.amount}
+                        value={amount}
                         symbol={transaction.symbol}
                         historicRate={historicRate}
                         useHistoricRate
@@ -81,7 +81,7 @@ const TransactionListItemValues = ({
             )}
 
             <CryptoAmountFormatter
-                value={amount || transaction.amount}
+                value={amount}
                 symbol={transaction.symbol}
                 isBalance={false}
                 numberOfLines={1}
@@ -116,14 +116,13 @@ export const TransactionTarget = ({
         if (isSolanaUnstakeTx) return null;
         switch (type) {
             case 'target':
-                return transaction.amount;
             case 'internal':
             case 'token':
                 return payload.amount;
             default:
                 return exhaustive(type);
         }
-    }, [type, payload, transaction, isSolanaUnstakeTx]);
+    }, [type, payload, isSolanaUnstakeTx]);
 
     const operation = useMemo(() => {
         switch (type) {

--- a/suite-native/transactions/src/tests/utils.test.ts
+++ b/suite-native/transactions/src/tests/utils.test.ts
@@ -1,7 +1,12 @@
+import { type Target } from '@suite-common/wallet-core';
 import { asTxTargetId } from '@suite-common/wallet-types';
 
 import { type VinVoutAddress } from '../types';
-import { mapTransactionInputsOutputsToAddresses, sortTargetAddressesToBeginning } from '../utils';
+import {
+    groupTargetOutputs,
+    mapTransactionInputsOutputsToAddresses,
+    sortTargetAddressesToBeginning,
+} from '../utils';
 import {
     transactionWithChangeAddress,
     transactionWithTargetInOutputs,
@@ -171,5 +176,74 @@ describe(sortTargetAddressesToBeginning.name, () => {
         expect(sortTargetAddressesToBeginning(outputAddresses, targetAddresses)).toEqual(
             expectedResult,
         );
+    });
+});
+
+describe(groupTargetOutputs.name, () => {
+    const makeSimpleTarget = (amount: string, n: number): Target => ({
+        type: 'target',
+        targetId: asTxTargetId(String(n)),
+        payload: { n, addresses: [`address${n}`], isAddress: true, amount },
+    });
+
+    const makeInternalTarget = (amount: string, n: number): Target => ({
+        type: 'internal',
+        targetId: asTxTargetId(String(n)),
+        payload: { type: 'sent', amount, from: 'from', to: 'to' },
+    });
+
+    test('returns empty array for empty input', () => {
+        expect(groupTargetOutputs([])).toEqual([]);
+    });
+
+    test('returns single target unchanged', () => {
+        const targets = [makeSimpleTarget('1000', 0)];
+        expect(groupTargetOutputs(targets)).toEqual(targets);
+    });
+
+    test('aggregates multiple target outputs into a single summed entry', () => {
+        const result = groupTargetOutputs([
+            makeSimpleTarget('1000', 0),
+            makeSimpleTarget('2000', 1),
+            makeSimpleTarget('3000', 2),
+        ]);
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({ type: 'target', payload: { amount: '6000' } });
+    });
+
+    test('preserves metadata of the first target in the aggregated entry', () => {
+        const first = makeSimpleTarget('1000', 0);
+        const result = groupTargetOutputs([first, makeSimpleTarget('500', 1)]);
+        expect(result[0]).toMatchObject({
+            targetId: first.targetId,
+            payload: { ...first.payload, amount: '1500' },
+        });
+    });
+
+    test('keeps non-target outputs individually after the aggregated target', () => {
+        const internal = makeInternalTarget('500', 10);
+        const result = groupTargetOutputs([
+            makeSimpleTarget('1000', 0),
+            makeSimpleTarget('2000', 1),
+            internal,
+        ]);
+        expect(result).toHaveLength(2);
+        expect(result[0]).toMatchObject({ type: 'target', payload: { amount: '3000' } });
+        expect(result[1]).toBe(internal);
+    });
+
+    test('returns non-target outputs as-is when no target outputs are present', () => {
+        const inputs = [makeInternalTarget('100', 0), makeInternalTarget('200', 1)];
+        expect(groupTargetOutputs(inputs)).toEqual(inputs);
+    });
+
+    test('treats missing target amount as zero', () => {
+        const noAmount: Target = {
+            type: 'target',
+            targetId: asTxTargetId('0'),
+            payload: { n: 0, isAddress: true },
+        };
+        const result = groupTargetOutputs([noAmount, makeSimpleTarget('500', 1)]);
+        expect(result[0]).toMatchObject({ type: 'target', payload: { amount: '500' } });
     });
 });

--- a/suite-native/transactions/src/tests/utils.test.ts
+++ b/suite-native/transactions/src/tests/utils.test.ts
@@ -1,10 +1,9 @@
 import { type Target } from '@suite-common/wallet-core';
-import { type WalletAccountTransaction, asTxTargetId } from '@suite-common/wallet-types';
+import { asTxTargetId } from '@suite-common/wallet-types';
 
 import { type VinVoutAddress } from '../types';
 import {
     groupTargetOutputs,
-    isTokenTransferTransaction,
     mapTransactionInputsOutputsToAddresses,
     sortTargetAddressesToBeginning,
 } from '../utils';
@@ -246,62 +245,5 @@ describe(groupTargetOutputs.name, () => {
         };
         const result = groupTargetOutputs([noAmount, makeSimpleTarget('500', 1)]);
         expect(result[0]).toMatchObject({ type: 'target', payload: { amount: '500' } });
-    });
-});
-
-describe(isTokenTransferTransaction.name, () => {
-    const makeTransaction = ({
-        symbol,
-        amount,
-        hasToken,
-    }: {
-        symbol: WalletAccountTransaction['symbol'];
-        amount: string;
-        hasToken: boolean;
-    }) =>
-        ({
-            symbol,
-            amount,
-            tokens: hasToken ? [{ type: 'sent', amount: '1' }] : [],
-        }) as unknown as WalletAccountTransaction;
-
-    test('returns false when the transaction has no token transfers', () => {
-        expect(
-            isTokenTransferTransaction(
-                makeTransaction({ symbol: 'btc', amount: '0', hasToken: false }),
-            ),
-        ).toBe(false);
-    });
-
-    test('returns true for an EVM token transfer with zero native amount', () => {
-        expect(
-            isTokenTransferTransaction(
-                makeTransaction({ symbol: 'eth', amount: '0', hasToken: true }),
-            ),
-        ).toBe(true);
-    });
-
-    test('returns false for an EVM transaction with a non-zero native amount', () => {
-        expect(
-            isTokenTransferTransaction(
-                makeTransaction({ symbol: 'eth', amount: '1000', hasToken: true }),
-            ),
-        ).toBe(false);
-    });
-
-    test('returns true for a Solana token transfer carrying native rent (non-zero amount)', () => {
-        expect(
-            isTokenTransferTransaction(
-                makeTransaction({ symbol: 'sol', amount: '2039280', hasToken: true }),
-            ),
-        ).toBe(true);
-    });
-
-    test('returns true for a Solana token transfer with zero native amount', () => {
-        expect(
-            isTokenTransferTransaction(
-                makeTransaction({ symbol: 'sol', amount: '0', hasToken: true }),
-            ),
-        ).toBe(true);
     });
 });

--- a/suite-native/transactions/src/tests/utils.test.ts
+++ b/suite-native/transactions/src/tests/utils.test.ts
@@ -1,9 +1,10 @@
 import { type Target } from '@suite-common/wallet-core';
-import { asTxTargetId } from '@suite-common/wallet-types';
+import { type WalletAccountTransaction, asTxTargetId } from '@suite-common/wallet-types';
 
 import { type VinVoutAddress } from '../types';
 import {
     groupTargetOutputs,
+    isTokenTransferTransaction,
     mapTransactionInputsOutputsToAddresses,
     sortTargetAddressesToBeginning,
 } from '../utils';
@@ -245,5 +246,62 @@ describe(groupTargetOutputs.name, () => {
         };
         const result = groupTargetOutputs([noAmount, makeSimpleTarget('500', 1)]);
         expect(result[0]).toMatchObject({ type: 'target', payload: { amount: '500' } });
+    });
+});
+
+describe(isTokenTransferTransaction.name, () => {
+    const makeTransaction = ({
+        symbol,
+        amount,
+        hasToken,
+    }: {
+        symbol: WalletAccountTransaction['symbol'];
+        amount: string;
+        hasToken: boolean;
+    }) =>
+        ({
+            symbol,
+            amount,
+            tokens: hasToken ? [{ type: 'sent', amount: '1' }] : [],
+        }) as unknown as WalletAccountTransaction;
+
+    test('returns false when the transaction has no token transfers', () => {
+        expect(
+            isTokenTransferTransaction(
+                makeTransaction({ symbol: 'btc', amount: '0', hasToken: false }),
+            ),
+        ).toBe(false);
+    });
+
+    test('returns true for an EVM token transfer with zero native amount', () => {
+        expect(
+            isTokenTransferTransaction(
+                makeTransaction({ symbol: 'eth', amount: '0', hasToken: true }),
+            ),
+        ).toBe(true);
+    });
+
+    test('returns false for an EVM transaction with a non-zero native amount', () => {
+        expect(
+            isTokenTransferTransaction(
+                makeTransaction({ symbol: 'eth', amount: '1000', hasToken: true }),
+            ),
+        ).toBe(false);
+    });
+
+    test('returns true for a Solana token transfer carrying native rent (non-zero amount)', () => {
+        expect(
+            isTokenTransferTransaction(
+                makeTransaction({ symbol: 'sol', amount: '2039280', hasToken: true }),
+            ),
+        ).toBe(true);
+    });
+
+    test('returns true for a Solana token transfer with zero native amount', () => {
+        expect(
+            isTokenTransferTransaction(
+                makeTransaction({ symbol: 'sol', amount: '0', hasToken: true }),
+            ),
+        ).toBe(true);
     });
 });

--- a/suite-native/transactions/src/utils.ts
+++ b/suite-native/transactions/src/utils.ts
@@ -1,6 +1,7 @@
 import { A, F, pipe } from '@mobily/ts-belt';
 
 import { type SignValue } from '@suite-common/suite-types';
+import { getNetworkType } from '@suite-common/wallet-config';
 import { type Target as ProcessedTarget, createSimpleTargetId } from '@suite-common/wallet-core';
 import { type TransactionType, type WalletAccountTransaction } from '@suite-common/wallet-types';
 import {
@@ -79,18 +80,29 @@ export const groupTargetOutputs = (outputs: ProcessedTarget[]): ProcessedTarget[
     );
     const otherOutputs = outputs.filter(o => o.type !== 'target');
 
-    if (targetOutputs.length === 0) return otherOutputs;
+    const [firstTarget] = targetOutputs;
+    if (firstTarget === undefined) return otherOutputs;
 
     const aggregatedAmount = targetOutputs
         .reduce((sum, o) => sum.plus(o.payload.amount ?? '0'), new BigNumber(0))
         .toFixed();
 
-    const [firstTarget] = targetOutputs;
-
     return [
         { ...firstTarget, payload: { ...firstTarget.payload, amount: aggregatedAmount } },
         ...otherOutputs,
     ];
+};
+
+// Decides whether a transaction should be summarized by its token transfer rather than its native
+// coin movement. EVM token transfers always have a zero native amount, but Solana SPL transfers
+// carry a non-zero native amount (token-account rent + fee) that is not user value — so any Solana
+// transaction that includes a token transfer is treated as a token transfer.
+export const isTokenTransferTransaction = (
+    transaction: Pick<WalletAccountTransaction, 'tokens' | 'amount' | 'symbol'>,
+): boolean => {
+    if (transaction.tokens.length === 0) return false;
+
+    return transaction.amount === '0' || getNetworkType(transaction.symbol) === 'solana';
 };
 
 export const getUnstakeTxAmount = (tx: WalletAccountTransaction) => {

--- a/suite-native/transactions/src/utils.ts
+++ b/suite-native/transactions/src/utils.ts
@@ -1,7 +1,6 @@
 import { A, F, pipe } from '@mobily/ts-belt';
 
 import { type SignValue } from '@suite-common/suite-types';
-import { getNetworkType } from '@suite-common/wallet-config';
 import { type Target as ProcessedTarget, createSimpleTargetId } from '@suite-common/wallet-core';
 import { type TransactionType, type WalletAccountTransaction } from '@suite-common/wallet-types';
 import {
@@ -91,18 +90,6 @@ export const groupTargetOutputs = (outputs: ProcessedTarget[]): ProcessedTarget[
         { ...firstTarget, payload: { ...firstTarget.payload, amount: aggregatedAmount } },
         ...otherOutputs,
     ];
-};
-
-// Decides whether a transaction should be summarized by its token transfer rather than its native
-// coin movement. EVM token transfers always have a zero native amount, but Solana SPL transfers
-// carry a non-zero native amount (token-account rent + fee) that is not user value — so any Solana
-// transaction that includes a token transfer is treated as a token transfer.
-export const isTokenTransferTransaction = (
-    transaction: Pick<WalletAccountTransaction, 'tokens' | 'amount' | 'symbol'>,
-): boolean => {
-    if (transaction.tokens.length === 0) return false;
-
-    return transaction.amount === '0' || getNetworkType(transaction.symbol) === 'solana';
 };
 
 export const getUnstakeTxAmount = (tx: WalletAccountTransaction) => {

--- a/suite-native/transactions/src/utils.ts
+++ b/suite-native/transactions/src/utils.ts
@@ -1,7 +1,7 @@
 import { A, F, pipe } from '@mobily/ts-belt';
 
 import { type SignValue } from '@suite-common/suite-types';
-import { createSimpleTargetId } from '@suite-common/wallet-core';
+import { type Target as ProcessedTarget, createSimpleTargetId } from '@suite-common/wallet-core';
 import { type TransactionType, type WalletAccountTransaction } from '@suite-common/wallet-types';
 import {
     getTxStakeNameByDataHex,
@@ -9,7 +9,7 @@ import {
     getUnstakeAmountByEthereumDataHex,
 } from '@suite-common/wallet-utils';
 import { type EnhancedVinVout, type Target } from '@trezor/blockchain-link-types';
-import { isNotNullOrUndefined } from '@trezor/utils';
+import { BigNumber, isNotNullOrUndefined } from '@trezor/utils';
 
 import { type AddressesType, type VinVoutAddress } from './types';
 
@@ -72,6 +72,26 @@ export const getTransactionValueSign = (transactionType: TransactionType) =>
 
 const resolveStakeType = (tx: WalletAccountTransaction) =>
     getTxStakeType(tx) ?? getTxStakeNameByDataHex(tx.ethereumSpecific?.data);
+
+export const groupTargetOutputs = (outputs: ProcessedTarget[]): ProcessedTarget[] => {
+    const targetOutputs = outputs.filter(
+        (o): o is Extract<ProcessedTarget, { type: 'target' }> => o.type === 'target',
+    );
+    const otherOutputs = outputs.filter(o => o.type !== 'target');
+
+    if (targetOutputs.length === 0) return otherOutputs;
+
+    const aggregatedAmount = targetOutputs
+        .reduce((sum, o) => sum.plus(o.payload.amount ?? '0'), new BigNumber(0))
+        .toFixed();
+
+    const [firstTarget] = targetOutputs;
+
+    return [
+        { ...firstTarget, payload: { ...firstTarget.payload, amount: aggregatedAmount } },
+        ...otherOutputs,
+    ];
+};
 
 export const getUnstakeTxAmount = (tx: WalletAccountTransaction) => {
     if (resolveStakeType(tx) !== 'unstake') return undefined;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When working on the previous iteration I misused the targets list output which caused displaying of incorrect tx amount summary in the list. 

Fix is to essentially group the outputs and display them as a single row.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

Please check for UTXO and account based networks. Bitcoin and EVM

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26852

## Screenshots:

Before: 
<img width="419" height="874" alt="image" src="https://github.com/user-attachments/assets/2debc41e-8af7-4306-a472-e66b46e6699e" />

After: 
<img width="411" height="613" alt="Screenshot 2026-06-19 at 17 37 07" src="https://github.com/user-attachments/assets/520c6978-d38c-44fd-8ce6-9952ae158ff2" />

EVM (initial change):

<img width="1206" height="2622" alt="simulator_screenshot_7220FF70-4C72-4A55-A5A5-E11136E70BDE" src="https://github.com/user-attachments/assets/3413522d-dc83-491e-983e-31fd5f5e17b7" />

+ Changed name for self transfers to self for consistency with Solana

<img width="1206" height="2622" alt="simulator_screenshot_DBC88BE8-71C1-49F2-980C-53CD810D57A4" src="https://github.com/user-attachments/assets/8eff5555-b019-4b9b-9387-3366a3f691df" />


Solana before:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-06-19 at 17 55 51" src="https://github.com/user-attachments/assets/cc441de0-4a7b-47f1-9798-8cce68ec0510" />

Solana after:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-06-19 at 18 56 33" src="https://github.com/user-attachments/assets/c68330eb-2469-4b88-9ee6-1432a65dd867" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/tx-list-amounts&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->