### PR TITLE
fix(suite-native): stabilize ignored networks banner

### DIFF
--- a/suite-native/module-home/src/screens/HomeScreen/components/IgnoredNetworksBanner.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/IgnoredNetworksBanner.tsx
@@ -1,0 +1,25 @@
+import { memo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { Box, Text } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+import { selectDeviceHistoryIgnoredNetworksString } from '../homescreenSelectors';
+
+const IgnoredNetworksBannerComponent = () => {
+    const networksString = useSelector(selectDeviceHistoryIgnoredNetworksString);
+
+    if (networksString === null) {
+        return null;
+    }
+
+    return (
+        <Box paddingHorizontal="sp16">
+            <Text textAlign="center" variant="body-sm" color="contentSecondary">
+                <Translation id="moduleHome.graphIgnoredNetworks" values={{ networksString }} />
+            </Text>
+        </Box>
+    );
+};
+
+export const IgnoredNetworksBanner = memo(IgnoredNetworksBannerComponent);

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
@@ -1,46 +1,24 @@
 import { forwardRef, useImperativeHandle } from 'react';
 import { useSelector } from 'react-redux';
 
-import { getNetwork } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectHasRunningDiscovery } from '@suite-common/wallet-core';
-import { Box, Text, VStack } from '@suite-native/atoms';
+import { VStack } from '@suite-native/atoms';
 import { selectSelectedDeviceTotalFiatBalance } from '@suite-native/device';
 import { useIsDiscoveryDurationTooLong } from '@suite-native/discovery';
 import {
     Graph,
-    selectDeviceHistoryIgnoredNetworkSymbols,
     selectHasDeviceHistoryEnabledAccounts,
     useGraphAtoms,
     useGraphForAllDeviceAccounts,
 } from '@suite-native/graph';
-import { Translation } from '@suite-native/intl';
 
 import { referencePointAtom, selectedPointAtom } from '../portfolioGraphAtoms';
+import { IgnoredNetworksBanner } from './IgnoredNetworksBanner';
 import { PortfolioGraphTimeSwitch } from './PortfolioGraphTimeSwitch';
 import { PortfolioHeader } from './PortfolioHeader';
 
 export type PortfolioGraphRef = {
     refetchGraph: () => Promise<void>;
-};
-
-const IgnoredNetworksBanner = () => {
-    const graphIgnoredNetworkSymbols = useSelector(selectDeviceHistoryIgnoredNetworkSymbols);
-
-    if (!graphIgnoredNetworkSymbols.length) {
-        return null;
-    }
-
-    const networksString = graphIgnoredNetworkSymbols
-        .map(symbol => getNetwork(symbol).name)
-        .join(', ');
-
-    return (
-        <Box paddingHorizontal="sp16">
-            <Text textAlign="center" variant="body-sm" color="contentSecondary">
-                <Translation id="moduleHome.graphIgnoredNetworks" values={{ networksString }} />
-            </Text>
-        </Box>
-    );
 };
 
 export const PortfolioGraph = forwardRef<PortfolioGraphRef>((_props, ref) => {

--- a/suite-native/module-home/src/screens/HomeScreen/homescreenSelectors.ts
+++ b/suite-native/module-home/src/screens/HomeScreen/homescreenSelectors.ts
@@ -18,7 +18,9 @@ import {
     selectHasDeviceSuiteSyncError,
     selectSuiteSyncInteraction,
 } from '@suite-common/suite-sync';
+import { getNetwork } from '@suite-common/wallet-config';
 import {
+    type AccountsRootState,
     type DiscoveryRootState,
     selectHasOnlyEmptyPortfolioTracker,
     selectHasRunningDiscovery,
@@ -27,12 +29,25 @@ import {
 } from '@suite-common/wallet-core';
 import { type NativeDeviceRootState, selectIsDeviceSetupSupported } from '@suite-native/device';
 import { selectIsFirmwareUpdateFeatureEnabled } from '@suite-native/firmware';
+import { selectDeviceHistoryIgnoredNetworkSymbols } from '@suite-native/graph';
 
 import { type HomeScreenState } from './homescreenTypes';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<
-    DeviceRootState & DiscoveryRootState & WithSuiteSyncState & MessageSystemRootState
+    DeviceRootState &
+        AccountsRootState &
+        DiscoveryRootState &
+        WithSuiteSyncState &
+        MessageSystemRootState
 >();
+
+export const selectDeviceHistoryIgnoredNetworksString = createMemoizedSelector(
+    [selectDeviceHistoryIgnoredNetworkSymbols],
+    networkSymbols =>
+        networkSymbols.length === 0
+            ? null
+            : networkSymbols.map(networkSymbol => getNetwork(networkSymbol).name).join(', '),
+);
 
 export const selectShouldDisplayUpgradeFirmwareAlert = createMemoizedSelector(
     [


### PR DESCRIPTION
## Description

Stabilizes the ignored-networks banner on the Home portfolio graph.

- Moves the ignored-networks message into a separate memoized `IgnoredNetworksBanner`.
- Changes the banner selector to return a primitive `string | null`, so account updates with the same displayed ignored networks do not notify the banner.
- Keeps the banner component isolated from parent `PortfolioGraph` rerenders.
- This does not affect the graph as a whole; total fiat balance stabilization is tracked in #29000 and implemented in #29348.

## Related issue

Closes #29380

## Screenshots

https://github.com/user-attachments/assets/96d798ae-c412-4fb6-8601-b57c2c44655e



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=issue-29000&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->