### PR TITLE
chore(scripts): lint the previously-ignored scripts/ci directory

### DIFF
--- a/packages/eslint/src/index.mjs
+++ b/packages/eslint/src/index.mjs
@@ -29,7 +29,6 @@ export const eslint = [
             '**/build-webextension/*',
             '**/node_modules/*',
             '**/public/*',
-            '**/ci/',
             '**/.expo/*',
             '**/.cache/*',
             '**/playwright-report/*',

--- a/scripts/ci/check-packages-same-deployment-type.ts
+++ b/scripts/ci/check-packages-same-deployment-type.ts
@@ -2,19 +2,19 @@ import semver from 'semver';
 
 import { getLocalVersion } from './helpers';
 
+const getReleaseType = (version: string): string => {
+    const prerelease = semver.prerelease(version);
+    if (!prerelease) {
+        return 'stable';
+    }
+
+    return prerelease[0] === 'alpha' ? 'alpha' : 'canary';
+};
+
 const checkVersions = (packages: string[], deploymentType: string): void => {
     const versions = packages.map(packageName => getLocalVersion(packageName));
 
-    const isCorrectType = versions.every(version => {
-        const prerelease = semver.prerelease(version);
-        const releaseType = prerelease
-            ? prerelease[0] === 'alpha'
-                ? 'alpha'
-                : 'canary'
-            : 'stable';
-
-        return deploymentType === releaseType;
-    });
+    const isCorrectType = versions.every(version => deploymentType === getReleaseType(version));
 
     if (!isCorrectType) {
         console.error(

--- a/scripts/ci/check-version.js
+++ b/scripts/ci/check-version.js
@@ -1,9 +1,7 @@
-/* eslint-disable camelcase */
-
-import semver from 'semver';
 import child_process from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import semver from 'semver';
 
 const args = process.argv.slice(2);
 

--- a/scripts/ci/connect-bump-versions.ts
+++ b/scripts/ci/connect-bump-versions.ts
@@ -1,14 +1,14 @@
-import path from 'node:path';
 import fs from 'node:fs';
-
+import path from 'node:path';
 import { promisify } from 'node:util';
+
 import {
-    getPackageDependencies,
-    gettingNpmDistributionTags,
-    exec,
-    commit,
     comment,
+    commit,
+    exec,
+    getPackageDependencies,
     getTrezorPackageDir,
+    gettingNpmDistributionTags,
 } from './helpers';
 
 const readFile = promisify(fs.readFile);
@@ -139,6 +139,7 @@ const bumpConnect = async () => {
             mainPackages.map(async pkg => {
                 const result = await getPackageDependencies(pkg);
                 console.log(`${pkg} dependencies to update:`, result);
+
                 return result.update;
             }),
         );
@@ -303,6 +304,7 @@ const bumpConnect = async () => {
 
             if (!connectGitLogText) {
                 console.info('no changelog for @trezor/connect');
+
                 return;
             }
 

--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -102,9 +102,7 @@ const inputs = [
 
     {
         key: 'firmware',
-        value: ({ model }) => {
-            return model === 'T1B1' ? firmwares1 : firmwares2;
-        },
+        value: ({ model }) => (model === 'T1B1' ? firmwares1 : firmwares2),
     },
     {
         key: 'transport',
@@ -112,14 +110,14 @@ const inputs = [
     },
     {
         key: 'groups',
-        value: ({ model, firmware }) => {
-            return Object.values(groups).filter(group => {
+        value: ({ model, firmware }) =>
+            Object.values(groups).filter(group => {
                 if (group.name === 'thp') {
                     return firmware !== '2.3.0' && model === 'T3W1';
                 }
+
                 return true;
-            });
-        },
+            }),
     },
     {
         key: 'env',
@@ -186,6 +184,7 @@ const createCartesian = inputs => {
     const create = (index, current) => {
         if (index === keys.length) {
             results.push(current);
+
             return;
         }
 
@@ -201,6 +200,7 @@ const createCartesian = inputs => {
     };
 
     create(0, {});
+
     return results;
 };
 
@@ -216,25 +216,28 @@ const filterCartesianResultByArgs = () => {
         if (typeof input === 'object') {
             return input.name;
         }
+
         return input;
     };
 
-    return cartesian.filter(m => {
-        return Object.keys(m).every(key => {
+    return cartesian.filter(m =>
+        Object.keys(m).every(key => {
             const filterBy = parsedArgs[key];
             if (filterBy === 'all') {
                 // experimental methods are opt-in; they never run as part of `all`
                 if (key === 'groups' && getValue(m[key]) === 'experimental') {
                     return false;
                 }
+
                 return true;
             }
             if (Array.isArray(filterBy)) {
                 return filterBy.includes(getValue(m[key]));
             }
+
             return getValue(m[key]) === filterBy;
-        });
-    });
+        }),
+    );
 };
 
 const filtered = filterCartesianResultByArgs();

--- a/scripts/ci/get-connect-dependencies-to-release.ts
+++ b/scripts/ci/get-connect-dependencies-to-release.ts
@@ -2,8 +2,8 @@
 // and stdout out those to be used by GitHub workflow.
 
 import fs from 'node:fs';
-import util from 'node:util';
 import path from 'node:path';
+import util from 'node:util';
 import semver from 'semver';
 
 import { getNpmRemoteGreatestVersion, getTrezorPackageDir } from './helpers';
@@ -40,11 +40,9 @@ const checkNonReleasedDependencies = async (packageName: string) => {
         return;
     }
 
-    // eslint-disable-next-line no-restricted-syntax
     for await (const [dependency] of Object.entries(dependencies)) {
         // is not a dependency released from monorepo. we don't care
         if (!dependency.startsWith('@trezor')) {
-            // eslint-disable-next-line no-continue
             continue;
         }
         const name = dependency.split('/')[1];
@@ -68,9 +66,10 @@ const getConnectDependenciesToRelease = async () => {
 
     // We do not want to include `connect`, `connect-web` and `connect-webextension` since we want
     // to release those separately and we always want to release them.
-    const onlyDependenciesToRelease = nonReleaseDependencies.filter(item => {
-        return !['connect', 'connect-web', 'connect-webextension', 'connect-mobile'].includes(item);
-    });
+    const onlyDependenciesToRelease = nonReleaseDependencies.filter(
+        item =>
+            !['connect', 'connect-web', 'connect-webextension', 'connect-mobile'].includes(item),
+    );
 
     // We use `onlyDependenciesToRelease` to trigger NPM releases
     const dependenciesToRelease = JSON.stringify(onlyDependenciesToRelease);

--- a/scripts/ci/get-connect-version.js
+++ b/scripts/ci/get-connect-version.js
@@ -1,7 +1,5 @@
-/* eslint-disable camelcase */
-
-import path from 'node:path';
 import fs from 'node:fs';
+import path from 'node:path';
 
 const ROOT = path.join(import.meta.dirname, '..', '..');
 

--- a/scripts/ci/helpers.ts
+++ b/scripts/ci/helpers.ts
@@ -1,8 +1,8 @@
+import fetch from 'cross-fetch';
+import { ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import semver from 'semver';
-import fetch from 'cross-fetch';
-import { ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
 
 const ROOT = path.join(import.meta.dirname, '..', '..');
 
@@ -24,15 +24,33 @@ export const getNpmRemoteGreatestVersion = async (moduleName: string) => {
         const distributionTags = await gettingNpmDistributionTags(moduleName);
 
         const versionArray: string[] = Object.values(distributionTags);
-        const greatestVersion = versionArray.reduce((max, current) => {
-            return semver.gt(current, max) ? current : max;
-        });
+        const greatestVersion = versionArray.reduce((max, current) =>
+            semver.gt(current, max) ? current : max,
+        );
 
         return greatestVersion;
     } catch (error) {
         console.error('error:', error);
         throw new Error('Not possible to get remote greatest version');
     }
+};
+
+export const getTrezorPackageDir = (packageName: string) =>
+    path.join(ROOT, packageName.startsWith('coins-') ? 'coins' : 'packages', packageName);
+
+export const getTrezorDependencies = async (packageNameWithoutTrezorPrefix: string) => {
+    const packageJsonPath = path.join(
+        getTrezorPackageDir(packageNameWithoutTrezorPrefix),
+        'package.json',
+    );
+    const packageJsonContent = await fs.promises.readFile(packageJsonPath, 'utf-8');
+    const packageJson = JSON.parse(packageJsonContent);
+    // We should ignore devDependencies.
+    const dependencies = packageJson.dependencies ? Object.keys(packageJson.dependencies) : [];
+
+    return dependencies
+        .filter(dep => dep.startsWith('@trezor/'))
+        .map(dep => dep.replace('@trezor/', ''));
 };
 
 /**
@@ -49,7 +67,6 @@ export const getPackageDependencies = async (
     const trezorDependencies = await getTrezorDependencies(packageNameWithoutTrezorPrefix);
     console.info(`Trezor dependencies: ${trezorDependencies.join(', ')}`);
 
-    // eslint-disable-next-line no-restricted-syntax
     for await (const trezorDependencyNameWithoutPrefix of trezorDependencies) {
         // trezorDependencyNameWithoutPrefix is like 'connect', 'suite', etc.
 
@@ -70,10 +87,7 @@ export const getPackageDependencies = async (
     };
 };
 
-export const exec = async (
-    cmd: string,
-    params: any[],
-): Promise<{ stdout: string; stderr: string }> => {
+export const exec = (cmd: string, params: any[]): Promise<{ stdout: string; stderr: string }> => {
     console.info(cmd, ...params);
 
     const res: ChildProcessWithoutNullStreams = spawn(cmd, params, {
@@ -130,22 +144,6 @@ export const getLocalVersion = (packageName: string) => {
         throw new Error(`package.json not found for package: ${packageName}`);
     }
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
     return packageJson.version;
-};
-
-export const getTrezorPackageDir = (packageName: string) =>
-    path.join(ROOT, packageName.startsWith('coins-') ? 'coins' : 'packages', packageName);
-
-export const getTrezorDependencies = async (packageNameWithoutTrezorPrefix: string) => {
-    const packageJsonPath = path.join(
-        getTrezorPackageDir(packageNameWithoutTrezorPrefix),
-        'package.json',
-    );
-    const packageJsonContent = await fs.promises.readFile(packageJsonPath, 'utf-8');
-    const packageJson = JSON.parse(packageJsonContent);
-    // We should ignore devDependencies.
-    const dependencies = packageJson.dependencies ? Object.keys(packageJson.dependencies) : [];
-    return dependencies
-        .filter(dep => dep.startsWith('@trezor/'))
-        .map(dep => dep.replace('@trezor/', ''));
 };

--- a/scripts/ci/pack-packages.ts
+++ b/scripts/ci/pack-packages.ts
@@ -17,7 +17,7 @@ const OUTPUT_DIR = path.join(ROOT_DIR, 'tmp/packed-packages');
 const walkFiles = async (directory: string): Promise<string[]> => {
     const entries = await fs.promises.readdir(directory, { withFileTypes: true });
     const files = await Promise.all(
-        entries.map(async entry => {
+        entries.map(entry => {
             const fullPath = path.join(directory, entry.name);
             if (entry.isDirectory()) {
                 return walkFiles(fullPath);


### PR DESCRIPTION
## Description

The `**/ci/` global ignore in `@trezor/eslint` excluded `scripts/ci/` — the only `ci/` directory in the repo — from ESLint entirely. Because that directory holds real CI/release TypeScript, it had silently accumulated lint errors and dead `eslint-disable` directives that no tooling could surface. A repo-wide audit (all 290 workspaces) found `scripts/ci/` to be the only committed-source lint blind spot; the rest of the linted codebase has zero unused disables, because `g:eslint` runs with `--max-warnings 0` and ESLint 9 reports unused directives by default.

This removes the ignore so `scripts/ci/` is linted like everywhere else, and fixes the 34 problems it exposed:

- auto-fixable: import order, blank-line padding, `arrow-body-style`
- `no-nested-ternary` extracted into a small helper (`check-packages-same-deployment-type.ts`)
- function ordering for `no-use-before-define` (`helpers.ts`)
- redundant `async` removed where there was no `await` — `require-await` (`helpers.ts`, `pack-packages.ts`)
- 5 dead `eslint-disable` directives dropped (`no-restricted-syntax` ×2, `camelcase` ×2, `no-continue` ×1)

No behavior change — every edit is stylistic, dead-comment removal, or an equivalent refactor. `scripts/ci/` is the only `ci/` directory in the repo, so removing the global ignore affects nothing else.

## Notes for QA

No QA needed. This only touches CI/release helper scripts and the shared ESLint ignore list; there is no runtime or product impact. Verified locally: `@trezor/scripts` `lint:js` (the real `--max-warnings 0` command) and `type-check` both pass, and `prettier --check` is clean. A glance from whoever owns the connect release scripts (`connect-bump-versions.ts`, `get-connect-dependencies-to-release.ts`) to sanity-check the mechanical refactors would be welcome.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All 8 changed files are CI/CD infrastructure scripts located in `scripts/ci/` — they handle tasks like version checking, package packing, connect dependency resolution, and test matrix generation. These scripts are not part of the Trezor Suite application runtime, are not imported by any application source code, and do not affect any user-facing functionality exercised by the E2E test suite. There is no static test coverage mapping and no inferrable relationship between these CI helper scripts and any of the 102 candidate E2E tests. No E2E tests need to be run for this change set.

<details><summary><b>Changed files (8)</b></summary>

- `scripts/ci/check-packages-same-deployment-type.ts`
- `scripts/ci/check-version.js`
- `scripts/ci/connect-bump-versions.ts`
- `scripts/ci/connect-test-matrix-generator.js`
- `scripts/ci/get-connect-dependencies-to-release.ts`
- `scripts/ci/get-connect-version.js`
- `scripts/ci/helpers.ts`
- `scripts/ci/pack-packages.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (8)**
- `scripts/ci/check-packages-same-deployment-type.ts`
- `scripts/ci/check-version.js`
- `scripts/ci/connect-bump-versions.ts`
- `scripts/ci/connect-test-matrix-generator.js`
- `scripts/ci/get-connect-dependencies-to-release.ts`
- `scripts/ci/get-connect-version.js`
- `scripts/ci/helpers.ts`
- `scripts/ci/pack-packages.ts`

_Updated: 2026-06-21T16:37:25.959Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/lint-scripts-ci&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/lint-scripts-ci&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-21T16:42:02.310Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-21T16:40:52.735Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/lint-scripts-ci/web/](https://dev.suite.sldev.cz/suite-web/mroz22/lint-scripts-ci/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->