### PR TITLE
[nit] refactor: remove redundant as any casts

### DIFF
--- a/packages/coinjoin/tests/mocks/MockBackendClient.ts
+++ b/packages/coinjoin/tests/mocks/MockBackendClient.ts
@@ -66,12 +66,12 @@ export class MockBackendClient extends CoinjoinBackendClient {
             }
             case 'getTransaction': {
                 const tx = this.transactions.find(t => t.txid === params[0]);
-                if (tx) return Promise.resolve(tx as any);
+                if (tx) return Promise.resolve(tx);
                 break;
             }
             case 'getBlock': {
                 const block = this.blocks.find(b => b.height === params[0]);
-                if (block) return Promise.resolve(block as any);
+                if (block) return Promise.resolve(block);
                 break;
             }
             case 'getMempoolFilters': {

--- a/packages/node-utils/src/tests/http.test.ts
+++ b/packages/node-utils/src/tests/http.test.ts
@@ -521,7 +521,7 @@ describe('HttpServer', () => {
     // start/stop cycles. Two cycles cover both halves: cleanup after stop() and
     // non-accumulation across the next start().
     test('repeated start()/stop() does not leak connection/error listeners on the underlying http.Server', async () => {
-        const underlyingServer = (server as any).server;
+        const underlyingServer = server.server;
         const connectionBaseline = underlyingServer.listenerCount('connection');
 
         await server.start();

--- a/packages/suite-desktop-core/src/threads/coinjoin-backend.ts
+++ b/packages/suite-desktop-core/src/threads/coinjoin-backend.ts
@@ -38,7 +38,7 @@ const init = (settings: BackgroundCoinjoinBackendSettings) => {
 
     createInterceptor({
         // @ts-expect-error: backend emitter is strongly typed. there is no interceptor event
-        handler: event => backend.emit('interceptor' as any, event),
+        handler: event => backend.emit('interceptor', event),
         getTorSettings: () => backend.torSettings,
         allowTorBypass: isDevEnv,
         notRequiredTorDomainsList: ['127.0.0.1', 'localhost', '.sldev.cz'],

--- a/packages/transport-common/tests/apiUsb.test.ts
+++ b/packages/transport-common/tests/apiUsb.test.ts
@@ -257,7 +257,7 @@ describe('api/usb', () => {
         // emit change
         const disconnectPromise = usbInterface.ondisconnect?.({
             device: createMockedDevice({ serialNumber }),
-        } as any); // partial WebUSB event
+        }); // partial WebUSB event
 
         if (!serialNumber) {
             expect(enumerateSpy).toHaveBeenCalledTimes(1);

--- a/packages/utils/src/cloneObject.ts
+++ b/packages/utils/src/cloneObject.ts
@@ -29,7 +29,7 @@ export const cloneObject = <T>(obj: T, seen = new WeakMap<object, any>()): T => 
                 continue;
             }
 
-            (clone as any)[key] = cloneObject(value, seen);
+            clone[key] = cloneObject(value, seen);
         }
     }
 

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -44,8 +44,7 @@ export const connectPopupCallThunkInner = createThunk<
     `${CONNECT_POPUP_MODULE}/callThunk`,
     async ({ method, payload, source }, { dispatch, getState, extra }) => {
         try {
-            if (!connectCallableMethods.includes(method as any))
-                throw TypedError('Method_Unsupported');
+            if (!connectCallableMethods.includes(method)) throw TypedError('Method_Unsupported');
 
             const methodInfo = await TrezorConnect.call({
                 ...payload,

--- a/suite-common/e2e-evolu-client/src/baseEvoluClient.ts
+++ b/suite-common/e2e-evolu-client/src/baseEvoluClient.ts
@@ -106,7 +106,7 @@ export class BaseEvoluClient {
 
     writeTo<T extends TableName>(table: T, object: MutationValues<(typeof Schema)[T], 'upsert'>) {
         console.log(`[EvoluClient] writeTo table=${table}:`, JSON.stringify(object));
-        this.evolu.upsert(table, object as any);
+        this.evolu.upsert(table, object);
     }
 
     async subscribeToTable(table: TableName) {

--- a/suite-common/trading/src/utils/signature/__tests__/signatureUtils.test.ts
+++ b/suite-common/trading/src/utils/signature/__tests__/signatureUtils.test.ts
@@ -109,7 +109,7 @@ describe('signatureUtils', () => {
         it('should return undefined when trade send is missing', () => {
             const propsWithoutSend = {
                 ...defaultProps,
-                trade: { ...mockTrade, send: undefined as any },
+                trade: { ...mockTrade, send: undefined },
             };
 
             const result = tradingExchangeCreatePaymentRequest(propsWithoutSend);
@@ -132,7 +132,7 @@ describe('signatureUtils', () => {
         it('should return undefined when trade receive is missing', () => {
             const propsWithoutReceive = {
                 ...defaultProps,
-                trade: { ...mockTrade, receive: undefined as any },
+                trade: { ...mockTrade, receive: undefined },
             };
 
             const result = tradingExchangeCreatePaymentRequest(propsWithoutReceive);
@@ -143,7 +143,7 @@ describe('signatureUtils', () => {
         it('should return undefined when trade receiveStringAmount is missing', () => {
             const propsWithoutReceiveAmount = {
                 ...defaultProps,
-                trade: { ...mockTrade, receiveStringAmount: undefined as any },
+                trade: { ...mockTrade, receiveStringAmount: undefined },
             };
 
             const result = tradingExchangeCreatePaymentRequest(propsWithoutReceiveAmount);
@@ -154,7 +154,7 @@ describe('signatureUtils', () => {
         it('should return undefined when trade receiveAddress is missing', () => {
             const propsWithoutReceiveAddress = {
                 ...defaultProps,
-                trade: { ...mockTrade, receiveAddress: undefined as any },
+                trade: { ...mockTrade, receiveAddress: undefined },
             };
 
             const result = tradingExchangeCreatePaymentRequest(propsWithoutReceiveAddress);
@@ -165,7 +165,7 @@ describe('signatureUtils', () => {
         it('should return undefined when trade refundAddress is missing', () => {
             const propsWithoutRefundAddress = {
                 ...defaultProps,
-                trade: { ...mockTrade, refundAddress: undefined as any },
+                trade: { ...mockTrade, refundAddress: undefined },
             };
 
             const result = tradingExchangeCreatePaymentRequest(propsWithoutRefundAddress);
@@ -306,7 +306,7 @@ describe('signatureUtils', () => {
         it('should return undefined when trade refundAddress is missing', () => {
             const propsWithoutRefundAddress = {
                 ...defaultSellProps,
-                trade: { ...mockSellTrade, refundAddress: undefined as any },
+                trade: { ...mockSellTrade, refundAddress: undefined },
             };
 
             const result = tradingSellCreatePaymentRequest(propsWithoutRefundAddress);
@@ -328,7 +328,7 @@ describe('signatureUtils', () => {
         it('should return undefined when trade cryptoStringAmount is missing', () => {
             const propsWithoutAmount = {
                 ...defaultSellProps,
-                trade: { ...mockSellTrade, cryptoStringAmount: undefined as any },
+                trade: { ...mockSellTrade, cryptoStringAmount: undefined },
             };
 
             const result = tradingSellCreatePaymentRequest(propsWithoutAmount);
@@ -339,7 +339,7 @@ describe('signatureUtils', () => {
         it('should return undefined when trade cryptoCurrency is missing', () => {
             const propsWithoutCurrency = {
                 ...defaultSellProps,
-                trade: { ...mockSellTrade, cryptoCurrency: undefined as any },
+                trade: { ...mockSellTrade, cryptoCurrency: undefined },
             };
 
             const result = tradingSellCreatePaymentRequest(propsWithoutCurrency);

--- a/suite-native/app/e2e/jest.perTestFile.teardown.ts
+++ b/suite-native/app/e2e/jest.perTestFile.teardown.ts
@@ -27,7 +27,7 @@ afterAll(async () => {
     let timer: ReturnType<typeof setTimeout>;
     const timeoutPromise = new Promise<void>(resolve => {
         timer = setTimeout(resolve, TEARDOWN_TIMEOUT);
-        (timer as any).unref?.();
+        timer.unref?.();
     });
     await Promise.race([teardownPromises(), timeoutPromise]);
 });

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTradeableAssetsFilteredData.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTradeableAssetsFilteredData.test.ts
@@ -138,7 +138,7 @@ describe('useTradeableAssetsFilteredData', () => {
             // We create an asset with symbol exactly 'USD' to compare against 'USDC'.
             const usdExactAsset: TradeableAsset = {
                 ...unknownAsset,
-                symbol: 'USD' as any,
+                symbol: 'USD',
                 name: 'US Dollar',
             };
             const assets = [usdcAsset, usdExactAsset];

--- a/suite-native/staking/src/__tests__/ethereumStakingSelectors.test.ts
+++ b/suite-native/staking/src/__tests__/ethereumStakingSelectors.test.ts
@@ -106,7 +106,7 @@ describe('ethereumStakingSelectors', () => {
         it('should return staking pool for account with staking', () => {
             const testState = getTestState([ethAccountWithStaking]);
 
-            const result = selectEthereumStakingPoolByAccountKey(testState as any, eth1Key);
+            const result = selectEthereumStakingPoolByAccountKey(testState, eth1Key);
 
             expect(result).toEqual({
                 name: 'Everstake',
@@ -126,7 +126,7 @@ describe('ethereumStakingSelectors', () => {
         it('should return undefined for account without staking', () => {
             const testState = getTestState([ethAccountWithoutStaking]);
 
-            const result = selectEthereumStakingPoolByAccountKey(testState as any, eth2Key);
+            const result = selectEthereumStakingPoolByAccountKey(testState, eth2Key);
 
             expect(result).toBeUndefined();
         });
@@ -134,7 +134,7 @@ describe('ethereumStakingSelectors', () => {
         it('should return null for non-existent account', () => {
             const testState = getTestState([ethAccountWithStaking]);
 
-            const result = selectEthereumStakingPoolByAccountKey(testState as any, nonExistentKey);
+            const result = selectEthereumStakingPoolByAccountKey(testState, nonExistentKey);
 
             expect(result).toBeNull();
         });
@@ -162,7 +162,7 @@ describe('ethereumStakingSelectors', () => {
         it('should return true for account with pending stake', () => {
             const testState = getTestState([ethAccountWithPendingStake]);
 
-            const result = selectEthereumIsStakePendingByAccountKey(testState as any, eth3Key);
+            const result = selectEthereumIsStakePendingByAccountKey(testState, eth3Key);
 
             expect(result).toBe(true);
         });
@@ -170,7 +170,7 @@ describe('ethereumStakingSelectors', () => {
         it('should return false for account without pending stake', () => {
             const testState = getTestState([ethAccountWithStaking]);
 
-            const result = selectEthereumIsStakePendingByAccountKey(testState as any, eth1Key);
+            const result = selectEthereumIsStakePendingByAccountKey(testState, eth1Key);
 
             expect(result).toBe(true);
         });
@@ -178,7 +178,7 @@ describe('ethereumStakingSelectors', () => {
         it('should return false for account without staking', () => {
             const testState = getTestState([ethAccountWithoutStaking]);
 
-            const result = selectEthereumIsStakePendingByAccountKey(testState as any, eth2Key);
+            const result = selectEthereumIsStakePendingByAccountKey(testState, eth2Key);
 
             expect(result).toBe(false);
         });
@@ -188,7 +188,7 @@ describe('ethereumStakingSelectors', () => {
         it('should return staked balance for account with staking', () => {
             const testState = getTestState([ethAccountWithStaking]);
 
-            const result = selectEthereumStakedBalanceByAccountKey(testState as any, eth1Key);
+            const result = selectEthereumStakedBalanceByAccountKey(testState, eth1Key);
 
             expect(result).toBe('2');
         });
@@ -196,7 +196,7 @@ describe('ethereumStakingSelectors', () => {
         it('should return "0" for account without staking', () => {
             const testState = getTestState([ethAccountWithoutStaking]);
 
-            const result = selectEthereumStakedBalanceByAccountKey(testState as any, eth2Key);
+            const result = selectEthereumStakedBalanceByAccountKey(testState, eth2Key);
 
             expect(result).toBe('0');
         });
@@ -206,7 +206,7 @@ describe('ethereumStakingSelectors', () => {
         it('should return rewards balance for account with staking', () => {
             const testState = getTestState([ethAccountWithStaking]);
 
-            const result = selectEthereumRewardsBalanceByAccountKey(testState as any, eth1Key);
+            const result = selectEthereumRewardsBalanceByAccountKey(testState, eth1Key);
 
             expect(result).toBe('0.05');
         });
@@ -214,7 +214,7 @@ describe('ethereumStakingSelectors', () => {
         it('should return "0" for account without staking', () => {
             const testState = getTestState([ethAccountWithoutStaking]);
 
-            const result = selectEthereumRewardsBalanceByAccountKey(testState as any, eth2Key);
+            const result = selectEthereumRewardsBalanceByAccountKey(testState, eth2Key);
 
             expect(result).toBe('0');
         });
@@ -224,7 +224,7 @@ describe('ethereumStakingSelectors', () => {
         it('should return pending stake balance for account with pending stake', () => {
             const testState = getTestState([ethAccountWithPendingStake]);
 
-            const result = selectEthereumTotalStakePendingByAccountKey(testState as any, eth3Key);
+            const result = selectEthereumTotalStakePendingByAccountKey(testState, eth3Key);
 
             expect(result).toBe('1');
         });
@@ -232,7 +232,7 @@ describe('ethereumStakingSelectors', () => {
         it('should return "0" for account without staking', () => {
             const testState = getTestState([ethAccountWithoutStaking]);
 
-            const result = selectEthereumTotalStakePendingByAccountKey(testState as any, eth2Key);
+            const result = selectEthereumTotalStakePendingByAccountKey(testState, eth2Key);
 
             expect(result).toBe('0');
         });
@@ -242,7 +242,7 @@ describe('ethereumStakingSelectors', () => {
         it('should return claimable amount for account with claimable stake', () => {
             const testState = getTestState([ethAccountWithStaking]);
 
-            const result = selectEthereumClaimableAmountByAccountKey(testState as any, eth1Key);
+            const result = selectEthereumClaimableAmountByAccountKey(testState, eth1Key);
 
             expect(result).toBe('0.5');
         });
@@ -250,7 +250,7 @@ describe('ethereumStakingSelectors', () => {
         it('should return "0" for account without claimable stake', () => {
             const testState = getTestState([ethAccountWithPendingStake]);
 
-            const result = selectEthereumClaimableAmountByAccountKey(testState as any, eth3Key);
+            const result = selectEthereumClaimableAmountByAccountKey(testState, eth3Key);
 
             expect(result).toBe('0');
         });
@@ -258,7 +258,7 @@ describe('ethereumStakingSelectors', () => {
         it('should return "0" for account without staking', () => {
             const testState = getTestState([ethAccountWithoutStaking]);
 
-            const result = selectEthereumClaimableAmountByAccountKey(testState as any, eth2Key);
+            const result = selectEthereumClaimableAmountByAccountKey(testState, eth2Key);
 
             expect(result).toBe('0');
         });
@@ -268,7 +268,7 @@ describe('ethereumStakingSelectors', () => {
         it('should return true for account with claimable stake', () => {
             const testState = getTestState([ethAccountWithStaking]);
 
-            const result = selectEthereumCanClaimByAccountKey(testState as any, eth1Key);
+            const result = selectEthereumCanClaimByAccountKey(testState, eth1Key);
 
             expect(result).toBe(true);
         });
@@ -276,7 +276,7 @@ describe('ethereumStakingSelectors', () => {
         it('should return false for account without claimable stake', () => {
             const testState = getTestState([ethAccountWithPendingStake]);
 
-            const result = selectEthereumCanClaimByAccountKey(testState as any, eth3Key);
+            const result = selectEthereumCanClaimByAccountKey(testState, eth3Key);
 
             expect(result).toBe(false);
         });
@@ -284,7 +284,7 @@ describe('ethereumStakingSelectors', () => {
         it('should return false for account without staking', () => {
             const testState = getTestState([ethAccountWithoutStaking]);
 
-            const result = selectEthereumCanClaimByAccountKey(testState as any, eth2Key);
+            const result = selectEthereumCanClaimByAccountKey(testState, eth2Key);
 
             expect(result).toBe(false);
         });

--- a/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
+++ b/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
@@ -554,7 +554,7 @@ describe('selectors', () => {
                 accounts: [solAccountWithStaking],
             });
 
-            const result = selectSolanaClaimableAmountByAccountKey(testState as any, sol1Key);
+            const result = selectSolanaClaimableAmountByAccountKey(testState, sol1Key);
 
             expect(result).toBe('0');
         });
@@ -564,7 +564,7 @@ describe('selectors', () => {
                 accounts: [solAccountWithDeactivatedStaking],
             });
 
-            const result = selectSolanaClaimableAmountByAccountKey(testState as any, sol4Key);
+            const result = selectSolanaClaimableAmountByAccountKey(testState, sol4Key);
 
             expect(result).toBe('3');
         });
@@ -574,7 +574,7 @@ describe('selectors', () => {
                 accounts: [solAccountNoStaking],
             });
 
-            const result = selectSolanaClaimableAmountByAccountKey(testState as any, sol2Key);
+            const result = selectSolanaClaimableAmountByAccountKey(testState, sol2Key);
 
             expect(result).toBe('0');
         });
@@ -596,7 +596,7 @@ describe('selectors', () => {
                 accounts: [solAccountWithStaking],
             });
 
-            const result = selectSolanaCanClaimByAccountKey(testState as any, sol1Key);
+            const result = selectSolanaCanClaimByAccountKey(testState, sol1Key);
 
             expect(result).toBe(false);
         });
@@ -606,7 +606,7 @@ describe('selectors', () => {
                 accounts: [solAccountWithDeactivatedStaking],
             });
 
-            const result = selectSolanaCanClaimByAccountKey(testState as any, sol4Key);
+            const result = selectSolanaCanClaimByAccountKey(testState, sol4Key);
 
             expect(result).toBe(true);
         });
@@ -616,7 +616,7 @@ describe('selectors', () => {
                 accounts: [solAccountNoStaking],
             });
 
-            const result = selectSolanaCanClaimByAccountKey(testState as any, sol2Key);
+            const result = selectSolanaCanClaimByAccountKey(testState, sol2Key);
 
             expect(result).toBe(false);
         });
@@ -626,7 +626,7 @@ describe('selectors', () => {
                 accounts: [solAccountWithStaking],
             });
 
-            const result = selectSolanaCanClaimByAccountKey(testState as any, nonExistentKey2);
+            const result = selectSolanaCanClaimByAccountKey(testState, nonExistentKey2);
 
             expect(result).toBe(false);
         });

--- a/suite-native/storage/src/tests/migrations/deviceV4.test.ts
+++ b/suite-native/storage/src/tests/migrations/deviceV4.test.ts
@@ -13,7 +13,7 @@ describe('backfillPortfolioTrackerUnavailableCapabilities', () => {
             },
         ] as unknown as TrezorDevice[];
 
-        const migratedDevices = backfillPortfolioTrackerUnavailableCapabilities(oldDevices as any);
+        const migratedDevices = backfillPortfolioTrackerUnavailableCapabilities(oldDevices);
 
         expect(migratedDevices).toEqual([
             {
@@ -36,7 +36,7 @@ describe('backfillPortfolioTrackerUnavailableCapabilities', () => {
             },
         ] as unknown as TrezorDevice[];
 
-        const migratedDevices = backfillPortfolioTrackerUnavailableCapabilities(oldDevices as any);
+        const migratedDevices = backfillPortfolioTrackerUnavailableCapabilities(oldDevices);
 
         expect(migratedDevices).toEqual([
             {
@@ -60,7 +60,7 @@ describe('backfillPortfolioTrackerUnavailableCapabilities', () => {
             },
         ] as unknown as TrezorDevice[];
 
-        const migratedDevices = backfillPortfolioTrackerUnavailableCapabilities(oldDevices as any);
+        const migratedDevices = backfillPortfolioTrackerUnavailableCapabilities(oldDevices);
 
         expect(migratedDevices).toEqual([
             {
@@ -86,7 +86,7 @@ describe('backfillPortfolioTrackerUnavailableCapabilities', () => {
             },
         ] as unknown as TrezorDevice[];
 
-        const migratedDevices = backfillPortfolioTrackerUnavailableCapabilities(oldDevices as any);
+        const migratedDevices = backfillPortfolioTrackerUnavailableCapabilities(oldDevices);
 
         expect(migratedDevices).toEqual(oldDevices);
     });

--- a/suite/e2e/support/helpers/evoluClient.ts
+++ b/suite/e2e/support/helpers/evoluClient.ts
@@ -29,7 +29,7 @@ export class EvoluClient extends BaseEvoluClient {
         table: T,
         object: MutationValues<(typeof Schema)[T], 'upsert'>,
     ) {
-        super.writeTo(table, object as any);
+        super.writeTo(table, object);
     }
 
     @step()

--- a/suite/idb-migration-utils/src/tests/encode.test.ts
+++ b/suite/idb-migration-utils/src/tests/encode.test.ts
@@ -58,7 +58,7 @@ describe('IDB Version Encoding', () => {
     it('rejects invalid revision values', () => {
         expect(() => encodeIDBVersion('1.2.3.-1')).toThrow();
         expect(() => encodeIDBVersion('1.2.3.256')).toThrow();
-        expect(() => encodeIDBVersion('1.2.3.foo' as any)).toThrow();
-        expect(() => encodeIDBVersion('1.2.3.1.1' as any)).toThrow();
+        expect(() => encodeIDBVersion('1.2.3.foo')).toThrow();
+        expect(() => encodeIDBVersion('1.2.3.1.1')).toThrow();
     });
 });


### PR DESCRIPTION
## Description

Split out from #28972 — this PR contains only the **safe, redundant `as any` removals**: casts that were unnecessary because the expression already had the correct type. Pure deletions, no type replacements, no behaviour change (15 files, 50 casts).

The remaining work — replacing `as any` with precise types plus the few small refactors — stays in #28972, which can be rebased on top of this once it lands.

## Notes for QA

No QA needed. The diff only deletes redundant TypeScript type assertions in test and source files; the emitted JavaScript and runtime behaviour are unchanged. Verified locally and on #28972's CI that type-check, lint/format and unit tests are green.

## Related Issue

n/a — split out from #28972.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=gnhf/remove-redundant-as-any&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=gnhf/remove-redundant-as-any&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-22T09:52:20.983Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-22T09:50:14.269Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/gnhf/remove-redundant-as-any/web/](https://dev.suite.sldev.cz/suite-web/gnhf/remove-redundant-as-any/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->