### PR TITLE
feat(trading): exchange trade error resolver (POC)

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -181,7 +181,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@trezor/eslint": "workspace:*",
         "@types/file-saver": "^2.0.6",
-        "@types/invity-api": "^1.1.15",
+        "@types/invity-api": "^1.1.19",
         "@types/pako": "^2.0.4",
         "@types/pdfmake": "^0.3.1",
         "@types/react": "19.2.14",

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -1,9 +1,18 @@
 import { type ComponentType, type JSX } from 'react';
 import { useSelector } from 'react-redux';
 
-import { type ExtendedMessageDescriptor, Translation, type TranslationKey } from '@suite/intl';
+import { type ErrorCode } from 'invity-api';
+
+import {
+    type ExtendedMessageDescriptor,
+    Translation,
+    type TranslationKey,
+    useTranslation,
+} from '@suite/intl';
+import { TRADING_ERROR_MESSAGE } from '@suite/trading';
 import { selectSelectedDeviceLabelOrName } from '@suite-common/device';
 import { AUTH_DEVICE, type NotificationEntry } from '@suite-common/toast-notifications';
+import { getTradingErrorDisplay } from '@suite-common/trading';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { DEVICE } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
@@ -62,6 +71,7 @@ export const NotificationRenderer = ({
     render,
 }: NotificationRendererProps): JSX.Element => {
     const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
+    const { translationString } = useTranslation();
 
     const { type } = notification;
 
@@ -228,6 +238,37 @@ export const NotificationRenderer = ({
                 message: 'TOAST_GENERIC_ERROR',
                 values: { error: notification.error },
             });
+
+        case 'trading-error': {
+            const display = getTradingErrorDisplay(notification);
+            const entry =
+                TRADING_ERROR_MESSAGE[notification.errorCode as ErrorCode] ??
+                TRADING_ERROR_MESSAGE.unknown;
+
+            if (display.kind === 'detailed' && entry.detailed) {
+                return renderNotificationView(render, notification, {
+                    variant: 'error',
+                    message: entry.detailed,
+                    values: display.values,
+                });
+            }
+
+            if (display.kind === 'base' && display.message) {
+                return renderNotificationView(render, notification, {
+                    variant: 'error',
+                    message: 'TR_TRADING_ERROR_WITH_PARTNER_MESSAGE',
+                    values: {
+                        base: translationString(entry.base),
+                        partnerMessage: display.message,
+                    },
+                });
+            }
+
+            return renderNotificationView(render, notification, {
+                variant: 'error',
+                message: entry.base,
+            });
+        }
 
         case 'cannot-open-bluetooth-settings-error':
             return renderNotificationView(render, notification, {

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/__tests__/NotificationRenderer.test.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/__tests__/NotificationRenderer.test.tsx
@@ -1,0 +1,130 @@
+import '@suite-common/test-utils/src/globalOverrides';
+
+import { Translation } from '@suite/intl';
+import { configureMockStore, screen } from '@suite-common/test-utils';
+import { type NotificationEntry } from '@suite-common/toast-notifications';
+
+import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
+import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
+import { renderWithProviders } from 'src/support/tests/hooksHelper';
+
+import { type NotificationViewProps } from '../../Notifications/NotificationGroup/NotificationList/NotificationView';
+import { NotificationRenderer } from '../NotificationRenderer';
+
+type TradingErrorNotification = Extract<NotificationEntry, { type: 'trading-error' }>;
+
+const MessageView = ({ message, messageValues }: NotificationViewProps) => (
+    <Translation id={message} values={messageValues} />
+);
+
+const renderTradingError = (payload: Omit<TradingErrorNotification, 'context' | 'id'>) => {
+    const notification: TradingErrorNotification = { context: 'toast', id: 0, ...payload };
+    const store = configureMockStore({
+        preloadedState: initialAppState,
+        serializableCheck: { ignoredActions: [] },
+    });
+
+    return renderWithProviders(
+        store,
+        extraDependenciesDesktopMock.services,
+        <NotificationRenderer render={MessageView} notification={notification} />,
+    );
+};
+
+describe('NotificationRenderer trading-error', () => {
+    it('step 1: renders the structured message when data is present, ignoring the partner message', () => {
+        renderTradingError({
+            type: 'trading-error',
+            errorCode: 'invalid_pair',
+            values: { send: 'BTC', receive: 'ETH' },
+            message: 'raw provider noise that should not be shown',
+        });
+
+        expect(
+            screen.getByText('This trading pair (BTC → ETH) is not supported.'),
+        ).toBeInTheDocument();
+        expect(screen.queryByText(/raw provider noise/)).not.toBeInTheDocument();
+    });
+
+    it('step 1: renders the structured amount message with its range', () => {
+        renderTradingError({
+            type: 'trading-error',
+            errorCode: 'invalid_amount',
+            values: { min: '0.001', max: '5' },
+        });
+
+        expect(
+            screen.getByText('The amount is out of range. Minimum 0.001, maximum 5.'),
+        ).toBeInTheDocument();
+    });
+
+    it('step 2: appends the partner message to the per-code base when data is missing', () => {
+        renderTradingError({
+            type: 'trading-error',
+            errorCode: 'invalid_amount',
+            message: 'minimal amount is 0.669',
+        });
+
+        expect(
+            screen.getByText(
+                'The amount is out of range. Message from partner: minimal amount is 0.669',
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it('step 2: uses the global generic base for an unknown code with a partner message', () => {
+        renderTradingError({
+            type: 'trading-error',
+            errorCode: 'unknown',
+            message: 'Partner system down',
+        });
+
+        expect(
+            screen.getByText(
+                'An unexpected error occurred. Please try again. Message from partner: Partner system down',
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it('step 3: renders the per-code base when neither data nor partner message is present', () => {
+        renderTradingError({
+            type: 'trading-error',
+            errorCode: 'invalid_amount',
+        });
+
+        expect(screen.getByText('The amount is out of range.')).toBeInTheDocument();
+    });
+
+    it('step 4: renders the global generic for an unknown code with nothing to show', () => {
+        renderTradingError({
+            type: 'trading-error',
+            errorCode: 'unknown',
+        });
+
+        expect(
+            screen.getByText('An unexpected error occurred. Please try again.'),
+        ).toBeInTheDocument();
+    });
+
+    it('falls back to the global generic for an unrecognized error code', () => {
+        renderTradingError({
+            type: 'trading-error',
+            errorCode: 'totally_unknown_code',
+        });
+
+        expect(
+            screen.getByText('An unexpected error occurred. Please try again.'),
+        ).toBeInTheDocument();
+    });
+
+    it('renders the base for a code without a detailed template', () => {
+        renderTradingError({
+            type: 'trading-error',
+            errorCode: 'no_response',
+        });
+
+        expect(
+            screen.getByText('No response from the exchange. Please try again.'),
+        ).toBeInTheDocument();
+    });
+});

--- a/suite-common/flags/package.json
+++ b/suite-common/flags/package.json
@@ -14,6 +14,6 @@
         "@trezor/env-utils": "workspace:*"
     },
     "devDependencies": {
-        "@types/invity-api": "^1.1.15"
+        "@types/invity-api": "^1.1.19"
     }
 }

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -154,6 +154,12 @@ export type ToastPayload<TranslationKey extends UnknownTranslationKey = UnknownT
       }
     | ErrorToastPayload
     | {
+          type: 'trading-error';
+          errorCode: string;
+          values?: Record<string, string | number | boolean | undefined>;
+          message?: string;
+      }
+    | {
           type: 'auto-updater-error';
           state: DesktopAppUpdateState;
       }

--- a/suite-common/trading/package.json
+++ b/suite-common/trading/package.json
@@ -42,6 +42,6 @@
     "devDependencies": {
         "@suite-common/test-utils": "workspace:*",
         "@testing-library/react": "^16.3.2",
-        "@types/invity-api": "^1.1.15"
+        "@types/invity-api": "^1.1.19"
     }
 }

--- a/suite-common/trading/src/__tests__/invityAPI.test.ts
+++ b/suite-common/trading/src/__tests__/invityAPI.test.ts
@@ -100,7 +100,7 @@ describe('InvityAPI', () => {
 
         const info = await invityAPI.getInfo();
         expect(consoleSpy).toHaveBeenCalled();
-        expect(info).toEqual({ platforms: {}, coins: {} });
+        expect(info).toEqual({ platforms: {}, coins: {}, config: {} });
     });
 
     describe('getInfo', () => {
@@ -108,6 +108,7 @@ describe('InvityAPI', () => {
             const mockInfo: InfoResponse = {
                 coins,
                 platforms,
+                config: {},
             };
             (global.fetch as jest.Mock).mockResolvedValueOnce({
                 ok: true,
@@ -125,7 +126,7 @@ describe('InvityAPI', () => {
             });
 
             const info = await invityAPI.getInfo();
-            expect(info).toEqual({ platforms: {}, coins: {} });
+            expect(info).toEqual({ platforms: {}, coins: {}, config: {} });
         });
 
         it('should handle fetch info when there is error', async () => {
@@ -133,7 +134,7 @@ describe('InvityAPI', () => {
 
             const info = await invityAPI.getInfo();
             expect(consoleSpy).toHaveBeenCalledWith('[getInfo]', error);
-            expect(info).toEqual({ platforms: {}, coins: {} });
+            expect(info).toEqual({ platforms: {}, coins: {}, config: {} });
         });
     });
 

--- a/suite-common/trading/src/index.ts
+++ b/suite-common/trading/src/index.ts
@@ -38,6 +38,7 @@ export * from './utils/buy/buyUtils';
 export * from './utils/receiveAccountUtils';
 export * from './utils/tradeOperationUtils';
 export * from './utils/exchange/exchangeUtils';
+export * from './utils/exchange/resolveExchangeTradeError';
 export * from './utils/exchange/signDataUtils';
 export * from './utils/sell/sellUtils';
 export * from './utils/signature/signatureUtils';

--- a/suite-common/trading/src/invityAPI.ts
+++ b/suite-common/trading/src/invityAPI.ts
@@ -213,7 +213,7 @@ class InvityAPI {
             console.error('[getInfo]', error);
         }
 
-        return { platforms: {}, coins: {} };
+        return { platforms: {}, coins: {}, config: {} };
     };
 
     getExchangeList = async (): Promise<ExchangeListResponse> => {

--- a/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
@@ -74,6 +74,7 @@ const symbolsInfo: InfoResponse = {
             },
         },
     },
+    config: {},
 };
 
 const composedTransactionInfo: TradingComposedTransactionInfo = {

--- a/suite-common/trading/src/thunks/common/__tests__/loadInitialDataThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/loadInitialDataThunk.test.ts
@@ -151,6 +151,7 @@ const testUpdatedInfoData = async (type: 'outdated' | 'account-changed') => {
             payload: {
                 coins: {},
                 platforms: {},
+                config: {},
             },
         },
         { type: buyThunks.loadInfoThunk.pending.type, payload: undefined },

--- a/suite-common/trading/src/thunks/common/__tests__/loadInitialDataThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/loadInitialDataThunk.test.ts
@@ -86,6 +86,7 @@ const testUpdatedInfoData = async (type: 'outdated' | 'account-changed') => {
         Promise.resolve({
             coins: {},
             platforms: {},
+            config: {},
         });
 
     const getCurrentAccountDescriptorMock = jest.spyOn(invityAPI, 'getCurrentAccountDescriptor');

--- a/suite-common/trading/src/thunks/common/__tests__/logErrorThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/logErrorThunk.test.ts
@@ -1,4 +1,5 @@
 import { type TradingType } from '../../../types';
+import { type ResolvedTradeError } from '../../../utils/exchange/resolveExchangeTradeError';
 import { logErrorThunk } from '../logErrorThunk';
 
 jest.mock('@suite-common/toast-notifications', () => {
@@ -92,6 +93,67 @@ describe('logErrorThunk', () => {
         expect(dispatch).toHaveBeenCalledWith({
             type: 'mockedSetLastErrorMessageByTradingTypeAction',
             payload: { errorMessage: 'Test error message', tradingType: 'buy' },
+        });
+    });
+
+    it('should add a trading-error toast for a resolved trade error', async () => {
+        const errorMessage: ResolvedTradeError = {
+            code: 'invalid_pair',
+            values: { send: 'BTC', receive: 'ETH' },
+            message: 'Invalid currency',
+        };
+        const tradingType: TradingType = 'buy';
+
+        const thunk = logErrorThunk({
+            errorMessage,
+            tradingType,
+        });
+        await thunk(dispatch, getState, extra);
+
+        expect(dispatch).toHaveBeenCalledWith({
+            type: 'mockedAddToastAction',
+            payload: {
+                type: 'trading-error',
+                errorCode: 'invalid_pair',
+                values: { send: 'BTC', receive: 'ETH' },
+                message: 'Invalid currency',
+            },
+        });
+    });
+
+    it('should set the resolved message as the last error message', async () => {
+        const errorMessage: ResolvedTradeError = {
+            code: 'invalid_pair',
+            values: { send: 'BTC', receive: 'ETH' },
+            message: 'Invalid currency',
+        };
+        const tradingType: TradingType = 'buy';
+
+        const thunk = logErrorThunk({
+            errorMessage,
+            tradingType,
+        });
+        await thunk(dispatch, getState, extra);
+
+        expect(dispatch).toHaveBeenCalledWith({
+            type: 'mockedSetLastErrorMessageByTradingTypeAction',
+            payload: { errorMessage: 'Invalid currency', tradingType: 'buy' },
+        });
+    });
+
+    it('should default the last error message to an empty string when the resolved error has no message', async () => {
+        const errorMessage: ResolvedTradeError = { code: 'unknown' };
+        const tradingType: TradingType = 'buy';
+
+        const thunk = logErrorThunk({
+            errorMessage,
+            tradingType,
+        });
+        await thunk(dispatch, getState, extra);
+
+        expect(dispatch).toHaveBeenCalledWith({
+            type: 'mockedSetLastErrorMessageByTradingTypeAction',
+            payload: { errorMessage: '', tradingType: 'buy' },
         });
     });
 });

--- a/suite-common/trading/src/thunks/common/logErrorThunk.ts
+++ b/suite-common/trading/src/thunks/common/logErrorThunk.ts
@@ -3,10 +3,14 @@ import { type ErrorToastPayload, notificationsActions } from '@suite-common/toas
 
 import { TRADING_THUNK_PREFIX } from '../../constants';
 import { type TradingType } from '../../types';
+import {
+    type ResolvedTradeError,
+    isResolvedTradeError,
+} from '../../utils/exchange/resolveExchangeTradeError';
 import { setLastErrorMessageByTradingType } from '../common/setLastErrorMessageByTradingType';
 
 export type LogErrorThunkProps = {
-    errorMessage: ErrorToastPayload['error'];
+    errorMessage: string | ResolvedTradeError;
     toastType?: ErrorToastPayload['type'];
     tradingType: TradingType;
 };
@@ -14,18 +18,26 @@ export type LogErrorThunkProps = {
 export const logErrorThunk = createThunk(
     `${TRADING_THUNK_PREFIX}/logError`,
     ({ errorMessage, tradingType, toastType = 'error' }: LogErrorThunkProps, { dispatch }) => {
-        dispatch(
-            notificationsActions.addToast({
-                type: toastType,
-                error: errorMessage,
-            }),
-        );
+        if (isResolvedTradeError(errorMessage)) {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'trading-error',
+                    errorCode: errorMessage.code,
+                    values: errorMessage.values,
+                    message: errorMessage.message,
+                }),
+            );
+            dispatch(
+                setLastErrorMessageByTradingType({
+                    tradingType,
+                    errorMessage: errorMessage.message ?? '',
+                }),
+            );
 
-        dispatch(
-            setLastErrorMessageByTradingType({
-                tradingType,
-                errorMessage,
-            }),
-        );
+            return;
+        }
+
+        dispatch(notificationsActions.addToast({ type: toastType, error: errorMessage }));
+        dispatch(setLastErrorMessageByTradingType({ tradingType, errorMessage }));
     },
 );

--- a/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
@@ -317,29 +317,30 @@ describe('confirmExchangeTradeThunk', () => {
         it.each([
             [
                 'when response.error is defined',
-                {
-                    error: 'Server error',
-                },
+                { error: 'Server error' },
+                { code: 'unknown', message: 'Server error' },
             ],
+            ['when response.state is undefined', { status: undefined }, { code: 'unknown' }],
+            ['when response.orderId is undefined', { orderId: undefined }, { code: 'unknown' }],
+            ['when response.status is ERROR', { status: 'ERROR' }, { code: 'unknown' }],
             [
-                'when response.state is undefined',
-                {
-                    status: undefined,
-                },
-            ],
-            [
-                'when response.orderId is undefined',
-                {
-                    orderId: undefined,
-                },
-            ],
-            [
-                'when response.status is ERROR',
+                'when response has errorDetails but no error string',
                 {
                     status: 'ERROR',
+                    errorDetails: {
+                        origin: 'partner',
+                        externalCode: '-100',
+                        code: 'invalid_amount',
+                        amount: { key: 'BTC', value: '0.00001', min: '0.001', max: '5' },
+                    },
+                },
+                {
+                    code: 'invalid_amount',
+                    message: '-100',
+                    values: { min: '0.001', max: '5' },
                 },
             ],
-        ])(`%s`, async (_, mockResponse) => {
+        ])(`%s`, async (_, mockResponse, expectedErrorMessage) => {
             const {
                 store,
                 returnUrl,
@@ -375,10 +376,7 @@ describe('confirmExchangeTradeThunk', () => {
 
             expect(actionToast?.payload).toEqual({
                 tradingType: 'exchange',
-                errorMessage:
-                    'error' in mockResponse
-                        ? mockResponse?.error
-                        : 'Error response from the server',
+                errorMessage: expectedErrorMessage,
             });
 
             expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);

--- a/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
@@ -1,4 +1,4 @@
-import { type ExchangeTrade } from 'invity-api';
+import { type CryptoId, type ExchangeTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
 import { type Account } from '@suite-common/wallet-types';
@@ -8,11 +8,13 @@ import { invityAPI } from '../../invityAPI';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
 import { tradingActions } from '../../reducers/tradingCommonReducer';
 import {
+    selectTradingCoinSymbolByCryptoId,
     selectTradingExchangeAccountKey,
     selectTradingExchangeReceiveAccountKey,
     selectTradingExchangeSelectedQuote,
 } from '../../selectors/tradingSelectors';
 import { getUnusedAddressFromAccount } from '../../utils';
+import { resolveExchangeTradeError } from '../../utils/exchange/resolveExchangeTradeError';
 import { logErrorThunk } from '../common/logErrorThunk';
 
 export type ConfirmExchangeTradeThunkProps = {
@@ -44,6 +46,9 @@ export const confirmExchangeTradeThunk = createThunk(
         }: ConfirmExchangeTradeThunkProps,
         { dispatch, getState, signal },
     ) => {
+        const getCoinSymbol = (cryptoId: CryptoId) =>
+            selectTradingCoinSymbolByCryptoId(getState(), cryptoId);
+
         triggerAnalyticsTradeConfirmation();
 
         const selectedQuote = selectTradingExchangeSelectedQuote(getState());
@@ -108,7 +113,7 @@ export const confirmExchangeTradeThunk = createThunk(
         ) {
             dispatch(
                 logErrorThunk({
-                    errorMessage: response.error || 'Error response from the server',
+                    errorMessage: resolveExchangeTradeError(response, { getCoinSymbol }),
                     tradingType: 'exchange',
                 }),
             );

--- a/suite-common/trading/src/utils/exchange/__tests__/resolveExchangeTradeError.test.ts
+++ b/suite-common/trading/src/utils/exchange/__tests__/resolveExchangeTradeError.test.ts
@@ -1,0 +1,418 @@
+import type { CryptoId, TradeError } from 'invity-api';
+
+import {
+    getTradingErrorDisplay,
+    isResolvedTradeError,
+    resolveExchangeTradeError,
+} from '../resolveExchangeTradeError';
+
+const coinSymbols: Record<string, string> = {
+    bitcoin: 'BTC',
+    ethereum: 'ETH',
+    'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7': 'USDT',
+};
+
+const getCoinSymbol = (cryptoId: CryptoId) => coinSymbols[cryptoId];
+
+describe('resolveExchangeTradeError', () => {
+    it('returns unknown with the backend error as the message when errorDetails is missing', () => {
+        const source: Partial<TradeError> = { error: 'Something broke' };
+
+        expect(resolveExchangeTradeError(source)).toEqual({
+            code: 'unknown',
+            message: 'Something broke',
+        });
+    });
+
+    it('returns unknown with nothing when the source is empty', () => {
+        expect(resolveExchangeTradeError({})).toEqual({ code: 'unknown', message: undefined });
+    });
+
+    it('uses errorDetails.message as the message, ignoring the backend error', () => {
+        const source: Partial<TradeError> = {
+            error: 'Untranslated backend error',
+            errorDetails: {
+                origin: 'partner',
+                externalCode: '-32602',
+                message: 'The requested currency pair is not supported by this provider.',
+                code: 'unknown',
+            },
+        };
+
+        expect(resolveExchangeTradeError(source)).toEqual({
+            code: 'unknown',
+            message: 'The requested currency pair is not supported by this provider.',
+        });
+    });
+
+    it('falls back to externalCode as the message when errorDetails.message is absent', () => {
+        const source: Partial<TradeError> = {
+            errorDetails: { origin: 'partner', externalCode: '-32602', code: 'unknown' },
+        };
+
+        expect(resolveExchangeTradeError(source)).toMatchObject({
+            code: 'unknown',
+            message: '-32602',
+        });
+    });
+
+    it('falls back to the backend error as the message when errorDetails carries neither message nor externalCode', () => {
+        const source: Partial<TradeError> = {
+            error: 'Backend went boom',
+            errorDetails: { origin: 'partner', code: 'unknown' },
+        };
+
+        expect(resolveExchangeTradeError(source)).toEqual({
+            code: 'unknown',
+            message: 'Backend went boom',
+        });
+    });
+
+    describe('invalid_amount', () => {
+        it('fills values when both bounds are present', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: {
+                    origin: 'partner',
+                    code: 'invalid_amount',
+                    amount: { key: 'BTC', value: '0.00001', min: '0.001', max: '5' },
+                },
+            };
+
+            expect(resolveExchangeTradeError(source)).toEqual({
+                code: 'invalid_amount',
+                message: undefined,
+                values: { min: '0.001', max: '5' },
+            });
+        });
+
+        it('leaves values undefined (not {}) when a bound is missing, keeping the partner message', () => {
+            const source: Partial<TradeError> = {
+                error: 'raw backend error',
+                errorDetails: {
+                    origin: 'partner',
+                    code: 'invalid_amount',
+                    message: 'minimal amount is 0.669',
+                    amount: { key: 'BTC', value: '0.00001', min: '0.669' },
+                },
+            };
+
+            const result = resolveExchangeTradeError(source);
+
+            expect(result.values).toBeUndefined();
+            expect(result).toMatchObject({
+                code: 'invalid_amount',
+                message: 'minimal amount is 0.669',
+            });
+        });
+
+        it('leaves values undefined when amount is absent', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: { origin: 'internal', code: 'invalid_amount' },
+            };
+
+            expect(resolveExchangeTradeError(source).values).toBeUndefined();
+        });
+    });
+
+    describe('invalid_pair', () => {
+        it('resolves cryptoIds into coin symbols', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: {
+                    origin: 'partner',
+                    code: 'invalid_pair',
+                    pair: { send: 'bitcoin', receive: 'ethereum' },
+                },
+            };
+
+            expect(resolveExchangeTradeError(source, { getCoinSymbol }).values).toEqual({
+                send: 'BTC',
+                receive: 'ETH',
+            });
+        });
+
+        it('resolves tokens to their precise symbol, not the network', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: {
+                    origin: 'partner',
+                    code: 'invalid_pair',
+                    pair: {
+                        send: 'bitcoin',
+                        receive: 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7',
+                    },
+                },
+            };
+
+            expect(resolveExchangeTradeError(source, { getCoinSymbol }).values).toEqual({
+                send: 'BTC',
+                receive: 'USDT',
+            });
+        });
+
+        it('falls back to the raw cryptoId when no resolver is supplied', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: {
+                    origin: 'partner',
+                    code: 'invalid_pair',
+                    pair: { send: 'bitcoin', receive: 'ethereum' },
+                },
+            };
+
+            expect(resolveExchangeTradeError(source).values).toEqual({
+                send: 'bitcoin',
+                receive: 'ethereum',
+            });
+        });
+
+        it('falls back to the raw cryptoId when the resolver returns undefined for it', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: {
+                    origin: 'partner',
+                    code: 'invalid_pair',
+                    pair: { send: 'dogecoin', receive: 'ethereum' },
+                },
+            };
+
+            expect(resolveExchangeTradeError(source, { getCoinSymbol }).values).toEqual({
+                send: 'dogecoin',
+                receive: 'ETH',
+            });
+        });
+
+        it('leaves values undefined when only one side is present', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: {
+                    origin: 'partner',
+                    code: 'invalid_pair',
+                    pair: { send: 'bitcoin', receive: '' },
+                },
+            };
+
+            expect(resolveExchangeTradeError(source, { getCoinSymbol }).values).toBeUndefined();
+        });
+
+        it('leaves values undefined when pair is absent', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: { origin: 'internal', code: 'invalid_pair' },
+            };
+
+            expect(resolveExchangeTradeError(source).values).toBeUndefined();
+        });
+    });
+
+    describe('invalid_address', () => {
+        it('fills values with the address key', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: {
+                    origin: 'partner',
+                    code: 'invalid_address',
+                    address: { key: 'receiveAddress', value: 'bc1invalid' },
+                },
+            };
+
+            expect(resolveExchangeTradeError(source).values).toEqual({ key: 'receiveAddress' });
+        });
+
+        it('leaves values undefined when the address key is absent', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: { origin: 'partner', code: 'invalid_address' },
+            };
+
+            expect(resolveExchangeTradeError(source).values).toBeUndefined();
+        });
+    });
+
+    describe('unavailable', () => {
+        it('fills values with entity type and value', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: {
+                    origin: 'internal',
+                    code: 'unavailable',
+                    entity: { type: 'partner', value: 'changelly' },
+                    reason: 'maintenance',
+                },
+            };
+
+            expect(resolveExchangeTradeError(source).values).toEqual({
+                entityType: 'partner',
+                entityValue: 'changelly',
+            });
+        });
+
+        it('leaves values undefined when entity is incomplete', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: {
+                    origin: 'internal',
+                    code: 'unavailable',
+                    entity: { type: 'partner', value: '' },
+                },
+            };
+
+            expect(resolveExchangeTradeError(source).values).toBeUndefined();
+        });
+    });
+
+    describe('invalid_input / invalid_response', () => {
+        it('joins invalid_input inputs into a string', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: {
+                    origin: 'partner',
+                    code: 'invalid_input',
+                    inputs: ['fromAddress', 'refundAddress'],
+                },
+            };
+
+            expect(resolveExchangeTradeError(source).values).toEqual({
+                inputs: 'fromAddress, refundAddress',
+            });
+        });
+
+        it('leaves invalid_input values undefined when there are no inputs', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: { origin: 'partner', code: 'invalid_input' },
+            };
+
+            expect(resolveExchangeTradeError(source).values).toBeUndefined();
+        });
+
+        it('joins invalid_response errors into a string', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: {
+                    origin: 'external',
+                    code: 'invalid_response',
+                    errors: ['missing rate', 'bad payload'],
+                },
+            };
+
+            expect(resolveExchangeTradeError(source).values).toEqual({
+                errors: 'missing rate, bad payload',
+            });
+        });
+
+        it('leaves invalid_response values undefined when there are no errors', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: { origin: 'external', code: 'invalid_response' },
+            };
+
+            expect(resolveExchangeTradeError(source).values).toBeUndefined();
+        });
+    });
+
+    describe('trade_not_found', () => {
+        it('fills values with the id', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: { origin: 'partner', code: 'trade_not_found', id: 'abc123' },
+            };
+
+            expect(resolveExchangeTradeError(source).values).toEqual({ id: 'abc123' });
+        });
+
+        it('leaves values undefined when id is absent', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: { origin: 'partner', code: 'trade_not_found' },
+            };
+
+            expect(resolveExchangeTradeError(source).values).toBeUndefined();
+        });
+    });
+
+    describe('trade lifecycle', () => {
+        it.each(['trade_expired', 'trade_failed', 'trade_refunded'] as const)(
+            'fills orderId for %s',
+            code => {
+                const source: Partial<TradeError> = {
+                    errorDetails: { origin: 'partner', code, orderId: 'order-9' },
+                };
+
+                const result = resolveExchangeTradeError(source);
+
+                expect(result.code).toBe(code);
+                expect(result.values).toEqual({ orderId: 'order-9' });
+            },
+        );
+
+        it('leaves values undefined when orderId is absent', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: { origin: 'partner', code: 'trade_failed' },
+            };
+
+            expect(resolveExchangeTradeError(source).values).toBeUndefined();
+        });
+    });
+
+    describe('generic codes', () => {
+        it('returns no_response with no values', () => {
+            const source: Partial<TradeError> = {
+                errorDetails: { origin: 'external', code: 'no_response' },
+            };
+
+            expect(resolveExchangeTradeError(source)).toEqual({
+                code: 'no_response',
+                message: undefined,
+            });
+        });
+
+        it('returns unknown with the partner message', () => {
+            const source: Partial<TradeError> = {
+                error: 'weird',
+                errorDetails: { origin: 'internal', externalCode: 'X1', code: 'unknown' },
+            };
+
+            expect(resolveExchangeTradeError(source)).toEqual({
+                code: 'unknown',
+                message: 'X1',
+            });
+        });
+
+        it('degrades an unrecognized backend code to unknown without throwing', () => {
+            const source = {
+                error: 'raw backend error',
+                errorDetails: {
+                    origin: 'partner',
+                    externalCode: 'X9',
+                    message: 'Provider-specific explanation.',
+                    code: 'future_code_from_api',
+                },
+            } as unknown as Partial<TradeError>;
+
+            expect(() => resolveExchangeTradeError(source)).not.toThrow();
+            expect(resolveExchangeTradeError(source)).toEqual({
+                code: 'unknown',
+                message: 'Provider-specific explanation.',
+            });
+        });
+    });
+});
+
+describe('isResolvedTradeError', () => {
+    it('returns true for a resolved trade error', () => {
+        expect(isResolvedTradeError({ code: 'unknown' })).toBe(true);
+    });
+
+    it('returns false for a plain string', () => {
+        expect(isResolvedTradeError('Server error')).toBe(false);
+    });
+
+    it('returns false for null and unrelated objects', () => {
+        expect(isResolvedTradeError(null)).toBe(false);
+        expect(isResolvedTradeError({ foo: 'bar' })).toBe(false);
+    });
+});
+
+describe('getTradingErrorDisplay', () => {
+    it('returns detailed with values when values are present', () => {
+        expect(
+            getTradingErrorDisplay({ values: { min: '1', max: '5' }, message: 'ignored' }),
+        ).toEqual({ kind: 'detailed', values: { min: '1', max: '5' } });
+    });
+
+    it('returns base with the message when values are absent', () => {
+        expect(getTradingErrorDisplay({ message: 'minimal amount is 0.669' })).toEqual({
+            kind: 'base',
+            message: 'minimal amount is 0.669',
+        });
+    });
+
+    it('returns base without a message when nothing is present', () => {
+        expect(getTradingErrorDisplay({})).toEqual({ kind: 'base', message: undefined });
+    });
+});

--- a/suite-common/trading/src/utils/exchange/resolveExchangeTradeError.ts
+++ b/suite-common/trading/src/utils/exchange/resolveExchangeTradeError.ts
@@ -1,0 +1,150 @@
+import type { CryptoId, ErrorCode, TradeError } from 'invity-api';
+
+export type ResolveTradeErrorOptions = {
+    getCoinSymbol?: (cryptoId: CryptoId) => string | undefined;
+};
+
+type TradingErrorValuesRecord = Record<string, string | number | boolean | undefined>;
+
+type StrictErrorMap<
+    T extends Record<ErrorCode, TradingErrorValuesRecord | undefined> &
+        Record<Exclude<keyof T, ErrorCode>, never>,
+> = T;
+
+export type TradingErrorValues = StrictErrorMap<{
+    invalid_amount: { min: string; max: string };
+    invalid_pair: { send: string; receive: string };
+    invalid_address: { key: string };
+    unavailable: { entityType: string; entityValue: string };
+    invalid_input: { inputs: string };
+    invalid_response: { errors: string };
+    trade_not_found: { id: string };
+    trade_expired: { orderId: string };
+    trade_failed: { orderId: string };
+    trade_refunded: { orderId: string };
+    no_response: undefined;
+    unknown: undefined;
+}>;
+
+export type ResolvedTradeError = {
+    message?: string;
+} & {
+    [C in ErrorCode]: { code: C; values?: TradingErrorValues[C] };
+}[ErrorCode];
+
+export const isResolvedTradeError = (value: unknown): value is ResolvedTradeError =>
+    typeof value === 'object' &&
+    value !== null &&
+    'code' in value &&
+    typeof (value as { code: unknown }).code === 'string';
+
+export type TradingErrorDisplay =
+    | { kind: 'detailed'; values: TradingErrorValuesRecord }
+    | { kind: 'base'; message?: string };
+
+// This helper is prepared for using in desktop and native mobile apps,
+// where we can use rich text formatting for structured error messages.
+export const getTradingErrorDisplay = ({
+    values,
+    message,
+}: {
+    values?: TradingErrorValuesRecord;
+    message?: string;
+}): TradingErrorDisplay => (values ? { kind: 'detailed', values } : { kind: 'base', message });
+
+export const resolveExchangeTradeError = (
+    source: Partial<TradeError>,
+    { getCoinSymbol }: ResolveTradeErrorOptions = {},
+): ResolvedTradeError => {
+    const details = source.errorDetails;
+
+    if (!details) {
+        return { code: 'unknown', message: source.error };
+    }
+
+    const resolveSymbol = (cryptoId: string): string =>
+        getCoinSymbol?.(cryptoId as CryptoId) ?? cryptoId;
+
+    const base = { message: details.message ?? details.externalCode ?? source.error };
+    const asUnknown = (): ResolvedTradeError => ({ ...base, code: 'unknown' });
+
+    switch (details.code) {
+        case 'invalid_amount': {
+            const { min, max } = details.amount ?? {};
+
+            return {
+                ...base,
+                code: 'invalid_amount',
+                values: min && max ? { min, max } : undefined,
+            };
+        }
+        case 'invalid_pair': {
+            const { send, receive } = details.pair ?? {};
+
+            return {
+                ...base,
+                code: 'invalid_pair',
+                values:
+                    send && receive
+                        ? { send: resolveSymbol(send), receive: resolveSymbol(receive) }
+                        : undefined,
+            };
+        }
+        case 'invalid_address': {
+            const key = details.address?.key;
+
+            return { ...base, code: 'invalid_address', values: key ? { key } : undefined };
+        }
+        case 'unavailable': {
+            const { type, value } = details.entity ?? {};
+
+            return {
+                ...base,
+                code: 'unavailable',
+                values: type && value ? { entityType: type, entityValue: value } : undefined,
+            };
+        }
+        case 'invalid_input': {
+            return {
+                ...base,
+                code: 'invalid_input',
+                // temporary comma join; replace with locale-aware list formatting at render later
+                // TODO: Solve with design/UX team how to display multiple errors in a user-friendly way
+                values: details.inputs?.length ? { inputs: details.inputs.join(', ') } : undefined,
+            };
+        }
+        case 'invalid_response': {
+            return {
+                ...base,
+                code: 'invalid_response',
+                // temporary comma join; replace with locale-aware list formatting at render later
+                // TODO: Solve with design/UX team how to display multiple errors in a user-friendly way
+                values: details.errors?.length ? { errors: details.errors.join(', ') } : undefined,
+            };
+        }
+        case 'trade_not_found': {
+            return {
+                ...base,
+                code: 'trade_not_found',
+                values: details.id ? { id: details.id } : undefined,
+            };
+        }
+        case 'trade_expired':
+        case 'trade_failed':
+        case 'trade_refunded': {
+            return {
+                ...base,
+                code: details.code,
+                values: details.orderId ? { orderId: details.orderId } : undefined,
+            };
+        }
+        case 'no_response':
+            return { ...base, code: 'no_response' };
+        case 'unknown':
+            return asUnknown();
+        default:
+            details satisfies never;
+
+            return asUnknown();
+    }
+};

--- a/suite-common/wallet-types/package.json
+++ b/suite-common/wallet-types/package.json
@@ -19,7 +19,7 @@
         "@trezor/device-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:^",
-        "@types/invity-api": "^1.1.15",
+        "@types/invity-api": "^1.1.19",
         "react": "19.2.4"
     }
 }

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -103,6 +103,6 @@
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
         "@trezor/requirements": "workspace:*",
-        "@types/invity-api": "^1.1.15"
+        "@types/invity-api": "^1.1.19"
     }
 }

--- a/suite-native/trading-analytics/package.json
+++ b/suite-native/trading-analytics/package.json
@@ -25,6 +25,6 @@
     "devDependencies": {
         "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
-        "@types/invity-api": "^1.1.15"
+        "@types/invity-api": "^1.1.19"
     }
 }

--- a/suite-native/trading-atoms/package.json
+++ b/suite-native/trading-atoms/package.json
@@ -45,6 +45,6 @@
         "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
-        "@types/invity-api": "^1.1.15"
+        "@types/invity-api": "^1.1.19"
     }
 }

--- a/suite-native/trading-browser-auth/package.json
+++ b/suite-native/trading-browser-auth/package.json
@@ -44,6 +44,6 @@
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
         "@suite-native/transaction-management": "workspace:*",
-        "@types/invity-api": "^1.1.15"
+        "@types/invity-api": "^1.1.19"
     }
 }

--- a/suite-native/trading-fixtures/package.json
+++ b/suite-native/trading-fixtures/package.json
@@ -25,6 +25,6 @@
     },
     "devDependencies": {
         "@suite-native/trading-types": "workspace:*",
-        "@types/invity-api": "^1.1.15"
+        "@types/invity-api": "^1.1.19"
     }
 }

--- a/suite-native/trading-history/package.json
+++ b/suite-native/trading-history/package.json
@@ -47,6 +47,6 @@
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
-        "@types/invity-api": "^1.1.15"
+        "@types/invity-api": "^1.1.19"
     }
 }

--- a/suite-native/trading-provider-utils/package.json
+++ b/suite-native/trading-provider-utils/package.json
@@ -35,6 +35,6 @@
         "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
-        "@types/invity-api": "^1.1.15"
+        "@types/invity-api": "^1.1.19"
     }
 }

--- a/suite-native/trading-quote-utils/package.json
+++ b/suite-native/trading-quote-utils/package.json
@@ -31,6 +31,6 @@
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
-        "@types/invity-api": "^1.1.15"
+        "@types/invity-api": "^1.1.19"
     }
 }

--- a/suite-native/trading-slippage/package.json
+++ b/suite-native/trading-slippage/package.json
@@ -38,6 +38,6 @@
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
-        "@types/invity-api": "^1.1.15"
+        "@types/invity-api": "^1.1.19"
     }
 }

--- a/suite-native/trading-state/package.json
+++ b/suite-native/trading-state/package.json
@@ -44,6 +44,6 @@
         "@suite-common/test-utils": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
-        "@types/invity-api": "^1.1.15"
+        "@types/invity-api": "^1.1.19"
     }
 }

--- a/suite-native/trading-types/package.json
+++ b/suite-native/trading-types/package.json
@@ -20,6 +20,6 @@
         "@suite-native/intl": "workspace:*",
         "@suite-native/navigation": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",
-        "@types/invity-api": "^1.1.15"
+        "@types/invity-api": "^1.1.19"
     }
 }

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -64,7 +64,7 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "@types/invity-api": "^1.1.15",
+        "@types/invity-api": "^1.1.19",
         "@types/lodash": "^4.17.16",
         "@walletconnect/sign-client": "^2.23.9",
         "@walletconnect/types": "^2.23.9",

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -335,6 +335,98 @@ export const messages = defineMessages({
         defaultMessage: 'Missing fee level',
         id: 'TR_TRADING_MISSING_FEE_LEVEL',
     },
+    TR_TRADING_ERROR_WITH_PARTNER_MESSAGE: {
+        defaultMessage: '{base} Message from partner: {partnerMessage}',
+        id: 'TR_TRADING_ERROR_WITH_PARTNER_MESSAGE',
+    },
+    TR_TRADING_ERROR_UNKNOWN: {
+        defaultMessage: 'An unexpected error occurred. Please try again.',
+        id: 'TR_TRADING_ERROR_UNKNOWN',
+    },
+    TR_TRADING_ERROR_INVALID_AMOUNT: {
+        defaultMessage: 'The amount is out of range.',
+        id: 'TR_TRADING_ERROR_INVALID_AMOUNT',
+    },
+    TR_TRADING_ERROR_INVALID_AMOUNT_DETAILED: {
+        defaultMessage: 'The amount is out of range. Minimum {min}, maximum {max}.',
+        id: 'TR_TRADING_ERROR_INVALID_AMOUNT_DETAILED',
+    },
+    TR_TRADING_ERROR_INVALID_PAIR: {
+        defaultMessage: 'This trading pair is not supported.',
+        id: 'TR_TRADING_ERROR_INVALID_PAIR',
+    },
+    TR_TRADING_ERROR_INVALID_PAIR_DETAILED: {
+        defaultMessage: 'This trading pair ({send} → {receive}) is not supported.',
+        id: 'TR_TRADING_ERROR_INVALID_PAIR_DETAILED',
+    },
+    TR_TRADING_ERROR_INVALID_ADDRESS: {
+        defaultMessage: 'The provided address is invalid.',
+        id: 'TR_TRADING_ERROR_INVALID_ADDRESS',
+    },
+    TR_TRADING_ERROR_INVALID_ADDRESS_DETAILED: {
+        defaultMessage: 'The provided {key} address is invalid.',
+        id: 'TR_TRADING_ERROR_INVALID_ADDRESS_DETAILED',
+    },
+    TR_TRADING_ERROR_UNAVAILABLE: {
+        defaultMessage: 'This service is currently unavailable.',
+        id: 'TR_TRADING_ERROR_UNAVAILABLE',
+    },
+    TR_TRADING_ERROR_UNAVAILABLE_DETAILED: {
+        defaultMessage: '{entityType} {entityValue} is currently unavailable.',
+        id: 'TR_TRADING_ERROR_UNAVAILABLE_DETAILED',
+    },
+    TR_TRADING_ERROR_INVALID_INPUT: {
+        defaultMessage: 'There was a problem with the trade parameters.',
+        id: 'TR_TRADING_ERROR_INVALID_INPUT',
+    },
+    TR_TRADING_ERROR_INVALID_INPUT_DETAILED: {
+        defaultMessage: 'Invalid trade parameters: {inputs}.',
+        id: 'TR_TRADING_ERROR_INVALID_INPUT_DETAILED',
+    },
+    TR_TRADING_ERROR_INVALID_RESPONSE: {
+        defaultMessage: 'Invalid response from the exchange.',
+        id: 'TR_TRADING_ERROR_INVALID_RESPONSE',
+    },
+    TR_TRADING_ERROR_INVALID_RESPONSE_DETAILED: {
+        defaultMessage: 'Invalid response from the exchange: {errors}.',
+        id: 'TR_TRADING_ERROR_INVALID_RESPONSE_DETAILED',
+    },
+    TR_TRADING_ERROR_NO_RESPONSE: {
+        defaultMessage: 'No response from the exchange. Please try again.',
+        id: 'TR_TRADING_ERROR_NO_RESPONSE',
+    },
+    TR_TRADING_ERROR_TRADE_NOT_FOUND: {
+        defaultMessage: 'The trade could not be found.',
+        id: 'TR_TRADING_ERROR_TRADE_NOT_FOUND',
+    },
+    TR_TRADING_ERROR_TRADE_NOT_FOUND_DETAILED: {
+        defaultMessage: 'Trade {id} could not be found.',
+        id: 'TR_TRADING_ERROR_TRADE_NOT_FOUND_DETAILED',
+    },
+    TR_TRADING_ERROR_TRADE_EXPIRED: {
+        defaultMessage: 'The trade expired. Please start a new one.',
+        id: 'TR_TRADING_ERROR_TRADE_EXPIRED',
+    },
+    TR_TRADING_ERROR_TRADE_EXPIRED_DETAILED: {
+        defaultMessage: 'The trade expired (order ID {orderId}). Please start a new one.',
+        id: 'TR_TRADING_ERROR_TRADE_EXPIRED_DETAILED',
+    },
+    TR_TRADING_ERROR_TRADE_FAILED: {
+        defaultMessage: 'The trade failed. Please contact support.',
+        id: 'TR_TRADING_ERROR_TRADE_FAILED',
+    },
+    TR_TRADING_ERROR_TRADE_FAILED_DETAILED: {
+        defaultMessage: 'The trade failed. Please contact support with order ID {orderId}.',
+        id: 'TR_TRADING_ERROR_TRADE_FAILED_DETAILED',
+    },
+    TR_TRADING_ERROR_TRADE_REFUNDED: {
+        defaultMessage: 'The trade failed and will be refunded.',
+        id: 'TR_TRADING_ERROR_TRADE_REFUNDED',
+    },
+    TR_TRADING_ERROR_TRADE_REFUNDED_DETAILED: {
+        defaultMessage: 'The trade failed and will be refunded. Order ID {orderId}.',
+        id: 'TR_TRADING_ERROR_TRADE_REFUNDED_DETAILED',
+    },
     TR_TRADING_CANNOT_CREATE_TRANSACTION: {
         defaultMessage: 'Unable to create transaction',
         id: 'TR_TRADING_CANNOT_CREATE_TRANSACTION',

--- a/suite/trading/package.json
+++ b/suite/trading/package.json
@@ -26,5 +26,8 @@
         "@trezor/theme": "workspace:*",
         "react": "19.2.4",
         "styled-components": "^6.3.9"
+    },
+    "devDependencies": {
+        "@types/invity-api": "^1.1.19"
     }
 }

--- a/suite/trading/src/constants/errorMessages.ts
+++ b/suite/trading/src/constants/errorMessages.ts
@@ -1,0 +1,51 @@
+import type { ErrorCode } from 'invity-api';
+
+import { type TranslationKey } from '@suite/intl';
+
+export const TRADING_ERROR_MESSAGE: Record<
+    ErrorCode,
+    { detailed?: TranslationKey; base: TranslationKey }
+> = {
+    invalid_amount: {
+        detailed: 'TR_TRADING_ERROR_INVALID_AMOUNT_DETAILED',
+        base: 'TR_TRADING_ERROR_INVALID_AMOUNT',
+    },
+    invalid_pair: {
+        detailed: 'TR_TRADING_ERROR_INVALID_PAIR_DETAILED',
+        base: 'TR_TRADING_ERROR_INVALID_PAIR',
+    },
+    invalid_address: {
+        detailed: 'TR_TRADING_ERROR_INVALID_ADDRESS_DETAILED',
+        base: 'TR_TRADING_ERROR_INVALID_ADDRESS',
+    },
+    unavailable: {
+        detailed: 'TR_TRADING_ERROR_UNAVAILABLE_DETAILED',
+        base: 'TR_TRADING_ERROR_UNAVAILABLE',
+    },
+    invalid_input: {
+        detailed: 'TR_TRADING_ERROR_INVALID_INPUT_DETAILED',
+        base: 'TR_TRADING_ERROR_INVALID_INPUT',
+    },
+    invalid_response: {
+        detailed: 'TR_TRADING_ERROR_INVALID_RESPONSE_DETAILED',
+        base: 'TR_TRADING_ERROR_INVALID_RESPONSE',
+    },
+    trade_not_found: {
+        detailed: 'TR_TRADING_ERROR_TRADE_NOT_FOUND_DETAILED',
+        base: 'TR_TRADING_ERROR_TRADE_NOT_FOUND',
+    },
+    trade_expired: {
+        detailed: 'TR_TRADING_ERROR_TRADE_EXPIRED_DETAILED',
+        base: 'TR_TRADING_ERROR_TRADE_EXPIRED',
+    },
+    trade_failed: {
+        detailed: 'TR_TRADING_ERROR_TRADE_FAILED_DETAILED',
+        base: 'TR_TRADING_ERROR_TRADE_FAILED',
+    },
+    trade_refunded: {
+        detailed: 'TR_TRADING_ERROR_TRADE_REFUNDED_DETAILED',
+        base: 'TR_TRADING_ERROR_TRADE_REFUNDED',
+    },
+    no_response: { base: 'TR_TRADING_ERROR_NO_RESPONSE' },
+    unknown: { base: 'TR_TRADING_ERROR_UNKNOWN' },
+};

--- a/suite/trading/src/index.ts
+++ b/suite/trading/src/index.ts
@@ -1,3 +1,4 @@
+export * from './constants/errorMessages';
 export * from './hooks';
 export * from './tradingMiddleware';
 export * from './ui';

--- a/yarn.lock
+++ b/yarn.lock
@@ -15431,6 +15431,7 @@ __metadata:
     "@trezor/components": "workspace:*"
     "@trezor/product-components": "workspace:*"
     "@trezor/theme": "workspace:*"
+    "@types/invity-api": "npm:^1.1.19"
     react: "npm:19.2.4"
     styled-components: "npm:^6.3.9"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -10798,7 +10798,7 @@ __metadata:
   resolution: "@suite-common/flags@workspace:suite-common/flags"
   dependencies:
     "@trezor/env-utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.15"
+    "@types/invity-api": "npm:^1.1.19"
   languageName: unknown
   linkType: soft
 
@@ -11378,7 +11378,7 @@ __metadata:
     "@trezor/react-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.15"
+    "@types/invity-api": "npm:^1.1.19"
     react: "npm:19.2.4"
     react-redux: "npm:9.3.0"
   languageName: unknown
@@ -11507,7 +11507,7 @@ __metadata:
     "@trezor/device-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:^"
-    "@types/invity-api": "npm:^1.1.15"
+    "@types/invity-api": "npm:^1.1.19"
     react: "npm:19.2.4"
   languageName: unknown
   linkType: soft
@@ -13642,7 +13642,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.15"
+    "@types/invity-api": "npm:^1.1.19"
     expo-linear-gradient: "npm:~55.0.8"
     react: "npm:19.2.4"
     react-intl: "npm:^8.1.3"
@@ -14246,7 +14246,7 @@ __metadata:
     "@suite-native/test-utils-store": "workspace:*"
     "@suite-native/trading-atoms": "workspace:*"
     "@suite-native/trading-fixtures": "workspace:*"
-    "@types/invity-api": "npm:^1.1.15"
+    "@types/invity-api": "npm:^1.1.19"
     react: "npm:19.2.4"
     react-redux: "npm:9.3.0"
   languageName: unknown
@@ -14280,7 +14280,7 @@ __metadata:
     "@trezor/theme": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.15"
+    "@types/invity-api": "npm:^1.1.19"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
     react-native-gesture-handler: "npm:2.31.1"
@@ -14315,7 +14315,7 @@ __metadata:
     "@suite-native/transaction-management": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.15"
+    "@types/invity-api": "npm:^1.1.19"
     expo-linking: "npm:~55.0.7"
     expo-web-browser: "npm:~55.0.9"
     react: "npm:19.2.4"
@@ -14371,7 +14371,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.15"
+    "@types/invity-api": "npm:^1.1.19"
   languageName: unknown
   linkType: soft
 
@@ -14406,7 +14406,7 @@ __metadata:
     "@suite-native/trading-state": "workspace:*"
     "@trezor/styles-native": "workspace:*"
     "@trezor/type-utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.15"
+    "@types/invity-api": "npm:^1.1.19"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
     react-native-safe-area-context: "npm:5.6.2"
@@ -14433,7 +14433,7 @@ __metadata:
     "@trezor/styles-native": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
-    "@types/invity-api": "npm:^1.1.15"
+    "@types/invity-api": "npm:^1.1.19"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
     react-native-reanimated: "npm:~4.2.1"
@@ -14457,7 +14457,7 @@ __metadata:
     "@suite-native/trading-fixtures": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.15"
+    "@types/invity-api": "npm:^1.1.19"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
     react-redux: "npm:9.3.0"
@@ -14520,7 +14520,7 @@ __metadata:
     "@trezor/styles-native": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.15"
+    "@types/invity-api": "npm:^1.1.19"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
     react-redux: "npm:9.3.0"
@@ -14557,7 +14557,7 @@ __metadata:
     "@trezor/device-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.15"
+    "@types/invity-api": "npm:^1.1.19"
     react-native: "npm:0.83.2"
   languageName: unknown
   linkType: soft
@@ -14574,7 +14574,7 @@ __metadata:
     "@suite-native/intl": "workspace:*"
     "@suite-native/navigation": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"
-    "@types/invity-api": "npm:^1.1.15"
+    "@types/invity-api": "npm:^1.1.19"
   languageName: unknown
   linkType: soft
 
@@ -16894,7 +16894,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.15"
+    "@types/invity-api": "npm:^1.1.19"
     "@types/lodash": "npm:^4.17.16"
     "@walletconnect/sign-client": "npm:^2.23.9"
     "@walletconnect/types": "npm:^2.23.9"
@@ -17088,7 +17088,7 @@ __metadata:
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/file-saver": "npm:^2.0.6"
-    "@types/invity-api": "npm:^1.1.15"
+    "@types/invity-api": "npm:^1.1.19"
     "@types/pako": "npm:^2.0.4"
     "@types/pdfmake": "npm:^0.3.1"
     "@types/react": "npm:19.2.14"
@@ -17883,10 +17883,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/invity-api@npm:^1.1.15":
-  version: 1.1.15
-  resolution: "@types/invity-api@npm:1.1.15"
-  checksum: 10/cbb8439b5b23eea8ac4f38a961b691b09871badbdc044940a04726a5850770b98ea203d3091a298acbec2d6de6d8b2cc4fc981b6d249cc99792273fded8c016c
+"@types/invity-api@npm:^1.1.19":
+  version: 1.1.19
+  resolution: "@types/invity-api@npm:1.1.19"
+  checksum: 10/45fee2e4e68537a544ee34800f7a1c5c799154b59748504014b3fcbae469d9954d4971e7dd265eb39f7cc0a7ac543cc0f8a94b5377b04e45d1cf4285159e17a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

POC: resolver mapping structured trade errors from `trezor-trade-api` to readable/translatable toast messages. Exchange (Swap) only, wired into trade confirmation.

- Resolver verified against debug throws (unit tests + checked in the browser, debug code removed).
- Error message translations are copies of the BE `errorMessages` — final wording needs to be defined with design.
- This PR is a POC; a follow-up PR needs to define and handle all API calls the resolver is relevant to.
- Desktop-only implementation, but prepared to work on native as well.

## Notes for QA

POC – only the exchange/Swap confirmation produces the new error toasts. Wording is placeholder (BE copy), don't QA the exact text.

## Related Issue

Resolve #26471

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/26471-trade-error-resolver&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/26471-trade-error-resolver&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/26471-trade-error-resolver&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T16:20:53.603Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T16:20:39.731Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/26471-trade-error-resolver/web/](https://dev.suite.sldev.cz/suite-web/feat/26471-trade-error-resolver/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->