### PR TITLE
fix(connect): size bare uint/int EIP-712 fields as 256-bit

### DIFF
--- a/packages/connect/src/api/ethereum/__fixtures__/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/__fixtures__/ethereumSignTypedData.ts
@@ -61,25 +61,25 @@ export const getFieldType = [
         },
     },
     {
-        description: `bare uint is currently mis-sized as NaN (pre-fix behavior)`,
+        description: `should parse bare uint as uint256`,
         input: {
             typeName: 'uint',
             types: {},
         },
         output: {
             data_type: PROTO.EthereumDataType.UINT,
-            size: NaN,
+            size: 32,
         },
     },
     {
-        description: `bare int is currently mis-sized as NaN (pre-fix behavior)`,
+        description: `should parse bare int as int256`,
         input: {
             typeName: 'int',
             types: {},
         },
         output: {
             data_type: PROTO.EthereumDataType.INT,
-            size: NaN,
+            size: 32,
         },
     },
     {
@@ -307,20 +307,20 @@ export const encodeData = [
         output: 'c000000000000000000000000000000000000000000000000000000000000001',
     },
     {
-        description: `bare uint is currently left unpadded (pre-fix behavior)`,
+        description: `should encode bare uint as 32 bytes (uint256 alias)`,
         input: {
             typeName: 'uint',
             data: 255,
         },
-        output: 'ff',
+        output: '00000000000000000000000000000000000000000000000000000000000000ff',
     },
     {
-        description: `bare int is currently left unpadded (pre-fix behavior)`,
+        description: `should encode bare int as 32 bytes (int256 alias)`,
         input: {
             typeName: 'int',
             data: 127,
         },
-        output: '7f',
+        output: '000000000000000000000000000000000000000000000000000000000000007f',
     },
     {
         description: `should throw overflow error when signed int is too large`,

--- a/packages/connect/src/api/ethereum/__fixtures__/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/__fixtures__/ethereumSignTypedData.ts
@@ -61,6 +61,28 @@ export const getFieldType = [
         },
     },
     {
+        description: `bare uint is currently mis-sized as NaN (pre-fix behavior)`,
+        input: {
+            typeName: 'uint',
+            types: {},
+        },
+        output: {
+            data_type: PROTO.EthereumDataType.UINT,
+            size: NaN,
+        },
+    },
+    {
+        description: `bare int is currently mis-sized as NaN (pre-fix behavior)`,
+        input: {
+            typeName: 'int',
+            types: {},
+        },
+        output: {
+            data_type: PROTO.EthereumDataType.INT,
+            size: NaN,
+        },
+    },
+    {
         description: `should parse booleans`,
         input: {
             typeName: 'bool',
@@ -283,6 +305,22 @@ export const encodeData = [
             data: '0xc000000000000000000000000000000000000000000000000000000000000001',
         },
         output: 'c000000000000000000000000000000000000000000000000000000000000001',
+    },
+    {
+        description: `bare uint is currently left unpadded (pre-fix behavior)`,
+        input: {
+            typeName: 'uint',
+            data: 255,
+        },
+        output: 'ff',
+    },
+    {
+        description: `bare int is currently left unpadded (pre-fix behavior)`,
+        input: {
+            typeName: 'int',
+            data: 127,
+        },
+        output: '7f',
     },
     {
         description: `should throw overflow error when signed int is too large`,

--- a/packages/connect/src/api/ethereum/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/ethereumSignTypedData.ts
@@ -112,7 +112,8 @@ export function encodeData(typeName: string, data: any) {
     if (numberMatch) {
         const intType = numberMatch[1] ?? '';
         const bits = numberMatch[2] ?? '';
-        const bytes = Math.ceil(parseInt(bits, 10) / 8);
+        // bare `uint`/`int` are aliases for `uint256`/`int256`, so default empty bits to 256
+        const bytes = Math.ceil((bits === '' ? 256 : parseInt(bits, 10)) / 8);
 
         return intToHex(data, bytes, intType === 'int');
     }
@@ -164,7 +165,8 @@ export function getFieldType(
 
         return {
             data_type: type === 'uint' ? PROTO.EthereumDataType.UINT : PROTO.EthereumDataType.INT,
-            size: Math.floor(parseInt(bits, 10) / 8),
+            // bare `uint`/`int` are aliases for `uint256`/`int256`, so default empty bits to 256
+            size: Math.floor((bits === '' ? 256 : parseInt(bits, 10)) / 8),
         };
     }
 


### PR DESCRIPTION
## Description

Bare `uint` / `int` in an EIP-712 message — valid atomic types that alias `uint256` / `int256` — were sized as `NaN`:

- `getFieldType` returned `size: NaN`, which cannot be serialised into the protobuf `EthereumTypedDataStructAck` sent to the device, so signing any typed-data message containing a bare `uint`/`int` field failed.
- `encodeData` computed `NaN` bytes, leaving the value unpadded and skipping the overflow check.

`parseInt('')` is `NaN`, and the type regex deliberately allows an empty bit-width.

### Fix

Default an empty bit-width to 256 in both spots (`bits === '' ? 256 : parseInt(bits, 10)`) — an explicit empty-string check rather than `|| 256`, so only the bare-alias case is affected and every explicit width (including the degenerate `uint0`, which `|| 256` would wrongly promote) is left untouched.

### Test

Added `getFieldType` and `encodeData` fixtures for bare `uint`/`int`. The change is split into two commits so the bug is self-evident from history:

1. **`test:`** pins the current (broken) behavior — the fixtures assert `size: NaN` and the unpadded `ff`/`7f` that the unfixed code actually produces, so they pass against `develop`. Proof they pass on the unfixed commit: [Unit Tests (suite) run](https://github.com/trezor/trezor-suite/actions/runs/28578507405/job/84762858872).
2. **`fix:`** applies the fix and flips those fixtures to the corrected 256-bit results (`size: 32`, full 32-byte padding).

Net effect: the fixtures fail on the pre-fix code (size `NaN`, unpadded value) and pass after.

## Notes for QA

Low blast radius, confined to EIP-712 typed-data signing. Worth testing: sign a typed-data message that uses a bare `uint`/`int` field (e.g. from a dApp or `eth-sig-util`) — it should now sign instead of failing. Sized integer types (`uint256`, `int8`, …) are unaffected.

---

First of a small split-out series carved from #28977 (each PR = one focused runtime fix).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are scoped to `ethereumSignTypedData.ts` and its fixtures file within `@trezor/connect`. This is a specific Ethereum signing method (EIP-712 typed data signing) rather than a broadly shared utility. The static mapping shows 10 tests referencing the module file, but this is because all Ethereum-related E2E tests transitively import the connect Ethereum API bundle. None of the 10 mapped tests directly exercise EIP-712 typed data signing — there is no dedicated E2E test for `ethereumSignTypedData`. The closest test is sign-and-verify-eth which tests the related `signMessage`/`verifyMessage` Ethereum flows, and send-eth which exercises Ethereum transaction signing. The risk of regression to unrelated Ethereum flows (staking, trading, receive) is low since the change is isolated to a specific API method.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect/src/api/ethereum/__fixtures__/ethereumSignTypedData.ts`
- `packages/connect/src/api/ethereum/ethereumSignTypedData.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — This test directly exercises Ethereum message signing and verification via TrezorConnect, which is the closest E2E flow to the changed ethereumSignTypedData functionality. Both sign-typed-data and sign-message share the same Ethereum signing infrastructure in @trezor/connect, making regressions here most likely.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — This test exercises Ethereum transaction signing with custom gas parameters through the connect layer. While ethereumSignTypedData is a different method than ethereumSignTransaction, they share Ethereum-specific connect infrastructure and any breaking change to the Ethereum API module could surface here.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/connect/src/api/ethereum/__fixtures__/ethereumSignTypedData.ts`

_Updated: 2026-07-02T12:29:13.052Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/eip712-bare-uint-int&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/eip712-bare-uint-int&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/eip712-bare-uint-int&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T12:34:13.550Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-02T12:32:16.170Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/eip712-bare-uint-int/web/](https://dev.suite.sldev.cz/suite-web/mroz22/eip712-bare-uint-int/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->