### PR TITLE
fix: staging — small logical/correctness bug fixes from codebase sweep

### DIFF
--- a/packages/coinjoin/src/client/round/outputDecomposition.ts
+++ b/packages/coinjoin/src/client/round/outputDecomposition.ts
@@ -230,7 +230,7 @@ const findCredentialsForTarget = (
     maxValue: number,
 ): [middleware.Credentials, middleware.Credentials] | undefined => {
     // sort descending. higher possibility for match
-    const sorted = credentials.sort((a, b) => (a.Value > b.Value ? -1 : 1));
+    const sorted = credentials.sort((a, b) => b.Value - a.Value);
 
     // find one Credential big enough to cover requested target
     const bigCredential = sorted.find(cre => cre.Value >= target);
@@ -361,7 +361,7 @@ const createOutputsCredentials = async (params: CreateOutputsCredentials): Promi
             options.logger.info(`Vsize dust: ${vsizeDust}`);
             options.logger.info('Decomposition completed');
 
-            return result.sort((a, b) => (a.amount > b.amount ? -1 : 1));
+            return result.sort((a, b) => b.amount - a.amount);
         }
 
         // try to create another output

--- a/packages/connect/src/api/ethereum/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/ethereumSignTypedData.ts
@@ -164,7 +164,7 @@ export function getFieldType(
 
         return {
             data_type: type === 'uint' ? PROTO.EthereumDataType.UINT : PROTO.EthereumDataType.INT,
-            size: Math.floor(parseInt(bits, 10) / 8),
+            size: Math.floor((parseInt(bits, 10) || 256) / 8),
         };
     }
 

--- a/packages/connect/src/api/ethereum/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/ethereumSignTypedData.ts
@@ -112,7 +112,7 @@ export function encodeData(typeName: string, data: any) {
     if (numberMatch) {
         const intType = numberMatch[1] ?? '';
         const bits = numberMatch[2] ?? '';
-        const bytes = Math.ceil(parseInt(bits, 10) / 8);
+        const bytes = Math.ceil((parseInt(bits, 10) || 256) / 8);
 
         return intToHex(data, bytes, intType === 'int');
     }

--- a/packages/connect/src/device/thp/handshake.ts
+++ b/packages/connect/src/device/thp/handshake.ts
@@ -75,9 +75,11 @@ export const thpHandshake = async (device: IDevice, unlockPin = false) => {
 
     const settings = settingsStore.get('thp');
     // sort credentials by autoconnect field
-    const knownCredentials = (settings?.knownCredentials || []).sort(cre =>
-        cre.autoconnect ? -1 : 1,
-    );
+    const knownCredentials = (settings?.knownCredentials || []).sort((a, b) => {
+        if (a.autoconnect === b.autoconnect) return 0;
+
+        return a.autoconnect ? -1 : 1;
+    });
     const tryToUnlock = unlockPin ? 1 : 0;
 
     // 1. Generate a new ephemeral X25519 key pair (host_ephemeral_privkey, host_ephemeral_pubkey).

--- a/packages/product-components/src/components/PasswordStrengthIndicator/PasswordStrengthIndicator.tsx
+++ b/packages/product-components/src/components/PasswordStrengthIndicator/PasswordStrengthIndicator.tsx
@@ -38,7 +38,7 @@ const Line = styled.div<LineProps>`
 type OptionalZXCVBNScore = ZXCVBNScore | undefined;
 
 const getColor = (score: OptionalZXCVBNScore, password: string) => {
-    if (password === '' || Number.isNaN(score)) return 'transparent';
+    if (password === '' || score === undefined) return 'transparent';
     switch (score) {
         case 0:
         case 1:

--- a/packages/suite-desktop-core/src/modules/coinjoin.ts
+++ b/packages/suite-desktop-core/src/modules/coinjoin.ts
@@ -98,7 +98,10 @@ export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) 
                     logger.debug(SERVICE_NAME, `${BACKEND_CHANNEL} call ${method}`);
                     if (method === 'disable') {
                         backend.dispose();
-                        backends.splice(backends.indexOf(backend), 1);
+                        const backendIndex = backends.indexOf(backend);
+                        if (backendIndex !== -1) {
+                            backends.splice(backendIndex, 1);
+                        }
 
                         return Promise.resolve();
                     }
@@ -157,7 +160,10 @@ export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) 
                         }
                     }
                     if (method === 'disable') {
-                        clients.splice(clients.indexOf(client), 1);
+                        const clientIndex = clients.indexOf(client);
+                        if (clientIndex !== -1) {
+                            clients.splice(clientIndex, 1);
+                        }
 
                         if (clients.length === 0) {
                             logger.debug(SERVICE_NAME, `${CLIENT_CHANNEL} binary stop`);

--- a/packages/suite-desktop-core/src/modules/event-logging/contents.ts
+++ b/packages/suite-desktop-core/src/modules/event-logging/contents.ts
@@ -37,7 +37,7 @@ export const init: ModuleInit = ({ mainWindowProxy }) => {
             if (unresponsiveStart !== 0) {
                 logger.warn(
                     SERVICE_NAME,
-                    `Responsive again after ${(+new Date() - unresponsiveStart / 1000).toFixed(1)}s`,
+                    `Responsive again after ${((+new Date() - unresponsiveStart) / 1000).toFixed(1)}s`,
                 );
                 unresponsiveStart = 0;
             }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
@@ -101,7 +101,7 @@ export const AddTokenModal = ({ onCancel }: AddTokenModalProps) => {
                 type: events.addTokenEvent.name,
                 payload: {
                     networkSymbol: account.symbol,
-                    addedNth: account.tokens ? account.tokens.length + 1 : 0,
+                    addedNth: account.tokens?.length ? account.tokens.length + 1 : 1,
                     token: tokenInfo[0]?.symbol?.toLowerCase() || '',
                 },
             });

--- a/packages/suite/src/hooks/guide/useGuideSearch.ts
+++ b/packages/suite/src/hooks/guide/useGuideSearch.ts
@@ -24,7 +24,9 @@ export type SearchResult = {
 
 const getPreview = (markdown: string, query: string, index: number) => {
     const previewStart = markdown.substring(0, Math.max(index - 10, 0)).lastIndexOf(' ') + 1;
-    const previewEnd = markdown.indexOf(' ', index + query.length + 20);
+    const previewEndIndex = markdown.indexOf(' ', index + query.length + 20);
+    // indexOf returns -1 when no space is found; slice(n, -1) would drop the last character
+    const previewEnd = previewEndIndex === -1 ? undefined : previewEndIndex;
 
     return {
         content: markdown.slice(previewStart, previewEnd),

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -239,7 +239,7 @@ const addTxCandidate = (
     if (!account.transactionCandidates) {
         account.transactionCandidates = [];
     }
-    if (!account.transactionCandidates.some(tx => tx.roundId !== payload.roundId)) {
+    if (!account.transactionCandidates.some(tx => tx.roundId === payload.roundId)) {
         account.transactionCandidates.push({ roundId: payload.roundId });
     }
 };

--- a/packages/suite/src/reducers/wallet/graphReducer.ts
+++ b/packages/suite/src/reducers/wallet/graphReducer.ts
@@ -74,7 +74,9 @@ const remove = (draft: State, accounts: Account[]) => {
         );
         affected.forEach(d => {
             const index = draft.data.indexOf(d);
-            draft.data.splice(index, 1);
+            if (index !== -1) {
+                draft.data.splice(index, 1);
+            }
         });
     });
     updateError(draft);

--- a/suite-common/assets/src/utils.ts
+++ b/suite-common/assets/src/utils.ts
@@ -18,7 +18,7 @@ export const calculateAssetsPercentage = <T>(
 
     return assetsData.map(asset => {
         const fiatBalance = Number(asset.fiatBalance);
-        if (fiatTotal === 0 || Number.isNaN(asset.fiatBalance) || fiatBalance === 0) {
+        if (fiatTotal === 0 || Number.isNaN(fiatBalance) || fiatBalance === 0) {
             return { ...asset, fiatPercentage: 0, fiatPercentageOffset: 0 };
         }
 

--- a/suite-common/graph/src/graphUtils.ts
+++ b/suite-common/graph/src/graphUtils.ts
@@ -89,7 +89,7 @@ export const mapCryptoBalanceMovementToFixedTimeFrame = ({
                 };
             }
 
-            // Find the latest account balance before or at the fiatRatePoint time
+            // Find the first known account balance at or after the fiatRatePoint time
             const accountBalancePoint = balanceHistory.find(
                 point => point.time >= fiatRatePoint.time,
             );

--- a/suite-common/icons/scripts/downloadCryptoIcons.ts
+++ b/suite-common/icons/scripts/downloadCryptoIcons.ts
@@ -167,7 +167,7 @@ async function ensureDirectoryExists(path: string) {
         await fs.writeFile(UPDATED_ICONS_LIST_FILE, JSON.stringify(updatedIcons, null, 2));
 
         if (Date.now() - startedAt > RUN_LIMIT_SECONDS * 1000) {
-            console.log(`${i + 1 / coins.length}: Run limit reached`);
+            console.log(`${i + 1}/${coins.length}: Run limit reached`);
             break;
         }
 

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -392,7 +392,7 @@ export const getDeviceInstances = (
             if (!a.instance) return -1;
             if (!b.instance) return 1;
 
-            return a.instance > b.instance ? 1 : -1;
+            return a.instance - b.instance;
         }) as AcquiredDevice[];
 };
 

--- a/suite-common/toast-notifications/src/notificationsReducer.ts
+++ b/suite-common/toast-notifications/src/notificationsReducer.ts
@@ -34,7 +34,9 @@ export function createNotificationsReducer<
                 const arr = !Array.isArray(payload) ? [payload] : payload;
                 arr.forEach(item => {
                     const index = state.findIndex(n => n.id === item.id);
-                    state.splice(index, 1);
+                    if (index !== -1) {
+                        state.splice(index, 1);
+                    }
                 });
             })
             .addMatcher(

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -47,7 +47,9 @@ const update = (state: Account[], account: Account) => {
 const remove = (state: Account[], accounts: Account[]) => {
     accounts.forEach(a => {
         const index = state.findIndex(accountEqualTo(a));
-        state.splice(index, 1);
+        if (index !== -1) {
+            state.splice(index, 1);
+        }
     });
 };
 

--- a/suite-common/wallet-core/src/accounts/accountsSelectors.ts
+++ b/suite-common/wallet-core/src/accounts/accountsSelectors.ts
@@ -172,7 +172,7 @@ export const selectVisibleNonEmptyDeviceAccountsByNetworkSymbol = createMemoized
     accounts =>
         pipe(
             accounts,
-            A.filter(account => !account.empty || account.visible),
+            A.filter(account => !account.empty && account.visible),
             returnStableArrayIfEmpty,
         ),
 );

--- a/suite-common/wallet-utils/src/balanceUtils.ts
+++ b/suite-common/wallet-utils/src/balanceUtils.ts
@@ -35,7 +35,7 @@ export const formatCoinBalance = (value: string, locale: Locale = 'en-US') => {
         const fixedBalanceBig = new BigNumber(fixedBalance);
 
         // indicate the dust
-        const noDecimalsLeft = fixedBalanceBig.modulo(2).toFixed() === '0';
+        const noDecimalsLeft = fixedBalanceBig.modulo(1).toFixed() === '0';
         if (noDecimalsLeft) {
             return localizeNumber(fixedBalanceBig, locale, 2);
         }

--- a/suite-native/accounts/src/utils.ts
+++ b/suite-native/accounts/src/utils.ts
@@ -104,14 +104,18 @@ export const groupAccountsByNetworkAccountType = A.groupBy((account: Account) =>
 
 export const sortAccountsByNetworksAndAccountTypes = <T extends Account>(accounts: readonly T[]) =>
     A.sort(accounts, (a, b) => {
-        const aOrder = networkSymbolCollection.indexOf(a.symbol) ?? Number.MAX_SAFE_INTEGER;
-        const bOrder = networkSymbolCollection.indexOf(b.symbol) ?? Number.MAX_SAFE_INTEGER;
+        const aSymbolIndex = networkSymbolCollection.indexOf(a.symbol);
+        const aOrder = aSymbolIndex >= 0 ? aSymbolIndex : Number.MAX_SAFE_INTEGER;
+        const bSymbolIndex = networkSymbolCollection.indexOf(b.symbol);
+        const bOrder = bSymbolIndex >= 0 ? bSymbolIndex : Number.MAX_SAFE_INTEGER;
 
         if (aOrder === bOrder) {
+            const aAccountTypeIndex = orderedAccountTypes.indexOf(a.accountType);
             const aAccountTypeOrder =
-                orderedAccountTypes.indexOf(a.accountType) ?? Number.MAX_SAFE_INTEGER;
+                aAccountTypeIndex >= 0 ? aAccountTypeIndex : Number.MAX_SAFE_INTEGER;
+            const bAccountTypeIndex = orderedAccountTypes.indexOf(b.accountType);
             const bAccountTypeOrder =
-                orderedAccountTypes.indexOf(b.accountType) ?? Number.MAX_SAFE_INTEGER;
+                bAccountTypeIndex >= 0 ? bAccountTypeIndex : Number.MAX_SAFE_INTEGER;
 
             return aAccountTypeOrder - bAccountTypeOrder;
         }

--- a/suite-native/accounts/src/utils.ts
+++ b/suite-native/accounts/src/utils.ts
@@ -45,8 +45,8 @@ export const isFilterValueMatchingAccount = (
         formattedAccountTypeMap[account.networkType]?.[account.accountType]?.toLowerCase();
 
     const isMatchingAccountType =
-        (lowercasedSectionHeader?.includes(filterValue) ||
-            (isBitcoinNetworkType && lowerCasedAccountType?.includes(filterValue))) ??
+        (lowercasedSectionHeader?.includes(lowerCaseFilterValue) ||
+            (isBitcoinNetworkType && lowerCasedAccountType?.includes(lowerCaseFilterValue))) ??
         false;
 
     if (isMatchingAccountType) return true;

--- a/suite-native/device-mutex/src/DeviceAccessMutex.ts
+++ b/suite-native/device-mutex/src/DeviceAccessMutex.ts
@@ -13,7 +13,7 @@ class DeviceAccessMutex {
         if (this.isLocked) {
             return new Promise(resolve => {
                 // Put prioritized task at the beginning of the queue.
-                this.taskQueue.splice(1, 0, () => resolve(true));
+                this.taskQueue.unshift(() => resolve(true));
             });
         }
         this.isLocked = true;

--- a/suite-native/device-mutex/src/tests/DeviceAccessMutex.test.ts
+++ b/suite-native/device-mutex/src/tests/DeviceAccessMutex.test.ts
@@ -105,10 +105,12 @@ describe('RequestPrioritizedDeviceAccess', () => {
         // Execute prioritized task.
         await requestPrioritizedDeviceAccess(deviceAccessCallbackMock);
 
-        // The prioritized task should be put at the beginning of the queue, so after its execution,
-        // so there should be still the rest of the tasks in the queue.
+        // The prioritized task was put at the beginning of the queue (position 0), so it ran
+        // right after task 0 finished, skipping all previously queued tasks.
+        // After the prioritized task finishes: task 1 has been dequeued and is running,
+        // tasks 2, 3, 4 remain in the queue.
         expect(deviceAccessMutex.isLocked).toBe(true);
-        expect(deviceAccessMutex.taskQueue.length).toBe(2);
+        expect(deviceAccessMutex.taskQueue.length).toBe(3);
     });
 });
 

--- a/suite/e2e/support/common.ts
+++ b/suite/e2e/support/common.ts
@@ -9,7 +9,7 @@ import { validJws } from '@suite-common/message-system/src/__fixtures__/messageS
 import { type TradingCountryCode, regional } from '@suite-common/trading';
 import { getAccountDecimals, localizeNumber } from '@suite-common/wallet-utils';
 import { Model } from '@trezor/trezor-user-env-link';
-import { BigNumber, splitStringEveryNCharacters } from '@trezor/utils';
+import { BigNumber, splitStringEveryNCharacters, versionUtils } from '@trezor/utils';
 
 import { PlaywrightTarget } from './testExtends/suiteTestOptions';
 import { PercentageOfBalanceParams } from './types';
@@ -99,8 +99,13 @@ export const findLatestVersionForModel = (model: Model): string => {
     const firmwareVersions = releases.firmware;
     const versions = Object.keys(firmwareVersions);
 
-    // Sort versions in descending order
-    versions.sort((a, b) => (a > b ? -1 : 1));
+    // Sort versions in descending order (semantic, not lexicographic)
+    versions.sort((a, b) => {
+        if (versionUtils.isNewer(a, b)) return -1;
+        if (versionUtils.isNewer(b, a)) return 1;
+
+        return 0;
+    });
 
     // Find the latest version supporting our model
     for (const version of versions) {


### PR DESCRIPTION
## Description

Staging branch for a small automated bug-fix sweep, now triaged. The original 23 commits were each reviewed (is it a real bug? is the fix correct? does it regress anything?); harmful and no-op commits were dropped, leaving **15 curated fixes** that are being split out into small, single-purpose PRs for review.

**Dropped after review:** a `getMevProtectedTxData` change that would have broken Bitcoin sending, a `sortByCoin` change that inverted account ordering and broke a test, an obsolete hidden-token sort (already reworked on `develop`), and several no-op changes over unreachable/dead code.

This umbrella PR is **not a merge candidate** — it tracks the split-out. Review and merge happen in the child PRs below.

## Split-out PRs

- [ ] #28995 — `fix(connect)`: size bare uint/int EIP-712 fields as 256-bit
- [ ] #28997 — `fix(connect)`: remove stray `$` in HTTP status error messages
- [ ] #29073 — `fix(utils)`: cap bytesToHumanReadable (infinite-loop guard) + test
- [ ] #29074 — `fix(wallet-utils)`: sum staked + free Tron bandwidth (phantom fee) + test
- [ ] #29082 — `fix(wallet-core)`: guard removeAccount from deleting the wrong account + tests
- [ ] #29392 — `fix(device-mutex)`: prioritizedLock enqueue at front + clearQueue cancel a prioritized waiter
- [ ] #30011 — `fix(suite-desktop-core, icons)`: operator precedence in two log statements
- [ ] #30012 — `fix(suite-desktop-core)`: guard coinjoin splice(indexOf) on disable race
- [ ] remaining reducer / array-index `splice(-1)` guards (coinjoin dedup, guide search) — _to be opened_
- [ ] `wallet-utils` numeric fixes (dust rounding, assets %) — _to be opened_
- [ ] misc (device-mutex priority, desktop log precedence, account-type search, e2e fw sort) — _to be opened_

## Notes for QA

No QA on this umbrella branch — QA happens per child PR.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/logic-bug-fixes-staging/web/](https://dev.suite.sldev.cz/suite-web/mroz22/logic-bug-fixes-staging/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/logic-bug-fixes-staging&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/logic-bug-fixes-staging&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/logic-bug-fixes-staging&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T14:10:17.457Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-02T14:07:07.891Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->



