### PR TITLE
feat(device-utils): add new t3w1 color for le

### DIFF
--- a/packages/device-utils/src/models.ts
+++ b/packages/device-utils/src/models.ts
@@ -51,11 +51,13 @@ export const models: Record<DeviceModelInternal, ModelConfig> = {
             '1': 'Charcoal Black',
             '2': 'Obsidian Green',
             '3': 'Bitcoin Orange',
+            '4': 'Limited Edition',
         },
         frontColors: {
             '1': '1',
             '2': '2',
             '3': '1',
+            '4': '3',
         },
     },
 };


### PR DESCRIPTION
## Description

Adding new color variant for our upcoming LE of T3W1


## Notes for QA

You should see a new color and device name upon connection of T3W1 with unit_color=4
Can be tested on testing devices we have in the office



## Screenshots

Will be added once we have testing devices 



Resolves https://github.com/trezor/trezor-suite/issues/30184

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/t3w1-le/web/](https://dev.suite.sldev.cz/suite-web/chore/t3w1-le/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/t3w1-le&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/t3w1-le&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-22T11:01:22.149Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| TrezorConnect > Error screen | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-22T11:01:19.162Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to packages/device-utils/src/models.ts, which is a broadly imported utility that maps to all 121 candidate tests. Since this file defines device model types/constants used throughout the application, the risk is moderate — most tests use it transitively but few directly depend on model-specific logic. The recommended strategy focuses on tests that explicitly exercise model-specific behavior: device-specific onboarding flows, device settings pages for particular models, and analytics events that assert on model identifiers. Most other tests only transitively import this module and are unlikely to be affected.

<details><summary><b>Changed files (1)</b></summary>

- `packages/device-utils/src/models.ts`

</details>

**Recommended tests (9)**

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test explicitly asserts on device model information (model T3T1) in the DeviceConnect event payload. Changes to models.ts could affect how device model identifiers are resolved, directly impacting these assertions.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — This test operates on a specific device model (T3T1) and exercises the full onboarding flow including device interaction. Changes to model definitions could affect device identification, firmware matching, or model-specific branching during onboarding.
- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` — This test is model-specific (T1B1) and exercises device-specific flows like blind matrix PIN entry and seed confirmation that may depend on model identification from models.ts.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — This test changes device-specific settings (name, rotation, homescreen, wipe) on a T2T1 model. Device settings behavior may branch on model type, which is defined in models.ts.
- `suite/e2e/tests/settings/t1b1-device-settings.test.ts` — T1B1-specific device settings test (PIN via blind matrix, homescreen) that exercises model-dependent UI paths. Model identification changes could affect which device-specific UI is rendered.
- `suite/e2e/tests/settings/t3b1-device-settings.test.ts` — T3B1-specific device settings test that exercises model-dependent device management features. Changes to model definitions could affect device identification and model-specific behavior.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/backup/t3t1-t2t1-create-additional-share.test.ts` — This test creates additional Shamir backup shares on specific device models (T3T1/T2T1). Model identification from models.ts could affect which backup options are available per model.
- `suite/e2e/tests/firmware/custom-firmware.test.ts` — Custom firmware installation may use model identification to validate firmware compatibility. Changes to models.ts could affect firmware validation logic.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test uses asWalletDescriptor from @trezor/device-utils, which is in the same package as models.ts. Wallet descriptor generation may depend on model information.

</details>

_Updated: 2026-06-23T15:15:16.864Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->