### PR TITLE
Redact deeplink error content

### DIFF
--- a/suite-native/module-connect-popup/src/hooks/useConnectPopupNavigation.ts
+++ b/suite-native/module-connect-popup/src/hooks/useConnectPopupNavigation.ts
@@ -64,7 +64,12 @@ export const useConnectPopupNavigation = () => {
         if (connectPopupCall?.state === 'deeplink-callback') {
             // Note: we intentionally don't use canOpenURL here.
             // It would require us to add all possible schemes of 3rd party apps to the Info.plist
-            Linking.openURL(connectPopupCall.callbackUrl);
+            Linking.openURL(connectPopupCall.callbackUrl).catch(error => {
+                // Sanitize error message to prevent sensitive URL query parameters from being sent to Sentry.
+                throw error instanceof Error
+                    ? new Error(error.message.replace(/response=[^&:' ]*/, 'response=[redacted]'))
+                    : error;
+            });
         } else if (connectPopupCall) {
             navigation.navigate(RootStackRoutes.ConnectPopup);
         }


### PR DESCRIPTION
## Description

This pull request introduces improved error handling for opening URLs in the `useConnectPopupNavigation` hook. The key change is the sanitization of error messages to prevent sensitive information from being exposed.

**Error handling and security improvements:**

* Updated the call to `Linking.openURL` to catch errors and sanitize the error message by redacting sensitive query parameters (specifically, the `response` parameter) before rethrowing, enhancing security and privacy.

## Related Sentry issues

- https://satoshilabs.sentry.io/issues/7263587560/?project=4504214699245568
- https://satoshilabs.sentry.io/issues/7153272183/?project=4504214699245568

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/redact-deepllink-error&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->