### PR TITLE
fix(suite-native): align yield withdraw fee source

### DIFF
--- a/suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts
+++ b/suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { asEvmAddress } from '@suite-common/calldata';
 import { buildStablecoinYieldTransactionReview } from '@suite-common/earn-stablecoin/src/signing';
+import { createThunk } from '@suite-common/redux-utils';
 import { getNetwork } from '@suite-common/wallet-config';
 import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import {
@@ -16,6 +17,7 @@ import {
     formDraftActions,
     getYieldWithdrawInputToken,
     selectConvertedNetworkFeeInfo,
+    selectDeepCopyOfFormDraft,
     selectFormDraft,
 } from '@suite-common/wallet-core';
 import {
@@ -23,11 +25,13 @@ import {
     type FeeLevelLabel,
     type FormState,
     type PrecomposedLevels,
+    type PrecomposedTransactionFinal,
     isFinalPrecomposedTransaction,
 } from '@suite-common/wallet-types';
 import { getAccountIdentity } from '@suite-common/wallet-utils';
 import {
     type NativeSendRootState,
+    type UpdateSelectedFeeLevelThunkParams,
     getFeeAvailability,
     selectFeeLevels,
     transactionManagementActions,
@@ -35,7 +39,7 @@ import {
 import TrezorConnect from '@trezor/connect';
 import { useDebounce } from '@trezor/react-utils';
 
-import { updateEarnSelectedFeeLevelThunk } from './useComposeEarnFees';
+import { EARN_MODULE_PREFIX } from '../constants';
 import { type ResolvedYieldFlowData } from './useResolvedYieldFlowData';
 import { getYieldWithdrawFormDraftKey } from '../utils/yieldWithdrawUtils';
 
@@ -61,7 +65,7 @@ type UseYieldWithdrawFeesResult = {
     isFeeUnavailable: boolean;
     preparedAction: PreparedYieldWithdrawAction | null;
     selectedFee: FeeLevelLabel;
-    updateFeeLevelThunk: typeof updateEarnSelectedFeeLevelThunk;
+    updateFeeLevelThunk: typeof updateYieldWithdrawSelectedFeeLevelThunk;
 };
 
 // Only the inputs that should trigger a fresh (network) fee composition. The fee context
@@ -91,6 +95,78 @@ type BuildYieldWithdrawFeeLevelsParams = {
 };
 
 const FEE_LEVEL_LABELS_BY_PRICE: FeeLevelLabel[] = ['economy', 'low', 'normal', 'high'];
+
+const getYieldWithdrawSelectedFeeFields = (
+    selectedFeeTransaction: PrecomposedTransactionFinal,
+): Pick<FormState, 'feePerUnit' | 'feeLimit' | 'maxFeePerGas' | 'maxPriorityFeePerGas'> => ({
+    feePerUnit: selectedFeeTransaction.feePerByte,
+    feeLimit: selectedFeeTransaction.feeLimit ?? '',
+    maxFeePerGas: selectedFeeTransaction.maxFeePerGas,
+    maxPriorityFeePerGas: selectedFeeTransaction.maxPriorityFeePerGas,
+});
+
+export const updateYieldWithdrawSelectedFeeLevelThunk = createThunk(
+    `${EARN_MODULE_PREFIX}/updateYieldWithdrawSelectedFeeLevelThunk`,
+    (
+        {
+            feeLevelLabel,
+            feePerUnit,
+            feeLimit,
+            formDraftKey,
+            maxFeePerGas,
+            maxPriorityFeePerGas,
+        }: UpdateSelectedFeeLevelThunkParams,
+        { dispatch, getState },
+    ) => {
+        if (!formDraftKey) return;
+
+        const formDraft = selectDeepCopyOfFormDraft(getState(), formDraftKey);
+
+        if (!formDraft) {
+            return;
+        }
+
+        formDraft.selectedFee = feeLevelLabel;
+
+        if (feeLevelLabel === 'custom') {
+            if (feePerUnit) {
+                formDraft.feePerUnit = feePerUnit;
+            }
+
+            if (feeLimit) {
+                formDraft.feeLimit = feeLimit;
+            }
+
+            if (maxFeePerGas) {
+                formDraft.maxFeePerGas = maxFeePerGas;
+            }
+
+            if (maxPriorityFeePerGas) {
+                formDraft.maxPriorityFeePerGas = maxPriorityFeePerGas;
+            }
+
+            dispatch(formDraftActions.storeDraft({ key: formDraftKey, formDraft }));
+
+            return;
+        }
+
+        const selectedFeeTransaction = selectFeeLevels(getState())[feeLevelLabel];
+
+        if (!isFinalPrecomposedTransaction(selectedFeeTransaction)) {
+            return;
+        }
+
+        dispatch(
+            formDraftActions.storeDraft({
+                key: formDraftKey,
+                formDraft: {
+                    ...formDraft,
+                    ...getYieldWithdrawSelectedFeeFields(selectedFeeTransaction),
+                },
+            }),
+        );
+    },
+);
 
 const getFeeLevelForUnsignedTransaction = (feeInfo: FeeInfo) =>
     FEE_LEVEL_LABELS_BY_PRICE.map(label =>
@@ -370,10 +446,7 @@ export const useYieldWithdrawFees = ({
                         formDraft: {
                             ...mergedFormState,
                             selectedFee: resolvedSelectedFee,
-                            feePerUnit: selectedFeeTransaction.feePerByte,
-                            feeLimit: selectedFeeTransaction.feeLimit,
-                            maxFeePerGas: selectedFeeTransaction.maxFeePerGas,
-                            maxPriorityFeePerGas: selectedFeeTransaction.maxPriorityFeePerGas,
+                            ...getYieldWithdrawSelectedFeeFields(selectedFeeTransaction),
                         },
                     }),
                 );
@@ -443,6 +516,6 @@ export const useYieldWithdrawFees = ({
         isFeeUnavailable,
         preparedAction,
         selectedFee,
-        updateFeeLevelThunk: updateEarnSelectedFeeLevelThunk,
+        updateFeeLevelThunk: updateYieldWithdrawSelectedFeeLevelThunk,
     };
 };

--- a/suite-native/module-earn/src/hooks/useYieldWithdrawReview.ts
+++ b/suite-native/module-earn/src/hooks/useYieldWithdrawReview.ts
@@ -13,14 +13,13 @@ import {
     selectFormDraft,
     selectStablecoinYieldTxReview,
 } from '@suite-common/wallet-core';
-import { type FormState, isFinalPrecomposedTransaction } from '@suite-common/wallet-types';
+import { type FormState } from '@suite-common/wallet-types';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import type {
     StackNavigationProps,
     YieldStackParamList,
     YieldStackRoutes,
 } from '@suite-native/navigation';
-import { type NativeSendRootState, selectFeeLevels } from '@suite-native/transaction-management';
 
 import {
     type YieldReviewActionStatus,
@@ -30,7 +29,7 @@ import {
 import { isUserCancelledSignError } from '../utils';
 import { useShowPushTransactionFailedDuringReviewAlert } from './useShowPushTransactionFailedDuringReviewAlert';
 import { useYieldActionReviewBackNavigation } from './useYieldActionReviewBackNavigation';
-import { getSelectedEvmFeeFromPrecomposedTransaction } from '../utils/yieldSelectedFeeUtils';
+import { getSelectedEvmFeeFromFormDraft } from '../utils/yieldSelectedFeeUtils';
 import { getYieldWithdrawFormDraftKey } from '../utils/yieldWithdrawUtils';
 import { pushYieldActionReviewThunk, signYieldActionReviewThunk } from '../yieldTransactionThunks';
 
@@ -77,19 +76,7 @@ export const useYieldWithdrawReview = ({
     const formDraft = useSelector((state: FormDraftRootState) =>
         selectFormDraft<FormState>(state, formDraftKey),
     );
-    const feeLevels = useSelector((state: NativeSendRootState) => selectFeeLevels(state));
-    const selectedFeeTransaction = formDraft?.selectedFee
-        ? feeLevels[formDraft.selectedFee]
-        : undefined;
-    const selectedFee = useMemo(
-        () =>
-            getSelectedEvmFeeFromPrecomposedTransaction(
-                isFinalPrecomposedTransaction(selectedFeeTransaction)
-                    ? selectedFeeTransaction
-                    : undefined,
-            ),
-        [selectedFeeTransaction],
-    );
+    const selectedFee = useMemo(() => getSelectedEvmFeeFromFormDraft(formDraft), [formDraft]);
     const isWithdrawSigned =
         txReview.accountKey === flowData.account.key && !!txReview.serializedTx;
     const withdrawStatus: YieldReviewStatus =

--- a/suite-native/module-earn/src/screens/YieldWithdrawReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawReviewScreen.tsx
@@ -11,18 +11,17 @@ import {
     selectFormDraft,
     selectStablecoinYieldSessionByFlowKey,
 } from '@suite-common/wallet-core';
-import { type FormState, isFinalPrecomposedTransaction } from '@suite-common/wallet-types';
+import { type FormState } from '@suite-common/wallet-types';
 import {
     type StackNavigationProps,
     type YieldStackParamList,
     YieldStackRoutes,
 } from '@suite-native/navigation';
-import { type NativeSendRootState, selectFeeLevels } from '@suite-native/transaction-management';
 
 import { YieldWithdrawReviewContent } from '../components/YieldWithdrawReviewContent';
 import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
 import { buildYieldReviewPreview } from '../utils/yieldReviewOutputUtils';
-import { getSelectedEvmFeeFromPrecomposedTransaction } from '../utils/yieldSelectedFeeUtils';
+import { getSelectedEvmFeeFromFormDraft } from '../utils/yieldSelectedFeeUtils';
 import { getYieldWithdrawFormDraftKey } from '../utils/yieldWithdrawUtils';
 
 type RouteProps = RouteProp<YieldStackParamList, YieldStackRoutes.YieldWithdrawReview>;
@@ -44,7 +43,6 @@ export const YieldWithdrawReviewScreen = () => {
     const formDraft = useSelector((state: FormDraftRootState) =>
         formDraftKey ? selectFormDraft<FormState>(state, formDraftKey) : undefined,
     );
-    const feeLevels = useSelector((state: NativeSendRootState) => selectFeeLevels(state));
     const actionReview = session?.action.review;
     const review = useMemo(
         () =>
@@ -63,18 +61,9 @@ export const YieldWithdrawReviewScreen = () => {
 
         return getYieldWithdrawInputToken({ flowData, flowType });
     }, [flowData, flowType]);
-    const selectedFeePreview = formDraft?.selectedFee
-        ? feeLevels[formDraft.selectedFee]
-        : undefined;
-    const selectedFee = useMemo(
-        () =>
-            getSelectedEvmFeeFromPrecomposedTransaction(
-                isFinalPrecomposedTransaction(selectedFeePreview) ? selectedFeePreview : undefined,
-            ),
-        [selectedFeePreview],
-    );
+    const selectedFee = useMemo(() => getSelectedEvmFeeFromFormDraft(formDraft), [formDraft]);
     const preview = useMemo(() => {
-        if (!review || !device || !flowData || !reviewToken) {
+        if (!review || !device || !flowData || !reviewToken || !selectedFee) {
             return null;
         }
 
@@ -99,10 +88,10 @@ export const YieldWithdrawReviewScreen = () => {
             return;
         }
 
-        if (!review || session?.step !== 'action') {
+        if (!review || !selectedFee || session?.step !== 'action') {
             navigation.navigate(YieldStackRoutes.YieldWithdraw, route.params);
         }
-    }, [navigation, resolutionStatus, review, route.params, session?.step]);
+    }, [navigation, resolutionStatus, review, route.params, selectedFee, session?.step]);
 
     if (resolutionStatus !== 'resolved' || !flowData || !review || !reviewToken || !preview) {
         return null;

--- a/suite-native/module-earn/src/utils/yieldSelectedFeeUtils.ts
+++ b/suite-native/module-earn/src/utils/yieldSelectedFeeUtils.ts
@@ -1,29 +1,36 @@
 import { buildEvmSelectedFee } from '@suite-common/wallet-core';
-import { type EvmSelectedFee, type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import { type EvmSelectedFee, type FormState } from '@suite-common/wallet-types';
 
-export const getSelectedEvmFeeFromPrecomposedTransaction = (
-    precomposedTransaction: PrecomposedTransactionFinal | undefined,
+type FormDraftEvmFeeFields = Pick<
+    FormState,
+    'feeLimit' | 'feePerUnit' | 'maxFeePerGas' | 'maxPriorityFeePerGas'
+>;
+
+export const getSelectedEvmFeeFromFormDraft = (
+    formDraft: FormDraftEvmFeeFields | null | undefined,
 ): EvmSelectedFee | null => {
-    if (!precomposedTransaction?.feeLimit) {
+    if (!formDraft?.feeLimit) {
         return null;
     }
 
-    if (precomposedTransaction.maxFeePerGas && precomposedTransaction.maxPriorityFeePerGas) {
+    const { feeLimit, feePerUnit, maxFeePerGas, maxPriorityFeePerGas } = formDraft;
+
+    if (maxFeePerGas && maxPriorityFeePerGas) {
         return buildEvmSelectedFee({
             feeLevel: {
-                feePerUnit: precomposedTransaction.feePerByte,
-                maxFeePerGas: precomposedTransaction.maxFeePerGas,
-                maxPriorityFeePerGas: precomposedTransaction.maxPriorityFeePerGas,
+                feePerUnit: feePerUnit || maxFeePerGas,
+                maxFeePerGas,
+                maxPriorityFeePerGas,
                 baseFeePerGas: '0',
             },
-            gasLimit: precomposedTransaction.feeLimit,
+            gasLimit: feeLimit,
         });
     }
 
-    if (precomposedTransaction.feePerByte) {
+    if (feePerUnit) {
         return buildEvmSelectedFee({
-            feeLevel: { feePerUnit: precomposedTransaction.feePerByte },
-            gasLimit: precomposedTransaction.feeLimit,
+            feeLevel: { feePerUnit },
+            gasLimit: feeLimit,
         });
     }
 

--- a/suite-native/module-earn/src/yieldTransactionThunks.ts
+++ b/suite-native/module-earn/src/yieldTransactionThunks.ts
@@ -66,6 +66,13 @@ export const signYieldActionReviewThunk = createThunk<
             });
         }
 
+        if (flowType === 'withdraw' && !selectedFee) {
+            return rejectWithValue({
+                error: 'sign-transaction-failed',
+                message: 'Fee information is missing for the transaction.',
+            });
+        }
+
         let transactionReview: ReturnType<typeof buildStablecoinYieldTransactionReview>;
 
         try {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use the Withdraw form draft fee for both the app review and Trezor signing so changed fees stay in parity.

## Notes for QA

- The selected fee should match on the device and in the app.
## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/yield-withdraw&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->