### PR TITLE
Mobile trade: crypto icon based on CryptoId

### DIFF
--- a/packages/suite/src/hooks/wallet/useTradingRedirect.ts
+++ b/packages/suite/src/hooks/wallet/useTradingRedirect.ts
@@ -78,8 +78,9 @@ const getTokenInfo = (cryptoId: CryptoId): TokenInfo | undefined => {
 
     if (!contractAddress) return;
 
+    // TODO this conversion is not valid, not all required fields are present
     return {
-        contract: contractAddress,
+        contract: contractAddress as string,
     } as TokenInfo;
 };
 

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -30,6 +30,7 @@ import {
     type BaseCurrencyOption,
     type FormState,
     type GeneralPrecomposedTransactionFinal,
+    type TokenAddress,
 } from '@suite-common/wallet-types';
 import { type PROTO } from '@trezor/connect';
 import { type SerializedError } from '@trezor/connect-common/src/constants/errors';
@@ -104,7 +105,7 @@ export type TradingUtilsProvidersProps = {
 
 export type TradingParsedCryptoIdProps = {
     networkId: CryptoId;
-    contractAddress: string | undefined;
+    contractAddress: TokenAddress | undefined;
 };
 
 export type TradingFiatCurrenciesProps = Map<FiatCurrencyCode, string>;

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -19,7 +19,12 @@ import {
     getNetworkByCoingeckoId,
     getNetworkByTradeCryptoId,
 } from '@suite-common/wallet-config';
-import type { Account, AccountKey, FormStateTrading } from '@suite-common/wallet-types';
+import type {
+    Account,
+    AccountKey,
+    FormStateTrading,
+    TokenAddress,
+} from '@suite-common/wallet-types';
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { type TokenInfo } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
@@ -45,7 +50,7 @@ import { getCountrySubdivisionByCode } from './utils/countryUtils';
 
 type NetworkAndContractAddress = {
     network: Network | undefined;
-    contractAddress: string | undefined;
+    contractAddress: TokenAddress | undefined;
 };
 
 type TradingGetFormStateSellProps = {
@@ -91,8 +96,11 @@ export const isExchangeProvider = (provider: TradingProviderInfo) =>
 export const parseCryptoId = (cryptoId: CryptoId): TradingParsedCryptoIdProps => {
     const parts = cryptoId.split(CRYPTO_PLATFORM_SEPARATOR);
 
-    // TODO: This casting doesn't make any sense. Return new type called `NetworkId` instead of `CryptoId`
-    return { networkId: parts[0] as CryptoId, contractAddress: parts[1] };
+    return {
+        // TODO: This casting doesn't make any sense. Return new type called `NetworkId` instead of `CryptoId`
+        networkId: parts[0] as CryptoId,
+        contractAddress: parts[1] as TokenAddress | undefined,
+    };
 };
 
 export function composeCryptoId(coingeckoId: string, contractAddress?: string | null): CryptoId {

--- a/suite-native/module-trading/src/components/general/CryptoAmountRow.tsx
+++ b/suite-native/module-trading/src/components/general/CryptoAmountRow.tsx
@@ -1,9 +1,7 @@
 import type { CryptoId } from 'invity-api';
 
-import { cryptoIdToNetworkSymbolAndContractAddress } from '@suite-common/trading';
 import { type BoxProps, HStack, Text } from '@suite-native/atoms';
-import { CryptoIcon } from '@suite-native/icons';
-import { useFormatCryptoValue } from '@suite-native/trading-atoms';
+import { IconByCryptoId, useFormatCryptoValue } from '@suite-native/trading-atoms';
 import { CryptoToFiatValueBadge } from '@suite-native/trading-quote-utils';
 
 export type CryptoAmountRowProps = {
@@ -15,9 +13,7 @@ export type CryptoAmountRowProps = {
 
 export const CryptoAmountRow = ({ cryptoId, amount, direction, style }: CryptoAmountRowProps) => {
     const formatCryptoValue = useFormatCryptoValue();
-    const { symbol, contractAddress } = cryptoIdToNetworkSymbolAndContractAddress(cryptoId);
-
-    if (!symbol || !cryptoId || !amount) {
+    if (!cryptoId || !amount) {
         return null;
     }
 
@@ -28,7 +24,7 @@ export const CryptoAmountRow = ({ cryptoId, amount, direction, style }: CryptoAm
     return (
         <HStack justifyContent="space-between" alignItems="center" flex={1} style={style}>
             <HStack alignItems="center">
-                <CryptoIcon symbol={symbol} contractAddress={contractAddress} size="extraSmall" />
+                <IconByCryptoId cryptoId={cryptoId} size="extraSmall" />
                 {formattedAmount && (
                     <Text variant="body-sm" color={color}>
                         {prefix + formattedAmount}

--- a/suite-native/module-trading/src/components/general/CryptoAmountRow.tsx
+++ b/suite-native/module-trading/src/components/general/CryptoAmountRow.tsx
@@ -9,9 +9,16 @@ export type CryptoAmountRowProps = {
     amount?: string;
     direction: 'from' | 'to';
     style?: BoxProps['style'];
+    withNetworkIcon?: boolean;
 };
 
-export const CryptoAmountRow = ({ cryptoId, amount, direction, style }: CryptoAmountRowProps) => {
+export const CryptoAmountRow = ({
+    cryptoId,
+    amount,
+    direction,
+    style,
+    withNetworkIcon,
+}: CryptoAmountRowProps) => {
     const formatCryptoValue = useFormatCryptoValue();
     if (!cryptoId || !amount) {
         return null;
@@ -24,7 +31,11 @@ export const CryptoAmountRow = ({ cryptoId, amount, direction, style }: CryptoAm
     return (
         <HStack justifyContent="space-between" alignItems="center" flex={1} style={style}>
             <HStack alignItems="center">
-                <IconByCryptoId cryptoId={cryptoId} size="extraSmall" />
+                <IconByCryptoId
+                    cryptoId={cryptoId}
+                    size="extraSmall"
+                    withNetwork={withNetworkIcon}
+                />
                 {formattedAmount && (
                     <Text variant="body-sm" color={color}>
                         {prefix + formattedAmount}

--- a/suite-native/module-trading/src/components/general/TradeableAssetButton.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetButton.tsx
@@ -5,9 +5,9 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 import { invariant } from '@suite-common/suite-utils';
 import { cryptoIdToSymbol } from '@suite-common/trading';
-import { type NetworkDisplaySymbol, getDisplaySymbol } from '@suite-common/wallet-config';
 import { Box, buttonSizeToDimensionsMap } from '@suite-native/atoms';
-import { CryptoIcon, Icon } from '@suite-native/icons';
+import { Icon } from '@suite-native/icons';
+import { IconByCryptoId } from '@suite-native/trading-atoms';
 import { type TradeableAsset } from '@suite-native/trading-types';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { hexToRgba } from '@trezor/utils';
@@ -61,12 +61,6 @@ export const TradeableAssetButton = ({
         [dominantAssetColor],
     );
 
-    // when there is no contract address, we want to use display symbol instead
-    // this way we can present ETH icon for EVMs instead of network icon
-    const adjustedSymbol = contractAddress
-        ? networkSymbol
-        : (getDisplaySymbol(networkSymbol) as NetworkDisplaySymbol);
-
     const symbolTestID = testID ? `${testID}/symbol` : undefined;
 
     return (
@@ -84,7 +78,7 @@ export const TradeableAssetButton = ({
                 accessibilityLabel={accessibilityLabel}
                 testID={testID}
             >
-                <CryptoIcon symbol={adjustedSymbol} contractAddress={contractAddress} size="tiny" />
+                <IconByCryptoId cryptoId={cryptoId} size="tiny" />
                 <NetworkSymbolExtendedFormatter
                     symbol={symbol}
                     variant="body-sm-strong"

--- a/suite-native/module-trading/src/hooks/reviewOutputs/useTradingContentBuilder.tsx
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/useTradingContentBuilder.tsx
@@ -41,11 +41,13 @@ export const useTradingContentBuilder = (): ContentBuilderFunction => {
                             direction="from"
                             amount={send.amount}
                             cryptoId={send.cryptoId}
+                            withNetworkIcon
                         />
                         <CryptoAmountRow
                             direction="to"
                             amount={receiveAmountMultiplier(receive.amount)}
                             cryptoId={receive.cryptoId}
+                            withNetworkIcon
                         />
                         {!!account && (
                             <HStack

--- a/suite-native/trading-atoms/src/components/IconByCryptoId.tsx
+++ b/suite-native/trading-atoms/src/components/IconByCryptoId.tsx
@@ -1,18 +1,21 @@
 import type { CryptoId } from 'invity-api';
 
-import { invariant } from '@suite-common/suite-utils';
 import { cryptoIdToNetworkSymbolAndContractAddress } from '@suite-common/trading';
 import { type NetworkDisplaySymbol, getDisplaySymbol } from '@suite-common/wallet-config';
-import { CryptoIcon, type CryptoIconSize } from '@suite-native/icons';
+import { CryptoIcon, type CryptoIconSize, CryptoIconWithNetwork } from '@suite-native/icons';
 
 export type IconByCryptoIdProps = {
     cryptoId: CryptoId;
-    size?: CryptoIconSize | number;
+    size?: CryptoIconSize;
+    withNetwork?: boolean;
 };
 
-export const IconByCryptoId = ({ cryptoId, size }: IconByCryptoIdProps) => {
+export const IconByCryptoId = ({ cryptoId, size, withNetwork = false }: IconByCryptoIdProps) => {
     const { symbol, contractAddress } = cryptoIdToNetworkSymbolAndContractAddress(cryptoId);
-    invariant(symbol, `Network symbol not found for cryptoId: ${cryptoId}`);
+
+    if (!symbol) {
+        return null;
+    }
 
     // when there is no contract address, we want to use display symbol instead
     // this way we can present ETH icon for EVMs instead of network icon
@@ -20,5 +23,9 @@ export const IconByCryptoId = ({ cryptoId, size }: IconByCryptoIdProps) => {
         ? symbol
         : (getDisplaySymbol(symbol) as NetworkDisplaySymbol);
 
-    return <CryptoIcon symbol={adjustedSymbol} contractAddress={contractAddress} size={size} />;
+    return withNetwork ? (
+        <CryptoIconWithNetwork symbol={symbol} contractAddress={contractAddress} size={size} />
+    ) : (
+        <CryptoIcon symbol={adjustedSymbol} contractAddress={contractAddress} size={size} />
+    );
 };

--- a/suite-native/trading-atoms/src/components/IconByCryptoId.tsx
+++ b/suite-native/trading-atoms/src/components/IconByCryptoId.tsx
@@ -1,0 +1,24 @@
+import type { CryptoId } from 'invity-api';
+
+import { invariant } from '@suite-common/suite-utils';
+import { cryptoIdToNetworkSymbolAndContractAddress } from '@suite-common/trading';
+import { type NetworkDisplaySymbol, getDisplaySymbol } from '@suite-common/wallet-config';
+import { CryptoIcon, type CryptoIconSize } from '@suite-native/icons';
+
+export type IconByCryptoIdProps = {
+    cryptoId: CryptoId;
+    size?: CryptoIconSize | number;
+};
+
+export const IconByCryptoId = ({ cryptoId, size }: IconByCryptoIdProps) => {
+    const { symbol, contractAddress } = cryptoIdToNetworkSymbolAndContractAddress(cryptoId);
+    invariant(symbol, `Network symbol not found for cryptoId: ${cryptoId}`);
+
+    // when there is no contract address, we want to use display symbol instead
+    // this way we can present ETH icon for EVMs instead of network icon
+    const adjustedSymbol = contractAddress
+        ? symbol
+        : (getDisplaySymbol(symbol) as NetworkDisplaySymbol);
+
+    return <CryptoIcon symbol={adjustedSymbol} contractAddress={contractAddress} size={size} />;
+};

--- a/suite-native/trading-atoms/src/components/__tests__/IconByCryptoId.test.tsx
+++ b/suite-native/trading-atoms/src/components/__tests__/IconByCryptoId.test.tsx
@@ -1,0 +1,43 @@
+import { renderWithBasicProvider } from '@suite-native/test-utils';
+import {
+    btcAsset,
+    ethOnBaseAsset,
+    rethOnBaseAsset,
+    usdcAsset,
+} from '@suite-native/trading-fixtures';
+
+import { IconByCryptoId } from '../IconByCryptoId';
+
+describe('IconByCryptoId', () => {
+    it('should render display symbol icon for native L1 asset', () => {
+        const { getByLabelText } = renderWithBasicProvider(
+            <IconByCryptoId cryptoId={btcAsset.cryptoId} />,
+        );
+
+        expect(getByLabelText('BTC')).toBeTruthy();
+    });
+
+    it('should render ETH icon for native asset on L2 EVM network', () => {
+        const { getByLabelText } = renderWithBasicProvider(
+            <IconByCryptoId cryptoId={ethOnBaseAsset.cryptoId} />,
+        );
+
+        expect(getByLabelText('ETH')).toBeTruthy();
+    });
+
+    it('should render token icon with contract address for ERC-20 token', () => {
+        const { getByLabelText } = renderWithBasicProvider(
+            <IconByCryptoId cryptoId={usdcAsset.cryptoId} />,
+        );
+
+        expect(getByLabelText('eth0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')).toBeTruthy();
+    });
+
+    it('should render token icon with contract address for token on L2 EVM network', () => {
+        const { getByLabelText } = renderWithBasicProvider(
+            <IconByCryptoId cryptoId={rethOnBaseAsset.cryptoId} />,
+        );
+
+        expect(getByLabelText('base0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c')).toBeTruthy();
+    });
+});

--- a/suite-native/trading-atoms/src/components/__tests__/IconByCryptoId.test.tsx
+++ b/suite-native/trading-atoms/src/components/__tests__/IconByCryptoId.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { act, renderWithBasicProvider } from '@suite-native/test-utils';
 import {
     btcAsset,
     ethOnBaseAsset,
@@ -6,38 +6,101 @@ import {
     usdcAsset,
 } from '@suite-native/trading-fixtures';
 
-import { IconByCryptoId } from '../IconByCryptoId';
+import { IconByCryptoId, type IconByCryptoIdProps } from '../IconByCryptoId';
+
+const cryptoIconHint = 'Crypto Icon';
+const networkIconHint = 'Network Icon';
 
 describe('IconByCryptoId', () => {
-    it('should render display symbol icon for native L1 asset', () => {
-        const { getByLabelText } = renderWithBasicProvider(
-            <IconByCryptoId cryptoId={btcAsset.cryptoId} />,
-        );
+    const renderIcon = async (props: IconByCryptoIdProps) => {
+        const result = renderWithBasicProvider(<IconByCryptoId {...props} />);
+        await act(async () => {});
+
+        return result;
+    };
+
+    it('should render display symbol icon for native L1 asset', async () => {
+        const { getByLabelText } = await renderIcon({ cryptoId: btcAsset.cryptoId });
 
         expect(getByLabelText('BTC')).toBeTruthy();
     });
 
-    it('should render ETH icon for native asset on L2 EVM network', () => {
-        const { getByLabelText } = renderWithBasicProvider(
-            <IconByCryptoId cryptoId={ethOnBaseAsset.cryptoId} />,
-        );
+    it('should render ETH icon for native asset on L2 EVM network', async () => {
+        const { getByLabelText, queryByHintText } = await renderIcon({
+            cryptoId: ethOnBaseAsset.cryptoId,
+        });
 
         expect(getByLabelText('ETH')).toBeTruthy();
+        expect(queryByHintText(networkIconHint)).toBeNull();
     });
 
-    it('should render token icon with contract address for ERC-20 token', () => {
-        const { getByLabelText } = renderWithBasicProvider(
-            <IconByCryptoId cryptoId={usdcAsset.cryptoId} />,
-        );
+    it('should render token icon with contract address for ERC-20 token', async () => {
+        const { getByLabelText, queryByHintText } = await renderIcon({
+            cryptoId: usdcAsset.cryptoId,
+        });
 
         expect(getByLabelText('eth0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')).toBeTruthy();
+        expect(queryByHintText(networkIconHint)).toBeNull();
     });
 
-    it('should render token icon with contract address for token on L2 EVM network', () => {
-        const { getByLabelText } = renderWithBasicProvider(
-            <IconByCryptoId cryptoId={rethOnBaseAsset.cryptoId} />,
-        );
+    it('should render token icon with contract address for token on L2 EVM network', async () => {
+        const { getByLabelText, queryByHintText } = await renderIcon({
+            cryptoId: rethOnBaseAsset.cryptoId,
+        });
 
         expect(getByLabelText('base0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c')).toBeTruthy();
+        expect(queryByHintText(networkIconHint)).toBeNull();
+    });
+
+    it('should render nothing for unknown cryptoId', async () => {
+        const { toJSON } = await renderIcon({ cryptoId: 'unknown' as any });
+
+        expect(toJSON()).toBeNull();
+    });
+
+    describe('withNetwork', () => {
+        it('should render L1 asset icon without network badge', async () => {
+            const { getByLabelText, getByHintText, queryByHintText } = await renderIcon({
+                cryptoId: btcAsset.cryptoId,
+                withNetwork: true,
+            });
+
+            expect(getByHintText(cryptoIconHint)).toBeTruthy();
+            expect(getByLabelText('BTC')).toBeTruthy();
+            expect(queryByHintText(networkIconHint)).toBeNull();
+        });
+
+        it('should render ETH icon with network badge for native asset on L2 EVM network', async () => {
+            const { getByLabelText, getByHintText } = await renderIcon({
+                cryptoId: ethOnBaseAsset.cryptoId,
+                withNetwork: true,
+            });
+
+            expect(getByHintText(cryptoIconHint)).toBeTruthy();
+            expect(getByLabelText('ETH')).toBeTruthy();
+            expect(getByHintText(networkIconHint)).toBeTruthy();
+        });
+
+        it('should render ERC-20 token icon with network badge', async () => {
+            const { getByLabelText, getByHintText } = await renderIcon({
+                cryptoId: usdcAsset.cryptoId,
+                withNetwork: true,
+            });
+
+            expect(getByHintText(cryptoIconHint)).toBeTruthy();
+            expect(getByLabelText('eth0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')).toBeTruthy();
+            expect(getByHintText(networkIconHint)).toBeTruthy();
+        });
+
+        it('should render L2 EVM token icon with network badge', async () => {
+            const { getByLabelText, getByHintText } = await renderIcon({
+                cryptoId: rethOnBaseAsset.cryptoId,
+                withNetwork: true,
+            });
+
+            expect(getByHintText(cryptoIconHint)).toBeTruthy();
+            expect(getByLabelText('base0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c')).toBeTruthy();
+            expect(getByHintText(networkIconHint)).toBeTruthy();
+        });
     });
 });

--- a/suite-native/trading-atoms/src/index.ts
+++ b/suite-native/trading-atoms/src/index.ts
@@ -20,6 +20,7 @@ export * from './components/BottomSheetSectionList';
 export * from './components/CardTitle';
 export * from './components/EmptyComponent';
 export * from './components/FilterTabs';
+export * from './components/IconByCryptoId';
 export * from './components/NetworkBadge';
 export * from './components/OverviewRow';
 export * from './components/OverviewValueSkeleton';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- New component for trading icons introduced
- New component used for all places specified in the issue
<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #29003

## Screenshots:
<img width="300" alt="Simulator Screenshot - iPhone 17 - 2026-06-23 at 10 16 00" src="https://github.com/user-attachments/assets/4496467b-e663-46b4-bcc0-2a6fd22e66ee" />
<img width="300" alt="Simulator Screenshot - iPhone 17 - 2026-06-23 at 10 16 38" src="https://github.com/user-attachments/assets/265c9d66-8624-4317-89a9-7f046c6ab3ef" />
<img width="300" alt="Simulator Screenshot - iPhone 17 - 2026-06-23 at 10 16 53" src="https://github.com/user-attachments/assets/1a833973-4272-4e81-930b-1a1b3365ef73" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=29003-mobile-trade-crypto-icon-based-on-cryptoid&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=29003-mobile-trade-crypto-icon-based-on-cryptoid&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=29003-mobile-trade-crypto-icon-based-on-cryptoid&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes span two main areas: (1) suite-web trading hooks/utilities (useTradingRedirect, trading types and utils) affecting the coinmarket buy/sell/swap flows, and (2) suite-native trading components (CryptoAmountRow, TradeableAssetButton, IconByCryptoId, useTradingContentBuilder) which have no E2E web test coverage since they're React Native components. The highest risk is in useTradingRedirect.ts which directly controls trading flow navigation, and suite-common/trading/src/utils.ts which is a broadly imported utility. Testing strategy focuses on trading flow tests that directly exercise redirects and trading utilities, while the native mobile components remain uncovered by web E2E tests.

<details><summary><b>Changed files (9)</b></summary>

- `packages/suite/src/hooks/wallet/useTradingRedirect.ts`
- `suite-common/trading/src/types.ts`
- `suite-common/trading/src/utils.ts`
- `suite-native/module-trading/src/components/general/CryptoAmountRow.tsx`
- `suite-native/module-trading/src/components/general/TradeableAssetButton.tsx`
- `suite-native/module-trading/src/hooks/reviewOutputs/useTradingContentBuilder.tsx`
- `suite-native/trading-atoms/src/components/IconByCryptoId.tsx`
- `suite-native/trading-atoms/src/components/__tests__/IconByCryptoId.test.tsx`
- `suite-native/trading-atoms/src/index.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test directly exercises the coinmarket buy flow which uses useTradingRedirect hook for navigation. Changes to useTradingRedirect.ts could break the redirect behavior after trade confirmation, quote selection, and back-to-account navigation that this test validates.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests the buy Ethereum flow end-to-end including asset selection, trade confirmation, and redirect completion. Directly depends on useTradingRedirect for navigation between trading states and uses trading utils for crypto ID resolution.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — The sell BTC flow uses useTradingRedirect for navigating between sell form, confirmation, and transaction detail screens. Changes to the redirect hook or trading utils could break the sell trade confirmation and redirect flow.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Tests buying a Solana SPL token which exercises the trading redirect hook and trading utilities. This is a token-level buy flow that validates the redirect works correctly for non-native assets.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests the sell Ethereum flow with custom gas fees, relying on useTradingRedirect for navigation after trade confirmation and redirect completion.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token (USDC) through the sell flow, which depends on useTradingRedirect for the post-confirmation redirect behavior.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests the full Solana sell flow including offer comparison and transaction status polling. Uses useTradingRedirect for navigation between sell states.
- `suite/e2e/tests/trading/navigation.test.ts` — Explicitly tests navigation to Buy/Sell/Swap forms from multiple entry points (dashboard, account, global header, tokens). Changes to useTradingRedirect could break these navigation paths. Uses trading utils for crypto ID and form verification.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Tests a full SOL-to-BTC swap flow that uses trading utils (getCryptoId, localizeNumber) and the trading redirect mechanism for post-swap navigation. Changes to suite-common/trading/src/utils.ts could affect crypto ID resolution or amount formatting.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests swapping SOL to USDC token, directly importing getCryptoId from @suite-common/trading and using localizeNumber for amount formatting. Changes to trading utils could break crypto ID matching or formatted amount display.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping a Solana USDT token to BTC, using getCryptoId from trading utils for asset identification. A secondary swap flow that would catch regressions in crypto ID utilities.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests negative/error states in the buy form (max/min limits, empty quotes). While it doesn't directly test redirects, it validates the buy form behavior which may be affected by changes to trading utils used for amount validation.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests Ethereum swap with custom fees, using getCryptoId and localizeNumber from trading utils. Changes to these utilities could affect fee calculation display.

</details>

⚠️ **Changes with no test coverage (7)**
- `suite-common/trading/src/types.ts`
- `suite-native/module-trading/src/components/general/CryptoAmountRow.tsx`
- `suite-native/module-trading/src/components/general/TradeableAssetButton.tsx`
- `suite-native/module-trading/src/hooks/reviewOutputs/useTradingContentBuilder.tsx`
- `suite-native/trading-atoms/src/components/IconByCryptoId.tsx`
- `suite-native/trading-atoms/src/components/__tests__/IconByCryptoId.test.tsx`
- `suite-native/trading-atoms/src/index.ts`

_Updated: 2026-06-24T17:33:08.046Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-24T17:38:20.382Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-24T09:08:32.125Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/29003-mobile-trade-crypto-icon-based-on-cryptoid/web/](https://dev.suite.sldev.cz/suite-web/29003-mobile-trade-crypto-icon-based-on-cryptoid/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->