### PR TITLE
selectBuySelectedReceiveAccount should not throw

### DIFF
--- a/suite-native/trading-state/package.json
+++ b/suite-native/trading-state/package.json
@@ -21,7 +21,6 @@
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-sync": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
-        "@suite-common/suite-utils": "workspace:*",
         "@suite-common/token-definitions": "workspace:*",
         "@suite-common/trading": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",

--- a/suite-native/trading-state/src/selectors/__tests__/buySelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/buySelectors.test.ts
@@ -76,13 +76,12 @@ describe('buySelectors', () => {
             );
         });
 
-        it('should throw when no account with given key exists', () => {
-            const unknownAccountKey = mockAccountKey({ descriptor: 'unknownAccountKey' });
-            state.wallet.trading.buy.tradingAccountKey = unknownAccountKey;
+        it('should return undefined when no account with given key exists', () => {
+            state.wallet.trading.buy.tradingAccountKey = mockAccountKey({
+                descriptor: 'unknownAccountKey',
+            });
 
-            expect(() => selectBuySelectedReceiveAccount(state)).toThrow(
-                `Unknown tradingAccountKey: [${unknownAccountKey}]`,
-            );
+            expect(selectBuySelectedReceiveAccount(state)).toBeUndefined();
         });
     });
 

--- a/suite-native/trading-state/src/selectors/buySelectors.ts
+++ b/suite-native/trading-state/src/selectors/buySelectors.ts
@@ -3,7 +3,6 @@ import { Platform } from 'react-native';
 import type { BuyTrade } from 'invity-api';
 
 import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
-import { invariant } from '@suite-common/suite-utils';
 import {
     type TradingCountryCode,
     type TradingPaymentMethodProps,
@@ -49,7 +48,9 @@ export const selectBuySelectedReceiveAccount = createMemoizedSelectorWithAccount
         }
 
         const account = selectAccountByKey(state, tradingAccountKey);
-        invariant(account, `Unknown tradingAccountKey: [${tradingAccountKey}]`);
+        if (!account) {
+            return undefined;
+        }
 
         return getReceiveAccountFromAccountAndAddressString(account, receiveAddress);
     },

--- a/suite-native/trading-state/tsconfig.json
+++ b/suite-native/trading-state/tsconfig.json
@@ -16,9 +16,6 @@
             "path": "../../suite-common/suite-types"
         },
         {
-            "path": "../../suite-common/suite-utils"
-        },
-        {
             "path": "../../suite-common/token-definitions"
         },
         { "path": "../../suite-common/trading" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14279,7 +14279,6 @@ __metadata:
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-sync": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
-    "@suite-common/suite-utils": "workspace:*"
     "@suite-common/test-utils": "workspace:*"
     "@suite-common/token-definitions": "workspace:*"
     "@suite-common/trading": "workspace:*"


### PR DESCRIPTION

## Description

selectBuySelectedReceiveAccount returns undefined on unknown account instead of throwing error

<!--- Describe your changes in detail -->

## Notes for QA
Nothing to test
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=no-invariant-on-unknown-key&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=no-invariant-on-unknown-key&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=no-invariant-on-unknown-key&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are entirely within the `suite-native/trading-state` package, which is a React Native / mobile-specific module (`suite-native` prefix). The changed files include buy selectors, their unit tests, and package/tsconfig configuration — all scoped to the native mobile trading state layer. None of the 118 candidate E2E tests (which target the Trezor Suite web/desktop app) exercise native mobile trading state selectors. There is no static mapping and no inferrable connection between these native mobile selectors and any of the Playwright E2E tests. No E2E tests need to be run for this change.

<details><summary><b>Changed files (4)</b></summary>

- `suite-native/trading-state/package.json`
- `suite-native/trading-state/src/selectors/__tests__/buySelectors.test.ts`
- `suite-native/trading-state/src/selectors/buySelectors.ts`
- `suite-native/trading-state/tsconfig.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (4)**
- `suite-native/trading-state/package.json`
- `suite-native/trading-state/src/selectors/__tests__/buySelectors.test.ts`
- `suite-native/trading-state/src/selectors/buySelectors.ts`
- `suite-native/trading-state/tsconfig.json`

_Updated: 2026-06-23T06:17:44.776Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-23T06:21:45.980Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-23T06:21:26.138Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/no-invariant-on-unknown-key/web/](https://dev.suite.sldev.cz/suite-web/no-invariant-on-unknown-key/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->