### PR TITLE
chore(wallet-core): remove dead reducer helpers

### DIFF
--- a/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
@@ -23,15 +23,6 @@ import {
     selectEnabledNetworks,
 } from '../settings/walletSettingsReducer';
 
-/*
-  get url suffix from default network and generate url for selected network
-  regex source: https://www.oreilly.com/library/view/regular-expressions-cookbook/9780596802837/ch07s12.html
-*/
-export const getBlockExplorerUrlSuffix = (url: string) =>
-    url.match(/^([a-z][a-z0-9+\-.]*:(\/\/[^/?#]+)?)?([a-z0-9\-._~%!$&'()*+,;=:@/]*)/)!.pop();
-
-export const isHttpProtocol = (url: string) => /^https?:\/\//.test(url);
-
 export type BlockchainState = BlockchainNetworks;
 
 const initialStatePredefined: Partial<BlockchainState> = {};

--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
@@ -9,7 +9,6 @@ import {
 import {
     type NetworkSymbol,
     getNetwork,
-    getNetworkType,
     networkSymbolCollection,
 } from '@suite-common/wallet-config';
 import { AddressDisplayOptions, type WalletSettings } from '@suite-common/wallet-types';
@@ -125,11 +124,6 @@ export const selectIsAnyNetworkEnabled = (state: WalletSettingsRootState) =>
 export const selectIsBitcoinEnabled = createMemoizedSelector(
     [selectEnabledNetworks],
     enabledNetworks => enabledNetworks.includes('btc'),
-);
-
-export const selectIsAnyNonBitcoinLikeNetworkEnabled = createMemoizedSelector(
-    [selectEnabledNetworks],
-    enabledNetworks => enabledNetworks.some(network => getNetworkType(network) !== 'bitcoin'),
 );
 
 export const selectAreSatsAmountUnit = (state: WalletSettingsRootState) => {


### PR DESCRIPTION
Part of the dead-code-elimination sweep (staging #28463).

Removes unused reducer helpers with no remaining references: `getBlockExplorerUrlSuffix` and `isHttpProtocol` (blockchainReducer), and `selectIsAnyNonBitcoinLikeNetworkEnabled` (walletSettingsReducer). The now-orphaned `getNetworkType` import is dropped with it.

All removed symbols are verified unused across the repository, so this is a pure deletion with no behaviour change.

Sibling PRs in this batch: #29021, #29022, #29023

### Notes for QA

No QA needed — pure dead-code removal; every deleted symbol has zero remaining references and there is no runtime effect.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Both changed files (blockchainReducer and walletSettingsReducer) are foundational Redux reducers imported by virtually all 121 E2E tests, making them broad global dependencies. The blockchainReducer manages blockchain connection state, backend configurations, and discovery lifecycle, while walletSettingsReducer manages enabled networks, fiat currency, and other wallet-level settings. The highest risk is in tests that directly exercise network enablement, custom backend configuration, and wallet discovery flows. The recommended strategy focuses on the ~12 tests that most directly exercise these reducer behaviors — coin settings, backend configuration, discovery, and balance display — rather than broadly running all 121 tests.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-core/src/blockchain/blockchainReducer.ts`
- `suite-common/wallet-core/src/settings/walletSettingsReducer.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test directly exercises enabling cryptocurrency networks and configuring custom blockbook backends, which are core behaviors managed by both blockchainReducer (backend connection state) and walletSettingsReducer (enabled networks/coins settings). Changes to either reducer could break network activation, backend configuration, or discovery flows tested here.
- `suite/e2e/tests/settings/coins.test.ts` — This test validates enabling/disabling mainnet and testnet networks, activating assets via modal, and configuring custom backends — all of which directly depend on walletSettingsReducer for network enablement state and blockchainReducer for backend connection management. The empty-state-to-activated flow is a critical path for these reducers.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends for BTC and LTC and verifies wallet discovery completes successfully. The blockchainReducer manages blockchain connection state and backend configuration, making this a direct test of its functionality. walletSettingsReducer controls which networks are enabled.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coins (btc, eth, ltc, etc, bch, doge, xrp, zec), triggers discovery, interrupts with a reload, and verifies discovery recovers. It directly exercises walletSettingsReducer for network activation and blockchainReducer for blockchain connection/discovery state management across interruptions.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test verifies that SuiteReady analytics events correctly report enabledNetworks, customBackends, and other wallet settings after changing them. The walletSettingsReducer stores enabled networks and custom backend state that feeds into the analytics payload, and blockchainReducer manages custom backend configuration.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test enables new networks via the 'Activate Assets' modal and verifies they appear in the dashboard, relying on walletSettingsReducer for network enablement and blockchainReducer for discovery after activation. A regression in either reducer could prevent assets from appearing.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test ejects and re-adds a standard wallet, verifying BTC discovery and balance display. The blockchainReducer manages blockchain connections during wallet switching, and walletSettingsReducer tracks which networks to discover.
- `suite/e2e/tests/settings/general.test.ts` — This test changes fiat currency, theme, language, and analytics toggle — settings managed by walletSettingsReducer (fiat currency in particular is a wallet setting). Changes to the reducer structure could break settings persistence or analytics event payloads.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test enables regtest, sends BTC, and verifies real-time balance updates. The blockchainReducer handles blockchain event subscriptions and balance state, while walletSettingsReducer manages testnet network enablement.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test enables regtest network, funds an account, and tests the send form including pending transaction display. The blockchainReducer manages blockchain state for transaction broadcasting and pending transaction tracking.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Discreet mode is a wallet setting stored in walletSettingsReducer. While the test focuses on UI hiding behavior, a structural change to the reducer could break the discreet mode toggle persistence.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Adding different account types requires enabled networks (walletSettingsReducer) and may trigger blockchain connections (blockchainReducer). Changes to how networks are stored could affect account type availability.

</details>

_Updated: 2026-06-23T08:46:02.508Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-wallet-core-reducers&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-wallet-core-reducers&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-wallet-core-reducers&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-23T08:50:22.682Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-23T08:49:08.291Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-wallet-core-reducers/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-wallet-core-reducers/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->