### PR TITLE
fix(suite): hide redundant "+ Standard wallet" button for unauthorize…

### DIFF
--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
@@ -22,8 +22,11 @@ interface AddWalletButtonProps {
 }
 
 export const AddWalletButton = ({ device, instances, onCancel }: AddWalletButtonProps) => {
-    // Find a "standard wallet" among user's wallet instances. If no such wallet is found, the variable is undefined.
-    const emptyPassphraseWalletExists = instances.find(d => d.useEmptyPassphrase && d.state);
+    // Standard wallet = useEmptyPassphrase not explicitly false (true, or undefined when not yet authorized).
+    // Mirrors useWalletLabel so the list and this button agree on what counts as a standard wallet.
+    const emptyPassphraseWalletExists = instances.find(
+        d => d.useEmptyPassphrase !== false && d.state,
+    );
 
     const isDeviceOrUiLocked = useSelector(selectIsDeviceOrUiLocked);
     const isAnyNetworkEnabled = useSelector(selectIsAnyNetworkEnabled);


### PR DESCRIPTION
…d devices

The wallet switcher could show a "Standard wallet" in the list and a "+ Standard wallet" button at the same time for a freshly connected, not-yet-authorized device (e.g. a TS7 over Bluetooth before discovery runs).

useWalletLabel labels a wallet as standard whenever useEmptyPassphrase is not explicitly false (true, or undefined in the unauthorized state), but AddWalletButton only treated useEmptyPassphrase === true as an existing standard wallet - so for the undefined case it missed it and still offered to add one.

Align the button's check with the label logic (useEmptyPassphrase \!== false) so the list and the button agree on what counts as a standard wallet.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28376

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to AddWalletButton.tsx, a component within the SwitchDevice/DeviceItem view. While it maps to 121 tests via static analysis (indicating it's a broadly imported component), the actual risk is concentrated in tests that directly interact with the device switcher panel to add, eject, or manage wallets. The highest-priority tests are those that explicitly add standard or hidden wallets through the device switcher UI and validate wallet creation, numbering, and duplicate detection. Medium-priority tests cover adjacent flows like wallet reconnection, metadata labeling on wallets, and multi-session management within the device switcher panel.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — This test directly exercises the AddWalletButton functionality by adding multiple passphrase wallets via the device switcher, ejecting wallets, and re-adding them. It validates wallet numbering in the device switcher panel, which is the core UI rendered by AddWalletButton.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test adds hidden wallets via the device switcher (addUnusedHiddenWallet, addHiddenWallet), switches between wallets, and verifies passphrase mismatch flows — all interactions that directly involve the AddWalletButton component in the SwitchDevice/DeviceItem view.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — This test adds a hidden wallet and then attempts to add a duplicate, directly exercising the AddWalletButton's flow for creating new wallets and its handling of duplicate passphrase detection.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test uses the device switcher to eject the current wallet and then adds a standard wallet via addStandardWallet — directly exercising the AddWalletButton component's standard wallet creation path.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test opens the device switching panel, checks wallet entries, and uses solveIssuesButton — it interacts with the SwitchDevice panel where AddWalletButton lives and validates wallet visibility and session state within it.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test adds a passphrase wallet via the device switcher and checks that it persists after device disconnect/reconnect, validating that the AddWalletButton-created wallet entry survives reconnection flows.
- `suite/e2e/tests/passphrase/passphrase-cancel.test.ts` — This test opens device switching, adds a hidden wallet, and then cancels the passphrase confirmation — directly testing the AddWalletButton's passphrase flow and its cancellation behavior.
- `suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — This test adds hidden wallets via the device switcher and labels them, directly interacting with the AddWalletButton to create both standard and passphrase-protected wallets in the switch device panel.
- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — This test adds hidden wallets, ejects all wallets, and re-adds standard wallets through the device switcher — exercising the AddWalletButton for both hidden and standard wallet creation paths across lifecycle events.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test adds multiple hidden wallets via addUnusedHiddenWallet in the device switcher, directly exercising AddWalletButton's wallet creation flow for passphrase wallets with Suite Sync integration.

</details>

_Updated: 2026-06-24T09:04:21.518Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=28376-weird-standard-wallet-displaying&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=28376-weird-standard-wallet-displaying&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-24T09:08:50.510Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-24T09:07:48.464Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/28376-weird-standard-wallet-displaying/web/](https://dev.suite.sldev.cz/suite-web/28376-weird-standard-wallet-displaying/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->