### PR TITLE
fix(suite): gate exchange auto-confirm on quote matching selected receive coin (#28143)

### DIFF
--- a/packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx
@@ -42,7 +42,7 @@ export const TradingFormOfferExchangeActions = () => {
     const fee = composedTransactionInfo?.composed?.fee;
     const isFeeRequiredButMissingValue = fee === undefined || fee === '';
 
-    const { outputs, sendCryptoSelect } = watch();
+    const { outputs, sendCryptoSelect, receiveCryptoSelect } = watch();
     const { amount, tokenAddress } = getTradingFirstOutput(outputs);
     const areSatsUsed = !!shouldSendInSats;
 
@@ -63,6 +63,9 @@ export const TradingFormOfferExchangeActions = () => {
     const isReceiveAddressSelected = !!tradingReceiveAddress.receiveAddress;
     const shouldShowApprovalStep = quote !== undefined && requiresTokenApproval(quote);
     const isQuoteOutdated = quote?.send !== sendCryptoSelect?.id;
+    const isQuoteForSelectedReceive =
+        quote?.receive === receiveCryptoSelect?.id &&
+        quote?.receiveAddress === tradingReceiveAddress.receiveAddress;
     const amountTooHigh = isAmountTooHigh({
         amount,
         contractAddress: tokenAddress,
@@ -79,7 +82,11 @@ export const TradingFormOfferExchangeActions = () => {
 
     useEffect(() => {
         const initConfirmTrade = async () => {
-            if (shouldShowApprovalStep && tradingReceiveAddress.receiveAddress) {
+            if (
+                shouldShowApprovalStep &&
+                tradingReceiveAddress.receiveAddress &&
+                isQuoteForSelectedReceive
+            ) {
                 dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
                 const { receiveAddress } = tradingReceiveAddress;
 
@@ -96,7 +103,12 @@ export const TradingFormOfferExchangeActions = () => {
 
         initConfirmTrade();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [quote, shouldShowApprovalStep, tradingReceiveAddress.receiveAddress]);
+    }, [
+        quote,
+        shouldShowApprovalStep,
+        tradingReceiveAddress.receiveAddress,
+        isQuoteForSelectedReceive,
+    ]);
 
     const onSelectQuote = async () => {
         if (!quote || !tradingReceiveAddress.receiveAddress) return;


### PR DESCRIPTION
## Description

Follow-up to merged #28166 — a stale receive address still leaked into a swap request on rapid TO-asset switching.

`receiveAddress` lags `receiveCryptoSelect` by a render, so the auto-confirm effect fired `confirmTrade` with a stale pair → Invity "Invalid toAddress". The effect now also requires `quote.receive === receiveCryptoSelect.id` before firing.

Targeted gate; full desync removal tracked in epic #26280 Phase 3.

## Notes for QA

Exchange/swap: rapidly switch the TO asset/network right after a quote loads. No "Invalid toAddress" toast should appear. Covered by `trading/swap-inputs.test.ts` (green at `--repeat-each=15`).

## Related Issue

Resolve #28143

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to TradingFormOfferExchangeActions.tsx, a component in the swap/exchange trading flow responsible for exchange offer action buttons (e.g., confirming swap offers, initiating sends). No static test mapping exists, so all recommendations are inferred from LLM analysis. The highest risk is in the core swap E2E flows that exercise offer confirmation and transaction initiation. The recommended strategy focuses on running the main swap flow tests (coin-to-coin, coin-to-token, token-to-coin, token-to-token) at high priority, with fee-related and edge-case swap tests at medium priority.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-coins.test.ts` — This test exercises the full swap (exchange) flow including confirming swap offers, which directly exercises TradingFormOfferExchangeActions — the component responsible for exchange offer action buttons. It covers SOL-to-BTC swap with offer confirmation, transaction sending, and status progression.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test covers swapping a coin (SOL) to a token (USDC) through the exchange/swap flow, including viewing and confirming the best swap offer — directly exercising the exchange offer actions component.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — This test covers swapping a token (USDT) to a coin (BTC) through the exchange flow, including confirming the best offer and initiating the send — directly exercising the TradingFormOfferExchangeActions component.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — This test covers token-to-token swap (USDT to USDC on Solana), including viewing/confirming best swap offer and completing the exchange transaction — directly exercising exchange offer actions.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test exercises the swap flow with custom Bitcoin fee settings, including selecting the best swap offer and proceeding to confirmation — the offer action component is part of this flow.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test exercises the swap flow with custom Ethereum fee settings and proceeds through the exchange offer confirmation — exercising the exchange actions component.
- `suite/e2e/tests/trading/swap-history.test.ts` — This test covers swap/exchange trade history viewing and detail pages. While primarily about history display, it interacts with the exchange trading flow and the swap watch endpoint which may be influenced by exchange action components.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test covers swapping a token to an asset on a disabled network, verifying provider info in swap quotes — the exchange offer actions component is part of the swap flow being tested.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test covers swap form input validation including best offer display, provider selection, and fee calculation — the exchange actions component participates in the swap offer selection flow.

</details>

_Updated: 2026-06-29T09:04:20.126Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/28143-exchange-auto-confirm-receive-coin&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/28143-exchange-auto-confirm-receive-coin&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T09:09:25.764Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T09:07:59.823Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/28143-exchange-auto-confirm-receive-coin/web/](https://dev.suite.sldev.cz/suite-web/fix/28143-exchange-auto-confirm-receive-coin/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->