### PR TITLE
fix(connect): remove stray $ in HTTP status error messages

### DIFF
--- a/packages/connect/src/api/ethereum/ethereumDefinitions.ts
+++ b/packages/connect/src/api/ethereum/ethereumDefinitions.ts
@@ -39,7 +39,7 @@ export const getEthereumDefinitions = async ({
         if (networkDefinition.status === 200) {
             definitions.encoded_network = await networkDefinition.arrayBuffer();
         } else if (networkDefinition.status !== 404) {
-            throw new Error(`unexpected status: $${networkDefinition.status}`);
+            throw new Error(`unexpected status: ${networkDefinition.status}`);
         }
     } catch (err) {
         console.warn(`unable to download or parse ${chainId} definition. detail: ${err.message}`);
@@ -56,7 +56,7 @@ export const getEthereumDefinitions = async ({
             if (tokenDefinition.status === 200) {
                 definitions.encoded_token = await tokenDefinition.arrayBuffer();
             } else if (tokenDefinition.status !== 404) {
-                throw new Error(`unexpected status: $${tokenDefinition.status}`);
+                throw new Error(`unexpected status: ${tokenDefinition.status}`);
             }
         }
     } catch (err) {

--- a/packages/connect/src/api/solana/solanaDefinitions.ts
+++ b/packages/connect/src/api/solana/solanaDefinitions.ts
@@ -19,7 +19,7 @@ export const getSolanaTokenDefinition = async ({ mintAddress }: GetSolanaTokenDe
 
                 return arrayBuffer;
             } else if (tokenDefinition.status !== 404) {
-                throw new Error(`unexpected status: $${tokenDefinition.status}`);
+                throw new Error(`unexpected status: ${tokenDefinition.status}`);
             }
         }
     } catch (err) {


### PR DESCRIPTION
## Description

The HTTP-status error messages in the connect coin-definition fetchers had a stray `$` in the template literal (`$${...}`), so a failed fetch threw `unexpected status: $404` instead of `unexpected status: 404`.

### Fix

Drop the extra `$` — two occurrences in `ethereumDefinitions.ts`, one in `solanaDefinitions.ts`.

## Notes for QA

No QA needed — cosmetic fix to an error-message string on a rare non-200/404 response path, no behaviour change. No test added (trivial string fix).

---

Part of the small split-out series from #28977.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two core definition files for Ethereum and Solana in the @trezor/connect package, which handle network/chain resolution, token definitions, and transaction construction parameters for these two chains. The primary risk is breaking transaction signing, address derivation, or token resolution for ETH and SOL operations. The testing strategy focuses on tests that directly exercise transaction signing flows (send, stake, swap, sell) for both chains, with highest priority on tests that perform actual device-confirmed transactions. The solanaDefinitions file maps to 121 tests via broad static coverage, but only Solana-specific transaction tests are meaningfully affected — analytics, backup, browser, metadata, and other unrelated tests are omitted despite the static mapping.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect/src/api/ethereum/ethereumDefinitions.ts`
- `packages/connect/src/api/solana/solanaDefinitions.ts`

</details>

**Recommended tests (20)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the full ETH staking flow including transaction signing on the Everstake contract, which directly depends on ethereumDefinitions for token/contract resolution during the staking transaction.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Unstaking and claiming ETH from Everstake involves Ethereum transaction signing with contract interaction, directly using ethereumDefinitions for transaction data encoding and contract definitions.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test sends an Ethereum transaction with custom gas parameters and verifies device prompt details. ETH send directly exercises ethereumDefinitions for transaction construction and signing.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Selling an ERC-20 token (USDC) involves token-aware Ethereum transaction signing, which relies on ethereumDefinitions to resolve token definitions and contract metadata for the device prompt.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — Sign and verify for Ethereum directly calls TrezorConnect signMessage/verifyMessage which uses ethereumDefinitions for network/chain resolution.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — First-time SOL staking involves Solana transaction construction and signing, directly exercising solanaDefinitions for program/instruction definitions used in the staking transaction.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstaking and claiming involves Solana transaction signing with stake program instructions, directly dependent on solanaDefinitions for transaction construction.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Sending SOL from a hidden wallet exercises the Solana send transaction path which directly uses solanaDefinitions for transaction construction and device signing.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Staking additional ETH exercises the same Everstake contract interaction path as initial-stake, providing additional coverage of ethereumDefinitions in a different staking state.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Selling native ETH with custom gas fees exercises Ethereum transaction signing, which uses ethereumDefinitions. Provides coverage complementary to the token sell test.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Swapping ETH to BTC with custom fee settings exercises Ethereum transaction construction with gas parameters, relying on ethereumDefinitions for chain/network resolution.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Staking additional SOL exercises the Solana staking transaction path with an already-staked account, providing complementary coverage of solanaDefinitions.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Swapping SOL to USDC token involves Solana transaction signing and send, directly using solanaDefinitions for transaction construction.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swapping USDT (SPL token on Solana) to BTC exercises Solana token-aware transaction signing which relies on solanaDefinitions.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Swapping SOL to BTC exercises Solana send transaction signing, relying on solanaDefinitions for constructing the outgoing Solana transaction.
- `suite/e2e/tests/wallet/receive.test.ts` — Receiving ETH and SOL involves address derivation which may use ethereumDefinitions and solanaDefinitions for network/chain resolution during getAddress calls.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Selling SOL involves Solana transaction construction and device signing, directly using solanaDefinitions for the send transaction.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Swapping SPL tokens (USDT to USDC) on Solana exercises token-aware transaction signing using solanaDefinitions.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/sol/rewards.test.ts` — While primarily a read-only staking dashboard test, it exercises Solana account discovery and staking state queries which may indirectly use solanaDefinitions.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — The global receive flow for ETH involves address derivation that uses ethereumDefinitions. However, this is a navigation-focused test and the definitions impact is indirect.

</details>

_Updated: 2026-06-22T13:30:46.378Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-error-message-stray-dollar&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-error-message-stray-dollar&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/connect-error-message-stray-dollar&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-22T13:35:06.605Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-22T13:33:51.409Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-error-message-stray-dollar/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-error-message-stray-dollar/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->