### PR TITLE
chore(trading): remove dead module-trading code

### DIFF
--- a/suite-native/module-trading/src/components/general/AccountList/AccountListBaseItem.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListBaseItem.tsx
@@ -23,8 +23,6 @@ export type AccountListBaseItemProps = {
 
 type TextColor = 'contentPrimary' | 'contentSecondary';
 
-export const ACCOUNT_LIST_ITEM_HEIGHT = 68 as const;
-
 const labelTextStyle = prepareNativeStyle<{ textColor: TextColor; flex: number }>(
     ({ colors }, { textColor, flex }) => ({
         color: colors[textColor],


### PR DESCRIPTION
Part of the dead-code-elimination sweep (staging #28463).

Removes the unused `useExchangeFormAnalyticsPayload` hook (an empty leftover file) and the unused `ACCOUNT_LIST_ITEM_HEIGHT` constant.

All removed symbols are verified unused across the repository, so this is a pure deletion with no behaviour change.

Sibling PRs in this batch: #29020, #29021, #29023

### Notes for QA

No QA needed — pure dead-code removal; every deleted symbol has zero remaining references and there is no runtime effect.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-module-trading-dead&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->