### PR TITLE
fix(suite-desktop): displaying of tx count

### DIFF
--- a/packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx
@@ -44,6 +44,7 @@ type SummaryCardProps = {
     localCurrency: BaseCurrencyCode;
     account: Account;
     isLoading?: boolean;
+    isGraphDataLoaded?: boolean;
 };
 
 const DateWrapper = styled.span`
@@ -64,6 +65,7 @@ export const SummaryCards = ({
     localCurrency,
     account,
     isLoading,
+    isGraphDataLoaded,
 }: SummaryCardProps) => {
     const { isBelowDesktop } = useLayoutSize();
     const { BaseCurrencyAmountFormatter } = useFormatters();
@@ -71,8 +73,12 @@ export const SummaryCards = ({
 
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(account.symbol);
 
-    // aggregate values from shown graph data
-    const numOfTransactions = data.reduce((acc, d) => (acc += d.txs), 0) || account.history.total;
+    // Aggregate values from shown graph data.
+    const txsFromData = data.reduce((acc, d) => (acc += d.txs), 0);
+    // only fall back to account.history.total before graph data has loaded.
+    const numOfTransactions = isGraphDataLoaded
+        ? txsFromData
+        : txsFromData || account.history.total;
 
     // on some networks it is not easy to get total number of txs (e.g. Ripple & Stellar)
     if (numOfTransactions === -1) {

--- a/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
@@ -45,6 +45,7 @@ export const TransactionSummary = ({ account }: TransactionSummaryProps) => {
     const dispatch = useDispatch();
 
     const intervalGraphData = getGraphDataForInterval({ account, graph });
+    const isGraphDataLoaded = intervalGraphData.length > 0;
     const data = intervalGraphData[0]?.data
         ? aggregateBalanceHistory(intervalGraphData, selectedRange.groupBy, 'account')
         : [];
@@ -154,6 +155,7 @@ export const TransactionSummary = ({ account }: TransactionSummaryProps) => {
                 localCurrency={baseCurrencyCode}
                 account={account}
                 isLoading={isLoading}
+                isGraphDataLoaded={isGraphDataLoaded}
             />
         </Column>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR addresses the issue and resolves TS error caused by silent OR statement to display total tx count if value over period was zero

## Notes for QA

See related issue for hints to reproduce the isssue

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26844

## Screenshots:


https://github.com/user-attachments/assets/b9d6cc1d-13d3-4fd0-bed3-85793c1c43ab


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to two components within the wallet transactions view: SummaryCards.tsx and TransactionSummary.tsx. These are rendered on the account transactions overview page. Although static mapping shows 59 tests (indicating these are broadly imported via the wallet view tree), only tests that directly interact with the transaction summary UI or depend on the transactions page rendering correctly are meaningfully at risk. The transactions.test.ts is the primary test that directly asserts on transaction summary behavior (graph range filters, date labels). Two other tests (export-transactions, pagination) interact heavily with the same page and could break if the summary components crash.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx`
- `packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly exercises the transaction summary view by cycling through graph time range filters and verifying date labels in the transactionSummaryTitle. The changed files SummaryCards.tsx and TransactionSummary.tsx are the exact components rendering this transaction summary UI, making this the most directly affected test.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test navigates to wallet account transaction views and triggers export actions from the transaction list view. The TransactionSummary and SummaryCards components are rendered on the same account transactions page, so a rendering break could block the export flow.
- `suite/e2e/tests/wallet/pagination.test.ts` — This test navigates paginated transaction pages on a BTC account and verifies transaction addresses. The transaction summary components are rendered above the transaction list on the same page, and a crash in SummaryCards or TransactionSummary could prevent the page from rendering properly.

</details>

_Updated: 2026-06-22T17:49:27.851Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/graph-tx-count/web/](https://dev.suite.sldev.cz/suite-web/fix/graph-tx-count/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/graph-tx-count&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/graph-tx-count&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-22T17:54:35.988Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-22T17:53:05.797Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->