### PR TITLE
chore(eslint): enable no-unnecessary-type-assertion (rule + divergence disables)

### DIFF
--- a/packages/connect/src/api/ethereum/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/ethereumSignTypedData.ts
@@ -304,6 +304,9 @@ export const transformTypedData = <
     if (data.primaryType !== 'EIP712Domain') {
         message_hash = hashStruct({
             data: data.message,
+            // Load-bearing widening: without it viem's hashStruct rejects `string | keyof T`
+            // for primaryType (TS2322); the lint rule mis-reports the assertion as a no-op.
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
             primaryType: data.primaryType as string,
             types: data.types as any,
         }).slice(2);

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -138,6 +138,17 @@ export const typescriptConfig = [
                 },
             ],
             '@typescript-eslint/prefer-optional-chain': ['error'],
+            // Known limitation: the rule mis-reports some load-bearing widening assertions
+            // (removing them breaks tsc); such spots carry a scoped disable with a justification.
+            '@typescript-eslint/no-unnecessary-type-assertion': ['error'],
+        },
+    },
+    {
+        // Type assertions on partial mocks and fixtures are idiomatic in tests,
+        // so scope the rule out of test and fixture files.
+        files: ['**/__tests__/**', '**/__fixtures__/**', '**/tests/**', '**/*.test.{ts,tsx}'],
+        rules: {
+            '@typescript-eslint/no-unnecessary-type-assertion': 'off',
         },
     },
 ];

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -679,12 +679,12 @@ export const TransactionReviewOutput = (props: TransactionReviewOutputProps) => 
         if (line.type === 'address') {
             const relevantAccounts = findAccountsByAddress(symbol, line.value, accounts);
 
+            const type: OutputElementLine['type'] =
+                isTrading || stakeType || relevantAccounts.length > 0 ? 'safe-address' : line.type;
+
             return {
                 ...line,
-                type:
-                    isTrading || stakeType || relevantAccounts.length > 0
-                        ? ('safe-address' as OutputElementLine['type'])
-                        : line.type,
+                type,
             };
         }
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -6,7 +6,6 @@ import { formatDurationStrict } from '@suite-common/suite-utils';
 import { type NetworkType, networks } from '@suite-common/wallet-config';
 import { selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import {
-    type AccountWithNetworkType,
     type FeeInfo,
     type GeneralPrecomposedTransactionFinal,
     type SendFormDraftKey,
@@ -100,10 +99,7 @@ export const TransactionReviewSummary = ({
                     )}
 
                     {isEthereumNetworkType && (
-                        <TransactionReviewEthereumNotes
-                            account={account as AccountWithNetworkType<'ethereum'>}
-                            tx={tx}
-                        />
+                        <TransactionReviewEthereumNotes account={account} tx={tx} />
                     )}
 
                     {!['ethereum', 'solana', 'tron'].includes(networkType) && (

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeFormDefaultValues.ts
@@ -66,12 +66,17 @@ export const useTradingExchangeFormDefaultValues = (accountKey: AccountKey, cryp
             sendCryptoSelect: defaultAsset,
             receiveCryptoSelect: null,
             receiveAddress: undefined,
+            // Load-bearing widening: without the assertions these literal constants widen to
+            // `string` in the object literal and defaultValues no longer satisfies the form's
+            // union field types; the lint rule mis-reports the assertions as no-ops.
+            /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
             [TRADING_EXCHANGE_RATE]: TRADING_EXCHANGE_RATE_FLOATING as TradingExchangeRateType,
             [TRADING_EXCHANGE_FORM]: TRADING_EXCHANGE_FORM_CEX as TradingExchangeFormType,
             [TRADING_EXCHANGE_COMPARATOR_KYC_FILTER]:
                 TRADING_EXCHANGE_COMPARATOR_KYC_FILTER_ALL as TradingExchangeKycFilter,
             [TRADING_EXCHANGE_COMPARATOR_RATE_FILTER]:
                 TRADING_EXCHANGE_COMPARATOR_RATE_FILTER_ALL as TradingExchangeRateFilter,
+            /* eslint-enable @typescript-eslint/no-unnecessary-type-assertion */
         }),
         [defaultAsset, defaultFormState],
     );

--- a/packages/suite/src/hooks/wallet/useEthereumCancelTxCompose.ts
+++ b/packages/suite/src/hooks/wallet/useEthereumCancelTxCompose.ts
@@ -13,7 +13,6 @@ import {
     type Account,
     type FormState,
     type PrecomposedTransactionFinalCancelRbf,
-    type RbfTransactionParamsEthereum,
     type WalletAccountTransactionWithRequiredRbfParams,
 } from '@suite-common/wallet-types';
 
@@ -62,7 +61,7 @@ export const useEthereumCancelTxCompose = ({ account, tx }: UseEthereumCancelTxC
                 throw new Error('Missing fee info or invalid RBF params for Ethereum cancellation');
             }
 
-            const rbfParams = tx.rbfParams as RbfTransactionParamsEthereum;
+            const { rbfParams } = tx;
             const network = getNetwork(account.symbol);
 
             const formState: FormState = {

--- a/packages/suite/src/hooks/wallet/useTradingRedirect.ts
+++ b/packages/suite/src/hooks/wallet/useTradingRedirect.ts
@@ -80,6 +80,9 @@ const getTokenInfo = (cryptoId: CryptoId): TokenInfo | undefined => {
 
     // TODO this conversion is not valid, not all required fields are present
     return {
+        // Load-bearing widening: with the branded TokenAddress the outer `as TokenInfo`
+        // conversion is rejected (TS2352); the lint rule mis-reports the assertion as a no-op.
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         contract: contractAddress as string,
     } as TokenInfo;
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC.tsx
@@ -12,7 +12,6 @@ import {
     useFetchOtc,
 } from '@suite-common/trading';
 import { selectBaseCurrency } from '@suite-common/wallet-core';
-import { type TokenAddress } from '@suite-common/wallet-types';
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { Banner, Column, Text } from '@trezor/components';
 
@@ -73,7 +72,7 @@ export const TradingFormOfferOTC = () => {
     const { fiatAmount: fiatAmountConverted } = useFiatFromCryptoValue({
         amount: cryptoAmount || '0',
         symbol: network?.symbol || 'btc',
-        tokenAddress: contractAddress as TokenAddress | undefined,
+        tokenAddress: contractAddress,
         rateType: 'current',
     });
 

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
@@ -5,7 +5,7 @@ import { Address } from '@suite/address';
 import { Translation, useTranslation } from '@suite/intl';
 import { cryptoIdToNetworkSymbolAndContractAddress, useTradingAssets } from '@suite-common/trading';
 import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
-import { type Account, type TokenAddress } from '@suite-common/wallet-types';
+import { type Account } from '@suite-common/wallet-types';
 import { Card, Column, Row, Skeleton, Text } from '@trezor/components';
 import { AssetLogo, CoinLogo } from '@trezor/product-components';
 
@@ -142,9 +142,7 @@ export const TradingInfoItem = ({
                                         amount={amount}
                                         symbol={currencyInfo.symbol}
                                         rateType="current"
-                                        tokenAddress={
-                                            currencyInfo.contractAddress as TokenAddress | undefined
-                                        }
+                                        tokenAddress={currencyInfo.contractAddress}
                                         showApproximationIndicator
                                     />
                                 </Text>

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
@@ -1,5 +1,3 @@
-import { type CryptoId } from 'invity-api';
-
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
@@ -93,7 +91,7 @@ export const TradingOfferExchange = () => {
                         key={amountLabels.sendLabel}
                         account={sendAccount}
                         label={amountLabels.sendLabel}
-                        currency={selectedTrade.send as CryptoId}
+                        currency={selectedTrade.send}
                         amount={selectedTrade.sendStringAmount ?? ''}
                     />
 

--- a/packages/utils/src/hexToRgba.ts
+++ b/packages/utils/src/hexToRgba.ts
@@ -1,4 +1,7 @@
-export function hexToRgba(hex: string, alpha?: number) {
+export function hexToRgba(
+    hex: string,
+    alpha?: number,
+): `rgba(${number}, ${number}, ${number}, ${number})` | `rgb(${number}, ${number}, ${number})` {
     const norm = hex.replace('#', '');
     const r = parseInt(norm.slice(0, 2), 16);
     const g = parseInt(norm.slice(2, 4), 16);
@@ -6,14 +9,14 @@ export function hexToRgba(hex: string, alpha?: number) {
     const embeddedAlpha = norm.length === 8 ? parseInt(norm.slice(6, 8), 16) / 255 : undefined;
 
     if (alpha !== undefined && alpha > 0) {
-        return `rgba(${r}, ${g}, ${b}, ${alpha})` as `rgba(${number}, ${number}, ${number}, ${number})`;
+        return `rgba(${r}, ${g}, ${b}, ${alpha})`;
     }
 
     if (embeddedAlpha !== undefined && embeddedAlpha < 1) {
         const formattedAlpha = Math.round(embeddedAlpha * 100) / 100;
 
-        return `rgba(${r}, ${g}, ${b}, ${formattedAlpha})` as `rgba(${number}, ${number}, ${number}, ${number})`;
+        return `rgba(${r}, ${g}, ${b}, ${formattedAlpha})`;
     }
 
-    return `rgb(${r}, ${g}, ${b})` as `rgb(${number}, ${number}, ${number})`;
+    return `rgb(${r}, ${g}, ${b})`;
 }

--- a/suite-common/calldata/src/encoder/evm.ts
+++ b/suite-common/calldata/src/encoder/evm.ts
@@ -39,6 +39,9 @@ export const createEvmEncoder = <const T extends Abi>(
             }
         }
 
+        // Load-bearing: without the assertion the inferred argument type does not satisfy
+        // viem's EncodeFunctionDataParameters (TS2345); the lint rule mis-reports it as a no-op.
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         return encodeFunctionData({
             abi,
             functionName: fn.name,

--- a/suite-common/trading/src/hooks/useTradingFiatValues.ts
+++ b/suite-common/trading/src/hooks/useTradingFiatValues.ts
@@ -69,9 +69,7 @@ export const useTradingFiatValues = ({
 
         return {
             network: assetInfo?.network,
-            contractAddress: isNativeToken
-                ? undefined
-                : (assetInfo?.contractAddress as TokenAddress | undefined),
+            contractAddress: isNativeToken ? undefined : assetInfo?.contractAddress,
             symbol: assetInfo?.network?.symbol ?? TRADING_DEFAULT_CRYPTO_CURRENCY,
         };
     }, [cryptoId, isNativeToken]);

--- a/suite-common/trading/src/utils/exchange/resolveExchangeTradeError.ts
+++ b/suite-common/trading/src/utils/exchange/resolveExchangeTradeError.ts
@@ -36,7 +36,7 @@ export const isResolvedTradeError = (value: unknown): value is ResolvedTradeErro
     typeof value === 'object' &&
     value !== null &&
     'code' in value &&
-    typeof (value as { code: unknown }).code === 'string';
+    typeof value.code === 'string';
 
 export type TradingErrorDisplay =
     | { kind: 'detailed'; values: TradingErrorValuesRecord }

--- a/suite-native/firmware/src/hooks/useFirmwareAnalytics.ts
+++ b/suite-native/firmware/src/hooks/useFirmwareAnalytics.ts
@@ -29,12 +29,12 @@ export const useFirmwareAnalytics = ({
     const toFwVersion = useSelector(selectDeviceUpdateFirmwareVersion);
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const prepareAnalyticsPayload = useCallback(
-        () => ({
+        (): FirmwareUpdatePayload => ({
             model: device?.features?.internal_model ?? DeviceModelInternal.UNKNOWN,
             fromBootloaderVersion: getBootloaderVersion(device),
             fromFwVersion: device?.firmware === 'none' ? 'none' : getFirmwareVersion(device),
             toFwVersion: toFwVersion ?? '?.?.?',
-            fromFwType: (device?.firmwareType || 'none') as FirmwareType | 'none',
+            fromFwType: device?.firmwareType || 'none',
             toFwType: targetFirmwareType,
             location: navigationLocation ?? null,
         }),

--- a/suite-native/module-trading/src/hooks/general/useTradingStellarActivateToken.tsx
+++ b/suite-native/module-trading/src/hooks/general/useTradingStellarActivateToken.tsx
@@ -7,7 +7,6 @@ import { isFulfilled } from '@reduxjs/toolkit';
 import { type BuyTrade, type CryptoId, type ExchangeTrade } from 'invity-api';
 
 import { cryptoIdToNetworkAndContractAddress } from '@suite-common/trading';
-import { type TokenAddress } from '@suite-common/wallet-types';
 import { useAlert } from '@suite-native/alerts';
 import { AnimatedBox, Button } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
@@ -63,7 +62,7 @@ export const useTradingStellarActivateToken = ({
         if (!receiveContractAddress) return;
 
         const accountKey = selectedReceiveAccount.account.key;
-        const tokenContract = receiveContractAddress as TokenAddress;
+        const tokenContract = receiveContractAddress;
 
         setIsComposingFees(true);
 
@@ -77,7 +76,7 @@ export const useTradingStellarActivateToken = ({
                     screen: StellarManageTokenStackRoutes.ActivationFee,
                     params: {
                         accountKey: selectedReceiveAccount.account.key,
-                        tokenContract: receiveContractAddress as TokenAddress,
+                        tokenContract: receiveContractAddress,
                         isTrading: true,
                     },
                 });

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -36,7 +36,6 @@ import {
     type FeeInfo,
     type FeeLevelLabel,
     type PrecomposedTransactionFinal,
-    type TokenAddress,
     isFinalPrecomposedTransaction,
 } from '@suite-common/wallet-types';
 import {
@@ -299,11 +298,7 @@ export const composeEvmApprovalFeeLevelsThunk = createThunk(
                 return rejectWithValue('Could not extract token contract address');
             }
 
-            const token = selectAccountTokenInfo(
-                getState(),
-                account.key,
-                contractAddress as TokenAddress,
-            );
+            const token = selectAccountTokenInfo(getState(), account.key, contractAddress);
 
             if (!token) {
                 return rejectWithValue('Token not found in account');
@@ -375,7 +370,7 @@ export const composeEvmApprovalFeeLevelsThunk = createThunk(
                                       fiat: '',
                                       currency: { label: '', value: '' },
                                       label: '',
-                                      token: contractAddress as TokenAddress,
+                                      token: contractAddress,
                                   },
                               ];
 

--- a/suite-native/storage/src/transforms/tokenDefinitionsTransforms.ts
+++ b/suite-native/storage/src/transforms/tokenDefinitionsTransforms.ts
@@ -29,6 +29,6 @@ export const tokenDefinitionsPersistTransform = createTransform<
 
         return result;
     },
-    outboundState => outboundState as TokenDefinitionsState,
+    outboundState => outboundState,
     { whitelist: ['tokenDefinitions'] },
 );

--- a/suite-native/transaction-management/src/selectors.ts
+++ b/suite-native/transaction-management/src/selectors.ts
@@ -32,7 +32,6 @@ import {
 import { BigNumber, isNotNullOrUndefined } from '@trezor/utils';
 
 import { type NativeSendRootState } from './sendFormSlice';
-import { type StatefulReviewOutput } from './types';
 
 const isStakingPrefix = (
     prefix: FormDraftWithSendKeyPrefix,
@@ -122,15 +121,13 @@ export const selectTransactionReviewOutputs = createSendMemoizedSelector(
             ? outputs
             : outputs?.filter(output => output.type !== 'fee'); // The `fee` output is already included in the final transaction summary output.
 
-        return newFlowOutputs.map(
-            (output, outputIndex) =>
-                ({
-                    ...output,
-                    state: isTransactionAlreadySigned
-                        ? 'success'
-                        : getTransactionReviewOutputState(outputIndex, sendReviewButtonRequests),
-                }) as StatefulReviewOutput,
-        );
+        return newFlowOutputs.map((output, outputIndex) => {
+            const outputState: ReviewOutputState = isTransactionAlreadySigned
+                ? 'success'
+                : getTransactionReviewOutputState(outputIndex, sendReviewButtonRequests);
+
+            return { ...output, state: outputState };
+        });
     },
 );
 
@@ -230,7 +227,7 @@ export const selectReviewSummaryOutputState = (
     prefix: FormDraftWithSendKeyPrefix,
     accountKey: AccountKey,
     tokenContract?: TokenAddress,
-) => {
+): ReviewOutputState => {
     const isTransactionAlreadySigned = selectIsTransactionAlreadySigned(state);
 
     if (isTransactionAlreadySigned) {
@@ -259,7 +256,7 @@ export const selectReviewSummaryOutput = createSendMemoizedSelector(
         }
 
         return {
-            state: outputState as ReviewOutputState,
+            state: outputState,
             totalSpent: precomposedTx.totalSpent,
             fee: precomposedTx.fee,
         };

--- a/suite/router/src/routerReducer.ts
+++ b/suite/router/src/routerReducer.ts
@@ -62,6 +62,10 @@ const initialState: RouterState = {
 
 const routerSlice = createSlice({
     name: ROUTER_PREFIX,
+    // Load-bearing un-narrowing: TS narrows the const's declared union by its initializer
+    // (the `app: 'unknown'` variant), so createSlice would infer that narrowed State; the
+    // assertion restores the full RouterState. The lint rule mis-reports it as a no-op.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     initialState: initialState as RouterState,
     reducers: {
         routerLocationChange: (state, action: PayloadAction<LocationChangePayload>) => {


### PR DESCRIPTION
## Summary

Final step of the repo-wide rollout of the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion`. All the per-package fix PRs (the assertion removals) have been merged; **this PR flips the switch** — it enables the rule and adds scoped `eslint-disable`s to the handful of divergence cases. Merging this completes the initiative.

Follow-up: #29607 extracts the `RgbColor`/`RgbaColor` template-literal types into `@trezor/utils` per review feedback (stacked on this PR).

## What this PR does

- **Enables the rule** on `**/src/**/*.{ts,tsx}` (where type information is available), reusing the TypeScript program the existing type-aware rules already build — so the marginal lint cost is negligible.
- **Excludes tests & fixtures** (`**/__tests__/**`, `**/__fixtures__/**`, `**/tests/**`, `**/*.test.{ts,tsx}`): type assertions on partial mocks/fixtures there are idiomatic.
- **Keeps 8 load-bearing assertions (5 files)** behind a scoped `eslint-disable`, each with a comment stating what breaks without it. The rule mis-reports these widening/un-narrowing assertions as no-ops, but removing any of them fails `tsc --build` (verified by removing each one and running the full-repo type-check): viem conditional generics (`ethereumSignTypedData.ts`, `calldata/encoder/evm.ts`), literal widening in exchange form defaults (`useTradingExchangeFormDefaultValues.ts`), branded `TokenAddress` vs the `as TokenInfo` conversion (`useTradingRedirect.ts`), and `createSlice` state inference vs const union narrowing (`routerReducer.ts`).
- **Replaces two would-be disables with explicit annotations instead**: `hexToRgba` now declares its precise template-literal return type (emitted `.d.ts` is unchanged), and `selectReviewSummaryOutputState` declares `ReviewOutputState`, which removes the need for the assertion in `selectReviewSummaryOutput`.

Diff = the ESLint config + the disable/annotation files above + a small set of late-arriving assertion removals in trading code that landed on `develop` during the rollout (the rule flags them, so they ship here).

## Fix PRs (all merged)

The assertion removals were split out per package for easy review and have all landed:

**Batch 1 — large packages:** #29189 utxo-lib · #29190/#29191/#29192/#29193 suite (components/views/hooks/actions) · #29194 wallet-core · #29195 connect · #29196 module-trading · #29197 components

**Batch 2 — medium packages:** #29214 transaction-management · #29215 metadata · #29216 atoms · #29217 wallet-utils · #29218 trading · #29219 suite-sync · #29220 coinjoin · #29222 trading-state · #29224 module-stellar-token-management · #29225 module-earn · #29226 test-utils · #29227 suite-sync-evolu · #29228 staking · #29241 small bundle (router / utils / storage / address-validator)

**Batch 3 — small single-file bundles:** #29244 packages/* · #29245 suite-common/* · #29246 suite-native/*

## Notes for QA

No QA needed — enabling a lint rule plus compile-time-only `eslint-disable` comments. No runtime effect. The removals themselves shipped (and were QA-assessed as no-ops) in the fix PRs above.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This changeset primarily affects trading/swap UI components (TradingOfferExchange, TradingInfoItem), the transaction review modal (TransactionReviewOutput, TransactionReviewSummary), trading hooks (useTradingExchangeFormDefaultValues, useTradingRedirect, useTradingFiatValues), and several suite-native files with no web E2E coverage. The highest risk is in the swap/sell confirmation flows where TradingOfferExchange and TradingInfoItem render trade details. The transaction review modal changes affect all send flows. Several changed files (suite-native/*, resolveExchangeTradeError, TradingFormOfferOTC, useEthereumCancelTxCompose, routerReducer) have no direct E2E test coverage. Testing should focus on swap and sell confirmation screens first, then send transaction review flows.

<details><summary><b>Changed files (19)</b></summary>

- `packages/connect/src/api/ethereum/ethereumSignTypedData.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx`
- `packages/suite/src/hooks/wallet/trading/form/useTradingExchangeFormDefaultValues.ts`
- `packages/suite/src/hooks/wallet/useEthereumCancelTxCompose.ts`
- `packages/suite/src/hooks/wallet/useTradingRedirect.ts`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx`
- `packages/utils/src/hexToRgba.ts`
- `suite-common/calldata/src/encoder/evm.ts`
- `suite-common/trading/src/hooks/useTradingFiatValues.ts`
- `suite-common/trading/src/utils/exchange/resolveExchangeTradeError.ts`
- `suite-native/firmware/src/hooks/useFirmwareAnalytics.ts`
- `suite-native/module-trading/src/hooks/general/useTradingStellarActivateToken.tsx`
- `suite-native/module-trading/src/thunks.ts`
- `suite-native/storage/src/transforms/tokenDefinitionsTransforms.ts`
- `suite-native/transaction-management/src/selectors.ts`
- `suite/router/src/routerReducer.ts`

</details>

**Recommended tests (20)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/trading/swap-coins.test.ts` — Directly exercises TradingOfferExchange, TradingInfoItem, and useTradingExchangeFormDefaultValues — all changed. This test verifies swap confirmation details (exchange type, provider name, amounts), transaction detail status transitions, and the full swap flow which are rendered by the changed components.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests swap confirmation screen showing exchange type, provider name, and crypto amounts — directly rendered by the changed TradingOfferExchange and TradingInfoItem components. Also exercises the swap form default values hook.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Tests DEX swap via LI.FI which heavily exercises TradingOfferExchange (exchange type, slippage, minimum received, provider, accounts) and TradingInfoItem for rendering confirmation details. Also validates the exchange trade error resolution path (resolveExchangeTradeError).
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Sell flow exercises TradingOfferExchange for confirmation screen (fiat amount, crypto amount, provider, payment method, destination address) and useTradingRedirect for the redirect completion flow. Directly tests changed components.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Sell ETH flow validates confirmation screen details rendered by TradingOfferExchange and TradingInfoItem, and uses the trading redirect hook. Also touches Ethereum-specific transaction review via TransactionReviewOutput.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests sell SOL flow exercising TradingOfferExchange for confirmation details, TradingInfoItem for displaying provider/amount info, and useTradingRedirect. Verifies transaction detail status transitions which may be affected by resolveExchangeTradeError changes.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swap token-to-coin tests confirmation screen with exchange type, provider name, and crypto amounts — directly rendered by changed TradingOfferExchange and TradingInfoItem.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Swap SPL tokens test verifies exchange type, provider name, and amounts on the confirmation screen, directly exercising the changed TradingOfferExchange and TradingInfoItem components.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Buy BTC flow uses TradingInfoItem on the preview/confirmation screen (fiat amount, crypto amount, provider) and useTradingRedirect for redirect completion. Tests transaction detail status after trade confirmation.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Buy ETH flow exercises TradingInfoItem for confirmation screen rendering and useTradingRedirect for the redirect flow. Changes to these components could affect displayed amounts and provider details.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Buy Solana token flow uses TradingInfoItem for confirmation details and useTradingRedirect. Tests correct display of fiat/crypto amounts on confirmation.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Sell ETH token (USDC) flow exercises TradingOfferExchange and TradingInfoItem for confirmation screen, and useTradingRedirect for redirect handling.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests swap BTC→ETH with custom fees. Exercises TradingOfferExchange for confirmation details and TradingInfoItem. The fee display may be affected by TradingInfoItem changes.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests swap ETH→BTC with custom Ethereum fees. Exercises TradingOfferExchange and TradingInfoItem components, and the confirmation flow where fee details are displayed.
- `suite/e2e/tests/trading/swap-history.test.ts` — Swap history test verifies trade detail sidebar (amounts, provider, status) which uses TradingInfoItem. Changes to this component could affect how trade details are rendered.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Send ETH test verifies the transaction review modal including recipient address and fee display, directly exercising the changed TransactionReviewOutput and TransactionReviewSummary components.
- `suite/e2e/tests/wallet/send-base.test.ts` — Send Base test exercises the transaction review flow including amount/fee display on the review modal, directly using the changed TransactionReviewOutput and TransactionReviewSummary components.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Send SOL test verifies the review & send modal with recipient address, amount, and fee — components rendered by the changed TransactionReviewOutput and TransactionReviewSummary.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — Navigation test verifies that trading forms open correctly from various entry points. Changes to useTradingRedirect could affect navigation routing to buy/sell/swap forms.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Send DOGE exercises the transaction review output modal for displaying amount/fee/address. Changes to TransactionReviewOutput could affect the display of these details.

</details>

⚠️ **Changes with no test coverage (9)**
- `suite-native/firmware/src/hooks/useFirmwareAnalytics.ts`
- `suite-native/module-trading/src/hooks/general/useTradingStellarActivateToken.tsx`
- `suite-native/module-trading/src/thunks.ts`
- `suite-native/storage/src/transforms/tokenDefinitionsTransforms.ts`
- `suite-native/transaction-management/src/selectors.ts`
- `packages/suite/src/hooks/wallet/useEthereumCancelTxCompose.ts`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC.tsx`
- `suite-common/trading/src/utils/exchange/resolveExchangeTradeError.ts`
- `suite/router/src/routerReducer.ts`

_Updated: 2026-07-09T09:03:30.553Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/no-unnecessary-type-assertion&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/no-unnecessary-type-assertion&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-09T09:06:08.995Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-09T09:05:42.263Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/no-unnecessary-type-assertion/web/](https://dev.suite.sldev.cz/suite-web/mroz22/no-unnecessary-type-assertion/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->


