### PR TITLE
feat(suite): add Tron staking guide link

### DIFF
--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakingDashboard.tsx
@@ -3,6 +3,7 @@ import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { Column, Row, TextButton } from '@trezor/components';
 
 import { WalletLayout } from 'src/components/wallet';
+import { useGuideOpenNode } from 'src/hooks/guide';
 
 import { TronResourcesCard } from './TronResourcesCard/TronResourcesCard';
 import { TronStakedCard } from './TronStakedCard';
@@ -10,12 +11,15 @@ import { TronUnstakingCard } from './TronUnstakingCard';
 import { TronVotingRewardsCard } from './TronVotingRewardsCard';
 import { TronWithdrawReadyBanner } from './TronWithdrawReadyBanner';
 
+const TRON_STAKING_GUIDE_PATH = '/earn/staking/tron-trx-staking.md';
+
 interface TronStakingDashboardProps {
     selectedAccount: SelectedAccountLoaded;
 }
 
 export const TronStakingDashboard = ({ selectedAccount }: TronStakingDashboardProps) => {
     const { account } = selectedAccount;
+    const { openNodeById } = useGuideOpenNode();
 
     return (
         <WalletLayout title="TR_NAV_STAKING" account={selectedAccount}>
@@ -32,7 +36,12 @@ export const TronStakingDashboard = ({ selectedAccount }: TronStakingDashboardPr
                 <TronStakedCard account={account} />
                 <TronResourcesCard account={account} />
                 <Row justifyContent="center" padding={{ vertical: 20 }}>
-                    <TextButton size="small" iconLeft="question" isUnderlined>
+                    <TextButton
+                        size="small"
+                        iconLeft="question"
+                        isUnderlined
+                        onClick={() => openNodeById(TRON_STAKING_GUIDE_PATH)}
+                    >
                         <Translation id="TR_EARN_TRON_HOW_IT_WORKS" />
                     </TextButton>
                 </Row>


### PR DESCRIPTION
## Description

Add a link to guide for the `How does TRX staking work?` button.

## Related Issue

Resolve #28907 

## Screenshots

https://github.com/user-attachments/assets/64c0e9d8-312e-4efb-9e3a-57b5cbe9d46d

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change modifies TronStakingDashboard.tsx, a Tron-specific staking dashboard component. There are no dedicated E2E tests for Tron staking in the test suite — the existing staking tests cover only ETH, ADA, and SOL. The check-links test is the only test that navigates to Tron staking routes and could detect rendering failures. This change has a significant gap in E2E test coverage for its specific functionality.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakingDashboard.tsx`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test crawls all application routes including /earn/tron, /earn/tron/stake, /earn/tron/vote, /earn/tron/unstake, /earn/tron/withdraw which render Tron staking components. Changes to TronStakingDashboard could affect page rendering and link availability on these routes.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakingDashboard.tsx`

_Updated: 2026-06-23T07:56:45.581Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-staking-guide-link/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-staking-guide-link/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-staking-guide-link&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-staking-guide-link&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-23T08:01:57.526Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-23T07:59:56.829Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->