### PR TITLE
feat(suite-native): allow backend configuration for all networks

### DIFF
--- a/suite-common/wallet-config/src/backends.ts
+++ b/suite-common/wallet-config/src/backends.ts
@@ -1,0 +1,32 @@
+import { exhaustive } from '@trezor/type-utils';
+import { isUrlWithQuery, parseElectrumUrl } from '@trezor/utils';
+
+import type { NetworkSymbol, ServerType } from './types';
+
+export const getServerAddressExample = (networkSymbol: NetworkSymbol, serverType: ServerType) => {
+    switch (serverType) {
+        case 'blockbook':
+        case 'solana':
+        case 'stellar':
+        case 'evm-rpc':
+            return `https://${networkSymbol}.trezor.io`;
+        case 'blockfrost':
+        case 'ripple':
+            return `wss://${networkSymbol}.trezor.io`;
+        case 'electrum':
+            return `electrum.example.com:50002:s`;
+        case 'coinjoin':
+        case 'default':
+            return undefined;
+        default:
+            return exhaustive(serverType);
+    }
+};
+
+export const validateServerAddress = (type: ServerType | undefined, value: string) => {
+    if (type === 'electrum') {
+        return !!parseElectrumUrl(value);
+    }
+
+    return isUrlWithQuery(value);
+};

--- a/suite-common/wallet-config/src/index.ts
+++ b/suite-common/wallet-config/src/index.ts
@@ -1,3 +1,4 @@
+export * from './backends';
 export * from './earnRewardsProvider';
 export * from './networksConfig';
 export * from './stakingProviders';

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -63,6 +63,7 @@ export const TREZOR_CONNECT_BACKENDS = [
 export type TrezorConnectBackendType = (typeof TREZOR_CONNECT_BACKENDS)[number];
 type NonStandardBackendType = 'coinjoin';
 export type BackendType = TrezorConnectBackendType | NonStandardBackendType;
+export type ServerType = BackendType | 'default';
 
 export type BackendOption = {
     type: BackendType;

--- a/suite-native/coin-enabling/src/components/NetworkBackendsButton.tsx
+++ b/suite-native/coin-enabling/src/components/NetworkBackendsButton.tsx
@@ -44,7 +44,8 @@ export const NetworkBackendsButton = ({ symbol }: NetworkBackendsButtonProps) =>
 
     const navigateToNetworkBackends = () =>
         navigation.navigate(RootStackRoutes.SettingsScreenStack, {
-            screen: SettingsStackRoutes.BitcoinBackends,
+            screen: SettingsStackRoutes.SettingsNetworkBackends,
+            params: { networkSymbol: symbol },
         });
 
     return (

--- a/suite-native/coin-enabling/src/components/NetworkListItem.tsx
+++ b/suite-native/coin-enabling/src/components/NetworkListItem.tsx
@@ -74,7 +74,7 @@ export const NetworkListItem = ({
                             )}
                         </VStack>
                         <HStack spacing="sp16" alignItems="center">
-                            {symbol === 'btc' && <NetworkBackendsButton symbol={symbol} />}
+                            <NetworkBackendsButton symbol={symbol} />
                             {accessory}
                         </HStack>
                     </HStack>

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1279,6 +1279,42 @@ export const messages = {
             subtitle:
                 'Enable coins to buy or receive assets. Disable unused coins to improve loading speed.',
         },
+        networkBackends: {
+            title: '{networkName} backend',
+            description: 'Connect to a custom backend server for enhanced privacy.',
+            servers: {
+                title: 'Backend server',
+                status: {
+                    connected: 'Connected',
+                    disconnected: 'Disconnected',
+                },
+                serverType: 'Server',
+                serverTypeDefault: 'Trezor (default)',
+                serverAddress: 'Server address',
+                connectButton: 'Connect',
+                invalidFormat:
+                    'Invalid format. Enter the server address in this format: host:port:[t|s].',
+                unableToConnect: {
+                    clearnet: 'Unable to connect to the server. Check the address and connection.',
+                    tor: 'Can’t connect to the server. Check the address and make sure Orbot is running.',
+                },
+            },
+            closeAction: {
+                title: 'Discard changes?',
+                description: 'Any unsaved changes will be lost.',
+                discardButton: 'Discard',
+                continueEditingButton: 'Keep editing',
+            },
+            connectionInfo: {
+                title: 'Connection info',
+                connectedTo: 'Connected to',
+                blockHash: 'Block hash',
+                blockHeight: 'Block height',
+                backendVersion: 'Backend version',
+                disconnected:
+                    'Connection to the backend server failed. Check your internet connection, verify your custom backend address, reconnect your device, and make sure {networkName} is enabled in Settings.',
+            },
+        },
         coinEnabling: {
             unsupportedSubtitle: 'Not supported on this device',
             labels: {

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1288,12 +1288,16 @@ export const messages = {
                     connected: 'Connected',
                     disconnected: 'Disconnected',
                 },
-                serverType: 'Server',
-                serverTypeDefault: 'Trezor (default)',
-                serverAddress: 'Server address',
+                serverType: {
+                    label: 'Server type',
+                    defaultLabel: 'Trezor (default)',
+                },
+                serverAddress: {
+                    label: 'Server address',
+                    hint: 'Format: {example}',
+                },
                 connectButton: 'Connect',
-                invalidFormat:
-                    'Invalid format. Enter the server address in this format: host:port:[t|s].',
+                invalidFormat: "Server address format isn't valid.",
                 unableToConnect: {
                     clearnet: 'Unable to connect to the server. Check the address and connection.',
                     tor: 'Can’t connect to the server. Check the address and make sure Orbot is running.',

--- a/suite-native/module-settings/src/components/ConnectionInfoButton.tsx
+++ b/suite-native/module-settings/src/components/ConnectionInfoButton.tsx
@@ -1,6 +1,7 @@
 import { Keyboard } from 'react-native';
 import { useSelector } from 'react-redux';
 
+import { type Network } from '@suite-common/wallet-config';
 import { type BlockchainRootState, selectNetworkBlockchainInfo } from '@suite-common/wallet-core';
 import {
     BottomSheetModal,
@@ -10,6 +11,10 @@ import {
     useBottomSheetModal,
 } from '@suite-native/atoms';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
+
+type ConnectionInfoButtonProps = {
+    network: Network;
+};
 
 type InfoLineProps = {
     title: TxKeyPath;
@@ -25,11 +30,11 @@ const InfoLine = ({ title, value }: InfoLineProps) => (
     </VStack>
 );
 
-export const ConnectionInfoButton = () => {
+export const ConnectionInfoButton = ({ network }: ConnectionInfoButtonProps) => {
     const { bottomSheetRef, openModal } = useBottomSheetModal();
 
     const { connected, url, blockHash, blockHeight, version } = useSelector(
-        (state: BlockchainRootState) => selectNetworkBlockchainInfo(state, 'btc'),
+        (state: BlockchainRootState) => selectNetworkBlockchainInfo(state, network.symbol),
     );
 
     const openBottomSheet = () => {
@@ -47,34 +52,35 @@ export const ConnectionInfoButton = () => {
             />
             <BottomSheetModal
                 ref={bottomSheetRef}
-                title={
-                    <Translation id="moduleSettings.advanced.bitcoinBackends.connectionInfo.title" />
-                }
+                title={<Translation id="moduleSettings.networkBackends.connectionInfo.title" />}
                 isCloseDisplayed
             >
                 <VStack marginHorizontal="sp8" spacing="sp16">
                     {connected ? (
                         <>
                             <InfoLine
-                                title="moduleSettings.advanced.bitcoinBackends.connectionInfo.connectedTo"
+                                title="moduleSettings.networkBackends.connectionInfo.connectedTo"
                                 value={url}
                             />
                             <InfoLine
-                                title="moduleSettings.advanced.bitcoinBackends.connectionInfo.blockHash"
+                                title="moduleSettings.networkBackends.connectionInfo.blockHash"
                                 value={blockHash}
                             />
                             <InfoLine
-                                title="moduleSettings.advanced.bitcoinBackends.connectionInfo.blockHeight"
+                                title="moduleSettings.networkBackends.connectionInfo.blockHeight"
                                 value={blockHeight}
                             />
                             <InfoLine
-                                title="moduleSettings.advanced.bitcoinBackends.connectionInfo.backendVersion"
+                                title="moduleSettings.networkBackends.connectionInfo.backendVersion"
                                 value={version}
                             />
                         </>
                     ) : (
                         <Text>
-                            <Translation id="moduleSettings.advanced.bitcoinBackends.connectionInfo.disconnected" />
+                            <Translation
+                                id="moduleSettings.networkBackends.connectionInfo.disconnected"
+                                values={{ networkName: network.name }}
+                            />
                         </Text>
                     )}
                 </VStack>

--- a/suite-native/module-settings/src/hooks/useBackendServersForm.ts
+++ b/suite-native/module-settings/src/hooks/useBackendServersForm.ts
@@ -6,7 +6,13 @@ import { useFocusEffect } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { yup } from '@suite-common/validators';
-import { type BackendType } from '@suite-common/wallet-config';
+import {
+    type BackendType,
+    type Network,
+    type ServerType,
+    getServerAddressExample,
+    validateServerAddress,
+} from '@suite-common/wallet-config';
 import {
     type BlockchainRootState,
     blockchainActions,
@@ -18,18 +24,13 @@ import { type SelectItemType } from '@suite-native/atoms';
 import { useForm } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import TrezorConnect, { BLOCKCHAIN, type BlockchainError } from '@trezor/connect';
-import { parseElectrumUrl } from '@trezor/utils';
-
-const symbol = 'btc';
-
-export type ServerType = BackendType | 'default';
 
 type FormValues = {
     serverType: ServerType;
     serverAddress: string;
 };
 
-export const useBackendServersForm = () => {
+export const useBackendServersForm = ({ symbol, backendOptions }: Network) => {
     const dispatch = useDispatch();
     const { translate } = useTranslate();
     const { analytics } = useServices(selectNativeAnalyticsDep);
@@ -39,26 +40,36 @@ export const useBackendServersForm = () => {
         backends: { selected, urls },
     } = useSelector((state: BlockchainRootState) => selectNetworkBlockchainInfo(state, symbol));
 
-    const serverTypes = useMemo<SelectItemType<ServerType>[]>(
-        () => [
-            {
-                value: 'default',
-                label: translate('moduleSettings.networkBackends.servers.serverTypeDefault'),
-            },
+    const serverTypes = useMemo(() => {
+        const defaultItem: SelectItemType<ServerType> = {
+            value: 'default',
+            label: translate('moduleSettings.networkBackends.servers.serverType.defaultLabel'),
+        };
+        const supportedItems: SelectItemType<BackendType>[] = [
+            { value: 'blockbook', label: 'Blockbook' },
             { value: 'electrum', label: 'Electrum' },
-        ],
-        [translate],
-    );
+            { value: 'ripple', label: 'Ripple' },
+            { value: 'blockfrost', label: 'Blockfrost' },
+            { value: 'solana', label: 'Solana' },
+            { value: 'stellar', label: 'Stellar' },
+            { value: 'evm-rpc', label: 'RPC' },
+        ];
+        const availableItems = supportedItems.filter(({ value }) =>
+            backendOptions.some(({ type }) => type === value),
+        );
+
+        return symbol !== 'regtest' ? [defaultItem, ...availableItems] : availableItems;
+    }, [translate, symbol, backendOptions]);
 
     const defaultValues = useMemo<FormValues>(
         () => ({
             serverType: selected ?? 'default',
-            serverAddress: urls?.electrum?.[0] ?? '',
+            serverAddress: (selected && urls?.[selected]?.[0]) ?? '',
         }),
         [selected, urls],
     );
 
-    const form = useForm({
+    const form = useForm<FormValues>({
         validation: yup.object({
             serverType: yup
                 .string<ServerType>()
@@ -69,13 +80,24 @@ export const useBackendServersForm = () => {
                 .test(
                     'format',
                     translate('moduleSettings.networkBackends.servers.invalidFormat'),
-                    value => !!value && !!parseElectrumUrl(value),
+                    (value, context) =>
+                        !!value &&
+                        validateServerAddress(context.resolve(yup.ref('serverType')), value),
                 ),
         }),
         defaultValues,
         mode: 'onSubmit',
     });
 
+    const setServerType = (value: ServerType) => {
+        form.clearErrors();
+        form.setValue('serverType', value, { shouldDirty: true });
+        if (value !== 'default') {
+            form.setValue('serverAddress', urls?.[value]?.[0] ?? '', { shouldDirty: true });
+        }
+    };
+
+    const selectedServerType = form.watch('serverType');
     const isOnionAddress = form.watch('serverAddress').includes('.onion:');
     const [isConnecting, setIsConnecting] = useState(false);
 
@@ -84,7 +106,7 @@ export const useBackendServersForm = () => {
             blockchainActions.setBackend({
                 symbol,
                 type: serverType,
-                urls: serverType === 'electrum' ? [serverAddress] : [],
+                urls: serverType !== 'default' ? [serverAddress] : [],
             }),
         );
         dispatch(reconnectBlockchainThunk({ symbol }));
@@ -142,6 +164,9 @@ export const useBackendServersForm = () => {
     return {
         form,
         serverTypes,
+        selectedServerType,
+        setServerType,
+        serverAddressExample: getServerAddressExample(symbol, selectedServerType),
         isConnected: connected,
         isConnecting,
         submit,

--- a/suite-native/module-settings/src/hooks/useBackendServersForm.ts
+++ b/suite-native/module-settings/src/hooks/useBackendServersForm.ts
@@ -43,9 +43,7 @@ export const useBackendServersForm = () => {
         () => [
             {
                 value: 'default',
-                label: translate(
-                    'moduleSettings.advanced.bitcoinBackends.servers.serverTypeDefault',
-                ),
+                label: translate('moduleSettings.networkBackends.servers.serverTypeDefault'),
             },
             { value: 'electrum', label: 'Electrum' },
         ],
@@ -70,7 +68,7 @@ export const useBackendServersForm = () => {
                 .string()
                 .test(
                     'format',
-                    translate('moduleSettings.advanced.bitcoinBackends.servers.invalidFormat'),
+                    translate('moduleSettings.networkBackends.servers.invalidFormat'),
                     value => !!value && !!parseElectrumUrl(value),
                 ),
         }),
@@ -117,8 +115,8 @@ export const useBackendServersForm = () => {
                 form.setError('serverAddress', {
                     message: translate(
                         isOnionAddress
-                            ? 'moduleSettings.advanced.bitcoinBackends.servers.unableToConnect.tor'
-                            : 'moduleSettings.advanced.bitcoinBackends.servers.unableToConnect.clearnet',
+                            ? 'moduleSettings.networkBackends.servers.unableToConnect.tor'
+                            : 'moduleSettings.networkBackends.servers.unableToConnect.clearnet',
                     ),
                 });
                 setIsConnecting(false);

--- a/suite-native/module-settings/src/hooks/useBackendServersForm.ts
+++ b/suite-native/module-settings/src/hooks/useBackendServersForm.ts
@@ -129,14 +129,16 @@ export const useBackendServersForm = () => {
 
     useFocusEffect(
         useCallback(() => {
-            TrezorConnect.on(BLOCKCHAIN.CONNECT, onConnectionSuccess);
-            TrezorConnect.on(BLOCKCHAIN.ERROR, onConnectionError);
+            if (isConnecting) {
+                TrezorConnect.on(BLOCKCHAIN.CONNECT, onConnectionSuccess);
+                TrezorConnect.on(BLOCKCHAIN.ERROR, onConnectionError);
 
-            return () => {
-                TrezorConnect.off(BLOCKCHAIN.CONNECT, onConnectionSuccess);
-                TrezorConnect.off(BLOCKCHAIN.ERROR, onConnectionError);
-            };
-        }, [onConnectionSuccess, onConnectionError]),
+                return () => {
+                    TrezorConnect.off(BLOCKCHAIN.CONNECT, onConnectionSuccess);
+                    TrezorConnect.off(BLOCKCHAIN.ERROR, onConnectionError);
+                };
+            }
+        }, [isConnecting, onConnectionSuccess, onConnectionError]),
     );
 
     return {

--- a/suite-native/module-settings/src/navigation/SettingsStackNavigator.tsx
+++ b/suite-native/module-settings/src/navigation/SettingsStackNavigator.tsx
@@ -7,7 +7,7 @@ import {
 } from '@suite-native/navigation';
 import { SettingsTradingLocationScreen } from '@suite-native/trading-residence';
 
-import { BitcoinBackendsScreen } from '../screens/BitcoinBackendsScreen';
+import { NetworkBackendsScreen } from '../screens/NetworkBackendsScreen';
 import { SettingsAdvancedScreen } from '../screens/SettingsAdvancedScreen';
 import { SettingsAppLogScreen } from '../screens/SettingsAppLogScreen';
 import { SettingsAutoEjectScreen } from '../screens/SettingsAutoEjectScreen';
@@ -30,7 +30,6 @@ export const SettingsStackNavigator = () => (
             name={SettingsStackRoutes.SettingsPreferences}
             component={SettingsPreferencesScreen}
         />
-
         <SettingsStack.Screen
             options={{ title: SettingsStackRoutes.SettingsPrivacy }}
             name={SettingsStackRoutes.SettingsPrivacy}
@@ -57,6 +56,10 @@ export const SettingsStackNavigator = () => (
             component={SettingsNetworksScreen}
         />
         <SettingsStack.Screen
+            name={SettingsStackRoutes.SettingsNetworkBackends}
+            component={NetworkBackendsScreen}
+        />
+        <SettingsStack.Screen
             options={{ title: SettingsStackRoutes.SettingsSuiteSync }}
             name={SettingsStackRoutes.SettingsSuiteSync}
             component={SettingsSuiteSyncScreen}
@@ -80,10 +83,6 @@ export const SettingsStackNavigator = () => (
         <SettingsStack.Screen
             name={SettingsStackRoutes.TurnOffDeviceAuthenticityCheck}
             component={TurnOffDeviceAuthenticityCheckScreen}
-        />
-        <SettingsStack.Screen
-            name={SettingsStackRoutes.BitcoinBackends}
-            component={BitcoinBackendsScreen}
         />
         <SettingsStack.Screen
             options={{ title: SettingsStackRoutes.SettingsTradingLocation }}

--- a/suite-native/module-settings/src/navigation/useSettingsNavigateTo.ts
+++ b/suite-native/module-settings/src/navigation/useSettingsNavigateTo.ts
@@ -13,7 +13,9 @@ export const useSettingsNavigateTo = () => {
     const navigation = useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes>>();
 
     return useCallback(
-        (routeName: SettingsStackRoutes): void => {
+        (
+            routeName: Exclude<SettingsStackRoutes, SettingsStackRoutes.SettingsNetworkBackends>,
+        ): void => {
             navigation.navigate(RootStackRoutes.SettingsScreenStack, { screen: routeName });
         },
         [navigation],

--- a/suite-native/module-settings/src/screens/NetworkBackendsScreen.tsx
+++ b/suite-native/module-settings/src/screens/NetworkBackendsScreen.tsx
@@ -1,20 +1,30 @@
 import { useNavigation } from '@react-navigation/native';
 
+import { getNetwork } from '@suite-common/wallet-config';
 import { useAlert } from '@suite-native/alerts';
 import { Button, Card, HStack, InlineAlertText, Select, Text, VStack } from '@suite-native/atoms';
 import { Form, TextInputField } from '@suite-native/forms';
 import { Icon } from '@suite-native/icons';
 import { Translation, useTranslate } from '@suite-native/intl';
-import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
+import {
+    DynamicScreenHeader,
+    Screen,
+    type SettingsStackParamList,
+    type SettingsStackRoutes,
+    type StackProps,
+} from '@suite-native/navigation';
 
 import { ConnectionInfoButton } from '../components/ConnectionInfoButton';
 import { type ServerType, useBackendServersForm } from '../hooks/useBackendServersForm';
 
-export const BitcoinBackendsScreen = () => {
+export const NetworkBackendsScreen = ({
+    route,
+}: StackProps<SettingsStackParamList, SettingsStackRoutes.SettingsNetworkBackends>) => {
     const { showAlert } = useAlert();
     const { translate } = useTranslate();
     const navigation = useNavigation();
 
+    const network = getNetwork(route.params.networkSymbol);
     const { form, serverTypes, isConnected, isConnecting, submit, discard } =
         useBackendServersForm();
 
@@ -31,19 +41,17 @@ export const BitcoinBackendsScreen = () => {
     const closeAction = () => {
         if (isDirty) {
             showAlert({
-                title: (
-                    <Translation id="moduleSettings.advanced.bitcoinBackends.closeAction.title" />
-                ),
+                title: <Translation id="moduleSettings.networkBackends.closeAction.title" />,
                 description: (
-                    <Translation id="moduleSettings.advanced.bitcoinBackends.closeAction.description" />
+                    <Translation id="moduleSettings.networkBackends.closeAction.description" />
                 ),
                 primaryButtonTitle: (
-                    <Translation id="moduleSettings.advanced.bitcoinBackends.closeAction.discardButton" />
+                    <Translation id="moduleSettings.networkBackends.closeAction.discardButton" />
                 ),
                 primaryButtonColorProps: { intent: 'critical', priority: 'primary' },
                 onPressPrimaryButton: discardChanges,
                 secondaryButtonTitle: (
-                    <Translation id="moduleSettings.advanced.bitcoinBackends.closeAction.continueEditingButton" />
+                    <Translation id="moduleSettings.networkBackends.closeAction.continueEditingButton" />
                 ),
                 secondaryButtonColorProps: { intent: 'critical', priority: 'secondary' },
             });
@@ -56,11 +64,14 @@ export const BitcoinBackendsScreen = () => {
         <Screen
             header={
                 <DynamicScreenHeader
-                    title={<Translation id="moduleSettings.advanced.bitcoinBackends.title" />}
-                    subtitle={
-                        <Translation id="moduleSettings.advanced.bitcoinBackends.description" />
+                    title={
+                        <Translation
+                            id="moduleSettings.networkBackends.title"
+                            values={{ networkName: network.name }}
+                        />
                     }
-                    rightIcon={<ConnectionInfoButton />}
+                    subtitle={<Translation id="moduleSettings.networkBackends.description" />}
+                    rightIcon={<ConnectionInfoButton network={network} />}
                     closeAction={closeAction}
                 />
             }
@@ -71,24 +82,24 @@ export const BitcoinBackendsScreen = () => {
                         <HStack>
                             <Icon name="database" size="mediumLarge" />
                             <Text variant="body-md">
-                                <Translation id="moduleSettings.advanced.bitcoinBackends.servers.title" />
+                                <Translation id="moduleSettings.networkBackends.servers.title" />
                             </Text>
                         </HStack>
                         {!isDirty &&
                             (isConnected ? (
                                 <InlineAlertText variant="success">
-                                    <Translation id="moduleSettings.advanced.bitcoinBackends.servers.status.connected" />
+                                    <Translation id="moduleSettings.networkBackends.servers.status.connected" />
                                 </InlineAlertText>
                             ) : (
                                 <InlineAlertText variant="critical">
-                                    <Translation id="moduleSettings.advanced.bitcoinBackends.servers.status.disconnected" />
+                                    <Translation id="moduleSettings.networkBackends.servers.status.disconnected" />
                                 </InlineAlertText>
                             ))}
                     </HStack>
                     <Form form={form}>
                         <Select<ServerType>
                             title={
-                                <Translation id="moduleSettings.advanced.bitcoinBackends.servers.serverType" />
+                                <Translation id="moduleSettings.networkBackends.servers.serverType" />
                             }
                             items={serverTypes}
                             value={serverType}
@@ -99,7 +110,7 @@ export const BitcoinBackendsScreen = () => {
                             <TextInputField
                                 name="serverAddress"
                                 label={translate(
-                                    'moduleSettings.advanced.bitcoinBackends.servers.serverAddress',
+                                    'moduleSettings.networkBackends.servers.serverAddress',
                                 )}
                                 autoCapitalize="none"
                                 keyboardType="url"
@@ -107,7 +118,7 @@ export const BitcoinBackendsScreen = () => {
                         )}
                         {(isDirty || !isConnected) && (
                             <Button onPress={submit} isLoading={isConnecting}>
-                                <Translation id="moduleSettings.advanced.bitcoinBackends.servers.connectButton" />
+                                <Translation id="moduleSettings.networkBackends.servers.connectButton" />
                             </Button>
                         )}
                     </Form>

--- a/suite-native/module-settings/src/screens/NetworkBackendsScreen.tsx
+++ b/suite-native/module-settings/src/screens/NetworkBackendsScreen.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 
-import { getNetwork } from '@suite-common/wallet-config';
+import { type ServerType, getNetwork } from '@suite-common/wallet-config';
 import { useAlert } from '@suite-native/alerts';
 import { Button, Card, HStack, InlineAlertText, Select, Text, VStack } from '@suite-native/atoms';
 import { Form, TextInputField } from '@suite-native/forms';
@@ -15,7 +15,7 @@ import {
 } from '@suite-native/navigation';
 
 import { ConnectionInfoButton } from '../components/ConnectionInfoButton';
-import { type ServerType, useBackendServersForm } from '../hooks/useBackendServersForm';
+import { useBackendServersForm } from '../hooks/useBackendServersForm';
 
 export const NetworkBackendsScreen = ({
     route,
@@ -25,13 +25,19 @@ export const NetworkBackendsScreen = ({
     const navigation = useNavigation();
 
     const network = getNetwork(route.params.networkSymbol);
-    const { form, serverTypes, isConnected, isConnecting, submit, discard } =
-        useBackendServersForm();
+    const {
+        form,
+        serverTypes,
+        selectedServerType,
+        setServerType,
+        serverAddressExample,
+        isConnected,
+        isConnecting,
+        submit,
+        discard,
+    } = useBackendServersForm(network);
 
     const { isDirty } = form.formState;
-    const serverType = form.watch('serverType');
-    const setServerType = (value: ServerType) =>
-        form.setValue('serverType', value, { shouldDirty: true });
 
     const discardChanges = () => {
         discard();
@@ -99,18 +105,22 @@ export const NetworkBackendsScreen = ({
                     <Form form={form}>
                         <Select<ServerType>
                             title={
-                                <Translation id="moduleSettings.networkBackends.servers.serverType" />
+                                <Translation id="moduleSettings.networkBackends.servers.serverType.label" />
                             }
                             items={serverTypes}
-                            value={serverType}
+                            value={selectedServerType}
                             onSelectItem={setServerType}
                             isLabelShown
                         />
-                        {serverType === 'electrum' && (
+                        {selectedServerType !== 'default' && (
                             <TextInputField
                                 name="serverAddress"
                                 label={translate(
-                                    'moduleSettings.networkBackends.servers.serverAddress',
+                                    'moduleSettings.networkBackends.servers.serverAddress.label',
+                                )}
+                                hint={translate(
+                                    'moduleSettings.networkBackends.servers.serverAddress.hint',
+                                    { example: serverAddressExample },
                                 )}
                                 autoCapitalize="none"
                                 keyboardType="url"

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -156,13 +156,15 @@ export type SettingsStackParamList = {
     [SettingsStackRoutes.SettingsSupport]: undefined;
     [SettingsStackRoutes.SettingsAppLog]: undefined;
     [SettingsStackRoutes.SettingsNetworks]: undefined;
+    [SettingsStackRoutes.SettingsNetworkBackends]: {
+        networkSymbol: NetworkSymbol;
+    };
     [SettingsStackRoutes.SettingsSuiteSync]: undefined;
     [SettingsStackRoutes.SettingsAdvanced]: undefined;
     [SettingsStackRoutes.SettingsDustPhishing]: undefined;
     [SettingsStackRoutes.SettingsExperimental]: undefined;
     [SettingsStackRoutes.TurnOffDeviceAuthenticityCheck]: undefined;
     [SettingsStackRoutes.TurnOffFirmwareAuthenticityCheck]: undefined;
-    [SettingsStackRoutes.BitcoinBackends]: undefined;
     [SettingsStackRoutes.SettingsTradingLocation]: undefined;
 };
 

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -285,13 +285,13 @@ export enum SettingsStackRoutes {
     SettingsSupport = 'SettingsSupport',
     SettingsAppLog = 'SettingsAppLog',
     SettingsNetworks = 'SettingsNetworks',
+    SettingsNetworkBackends = 'SettingsNetworkBackends',
     SettingsSuiteSync = 'SettingsSuiteSync',
     SettingsAdvanced = 'SettingsAdvanced',
     SettingsDustPhishing = 'SettingsDustPhishing',
     SettingsExperimental = 'SettingsExperimental',
     TurnOffDeviceAuthenticityCheck = 'TurnOffDeviceAuthenticityCheck',
     TurnOffFirmwareAuthenticityCheck = 'TurnOffFirmwareAuthenticityCheck',
-    BitcoinBackends = 'BitcoinBackends',
     SettingsTradingLocation = 'SettingsTradingLocation',
 }
 


### PR DESCRIPTION
- Connection status change handled only after submit.
- `BitcoinBackendsScreen` made generic.
- Backend configuration allowed for all networks.

## Related Issue

Resolve #27015

## Screenshots:
| Settings | Format validation | Validated connection |
| --- | --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/e81d90c0-fdbd-456e-a4b8-3a99cf2e551b" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/88fba1a7-bde0-4fb3-843b-36f3deb591fb" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/df3d9e52-39a1-4efe-9c75-4578b5c4fdd4" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/network-custom-backends&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/network-custom-backends&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/network-custom-backends&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are split between two domains: (1) suite-common/wallet-config backend configuration types and exports, and (2) suite-native mobile settings/navigation for network backends. The wallet-config changes (backends.ts, types.ts, index.ts) affect shared infrastructure used by the web/desktop Suite for backend configuration, so tests covering custom backend setup and coin discovery are critical. The suite-native changes (11 files) cover mobile-only React Native components, navigation, and hooks that have zero E2E test coverage since the Playwright E2E suite only targets web/desktop. Testing strategy should focus on the 4 high-priority tests that directly exercise custom backend configuration flows.

<details><summary><b>Changed files (13)</b></summary>

- `suite-common/wallet-config/src/backends.ts`
- `suite-common/wallet-config/src/index.ts`
- `suite-common/wallet-config/src/types.ts`
- `suite-native/coin-enabling/src/components/NetworkBackendsButton.tsx`
- `suite-native/coin-enabling/src/components/NetworkListItem.tsx`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-settings/src/components/ConnectionInfoButton.tsx`
- `suite-native/module-settings/src/hooks/useBackendServersForm.ts`
- `suite-native/module-settings/src/navigation/SettingsStackNavigator.tsx`
- `suite-native/module-settings/src/navigation/useSettingsNavigateTo.ts`
- `suite-native/module-settings/src/screens/NetworkBackendsScreen.tsx`
- `suite-native/navigation/src/navigators.ts`
- `suite-native/navigation/src/routes.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test directly exercises custom backend configuration for coins (BTC, ETH), which is the core functionality affected by changes to suite-common/wallet-config/src/backends.ts and types.ts. The test configures blockbook backend URLs, checks backend indicators, and verifies discovery with custom backends.
- `suite/e2e/tests/settings/coins.test.ts` — This test covers coin network activation, custom backend configuration (blockbook type for ETH), and backend indicator display — all directly related to the wallet-config backends.ts and types.ts changes. It validates the end-to-end flow of enabling networks and setting custom backends.
- `suite/e2e/tests/settings/electrum.test.ts` — This test configures a custom Electrum backend for the Regtest network and verifies discovery completes successfully. Changes to backends.ts (backend type definitions) and types.ts could directly affect Electrum backend configuration and type handling.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test specifically configures custom Blockbook backends for BTC and LTC and verifies wallet discovery completes. Changes to backend configuration types and definitions in wallet-config directly impact this flow.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — The SuiteReady analytics event includes customBackends information (e.g., 'eth') which is derived from wallet-config backend settings. Changes to backend types could affect how custom backends are reported in analytics events.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple cryptocurrency coins and verifies discovery completes. While it doesn't configure custom backends, changes to wallet-config types (NetworkSymbol, network configuration) could affect multi-coin discovery behavior.

</details>

⚠️ **Changes with no test coverage (10)**
- `suite-native/coin-enabling/src/components/NetworkBackendsButton.tsx`
- `suite-native/coin-enabling/src/components/NetworkListItem.tsx`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-settings/src/components/ConnectionInfoButton.tsx`
- `suite-native/module-settings/src/hooks/useBackendServersForm.ts`
- `suite-native/module-settings/src/navigation/SettingsStackNavigator.tsx`
- `suite-native/module-settings/src/navigation/useSettingsNavigateTo.ts`
- `suite-native/module-settings/src/screens/NetworkBackendsScreen.tsx`
- `suite-native/navigation/src/navigators.ts`
- `suite-native/navigation/src/routes.ts`

_Updated: 2026-06-24T11:39:29.742Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-24T11:44:30.627Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-24T11:43:18.776Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native/network-custom-backends/web/](https://dev.suite.sldev.cz/suite-web/feat/native/network-custom-backends/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->