### PR TITLE
refactor: type props on argument instead of React.FC

### DIFF
--- a/packages/components/src/components/typography/Code/Code.tsx
+++ b/packages/components/src/components/typography/Code/Code.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 
 import styled from 'styled-components';
 
@@ -17,6 +17,4 @@ const StyledCode = styled.code`
     border-radius: ${() => borders.radii.xxs};
 `;
 
-export const Code: React.FC<{ children: ReactNode }> = ({ children }) => (
-    <StyledCode>{children}</StyledCode>
-);
+export const Code = ({ children }: { children: ReactNode }) => <StyledCode>{children}</StyledCode>;

--- a/packages/transport-bluetooth/src/ui/app.tsx
+++ b/packages/transport-bluetooth/src/ui/app.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { TrezorBluetooth } from '../client/trezor-bluetooth';
 import {
@@ -57,7 +57,7 @@ const getPort = () => {
     return 21327;
 };
 
-export const App: React.FC = () => {
+export const App = () => {
     // inject inline styles on mount
     useEffect(() => {
         const style = document.createElement('style');

--- a/suite/receive/src/useReceiveDisabled.tsx
+++ b/suite/receive/src/useReceiveDisabled.tsx
@@ -1,4 +1,4 @@
-import { type FC, type PropsWithChildren, type ReactNode } from 'react';
+import { type PropsWithChildren, type ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 
 import {
@@ -31,10 +31,8 @@ export const useReceiveDisabled = () => {
     };
     const tooltipContent = getTooltipContent();
 
-    const ReceiveDisabledWrapper: FC<PropsWithChildren> =
-        tooltipContent !== null
-            ? ({ children }) => <Tooltip content={tooltipContent}>{children}</Tooltip>
-            : ({ children }) => children;
+    const ReceiveDisabledWrapper = ({ children }: PropsWithChildren) =>
+        tooltipContent !== null ? <Tooltip content={tooltipContent}>{children}</Tooltip> : children;
 
     return {
         isReceiveDisabled,


### PR DESCRIPTION
Nitpick: drop `React.FC` and type props directly on the argument (the recommended pattern).

### Notes for QA
No QA needed — type-level only, no runtime/behaviour change.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies three files: a typography Code component (very broad dependency, 121 tests), a Bluetooth transport UI component (no test coverage), and a receive-disabled hook (no static test mapping but clearly exercised by receive/address-related tests). The Code component change is cosmetic/presentational and maps to nearly all tests, so no tests are recommended specifically for it. The primary risk is in useReceiveDisabled.tsx which gates the receive address flow — tests exercising receive functionality across different coin types, passphrase wallets, and device states are recommended. The Bluetooth transport UI has no E2E coverage.

<details><summary><b>Changed files (3)</b></summary>

- `packages/components/src/components/typography/Code/Code.tsx`
- `packages/transport-bluetooth/src/ui/app.tsx`
- `suite/receive/src/useReceiveDisabled.tsx`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — The changed file suite/receive/src/useReceiveDisabled.tsx directly controls whether the receive address flow is enabled/disabled. This test exercises the full receive flow (reveal address, confirm on device, copy address) for multiple coin types (BTC, ETH, SOL, TRX), making it the most direct test for the useReceiveDisabled hook.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — This test includes a Cardano receive address flow (revealing address, confirming on device, copying) which would exercise the useReceiveDisabled hook for ADA accounts specifically.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test exercises the global receive flow including opening the receive form, adding accounts, and revealing addresses. Changes to useReceiveDisabled could affect whether the receive button is enabled in the global receive modal.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test reveals Cardano receive addresses on passphrase-protected wallets and checks address confirmation flows. The useReceiveDisabled hook may gate the reveal address button behavior in passphrase wallet contexts.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test checks that receive address reveal works after device disconnection/reconnection with passphrase wallets. The useReceiveDisabled hook likely determines button enabled state based on device connection status.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test exercises receive address reveal for multiple passphrase wallets, including switching between them. The useReceiveDisabled hook could affect the reveal address button availability across wallet switches.
- `suite/e2e/tests/wallet/without-device.test.ts` — This test verifies that send/receive flows properly handle a disconnected device. The useReceiveDisabled hook likely disables the receive flow when no device is connected, which this test validates indirectly.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/remembered-wallet-loading.test.ts` — This test loads a remembered wallet without a device and opens the receive form. The useReceiveDisabled hook may affect whether the receive button is accessible in a device-disconnected remembered wallet scenario.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/transport-bluetooth/src/ui/app.tsx`

_Updated: 2026-06-22T08:27:46.296Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/remove-react-fc/web/](https://dev.suite.sldev.cz/suite-web/mroz22/remove-react-fc/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/remove-react-fc&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/remove-react-fc&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-22T08:31:22.593Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-22T08:30:35.153Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->