### PR TITLE
perf(suite-native): react compiler

### DIFF
--- a/packages/components/src/components/Tabs/Tabs.tsx
+++ b/packages/components/src/components/Tabs/Tabs.tsx
@@ -90,7 +90,7 @@ const Tabs = ({
 
         setIndicatorWidth(width ?? 0);
         setIndicatorPosition(position ?? 0);
-    }, [activeItemId]);
+    }, [activeItemId, setIndicatorWidth, setIndicatorPosition]);
 
     useEffect(() => {
         updateIndicator();

--- a/packages/eslint/src/reactConfig.mjs
+++ b/packages/eslint/src/reactConfig.mjs
@@ -33,8 +33,6 @@ export const reactConfig = [
             'react-hooks/static-components': 'off', // TODO fix & reenable
             'react-hooks/set-state-in-effect': 'off', // TODO fix & reenable, though this anti-pattern is unfortunately quite widespread
             'react-hooks/refs': 'off', // Too restrictive. Reading ref in render is often desired, though must be carefully considered
-            'react-hooks/incompatible-library': 'warn', // React Compiler rule: flags libraries that may break under compilation
-            'react-hooks/preserve-manual-memoization': 'warn', // React Compiler rule: flags manual memoization the compiler can't preserve (would bail out the component)
             'react-hooks/use-memo': 'off', // Too restrictive: enforces inline function in useMemo (forbids using variable)
         },
     },

--- a/packages/eslint/src/reactConfig.mjs
+++ b/packages/eslint/src/reactConfig.mjs
@@ -33,8 +33,8 @@ export const reactConfig = [
             'react-hooks/static-components': 'off', // TODO fix & reenable
             'react-hooks/set-state-in-effect': 'off', // TODO fix & reenable, though this anti-pattern is unfortunately quite widespread
             'react-hooks/refs': 'off', // Too restrictive. Reading ref in render is often desired, though must be carefully considered
-            'react-hooks/incompatible-library': 'off', // Rule for React Compiler; it's unlikely we'll use it anytime soon
-            'react-hooks/preserve-manual-memoization': 'off', // Rule for React Compiler; it's unlikely we'll use it anytime soon
+            'react-hooks/incompatible-library': 'warn', // React Compiler rule: flags libraries that may break under compilation
+            'react-hooks/preserve-manual-memoization': 'warn', // React Compiler rule: flags manual memoization the compiler can't preserve (would bail out the component)
             'react-hooks/use-memo': 'off', // Too restrictive: enforces inline function in useMemo (forbids using variable)
         },
     },

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { type UseFormReturn, useForm } from 'react-hook-form';
+import { type UseFormReturn, useForm, useWatch } from 'react-hook-form';
 
 import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
@@ -435,7 +435,7 @@ export const useYieldFlow = ({
         openDeviceConnectionModal,
     ]);
 
-    const liveAmount = methods.watch('amountInput');
+    const liveAmount = useWatch({ control: methods.control, name: 'amountInput' });
 
     const approvalAction = getYieldApprovalAction({
         liveAmount,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -153,17 +153,17 @@ export const AddAccountModal = ({
     const enabledNetworks = availableNetworksSymbols.map(networkSymbol =>
         getNetwork(networkSymbol),
     );
-    const [enabledMainnetNetworks, enabledTestnetNetworks] = arrayPartition(
-        enabledNetworks,
-        network => !network?.testnet,
+    const [enabledMainnetNetworks, enabledTestnetNetworks] = useMemo(
+        () => arrayPartition(enabledNetworks, network => !network?.testnet),
+        [enabledNetworks],
     );
     const disabledNetworks = supportedNetworks.filter(
         network => !availableNetworksSymbols.includes(network.symbol),
     );
 
-    const [disabledMainnetNetworks, disabledTestnetNetworks] = arrayPartition(
-        disabledNetworks,
-        network => !network?.testnet,
+    const [disabledMainnetNetworks, disabledTestnetNetworks] = useMemo(
+        () => arrayPartition(disabledNetworks, network => !network?.testnet),
+        [disabledNetworks],
     );
     const testnetNetworks = useMemo(
         () => [...enabledTestnetNetworks, ...disabledTestnetNetworks],
@@ -276,7 +276,7 @@ export const AddAccountModal = ({
             const defaultAccount = networkScopedAccounts
                 .toSorted((a, b) => a.index - b.index)
                 .at(-1);
-            const unavailableCapability = device?.unavailableCapabilities?.[defaultAccountTypeName];
+            const unavailableCapability = device.unavailableCapabilities?.[defaultAccountTypeName];
 
             const disabledMessage = verifyAvailability({
                 emptyAccounts: networkScopedAccounts.filter(
@@ -291,7 +291,7 @@ export const AddAccountModal = ({
         [
             accounts,
             device.state?.staticSessionId,
-            device?.unavailableCapabilities,
+            device.unavailableCapabilities,
             enabledNetworkSymbols,
             getAccountTypesForNetwork,
         ],

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { FormProvider, useForm } from 'react-hook-form';
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
 
 import { selectSelectedAccount } from '@suite/account';
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
@@ -83,9 +83,8 @@ export const StellarManageTokenModal = (props: StellarManageTokenModalProps) => 
         composeRequest: () => {},
     });
 
-    const { watch, handleSubmit } = methods;
-    const selectedFee = watch('selectedFee');
-    const feePerUnit = watch('feePerUnit');
+    const { control, handleSubmit } = methods;
+    const [selectedFee, feePerUnit] = useWatch({ control, name: ['selectedFee', 'feePerUnit'] });
 
     const composedLevels = useComposedLevelsPlaceholder({
         feeInfo,
@@ -142,8 +141,11 @@ export const StellarManageTokenModal = (props: StellarManageTokenModalProps) => 
         );
     }
 
-    const handleSubmitTrustline = async ({ selectedFee, feePerUnit }: FormState) => {
-        const resolvedSelectedFee = selectedFee || 'normal';
+    const handleSubmitTrustline = async ({
+        selectedFee: submittedSelectedFee,
+        feePerUnit: submittedFeePerUnit,
+    }: FormState) => {
+        const resolvedSelectedFee = submittedSelectedFee || 'normal';
         setIsProcessing(true);
 
         try {
@@ -151,7 +153,8 @@ export const StellarManageTokenModal = (props: StellarManageTokenModalProps) => 
                 account,
                 contractAddress,
                 selectedFee: resolvedSelectedFee,
-                customFeePerUnit: resolvedSelectedFee === 'custom' ? feePerUnit : undefined,
+                customFeePerUnit:
+                    resolvedSelectedFee === 'custom' ? submittedFeePerUnit : undefined,
             };
 
             const thunk =

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarTokenInputModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarTokenInputModal.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 
 import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
 import { Button, Column, Input, Modal, Row, Text } from '@trezor/components';
@@ -35,7 +35,7 @@ export const StellarTokenInputModal = ({ onSubmit, onCancel }: StellarTokenInput
         register,
         handleSubmit,
         formState: { errors, isValid },
-        watch,
+        control,
     } = useForm<FormData>({
         mode: 'onChange',
         defaultValues: {
@@ -50,8 +50,7 @@ export const StellarTokenInputModal = ({ onSubmit, onCancel }: StellarTokenInput
     // `input:not([value='']) ~ &` selector moves the label up when value is not empty.
     // Without explicitly passing the value prop, the label won't animate correctly
     // when using react-hook-form's uncontrolled mode.
-    const assetCode = watch('assetCode');
-    const assetIssuer = watch('assetIssuer');
+    const [assetCode, assetIssuer] = useWatch({ control, name: ['assetCode', 'assetIssuer'] });
 
     const { ref: assetCodeRef, ...assetCodeField } = register('assetCode', {
         required: true,

--- a/packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts
+++ b/packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 
 import { type TxSimulationEVMResult } from '@suite-common/tx-simulation';
 import {
@@ -56,11 +56,10 @@ export function useEvmTxSimulationFeesForm({
         feeInfo,
     });
 
-    const { watch } = form;
-    const selectedFee = watch('selectedFee');
-    const feePerUnit = watch('feePerUnit');
-    const maxFeePerGas = watch('maxFeePerGas');
-    const feeLimit = watch('feeLimit');
+    const [selectedFee, feePerUnit, maxFeePerGas, feeLimit] = useWatch({
+        control: form.control,
+        name: ['selectedFee', 'feePerUnit', 'maxFeePerGas', 'feeLimit'],
+    });
 
     // calculate levels with total max fee
     const feeTotalCalculation = useCallback(

--- a/packages/suite/src/components/wallet/Pagination.tsx
+++ b/packages/suite/src/components/wallet/Pagination.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 
 import styled, { css } from 'styled-components';
 
@@ -119,13 +119,13 @@ export const Pagination = ({
     const showPrev = currentPage > 1;
     const showNext = noUpperBound || currentPage < totalPages;
 
-    const { control, watch } = useForm({
+    const { control } = useForm({
         defaultValues: {
             pageInput: currentPage.toString(),
         },
     });
 
-    const pageInput = watch('pageInput');
+    const pageInput = useWatch({ control, name: 'pageInput' });
 
     const isPageInputInvalid =
         !Number.isInteger(Number(pageInput)) ||

--- a/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
+++ b/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useTranslation } from '@suite/intl';
@@ -26,7 +26,7 @@ type BackendsFormData = {
 const useBackendUrlInput = (symbol: NetworkSymbol, type: ServerType, currentUrls: string[]) => {
     const {
         register,
-        watch,
+        control,
         setValue,
         formState: { errors },
     } = useForm<{ url: string }>({
@@ -48,13 +48,15 @@ const useBackendUrlInput = (symbol: NetworkSymbol, type: ServerType, currentUrls
         url: getServerAddressExample(symbol, type),
     });
 
+    const value = useWatch({ control, name });
+
     return {
         name,
         placeholder,
         register,
         validate,
         error: errors[name],
-        value: watch(name) || '',
+        value: value || '',
         reset: () => setValue(name, ''),
     };
 };

--- a/packages/suite/src/hooks/settings/useExplorerForm.ts
+++ b/packages/suite/src/hooks/settings/useExplorerForm.ts
@@ -20,7 +20,10 @@ const useExplorerInput = (currentValues: Explorer) => {
         defaultValues: currentValues,
     });
 
-    const values = useWatch({ control });
+    const [base, tx, address, token, nft, queryString] = useWatch({
+        control,
+        name: ['base', 'tx', 'address', 'token', 'nft', 'queryString'],
+    });
 
     const { translationString } = useTranslation();
 
@@ -70,37 +73,37 @@ const useExplorerInput = (currentValues: Explorer) => {
         fields: {
             base: {
                 ref: baseInputRef,
-                value: values.base,
+                value: base,
                 field: baseInputField,
                 error: errors.base?.message,
             },
             tx: {
                 ref: txInputRef,
-                value: values.tx,
+                value: tx,
                 field: txInputField,
                 error: errors.tx?.message,
             },
             address: {
                 ref: addressInputRef,
-                value: values.address,
+                value: address,
                 field: addressInputField,
                 error: errors.address?.message,
             },
             token: {
                 ref: tokenInputRef,
-                value: values.token,
+                value: token,
                 field: tokenInputField,
                 error: errors.token?.message,
             },
             nft: {
                 ref: nftInputRef,
-                value: values.nft,
+                value: nft,
                 field: nftInputField,
                 error: errors.nft?.message,
             },
             queryString: {
                 ref: queryStringInputRef,
-                value: values.queryString,
+                value: queryString,
                 field: queryStringInputField,
                 error: errors.queryString?.message,
             },

--- a/packages/suite/src/hooks/settings/useExplorerForm.ts
+++ b/packages/suite/src/hooks/settings/useExplorerForm.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 
 import { useTranslation } from '@suite/intl';
 import { type Explorer, type NetworkSymbol } from '@suite-common/wallet-config';
@@ -13,12 +13,14 @@ const useExplorerInput = (currentValues: Explorer) => {
         register,
         formState: { errors },
         trigger,
-        watch,
+        control,
         setValue,
     } = useForm<Explorer>({
         mode: 'onChange',
         defaultValues: currentValues,
     });
+
+    const values = useWatch({ control });
 
     const { translationString } = useTranslation();
 
@@ -68,37 +70,37 @@ const useExplorerInput = (currentValues: Explorer) => {
         fields: {
             base: {
                 ref: baseInputRef,
-                value: watch('base'),
+                value: values.base,
                 field: baseInputField,
                 error: errors.base?.message,
             },
             tx: {
                 ref: txInputRef,
-                value: watch('tx'),
+                value: values.tx,
                 field: txInputField,
                 error: errors.tx?.message,
             },
             address: {
                 ref: addressInputRef,
-                value: watch('address'),
+                value: values.address,
                 field: addressInputField,
                 error: errors.address?.message,
             },
             token: {
                 ref: tokenInputRef,
-                value: watch('token'),
+                value: values.token,
                 field: tokenInputField,
                 error: errors.token?.message,
             },
             nft: {
                 ref: nftInputRef,
-                value: watch('nft'),
+                value: values.nft,
                 field: nftInputField,
                 error: errors.nft?.message,
             },
             queryString: {
                 ref: queryStringInputRef,
-                value: watch('queryString'),
+                value: values.queryString,
                 field: queryStringInputField,
                 error: errors.queryString?.message,
             },

--- a/packages/suite/src/hooks/suite/useChangeDeviceLabel.ts
+++ b/packages/suite/src/hooks/suite/useChangeDeviceLabel.ts
@@ -1,4 +1,4 @@
-import { type UseFormReturn, useForm } from 'react-hook-form';
+import { type UseFormReturn, useForm, useWatch } from 'react-hook-form';
 
 import { yupResolver } from '@hookform/resolvers/yup';
 
@@ -56,8 +56,8 @@ export const useChangeDeviceLabel = (): {
         reValidateMode: 'onChange',
     });
 
-    const { watch } = form;
-    const currentLabel = watch('deviceLabel');
+    const { control } = form;
+    const currentLabel = useWatch({ control, name: 'deviceLabel' });
 
     const onSubmit = form.handleSubmit(({ deviceLabel }) => {
         dispatch(applySettings({ label: deviceLabel }));

--- a/packages/suite/src/hooks/wallet/form/useCoinjoinRegisteredUtxos.ts
+++ b/packages/suite/src/hooks/wallet/form/useCoinjoinRegisteredUtxos.ts
@@ -18,17 +18,19 @@ export const useCoinjoinRegisteredUtxos = ({ account }: UseCoinjoinRegisteredUtx
         selectRegisteredUtxosByAccountKey(state, account.key),
     );
 
+    const { utxo } = account;
+
     return useMemo(() => {
         const registeredUtxos: AccountUtxo[] = [];
 
         if (sessionPrison && Object.keys(sessionPrison).length > 0) {
-            account?.utxo?.forEach(utxo => {
-                if (sessionPrison?.[getUtxoOutpoint(utxo)]) {
-                    registeredUtxos.push(utxo);
+            utxo?.forEach(accountUtxo => {
+                if (sessionPrison?.[getUtxoOutpoint(accountUtxo)]) {
+                    registeredUtxos.push(accountUtxo);
                 }
             });
         }
 
         return registeredUtxos;
-    }, [sessionPrison, account?.utxo]);
+    }, [sessionPrison, utxo]);
 };

--- a/packages/suite/src/hooks/wallet/form/useCoinjoinUnavailableUtxos.ts
+++ b/packages/suite/src/hooks/wallet/form/useCoinjoinUnavailableUtxos.ts
@@ -47,5 +47,5 @@ export const useCoinjoinUnavailableUtxos = ({
         if (amountBN.gt(coinjoinClient.allowedInputAmounts.max)) {
             return translationString('TR_AMOUNT_TOO_BIG_FOR_COINJOIN');
         }
-    }, [utxo, coinjoinAccount?.prison, coinjoinClient?.allowedInputAmounts, translationString]);
+    }, [utxo, coinjoinAccount?.prison, coinjoinClient, translationString]);
 };

--- a/packages/suite/src/hooks/wallet/sign-verify/useSignVerifyForm.ts
+++ b/packages/suite/src/hooks/wallet/sign-verify/useSignVerifyForm.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useController, useForm } from 'react-hook-form';
+import { useController, useForm, useWatch } from 'react-hook-form';
 
 import { yupResolver } from '@hookform/resolvers/yup';
 
@@ -73,30 +73,21 @@ const DEFAULT_VALUES: SignVerifyFields = {
 };
 
 export const useSignVerifyForm = (isSignPage: boolean, account: Account) => {
-    const {
-        register,
-        handleSubmit,
-        formState,
-        reset,
-        setValue,
-        clearErrors,
-        control,
-        trigger,
-        watch,
-    } = useForm<SignVerifyFields, SignVerifyContext>({
-        mode: 'onBlur',
-        reValidateMode: 'onChange',
-        resolver: yupResolver(signVerifySchema),
-        context: {
-            isSignPage,
-            symbol: account?.symbol,
-        },
-        defaultValues: DEFAULT_VALUES,
-    });
+    const { register, handleSubmit, formState, reset, setValue, clearErrors, control, trigger } =
+        useForm<SignVerifyFields, SignVerifyContext>({
+            mode: 'onBlur',
+            reValidateMode: 'onChange',
+            resolver: yupResolver(signVerifySchema),
+            context: {
+                isSignPage,
+                symbol: account?.symbol,
+            },
+            defaultValues: DEFAULT_VALUES,
+        });
 
     const { isDirty, errors, isSubmitting } = formState;
 
-    const formValues = watch();
+    const formValues = useWatch({ control });
 
     const { field: addressField } = useController({
         control,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 
 import { type CryptoId } from 'invity-api';
 
@@ -284,8 +284,8 @@ export const useTradingReceiveAddress = ({
         methods,
     ]);
 
-    const receiveAddressValue = methods.watch('address');
-    const extraFieldValue = methods.watch('extraField');
+    const receiveAddressValue = useWatch({ control: methods.control, name: 'address' });
+    const extraFieldValue = useWatch({ control: methods.control, name: 'extraField' });
 
     const addressDictionary = useAccountAddressDictionary(receiveAccount ?? undefined);
     const accountAddress = receiveAddressValue ? addressDictionary[receiveAddressValue] : undefined;

--- a/packages/suite/src/hooks/wallet/useAccounts.ts
+++ b/packages/suite/src/hooks/wallet/useAccounts.ts
@@ -4,41 +4,39 @@ import type { AccountAddress } from '@trezor/connect';
 
 import type { Account } from 'src/types/wallet';
 
-export const useAccountAddressDictionary = (account: Account | undefined) =>
-    useMemo(() => {
-        switch (account?.networkType) {
+export const useAccountAddressDictionary = (account: Account | undefined) => {
+    const { addresses, descriptor, networkType, path } = account ?? {};
+    const { unused: unusedAddresses = [], used: usedAddresses = [] } = addresses ?? {};
+
+    return useMemo(() => {
+        switch (networkType) {
             case 'cardano':
             case 'bitcoin': {
-                return (account?.addresses?.unused ?? [])
-                    .concat(account?.addresses?.used ?? [])
-                    .reduce(
-                        (previous, current) => {
-                            previous[current.address] = current;
+                return (unusedAddresses ?? []).concat(usedAddresses ?? []).reduce(
+                    (previous, current) => {
+                        previous[current.address] = current;
 
-                            return previous;
-                        },
-                        {} as { [address: string]: AccountAddress },
-                    );
+                        return previous;
+                    },
+                    {} as { [address: string]: AccountAddress },
+                );
             }
             case 'solana':
             case 'ripple':
             case 'stellar':
             case 'tron':
             case 'ethereum': {
+                if (!descriptor || path === undefined) return {};
+
                 return {
-                    [account.descriptor]: {
-                        address: account.descriptor,
-                        path: account.path,
+                    [descriptor]: {
+                        address: descriptor,
+                        path,
                     },
                 };
             }
             default:
                 return {};
         }
-    }, [
-        account?.addresses?.unused,
-        account?.addresses?.used,
-        account?.descriptor,
-        account?.networkType,
-        account?.path,
-    ]);
+    }, [unusedAddresses, usedAddresses, descriptor, networkType, path]);
+};

--- a/packages/suite/src/views/wallet/send/SendRaw.tsx
+++ b/packages/suite/src/views/wallet/send/SendRaw.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
@@ -28,7 +28,7 @@ export const SendRaw = ({ account }: SendRawProps) => {
     const {
         register,
         setValue,
-        watch,
+        control,
         formState: { errors },
     } = useForm({
         mode: 'onChange',
@@ -39,7 +39,7 @@ export const SendRaw = ({ account }: SendRawProps) => {
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
-    const inputValue = watch(INPUT_NAME);
+    const inputValue = useWatch({ control, name: INPUT_NAME });
     const error = errors[INPUT_NAME];
     const hasError = !!error;
     const prefix = account.networkType === 'ethereum' ? '0x' : undefined;

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 
 import {
     TRADING_FORM_OUTPUT_AMOUNT,
@@ -53,9 +53,12 @@ export const TradingSellFormInputs = () => {
         showReserveBanner,
     } = context;
 
-    const { getValues } = useFormContext<TradingSellFormProps>();
+    const { control } = useFormContext<TradingSellFormProps>();
 
-    const { outputs, sendCryptoSelect, amountInCrypto, countrySelect } = getValues();
+    const [outputs, sendCryptoSelect, amountInCrypto, countrySelect] = useWatch({
+        control,
+        name: ['outputs', 'sendCryptoSelect', 'amountInCrypto', 'countrySelect'],
+    });
     const output = outputs[0];
     const currencySelect = output?.currency;
     const tokenAddress = (output?.token ?? undefined) as TokenAddress | undefined;

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddressModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddressModal.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 
 import { Translation, useTranslation } from '@suite/intl';
 import { cryptoIdToNetwork, parseCryptoId, useTradingUtils } from '@suite-common/trading';
@@ -83,7 +83,7 @@ export const TradingReceiveAddressModal = () => {
         },
     });
 
-    const receiveAddress = form.watch('address');
+    const receiveAddress = useWatch({ control: form.control, name: 'address' });
 
     const onCancel = () => {
         modalControls.close();

--- a/suite-common/earn-stablecoin/src/allowance/hooks/useYieldVaultName.ts
+++ b/suite-common/earn-stablecoin/src/allowance/hooks/useYieldVaultName.ts
@@ -20,16 +20,19 @@ export const useYieldVaultName = ({
     account,
     precomposedForm,
 }: UseYieldVaultNameParams): string | undefined => {
+    const networkType = account?.networkType;
+    const outputs = precomposedForm?.outputs;
+    const transactionData = precomposedForm?.transactionData;
     const outputToken = useMemo(() => {
-        if (account?.networkType !== 'ethereum' || !precomposedForm?.transactionData) {
+        if (networkType !== 'ethereum' || !transactionData) {
             return undefined;
         }
 
         return getMatchAddress({
-            to: precomposedForm.outputs?.[0]?.address,
-            data: precomposedForm.transactionData,
+            to: outputs?.[0]?.address,
+            data: transactionData,
         });
-    }, [account?.networkType, precomposedForm?.outputs, precomposedForm?.transactionData]);
+    }, [networkType, outputs, transactionData]);
 
     const { data: vault } = useGetVaultByAddress({ enabled, outputToken });
 

--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -322,6 +322,9 @@ export default ({ config }: ConfigContext): ExpoConfig => {
                     : ['applinks:dev.suite.sldev.cz', 'applinks:dev.trezorio.sldev.cz'],
         },
         plugins: getPlugins(),
+        experiments: {
+            reactCompiler: true,
+        },
         extra: {
             // FIXME: Fingerprint is always changed between commits because of this. We need to find a better solution.
             commitHash:

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -144,6 +144,8 @@ export const YieldWithdrawScreen = () => {
         decimals: activeInputToken?.decimals,
     });
 
+    const isAmountValidationErrorDisplayed = !!amountValidationError;
+
     const depositedAmount = useMemo(() => {
         if (resolutionStatus !== 'resolved') {
             return null;
@@ -190,7 +192,7 @@ export const YieldWithdrawScreen = () => {
             resolutionStatus === 'resolved' &&
             !!amount &&
             !isAmountTooHigh &&
-            !amountValidationError,
+            !isAmountValidationErrorDisplayed,
     });
     const feeFiatConverters = useCryptoFiatConverters({
         symbol: account?.symbol ?? null,
@@ -207,7 +209,7 @@ export const YieldWithdrawScreen = () => {
     const shouldShowNetworkFeeWarning = useMemo(() => {
         if (
             !amount ||
-            amountValidationError ||
+            isAmountValidationErrorDisplayed ||
             !withdrawFee ||
             resolutionStatus !== 'resolved' ||
             preparedAction?.amount !== amount ||
@@ -227,7 +229,7 @@ export const YieldWithdrawScreen = () => {
     }, [
         account,
         amount,
-        amountValidationError,
+        isAmountValidationErrorDisplayed,
         amountFiatConverters,
         feeFiatConverters,
         preparedAction,
@@ -258,7 +260,7 @@ export const YieldWithdrawScreen = () => {
         !amount ||
         isWithdrawPending ||
         isAmountTooHigh ||
-        !!amountValidationError ||
+        isAmountValidationErrorDisplayed ||
         !isWithdrawReviewReady ||
         isComposingWithdrawFee ||
         isFeeUnavailable;
@@ -558,7 +560,7 @@ export const YieldWithdrawScreen = () => {
                                     editable={!isMaxSelected && !isDisabled}
                                     onChangeText={handleAmountChange}
                                     onPress={onPress}
-                                    hasError={!isDisabled && !!amountValidationError}
+                                    hasError={!isDisabled && isAmountValidationErrorDisplayed}
                                     accessibilityLabel={translate(
                                         'earn.yieldWithdrawFlowScreen.amountToWithdraw',
                                     )}
@@ -585,7 +587,7 @@ export const YieldWithdrawScreen = () => {
                                     onChangeText={handleAmountChange}
                                     onPress={onPress}
                                     style={applyStyle(withdrawOutputAmountInputStyle)}
-                                    hasError={!isDisabled && !!amountValidationError}
+                                    hasError={!isDisabled && isAmountValidationErrorDisplayed}
                                     accessibilityLabel={translate(
                                         'earn.yieldWithdrawFlowScreen.amountToWithdraw',
                                     )}
@@ -638,10 +640,10 @@ export const YieldWithdrawScreen = () => {
                 )}
 
                 <YieldWithdrawWarning
-                    isAmountTooHigh={!amountValidationError && isAmountTooHigh}
+                    isAmountTooHigh={!isAmountValidationErrorDisplayed && isAmountTooHigh}
                     isMaxWithdrawInfoVisible={isMaxWithdrawInfoVisible}
                     shouldShowNetworkFeeWarning={
-                        !amountValidationError && shouldShowNetworkFeeWarning
+                        !isAmountValidationErrorDisplayed && shouldShowNetworkFeeWarning
                     }
                     vaultTokenSymbol={vaultTokenSymbol}
                 />

--- a/suite-native/module-stellar-token-management/src/hooks/useInactiveStellarTokens.ts
+++ b/suite-native/module-stellar-token-management/src/hooks/useInactiveStellarTokens.ts
@@ -41,11 +41,12 @@ export const useInactiveStellarTokens = (accountKey?: AccountKey) => {
         }
     }, [tokenMetadata]);
 
+    const tokens = account?.tokens;
     const activatedTokenContracts = useMemo(() => {
-        if (!account?.tokens) return new Set<string>();
+        if (!tokens) return new Set<string>();
 
-        return new Set(account.tokens.map(token => token.contract));
-    }, [account?.tokens]);
+        return new Set(tokens.map(token => token.contract));
+    }, [tokens]);
 
     const inactiveTokens = useMemo(() => {
         const tokenAddresses = coinDefinitions?.data ?? [];

--- a/suite/suite-sync/src/SelectSuiteSyncServer.tsx
+++ b/suite/suite-sync/src/SelectSuiteSyncServer.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, useForm, useWatch } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -62,8 +62,9 @@ export const SelectSuiteSyncServer = ({ onCancel }: SelectSuiteSyncServerProps) 
         reValidateMode: 'onChange',
     });
 
-    const { handleSubmit, watch } = form;
-    const watchedServer = watch('server');
+    const { handleSubmit, control } = form;
+
+    const watchedServer = useWatch({ control, name: 'server' });
 
     const onSubmit = handleSubmit(async values => {
         const relayUrl =


### PR DESCRIPTION
## Description

1. Enables React Compiler for `suite-native` and turns on its two lint rules (`react-hooks/incompatible-library`, `react-hooks/preserve-manual-memoization`) as warnings. These additions were made to the shared ESLint configuration, so they apply to the entire repository, not just to the suite-native code. This is because the analysis is executed before compiling the application, making it challenging to determine where it should be run.

2. Fixes every react compiler related error surfaced:
- Replaced react-hook-form `watch()`/`getValues()` with `useWatch()` across forms (most of the errors)
- Hoisted optional-chained property reads into local variables so manual `useMemo`/`useCallback` deps match the compiler's inference.
- Wrapped a few unmemoized derived values (e.g. `arrayPartition(...)`) used in `useMemo`.
- Fixed two latent bugs found along the way: a dropped `return` in `useAccounts.ts`, and a variable shadow in `StellarManageTokenModal`.

3. As a side effect, all the React compiler-related lint errors that occurred in desktop code were also fixed. This means that this PR provides a solid foundation for enabling the compiler in desktop as well. 

## Notes for QA

No behavior change intended — pure memoization/subscription refactor. Smoke-test the app in general and also focus on forms on both platforms (desktop and mobile), e.g. trading, add-account, sign & verify, settings, Stellar tokens, yield deposit/withdraw.This is necessary because most of the react compiler incompatible warnings were connected to the forms code. 

## Related Issue

Resolve #28390 

## Screenshots

https://github.com/user-attachments/assets/82792a53-1069-4082-9a0e-30c718bfbfef

<img width="388" height="58" alt="Screenshot 2026-07-21 at 14 43 10" src="https://github.com/user-attachments/assets/74a35106-0beb-414e-a7b7-ce2885ec6b47" />




<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=perf/native/react-compiler&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=perf/native/react-compiler&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=perf/native/react-compiler&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-21T12:38:54.673Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-21T12:38:49.592Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/perf/native/react-compiler/web/](https://dev.suite.sldev.cz/suite-web/perf/native/react-compiler/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set touches several distinct areas: pagination UI, sign/verify form hook, settings backend/explorer form hooks, device label change hook, account addition modal, trading sell form inputs, trading receive address hook/modal, and the SendRaw send view. Many changed files (Tabs.tsx, useYieldFlow.ts, useYieldVaultName.ts, useCoinjoinRegisteredUtxos.ts) map to 133 tests as broad shared dependencies with no specific evidence of behavioral impact, so they were excluded from recommendations per the broad-utility heuristic. The recommended strategy focuses on targeted high-priority tests directly exercising the pagination component, sign/verify flow, backend/explorer settings, device label changes, add-account modal, and trading sell/receive-address flows, supplemented by medium/low priority tests that transitively touch the changed send/trading code paths. Several native/module files (app.config.ts, YieldWithdrawScreen.tsx, useInactiveStellarTokens.ts, SelectSuiteSyncServer.tsx, useEvmTxSimulationFeesForm.ts) and Stellar modal components have no E2E test coverage in this suite and should be verified via other means (unit tests, manual QA, or native E2E if available).

<details><summary><b>Changed files (23)</b></summary>

- `packages/components/src/components/Tabs/Tabs.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarTokenInputModal.tsx`
- `packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts`
- `packages/suite/src/components/wallet/Pagination.tsx`
- `packages/suite/src/hooks/settings/backends/useBackendsForm.ts`
- `packages/suite/src/hooks/settings/useExplorerForm.ts`
- `packages/suite/src/hooks/suite/useChangeDeviceLabel.ts`
- `packages/suite/src/hooks/wallet/form/useCoinjoinRegisteredUtxos.ts`
- `packages/suite/src/hooks/wallet/form/useCoinjoinUnavailableUtxos.ts`
- `packages/suite/src/hooks/wallet/sign-verify/useSignVerifyForm.ts`
- `packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts`
- `packages/suite/src/hooks/wallet/useAccounts.ts`
- `packages/suite/src/views/wallet/send/SendRaw.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddressModal.tsx`
- `suite-common/earn-stablecoin/src/allowance/hooks/useYieldVaultName.ts`
- `suite-native/app/app.config.ts`
- `suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx`
- `suite-native/module-stellar-token-management/src/hooks/useInactiveStellarTokens.ts`
- `suite/suite-sync/src/SelectSuiteSyncServer.tsx`

</details>

**Recommended tests (27)**

<details><summary>🔴 <b>High priority (13)</b></summary>

- `suite/e2e/tests/wallet/pagination.test.ts` — Directly tests the Pagination component behavior (page navigation, active/inactive states, jump-to-page) which is the changed file packages/suite/src/components/wallet/Pagination.tsx.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Directly exercises the sign/verify form flow which is implemented by the changed hook useSignVerifyForm.ts.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — Directly exercises the Ethereum sign/verify form flow which is implemented by the changed hook useSignVerifyForm.ts.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Tests custom backend configuration UI/flow (blockbook backend, correct/wrong URL) directly exercising useBackendsForm.ts logic.
- `suite/e2e/tests/settings/coins.test.ts` — Covers custom backend server configuration and indicator display, directly touching the changed useBackendsForm/useExplorerForm hooks.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Tests configuring a custom Blockbook backend and discovery completion, directly exercising the changed useBackendsForm and useExplorerForm hooks.
- `suite/e2e/tests/settings/electrum.test.ts` — Configures a custom Electrum backend for RegTest network, directly exercising the changed backend/explorer form hooks.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — Directly tests changing the device name/label, which is the functionality implemented in the changed useChangeDeviceLabel.ts hook.
- `suite/e2e/tests/settings/t3b1-device-settings.test.ts` — Directly tests changing device name and seeing it reflected in the menu label, exercising the changed useChangeDeviceLabel.ts hook.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Directly tests the Add Account modal flow (adding BTC-like, ETH, ADA account types), which is the changed component AddAccountModal.tsx.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Directly exercises the Trading Sell form inputs (validation, percentage buttons, fee) implemented by the changed TradingSellFormInputs.tsx component.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Exercises the sell form (fill sell form, best offer) directly built on the changed TradingSellFormInputs.tsx and useTradingReceiveAddress.ts.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation to buy/sell/swap forms which exercises TradingSellFormInputs, useTradingReceiveAddress, useAccounts, and TradingReceiveAddressModal - all changed files.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/settings/t1b1-device-settings.test.ts` — Covers device settings changes on T1B1 including background change; device label change logic shares the same changed hook (useChangeDeviceLabel.ts) though this test focuses more on PIN.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Exercises the receive account selection modal (TradingReceiveAddressModal) and useTradingReceiveAddress hook, both changed, during the buy flow.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Uses receiveAccount selector (TradingReceiveAddressModal, useTradingReceiveAddress) during swap flow, both changed files.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Directly tests the swap form's receive account selection (selectSuiteReceiveAccount) and fraction/max buttons tied to useAccounts and TradingReceiveAddressModal changes.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — Tests global send flow via SendRaw.tsx and account addition, both changed (SendRaw.tsx, useAccounts.ts), affecting account selection/labeling in send flows.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Exercises the Send form (SendRaw.tsx) for Ethereum, a directly changed source file governing raw send behavior.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Exercises the Send form (SendRaw.tsx) for Solana with max-amount/fee calculation, directly touching the changed send view.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Extensively exercises the send form UI (add/remove outputs, locktime, OP_RETURN) built on the changed SendRaw.tsx component.

</details>

<details><summary>🟢 <b>Low priority (6)</b></summary>

- `suite/e2e/tests/wallet/send-doge.test.ts` — Uses the send form (SendRaw.tsx) to trigger a sign error path; relevant but lower priority since it targets an edge-case error condition rather than core send behavior.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Exercises the send form (SendRaw.tsx) broadcast mode for LTC; relevant but a narrower edge-case scenario.
- `suite/e2e/tests/wallet/without-device.test.ts` — Tests send flow behavior when device disconnected using SendRaw.tsx form; relevant to the changed file but focused on a specific disconnect edge case.
- `suite/e2e/tests/wallet/cardano.test.ts` — Send form for Cardano briefly touches the changed SendRaw.tsx, but this test is primarily about receive/account details rather than send-specific logic.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — Exercises the send form (SendRaw.tsx) for importing CSV outputs, touching the changed file but focused on CSV import parsing rather than the core send raw logic.
- `suite/e2e/tests/dashboard/assets.test.ts` — Enables new assets and touches account listing (useAccounts.ts) and buy flow (useTradingReceiveAddress, TradingReceiveAddressModal), all changed, though the test's focus is on asset activation rather than these specific behaviors.

</details>

⚠️ **Changes with no test coverage (8)**
- `packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts`
- `suite-native/app/app.config.ts`
- `suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx`
- `suite-native/module-stellar-token-management/src/hooks/useInactiveStellarTokens.ts`
- `suite/suite-sync/src/SelectSuiteSyncServer.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarTokenInputModal.tsx`
- `packages/suite/src/hooks/wallet/form/useCoinjoinUnavailableUtxos.ts`

_Updated: 2026-07-21T12:36:13.485Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->