### PR TITLE
fix(suite): do not show address verification error toast on receive modal close

### DIFF
--- a/suite/receive/src/showAddressThunk.ts
+++ b/suite/receive/src/showAddressThunk.ts
@@ -87,7 +87,11 @@ export const showAddressThunk =
                 // Special case: device no-backup permissions not granted
                 response.error.code === 'Method_PermissionsNotGranted' ||
                 // User action: address cancelled on device
-                response.error.code === 'Failure_ActionCancelled'
+                response.error.code === 'Failure_ActionCancelled' ||
+                // User action: receive modal closed, cancelling the request
+                response.error.code === 'Method_Cancel' ||
+                // User action: connect popup closed, interrupting the request
+                response.error.code === 'Method_Interrupted'
             )
                 return;
 


### PR DESCRIPTION
## Description

Follow-up to #28725 

- no error when cancelling receive flow by closing passphrase
- no error when cancelling receive modal 
- no error when cancelling receive flow on device

https://github.com/user-attachments/assets/621e6290-aa0d-42dd-95ce-eff4372cf3d2

## Related Issue

Follow-up to #28725

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to showAddressThunk.ts directly impacts the core receive address flow in Trezor Suite — the thunk responsible for revealing and verifying addresses on the hardware device. High-priority tests focus on the receive address reveal flow across multiple coin types (BTC, ETH, SOL, TRX, ADA) and passphrase-protected wallet scenarios, which are the primary consumers of this thunk. Medium-priority tests cover related device prompt and address verification infrastructure. The change has no static coverage mapping, so all recommendations are inferred from LLM analysis of test behaviors.

<details><summary><b>Changed files (1)</b></summary>

- `suite/receive/src/showAddressThunk.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — This test directly exercises the receive address flow including revealing addresses on device and copying them — the core functionality of showAddressThunk. It tests BTC, ETH, SOL, and TRX address reveal flows, which are the primary consumers of this thunk.
- `suite/e2e/tests/wallet/cardano.test.ts` — This test explicitly exercises the Cardano receive address reveal and device confirmation flow, which directly invokes showAddressThunk for ADA addresses. It verifies address display on device and copy functionality.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test exercises revealing a Cardano receive address with passphrase re-entry after device restart, directly invoking showAddressThunk. It also tests the error case (wrong passphrase producing a verify address error toast), which is a key error path in the thunk.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test exercises revealing receive addresses before and after device disconnect/reconnect, testing passphrase re-confirmation during address reveal. The showAddressThunk handles the device interaction for address verification, including passphrase caching behavior.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test reveals receive addresses for multiple passphrase-protected wallets and verifies on-device address confirmation — directly exercising showAddressThunk. It also tests that previously revealed addresses persist when switching wallets.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test exercises the global receive flow including address reveal and device verification for ETH accounts, which directly calls showAddressThunk. It verifies the address matches between Suite UI and device display.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This test exercises TrezorConnect.getAddress with on-device verification (showOnTrezor: true), which shares the address display/verification infrastructure with showAddressThunk. Changes to address display logic could affect the verified badge flow.
- `suite/e2e/tests/wallet/public-keys.test.ts` — This test reveals public keys via a device prompt for BTC, LTC, and ADA accounts. While it uses showPublicKey rather than showAddress, they share similar device prompt and confirmation infrastructure that showAddressThunk may affect.
- `suite/e2e/tests/wallet/without-device.test.ts` — This test verifies that attempting to interact with the receive flow when the device is disconnected shows a connection modal. The showAddressThunk likely handles the device-not-connected error path that triggers this modal.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises TrezorConnect.getAddress via the web popup, which shares address confirmation UI components with Suite's receive flow. Changes to showAddressThunk are unlikely to affect the popup flow directly, but the address verification badge logic is shared.

</details>

_Updated: 2026-06-22T10:15:03.200Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/address-verification-cancel-toast-on-modal-close/web/](https://dev.suite.sldev.cz/suite-web/fix/address-verification-cancel-toast-on-modal-close/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/address-verification-cancel-toast-on-modal-close&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/address-verification-cancel-toast-on-modal-close&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-22T10:20:04.294Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-22T10:18:31.530Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->