### PR TITLE
fix(connect): three device-layer concurrency races found via fuzzing

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -67,6 +67,7 @@
     ],
     "scripts": {
         "test:unit": "jest --version && jest",
+        "test:fuzz": "jest --testPathPattern fuzz",
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib",
@@ -117,6 +118,7 @@
         "@types/w3c-web-usb": "^1.0.14",
         "@vitest/browser-playwright": "^4.1.9",
         "crypto-browserify": "3.12.1",
+        "fast-check": "^4.8.0",
         "jest": "29.7.0",
         "process": "^0.11.10",
         "stream-browserify": "^3.0.0",

--- a/packages/connect/src/device/CONCURRENCY_MODEL.md
+++ b/packages/connect/src/device/CONCURRENCY_MODEL.md
@@ -271,13 +271,27 @@ An earlier abort-agnostic `fn` produced a spurious "two fn bodies concurrent"
 INV-1 report — a harness artifact, not a Device bug — which is why the body must
 model prompt abort response.
 
-### Deferred to PHASE 3
+### INV-5 harness (`DeviceList` registry consistency)
 
-- INV-5 (`DeviceList` consistency) needs a `DeviceList`/`Core`-level harness, not
-  a single `Device`; it is out of scope for this file. The `requestRelease`
-  (`usedElsewhere`) op is now generated together with `externalSession`; with the
-  strengthened INV-3 quiescence check (`checkSessionBalanceAtQuiescence`) it
-  surfaced Finding 2 below.
+`__tests__/deviceListConsistency.fuzz.test.ts` drives the shared
+`DeviceList.devices` registry directly. It wires a `ControllableTransport`'s
+`DEVICE_CONNECTED` event to `DeviceList.onDeviceConnected` exactly as
+`initializeTransport` does (fire-and-forget), and lets `Device.handshake()` run
+**for real** against the transport (acquire → `getFeatures` (stubbed) → release),
+so a disconnect arriving mid-handshake interrupts the run and makes `handshake()`
+return `false` — the production signal that gates `devices.push`. `fast-check`
+generates connect/disconnect/acquire/release sequences over a small path set;
+after every step it asserts **no duplicate path** and at full quiescence
+**present iff connected** (no _lost_ device — connected but absent — and no
+_leaked_ device — present but disconnected). It surfaced Finding 3 below.
+
+The harness's faithfulness rests on the transport modelling a physically-gone
+device correctly: `disconnectPath` fails any in-flight op for that path, and
+`completeAcquire` fails (rather than succeeds-and-resurrects) a path with no live
+descriptor — otherwise a stale acquire settled as success would fake the device
+back into existence and produce spurious findings. The disconnect error code must
+be the verbatim value (`'device disconnected during action'`), not the
+SCREAMING_CASE key, because `Device.handshake` matches on the value.
 
 For each distinct, **verified** violation: shrink, commit a minimal deterministic
 repro + a note (invariant, interleaving, suspected root cause), and only commit a
@@ -368,3 +382,44 @@ regression guard for this finding. The fuzz harness gained
 interleaving is rare and the harness does not reliably rediscover it at the
 committed default `FUZZ_SEED`/`FUZZ_RUNS` — raise `FUZZ_RUNS` or rotate seeds to
 hunt it. Treat the deterministic repro, not the fuzz, as the guard for INV-3.
+
+### Finding 3 — INV-2/INV-5: `handshakeLock` deadlock from a disconnected device's queued handshake (FIXED)
+
+**Invariant:** INV-2 (liveness — no promise hangs after flush) and INV-5
+(`DeviceList` consistency — a connected device is registered exactly once).
+
+**Interleaving (shrunk):** `connect '1'` → `connect '2'` → `disconnect '2'` →
+`connect '2'` → (drain). Device `'1'` starts handshaking and holds
+`DeviceList`'s global `handshakeLock` (`DeviceList.ts:190`); device `'2'`'s
+handshake is **queued** behind it. `'2'` then disconnects (while still queued) and
+reconnects on the same path.
+
+**Root cause:** `Device.disconnect()` removes the instance's
+`onTransportDeviceEvent` listener (`Device.ts:917`) but the queued handshake
+closure (`resolveAfter(...).then(() => device.handshake())`, already inside
+`handshakeLock`) survives — `interrupt()` is a no-op because the run never
+started (`runAbort` is `undefined`). When the lock reaches it, the **stale**
+`'2'` instance runs `handshake()` → `run()` → `acquire()`; the reconnected path is
+live, so the acquire succeeds, but `waitAndCompareSession` then awaits a
+`sessionDfd` that only the now-removed listener (`updateDescriptor`) would resolve
+(`Device.ts:242`, `224-235`). It hangs **forever**, holding `handshakeLock`, so
+every later device's handshake — including the reconnected `'2'` — is starved.
+The auth-penalty delay before each handshake
+(`resolveAfter(penalty && penalty + 501)`, seconds when penalized) widens the
+queued window substantially.
+
+**Fix (applied — obviously correct):** mark a `Device` terminal on
+`disconnect()` (`this.disconnected = true`, `Device.ts`) and bail before doing any
+transport work: `run()` throws `Device_Disconnected` and `handshake()` returns
+`false` when `disconnected`. A disconnected instance is already terminal (listeners
+torn down, replaced by a fresh `Device` on reconnect), and `core` only dispatches
+to registry devices, so nothing legitimately runs a disconnected device — the
+guard only short-circuits the stale queued handshake, releasing the lock so the
+reconnected device handshakes and registers normally.
+
+**Tests:** `deviceListHandshakeLockDeadlock.repro.test.ts` (minimal deterministic
+repro — pre-fix the reconnected `'2'` is never registered; passes post-fix). The
+`deviceListConsistency.fuzz.test.ts` harness asserts no-duplicate + present-iff-
+connected; it reds without the fix (counterexample
+`connect 1, connect 3, disconnect 3, connect 3, connect 1`) and is green with it
+across 1600 runs × seeds 1/7/42/99.

--- a/packages/connect/src/device/CONCURRENCY_MODEL.md
+++ b/packages/connect/src/device/CONCURRENCY_MODEL.md
@@ -273,15 +273,47 @@ model prompt abort response.
 
 ### Deferred to PHASE 3
 
-- The externally-driven `requestRelease` / `externalSession` (`usedElsewhere`)
-  ops are implemented in the harness `step()` but held out of the generator. They
-  open the **acquire-vs-session-change** race where `updateDescriptor` awaits a
-  rejecting `acquirePromise` (`Device.ts:385`) on an event-handler path with no
-  `catch` → a candidate unhandled rejection. This must be confirmed against real
-  Device semantics (not the mock) before being asserted on.
 - INV-5 (`DeviceList` consistency) needs a `DeviceList`/`Core`-level harness, not
-  a single `Device`; it is out of scope for this file.
+  a single `Device`; it is out of scope for this file. The `requestRelease`
+  (`usedElsewhere`) op remains implemented in `step()` but out of the generator
+  (next hunt target).
 
 For each distinct, **verified** violation: shrink, commit a minimal deterministic
 repro + a note (invariant, interleaving, suspected root cause), and only commit a
 fix if it is obviously correct and all existing tests pass.
+
+---
+
+## 5. PHASE 3 findings
+
+### Finding 1 — INV-2: leaked unhandled rejection from `updateDescriptor` (FIXED)
+
+**Invariant:** INV-2 (liveness — no rejection escapes the device layer
+unhandled).
+
+**Interleaving (shrunk):** `run` → `externalSession` → (drain). A `run()` reaches
+`transport.acquire()`; before that acquire settles, an external client takes the
+device, so a `DEVICE_SESSION_CHANGED` for a **different** session arrives. The
+acquire's `waitAndCompareSession` then rejects with `SESSION_WRONG_PREVIOUS`
+(`Device.ts:242-246, 279`).
+
+**Root cause:** `updateDescriptor` (the `onTransportDeviceEvent` handler, invoked
+**fire-and-forget** — its returned promise is discarded by `EventEmitter.emit`)
+did `await Promise.all([this.acquirePromise, this.releasePromise])`. It only needs
+those to **settle** before reading `sessionAcquired`, but `Promise.all` re-raises
+the acquire rejection — and there is no `catch` on the event path, so it leaks as
+an unhandled rejection (one per session-changed event that observed the still-
+pending acquire; the shrunk case produces two). The **run** path already handles
+the same rejection (`run().catch` + `await this.acquirePromise`), so the event
+path must not re-raise it.
+
+**Fix (applied — obviously correct):** `Promise.allSettled` in `updateDescriptor`
+(`Device.ts:390`). Behavior is otherwise unchanged: the post-await session
+reconciliation (`usedElsewhere` / `keepTransportSession` reset / `DEVICE.CHANGED`)
+now also runs in the taken-elsewhere case, which is the intended handling.
+
+**Tests:** `deviceSessionRace.repro.test.ts` (minimal deterministic repro — fails
+pre-fix with 2 rejections, passes post-fix). The fuzz harness now generates
+`externalSession` and asserts no `updateDescriptor` promise rejects
+(`checkDescriptorRejections`); it reds without the fix (counterexample
+`run, externalSession, completeFn`) and is green with it across 2000 runs.

--- a/packages/connect/src/device/CONCURRENCY_MODEL.md
+++ b/packages/connect/src/device/CONCURRENCY_MODEL.md
@@ -275,8 +275,9 @@ model prompt abort response.
 
 - INV-5 (`DeviceList` consistency) needs a `DeviceList`/`Core`-level harness, not
   a single `Device`; it is out of scope for this file. The `requestRelease`
-  (`usedElsewhere`) op remains implemented in `step()` but out of the generator
-  (next hunt target).
+  (`usedElsewhere`) op is now generated together with `externalSession`; with the
+  strengthened INV-3 quiescence check (`checkSessionBalanceAtQuiescence`) it
+  surfaced Finding 2 below.
 
 For each distinct, **verified** violation: shrink, commit a minimal deterministic
 repro + a note (invariant, interleaving, suspected root cause), and only commit a
@@ -317,3 +318,53 @@ pre-fix with 2 rejections, passes post-fix). The fuzz harness now generates
 `externalSession` and asserts no `updateDescriptor` promise rejects
 (`checkDescriptorRejections`); it reds without the fix (counterexample
 `run, externalSession, completeFn`) and is green with it across 2000 runs.
+
+### Finding 2 — INV-3: leaked session from a run aborted before it acquires (FIXED)
+
+**Invariant:** INV-3 (session balance — `acquire`/`release` paired; a session is
+held only deliberately via `keepTransportSession`).
+
+**Interleaving (shrunk):** `run, completeFn, completeAcquire, requestRelease, run,
+interrupt` (fast-check seed 99; the two-`interrupt` variant `run, completeFn,
+completeAcquire, interrupt, run, interrupt, completeFn` reproduces it equally).
+Step by step:
+
+1. Run A acquires `s0`, runs its `fn`, then issues its final `release()` (release
+   in-flight) and is awaiting it inside `_runInner`.
+2. Run A is aborted (`DEVICE_REQUEST_RELEASE → usedElsewhere`, or an `interrupt`).
+   The `Promise.race` abort branch settles run A's `runPromise`; its `catch`
+   handler runs `release()` — a **no-op** because a release is already pending —
+   and clears `runPromise`. Run A's `_runInner` is **still suspended** at
+   `await this.releasePromise`.
+3. Run B starts (allowed: `runPromise` is clear) and parks at the **same**
+   `await this.releasePromise`.
+4. Run B is aborted before it ever reaches `acquire()`. At abort time its
+   `acquirePromise` is `undefined`, so run B's `catch` handler awaits nothing and
+   releases nothing.
+5. The pending release settles. Run B's orphaned `_runInner` resumes past the
+   park, sees `acquireNeeded` and calls `acquire()` — for an already-finished run.
+   The acquire succeeds and sets `sessionAcquired = s1`, but nothing releases it.
+
+**Root cause:** `_runInner` only checked `abortSignal.aborted` **after**
+`acquire()` (`Device.ts:513`). A run aborted while parked **before** the acquire
+decision keeps running in the background — it merely lost the `Promise.race`, it
+was not cancelled — and proceeds to `acquire()` a session the already-settled run
+can never release. The leaked session keeps the device's transport interface
+occupied with `keepTransportSession === false`, contradicting INV-3.
+
+**Fix (applied — obviously correct):** check `abortSignal.aborted` **before**
+`acquire()` in `_runInner` (`Device.ts:508`). This only adds an early throw on an
+already-aborted signal — identical in spirit to the existing post-acquire check,
+just moved ahead of the acquire — so a non-aborted run is unaffected and an
+aborted run no longer acquires a session it would leak. (The post-acquire window
+remains safe: if abort fires _during_ `await this.acquire()`, `acquirePromise` is
+set, so run's `catch` awaits it and releases.)
+
+**Tests:** `deviceRunInterruptLeak.repro.test.ts` (minimal deterministic repro —
+fails pre-fix with `sessionAcquired === 's1'`, passes post-fix) is the primary
+regression guard for this finding. The fuzz harness gained
+`checkSessionBalanceAtQuiescence` (INV-3: no session held after drain unless
+`keepTransportSession`); the assertion has teeth, but this abort-before-acquire
+interleaving is rare and the harness does not reliably rediscover it at the
+committed default `FUZZ_SEED`/`FUZZ_RUNS` — raise `FUZZ_RUNS` or rotate seeds to
+hunt it. Treat the deterministic repro, not the fuzz, as the guard for INV-3.

--- a/packages/connect/src/device/CONCURRENCY_MODEL.md
+++ b/packages/connect/src/device/CONCURRENCY_MODEL.md
@@ -24,21 +24,21 @@ acquire -> (handshake/getFeatures/initialize) -> firmware/language checks
 
 State fields that form the concurrency surface (`Device.ts:124-178`):
 
-| field | role |
-| --- | --- |
-| `runPromise?: Promise<void>` | the single in-flight run; presence ⇒ device busy |
-| `runAbort?: AbortController` | abort handle for the in-flight run |
-| `acquirePromise?` | in-flight `transport.acquire(...)` |
-| `releasePromise?` | in-flight `transport.release(...)` |
-| `sessionAcquired: Session \| null` | the session this instance owns (null ⇒ not held here) |
-| `keepTransportSession: boolean` | suppresses `release()` until a `keepSession:false` call |
-| `currentSession?: DeviceCurrentSession` | per-acquire transport call wrapper |
-| `sessionDfd?: Deferred<Session \| null>` | resolves on the next descriptor session change |
+| field                                    | role                                                    |
+| ---------------------------------------- | ------------------------------------------------------- |
+| `runPromise?: Promise<void>`             | the single in-flight run; presence ⇒ device busy        |
+| `runAbort?: AbortController`             | abort handle for the in-flight run                      |
+| `acquirePromise?`                        | in-flight `transport.acquire(...)`                      |
+| `releasePromise?`                        | in-flight `transport.release(...)`                      |
+| `sessionAcquired: Session \| null`       | the session this instance owns (null ⇒ not held here)   |
+| `keepTransportSession: boolean`          | suppresses `release()` until a `keepSession:false` call |
+| `currentSession?: DeviceCurrentSession`  | per-acquire transport call wrapper                      |
+| `sessionDfd?: Deferred<Session \| null>` | resolves on the next descriptor session change          |
 
 **`run(fn, options)` — `Device.ts:419-455`**
 
 - Re-entrancy guard: `if (this.runPromise) throw Device_CallInProgress`.
-  This is the *only* gate for "at most one run live per device".
+  This is the _only_ gate for "at most one run live per device".
 - Creates a fresh `runAbort`; `runPromise` is
   `Promise.race([_runInner(fn, options, signal), abortRejectPromise])`.
   The abort branch rejects with `signal.reason` when `runAbort.abort(reason)`
@@ -116,19 +116,19 @@ So `interrupt` waits for the targeted run to settle before returning.
 ### 1.3 Core method dispatch (`core/index.ts`)
 
 - `onCall` (`:186-259`): `methodSynchronize` (a `getSynchronize()` mutex,
-  `:777`) serializes method *loading*; then `resolveWaitForFirstMethod()` and
+  `:777`) serializes method _loading_; then `resolveWaitForFirstMethod()` and
   `callMethods.push(method)`.
 - `onCallDevice` (`:262-427`):
-  - `selectDevice` loop until a device is found.
-  - finds `previousCall` = other pending `callMethods` for the **same device
-    path** (`:307-312`).
-  - **override path** (`:313-330`): if `overridePreviousCall`, marks each
-    pending call `overridden = true`, then `await device.interrupt(Method_Override)`.
-    If *this* method was itself overridden meanwhile, responds false and throws.
-  - else if `device.currentRun` (`:331-344`): if `isUnacquired()` await
-    `currentRun` (corner case: first-load self-release), otherwise respond
-    `Device_CallInProgress`.
-  - `device.run(innerAction, { keepSession, skipFinalReload, useCardanoDerivation })`.
+    - `selectDevice` loop until a device is found.
+    - finds `previousCall` = other pending `callMethods` for the **same device
+      path** (`:307-312`).
+    - **override path** (`:313-330`): if `overridePreviousCall`, marks each
+      pending call `overridden = true`, then `await device.interrupt(Method_Override)`.
+      If _this_ method was itself overridden meanwhile, responds false and throws.
+    - else if `device.currentRun` (`:331-344`): if `isUnacquired()` await
+      `currentRun` (corner case: first-load self-release), otherwise respond
+      `Device_CallInProgress`.
+    - `device.run(innerAction, { keepSession, skipFinalReload, useCardanoDerivation })`.
 - `sendCoreMessage` (`:790-801`): on a RESPONSE event, splices the method out of
   `callMethods`; when the array empties, re-arms `waitForFirstMethod`.
 - `onCallCancel` / `abortController` reject in-flight work on cancel/dispose.
@@ -146,14 +146,14 @@ So `interrupt` waits for the targeted run to settle before returning.
 ### 1.5 Shared device registry (`device/DeviceList.ts`)
 
 - `devices: Device[]` (`:114`) is mutated from event handlers:
-  - `onDeviceConnected` (`:176-228`, **async**): creates a `Device`, runs its
-    `handshake()` under `handshakeLock` (a `getSynchronize()` mutex serializing
-    handshakes, `:149`), and — only if `stillConnected` — `devices.push(device)`
-    and wires lifecycle listeners. The `DEVICE.DISCONNECT` lifecycle handler
-    (`:219-225`) splices the device back out.
-  - `enumerate` (`:388-397`): per transport, `await transport.enumerate()` then
-    `transport.handleDescriptorsChange(payload)` (which in turn fans out
-    connect/disconnect/session-changed device events).
+    - `onDeviceConnected` (`:176-228`, **async**): creates a `Device`, runs its
+      `handshake()` under `handshakeLock` (a `getSynchronize()` mutex serializing
+      handshakes, `:149`), and — only if `stillConnected` — `devices.push(device)`
+      and wires lifecycle listeners. The `DEVICE.DISCONNECT` lifecycle handler
+      (`:219-225`) splices the device back out.
+    - `enumerate` (`:388-397`): per transport, `await transport.enumerate()` then
+      `transport.handleDescriptorsChange(payload)` (which in turn fans out
+      connect/disconnect/session-changed device events).
 - Lookups (`getDeviceByPath`, `getOnlyDevice`, `getDeviceByStaticState`,
   `getPrioritizedDevices`) all read the live `devices` array.
 
@@ -212,7 +212,7 @@ Under interleaved connect / disconnect / enumerate / session-change events:
 
 ## 3. Seams flagged for the harness (non-speculative)
 
-Concrete interleaving points worth driving — listed as *questions to verify*,
+Concrete interleaving points worth driving — listed as _questions to verify_,
 not as asserted bugs:
 
 1. **`release()` no-op returns `undefined`.** Callers that `await this.release()`
@@ -224,7 +224,7 @@ not as asserted bugs:
    no window where `runPromise` is still set when the override's `run()` is
    issued (would throw `Device_CallInProgress`).
 3. **Single `sessionDfd` shared by acquire & release.** Both `acquire()` and
-   `release()` arm/await the *same* `sessionDfd` slot (`getSessionChangePromise`,
+   `release()` arm/await the _same_ `sessionDfd` slot (`getSessionChangePromise`,
    `Device.ts:224-235`). Verify overlapping acquire/release (e.g. interrupt mid-
    acquire) cannot resolve the wrong waiter or drop a session-change.
 4. **`usedElsewhere()` during an in-flight `acquire()`.** `usedElsewhere` nulls
@@ -241,15 +241,47 @@ not as asserted bugs:
 
 ---
 
-## 4. Harness plan (PHASE 2/3, summary)
+## 4. Harness (PHASE 2 — implemented)
 
-Build a deterministic mock transport whose `acquire`/`release`/`call`/`send`/
-`enumerate` resolve **on command** (controllable deferreds), so the test drives
-every interleaving. Use `fast-check` to generate sequences of operations —
-*run method*, *override with a second run*, *abort via signal*,
-*disconnect/reconnect*, *toggle keepSession* — and their interleavings, then
-assert INV-1..INV-5 after each step and at quiescence. Follow the existing
-mock-transport conventions (`global.JestMocks.createTestTransport`, jest). For
-each distinct violation: shrink, commit a minimal deterministic repro + a note
-(invariant, interleaving, suspected root cause), and only commit a fix if it is
-obviously correct and all existing tests pass.
+A deterministic mock transport whose `acquire`/`release`/`call`/`send`/`receive`/
+`enumerate` settle **on command** (controllable deferreds) so the test drives
+every interleaving. `fast-check` generates operation sequences and the harness
+asserts the invariants after every step and at quiescence.
+
+- `__tests__/support/controllableTransport.ts` — `ControllableTransport extends
+AbstractTransport`. The transport methods the `Device` calls park their result
+  in a FIFO of deferreds; `completeAcquire`/`completeRelease`/`completeMessage`
+  settle them on command. Session transitions go through the **real**
+  `handleDescriptorsChange`, so `getSessionChangePromise`/`waitAndCompareSession`
+  run exactly as in production. (`init()`/`listen()` must run first — otherwise
+  `handleDescriptorsChange` short-circuits on `stopped` and no
+  `DEVICE_SESSION_CHANGED` ever fans out.)
+- `__tests__/deviceConcurrency.fuzz.test.ts` — drives `run` / `completeAcquire`
+  (+`Fail`) / `completeFn` / `completeRelease` / `completeMessage` / `interrupt`
+  with a `keepSession` toggle, then drains to quiescence. Asserts INV-1
+  (`live`/`activeFn` ≤ 1), INV-2 (drain reaches quiescence within a bound), INV-3
+  (releases never exceed acquires), INV-4 (post-quiescence the device accepts a
+  fresh `run`). The firmware/handshake/feature-reload middle of `_runInner` is
+  stubbed so only the queue + session mechanics are exercised. Run via
+  `yarn workspace @trezor/connect test:fuzz` (env `FUZZ_RUNS` / `FUZZ_SEED`).
+
+**Faithfulness note.** The generated `fn` body honors the run's abort signal,
+mirroring a real method whose in-flight `typedCall` is aborted by `interrupt`.
+An earlier abort-agnostic `fn` produced a spurious "two fn bodies concurrent"
+INV-1 report — a harness artifact, not a Device bug — which is why the body must
+model prompt abort response.
+
+### Deferred to PHASE 3
+
+- The externally-driven `requestRelease` / `externalSession` (`usedElsewhere`)
+  ops are implemented in the harness `step()` but held out of the generator. They
+  open the **acquire-vs-session-change** race where `updateDescriptor` awaits a
+  rejecting `acquirePromise` (`Device.ts:385`) on an event-handler path with no
+  `catch` → a candidate unhandled rejection. This must be confirmed against real
+  Device semantics (not the mock) before being asserted on.
+- INV-5 (`DeviceList` consistency) needs a `DeviceList`/`Core`-level harness, not
+  a single `Device`; it is out of scope for this file.
+
+For each distinct, **verified** violation: shrink, commit a minimal deterministic
+repro + a note (invariant, interleaving, suspected root cause), and only commit a
+fix if it is obviously correct and all existing tests pass.

--- a/packages/connect/src/device/CONCURRENCY_MODEL.md
+++ b/packages/connect/src/device/CONCURRENCY_MODEL.md
@@ -223,6 +223,7 @@ not as asserted bugs:
    `device.interrupt()` then expects to `device.run()` (override path). Verify
    no window where `runPromise` is still set when the override's `run()` is
    issued (would throw `Device_CallInProgress`).
+   _Verified safe — see §6 (override dispatch seam)._
 3. **Single `sessionDfd` shared by acquire & release.** Both `acquire()` and
    `release()` arm/await the _same_ `sessionDfd` slot (`getSessionChangePromise`,
    `Device.ts:224-235`). Verify overlapping acquire/release (e.g. interrupt mid-
@@ -423,3 +424,56 @@ repro — pre-fix the reconnected `'2'` is never registered; passes post-fix). T
 connected; it reds without the fix (counterexample
 `connect 1, connect 3, disconnect 3, connect 3, connect 1`) and is green with it
 across 1600 runs × seeds 1/7/42/99.
+
+---
+
+## 6. Override dispatch seam (verified safe — INV-4)
+
+The last objective-enumerated seam, the `core/index.ts` override path
+(`onCallDevice:313-330`), was driven directly. In production a method with
+`overridePreviousCall` preempts another in-flight call to the **same device**;
+`overridePreviousCall` is set by exactly **one** method — `setBusy` (`api/setBusy.ts:16`)
+— so the only production-reachable override is a single `setBusy` overriding a
+single in-flight call. Core's sequence is:
+
+```
+await device.interrupt(Method_Override);   // abort the in-flight run
+if (method.overridden) { respond(false, Method_Override); throw; }
+await device.run(innerAction, ...);        // start the overriding run
+```
+
+**The device-level contract this rests on:** the instant `await device.interrupt(reason)`
+resolves, the device is immediately runnable (`device.run()` on the next line must
+not throw `Device_CallInProgress`), and the interrupted run has rejected with
+**exactly** `reason` (so the overridden call responds with `Method_Override`, not a
+stray error).
+
+**Why it holds (code-grounded).** `interrupt()` ends with `await this.currentRun`
+(`Device.ts:489`); `currentRun` is `runPromise?.catch(()=>{})` (`Device.ts:492-494`),
+and `runPromise` is the full chain `…race().catch().finally(clear).then()`
+(`Device.ts:455-477`). The `.finally` that sets `runPromise = undefined` is part of
+that chain, so `await this.currentRun` cannot resolve until `runPromise` is already
+cleared. Therefore core's next-line `device.run()` always sees `runPromise ===
+undefined` and proceeds. The interrupted run rejects via the `Promise.race` abort
+branch with `signal.reason` (`Device.ts:457-459`), which the `.catch` re-throws
+unchanged — so the reason is verbatim `Method_Override`.
+
+**Tests:** `deviceOverrideDispatch.test.ts` drives the **real**
+`Device.interrupt` → immediate `Device.run` (no reproduction of `onCallDevice`'s
+bookkeeping) across the three in-flight states core can interrupt — a run blocked
+in its `fn` body, blocked in `acquire()`, and parked before `acquire()` at
+`await this.releasePromise` — asserting in each: the override `run()` does not
+throw, the interrupted run rejected with `Method_Override`, and the device drains
+with a balanced session ledger. A companion case asserts the other half of the
+contract: a **non-override** second run on a busy device is rejected with
+`Device_CallInProgress` (the `else if (device.currentRun)` branch). The existing
+fuzz harness only checks runnability after a full drain; core re-runs on the next
+microtask, so this immediate `interrupt → run` sequence is its own seam.
+
+**Not an INV violation (corner not reachable in production).** Two _concurrent_
+override-capable calls (two `setBusy`) to the same device have a timing-dependent
+window where both pass the `if (method.overridden)` re-check and both reach
+`device.run()`; the loser gets a `Device_CallInProgress` **response**. This is a
+defined error response, not a hang/leak/stuck device (INV-4 recovery still holds —
+the next call succeeds), and it is not reachable from normal usage (Suite never
+fires two `setBusy` concurrently). Flagged here for completeness, not as a defect.

--- a/packages/connect/src/device/CONCURRENCY_MODEL.md
+++ b/packages/connect/src/device/CONCURRENCY_MODEL.md
@@ -1,0 +1,255 @@
+# `packages/connect` device concurrency model
+
+> Scope: the device concurrency layer — `Device.ts` (per-device run-queue),
+> `core/index.ts` (method dispatch / override), `DeviceCurrentSession.ts`
+> (per-call transport loop) and `DeviceList.ts` (shared device registry).
+> This document maps the **actual** concurrency seams in the code as of this
+> branch and derives the **invariants** that must hold. It makes no claim about
+> specific bugs — those are the subject of the fuzz harness (PHASE 2/3).
+
+All line references are to the files in `packages/connect/src/`.
+
+---
+
+## 1. The seams
+
+### 1.1 `Device` per-device run-queue (`device/Device.ts`)
+
+A `Device` is the unit of mutual exclusion. The intended workflow per call is:
+
+```
+acquire -> (handshake/getFeatures/initialize) -> firmware/language checks
+        -> fn() -> reload features -> [keepSession?] -> release
+```
+
+State fields that form the concurrency surface (`Device.ts:124-178`):
+
+| field | role |
+| --- | --- |
+| `runPromise?: Promise<void>` | the single in-flight run; presence ⇒ device busy |
+| `runAbort?: AbortController` | abort handle for the in-flight run |
+| `acquirePromise?` | in-flight `transport.acquire(...)` |
+| `releasePromise?` | in-flight `transport.release(...)` |
+| `sessionAcquired: Session \| null` | the session this instance owns (null ⇒ not held here) |
+| `keepTransportSession: boolean` | suppresses `release()` until a `keepSession:false` call |
+| `currentSession?: DeviceCurrentSession` | per-acquire transport call wrapper |
+| `sessionDfd?: Deferred<Session \| null>` | resolves on the next descriptor session change |
+
+**`run(fn, options)` — `Device.ts:419-455`**
+
+- Re-entrancy guard: `if (this.runPromise) throw Device_CallInProgress`.
+  This is the *only* gate for "at most one run live per device".
+- Creates a fresh `runAbort`; `runPromise` is
+  `Promise.race([_runInner(fn, options, signal), abortRejectPromise])`.
+  The abort branch rejects with `signal.reason` when `runAbort.abort(reason)`
+  fires.
+- `.catch`: on any failure (incl. abort) it forces
+  `keepTransportSession = false`, awaits `acquirePromise`, `stopPiggybackAck()`,
+  `release()`, then rethrows.
+- `.finally`: clears `runAbort` and `runPromise` (this is what re-arms the
+  device for the next run).
+- `.then`: if the device went from unacquired → acquired, emits
+  `lifecycle DEVICE.CONNECT`.
+
+**`_runInner(fn, options, abortSignal)` — `Device.ts:490-602`**
+
+- If a `releasePromise` is in flight, awaits it first (a previous
+  cancel/override may still be releasing).
+- `acquireNeeded = !isUsedHere() || currentSession?.isDisposed()`; if so calls
+  `acquire()`.
+- Checks `abortSignal.aborted` right after acquire and throws `signal.reason`.
+- Runs handshake/`getFeatures`/`initialize` depending on protocol (`v1`/`v2`)
+  and whether `fn` is present; firmware-hash + revision checks; silent language
+  update.
+- `if (options.keepSession) this.keepTransportSession = true`.
+- `if (fn) { await fn(); if (!skipFinalReload) await getFeatures(); }`.
+- Trailing release: releases unless `keepTransportSession` is set / `keepSession`
+  was requested truthy.
+
+**`acquire()` — `Device.ts:259-287`**
+
+1. `sessionPromise = getSessionChangePromise()` (arms `sessionDfd`).
+2. reads `previous` = current descriptor session from the transport.
+3. `transport.acquire({ path, previous })` → `waitAndCompareSession` → on
+   success sets `wasUsedElsewhere=false`, `sessionAcquired`, builds a new
+   `DeviceCurrentSession`. Clears `acquirePromise` in `finally`.
+
+**`release()` — `Device.ts:302-324`**
+
+- Guard: `if (!sessionAcquired || keepTransportSession || releasePromise) return;`
+  (note: **returns `undefined`, not a promise**, in the no-op case).
+- `transport.release(...)` → `waitAndCompareSession` → on success
+  `sessionAcquired = null`. Clears `releasePromise` in `finally`.
+
+**`waitAndCompareSession` — `Device.ts:237-257`** confirms that after an
+acquire/release the descriptor's session changed to the expected value, by
+awaiting the `sessionDfd` promise (resolved from `updateDescriptor`). Mismatch ⇒
+`SESSION_WRONG_PREVIOUS`; rejection ⇒ `DEVICE_DISCONNECTED_DURING_ACTION`.
+
+**`interrupt(reason)` — `Device.ts:457-465`**
+
+```
+await abortThpWorkflow(this);
+await this.currentSession?.abort(reason);   // aborts the in-flight typedCall
+this.runAbort?.abort(reason);               // rejects the run-race
+await this.currentRun;                      // currentRun = runPromise.catch(()=>{})
+```
+
+So `interrupt` waits for the targeted run to settle before returning.
+
+### 1.2 Externally-driven session transitions (`Device.ts`)
+
+`onTransportDeviceEvent` (`Device.ts:212-222`) dispatches transport events:
+
+- `DEVICE_SESSION_CHANGED` → `updateDescriptor(descriptor)` (`:382-402`):
+  resolves `sessionDfd` with the new session; awaits `acquirePromise` &
+  `releasePromise`; if `descriptor.session` differs from `sessionAcquired` →
+  `usedElsewhere()`; if `descriptor.session` is null → `keepTransportSession=false`.
+- `DEVICE_REQUEST_RELEASE` → `usedElsewhere()` (`:471-488`): sets
+  `wasUsedElsewhere`, and if we hold a session, calls
+  `transport.releaseDevice(sessionAcquired)`, nulls `sessionAcquired`, and
+  `runAbort?.abort(Device_UsedElsewhere)`.
+- `DEVICE_DISCONNECTED` → `disconnect()` (`:902-919`): detaches listeners,
+  rejects `sessionDfd`, `transport.releaseSync(sessionAcquired)`, emits
+  `lifecycle DEVICE.DISCONNECT`, then `interrupt(Device_Disconnected)`.
+
+### 1.3 Core method dispatch (`core/index.ts`)
+
+- `onCall` (`:186-259`): `methodSynchronize` (a `getSynchronize()` mutex,
+  `:777`) serializes method *loading*; then `resolveWaitForFirstMethod()` and
+  `callMethods.push(method)`.
+- `onCallDevice` (`:262-427`):
+  - `selectDevice` loop until a device is found.
+  - finds `previousCall` = other pending `callMethods` for the **same device
+    path** (`:307-312`).
+  - **override path** (`:313-330`): if `overridePreviousCall`, marks each
+    pending call `overridden = true`, then `await device.interrupt(Method_Override)`.
+    If *this* method was itself overridden meanwhile, responds false and throws.
+  - else if `device.currentRun` (`:331-344`): if `isUnacquired()` await
+    `currentRun` (corner case: first-load self-release), otherwise respond
+    `Device_CallInProgress`.
+  - `device.run(innerAction, { keepSession, skipFinalReload, useCardanoDerivation })`.
+- `sendCoreMessage` (`:790-801`): on a RESPONSE event, splices the method out of
+  `callMethods`; when the array empties, re-arms `waitForFirstMethod`.
+- `onCallCancel` / `abortController` reject in-flight work on cancel/dispose.
+
+### 1.4 Per-call transport loop (`device/DeviceCurrentSession.ts`)
+
+- `typedCall` (`:105-159`): creates a per-call `abortController`, runs
+  `callLoop`, stores `callPromise`. The loop races each `transport.call` against
+  `abortPromise`; on abort during a `ButtonAck` it sends a `Cancel`.
+- `abort(reason)` (`:362-366`): aborts the call's controller, awaits
+  `callPromise`, sets `disposed = reason` (so later calls short-circuit).
+- A transport `deviceEvents.once` listener (`:89-98`) sets `disposed` and aborts
+  on disconnect / used-elsewhere.
+
+### 1.5 Shared device registry (`device/DeviceList.ts`)
+
+- `devices: Device[]` (`:114`) is mutated from event handlers:
+  - `onDeviceConnected` (`:176-228`, **async**): creates a `Device`, runs its
+    `handshake()` under `handshakeLock` (a `getSynchronize()` mutex serializing
+    handshakes, `:149`), and — only if `stillConnected` — `devices.push(device)`
+    and wires lifecycle listeners. The `DEVICE.DISCONNECT` lifecycle handler
+    (`:219-225`) splices the device back out.
+  - `enumerate` (`:388-397`): per transport, `await transport.enumerate()` then
+    `transport.handleDescriptorsChange(payload)` (which in turn fans out
+    connect/disconnect/session-changed device events).
+- Lookups (`getDeviceByPath`, `getOnlyDevice`, `getDeviceByStaticState`,
+  `getPrioritizedDevices`) all read the live `devices` array.
+
+---
+
+## 2. Invariants
+
+These are the properties the harness asserts after every step and at quiescence.
+
+### INV-1 — Mutual exclusion (one run body per device)
+
+At most one `_runInner` body is executing for a given `Device` at any time.
+Enforced solely by the `if (this.runPromise) throw Device_CallInProgress` guard
+(`Device.ts:420`). Corollary: `acquire()`/`release()`/`fn()` of two different
+runs never interleave on the same device.
+
+### INV-2 — Liveness (every run settles)
+
+Every `run()` that does not throw synchronously eventually settles (resolve or
+reject); no `runPromise`, `acquirePromise`, `releasePromise`, `sessionDfd`, or
+`callPromise` remains pending once the system is quiescent (no further
+transport events / no pending method). In particular `interrupt()` must return.
+
+### INV-3 — Session balance
+
+- `sessionAcquired` is non-null iff this instance currently owns a transport
+  session; every successful `acquire()` is matched by exactly one `release()`
+  (or an external `usedElsewhere`/`disconnect` that nulls it).
+- A `release()` only ever releases the session this instance owns — it never
+  releases another owner's session.
+- `keepTransportSession` is honored: while set, the trailing `release()` in
+  `_runInner` and the standalone `release()` are no-ops; it is cleared on a
+  `keepSession:false` call, on run failure, on descriptor session→null, and on
+  `setInstance` change.
+
+### INV-4 — Abort / override correctness
+
+`interrupt(reason)` rejects **exactly** the in-flight run for the target device
+(via `runAbort` + `currentSession.abort`), leaves `runPromise`/`runAbort`
+cleared, and leaves the device in a state from which the next `run()` succeeds
+(no stuck `Device_CallInProgress`, no orphaned session). In the override path
+(`core/index.ts:313-330`) the overriding method proceeds and each overridden
+method responds with `Method_Override`.
+
+### INV-5 — `DeviceList` consistency
+
+Under interleaved connect / disconnect / enumerate / session-change events:
+
+- no device path appears twice in `devices`;
+- a device that completed handshake and is still connected is present exactly
+  once; a disconnected device is removed exactly once;
+- no device is "lost" (handshaked + connected but missing from `devices`) and
+  none is leaked (disconnected but still in `devices`).
+
+---
+
+## 3. Seams flagged for the harness (non-speculative)
+
+Concrete interleaving points worth driving — listed as *questions to verify*,
+not as asserted bugs:
+
+1. **`release()` no-op returns `undefined`.** Callers that `await this.release()`
+   are fine, but any code expecting a promise in the guarded branch
+   (`Device.ts:303`) gets `undefined`. Verify all call sites tolerate it under
+   overlap with an in-flight `releasePromise`.
+2. **`run()` re-entrancy vs `interrupt()`.** `core` calls
+   `device.interrupt()` then expects to `device.run()` (override path). Verify
+   no window where `runPromise` is still set when the override's `run()` is
+   issued (would throw `Device_CallInProgress`).
+3. **Single `sessionDfd` shared by acquire & release.** Both `acquire()` and
+   `release()` arm/await the *same* `sessionDfd` slot (`getSessionChangePromise`,
+   `Device.ts:224-235`). Verify overlapping acquire/release (e.g. interrupt mid-
+   acquire) cannot resolve the wrong waiter or drop a session-change.
+4. **`usedElsewhere()` during an in-flight `acquire()`.** `usedElsewhere` nulls
+   `sessionAcquired` and aborts the run; an `acquire()` resolving afterwards sets
+   `sessionAcquired` again (`Device.ts:269`). Verify ordering cannot leave a
+   session owned-but-aborted or aborted-but-owned.
+5. **`DeviceList.onDeviceConnected` async gap.** Between `new Device(...)` and
+   `devices.push(...)` there is an `await handshakeLock(...)`; a disconnect for
+   the same path arriving in that window has no device in `devices` to splice.
+   Verify no duplicate (re-connect) or lost (disconnect-then-late-push) entry.
+6. **`enumerate()` concurrent with connect/disconnect.** `handleDescriptorsChange`
+   fans out events that mutate `devices` while another `enumerate()` /
+   connect handler is mid-flight. Verify registry consistency (INV-5).
+
+---
+
+## 4. Harness plan (PHASE 2/3, summary)
+
+Build a deterministic mock transport whose `acquire`/`release`/`call`/`send`/
+`enumerate` resolve **on command** (controllable deferreds), so the test drives
+every interleaving. Use `fast-check` to generate sequences of operations —
+*run method*, *override with a second run*, *abort via signal*,
+*disconnect/reconnect*, *toggle keepSession* — and their interleavings, then
+assert INV-1..INV-5 after each step and at quiescence. Follow the existing
+mock-transport conventions (`global.JestMocks.createTestTransport`, jest). For
+each distinct violation: shrink, commit a minimal deterministic repro + a note
+(invariant, interleaving, suspected root cause), and only commit a fix if it is
+obviously correct and all existing tests pass.

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -187,6 +187,13 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
 
     private sessionDfd?: Deferred<Session | null>;
 
+    // Terminal flag: set once `disconnect()` has torn down this instance's
+    // transport listeners. A disconnected Device must never start a new run — its
+    // `onTransportDeviceEvent` listener is gone, so `acquire()`'s
+    // `waitAndCompareSession` would await a `sessionDfd` nothing ever resolves and
+    // hang forever (see CONCURRENCY_MODEL.md Finding 3).
+    private disconnected = false;
+
     constructor({ id, transport, descriptor, createLogger }: DeviceParams) {
         super();
 
@@ -357,6 +364,12 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
 
     // call only once, right after device creation
     async handshake() {
+        // Disconnected while queued behind DeviceList's handshakeLock: report
+        // not-connected so DeviceList skips the push and the lock is released for
+        // the next device (see CONCURRENCY_MODEL.md Finding 3).
+        if (this.disconnected) {
+            return false;
+        }
         if (this.isUsedElsewhere()) {
             return true;
         }
@@ -450,6 +463,13 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
 
     // TODO empty fn variant can be split/removed
     run(fn?: () => Promise<void>, options: RunOptions = {}) {
+        if (this.disconnected) {
+            // A handshake queued behind DeviceList's handshakeLock can reach this
+            // point after the device disconnected; acquiring now would hang on a
+            // sessionDfd no listener resolves, stalling the lock for every later
+            // device (see CONCURRENCY_MODEL.md Finding 3).
+            throw ERRORS.TypedError('Device_Disconnected');
+        }
         if (this.runPromise) {
             this.logger.warn('Previous call is still running');
             throw ERRORS.TypedError('Device_CallInProgress');
@@ -960,6 +980,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
     private disconnect() {
         this.logger.debug('Disconnect cleanup');
 
+        this.disconnected = true;
         this.transport.off(TRANSPORT.STOPPED, this.onTransportStopped);
         this.transport.deviceEvents.off(this.descriptor.path, this.onTransportDeviceEvent);
         this.removeAllListeners();

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -534,6 +534,12 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
 
         const acquireNeeded = !this.isUsedHere() || this.currentSession?.isDisposed();
         if (acquireNeeded) {
+            // If the run was already aborted while parked above (e.g. interrupted
+            // while waiting on a previous release), bail before acquiring: the
+            // run's catch handler has already run its release path against the
+            // session state it saw at abort time, so a session acquired here would
+            // never be released — a leaked transport session.
+            if (abortSignal.aborted) throw abortSignal.reason;
             // acquire session
             await this.acquire();
         }

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -394,7 +394,12 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
     private async updateDescriptor(descriptor: Descriptor) {
         this.sessionDfd?.resolve(descriptor.session);
 
-        await Promise.all([this.acquirePromise, this.releasePromise]);
+        // Only wait for any in-flight acquire/release to settle before reading
+        // `sessionAcquired` below; their outcome is irrelevant here and a rejecting
+        // `acquirePromise` (e.g. SESSION_WRONG_PREVIOUS when the session was taken
+        // elsewhere mid-acquire) is already handled by the run path. `Promise.all`
+        // would re-raise that rejection on this uncaught event-handler path.
+        await Promise.allSettled([this.acquirePromise, this.releasePromise]);
 
         // TODO improve these conditions
 

--- a/packages/connect/src/device/__tests__/deviceConcurrency.fuzz.test.ts
+++ b/packages/connect/src/device/__tests__/deviceConcurrency.fuzz.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Deterministic interleaving fuzz harness for the per-device run-queue (PHASE 2).
+ *
+ * Scope: the `Device` concurrency seams documented in `../CONCURRENCY_MODEL.md`
+ * — `run` / `_runInner`, `interrupt`, `acquire` / `release`, `keepTransportSession`
+ * and the externally-driven `usedElsewhere` transition. The heavy firmware /
+ * handshake / feature-reload middle of `_runInner` is stubbed out so the harness
+ * exercises the *queue* mechanics, while `acquire` / `release` and the
+ * `sessionDfd` session machinery run for real against a controllable transport.
+ *
+ * DeviceList consistency (INV-5) and core override dispatch live in a separate
+ * harness (those need DeviceList / Core, not a single Device) and are out of
+ * scope for this file.
+ *
+ * fast-check generates a sequence of operations; after every step and at
+ * quiescence the harness asserts the invariants:
+ *   INV-1 mutual exclusion — at most one run body live at any time.
+ *   INV-2 liveness         — every issued run settles; the system drains.
+ *   INV-3 session balance  — releases never exceed acquires; no dangling session.
+ *   INV-4 abort/override    — interrupt settles and leaves the device runnable.
+ *
+ * Run a longer hunt with: `yarn workspace @trezor/connect test:fuzz`
+ * (raise FUZZ_RUNS / drop the fixed seed via env to search harder).
+ */
+import fc from 'fast-check';
+
+import { noopCreateLogger } from '@trezor/connect-common/src/utils/debug';
+import { TRANSPORT } from '@trezor/transport-common';
+import { type Deferred, createDeferred } from '@trezor/utils';
+
+import { Device } from '../Device';
+import {
+    type ControllableTransport,
+    createControllableTransport,
+} from './support/controllableTransport';
+
+// Neutralise the firmware / handshake middle of _runInner so only the run-queue
+// and session mechanics remain. These modules issue real transport messages
+// that are irrelevant to the concurrency invariants under test.
+jest.mock('../workflow/handshake', () => ({
+    handshakeCancel: jest.fn(() => Promise.resolve()),
+    handshake: jest.fn(() => Promise.resolve()),
+}));
+jest.mock('../workflow/checkFirmwareHashWithRetries', () => ({
+    checkFirmwareHashWithRetries: jest.fn(() => Promise.resolve()),
+}));
+
+const PATH = '1' as any;
+
+type Op =
+    | { t: 'run'; keepSession: boolean }
+    | { t: 'completeAcquire' }
+    | { t: 'completeAcquireFail' }
+    | { t: 'completeFn' }
+    | { t: 'completeRelease' }
+    | { t: 'completeMessage' }
+    | { t: 'interrupt' }
+    | { t: 'requestRelease' }
+    | { t: 'externalSession' };
+
+// PHASE 2 alphabet: the per-device run-queue core (run / acquire / fn / release /
+// interrupt / keepSession). The externally-driven `requestRelease` and
+// `externalSession` transitions are implemented in `step()` but deliberately held
+// out of the generator for now: they open the acquire-vs-session-change race
+// (Device.updateDescriptor awaiting a rejecting acquirePromise) which is the
+// subject of PHASE 3 hunting and must be verified as a real bug — not a mock
+// artifact — before being asserted on.
+const opArb: fc.Arbitrary<Op> = fc.oneof(
+    fc.record({ t: fc.constant('run' as const), keepSession: fc.boolean() }),
+    fc.constant({ t: 'completeAcquire' as const }),
+    fc.constant({ t: 'completeAcquireFail' as const }),
+    fc.constant({ t: 'completeFn' as const }),
+    fc.constant({ t: 'completeRelease' as const }),
+    fc.constant({ t: 'completeMessage' as const }),
+    fc.constant({ t: 'interrupt' as const }),
+);
+
+const flush = () => new Promise(resolve => setImmediate(resolve));
+
+class Harness {
+    readonly transport: ControllableTransport;
+    readonly device: Device;
+
+    /** runs that started (run() returned without throwing) and have not settled */
+    live = 0;
+    /** fn bodies currently executing — directly probes mutual exclusion */
+    activeFn = 0;
+    /** pending fn deferreds the drain must resolve */
+    private readonly fnDeferreds: Deferred<void>[] = [];
+    private session = 0;
+    /** invariant violations recorded during the program (asserted by the test) */
+    readonly violations: string[] = [];
+
+    constructor() {
+        this.transport = createControllableTransport(PATH);
+        this.device = new Device({
+            id: 'fuzz' as any,
+            transport: this.transport,
+            descriptor: { path: PATH, type: 1, session: null, apiType: 'usb' } as any,
+            createLogger: noopCreateLogger,
+        });
+        // getFeatures / initialize would issue real transport messages; the
+        // queue invariants do not depend on their result.
+        jest.spyOn(this.device, 'getFeatures').mockResolvedValue(undefined as any);
+        jest.spyOn(this.device as any, 'initialize').mockResolvedValue(undefined as any);
+        jest.spyOn(this.device as any, 'checkFirmwareRevisionWithRetries').mockResolvedValue(
+            undefined as any,
+        );
+    }
+
+    private makeFn() {
+        const dfd = createDeferred<void>();
+        this.fnDeferreds.push(dfd);
+
+        // Faithful method body: a real connect method drives the device through
+        // currentSession.typedCall, which interrupt() aborts — so the body rejects
+        // promptly once the run is aborted, rather than running to completion.
+        return async () => {
+            this.activeFn += 1;
+            const signal: AbortSignal | undefined = (this.device as any).runAbort?.signal;
+            try {
+                await new Promise<void>((resolve, reject) => {
+                    dfd.promise.then(resolve, reject);
+                    if (signal) {
+                        if (signal.aborted) reject(signal.reason);
+                        else signal.addEventListener('abort', () => reject(signal.reason));
+                    }
+                });
+            } finally {
+                this.activeFn -= 1;
+            }
+        };
+    }
+
+    step(op: Op) {
+        switch (op.t) {
+            case 'run': {
+                try {
+                    const p = this.device.run(this.makeFn(), {
+                        keepSession: op.keepSession,
+                        skipFirmwareChecks: true,
+                    });
+                    this.live += 1;
+                    // swallow rejection (abort/override is expected) and free the slot
+                    p.catch(() => {}).finally(() => {
+                        this.live -= 1;
+                    });
+                } catch {
+                    // Device_CallInProgress — the mutual-exclusion guard fired.
+                    // Drop the unused fn deferred so the drain stays balanced.
+                    this.fnDeferreds.pop();
+                }
+                break;
+            }
+            case 'completeAcquire':
+                this.transport.completeAcquire(`s${this.session++}`);
+                break;
+            case 'completeAcquireFail':
+                this.transport.completeAcquireFail();
+                break;
+            case 'completeFn':
+                this.fnDeferreds.shift()?.resolve();
+                break;
+            case 'completeRelease':
+                this.transport.completeRelease();
+                break;
+            case 'completeMessage':
+                this.transport.completeMessage();
+                break;
+            case 'interrupt':
+                // fire-and-forget: interrupt awaits the in-flight run, which the
+                // drain later unblocks. Swallow rejection.
+                this.device.interrupt(new Error('fuzz-interrupt')).catch(() => {});
+                break;
+            case 'requestRelease':
+                this.transport.emitDeviceEvent(PATH, { type: TRANSPORT.DEVICE_REQUEST_RELEASE });
+                break;
+            case 'externalSession':
+                // another client grabbed the device → usedElsewhere
+                this.transport.setSession(PATH, `ext${this.session++}`);
+                break;
+        }
+    }
+
+    checkStepInvariants() {
+        // INV-1 mutual exclusion
+        if (this.live > 1) this.violations.push(`INV-1: ${this.live} runs live concurrently`);
+        if (this.activeFn > 1) this.violations.push(`INV-1: ${this.activeFn} fn bodies concurrent`);
+        // INV-3 no over-release
+        if (this.transport.releasedCount > this.transport.acquiredCount) {
+            this.violations.push(
+                `INV-3: releases (${this.transport.releasedCount}) exceed acquires (${this.transport.acquiredCount})`,
+            );
+        }
+    }
+
+    /** Drive everything to settle; returns false on a liveness/deadlock failure. */
+    async drain() {
+        for (let i = 0; i < 300; i++) {
+            let progressed = false;
+            while (this.fnDeferreds.length) {
+                this.fnDeferreds.shift()?.resolve();
+                progressed = true;
+            }
+            if (this.transport.completeMessage()) progressed = true;
+            if (this.transport.completeAcquire(`s${this.session++}`)) progressed = true;
+            if (this.transport.completeRelease()) progressed = true;
+
+            await flush();
+
+            const quiescent =
+                !progressed &&
+                this.live === 0 &&
+                this.activeFn === 0 &&
+                this.fnDeferreds.length === 0 &&
+                !this.transport.hasPending();
+            if (quiescent) return true;
+        }
+
+        // Could not reach quiescence within the bound — a liveness / deadlock
+        // violation. Record the residual state so a failing case is diagnosable.
+        const state = {
+            live: this.live,
+            activeFn: this.activeFn,
+            fnDeferreds: this.fnDeferreds.length,
+            pending: this.transport.pending.map(p => p.kind),
+            sessionAcquired: (this.device as any).sessionAcquired,
+            runPromise: !!(this.device as any).runPromise,
+            keepTransportSession: (this.device as any).keepTransportSession,
+        };
+        this.violations.push(`INV-2: drain did not reach quiescence — ${JSON.stringify(state)}`);
+
+        return false;
+    }
+}
+
+describe('Device run-queue concurrency (fuzz)', () => {
+    const FUZZ_RUNS = Number(process.env.FUZZ_RUNS ?? 200);
+    const FUZZ_SEED = process.env.FUZZ_SEED ? Number(process.env.FUZZ_SEED) : 1;
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('preserves INV-1..INV-4 under arbitrary interleavings', async () => {
+        await fc.assert(
+            fc.asyncProperty(fc.array(opArb, { minLength: 1, maxLength: 40 }), async ops => {
+                const h = new Harness();
+
+                for (const op of ops) {
+                    h.step(op);
+
+                    await flush();
+                    h.checkStepInvariants();
+                }
+
+                // INV-2 liveness: the system must drain to quiescence.
+                const drained = await h.drain();
+                expect(drained).toBe(true);
+
+                // INV-4 recovery: after quiescence the device must accept a new run
+                // (no stuck Device_CallInProgress, no orphaned state).
+                let recovered = true;
+                try {
+                    const p = h.device.run(async () => {}, { skipFirmwareChecks: true });
+                    h.live += 1;
+                    p.catch(() => {}).finally(() => {
+                        h.live -= 1;
+                    });
+                } catch {
+                    recovered = false;
+                }
+                expect(recovered).toBe(true);
+                const drainedAgain = await h.drain();
+                expect(drainedAgain).toBe(true);
+
+                // INV-1/INV-3 recorded during the run.
+                expect(h.violations).toEqual([]);
+            }),
+            { numRuns: FUZZ_RUNS, seed: FUZZ_SEED },
+        );
+    }, 60000);
+});

--- a/packages/connect/src/device/__tests__/deviceConcurrency.fuzz.test.ts
+++ b/packages/connect/src/device/__tests__/deviceConcurrency.fuzz.test.ts
@@ -58,13 +58,14 @@ type Op =
     | { t: 'requestRelease' }
     | { t: 'externalSession' };
 
-// PHASE 2 alphabet: the per-device run-queue core (run / acquire / fn / release /
-// interrupt / keepSession). The externally-driven `requestRelease` and
-// `externalSession` transitions are implemented in `step()` but deliberately held
-// out of the generator for now: they open the acquire-vs-session-change race
-// (Device.updateDescriptor awaiting a rejecting acquirePromise) which is the
-// subject of PHASE 3 hunting and must be verified as a real bug — not a mock
-// artifact — before being asserted on.
+// Alphabet: the per-device run-queue core (run / acquire / fn / release /
+// interrupt / keepSession) plus the externally-driven `externalSession`
+// transition. `externalSession` opens the acquire-vs-session-change race
+// (`Device.updateDescriptor` awaiting a rejecting `acquirePromise`) — confirmed
+// in PHASE 3 as a real unhandled-rejection bug (see
+// `deviceSessionRace.repro.test.ts`) and fixed via `Promise.allSettled`. It is
+// now generated so the fix is exercised under arbitrary interleavings, with the
+// "no leaked updateDescriptor rejection" check below asserting INV-2.
 const opArb: fc.Arbitrary<Op> = fc.oneof(
     fc.record({ t: fc.constant('run' as const), keepSession: fc.boolean() }),
     fc.constant({ t: 'completeAcquire' as const }),
@@ -73,6 +74,7 @@ const opArb: fc.Arbitrary<Op> = fc.oneof(
     fc.constant({ t: 'completeRelease' as const }),
     fc.constant({ t: 'completeMessage' as const }),
     fc.constant({ t: 'interrupt' as const }),
+    fc.constant({ t: 'externalSession' as const }),
 );
 
 const flush = () => new Promise(resolve => setImmediate(resolve));
@@ -90,6 +92,13 @@ class Harness {
     private session = 0;
     /** invariant violations recorded during the program (asserted by the test) */
     readonly violations: string[] = [];
+    /**
+     * Every promise the transport-event handler (`updateDescriptor`) returns.
+     * It is invoked fire-and-forget from `onTransportDeviceEvent`, so any
+     * rejection escapes the device layer unhandled (INV-2). The drain checks that
+     * none of these reject.
+     */
+    private readonly descriptorPromises: Promise<unknown>[] = [];
 
     constructor() {
         this.transport = createControllableTransport(PATH);
@@ -98,6 +107,13 @@ class Harness {
             transport: this.transport,
             descriptor: { path: PATH, type: 1, session: null, apiType: 'usb' } as any,
             createLogger: noopCreateLogger,
+        });
+        const origUpdate = (this.device as any).updateDescriptor.bind(this.device);
+        jest.spyOn(this.device as any, 'updateDescriptor').mockImplementation((...a: any[]) => {
+            const p = origUpdate(...a) as Promise<unknown>;
+            this.descriptorPromises.push(p);
+
+            return p;
         });
         // getFeatures / initialize would issue real transport messages; the
         // queue invariants do not depend on their result.
@@ -194,6 +210,23 @@ class Harness {
         }
     }
 
+    /**
+     * INV-2: no `updateDescriptor` (fire-and-forget transport-event handler)
+     * rejected. A rejection here is an unhandled rejection escaping the device.
+     */
+    async checkDescriptorRejections() {
+        const rejected = (await Promise.allSettled(this.descriptorPromises)).filter(
+            r => r.status === 'rejected',
+        );
+        if (rejected.length) {
+            this.violations.push(
+                `INV-2: ${rejected.length} updateDescriptor promise(s) rejected — ${rejected
+                    .map(r => String((r as PromiseRejectedResult).reason?.message))
+                    .join(', ')}`,
+            );
+        }
+    }
+
     /** Drive everything to settle; returns false on a liveness/deadlock failure. */
     async drain() {
         for (let i = 0; i < 300; i++) {
@@ -273,6 +306,9 @@ describe('Device run-queue concurrency (fuzz)', () => {
                 expect(recovered).toBe(true);
                 const drainedAgain = await h.drain();
                 expect(drainedAgain).toBe(true);
+
+                // INV-2: no fire-and-forget updateDescriptor rejection leaked.
+                await h.checkDescriptorRejections();
 
                 // INV-1/INV-3 recorded during the run.
                 expect(h.violations).toEqual([]);

--- a/packages/connect/src/device/__tests__/deviceConcurrency.fuzz.test.ts
+++ b/packages/connect/src/device/__tests__/deviceConcurrency.fuzz.test.ts
@@ -74,6 +74,7 @@ const opArb: fc.Arbitrary<Op> = fc.oneof(
     fc.constant({ t: 'completeRelease' as const }),
     fc.constant({ t: 'completeMessage' as const }),
     fc.constant({ t: 'interrupt' as const }),
+    fc.constant({ t: 'requestRelease' as const }),
     fc.constant({ t: 'externalSession' as const }),
 );
 
@@ -211,6 +212,25 @@ class Harness {
     }
 
     /**
+     * INV-3 session balance at quiescence: a session may only remain acquired on
+     * purpose (`keepTransportSession`). Holding `sessionAcquired` with
+     * `keepTransportSession === false` after the system has drained means a
+     * release was lost — e.g. `release()`'s `waitAndCompareSession` failed and
+     * skipped the `sessionAcquired = null` assignment — leaving a stale session
+     * that the next run would reuse instead of re-acquiring (`acquireNeeded` keys
+     * off `isUsedHere() === !!sessionAcquired`).
+     */
+    checkSessionBalanceAtQuiescence() {
+        const held = (this.device as any).sessionAcquired;
+        const keep = (this.device as any).keepTransportSession;
+        if (held != null && !keep) {
+            this.violations.push(
+                `INV-3: session ${held} held at quiescence without keepTransportSession`,
+            );
+        }
+    }
+
+    /**
      * INV-2: no `updateDescriptor` (fire-and-forget transport-event handler)
      * rejected. A rejection here is an unhandled rejection escaping the device.
      */
@@ -290,6 +310,9 @@ describe('Device run-queue concurrency (fuzz)', () => {
                 // INV-2 liveness: the system must drain to quiescence.
                 const drained = await h.drain();
                 expect(drained).toBe(true);
+
+                // INV-3: no stale session held after the system drained.
+                h.checkSessionBalanceAtQuiescence();
 
                 // INV-4 recovery: after quiescence the device must accept a new run
                 // (no stuck Device_CallInProgress, no orphaned state).

--- a/packages/connect/src/device/__tests__/deviceListConsistency.fuzz.test.ts
+++ b/packages/connect/src/device/__tests__/deviceListConsistency.fuzz.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Deterministic interleaving fuzz harness for `DeviceList` consistency (INV-5).
+ *
+ * Scope: the shared `DeviceList.devices` registry documented in
+ * `../CONCURRENCY_MODEL.md` §1.5 / §3 (seams 5 & 6) — the array mutated from the
+ * async `onDeviceConnected` handler (`new Device` → `await handshakeLock` →
+ * `devices.push`) and from the per-device `DEVICE.DISCONNECT` lifecycle handler
+ * (`devices.splice`), under interleaved connect / disconnect / session-change
+ * events fanned out by the *real* `handleDescriptorsChange`.
+ *
+ * The per-device run-queue (INV-1..INV-4) is covered by
+ * `deviceConcurrency.fuzz.test.ts`; here `Device.handshake()` runs for real
+ * against the controllable transport (acquire → getFeatures → release, with the
+ * firmware/feature middle stubbed exactly as in that harness) so a disconnect
+ * arriving mid-handshake interrupts the run and makes `handshake()` return
+ * `false` — the production signal that gates `devices.push`.
+ *
+ * fast-check generates a sequence of connect/disconnect/acquire/release ops over
+ * a small set of paths; after every step (no-duplicate) and at full quiescence
+ * (present iff connected) the harness asserts INV-5.
+ *
+ * Run a longer hunt with: `yarn workspace @trezor/connect test:fuzz`
+ * (raise FUZZ_RUNS / drop the fixed seed via env to search harder).
+ */
+import fc from 'fast-check';
+
+import { noopCreateLogger } from '@trezor/connect-common/src/utils/debug';
+import { TRANSPORT } from '@trezor/transport-common';
+
+import { Device } from '../Device';
+import { DeviceList } from '../DeviceList';
+import {
+    type ControllableTransport,
+    createControllableTransport,
+} from './support/controllableTransport';
+
+// Neutralise the firmware / handshake middle of _runInner so each handshake
+// reduces to acquire → release driven by the controllable transport (see the
+// per-device harness for the rationale).
+jest.mock('../workflow/handshake', () => ({
+    handshakeCancel: jest.fn(() => Promise.resolve()),
+    handshake: jest.fn(() => Promise.resolve()),
+}));
+jest.mock('../workflow/checkFirmwareHashWithRetries', () => ({
+    checkFirmwareHashWithRetries: jest.fn(() => Promise.resolve()),
+}));
+
+const PATHS = ['1', '2', '3'] as const;
+type Path = (typeof PATHS)[number];
+
+// Drain across timer + microtask phases: `onDeviceConnected` defers the
+// handshake behind `resolveAfter(0)` (a setTimeout), and the run-queue resolves
+// on microtasks, so a faithful flush must let both run.
+const flush = async () => {
+    for (let i = 0; i < 4; i++) {
+        await new Promise(resolve => setTimeout(resolve, 0));
+    }
+};
+
+type Op =
+    | { t: 'connect'; path: Path }
+    | { t: 'disconnect'; path: Path }
+    | { t: 'completeAcquire' }
+    | { t: 'completeRelease' };
+
+const pathArb = fc.constantFrom(...PATHS);
+const opArb: fc.Arbitrary<Op> = fc.oneof(
+    fc.record({ t: fc.constant('connect' as const), path: pathArb }),
+    fc.record({ t: fc.constant('disconnect' as const), path: pathArb }),
+    fc.constant({ t: 'completeAcquire' as const }),
+    fc.constant({ t: 'completeRelease' as const }),
+);
+
+class Harness {
+    readonly transport: ControllableTransport;
+    readonly deviceList: DeviceList;
+    private session = 0;
+    readonly violations: string[] = [];
+
+    constructor() {
+        this.transport = createControllableTransport(PATHS[0]);
+        // start with no devices visible; `connect` ops introduce them
+        this.transport.disconnectPath(PATHS[0] as any);
+
+        // The firmware/feature transport calls are irrelevant to registry
+        // consistency; stub them so each handshake is acquire → release only.
+        jest.spyOn(Device.prototype, 'getFeatures').mockResolvedValue(undefined as any);
+        jest.spyOn(Device.prototype as any, 'initialize').mockResolvedValue(undefined as any);
+        jest.spyOn(Device.prototype as any, 'checkFirmwareRevisionWithRetries').mockResolvedValue(
+            undefined as any,
+        );
+
+        this.deviceList = new DeviceList({
+            priority: 0,
+            manifest: { appName: 'fuzz', appUrl: 'fuzz' } as any,
+            createLogger: noopCreateLogger,
+        });
+
+        // Replicate the listener wiring `initializeTransport` installs, without
+        // standing up the full TransportManager stack: DEVICE_CONNECTED →
+        // onDeviceConnected (fire-and-forget, exactly as production emits it).
+        this.transport.on(TRANSPORT.DEVICE_CONNECTED, (descriptor: any) => {
+            (this.deviceList as any).onDeviceConnected(descriptor, this.transport);
+        });
+    }
+
+    step(op: Op) {
+        switch (op.t) {
+            case 'connect':
+                this.transport.connectPath(op.path as any);
+                break;
+            case 'disconnect':
+                this.transport.disconnectPath(op.path as any);
+                break;
+            case 'completeAcquire':
+                this.transport.completeAcquire(`s${this.session++}`);
+                break;
+            case 'completeRelease':
+                this.transport.completeRelease();
+                break;
+        }
+    }
+
+    private devicePaths(): string[] {
+        return this.deviceList.getAllDevices().map(d => d.getUniquePath());
+    }
+
+    private deviceDescriptorPaths(): string[] {
+        return this.deviceList.getAllDevices().map(d => (d as any).descriptor.path);
+    }
+
+    /** INV-5 part 1: a path never appears twice in the registry. */
+    checkNoDuplicates() {
+        const paths = this.deviceDescriptorPaths();
+        const seen = new Set<string>();
+        for (const p of paths) {
+            if (seen.has(p)) {
+                this.violations.push(`INV-5: duplicate device for path ${p} (${paths.join(',')})`);
+            }
+            seen.add(p);
+        }
+        // unique-path identity must also be unique (no two Device instances share id)
+        const ids = this.devicePaths();
+        if (new Set(ids).size !== ids.length) {
+            this.violations.push(`INV-5: duplicate device id (${ids.join(',')})`);
+        }
+    }
+
+    /**
+     * INV-5 part 2 (at full quiescence): the set of device descriptor paths in the
+     * registry equals the set of paths currently present at the transport. A path
+     * present at the transport but missing from `devices` is a *lost* device; a
+     * path in `devices` but gone from the transport is a *leaked* device.
+     */
+    checkPresentIffConnected() {
+        const inRegistry = new Set(this.deviceDescriptorPaths());
+        const live = new Set(this.transport.livePaths().map(String));
+
+        for (const p of live) {
+            if (!inRegistry.has(p))
+                this.violations.push(
+                    `INV-5: lost device — path ${p} connected but absent from registry`,
+                );
+        }
+        for (const p of inRegistry) {
+            if (!live.has(p))
+                this.violations.push(
+                    `INV-5: leaked device — path ${p} in registry but disconnected`,
+                );
+        }
+    }
+
+    /** Settle every parked acquire/release and let handshakes complete. */
+    async drain() {
+        for (let i = 0; i < 200; i++) {
+            let progressed = false;
+            while (this.transport.completeAcquire(`s${this.session++}`)) progressed = true;
+            while (this.transport.completeRelease()) progressed = true;
+
+            await flush();
+
+            if (!progressed && !this.transport.hasPending()) {
+                // one more flush so any late onDeviceConnected push/splice runs
+
+                await flush();
+                if (!this.transport.hasPending()) return true;
+            }
+        }
+
+        this.violations.push(
+            `INV-2: deviceList drain did not reach quiescence — pending ${this.transport.pending
+                .map(p => p.kind)
+                .join(',')}`,
+        );
+
+        return false;
+    }
+}
+
+describe('DeviceList registry consistency (fuzz)', () => {
+    const FUZZ_RUNS = Number(process.env.FUZZ_RUNS ?? 150);
+    const FUZZ_SEED = process.env.FUZZ_SEED ? Number(process.env.FUZZ_SEED) : 1;
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('preserves INV-5 under arbitrary connect/disconnect interleavings', async () => {
+        await fc.assert(
+            fc.asyncProperty(fc.array(opArb, { minLength: 1, maxLength: 30 }), async ops => {
+                const h = new Harness();
+
+                for (const op of ops) {
+                    h.step(op);
+
+                    await flush();
+                    h.checkNoDuplicates();
+                }
+
+                const drained = await h.drain();
+                expect(drained).toBe(true);
+
+                h.checkNoDuplicates();
+                h.checkPresentIffConnected();
+
+                expect(h.violations).toEqual([]);
+            }),
+            { numRuns: FUZZ_RUNS, seed: FUZZ_SEED },
+        );
+    }, 120000);
+});

--- a/packages/connect/src/device/__tests__/deviceListHandshakeLockDeadlock.repro.test.ts
+++ b/packages/connect/src/device/__tests__/deviceListHandshakeLockDeadlock.repro.test.ts
@@ -1,0 +1,105 @@
+/**
+ * PHASE 3 Finding 3 — minimal deterministic reproduction.
+ *
+ * INV-2 (liveness) + INV-5 (DeviceList consistency): a device whose handshake is
+ * still QUEUED behind `DeviceList`'s global `handshakeLock` when it disconnects
+ * must not stall the lock. `Device.disconnect()` removes the instance's
+ * `onTransportDeviceEvent` listener, but the queued handshake closure survives;
+ * when the lock reaches it, `device.run()` → `acquire()` →
+ * `waitAndCompareSession` awaits a `sessionDfd` that only the (now removed)
+ * listener would resolve, so it hangs forever — holding `handshakeLock` and
+ * starving every later device's handshake.
+ *
+ * Interleaving (shrunk from `deviceListConsistency.fuzz.test.ts`, seed 1):
+ *   connect '1' → connect '2' (queued behind '1') → disconnect '2' →
+ *   reconnect '2' → drain.
+ *
+ * Pre-fix: device '1' registers, but the stale '2' instance hangs the lock, so
+ * the reconnected '2' never registers (lost device) and the system never drains.
+ * Post-fix (`run()`/`handshake()` bail when `disconnected`): the stale instance
+ * reports not-connected, the lock is released, and the reconnected '2' registers.
+ */
+import { noopCreateLogger } from '@trezor/connect-common/src/utils/debug';
+import { TRANSPORT } from '@trezor/transport-common';
+
+import { Device } from '../Device';
+import { DeviceList } from '../DeviceList';
+import { createControllableTransport } from './support/controllableTransport';
+
+jest.mock('../workflow/handshake', () => ({
+    handshakeCancel: jest.fn(() => Promise.resolve()),
+    handshake: jest.fn(() => Promise.resolve()),
+}));
+jest.mock('../workflow/checkFirmwareHashWithRetries', () => ({
+    checkFirmwareHashWithRetries: jest.fn(() => Promise.resolve()),
+}));
+
+const flush = async () => {
+    for (let i = 0; i < 4; i++) {
+        await new Promise(resolve => setTimeout(resolve, 0));
+    }
+};
+
+describe('DeviceList handshakeLock deadlock (PHASE 3 Finding 3)', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('a device disconnected while its handshake is queued does not stall the lock', async () => {
+        const transport = createControllableTransport('1' as any);
+        transport.disconnectPath('1' as any);
+
+        // Reduce each handshake to acquire → release (firmware/feature middle stubbed).
+        jest.spyOn(Device.prototype, 'getFeatures').mockResolvedValue(undefined as any);
+        jest.spyOn(Device.prototype as any, 'checkFirmwareRevisionWithRetries').mockResolvedValue(
+            undefined as any,
+        );
+
+        const deviceList = new DeviceList({
+            priority: 0,
+            manifest: { appName: 'repro', appUrl: 'repro' } as any,
+            createLogger: noopCreateLogger,
+        });
+        transport.on(TRANSPORT.DEVICE_CONNECTED, (descriptor: any) => {
+            (deviceList as any).onDeviceConnected(descriptor, transport);
+        });
+
+        // '1' connects and starts handshaking (holds the handshakeLock, parked on
+        // acquire); '2' connects and its handshake is queued behind '1'.
+        transport.connectPath('1' as any);
+        await flush();
+        transport.connectPath('2' as any);
+        await flush();
+
+        // '2' disconnects while still queued, then reconnects on the same path.
+        transport.disconnectPath('2' as any);
+        await flush();
+        transport.connectPath('2' as any);
+        await flush();
+
+        // Drive every handshake to completion (bounded — a stalled lock shows up
+        // as failure to drain rather than an infinite hang).
+        let session = 0;
+        let drained = false;
+        for (let i = 0; i < 100; i++) {
+            let progressed = false;
+            while (transport.completeAcquire(`s${session++}`)) progressed = true;
+            while (transport.completeRelease()) progressed = true;
+
+            await flush();
+            if (!progressed && !transport.hasPending()) {
+                drained = true;
+                break;
+            }
+        }
+
+        expect(drained).toBe(true);
+
+        const registeredPaths = deviceList.getAllDevices().map(d => (d as any).descriptor.path);
+        // Reconnected '2' must be registered, and exactly once.
+        expect(registeredPaths.filter(p => p === '2')).toHaveLength(1);
+        expect(new Set(registeredPaths)).toEqual(new Set(['1', '2']));
+
+        await deviceList.dispose();
+    });
+});

--- a/packages/connect/src/device/__tests__/deviceOverrideDispatch.test.ts
+++ b/packages/connect/src/device/__tests__/deviceOverrideDispatch.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Override-dispatch seam — INV-4 (abort/override correctness).
+ *
+ * Scope: the device-level contract that `core/index.ts`'s override path
+ * (`onCallDevice`, lines 313-330) depends on. When a method with
+ * `overridePreviousCall` (in production only `setBusy`) preempts an in-flight
+ * call to the same device, core does:
+ *
+ *     await device.interrupt(Method_Override);   // abort the in-flight run
+ *     // ... then immediately:
+ *     await device.run(innerAction, ...);        // start the overriding run
+ *
+ * The whole override mechanism rests on one device-level guarantee: the instant
+ * `await device.interrupt(reason)` resolves, the device must be immediately
+ * runnable — `device.run()` issued on the very next line must NOT throw
+ * `Device_CallInProgress`, and the interrupted run must have rejected with
+ * exactly `reason` (so the overridden method responds with `Method_Override`,
+ * not some other error). If `interrupt()` returned while `runPromise` were still
+ * set, the override's `run()` would spuriously throw and the overriding call
+ * would be lost.
+ *
+ * The existing fuzz harness (`deviceConcurrency.fuzz.test.ts`) only asserts
+ * runnability *after a full drain to quiescence*. Core does not drain — it
+ * re-runs on the next microtask after interrupt resolves — so this immediate
+ * interrupt→run sequence is its own seam. These tests drive the *real*
+ * `Device.interrupt` / `Device.run` (no reproduction of `onCallDevice`'s
+ * bookkeeping) over the controllable transport, across the three in-flight states
+ * core can interrupt: a run blocked in its `fn` body, a run blocked in
+ * `acquire()`, and a run parked before `acquire()` at `await this.releasePromise`.
+ */
+import { ERRORS } from '@trezor/connect-common';
+import { noopCreateLogger } from '@trezor/connect-common/src/utils/debug';
+import { type Deferred, createDeferred } from '@trezor/utils';
+
+import { Device } from '../Device';
+import {
+    type ControllableTransport,
+    createControllableTransport,
+} from './support/controllableTransport';
+
+// Neutralise the firmware / handshake middle of _runInner; only the run-queue and
+// session mechanics are under test (same stubs as the fuzz harness).
+jest.mock('../workflow/handshake', () => ({
+    handshakeCancel: jest.fn(() => Promise.resolve()),
+    handshake: jest.fn(() => Promise.resolve()),
+}));
+jest.mock('../workflow/checkFirmwareHashWithRetries', () => ({
+    checkFirmwareHashWithRetries: jest.fn(() => Promise.resolve()),
+}));
+
+const PATH = '1' as any;
+const flush = () => new Promise(resolve => setImmediate(resolve));
+
+const makeDevice = (transport: ControllableTransport) => {
+    const device = new Device({
+        id: 'override' as any,
+        transport,
+        descriptor: { path: PATH, type: 1, session: null, apiType: 'usb' } as any,
+        createLogger: noopCreateLogger,
+    });
+    jest.spyOn(device, 'getFeatures').mockResolvedValue(undefined as any);
+    jest.spyOn(device as any, 'initialize').mockResolvedValue(undefined as any);
+    jest.spyOn(device as any, 'checkFirmwareRevisionWithRetries').mockResolvedValue(
+        undefined as any,
+    );
+
+    return device;
+};
+
+/**
+ * Faithful method body: a real connect method drives the device through
+ * `currentSession.typedCall`, which `interrupt()` aborts — so the body rejects
+ * promptly once the run is aborted rather than running to completion. Resolves on
+ * its deferred (normal completion) or rejects on the run's abort signal.
+ */
+const makeAbortableFn = (device: Device, dfd: Deferred<void>) => () => {
+    const signal: AbortSignal | undefined = (device as any).runAbort?.signal;
+
+    return new Promise<void>((resolve, reject) => {
+        dfd.promise.then(resolve, reject);
+        if (signal) {
+            if (signal.aborted) reject(signal.reason);
+            else signal.addEventListener('abort', () => reject(signal.reason));
+        }
+    });
+};
+
+/**
+ * Settle pending transport ops (and the in-flight run's `fn`) until `promise`
+ * settles. `device.interrupt()` awaits the interrupted run, whose abort `catch`
+ * may issue a `release()` (or be parked on an earlier one); the real transport
+ * resolves those, so the harness must too for `interrupt()` to return — exactly
+ * the production flow.
+ */
+const settleUntil = async (
+    promise: Promise<unknown>,
+    transport: ControllableTransport,
+    nextSession: () => string,
+    fnDeferreds: Deferred<void>[],
+) => {
+    let done = false;
+    const tracked = promise.then(
+        () => {
+            done = true;
+        },
+        () => {
+            done = true;
+        },
+    );
+    for (let i = 0; i < 200 && !done; i++) {
+        while (fnDeferreds.length) fnDeferreds.shift()?.resolve();
+        transport.completeMessage();
+        transport.completeAcquire(nextSession());
+        transport.completeRelease();
+
+        await flush();
+    }
+    await tracked;
+};
+
+/** Drive everything still in flight to a clean stop. */
+const drain = async (
+    transport: ControllableTransport,
+    nextSession: () => string,
+    fnDeferreds: Deferred<void>[],
+) => {
+    for (let i = 0; i < 200; i++) {
+        let progressed = false;
+        while (fnDeferreds.length) {
+            fnDeferreds.shift()?.resolve();
+            progressed = true;
+        }
+        if (transport.completeMessage()) progressed = true;
+        if (transport.completeAcquire(nextSession())) progressed = true;
+        if (transport.completeRelease()) progressed = true;
+
+        await flush();
+        if (!progressed && !transport.hasPending()) return;
+    }
+};
+
+describe('Device override dispatch (INV-4: interrupt → immediate run)', () => {
+    let sessionCounter = 0;
+    const nextSession = () => `s${sessionCounter++}`;
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    // The three in-flight states core's override path can interrupt. Each sets up a
+    // run in that state and returns the captured run promise + its pending fn
+    // deferreds, so the shared assertions below run against all of them.
+    const scenarios: Array<{
+        name: string;
+        setup: (
+            device: Device,
+            transport: ControllableTransport,
+        ) => Promise<{ runA: Promise<unknown>; fnDeferreds: Deferred<void>[] }>;
+    }> = [
+        {
+            name: 'run blocked in its fn body',
+            setup: async (device, transport) => {
+                const fnDeferreds: Deferred<void>[] = [];
+                const fnA = createDeferred<void>();
+                fnDeferreds.push(fnA);
+                const runA = device.run(makeAbortableFn(device, fnA), { skipFirmwareChecks: true });
+                await flush(); // reaches acquire()
+                transport.completeAcquire(nextSession());
+                await flush(); // acquire settled → fn body now executing
+
+                return { runA, fnDeferreds };
+            },
+        },
+        {
+            name: 'run blocked in acquire()',
+            setup: async device => {
+                const fnDeferreds: Deferred<void>[] = [];
+                const fnA = createDeferred<void>();
+                fnDeferreds.push(fnA);
+                const runA = device.run(makeAbortableFn(device, fnA), { skipFirmwareChecks: true });
+                await flush(); // reaches acquire(), left pending on purpose
+
+                return { runA, fnDeferreds };
+            },
+        },
+        {
+            name: 'run parked before acquire at releasePromise',
+            setup: async (device, transport) => {
+                const fnDeferreds: Deferred<void>[] = [];
+                // First run acquires, runs fn, then issues its trailing release.
+                const fn0 = createDeferred<void>();
+                const run0 = device
+                    .run(makeAbortableFn(device, fn0), { skipFirmwareChecks: true })
+                    .catch(() => {});
+                await flush();
+                transport.completeAcquire(nextSession());
+                await flush();
+                fn0.resolve(); // fn done → _runInner reaches trailing release()
+                await flush();
+                // run0 settles (resolved) but its release is still in flight; clear it
+                // by aborting so runPromise frees and a fresh run can park on the
+                // pending release.
+                device.interrupt(ERRORS.TypedError('Method_Override')).catch(() => {});
+                await run0.catch(() => {});
+                await flush();
+
+                // Now a new run starts while the release is still pending → parks at
+                // `await this.releasePromise`, before acquire().
+                const fnA = createDeferred<void>();
+                fnDeferreds.push(fnA);
+                const runA = device.run(makeAbortableFn(device, fnA), { skipFirmwareChecks: true });
+                await flush();
+
+                return { runA, fnDeferreds };
+            },
+        },
+    ];
+
+    scenarios.forEach(({ name, setup }) => {
+        it(`interrupt resolves immediately runnable — ${name}`, async () => {
+            sessionCounter = 0;
+            const transport = createControllableTransport(PATH);
+            const device = makeDevice(transport);
+
+            const { runA, fnDeferreds } = await setup(device, transport);
+            const firstReason = runA.then(
+                () => ({ rejected: false as const }),
+                (e: any) => ({ rejected: true as const, error: e }),
+            );
+
+            // Core's override path: await interrupt with the override error.
+            const reason = ERRORS.TypedError('Method_Override');
+            const interruptP = device.interrupt(reason);
+            await settleUntil(interruptP, transport, nextSession, fnDeferreds);
+            await interruptP;
+
+            // INV-4: the device must be immediately runnable on the very next line,
+            // exactly as onCallDevice issues device.run() right after interrupt.
+            let overrideThrew: unknown = null;
+            let overrideRun: Promise<unknown> | undefined;
+            const fnB = createDeferred<void>();
+            try {
+                overrideRun = device
+                    .run(makeAbortableFn(device, fnB), { skipFirmwareChecks: true })
+                    .catch(() => {});
+                fnDeferreds.push(fnB);
+            } catch (e) {
+                overrideThrew = e;
+            }
+            expect(overrideThrew).toBeNull();
+
+            // The interrupted run rejected with exactly the override reason, so the
+            // overridden method would respond with Method_Override (not e.g.
+            // Device_CallInProgress or a stray transport error).
+            const outcome = await firstReason;
+            expect(outcome.rejected).toBe(true);
+            expect((outcome as any).error?.code).toBe('Method_Override');
+
+            // The override run completes and the device drains with a balanced
+            // session ledger (no orphaned/leaked session).
+            await drain(transport, nextSession, fnDeferreds);
+            await overrideRun;
+            await drain(transport, nextSession, fnDeferreds);
+
+            expect((device as any).sessionAcquired).toBeNull();
+            expect((device as any).keepTransportSession).toBe(false);
+            expect((device as any).runPromise).toBeUndefined();
+            expect(transport.hasPending()).toBe(false);
+            expect(transport.releasedCount).toBeLessThanOrEqual(transport.acquiredCount);
+        });
+    });
+
+    it('a concurrent run WITHOUT interrupt is rejected (mutual exclusion the override path relies on)', async () => {
+        sessionCounter = 0;
+        const transport = createControllableTransport(PATH);
+        const device = makeDevice(transport);
+
+        const fnA = createDeferred<void>();
+        const fnDeferreds = [fnA];
+        const runA = device
+            .run(makeAbortableFn(device, fnA), { skipFirmwareChecks: true })
+            .catch(() => {});
+        await flush();
+        transport.completeAcquire(nextSession());
+        await flush();
+
+        // Without an interrupt, a second run on a busy device throws
+        // Device_CallInProgress — this is the `else if (device.currentRun)` branch
+        // core takes for a NON-override second call. The override branch is the only
+        // way to preempt; this asserts the contract's other half.
+        let threw: any = null;
+        try {
+            device.run(async () => {}, { skipFirmwareChecks: true });
+        } catch (e) {
+            threw = e;
+        }
+        expect(threw?.code).toBe('Device_CallInProgress');
+
+        // cleanup: fire the interrupt (do not await — it blocks on the run's
+        // trailing release, which only the drain below settles), then drain.
+        const interruptP = device.interrupt(ERRORS.TypedError('Method_Override')).catch(() => {});
+        await drain(transport, nextSession, fnDeferreds);
+        await interruptP;
+        await runA;
+    });
+});

--- a/packages/connect/src/device/__tests__/deviceRunInterruptLeak.repro.test.ts
+++ b/packages/connect/src/device/__tests__/deviceRunInterruptLeak.repro.test.ts
@@ -1,0 +1,120 @@
+/**
+ * PHASE 3 finding 2 — minimal deterministic reproduction.
+ *
+ * INVARIANT: INV-3 (session balance — acquire/release paired; a session is only
+ * held on purpose via `keepTransportSession`). See `../CONCURRENCY_MODEL.md`.
+ *
+ * INTERLEAVING:
+ *   1. run A acquires session `s0`, runs its fn, then issues the final
+ *      `release()` (release in-flight) and is awaiting it inside `_runInner`.
+ *   2. run A is interrupted (here via `DEVICE_REQUEST_RELEASE` → `usedElsewhere`,
+ *      an interrupt also reproduces it). The `Promise.race` abort branch settles
+ *      run A's `runPromise`; its catch handler runs `release()` — a no-op because
+ *      a release is already pending — and clears `runPromise`. But run A's
+ *      `_runInner` is still suspended at `await this.releasePromise`.
+ *   3. run B starts (allowed: `runPromise` was cleared) and parks at the very
+ *      same `await this.releasePromise`.
+ *   4. run B is interrupted. At abort time its `acquirePromise` is still
+ *      undefined (it never reached `acquire()`), so run B's catch handler has
+ *      nothing to await and releases nothing.
+ *   5. the pending release finally settles. Run B's `_runInner` resumes past the
+ *      park, sees `acquireNeeded` (no session held) and calls `acquire()` — for a
+ *      run that was aborted in step 4. That acquire succeeds and sets
+ *      `sessionAcquired`, but no one releases it: run B already settled.
+ *
+ * ROOT CAUSE: `_runInner` only checks `abortSignal.aborted` *after* `acquire()`.
+ * A run aborted while parked *before* the acquire decision keeps running in the
+ * background (it lost the `Promise.race`, it was not cancelled) and proceeds to
+ * acquire a session the already-finished run can never release.
+ *
+ * FIX: check `abortSignal.aborted` *before* `acquire()` in `_runInner`
+ * (Device.ts), so an already-aborted run bails out instead of acquiring a session
+ * it will leak. This test asserts no session is held after the system drains; it
+ * fails before the fix (`sessionAcquired` is a leaked session) and passes after.
+ */
+import { noopCreateLogger } from '@trezor/connect-common/src/utils/debug';
+import { TRANSPORT } from '@trezor/transport-common';
+import { createDeferred } from '@trezor/utils';
+
+import { Device } from '../Device';
+import { createControllableTransport } from './support/controllableTransport';
+
+// Neutralise the firmware / handshake middle of _runInner; only queue + session
+// mechanics are under test (same stubs as the fuzz harness).
+jest.mock('../workflow/handshake', () => ({
+    handshakeCancel: jest.fn(() => Promise.resolve()),
+    handshake: jest.fn(() => Promise.resolve()),
+}));
+jest.mock('../workflow/checkFirmwareHashWithRetries', () => ({
+    checkFirmwareHashWithRetries: jest.fn(() => Promise.resolve()),
+}));
+
+const PATH = '1' as any;
+const flush = () => new Promise(resolve => setImmediate(resolve));
+
+describe('Device run-interrupt session leak (INV-3 session balance)', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('does not leak a session when a run is interrupted while parked before acquire', async () => {
+        const transport = createControllableTransport(PATH);
+        const device = new Device({
+            id: 'repro' as any,
+            transport,
+            descriptor: { path: PATH, type: 1, session: null, apiType: 'usb' } as any,
+            createLogger: noopCreateLogger,
+        });
+        jest.spyOn(device, 'getFeatures').mockResolvedValue(undefined as any);
+        jest.spyOn(device as any, 'initialize').mockResolvedValue(undefined as any);
+        jest.spyOn(device as any, 'checkFirmwareRevisionWithRetries').mockResolvedValue(
+            undefined as any,
+        );
+
+        // --- run A: acquire s0, run fn, then issue the final release -------------
+        const fnA = createDeferred<void>();
+        const runA = device.run(() => fnA.promise, { skipFirmwareChecks: true }).catch(() => {});
+        await flush(); // _runInner reaches transport.acquire()
+
+        transport.completeAcquire('s0'); // run A acquires s0
+        await flush();
+        fnA.resolve(); // fn finishes → _runInner reaches its final release()
+        await flush();
+        expect(transport.pending.some(p => p.kind === 'release')).toBe(true); // release in-flight
+
+        // --- step 2: interrupt run A while its release is still pending ----------
+        // DEVICE_REQUEST_RELEASE → usedElsewhere aborts the run; its catch's
+        // release() is a no-op (release already pending) and runPromise is cleared.
+        transport.emitDeviceEvent(PATH, { type: TRANSPORT.DEVICE_REQUEST_RELEASE });
+        await runA;
+        await flush();
+
+        // --- step 3: run B starts and parks at `await this.releasePromise` -------
+        const fnB = createDeferred<void>();
+        const runB = device.run(() => fnB.promise, { skipFirmwareChecks: true }).catch(() => {});
+        await flush();
+
+        // --- step 4: interrupt run B before it ever acquires --------------------
+        await device.interrupt(new Error('override-run-B'));
+        await runB;
+        await flush();
+
+        // --- step 5: let the pending release settle; run B's orphaned _runInner
+        // resumes and (pre-fix) acquires a leaked session ------------------------
+        transport.completeRelease();
+        await flush();
+        transport.completeAcquire('s1'); // would-be leaked acquire for the dead run B
+        await flush();
+        await flush();
+        // settle anything the drain raised so nothing hangs
+        transport.completeRelease();
+        await flush();
+
+        // INV-3: after everything drains, no session may be held unless the device
+        // is deliberately keeping it (keepTransportSession). A leaked acquire from
+        // the aborted run B shows up here as a non-null sessionAcquired.
+        const held = (device as any).sessionAcquired;
+        const keep = (device as any).keepTransportSession;
+        expect({ held, keep }).toEqual({ held: null, keep: false });
+    });
+});

--- a/packages/connect/src/device/__tests__/deviceSessionRace.repro.test.ts
+++ b/packages/connect/src/device/__tests__/deviceSessionRace.repro.test.ts
@@ -1,0 +1,96 @@
+/**
+ * PHASE 3 finding — minimal deterministic reproduction.
+ *
+ * INVARIANT: INV-2 (liveness — no promise hangs / no unhandled rejection escapes
+ * the device layer). See `../CONCURRENCY_MODEL.md`.
+ *
+ * INTERLEAVING: a `run()` reaches `transport.acquire()` (acquire in-flight), then
+ * an *external* client grabs the device — a `DEVICE_SESSION_CHANGED` for a
+ * different session arrives before our acquire settles. `acquire()`'s
+ * `waitAndCompareSession` then rejects with `SESSION_WRONG_PREVIOUS`.
+ *
+ * ROOT CAUSE: `Device.updateDescriptor` (the transport-event handler) did
+ * `await Promise.all([this.acquirePromise, this.releasePromise])`. It only needs
+ * to wait for those to *settle* before reading `sessionAcquired`, but `Promise.all`
+ * re-raises the acquire rejection. `updateDescriptor` is invoked fire-and-forget
+ * from `onTransportDeviceEvent`, so that rejection is unhandled (two of them here,
+ * one per session-changed event that observes the still-pending acquire). The run
+ * path already handles the same rejection; the event path must not re-raise it.
+ *
+ * FIX: `Promise.allSettled` in `updateDescriptor` (Device.ts). This test asserts
+ * no `updateDescriptor` invocation rejects under the interleaving; it fails before
+ * the fix (2 rejections) and passes after.
+ */
+import { noopCreateLogger } from '@trezor/connect-common/src/utils/debug';
+import { createDeferred } from '@trezor/utils';
+
+import { Device } from '../Device';
+import { createControllableTransport } from './support/controllableTransport';
+
+// Neutralise the firmware / handshake middle of _runInner; only queue + session
+// mechanics are under test (same stubs as the fuzz harness).
+jest.mock('../workflow/handshake', () => ({
+    handshakeCancel: jest.fn(() => Promise.resolve()),
+    handshake: jest.fn(() => Promise.resolve()),
+}));
+jest.mock('../workflow/checkFirmwareHashWithRetries', () => ({
+    checkFirmwareHashWithRetries: jest.fn(() => Promise.resolve()),
+}));
+
+const PATH = '1' as any;
+const flush = () => new Promise(resolve => setImmediate(resolve));
+
+describe('Device session-change race (INV-2 liveness)', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('does not leak an unhandled rejection when the session is taken elsewhere mid-acquire', async () => {
+        const transport = createControllableTransport(PATH);
+        const device = new Device({
+            id: 'repro' as any,
+            transport,
+            descriptor: { path: PATH, type: 1, session: null, apiType: 'usb' } as any,
+            createLogger: noopCreateLogger,
+        });
+        jest.spyOn(device, 'getFeatures').mockResolvedValue(undefined as any);
+        jest.spyOn(device as any, 'initialize').mockResolvedValue(undefined as any);
+        jest.spyOn(device as any, 'checkFirmwareRevisionWithRetries').mockResolvedValue(
+            undefined as any,
+        );
+
+        // Capture every promise the transport-event handler (updateDescriptor)
+        // returns — those are the fire-and-forget promises that would leak.
+        const descriptorPromises: Promise<unknown>[] = [];
+        const origUpdate = (device as any).updateDescriptor.bind(device);
+        jest.spyOn(device as any, 'updateDescriptor').mockImplementation((...a: any[]) => {
+            const p = origUpdate(...a);
+            descriptorPromises.push(p);
+
+            return p;
+        });
+
+        const fnDfd = createDeferred<void>();
+        const runP = device.run(() => fnDfd.promise, { skipFirmwareChecks: true }).catch(() => {});
+
+        await flush(); // _runInner reaches transport.acquire(); acquire is in-flight
+
+        transport.setSession(PATH, 'ext0'); // external client grabs the device
+        await flush();
+
+        transport.completeAcquire('s0'); // our acquire settles with a *different* session
+        await flush();
+        await flush();
+
+        // Let the run unwind cleanly.
+        fnDfd.resolve();
+        transport.completeRelease();
+        await runP;
+        await flush();
+
+        const rejected = (await Promise.allSettled(descriptorPromises)).filter(
+            r => r.status === 'rejected',
+        );
+        expect(rejected).toEqual([]);
+    });
+});

--- a/packages/connect/src/device/__tests__/support/controllableTransport.ts
+++ b/packages/connect/src/device/__tests__/support/controllableTransport.ts
@@ -13,10 +13,20 @@
  * queue of deferreds. The test resolves them on command, which is what makes the
  * interleavings deterministic and fully under the harness's control.
  */
-import { AbstractTransport, type Descriptor, type Session } from '@trezor/transport-common';
+import {
+    AbstractTransport,
+    type Descriptor,
+    type Session,
+    TRANSPORT_ERROR,
+} from '@trezor/transport-common';
 import { type Deferred, createDeferred } from '@trezor/utils';
 
 type Path = Descriptor['path'];
+
+// The real transport reports this exact value (not the SCREAMING_CASE key) when a
+// device vanishes mid-op; `Device.handshake` matches on the value to decide
+// `stillConnected`, so the mock must use the value verbatim.
+const DISCONNECTED_CODE = TRANSPORT_ERROR.DEVICE_DISCONNECTED_DURING_ACTION;
 
 type Pending<T> = {
     kind: 'acquire' | 'release' | 'call' | 'send' | 'receive';
@@ -114,12 +124,57 @@ export class ControllableTransport extends AbstractTransport {
     /**
      * Drive a transport-level session change. Uses the *real*
      * `handleDescriptorsChange` so the proper `DEVICE_SESSION_CHANGED` /
-     * `DEVICE_DISCONNECTED` events fan out to the Device.
+     * `DEVICE_DISCONNECTED` events fan out to the Device. Descriptors for *other*
+     * paths are preserved so a multi-device harness can change one device's
+     * session without spuriously disconnecting the rest.
      */
     setSession(path: Path, session: string | null) {
+        const next = this.descriptors.map(d =>
+            d.path === path ? ({ ...d, session: asSession(session) } as Descriptor) : d,
+        );
+        if (!next.some(d => d.path === path)) {
+            next.push({ path, session: asSession(session), type: 1 } as Descriptor);
+        }
+        this.handleDescriptorsChange(next);
+    }
+
+    /** Add a new path to the descriptor set → fans out `DEVICE_CONNECTED`. */
+    connectPath(path: Path) {
+        if (this.descriptors.some(d => d.path === path)) return;
         this.handleDescriptorsChange([
-            { path, session: asSession(session), type: 1 } as Descriptor,
+            ...this.descriptors,
+            { path, session: null, type: 1, apiType: 'usb' } as Descriptor,
         ]);
+    }
+
+    /** Remove a path from the descriptor set → fans out `DEVICE_DISCONNECTED`. */
+    disconnectPath(path: Path) {
+        if (!this.descriptors.some(d => d.path === path)) return;
+        this.handleDescriptorsChange(this.descriptors.filter(d => d.path !== path));
+        // A physically-gone device fails any in-flight transport op against it
+        // (the real transport rejects acquire/release with
+        // DEVICE_DISCONNECTED_DURING_ACTION). Modelling that is essential: a stale
+        // acquire settled as *success* after disconnect would re-add the
+        // descriptor (via setSession) and fake the device back into existence.
+        this.failPending(path);
+    }
+
+    /** Fail (success:false) every parked transport op for a path. */
+    private failPending(path: Path) {
+        for (let i = this.pending.length - 1; i >= 0; i--) {
+            const op = this.pending[i];
+            if (op?.path !== path) continue;
+            this.pending.splice(i, 1);
+            op.dfd.resolve({
+                success: false,
+                error: { code: DISCONNECTED_CODE },
+            } as any);
+        }
+    }
+
+    /** Paths currently present at the transport level (live descriptors). */
+    livePaths(): Path[] {
+        return this.descriptors.map(d => d.path);
     }
 
     /** Emit a raw device event (used to model REQUEST_RELEASE / disconnect). */
@@ -127,16 +182,30 @@ export class ControllableTransport extends AbstractTransport {
         this.deviceEvents.emit(path, event);
     }
 
-    private firstPending(kind: Pending<any>['kind']) {
-        const idx = this.pending.findIndex(p => p.kind === kind);
+    private firstPending(kind: Pending<any>['kind'], path?: Path) {
+        const idx = this.pending.findIndex(
+            p => p.kind === kind && (path === undefined || p.path === path),
+        );
 
         return idx === -1 ? undefined : this.pending.splice(idx, 1)[0];
     }
 
     /** Settle the oldest in-flight acquire as success and advance the session. */
-    completeAcquire(session: string) {
-        const op = this.firstPending('acquire');
+    completeAcquire(session: string, path?: Path) {
+        const op = this.firstPending('acquire', path);
         if (!op) return false;
+        // A path with no live descriptor cannot be acquired — the real transport
+        // rejects (device gone). This matters when a handshake queued behind the
+        // global handshakeLock runs *after* its device disconnected: it must fail,
+        // not succeed-and-resurrect the descriptor.
+        if (!this.descriptors.some(d => d.path === op.path)) {
+            op.dfd.resolve({
+                success: false,
+                error: { code: DISCONNECTED_CODE },
+            } as any);
+
+            return true;
+        }
         this.acquiredCount += 1;
         op.dfd.resolve({ success: true, payload: asSession(session) as Session });
         this.setSession(op.path, session);
@@ -151,15 +220,15 @@ export class ControllableTransport extends AbstractTransport {
         // so Device.acquire's `throw new Error(result.error.code)` path is faithful.
         op.dfd.resolve({
             success: false,
-            error: { code: 'DEVICE_DISCONNECTED_DURING_ACTION' },
+            error: { code: DISCONNECTED_CODE },
         } as any);
 
         return true;
     }
 
     /** Settle the oldest in-flight release as success and clear the session. */
-    completeRelease() {
-        const op = this.firstPending('release');
+    completeRelease(path?: Path) {
+        const op = this.firstPending('release', path);
         if (!op) return false;
         this.releasedCount += 1;
         op.dfd.resolve({ success: true, payload: null });

--- a/packages/connect/src/device/__tests__/support/controllableTransport.ts
+++ b/packages/connect/src/device/__tests__/support/controllableTransport.ts
@@ -1,0 +1,195 @@
+/**
+ * Controllable mock transport for the device-concurrency fuzz harness (PHASE 2).
+ *
+ * Unlike `global.JestMocks.createTestTransport` (which is built on
+ * `AbstractApiTransport` and drives the *real* session background at the UsbApi
+ * read/write level), this transport implements the `Transport` interface
+ * directly so the harness controls when `acquire` / `release` / `call` / `send` /
+ * `receive` / `enumerate` settle. It still extends `AbstractTransport` so the
+ * real `deviceEvents` emitter, `getDescriptor` and `handleDescriptorsChange`
+ * machinery are exercised exactly as in production (see CONCURRENCY_MODEL.md).
+ *
+ * Every async operation the `Device` issues against the transport is parked in a
+ * queue of deferreds. The test resolves them on command, which is what makes the
+ * interleavings deterministic and fully under the harness's control.
+ */
+import { AbstractTransport, type Descriptor, type Session } from '@trezor/transport-common';
+import { type Deferred, createDeferred } from '@trezor/utils';
+
+type Path = Descriptor['path'];
+
+type Pending<T> = {
+    kind: 'acquire' | 'release' | 'call' | 'send' | 'receive';
+    path: Path;
+    dfd: Deferred<T>;
+};
+
+const asSession = (value: string | null): Session | null => value as Session | null;
+
+export class ControllableTransport extends AbstractTransport {
+    public readonly name = 'NodeUsbTransport' as const;
+
+    /** FIFO queues of operations the Device has issued but the test hasn't settled yet. */
+    public readonly pending: Pending<any>[] = [];
+
+    /** Bookkeeping for the session-balance invariant (INV-3). */
+    public readonly releaseDeviceCalls: Array<Session> = [];
+    public readonly releaseSyncCalls: Array<Session> = [];
+    public acquiredCount = 0;
+    public releasedCount = 0;
+
+    init() {
+        this.stopped = false;
+
+        return Promise.resolve({ success: true as const, payload: undefined });
+    }
+
+    listen() {
+        this.listening = true;
+
+        return { success: true as const, payload: undefined };
+    }
+
+    enumerate() {
+        return Promise.resolve({ success: true as const, payload: this.descriptors });
+    }
+
+    acquire({ input }: { input: { path: Path; previous: Session | null } }) {
+        const dfd = createDeferred<{ success: true; payload: Session } | { success: false }>();
+        this.pending.push({ kind: 'acquire', path: input.path, dfd });
+
+        return dfd.promise as any;
+    }
+
+    release({ path }: { session: Session; path?: Path }) {
+        const dfd = createDeferred<{ success: true; payload: null } | { success: false }>();
+        this.pending.push({ kind: 'release', path: path as Path, dfd });
+
+        return dfd.promise as any;
+    }
+
+    releaseDevice(session: Session) {
+        this.releaseDeviceCalls.push(session);
+
+        return Promise.resolve({ success: true as const, payload: undefined });
+    }
+
+    releaseSync(session: Session) {
+        this.releaseSyncCalls.push(session);
+    }
+
+    call({ session }: { session: Session }) {
+        const dfd = createDeferred<any>();
+        this.pending.push({ kind: 'call', path: this.pathForSession(session), dfd });
+
+        return dfd.promise as any;
+    }
+
+    send({ session }: { session: Session }) {
+        const dfd = createDeferred<any>();
+        this.pending.push({ kind: 'send', path: this.pathForSession(session), dfd });
+
+        return dfd.promise as any;
+    }
+
+    receive({ session }: { session: Session }) {
+        const dfd = createDeferred<any>();
+        this.pending.push({ kind: 'receive', path: this.pathForSession(session), dfd });
+
+        return dfd.promise as any;
+    }
+
+    private pathForSession(session: Session): Path {
+        return (this.descriptors.find(d => d.session === session)?.path ??
+            this.descriptors[0]?.path) as Path;
+    }
+
+    // --- harness control surface ---------------------------------------------
+
+    /** Seed an initial descriptor without emitting any device event. */
+    seedDescriptor(path: Path, session: string | null = null) {
+        this.descriptors = [{ path, session: asSession(session), type: 1 } as Descriptor];
+    }
+
+    /**
+     * Drive a transport-level session change. Uses the *real*
+     * `handleDescriptorsChange` so the proper `DEVICE_SESSION_CHANGED` /
+     * `DEVICE_DISCONNECTED` events fan out to the Device.
+     */
+    setSession(path: Path, session: string | null) {
+        this.handleDescriptorsChange([
+            { path, session: asSession(session), type: 1 } as Descriptor,
+        ]);
+    }
+
+    /** Emit a raw device event (used to model REQUEST_RELEASE / disconnect). */
+    emitDeviceEvent(path: Path, event: Parameters<typeof this.deviceEvents.emit>[1]) {
+        this.deviceEvents.emit(path, event);
+    }
+
+    private firstPending(kind: Pending<any>['kind']) {
+        const idx = this.pending.findIndex(p => p.kind === kind);
+
+        return idx === -1 ? undefined : this.pending.splice(idx, 1)[0];
+    }
+
+    /** Settle the oldest in-flight acquire as success and advance the session. */
+    completeAcquire(session: string) {
+        const op = this.firstPending('acquire');
+        if (!op) return false;
+        this.acquiredCount += 1;
+        op.dfd.resolve({ success: true, payload: asSession(session) as Session });
+        this.setSession(op.path, session);
+
+        return true;
+    }
+
+    completeAcquireFail() {
+        const op = this.firstPending('acquire');
+        if (!op) return false;
+        // The real transport always carries an error code on failure; mirror that
+        // so Device.acquire's `throw new Error(result.error.code)` path is faithful.
+        op.dfd.resolve({
+            success: false,
+            error: { code: 'DEVICE_DISCONNECTED_DURING_ACTION' },
+        } as any);
+
+        return true;
+    }
+
+    /** Settle the oldest in-flight release as success and clear the session. */
+    completeRelease() {
+        const op = this.firstPending('release');
+        if (!op) return false;
+        this.releasedCount += 1;
+        op.dfd.resolve({ success: true, payload: null });
+        this.setSession(op.path, null);
+
+        return true;
+    }
+
+    /** Settle every parked transport message call so workflows can't hang the drain. */
+    completeMessage() {
+        const op =
+            this.firstPending('call') ?? this.firstPending('send') ?? this.firstPending('receive');
+        if (!op) return false;
+        op.dfd.resolve({ success: true, payload: { type: 'Success', message: {} } });
+
+        return true;
+    }
+
+    hasPending() {
+        return this.pending.length > 0;
+    }
+}
+
+export const createControllableTransport = (path = '1') => {
+    const transport = new ControllableTransport({ id: 'fuzz-transport' });
+    // init()/listen() flip the `stopped` flag; without it handleDescriptorsChange
+    // short-circuits and no DEVICE_SESSION_CHANGED events ever fan out.
+    transport.init();
+    transport.listen();
+    transport.seedDescriptor(path as Path, null);
+
+    return transport;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -16381,6 +16381,7 @@ __metadata:
     "@vitest/browser-playwright": "npm:^4.1.9"
     cross-fetch: "npm:^4.1.0"
     crypto-browserify: "npm:3.12.1"
+    fast-check: "npm:^4.8.0"
     jest: "npm:29.7.0"
     jws: "npm:^4.0.1"
     process: "npm:^0.11.10"
@@ -27740,6 +27741,15 @@ __metadata:
   dependencies:
     pure-rand: "npm:^6.1.0"
   checksum: 10/dab344146b778e8bc2973366ea55528d1b58d3e3037270262b877c54241e800c4d744957722c24705c787020d702aece11e57c9e3dbd5ea19c3e10926bf1f3fe
+  languageName: node
+  linkType: hard
+
+"fast-check@npm:^4.8.0":
+  version: 4.8.0
+  resolution: "fast-check@npm:4.8.0"
+  dependencies:
+    pure-rand: "npm:^8.0.0"
+  checksum: 10/32101d27e69f7f0a3ea486f1a6feee6b34c824ba14bf3efce2ad1741fcd412817ac3ed14f53ef57a55d6fe2e00038e399c4a9c62444446a6e7a1a4b04bc6b88d
   languageName: node
   linkType: hard
 
@@ -39543,6 +39553,13 @@ __metadata:
   version: 7.0.1
   resolution: "pure-rand@npm:7.0.1"
   checksum: 10/c61a576fda5032ec9763ecb000da4a8f19263b9e2f9ae9aa2759c8fbd9dc6b192b2ce78391ebd41abb394a5fedb7bcc4b03c9e6141ac8ab20882dd5717698b80
+  languageName: node
+  linkType: hard
+
+"pure-rand@npm:^8.0.0":
+  version: 8.4.1
+  resolution: "pure-rand@npm:8.4.1"
+  checksum: 10/3bdbd3be06f672a397218eaabbfe60aab8ac489b0eeb01d3963497d6ce245b4ffc8e7aefe9d9f62eff925c4264e597b733a16c1c23a3d7d019af1d32edd0b266
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Three concurrency bugs in the `@trezor/connect` device layer, found by building a deterministic `fast-check` fuzz harness over `Device.ts`'s per-device run-queue and `DeviceList`'s shared registry. Each fix is a small, isolated change guarded by a deterministic repro test; a model document and a verified-safe analysis of the override-dispatch seam round out the series. The commits are split one-per-finding for review and bisectability.

The fixes:

- **Unhandled rejection in `updateDescriptor`** — when an external client takes the device mid-acquire, `acquire()` rejects with `SESSION_WRONG_PREVIOUS`. `updateDescriptor` runs on the fire-and-forget transport-event path (its returned promise is discarded by the emitter), so its `Promise.all` re-raised that rejection as an unhandled rejection even though the run path already handles the same error. Switched to `Promise.allSettled`.

- **Leaked transport session from an aborted run** — a run aborted while parked on a previous release was not cancelled (it lost the `Promise.race` but kept executing) and went on to `acquire()` a session that the already-settled run could never release. Added an `abortSignal` check before `acquire()`, mirroring the pre-existing post-acquire check; it is a no-op for any run that is not already aborted.

- **`handshakeLock` deadlock from a disconnected device** — a device whose handshake was queued behind `DeviceList`'s global `handshakeLock` when it disconnected later acquired and hung forever in `waitAndCompareSession` (its session-change listener was already removed), holding the lock and starving every later device's handshake. The instance is now marked terminal on `disconnect()` so it short-circuits instead of acquiring.

The override-dispatch seam (`core/index.ts` `interrupt → run`) was also driven by the harness and found correct as-is — no production change, just a regression test plus a note in the model.

`packages/connect/src/device/CONCURRENCY_MODEL.md` documents the seams, the five invariants, and each finding. It is included for review — happy to trim it or move it into the PR description if the team would rather not keep it in-tree.

These findings were independently re-verified (bug reality, fix correctness, regression/blast-radius, and that each repro goes red without its fix) before this PR. One honesty note carried into the model doc: the INV-3 (session-leak) interleaving is reliably guarded by its deterministic repro, not by the fuzz at the committed default seed/run-count.

## Notes for QA

These are timing-dependent races in the desktop/web device communication layer; they require precise interleavings (external session takeover mid-acquire, an interrupt landing while a release is in flight, or a device disconnecting while another device's handshake holds the global lock), so they are hard to reproduce by hand but real under multi-device / multi-client use. All three changes are defensive and behavior-preserving on the normal path: the `updateDescriptor` change only differs in the external-takeover race (it now emits `DEVICE.CHANGED` instead of dropping it); the abort-before-acquire guard is a no-op for non-aborted runs; the disconnected-device guard only fires for a physically-gone instance that is already removed from the registry and replaced by a fresh `Device` on reconnect, so it cannot affect a reconnected device, and its new synchronous `Device_Disconnected` throw is an already-handled error code at every `run()` call site.

Suggested focus for QA: multi-device connect/disconnect/reconnect churn, and switching a device between Suite and another client (e.g. a dapp) mid-operation. No new user-facing behavior and nothing in the happy path should change. Automated coverage: 110 device unit tests plus the new fuzz and repro suites pass.

## Related Issue

N/A — proactive hardening found via fuzzing.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=gnhf/research-task-hunt-f-b522b1&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=gnhf/research-task-hunt-f-b522b1&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=gnhf/research-task-hunt-f-b522b1&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-21T14:39:26.988Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.signTransaction > TrezorConnect.signTransaction | 🤖 auto |
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-21T14:38:29.333Z • 10 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/gnhf/research-task-hunt-f-b522b1/web/](https://dev.suite.sldev.cz/suite-web/gnhf/research-task-hunt-f-b522b1/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->