### PR TITLE
fix(sentry): reintroduce default integrations on desktop

### DIFF
--- a/packages/suite-desktop-ui/src/sentry.ts
+++ b/packages/suite-desktop-ui/src/sentry.ts
@@ -4,6 +4,7 @@ import { SENTRY_BROWSER_CONFIG } from '@suite/sentry';
 
 const ELECTRON_RENDERER_SENTRY_CONFIG = {
     ...SENTRY_BROWSER_CONFIG,
+    integrations: defaults => [...defaults, ...SENTRY_BROWSER_CONFIG.integrations],
 } satisfies BrowserOptions;
 
 export const initSentry = () => {


### PR DESCRIPTION
## Description

Followup to #28887, which removed default integrations on Desktop, I think by accident, so put them back.
Currently the integrations [are set as this array](https://github.com/trezor/trezor-suite/blob/80847788f327985a88654bff9f71309305c5bcb5/suite/sentry/src/config.ts#L106-L111), which means "those integrations and no other".



I understand this behavior is not clear from Sentry, which is why I created a docs issue there a few months ago, read it for details: https://github.com/getsentry/sentry-docs/issues/16676 
(unfortunately the docs have not been updated yet. I did want to create a PR there because I first wanted confirmation from Sentry team if I understand it correctly)


## Notes for QA

N/A, still part of #28874

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `packages/suite-desktop-ui/src/sentry.ts`, which is the Sentry error-reporting initialization module for the desktop UI. This is a global infrastructure concern (crash reporting / error telemetry) that runs at app startup but is not directly exercised by any E2E test's assertions or user-facing behaviors. None of the 84 candidate tests assert on Sentry behavior, error reporting payloads, or crash-handling flows. Static coverage mapping also found no tests referencing this file. The risk of this change is low from an E2E perspective — a regression would affect error reporting fidelity rather than user-visible functionality. No E2E tests are recommended; unit or integration tests for the Sentry module itself would be more appropriate.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite-desktop-ui/src/sentry.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/suite-desktop-ui/src/sentry.ts`

_Updated: 2026-06-21T15:43:41.735Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sentry-desktop-default-integrations&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sentry-desktop-default-integrations&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-21T15:48:31.536Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-21T15:46:29.186Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/sentry-desktop-default-integrations/web/](https://dev.suite.sldev.cz/suite-web/fix/sentry-desktop-default-integrations/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->