### PR TITLE
Feat/suite slip24 payment request validation

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx
@@ -14,7 +14,12 @@ import {
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { Card, Column, Divider, H4, InfoItem, Row, Text } from '@trezor/components';
 import { mapPaddingTypeToPadding } from '@trezor/components/src/components/Card/utils';
-import { AssetLogo, CoinLogo, isCoinSymbol } from '@trezor/product-components';
+import {
+    AssetLogo,
+    CoinLogo,
+    isCoinSymbol,
+    shouldShowNetworkIcon,
+} from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
 import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
@@ -60,16 +65,17 @@ const TransactionReviewOutputAssetsCryptoCurrency = ({
         if (contractAddress) {
             return (
                 <AssetLogo
-                    size={20}
+                    size={24}
                     symbol={symbol}
                     contractAddress={contractAddress}
                     placeholder={displaySymbol ?? ''}
+                    showNetworkIcon={shouldShowNetworkIcon(symbol, contractAddress)}
                 />
             );
         }
 
         if (isCoinSymbol(symbol)) {
-            return <CoinLogo size={20} symbol={symbol} type="tokenWithNetwork" />;
+            return <CoinLogo size={24} symbol={symbol} type="tokenWithNetwork" />;
         }
 
         return null;

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -1,6 +1,6 @@
 import { type MiddlewareAPI } from 'redux';
 
-import { selectAccountByKey } from '@suite-common/wallet-core';
+import { PAYMENT_REQUEST_BUTTON_NAMES, selectAccountByKey } from '@suite-common/wallet-core';
 import { UI_REQUEST } from '@trezor/connect';
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
@@ -58,6 +58,13 @@ const shouldRemapToSignTx = (
     }
 
     if (code !== 'ButtonRequest_Other') return false;
+
+    // SLIP-24 payment request review screens. Without remapping they route to ConfirmActionModal
+    // instead of the transaction review modal. Detected by name so it works on bitcoin-like networks
+    // (absent from SIGN_TX_NETWORK_TYPES) without affecting regular sends.
+    if (name !== undefined && PAYMENT_REQUEST_BUTTON_NAMES.includes(name)) {
+        return true;
+    }
 
     const account = getAccountForButtonRequest(state);
     const { activeCall } = state.connectPopup;

--- a/suite-common/device/src/deviceSelectors.ts
+++ b/suite-common/device/src/deviceSelectors.ts
@@ -183,7 +183,7 @@ export const selectSupportedDeviceLanguages = createMemoizedSelector(
     },
 );
 
-const selectDeviceButtonRequests = createMemoizedSelector(
+export const selectDeviceButtonRequests = createMemoizedSelector(
     [selectSelectedDevice],
     device => device?.buttonRequests ?? [],
 );

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -31,6 +31,9 @@ export type ButtonRequest = Omit<DeviceEvent['payload'], 'device' | 'code'> & {
         | 'ui-invalid_pin'
         | DeviceButtonRequest['payload']['code']
         | NonNullable<PROTO.PinMatrixRequest>['type'];
+    // Firmware screen identifier (e.g. 'confirm_payment_request'). Stored from the button request
+    // payload; used to distinguish screens that share the same generic code (ButtonRequest_Other).
+    name?: DeviceButtonRequest['payload']['name'];
 };
 
 /**

--- a/suite-common/trading/package.json
+++ b/suite-common/trading/package.json
@@ -14,6 +14,7 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.12.0",
+        "@suite-common/address": "workspace:*",
         "@suite-common/device": "workspace:*",
         "@suite-common/geolocation": "workspace:*",
         "@suite-common/react-query": "workspace:*",

--- a/suite-common/trading/src/constants.ts
+++ b/suite-common/trading/src/constants.ts
@@ -1,6 +1,6 @@
 import { type SellFiatFlowType } from 'invity-api';
 
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, type NetworkType } from '@suite-common/wallet-config';
 
 export const TRADING_PREFIX = '@trading';
 export const TRADING_EXTENDED_PREFIX = `${TRADING_PREFIX}-extended`;
@@ -16,6 +16,13 @@ export const TRADING_SELL_THUNK_PREFIX = `${TRADING_SELL_PREFIX}/thunk`;
 export const TRADING_DEFAULT_CRYPTO_CURRENCY = 'btc' satisfies NetworkSymbol;
 export const TRADING_DEFAULT_PAYMENT_METHOD = 'creditCard' as const;
 export const TRADING_DEFAULT_SELL_FLOWS: SellFiatFlowType[] = ['BANK_ACCOUNT', 'PAYMENT_GATE'];
+export const TRADING_SLIP24_SUPPORTED_NETWORK_TYPES: NetworkType[] = [
+    'bitcoin',
+    'ethereum',
+    'solana',
+    'stellar',
+    'ripple',
+];
 
 export const TRADING_EXCHANGE_RATE = 'rateType';
 export const TRADING_EXCHANGE_RATE_FIXED = 'fixed';

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -16,6 +16,7 @@ import coins from '../../__fixtures__/coins.json';
 import { invityAPIFixtures } from '../../__fixtures__/invityAPI';
 import platforms from '../../__fixtures__/platforms.json';
 import { accountBtc, accountEth } from '../../__fixtures__/utils';
+import { TRADING_SLIP24_SUPPORTED_NETWORK_TYPES } from '../../constants';
 import { getProviderMetadataFixture } from '../../reducers/__fixtures__/providerMetadata';
 import { type BuyInfo, type TradingBuyState } from '../../reducers/buyReducer';
 import { type ExchangeInfo, exchangeInitialState } from '../../reducers/exchangeReducer';
@@ -2114,29 +2115,17 @@ describe('tradingSelectors', () => {
             expect(selectTradingIsSlip24Allowed(state, accountBtc as any, true)).toBe(false);
         });
 
-        it('should return true when account is set, isSlip24Active is true, and firmware supports slip24', () => {
-            expect(selectTradingIsSlip24Allowed(state, accountBtc as any, true)).toBe(true);
-        });
+        it.each(TRADING_SLIP24_SUPPORTED_NETWORK_TYPES)(
+            'should return true for %s network when firmware supports slip24',
+            networkType => {
+                const account = {
+                    ...accountBtc,
+                    networkType,
+                };
 
-        it('should return true for supported network when firmware supports slip24 (e.g. ethereum account)', () => {
-            expect(selectTradingIsSlip24Allowed(state, accountEth as any, true)).toBe(true);
-        });
-
-        it('should return true for solana network when firmware supports slip24', () => {
-            const solanaAccount = {
-                ...accountBtc,
-                networkType: 'solana',
-            };
-            expect(selectTradingIsSlip24Allowed(state, solanaAccount as any, true)).toBe(true);
-        });
-
-        it('should return true for stellar network when firmware supports slip24', () => {
-            const stellarAccount = {
-                ...accountBtc,
-                networkType: 'stellar',
-            };
-            expect(selectTradingIsSlip24Allowed(state, stellarAccount as any, true)).toBe(true);
-        });
+                expect(selectTradingIsSlip24Allowed(state, account as any, true)).toBe(true);
+            },
+        );
 
         it('should return false for unsupported network even when firmware supports slip24', () => {
             const unsupportedNetworkAccount = {

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -12,11 +12,7 @@ import {
 
 import { type DeviceRootState, selectDeviceUnavailableCapabilities } from '@suite-common/device';
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
-import {
-    type NetworkSymbolExtended,
-    type NetworkType,
-    isNetworkSymbol,
-} from '@suite-common/wallet-config';
+import { type NetworkSymbolExtended, isNetworkSymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     selectAccounts,
@@ -27,6 +23,7 @@ import { getSupportedCoins } from '@trezor/address-validator';
 import { exhaustive } from '@trezor/type-utils';
 import { unique } from '@trezor/utils';
 
+import { TRADING_SLIP24_SUPPORTED_NETWORK_TYPES } from '../constants';
 import {
     EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES,
     type GroupedTradingExchangeQuotes,
@@ -888,9 +885,9 @@ export const selectTradingIsSlip24Allowed = createMemoizedSelectorWithDeviceAndA
         if (!account) return false;
 
         const isFirmwareVersionSlip24Compatible = !unavailableCapabilities?.['slip24'];
-        // TODO: slip24 - can be removed when slip24 is enabled for all networks
-        const supportedNetworks: NetworkType[] = ['bitcoin', 'ethereum', 'solana', 'stellar'];
-        const isNetworkSupported = supportedNetworks.includes(account.networkType);
+        const isNetworkSupported = TRADING_SLIP24_SUPPORTED_NETWORK_TYPES.includes(
+            account.networkType,
+        );
 
         return isSlip24Active && isFirmwareVersionSlip24Compatible && isNetworkSupported;
     },

--- a/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
+++ b/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
@@ -35,12 +35,14 @@ import {
     tradingExchangeCreatePaymentRequest,
     tradingSellCreatePaymentRequest,
 } from '../../utils/signature/signatureUtils';
+import { validatePaymentRequestSignature } from '../../utils/signature/validatePaymentRequest';
 
 type CreateSignatureThunkProps = {
     type: TradingTradeSellExchangeType;
     account: Account;
     composedLevels: GeneralPrecomposedTransaction;
     formattedMaxAmount: string | undefined;
+    destinationTag?: string;
 };
 
 export const createPaymentRequestsThunk = createThunk<
@@ -52,7 +54,7 @@ export const createPaymentRequestsThunk = createThunk<
 >(
     `${TRADING_THUNK_PREFIX}/createPaymentRequests`,
     async (
-        { type, account, composedLevels, formattedMaxAmount },
+        { type, account, composedLevels, formattedMaxAmount, destinationTag },
         { dispatch, getState, fulfillWithValue, rejectWithValue },
     ) => {
         const { mac: macRefund, path: pathRefund } = await dispatch(
@@ -103,7 +105,11 @@ export const createPaymentRequestsThunk = createThunk<
                 ).unwrap();
 
                 const outputs = await dispatch(
-                    getPaymentRequestOutputs({ network: sendNetwork, composedLevels }),
+                    getPaymentRequestOutputs({
+                        network: sendNetwork,
+                        composedLevels,
+                        destinationTag,
+                    }),
                 ).unwrap();
 
                 const sendSlip44 = getSlip44ByPath(validatePath(pathRefund));
@@ -156,6 +162,8 @@ export const createPaymentRequestsThunk = createThunk<
                     });
                 }
 
+                validatePaymentRequestSignature({ paymentRequest, sendSlip44, outputs });
+
                 return fulfillWithValue([paymentRequest]);
             }
             case 'sell': {
@@ -190,7 +198,11 @@ export const createPaymentRequestsThunk = createThunk<
                 const memoText = `Selling ${quote.cryptoStringAmount} ${cryptoSymbol?.symbol} for ${quote.fiatStringAmount} ${quote.fiatCurrency}`;
 
                 const outputs = await dispatch(
-                    getPaymentRequestOutputs({ network: sendNetwork, composedLevels }),
+                    getPaymentRequestOutputs({
+                        network: sendNetwork,
+                        composedLevels,
+                        destinationTag,
+                    }),
                 ).unwrap();
 
                 const sendSlip44 = getSlip44ByPath(validatePath(pathRefund));
@@ -238,6 +250,8 @@ export const createPaymentRequestsThunk = createThunk<
                         },
                     });
                 }
+
+                validatePaymentRequestSignature({ paymentRequest, sendSlip44, outputs });
 
                 return fulfillWithValue([paymentRequest]);
             }

--- a/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
+++ b/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
@@ -162,7 +162,15 @@ export const createPaymentRequestsThunk = createThunk<
                     });
                 }
 
-                validatePaymentRequestSignature({ paymentRequest, sendSlip44, outputs });
+                validatePaymentRequestSignature({
+                    paymentRequest,
+                    sendSlip44,
+                    outputs,
+                    sentAsset: {
+                        network: sendNetwork.symbol,
+                        isToken: !!composedLevels.token,
+                    },
+                });
 
                 return fulfillWithValue([paymentRequest]);
             }
@@ -251,7 +259,15 @@ export const createPaymentRequestsThunk = createThunk<
                     });
                 }
 
-                validatePaymentRequestSignature({ paymentRequest, sendSlip44, outputs });
+                validatePaymentRequestSignature({
+                    paymentRequest,
+                    sendSlip44,
+                    outputs,
+                    sentAsset: {
+                        network: sendNetwork.symbol,
+                        isToken: !!composedLevels.token,
+                    },
+                });
 
                 return fulfillWithValue([paymentRequest]);
             }

--- a/suite-common/trading/src/thunks/common/getPaymentRequestOutputs.ts
+++ b/suite-common/trading/src/thunks/common/getPaymentRequestOutputs.ts
@@ -15,11 +15,15 @@ import {
 
 export const getPaymentRequestOutputs = createThunk<
     PaymentRequestOutput[],
-    { network: Network; composedLevels: GeneralPrecomposedTransactionFinal },
+    {
+        network: Network;
+        composedLevels: GeneralPrecomposedTransactionFinal;
+        destinationTag?: string;
+    },
     { rejectValue: TradingSendRejectedProps }
 >(
     `${TRADING_THUNK_PREFIX}/getPaymentRequestOutputs`,
-    async ({ network, composedLevels }, { rejectWithValue, fulfillWithValue }) => {
+    async ({ network, composedLevels, destinationTag }, { rejectWithValue, fulfillWithValue }) => {
         const outputs: PaymentRequestOutput[] = [];
 
         for (const output of composedLevels.outputs) {
@@ -52,7 +56,11 @@ export const getPaymentRequestOutputs = createThunk<
 
                 outputs.push({
                     amount,
-                    address: formatSlip24AddressByNetwork({ address: sendAddress, network }),
+                    address: formatSlip24AddressByNetwork({
+                        address: sendAddress,
+                        network,
+                        destinationTag,
+                    }),
                 });
             }
 

--- a/suite-common/trading/src/thunks/common/getPaymentRequestOutputs.ts
+++ b/suite-common/trading/src/thunks/common/getPaymentRequestOutputs.ts
@@ -8,7 +8,10 @@ import TrezorConnect from '@trezor/connect';
 
 import { TRADING_THUNK_PREFIX } from '../../constants';
 import { type TradingSendRejectedProps } from '../../types';
-import { formatSlip24SendAmountByNetwork } from '../../utils/signature/signatureUtils';
+import {
+    formatSlip24AddressByNetwork,
+    formatSlip24SendAmountByNetwork,
+} from '../../utils/signature/signatureUtils';
 
 export const getPaymentRequestOutputs = createThunk<
     PaymentRequestOutput[],
@@ -49,7 +52,7 @@ export const getPaymentRequestOutputs = createThunk<
 
                 outputs.push({
                     amount,
-                    address: sendAddress,
+                    address: formatSlip24AddressByNetwork({ address: sendAddress, network }),
                 });
             }
 
@@ -71,7 +74,10 @@ export const getPaymentRequestOutputs = createThunk<
 
                 outputs.push({
                     amount: formatSlip24SendAmountByNetwork({ value: output.amount, network }),
-                    address: getAddress.payload.address,
+                    address: formatSlip24AddressByNetwork({
+                        address: getAddress.payload.address,
+                        network,
+                    }),
                 });
             }
         }

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -262,6 +262,7 @@ export const recomposeAndSignTxThunk = createThunk<
                       account,
                       composedLevels: precomposedToSign,
                       formattedMaxAmount,
+                      destinationTag,
                   }),
               ).unwrap()
             : [];

--- a/suite-common/trading/src/utils/signature/__tests__/signatureUtils.test.ts
+++ b/suite-common/trading/src/utils/signature/__tests__/signatureUtils.test.ts
@@ -1,6 +1,9 @@
 import { type CryptoId, type ExchangeProviderInfo, type SellProviderInfo } from 'invity-api';
 
+import { type Network } from '@suite-common/wallet-config';
+
 import {
+    formatSlip24AddressByNetwork,
     tradingExchangeCreatePaymentRequest,
     tradingSellCreatePaymentRequest,
 } from '../signatureUtils';
@@ -25,6 +28,61 @@ jest.mock('../../../utils', () => ({
 }));
 
 describe('signatureUtils', () => {
+    describe('formatSlip24AddressByNetwork', () => {
+        const createNetwork = (networkType: Network['networkType']) =>
+            ({
+                networkType,
+            }) as Network;
+
+        it('checksums ethereum addresses', () => {
+            expect(
+                formatSlip24AddressByNetwork({
+                    address: '0x52908400098527886e0f7030069857d2e4169ee7',
+                    network: createNetwork('ethereum'),
+                }),
+            ).toBe('0x52908400098527886E0F7030069857D2E4169EE7');
+        });
+
+        it('appends canonical ripple destination tags', () => {
+            expect(
+                formatSlip24AddressByNetwork({
+                    address: 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+                    network: createNetwork('ripple'),
+                    destinationTag: '0007',
+                }),
+            ).toBe('rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh?dt=7');
+        });
+
+        it('treats ripple destination tag zero as absent', () => {
+            expect(
+                formatSlip24AddressByNetwork({
+                    address: 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+                    network: createNetwork('ripple'),
+                    destinationTag: '0',
+                }),
+            ).toBe('rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
+        });
+
+        it('rejects invalid ripple destination tags', () => {
+            expect(() =>
+                formatSlip24AddressByNetwork({
+                    address: 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+                    network: createNetwork('ripple'),
+                    destinationTag: '1e3',
+                }),
+            ).toThrow('Invalid Ripple destination tag: 1e3');
+        });
+
+        it('returns other network addresses unchanged', () => {
+            expect(
+                formatSlip24AddressByNetwork({
+                    address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh',
+                    network: createNetwork('bitcoin'),
+                }),
+            ).toBe('bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh');
+        });
+    });
+
     describe('tradingExchangeCreatePaymentRequest', () => {
         const mockTrade = {
             send: 'bitcoin' as CryptoId,

--- a/suite-common/trading/src/utils/signature/__tests__/validatePaymentRequest.test.ts
+++ b/suite-common/trading/src/utils/signature/__tests__/validatePaymentRequest.test.ts
@@ -1,0 +1,205 @@
+import { createPublicKey, generateKeyPairSync, sign } from 'crypto';
+
+import { type PROTO } from '@trezor/connect';
+
+import {
+    type Slip24Output,
+    computePaymentRequestPayload,
+    validatePaymentRequestSignature,
+} from '../validatePaymentRequest';
+
+// Fixture taken from trezor-trade-api PaymentRequestSigner tests: the signature was
+// produced by the API implementation with the debug key (m/0h of "all all ... all" seed),
+// so this verifies both implementations compute the same SLIP-24 digest.
+const fixtureSignature =
+    '3d4828dd20272f1f10bd6aadaf7050eaf87fba2bd1418de8b320a9c4977c373926e7685ef520a2e9ec9d4bdd57845c673eba87c30e55e5e0aa68f1f55be53e32';
+
+const createFixturePaymentRequest = (
+    paymentRequest?: Partial<PROTO.PaymentRequest>,
+): PROTO.PaymentRequest => ({
+    recipient_name: 'Alice',
+    nonce: 'nonce',
+    memos: [
+        {
+            coin_purchase_memo: {
+                coin_type: 0,
+                amount: '1000 BTC',
+                address: '1A2B3C',
+                address_n: [0],
+                mac: '00',
+            },
+        },
+    ],
+    signature: fixtureSignature,
+    ...paymentRequest,
+});
+
+const fixtureSendSlip44 = 2;
+const fixtureOutputs: Slip24Output[] = [{ address: '1A2B3C', amount: '1000' }];
+const fixtureSentAsset = { network: 'btc', isToken: false };
+
+describe(validatePaymentRequestSignature.name, () => {
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    it('validates a signature created by the trade API', () => {
+        const isValid = validatePaymentRequestSignature({
+            paymentRequest: createFixturePaymentRequest(),
+            sendSlip44: fixtureSendSlip44,
+            outputs: fixtureOutputs,
+        });
+
+        expect(isValid).toBe(true);
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects a payment request with tampered recipient name', () => {
+        const isValid = validatePaymentRequestSignature({
+            paymentRequest: createFixturePaymentRequest({ recipient_name: 'Mallory' }),
+            sendSlip44: fixtureSendSlip44,
+            outputs: fixtureOutputs,
+            sentAsset: fixtureSentAsset,
+        });
+
+        expect(isValid).toBe(false);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'SLIP-24: Payment request signature does not match its content.',
+            JSON.stringify(fixtureSentAsset),
+        );
+    });
+
+    it('rejects a payment request with tampered memo amount', () => {
+        const isValid = validatePaymentRequestSignature({
+            paymentRequest: createFixturePaymentRequest({
+                memos: [
+                    {
+                        coin_purchase_memo: {
+                            coin_type: 0,
+                            amount: '9000 BTC',
+                            address: '1A2B3C',
+                            address_n: [0],
+                            mac: '00',
+                        },
+                    },
+                ],
+            }),
+            sendSlip44: fixtureSendSlip44,
+            outputs: fixtureOutputs,
+        });
+
+        expect(isValid).toBe(false);
+    });
+
+    it('rejects a payment request with tampered output address', () => {
+        const isValid = validatePaymentRequestSignature({
+            paymentRequest: createFixturePaymentRequest(),
+            sendSlip44: fixtureSendSlip44,
+            outputs: [{ address: 'mallory-address', amount: '1000' }],
+        });
+
+        expect(isValid).toBe(false);
+    });
+
+    it('rejects a payment request with tampered slip44', () => {
+        const isValid = validatePaymentRequestSignature({
+            paymentRequest: createFixturePaymentRequest(),
+            sendSlip44: 60,
+            outputs: fixtureOutputs,
+        });
+
+        expect(isValid).toBe(false);
+    });
+
+    it('verifies with the production public key being a valid P-256 key, no private key needed', () => {
+        // Mirrors PRODUCTION_PUBLIC_KEY and the SPKI encoding in validatePaymentRequest.ts.
+        // Guards against a typo in the constant silently hiding behind the debug key fallback.
+        const productionPublicKey =
+            '02aa9b94b306f1b50c19b4b953b6acdf2d3ac09eca5e5344a2bb2fbf19495d550c';
+        const spkiPrefix = '3039301306072a8648ce3d020106082a8648ce3d030107032200';
+        const pem = `-----BEGIN PUBLIC KEY-----\n${Buffer.from(
+            spkiPrefix + productionPublicKey,
+            'hex',
+        ).toString('base64')}\n-----END PUBLIC KEY-----`;
+
+        const publicKey = createPublicKey(pem);
+
+        expect(publicKey.asymmetricKeyType).toBe('ec');
+        expect(publicKey.asymmetricKeyDetails?.namedCurve).toBe('prime256v1');
+    });
+
+    it('rejects a well-formed signature created by an untrusted key', () => {
+        // A valid P-256 signature from a key other than the trusted ones must be rejected.
+        // Sign the exact payload that verification recomputes, so the only reason it fails is the
+        // untrusted key. This genuinely guards the allowlist: adding this key to TRUSTED_PUBLIC_KEYS
+        // would make the test pass.
+        const { privateKey } = generateKeyPairSync('ec', { namedCurve: 'prime256v1' });
+        const payload = computePaymentRequestPayload({
+            paymentRequest: createFixturePaymentRequest(),
+            sendSlip44: fixtureSendSlip44,
+            outputs: fixtureOutputs,
+        });
+        const untrustedSignature = sign('sha256', payload, {
+            key: privateKey,
+            dsaEncoding: 'ieee-p1363',
+        });
+
+        const isValid = validatePaymentRequestSignature({
+            paymentRequest: createFixturePaymentRequest({
+                signature: untrustedSignature.toString('hex'),
+            }),
+            sendSlip44: fixtureSendSlip44,
+            outputs: fixtureOutputs,
+            sentAsset: fixtureSentAsset,
+        });
+
+        expect(isValid).toBe(false);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'SLIP-24: Payment request signature does not match its content.',
+            JSON.stringify(fixtureSentAsset),
+        );
+    });
+
+    it('rejects a debug-key signature in production env', () => {
+        // The fixture signature is created by the debug key, which is derivable from
+        // the public test mnemonic and must only be trusted in dev builds.
+        const originalNodeEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'production';
+
+        try {
+            jest.isolateModules(() => {
+                const { validatePaymentRequestSignature: validateInProduction } =
+                    jest.requireActual<{
+                        validatePaymentRequestSignature: typeof validatePaymentRequestSignature;
+                    }>('../validatePaymentRequest');
+
+                const isValid = validateInProduction({
+                    paymentRequest: createFixturePaymentRequest(),
+                    sendSlip44: fixtureSendSlip44,
+                    outputs: fixtureOutputs,
+                });
+
+                expect(isValid).toBe(false);
+            });
+        } finally {
+            process.env.NODE_ENV = originalNodeEnv;
+        }
+    });
+
+    it('rejects and logs a payment request with malformed signature', () => {
+        const isValid = validatePaymentRequestSignature({
+            paymentRequest: createFixturePaymentRequest({ signature: 'not-a-signature' }),
+            sendSlip44: fixtureSendSlip44,
+            outputs: fixtureOutputs,
+        });
+
+        expect(isValid).toBe(false);
+        expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+});

--- a/suite-common/trading/src/utils/signature/signatureUtils.ts
+++ b/suite-common/trading/src/utils/signature/signatureUtils.ts
@@ -6,7 +6,7 @@ import {
 } from 'invity-api';
 
 import type { Network } from '@suite-common/wallet-config';
-import { asAmountUnit, unitsToSubunits } from '@suite-common/wallet-utils';
+import { asAmountUnit, toChecksumAddress, unitsToSubunits } from '@suite-common/wallet-utils';
 import { type PROTO } from '@trezor/connect';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: extract pathUtils to a shared location and remove this exception (see #27376 deferred work)
 import { validatePath } from '@trezor/connect/src/utils/pathUtils';
@@ -29,6 +29,22 @@ export const formatSlip24SendAmountByNetwork = ({
         bytesLength,
     });
 };
+
+/**
+ * Normalizes an output address to the exact string the firmware hashes into the
+ * SLIP-24 outputs digest. For EVM chains the firmware re-derives the recipient as
+ * an EIP-55 checksummed address (`address_from_bytes`), so the address signed by
+ * the trade API must be checksummed too, otherwise the device rejects the payment
+ * request with "Invalid signature in payment request". Non-EVM addresses are
+ * canonical already and pass through unchanged.
+ */
+export const formatSlip24AddressByNetwork = ({
+    address,
+    network,
+}: {
+    address: string;
+    network: Network;
+}): string => (network.networkType === 'ethereum' ? toChecksumAddress(address) : address);
 
 type TradingExchangeCreatePaymentRequestProps = {
     trade: ExchangeTradeSigned;

--- a/suite-common/trading/src/utils/signature/signatureUtils.ts
+++ b/suite-common/trading/src/utils/signature/signatureUtils.ts
@@ -5,8 +5,9 @@ import {
     type SellProviderInfo,
 } from 'invity-api';
 
+import { toChecksumAddress } from '@suite-common/address';
 import type { Network } from '@suite-common/wallet-config';
-import { asAmountUnit, toChecksumAddress, unitsToSubunits } from '@suite-common/wallet-utils';
+import { asAmountUnit, unitsToSubunits } from '@suite-common/wallet-utils';
 import { type PROTO } from '@trezor/connect';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: extract pathUtils to a shared location and remove this exception (see #27376 deferred work)
 import { validatePath } from '@trezor/connect/src/utils/pathUtils';
@@ -32,19 +33,50 @@ export const formatSlip24SendAmountByNetwork = ({
 
 /**
  * Normalizes an output address to the exact string the firmware hashes into the
- * SLIP-24 outputs digest. For EVM chains the firmware re-derives the recipient as
- * an EIP-55 checksummed address (`address_from_bytes`), so the address signed by
- * the trade API must be checksummed too, otherwise the device rejects the payment
- * request with "Invalid signature in payment request". Non-EVM addresses are
- * canonical already and pass through unchanged.
+ * SLIP-24 outputs digest, otherwise the device rejects the payment request with
+ * "Invalid signature in payment request".
+ *   - ethereum: the firmware re-derives the recipient as an EIP-55 checksummed
+ *     address (`address_from_bytes`), so the address signed by the trade API must
+ *     be checksummed too.
+ *   - ripple: the firmware appends `?dt=<destinationTag>` to the destination when
+ *     a destination tag is set (ripple/sign_tx.py), so the signed address must
+ *     carry the same suffix.
+ * Other networks hash a canonical/provided address and pass through unchanged.
  */
 export const formatSlip24AddressByNetwork = ({
     address,
     network,
+    destinationTag,
 }: {
     address: string;
     network: Network;
-}): string => (network.networkType === 'ethereum' ? toChecksumAddress(address) : address);
+    destinationTag?: string;
+}): string => {
+    switch (network.networkType) {
+        case 'ethereum':
+            return toChecksumAddress(address);
+        case 'ripple': {
+            // Mirror the firmware: it renders the destination_tag uint32 (`f"?dt={tag}"`)
+            // and only appends it when the tag is truthy, so 0/empty tags are treated as absent.
+            if (destinationTag === undefined || destinationTag === '') {
+                return address;
+            }
+
+            if (!/^\d+$/.test(destinationTag)) {
+                throw new Error(`Invalid Ripple destination tag: ${destinationTag}`);
+            }
+
+            const tag = Number(destinationTag);
+            if (!Number.isSafeInteger(tag) || tag > 0xffffffff) {
+                throw new Error(`Invalid Ripple destination tag: ${destinationTag}`);
+            }
+
+            return tag ? `${address}?dt=${tag}` : address;
+        }
+        default:
+            return address;
+    }
+};
 
 type TradingExchangeCreatePaymentRequestProps = {
     trade: ExchangeTradeSigned;

--- a/suite-common/trading/src/utils/signature/validatePaymentRequest.ts
+++ b/suite-common/trading/src/utils/signature/validatePaymentRequest.ts
@@ -1,0 +1,222 @@
+import { createHash, createVerify } from 'crypto';
+
+import { isDevEnv } from '@suite-common/suite-utils';
+import { type PROTO } from '@trezor/connect';
+
+/**
+ * Client-side verification of the SLIP-24 payment request signature created by the trade API.
+ * Mirrors the digest computation of `PaymentRequestSigner` (trezor-trade-api) and
+ * `PaymentRequestVerifier` (trezor-firmware, core/src/apps/common/payment_request.py),
+ * so a mismatch is caught before the request is sent to the device for signing.
+ *
+ * SLIP-0024: https://github.com/satoshilabs/slips/blob/master/slip-0024.md
+ */
+
+export type Slip24Output = {
+    // Little-endian hex amount of the SLIP-24 byte length for the chain.
+    amount: string;
+    address: string;
+};
+
+const SLIP24_MAGIC = Buffer.from([0x53, 0x4c, 0x00, 0x24]); // "SL" + 0024
+
+const MEMO_TYPE_TEXT = 1;
+const MEMO_TYPE_REFUND = 2;
+const MEMO_TYPE_COIN_PURCHASE = 3;
+const MEMO_TYPE_TEXT_DETAILS = 4;
+
+// Mirrors PaymentRequestVerifier.PUBLIC_KEY hardcoded in trezor-firmware.
+const PRODUCTION_PUBLIC_KEY = '02aa9b94b306f1b50c19b4b953b6acdf2d3ac09eca5e5344a2bb2fbf19495d550c';
+// nist256p1 public key of m/0h for "all all ... all" seed, used by debug firmware and dev API.
+// Its private key is derivable from the public test mnemonic, so it must never be
+// trusted in production builds.
+const DEBUG_PUBLIC_KEY = '03d9d93f89c6963b94bbd7a5118828e44c1c395915ace84888717f568cb01974c3';
+
+const TRUSTED_PUBLIC_KEYS = isDevEnv
+    ? [PRODUCTION_PUBLIC_KEY, DEBUG_PUBLIC_KEY]
+    : [PRODUCTION_PUBLIC_KEY];
+
+// ASN.1 SPKI prefix for a compressed P-256 (prime256v1) public key:
+// SEQUENCE { SEQUENCE { OID ecPublicKey, OID prime256v1 }, BIT STRING <point> }.
+const P256_SPKI_PREFIX = Buffer.from('3039301306072a8648ce3d020106082a8648ce3d030107032200', 'hex');
+
+const publicKeyToPem = (publicKey: Buffer): string => {
+    const spki = Buffer.concat([P256_SPKI_PREFIX, publicKey]);
+
+    return `-----BEGIN PUBLIC KEY-----\n${spki.toString('base64')}\n-----END PUBLIC KEY-----`;
+};
+
+// The API returns a compact 64-byte r||s signature, `crypto.verify` expects DER encoding.
+const compactSignatureToDer = (signature: Buffer): Buffer => {
+    if (signature.length !== 64) {
+        throw new Error('SLIP-24: Signature must be a compact 64-byte ECDSA signature.');
+    }
+
+    const derInteger = (bytes: Buffer): Buffer => {
+        // Strip leading zeros, then prefix 0x00 when the most significant bit is set.
+        let start = 0;
+        while (start < bytes.length - 1 && bytes.readUInt8(start) === 0) {
+            start += 1;
+        }
+        const value = bytes.subarray(start);
+        const prefix = value.readUInt8(0) >= 0x80 ? Buffer.from([0]) : Buffer.alloc(0);
+
+        return Buffer.concat([Buffer.from([0x02, value.length + prefix.length]), prefix, value]);
+    };
+
+    const r = derInteger(signature.subarray(0, 32));
+    const s = derInteger(signature.subarray(32, 64));
+
+    return Buffer.concat([Buffer.from([0x30, r.length + s.length]), r, s]);
+};
+
+const writeCompactSize = (n: number): Buffer => {
+    if (n < 253) {
+        return Buffer.from([n]);
+    }
+    if (n < 0x10000) {
+        const buffer = Buffer.alloc(3);
+        buffer.writeUInt8(253, 0);
+        buffer.writeUInt16LE(n, 1);
+
+        return buffer;
+    }
+    if (n < 0x100000000) {
+        const buffer = Buffer.alloc(5);
+        buffer.writeUInt8(254, 0);
+        buffer.writeUInt32LE(n, 1);
+
+        return buffer;
+    }
+
+    throw new Error('SLIP-24: Data too long to encode.');
+};
+
+const writePrefixed = (data: Buffer): Buffer =>
+    Buffer.concat([writeCompactSize(data.length), data]);
+
+const writeUint32Le = (n: number): Buffer => {
+    const buffer = Buffer.alloc(4);
+    buffer.writeUInt32LE(n, 0);
+
+    return buffer;
+};
+
+const writeMemo = (memo: PROTO.PaymentRequestMemo): Buffer => {
+    if (memo.text_memo !== undefined) {
+        return Buffer.concat([
+            writeUint32Le(MEMO_TYPE_TEXT),
+            writePrefixed(Buffer.from(memo.text_memo.text, 'utf-8')),
+        ]);
+    }
+    if (memo.refund_memo !== undefined) {
+        return Buffer.concat([
+            writeUint32Le(MEMO_TYPE_REFUND),
+            writePrefixed(Buffer.from(memo.refund_memo.address, 'utf-8')),
+        ]);
+    }
+    if (memo.coin_purchase_memo !== undefined) {
+        return Buffer.concat([
+            writeUint32Le(MEMO_TYPE_COIN_PURCHASE),
+            writeUint32Le(memo.coin_purchase_memo.coin_type),
+            writePrefixed(Buffer.from(memo.coin_purchase_memo.amount, 'utf-8')),
+            writePrefixed(Buffer.from(memo.coin_purchase_memo.address, 'utf-8')),
+        ]);
+    }
+    if (memo.text_details_memo !== undefined) {
+        return Buffer.concat([
+            writeUint32Le(MEMO_TYPE_TEXT_DETAILS),
+            writePrefixed(Buffer.from(memo.text_details_memo.title, 'utf-8')),
+            writePrefixed(Buffer.from(memo.text_details_memo.text, 'utf-8')),
+        ]);
+    }
+
+    throw new Error('SLIP-24: Unrecognized memo type in payment request.');
+};
+
+type ComputePaymentRequestPayloadProps = {
+    paymentRequest: PROTO.PaymentRequest;
+    sendSlip44: number;
+    outputs: Slip24Output[];
+};
+
+// Returns the signed payload, the SLIP-24 digest is its sha256 hash.
+// Exported for tests so they can sign the exact payload that verification recomputes.
+export const computePaymentRequestPayload = ({
+    paymentRequest,
+    sendSlip44,
+    outputs,
+}: ComputePaymentRequestPayloadProps): Buffer => {
+    const memos = paymentRequest.memos ?? [];
+
+    if (!paymentRequest.nonce && memos.length > 0) {
+        throw new Error('SLIP-24: Missing nonce in payment request.');
+    }
+
+    const nonce = Buffer.from(paymentRequest.nonce ?? '', 'hex');
+
+    // Outputs are hashed separately, each as raw little-endian amount bytes plus prefixed address.
+    const outputsHash = createHash('sha256')
+        .update(
+            Buffer.concat(
+                outputs.flatMap(output => [
+                    Buffer.from(output.amount, 'hex'),
+                    writePrefixed(Buffer.from(output.address, 'utf-8')),
+                ]),
+            ),
+        )
+        .digest();
+
+    return Buffer.concat([
+        SLIP24_MAGIC,
+        writePrefixed(nonce),
+        writePrefixed(Buffer.from(paymentRequest.recipient_name, 'utf-8')),
+        writeCompactSize(memos.length),
+        ...memos.map(writeMemo),
+        writeUint32Le(sendSlip44),
+        outputsHash,
+    ]);
+};
+
+type ValidatePaymentRequestSignatureProps = ComputePaymentRequestPayloadProps & {
+    sentAsset?: { network: string; isToken: boolean };
+};
+
+/**
+ * Returns false and logs an error when the signature received from the trade API
+ * does not match the payment request content passed to TrezorConnect.
+ */
+export const validatePaymentRequestSignature = ({
+    paymentRequest,
+    sendSlip44,
+    outputs,
+    sentAsset,
+}: ValidatePaymentRequestSignatureProps): boolean => {
+    try {
+        const payload = computePaymentRequestPayload({ paymentRequest, sendSlip44, outputs });
+        const signature = compactSignatureToDer(Buffer.from(paymentRequest.signature, 'hex'));
+
+        const isValid = TRUSTED_PUBLIC_KEYS.some(publicKey =>
+            createVerify('sha256')
+                .update(payload)
+                .verify({ key: publicKeyToPem(Buffer.from(publicKey, 'hex')) }, signature),
+        );
+
+        if (!isValid) {
+            console.error(
+                'SLIP-24: Payment request signature does not match its content.',
+                JSON.stringify(sentAsset),
+            );
+        }
+
+        return isValid;
+    } catch (error) {
+        console.error(
+            'SLIP-24: Payment request validation failed.',
+            JSON.stringify(sentAsset),
+            error,
+        );
+
+        return false;
+    }
+};

--- a/suite-common/trading/tsconfig.json
+++ b/suite-common/trading/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../address" },
         { "path": "../device" },
         { "path": "../geolocation" },
         { "path": "../react-query" },

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -44,6 +44,7 @@ export * from './selectors';
 export type * from './send/composeCancelTransaction/cancelTransactionTypes';
 export * from './send/composeCancelTransaction/composeCancelTransactionThunk';
 export * from './send/sendFormActions';
+export * from './send/sendFormConstants';
 export * from './send/sendFormReducer';
 export * from './send/sendFormSelectors';
 export * from './send/sendFormThunks';

--- a/suite-common/wallet-core/src/send/__tests__/sendFormSelectors.test.ts
+++ b/suite-common/wallet-core/src/send/__tests__/sendFormSelectors.test.ts
@@ -1,0 +1,153 @@
+import { type DeviceRootState } from '@suite-common/device';
+import { type ButtonRequest } from '@suite-common/suite-types';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+
+import { PAYMENT_REQUEST_BUTTON_NAMES } from '../sendFormConstants';
+import {
+    selectSendFormButtonRequestCodes,
+    selectSendFormReviewButtonRequestsCount,
+    selectSendFormReviewLastButtonCode,
+} from '../sendFormSelectors';
+
+const stateWith = (buttonRequests: ButtonRequest[]): DeviceRootState =>
+    ({
+        device: {
+            selectedDevice: mockSuiteDevice({ buttonRequests }),
+        },
+    }) as unknown as DeviceRootState;
+
+const SLIP24_SEQUENCE: ButtonRequest[] = [
+    { code: 'ButtonRequest_Other', name: 'confirm_payment_request' },
+    { code: 'ButtonRequest_Other', name: 'confirm_trade' },
+    { code: 'ButtonRequest_SignTx', name: 'confirm_total' },
+];
+
+describe('selectSendFormButtonRequestCodes', () => {
+    it('counts SLIP-24 payment request screens (ButtonRequest_Other by name) on bitcoin', () => {
+        PAYMENT_REQUEST_BUTTON_NAMES.forEach(name => {
+            const codes = selectSendFormButtonRequestCodes(
+                stateWith([{ code: 'ButtonRequest_Other', name }]),
+                'btc',
+            );
+            expect(codes).toEqual(['ButtonRequest_Other']);
+        });
+    });
+
+    it('ignores ButtonRequest_Other with an unrelated name on bitcoin', () => {
+        expect(
+            selectSendFormButtonRequestCodes(
+                stateWith([
+                    { code: 'ButtonRequest_Other', name: 'confirm_something_else' },
+                    { code: 'ButtonRequest_Other' },
+                ]),
+                'btc',
+            ),
+        ).toEqual([]);
+    });
+
+    it('maps the full bitcoin SLIP-24 sequence to its codes in order', () => {
+        expect(selectSendFormButtonRequestCodes(stateWith(SLIP24_SEQUENCE), 'btc')).toEqual([
+            'ButtonRequest_Other',
+            'ButtonRequest_Other',
+            'ButtonRequest_SignTx',
+        ]);
+    });
+
+    it('always counts ConfirmOutput and SignTx regardless of network', () => {
+        const requests: ButtonRequest[] = [
+            { code: 'ButtonRequest_ConfirmOutput' },
+            { code: 'ButtonRequest_SignTx' },
+        ];
+        expect(selectSendFormButtonRequestCodes(stateWith(requests), 'btc')).toEqual([
+            'ButtonRequest_ConfirmOutput',
+            'ButtonRequest_SignTx',
+        ]);
+    });
+
+    it('counts any ButtonRequest_Other on ethereum (by network, not name)', () => {
+        expect(
+            selectSendFormButtonRequestCodes(stateWith([{ code: 'ButtonRequest_Other' }]), 'eth'),
+        ).toEqual(['ButtonRequest_Other']);
+    });
+
+    it('counts Other and ProtectCall on stellar', () => {
+        expect(
+            selectSendFormButtonRequestCodes(
+                stateWith([{ code: 'ButtonRequest_Other' }, { code: 'ButtonRequest_ProtectCall' }]),
+                'xlm',
+            ),
+        ).toEqual(['ButtonRequest_Other', 'ButtonRequest_ProtectCall']);
+    });
+
+    it('counts every button request on cardano', () => {
+        expect(
+            selectSendFormButtonRequestCodes(
+                stateWith([
+                    { code: 'ButtonRequest_PinEntry' },
+                    { code: 'ButtonRequest_ConfirmOutput' },
+                ]),
+                'ada',
+            ),
+        ).toEqual(['ButtonRequest_PinEntry', 'ButtonRequest_ConfirmOutput']);
+    });
+
+    it('returns a stable reference for unchanged inputs', () => {
+        const state = stateWith(SLIP24_SEQUENCE);
+        expect(selectSendFormButtonRequestCodes(state, 'btc')).toBe(
+            selectSendFormButtonRequestCodes(state, 'btc'),
+        );
+    });
+});
+
+describe('selectSendFormReviewButtonRequestsCount', () => {
+    it('returns 0 when no symbol is provided', () => {
+        expect(selectSendFormReviewButtonRequestsCount(stateWith(SLIP24_SEQUENCE))).toBe(0);
+    });
+
+    it('counts the full bitcoin SLIP-24 sequence as 3 steps', () => {
+        expect(selectSendFormReviewButtonRequestsCount(stateWith(SLIP24_SEQUENCE), 'btc')).toBe(3);
+    });
+
+    it('subtracts one on cardano', () => {
+        const state = stateWith([
+            { code: 'ButtonRequest_ConfirmOutput' },
+            { code: 'ButtonRequest_SignTx' },
+        ]);
+        expect(selectSendFormReviewButtonRequestsCount(state, 'ada')).toBe(1);
+    });
+
+    it('does not return a negative count for cardano without button requests', () => {
+        expect(selectSendFormReviewButtonRequestsCount(stateWith([]), 'ada')).toBe(0);
+    });
+
+    it('drops one ConfirmOutput when decreasing an RBF output, without mutating the cached array', () => {
+        const state = stateWith([
+            { code: 'ButtonRequest_ConfirmOutput' },
+            { code: 'ButtonRequest_ConfirmOutput' },
+        ]);
+
+        expect(selectSendFormReviewButtonRequestsCount(state, 'btc', 0)).toBe(1);
+        // The memoized array must be untouched by the decrement above.
+        expect(selectSendFormButtonRequestCodes(state, 'btc')).toHaveLength(2);
+        // Without decreaseOutputId the full count is returned.
+        expect(selectSendFormReviewButtonRequestsCount(state, 'btc')).toBe(2);
+    });
+});
+
+describe('selectSendFormReviewLastButtonCode', () => {
+    it('returns null when no symbol is provided', () => {
+        expect(selectSendFormReviewLastButtonCode(stateWith(SLIP24_SEQUENCE))).toBeNull();
+    });
+
+    it('returns null when there are no relevant button requests', () => {
+        expect(
+            selectSendFormReviewLastButtonCode(stateWith([{ code: 'ButtonRequest_Other' }]), 'btc'),
+        ).toBeNull();
+    });
+
+    it('returns the last relevant code', () => {
+        expect(selectSendFormReviewLastButtonCode(stateWith(SLIP24_SEQUENCE), 'btc')).toBe(
+            'ButtonRequest_SignTx',
+        );
+    });
+});

--- a/suite-common/wallet-core/src/send/sendFormConstants.ts
+++ b/suite-common/wallet-core/src/send/sendFormConstants.ts
@@ -1,1 +1,8 @@
 export const SEND_MODULE_PREFIX = '@common/wallet-core/send';
+
+// SLIP-24 payment request review screens (provider + trade details) are emitted by firmware as
+// ButtonRequest_Other with these names. Unlike ConfirmOutput/SignTx they are not counted by default,
+// so on bitcoin-like networks the review modal would fall back to the generic confirm screen and the
+// stepper would not advance through them. Detected by name (not by the trading form flag) so the
+// actual payment request confirmation drives the review, regardless of feature state.
+export const PAYMENT_REQUEST_BUTTON_NAMES = ['confirm_payment_request', 'confirm_trade'];

--- a/suite-common/wallet-core/src/send/sendFormSelectors.ts
+++ b/suite-common/wallet-core/src/send/sendFormSelectors.ts
@@ -1,6 +1,7 @@
 import { G } from '@mobily/ts-belt';
 
-import { type DeviceRootState, selectDeviceButtonRequestsCodes } from '@suite-common/device';
+import { type DeviceRootState, selectDeviceButtonRequests } from '@suite-common/device';
+import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
 import {
     type AccountKey,
@@ -10,7 +11,10 @@ import {
 } from '@suite-common/wallet-types';
 import { getSendFormDraftKey } from '@suite-common/wallet-utils';
 
+import { PAYMENT_REQUEST_BUTTON_NAMES } from './sendFormConstants';
 import { type SendRootState } from './sendFormReducer';
+
+const createMemoizedSelector = createWeakMapSelector.withTypes<DeviceRootState>();
 
 export const selectSendPrecomposedTx = (state: SendRootState) => state.wallet.send.precomposedTx;
 export const selectSendSerializedTx = (state: SendRootState) => state.wallet.send.serializedTx;
@@ -43,26 +47,36 @@ export const selectSendFormDraftOutputsByAccountKey = (
     return draft?.outputs ?? null;
 };
 
-export const selectSendFormButtonRequestCodes = (state: DeviceRootState, symbol: NetworkSymbol) => {
-    const buttonRequestCodes = selectDeviceButtonRequestsCodes(state);
+export const selectSendFormButtonRequestCodes = createMemoizedSelector(
+    [selectDeviceButtonRequests, (_state: DeviceRootState, symbol: NetworkSymbol) => symbol],
+    (buttonRequests, symbol) => {
+        const networkType = getNetworkType(symbol);
 
-    const networkType = getNetworkType(symbol);
+        const isCardano = networkType === 'cardano';
+        const isEthereum = networkType === 'ethereum';
+        const isStellar = networkType === 'stellar';
 
-    const isCardano = networkType === 'cardano';
-    const isEthereum = networkType === 'ethereum';
-    const isStellar = networkType === 'stellar';
-
-    return buttonRequestCodes.filter(
-        code =>
-            code === 'ButtonRequest_ConfirmOutput' ||
-            code === 'ButtonRequest_SignTx' ||
-            isCardano ||
-            (isEthereum && code === 'ButtonRequest_Other') ||
-            // This is a special case for T1B1 devices (Stellar).
-            // See https://github.com/trezor/trezor-firmware/issues/5120
-            (isStellar && (code === 'ButtonRequest_Other' || code === 'ButtonRequest_ProtectCall')),
-    );
-};
+        return returnStableArrayIfEmpty(
+            buttonRequests
+                .filter(
+                    ({ code, name }) =>
+                        code === 'ButtonRequest_ConfirmOutput' ||
+                        code === 'ButtonRequest_SignTx' ||
+                        isCardano ||
+                        (isEthereum && code === 'ButtonRequest_Other') ||
+                        (code === 'ButtonRequest_Other' &&
+                            name !== undefined &&
+                            PAYMENT_REQUEST_BUTTON_NAMES.includes(name)) ||
+                        // This is a special case for T1B1 devices (Stellar).
+                        // See https://github.com/trezor/trezor-firmware/issues/5120
+                        (isStellar &&
+                            (code === 'ButtonRequest_Other' ||
+                                code === 'ButtonRequest_ProtectCall')),
+                )
+                .map(({ code }) => code),
+        );
+    },
+);
 
 export const selectSendFormReviewButtonRequestsCount = (
     state: DeviceRootState,
@@ -76,15 +90,18 @@ export const selectSendFormReviewButtonRequestsCount = (
 
     const sendFormReviewRequest = selectSendFormButtonRequestCodes(state, symbol);
 
+    let count = sendFormReviewRequest.length;
+
     // While confirming decrease amount in RBF, 'ButtonRequest_ConfirmOutput' is called twice (confirm decrease address, confirm decrease amount).
+    // Drop one from the count (without mutating the memoized array).
     if (
         G.isNumber(decreaseOutputId) &&
         sendFormReviewRequest.filter(code => code === 'ButtonRequest_ConfirmOutput').length > 1
     ) {
-        sendFormReviewRequest.splice(-1, 1);
+        count -= 1;
     }
 
-    return isCardano ? sendFormReviewRequest.length - 1 : sendFormReviewRequest.length;
+    return isCardano ? Math.max(0, count - 1) : count;
 };
 
 export const selectSendFormReviewLastButtonCode = (

--- a/suite-common/wallet-utils/src/validationUtils.ts
+++ b/suite-common/wallet-utils/src/validationUtils.ts
@@ -9,6 +9,7 @@ export {
     hasBitcoinCashAddressPrefix,
     isBitcoinCashAddressUppercase,
     isBech32AddressUppercase,
+    toChecksumAddress,
 } from '@suite-common/address';
 
 export const isDecimalsValid = (value: string, decimals: number) => {

--- a/suite-common/wallet-utils/src/validationUtils.ts
+++ b/suite-common/wallet-utils/src/validationUtils.ts
@@ -9,7 +9,6 @@ export {
     hasBitcoinCashAddressPrefix,
     isBitcoinCashAddressUppercase,
     isBech32AddressUppercase,
-    toChecksumAddress,
 } from '@suite-common/address';
 
 export const isDecimalsValid = (value: string, decimals: number) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11354,6 +11354,7 @@ __metadata:
   resolution: "@suite-common/trading@workspace:suite-common/trading"
   dependencies:
     "@reduxjs/toolkit": "npm:2.12.0"
+    "@suite-common/address": "workspace:*"
     "@suite-common/device": "workspace:*"
     "@suite-common/geolocation": "workspace:*"
     "@suite-common/react-query": "workspace:*"


### PR DESCRIPTION
- enable ripple for SLIP-24
- checksum addresses for SLIP-24 on EVM  
- adjustment for ripple tags
- fixes txn review for btc line networks payment requests
- updated flow for txn preview for SLIP-24
- Icons for clear signing show network icon where necessary
- eth like networks tokens will fail with SLIP-24 - waiting for fw
- added util to check whether locally created payment request fits the api message 

## Notes for QA
- should work: ethereum like (just native token), bitcoin like, solana, ripple, stellar
- ethereum tokens issue reported to firmware [#7140](https://github.com/trezor/trezor-firmware/issues/7140)
- disabled: cardano, tron

## Steps for testing:
1. enable debug mode
2. in debug menu change trading backend to staging
3. enable SLIP-24 in experiental features
4. Go to swap and initiate swap with CEX partner on supported chain
5. When reviewing the transaction, it should not fail and signing should succeed
6. UI in Suite should follow UI in trezor.


Resolve #28912

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-slip24-payment-request-validation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-slip24-payment-request-validation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/suite-slip24-payment-request-validation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T16:18:39.001Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T16:17:14.962Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/suite-slip24-payment-request-validation/web/](https://dev.suite.sldev.cz/suite-web/feat/suite-slip24-payment-request-validation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->