### PR TITLE
feat(suite-native): Add custom style support to TradeInfoRow

### DIFF
--- a/suite-native/trading-atoms/src/components/TradeInfo/TradeInfoRow.tsx
+++ b/suite-native/trading-atoms/src/components/TradeInfo/TradeInfoRow.tsx
@@ -2,7 +2,7 @@ import { type PropsWithChildren } from 'react';
 import { Pressable } from 'react-native';
 
 import { HStack } from '@suite-native/atoms';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+import { type NativeStyleObject, prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 const infoRowStyle = prepareNativeStyle<{ noBorder?: boolean }>((utils, { noBorder }) => ({
     paddingHorizontal: utils.spacings.sp16,
@@ -17,14 +17,15 @@ type TradeInfoRowProps = PropsWithChildren<{
     noBorder?: boolean;
     onPress?: () => void;
     testID?: string;
+    style?: NativeStyleObject;
 }>;
 
-export const TradeInfoRow = ({ children, noBorder, onPress, testID }: TradeInfoRowProps) => {
+export const TradeInfoRow = ({ children, noBorder, onPress, testID, style }: TradeInfoRowProps) => {
     const { applyStyle } = useNativeStyles();
 
     return (
         <Pressable onPress={onPress} testID={testID}>
-            <HStack style={applyStyle(infoRowStyle, { noBorder })}>{children}</HStack>
+            <HStack style={[applyStyle(infoRowStyle, { noBorder }), style]}>{children}</HStack>
         </Pressable>
     );
 };

--- a/suite-native/trading-slippage/package.json
+++ b/suite-native/trading-slippage/package.json
@@ -25,6 +25,7 @@
         "@suite-native/link": "workspace:*",
         "@suite-native/trading-atoms": "workspace:*",
         "@suite-native/trading-state": "workspace:*",
+        "@trezor/styles-native": "workspace:*",
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*",
         "react": "19.2.4",

--- a/suite-native/trading-slippage/src/components/SlippagePicker.tsx
+++ b/suite-native/trading-slippage/src/components/SlippagePicker.tsx
@@ -6,15 +6,21 @@ import { HStack, Text } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation, selectLocale } from '@suite-native/intl';
 import { TradeInfoRow, useBottomSheetControls } from '@suite-native/trading-atoms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { SlippageBottomSheet } from './SlippageBottomSheet';
 
 export const SLIPPAGE_PICKER_TEST_ID = '@trading/exchange/slippage-picker';
 
+const slippagePickerStyle = prepareNativeStyle(({ spacings }) => ({
+    height: spacings.sp56,
+}));
+
 export const SlippagePicker = () => {
     const { isSheetVisible, showSheet, hideSheet } = useBottomSheetControls();
     const { isDex, swapSlippage } = useSelector(selectTradingExchangeSelectedQuote) ?? {};
     const locale = useSelector(selectLocale);
+    const { applyStyle } = useNativeStyles();
 
     const percentFormatter = useMemo(
         () =>
@@ -33,7 +39,11 @@ export const SlippagePicker = () => {
 
     return (
         <>
-            <TradeInfoRow onPress={showSheet} testID={SLIPPAGE_PICKER_TEST_ID}>
+            <TradeInfoRow
+                onPress={showSheet}
+                testID={SLIPPAGE_PICKER_TEST_ID}
+                style={applyStyle(slippagePickerStyle)}
+            >
                 <Text variant="body-sm" color="contentSecondary">
                     <Translation id="moduleTrading.slippage.maxSlippageLabel" />
                 </Text>

--- a/suite-native/trading-slippage/tsconfig.json
+++ b/suite-native/trading-slippage/tsconfig.json
@@ -14,6 +14,9 @@
         { "path": "../link" },
         { "path": "../trading-atoms" },
         { "path": "../trading-state" },
+        {
+            "path": "../../packages/styles-native"
+        },
         { "path": "../../packages/urls" },
         { "path": "../../packages/utils" },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14238,6 +14238,7 @@ __metadata:
     "@suite-native/trading-atoms": "workspace:*"
     "@suite-native/trading-fixtures": "workspace:*"
     "@suite-native/trading-state": "workspace:*"
+    "@trezor/styles-native": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/invity-api": "npm:^1.1.15"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Allows to specify custom style for TradeInfoRow component.
- Specifies exact height for SlippagePicker.

<!--- Describe your changes in detail -->

## Notes for QA

Just a style update
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-06-22 at 09 58 29" src="https://github.com/user-attachments/assets/52785331-9177-4d1d-886b-938c5529bde6" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All four changed files are in the `suite-native/` directory, which contains React Native mobile app components (TradeInfoRow, SlippagePicker) and build configuration (package.json, tsconfig.json). The E2E test suite exclusively covers the desktop/web Trezor Suite application — none of the 103 candidate tests exercise native mobile components. There is no static mapping and no inferrable connection between these native trading UI components and any web/desktop E2E test. The risk to the web/desktop application is negligible, and no E2E tests need to be run for this change set.

<details><summary><b>Changed files (4)</b></summary>

- `suite-native/trading-atoms/src/components/TradeInfo/TradeInfoRow.tsx`
- `suite-native/trading-slippage/package.json`
- `suite-native/trading-slippage/src/components/SlippagePicker.tsx`
- `suite-native/trading-slippage/tsconfig.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (4)**
- `suite-native/trading-atoms/src/components/TradeInfo/TradeInfoRow.tsx`
- `suite-native/trading-slippage/package.json`
- `suite-native/trading-slippage/src/components/SlippagePicker.tsx`
- `suite-native/trading-slippage/tsconfig.json`

_Updated: 2026-06-22T09:18:26.226Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-slippage-picker-height&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-slippage-picker-height&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-22T09:23:02.557Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-22T09:22:14.998Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-slippage-picker-height/web/](https://dev.suite.sldev.cz/suite-web/fix-slippage-picker-height/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->