### PR TITLE
feat(suite): report tradeNavigate analytics on sidebar swap and OTC concierge

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
@@ -1,7 +1,9 @@
-import { type FC, useMemo } from 'react';
+import { type FC, useCallback, useMemo } from 'react';
 
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { selectIsInitialRun } from '@suite/flags';
 import { type Route } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectHasBitcoinOnlyFirmware } from '@suite-common/device';
 import { Column } from '@trezor/components';
 
@@ -25,11 +27,23 @@ type NavigationProps = {
 
 export const Navigation = ({ children }: NavigationProps) => {
     const { isSidebarCollapsed } = useResponsiveContext();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const isInitialRun = useSelector(selectIsInitialRun);
     const startRoute: Route['name'] = isInitialRun ? 'suite-start' : 'suite-index';
 
     const isBtcOnly = useSelector(selectHasBitcoinOnlyFirmware);
+
+    const reportSwapNavigation = useCallback(() => {
+        analytics.report({
+            type: events.tradeNavigateEvent.name,
+            payload: {
+                action: 'navigate',
+                type: 'exchange',
+                from: 'sidebar',
+            },
+        });
+    }, [analytics]);
 
     const navItems: Array<NavigationItemProps & { CustomComponent?: FC<NavigationItemProps> }> =
         useMemo(
@@ -47,6 +61,7 @@ export const Navigation = ({ children }: NavigationProps) => {
                               icon: 'repeat',
                               goToRoute: 'wallet-trading-exchange',
                               routes: ['wallet-trading-exchange'],
+                              onClick: reportSwapNavigation,
                           } as NavigationItemProps,
                           {
                               nameId: 'TR_EARN',
@@ -79,7 +94,7 @@ export const Navigation = ({ children }: NavigationProps) => {
                     'data-testid': '@suite/menu/settings',
                 },
             ],
-            [startRoute, isBtcOnly],
+            [startRoute, isBtcOnly, reportSwapNavigation],
         );
 
     return (

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC.tsx
@@ -1,8 +1,10 @@
 import { type FiatCurrencyCode } from 'invity-api';
 
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { selectLanguage } from '@suite/settings';
+import { useServices } from '@suite-common/dependency-injection';
 import {
     type TradingTradeBuySellType,
     cryptoIdToNetworkAndContractAddress,
@@ -24,6 +26,7 @@ import {
 
 export const TradingFormOfferOTC = () => {
     const dispatch = useDispatch();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const otcQuery = useFetchOtc();
     const { data: otcData, isSuccess } = otcQuery;
     const context = useTradingFormContext<TradingTradeBuySellType>();
@@ -97,6 +100,21 @@ export const TradingFormOfferOTC = () => {
 
     const isBuy = context.type === 'buy';
 
+    const handleConciergeClick = () => {
+        dispatch(goto({ routeName: 'wallet-trading-concierge' }));
+
+        analytics.report({
+            type: events.tradeNavigateEvent.name,
+            payload: {
+                action: 'navigate',
+                type: 'concierge',
+                from: 'otc-banner',
+                networkSymbol: network?.symbol,
+                contractAddress,
+            },
+        });
+    };
+
     return (
         <Banner
             intent="info"
@@ -111,10 +129,7 @@ export const TradingFormOfferOTC = () => {
                             }}
                         />
                     </Text>
-                    <Banner.Button
-                        intent="info"
-                        onClick={() => dispatch(goto({ routeName: 'wallet-trading-concierge' }))}
-                    >
+                    <Banner.Button intent="info" onClick={handleConciergeClick}>
                         <Translation
                             id={isBuy ? 'TR_TRADING_OTC_LINK_BUY' : 'TR_TRADING_OTC_LINK_SELL'}
                         />

--- a/suite/analytics/src/events/tradeNavigateEvent.ts
+++ b/suite/analytics/src/events/tradeNavigateEvent.ts
@@ -6,6 +6,8 @@ type Attributes = {
     action: AttributeDef<'navigate' | 'cancel'>;
     type: AttributeDef<'exchange' | 'buy' | 'sell' | 'buy/sell' | 'concierge'>;
     from: AttributeDef<
+        | 'sidebar'
+        | 'otc-banner'
         | 'dashboard/header'
         | 'dashboard/assets'
         | 'dashboard/empty-wallet'
@@ -43,6 +45,8 @@ export const tradeNavigateEvent: EventDef<Attributes, EventType.TradeNavigate> =
                 { version: '25.5.2', notes: 'added' },
                 { version: '26.3.0', notes: 'added `dashboard/empty-wallet` value' },
                 { version: '26.5.2', notes: 'added `earn-dashboard` value' },
+                { version: '26.7.0', notes: 'added `sidebar` value' },
+                { version: '26.7.0', notes: 'added `otc-banner` value' },
             ],
             description:
                 'Location where the user initiated the trading action (e.g., `dashboard/header`, `account/tradebox`, `dashboard/assets`)',


### PR DESCRIPTION
## Description

Adds dedicated `tradeNavigateEvent` analytics on two trading entry points that previously fired only the generic `routerLocationChangeEvent`:

- **Sidebar Swap** — fires `tradeNavigateEvent` `{ action: 'navigate', type: 'exchange', from: 'sidebar' }`.
- **OTC banner concierge link** (buy/sell form) — fires `tradeNavigateEvent` `{ action: 'navigate', type: 'concierge', from: 'otc-banner', networkSymbol, contractAddress }`.

Adds `sidebar` and `otc-banner` values to the event's `from` attribute (changelog `26.7.0`).

## Related

Ensures every navigation to trading dispatches `tradeNavigateEvent`, including concierge.

## Testing

Analytics-only change; not observable in browser preview. Verified lint/typecheck on changed files.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies three files: the Sidebar Navigation component (broadly used across 121+ tests), a TradingFormOfferOTC component (specific to OTC trading offers), and a tradeNavigateEvent analytics event definition. The Navigation.tsx change is a broad dependency so most tests are excluded unless they specifically exercise navigation-to-trading flows. The TradingFormOfferOTC and tradeNavigateEvent changes are trading-specific with no static test coverage, so tests are inferred from the LLM analysis of trading and navigation tests. The primary risk is in trading navigation flows, offer display for buy/sell, and analytics event correctness during trade navigation.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC.tsx`
- `suite/analytics/src/events/tradeNavigateEvent.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test exercises navigating to Buy/Sell/Swap trading forms from multiple entry points including the sidebar and global header. Changes to Sidebar/Navigation.tsx directly affect the navigation entry points used in this test, and tradeNavigateEvent.ts changes could affect analytics fired during trading navigation.
- `suite/e2e/tests/analytics/staking-events.test.ts` — This test verifies StakingNavigate analytics events when navigating to staking from the account menu and dashboard. The tradeNavigateEvent.ts change likely affects how navigation analytics events are structured/fired, and the sidebar Navigation.tsx change could affect the staking navigation entry point in the account menu.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading/swap-coins.test.ts` — This test opens swap trading from the wallet page which involves sidebar navigation. The TradingFormOfferOTC.tsx component is part of the trading form offer flow, and while this test focuses on DEX swaps, the offer display infrastructure is shared. The tradeNavigateEvent could fire during swap navigation.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test covers the full buy BTC flow including offer display and confirmation. Changes to TradingFormOfferOTC.tsx could affect how OTC offers are rendered in the buy flow, and tradeNavigateEvent.ts changes may affect analytics during trading navigation.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — The sell flow displays offers from providers which may include OTC providers rendered by TradingFormOfferOTC.tsx. The tradeNavigateEvent.ts change could affect analytics fired when navigating to the sell form.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test covers buying ETH including offer display. TradingFormOfferOTC.tsx changes could affect OTC offer rendering in the buy flow, and tradeNavigateEvent.ts changes could affect navigation analytics.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test covers the sell flow for Solana including offer confirmation. TradingFormOfferOTC.tsx could render OTC offers in sell flows, and tradeNavigateEvent could be fired during navigation to the sell form.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test covers buying a Solana token with offer display and confirmation. TradingFormOfferOTC.tsx changes could affect how OTC offers are presented in the buy token flow.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This swap test navigates through the sidebar to swap trading. While TradingFormOfferOTC is specific to OTC offers (not typically swaps), the Navigation.tsx sidebar change could affect the swap entry point.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test covers selling ETH with offer confirmation. TradingFormOfferOTC.tsx changes could affect OTC offer rendering if OTC providers are part of the sell quotes.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — This test covers selling an ERC-20 token (USDC) through the sell flow with offer display. TradingFormOfferOTC.tsx could affect how OTC offers appear in the token sell flow.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC.tsx`
- `suite/analytics/src/events/tradeNavigateEvent.ts`

_Updated: 2026-06-23T15:24:00.657Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trade-navigate-sidebar-concierge&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trade-navigate-sidebar-concierge&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-23T15:28:29.367Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-23T15:27:22.360Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/trade-navigate-sidebar-concierge/web/](https://dev.suite.sldev.cz/suite-web/feat/trade-navigate-sidebar-concierge/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->