### PR TITLE
fix(suite): don't show Cardano staking as excluded from balance

### DIFF
--- a/packages/suite/src/views/wallet/transactions/components/AccountOverviewBalance.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/AccountOverviewBalance.tsx
@@ -77,7 +77,11 @@ export const AccountOverviewBalance = ({ selectedAccount }: AccountOverviewBalan
     const shouldDisplayBaseCurrency = baseCurrency !== symbol;
     const isMainnet = !isTestnet(symbol);
     const hasTokens = !!account.tokens?.length;
-    const balanceExcludesTranslationId = getBalanceExcludesTranslationId(hasTokens, hasStaking);
+    const hasStakingExcludedFromBalance = hasStaking && account.networkType !== 'cardano';
+    const balanceExcludesTranslationId = getBalanceExcludesTranslationId(
+        hasTokens,
+        hasStakingExcludedFromBalance,
+    );
 
     return (
         <Row gap={16} justifyContent="space-between" alignItems="flex-end" flexWrap="wrap">


### PR DESCRIPTION
## Description

Cardano staking is liquid — staked ADA stays part of the account's spendable balance — so the "Staked amounts aren't included in the balance" notice on the account overview is misleading.

This stops treating Cardano staking as excluded from the balance. The only balance notice possible for Cardano is now `TR_BALANCE_EXCLUDES_TOKENS` (when the account holds native tokens) or none. Staking notices for other networks (e.g. Ethereum, Solana) are unchanged.

## Notes for QA

- Cardano account with active staking and no tokens → no balance notice.
- Cardano account with native tokens → "Token amounts aren't included in the balance." (no mention of staking).
- Ethereum/Solana accounts with staking → notice still mentions staking as before.

## Related Issue

Resolve #28494

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to AccountOverviewBalance.tsx, a component that renders account balance information on the wallet transactions/overview page. This is a UI-focused change with moderate risk — it could affect balance display, formatting, or layout on any wallet account page. The recommended strategy focuses on tests that directly verify balance visibility and correctness on the wallet page, with secondary coverage for tests that interact with the transactions overview where this component lives.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/transactions/components/AccountOverviewBalance.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/coin-balance.test.ts` — AccountOverviewBalance.tsx is the component responsible for displaying account balance on the wallet transactions/overview page. This test directly verifies that account balances are displayed correctly and update properly, which is the core functionality of the changed component.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test operates on the BTC account transactions overview page, cycling through graph time range filters and verifying transaction summary titles. The AccountOverviewBalance component is part of this transactions view and any rendering issues would be caught here.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test verifies that account balance values are properly hidden/revealed in discreet mode, including the balanceOfAccount check on the wallet page. Changes to AccountOverviewBalance could affect how balance values respond to discreet mode toggling.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test sends transactions on regtest and verifies pending/confirmed transaction states on the wallet account page. The AccountOverviewBalance component is rendered on this page and balance changes after transactions could be affected.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test verifies that the BTC account balance is visible after wallet discovery. The balanceOfAccount assertion directly tests the rendering output of the account balance component on the wallet page.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test navigates to wallet account pages (where AccountOverviewBalance renders) to export transactions. While the export functionality itself is separate, a rendering crash in AccountOverviewBalance could prevent reaching the export controls.

</details>

_Updated: 2026-06-20T07:38:59.393Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/cardano-staked-balance-28494&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/cardano-staked-balance-28494&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/cardano-staked-balance-28494/web/](https://dev.suite.sldev.cz/suite-web/fix/cardano-staked-balance-28494/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-20T07:43:59.231Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-20T07:42:30.172Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->