### PR TITLE
fix(suite-native): fixes android build after react-native-quick-crypto update

### DIFF
--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -137,6 +137,12 @@ const getPlugins = (): ExpoPlugins => {
                     // this fixes expo-updates build error
                     kotlinVersion: '2.1.20',
                     ndkVersion: '27.0.12077973',
+                    // react-native-quick-crypto (since v1) and expo-sqlite both bundle their
+                    // own OpenSSL libcrypto.so, which collides during mergeDebugNativeLibs.
+                    // pickFirst resolves the duplicate-.so packaging conflict.
+                    packagingOptions: {
+                        pickFirst: ['**/libcrypto.so'],
+                    },
                 },
                 ios: {
                     deploymentTarget: '15.1',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

After update of dependencies and more specifically https://github.com/trezor/trezor-suite/commit/0835525f8eade0b16a0bd27b0d087166ff9f4a8e, Android build started to fail. This change fixes the issue 

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Screenshots:

<img width="1080" height="2424" alt="Screenshot_1782121638" src="https://github.com/user-attachments/assets/fa745216-fa89-4d99-a4cf-305434d1eca3" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/android-build&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->