### PR TITLE
chore(message-system): fw update recommendation, SOL min staking amount, remove TEX banner

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2026-06-18T00:00:00+00:00",
-    "sequence": 144,
+    "timestamp": "2026-06-19T00:00:00+00:00",
+    "sequence": 145,
     "actions": [
         {
             "conditions": [
@@ -1160,18 +1160,18 @@
                 "variant": "info",
                 "category": "context",
                 "content": {
-                    "en": "Minimum amount to stake has changed to 1 SOL.",
-                    "es": "La cantidad mínima para hacer staking ha cambiado a 1 SOL.",
-                    "cs": "Minimální částka pro staking je nyní 1 SOL.",
-                    "ru": "Минимальная сумма для стейкинга изменилась на 1 SOL.",
-                    "ja": "ステーキングの最小額が1 SOLに変更されました",
-                    "hu": "A stakeléshez szükséges minimális összeg 1 SOL-ra változott.",
-                    "it": "L'importo minimo per lo staking è passato a 1 SOL.",
-                    "fr": "Le montant minimum pour le staking est passé à 1 SOL.",
-                    "de": "Der Mindestbetrag für das Staking hat sich auf 1 SOL geändert.",
-                    "tr": "Stake etmek için minimum miktar 1 SOL olarak değişti.",
-                    "pt": "O valor mínimo para staking mudou para 1 SOL.",
-                    "uk": "Мінімальна сума для стейкінгу змінилася на 1 SOL."
+                    "en": "The minimum amount you can stake is 1 SOL.",
+                    "es": "La cantidad mínima que puede poner en staking es 1 SOL.",
+                    "cs": "Minimální částka pro staking je 1 SOL.",
+                    "ru": "Минимальная сумма, которую вы можете отправить в стейкинг, составляет 1 SOL.",
+                    "ja": "ステーキングできる最小額は1 SOLです。",
+                    "hu": "A legkisebb összeg, amit stakelhet, az 1 SOL.",
+                    "it": "L'importo minimo che puoi mettere in staking è 1 SOL.",
+                    "fr": "Le montant minimum que vous pouvez mettre en staking est de 1 SOL.",
+                    "de": "Der Mindestbetrag, den Sie staken können, beträgt 1 SOL.",
+                    "tr": "Stake edebileceğiniz minimum miktar 1 SOL'dur.",
+                    "pt": "O valor mínimo que você pode colocar em staking é 1 SOL.",
+                    "uk": "Мінімальна сума, яку ви можете відправити у стейкінг, становить 1 SOL."
                 },
                 "context": {
                     "domain": "accounts.sol.staking"

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2026-06-17T00:00:00+00:00",
-    "sequence": 143,
+    "timestamp": "2026-06-18T00:00:00+00:00",
+    "sequence": 144,
     "actions": [
         {
             "conditions": [
@@ -1151,6 +1151,41 @@
                     "uk": "У нас виникли тимчасові проблеми з синхронізацією мережі INPUT HERE, що може спричинити затримки або помилки. Ваші активи INPUT HERE у цілковитій безпеці. Дякуємо за терпіння."
                 }
             }
+        },
+        {
+            "message": {
+                "id": "d41518e0-a21f-43ce-872c-4bf250f59d90",
+                "priority": 92,
+                "dismissible": true,
+                "variant": "info",
+                "category": "context",
+                "content": {
+                    "en": "Minimum amount to stake has changed to 1 SOL.",
+                    "es": "La cantidad mínima para hacer staking ha cambiado a 1 SOL.",
+                    "cs": "Minimální částka pro staking je nyní 1 SOL.",
+                    "ru": "Минимальная сумма для стейкинга изменилась на 1 SOL.",
+                    "ja": "ステーキングの最小額が1 SOLに変更されました",
+                    "hu": "A stakeléshez szükséges minimális összeg 1 SOL-ra változott.",
+                    "it": "L'importo minimo per lo staking è passato a 1 SOL.",
+                    "fr": "Le montant minimum pour le staking est passé à 1 SOL.",
+                    "de": "Der Mindestbetrag für das Staking hat sich auf 1 SOL geändert.",
+                    "tr": "Stake etmek için minimum miktar 1 SOL olarak değişti.",
+                    "pt": "O valor mínimo para staking mudou para 1 SOL.",
+                    "uk": "Мінімальна сума для стейкінгу змінилася на 1 SOL."
+                },
+                "context": {
+                    "domain": "accounts.sol.staking"
+                }
+            },
+            "conditions": [
+                {
+                    "environment": {
+                        "desktop": "*",
+                        "mobile": "!",
+                        "web": "*"
+                    }
+                }
+            ]
         },
         {
             "conditions": [

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2026-06-23T00:00:00+00:00",
-    "sequence": 146,
+    "timestamp": "2026-06-23T12:00:00+00:00",
+    "sequence": 147,
     "actions": [
         {
             "conditions": [
@@ -1180,7 +1180,7 @@
             "conditions": [
                 {
                     "environment": {
-                        "desktop": "*",
+                        "desktop": "<26.7.1",
                         "mobile": "!",
                         "web": "*"
                     }

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2026-06-02T00:00:00+00:00",
-    "sequence": 142,
+    "timestamp": "2026-06-17T00:00:00+00:00",
+    "sequence": 143,
     "actions": [
         {
             "conditions": [
@@ -376,18 +376,18 @@
                 "variant": "info",
                 "category": ["banner"],
                 "content": {
-                    "en": "Keep your Trezor secure and smooth — update firmware now for the latest features and enhancements.",
-                    "es": "Mantén tu Trezor seguro y funcionando sin problemas — actualiza el firmware ahora para obtener las últimas funciones y mejoras.",
-                    "cs": "Udržujte svůj Trezor bezpečný a plynulý — aktualizujte firmware nyní a získejte nejnovější funkce a vylepšení.",
-                    "ru": "Поддерживайте безопасность и стабильную работу вашего Trezor — обновите прошивку сейчас, чтобы получить новые функции и улучшения.",
-                    "ja": "Trezor を安全かつ快適に保ちましょう — 最新の機能と改善を利用するために、今すぐファームウェアを更新してください。",
-                    "hu": "Tartsa Trezorját biztonságosan és gördülékenyen — frissítse most a firmware-t a legújabb funkciókért és fejlesztésekért.",
-                    "it": "Mantieni il tuo Trezor sicuro e fluido — aggiorna ora il firmware per le ultime funzionalità e miglioramenti.",
-                    "fr": "Gardez votre Trezor sécurisé et fluide — mettez à jour le firmware maintenant pour profiter des dernières fonctionnalités et améliorations.",
-                    "de": "Halten Sie Ihr Trezor sicher und reibungslos — aktualisieren Sie jetzt die Firmware, um die neuesten Funktionen und Verbesserungen zu erhalten.",
-                    "tr": "Trezor'unuzu güvenli ve sorunsuz tutun — en son özellikler ve iyileştirmeler için firmware'i şimdi güncelleyin.",
-                    "pt": "Mantenha seu Trezor seguro e fluido — atualize o firmware agora para obter os recursos e melhorias mais recentes.",
-                    "uk": "Зберігайте свій Trezor безпечним і плавним — оновіть прошивку зараз, щоб отримати найновіші функції та вдосконалення."
+                    "en": "Update your Trezor firmware to get the latest security improvements and features.",
+                    "es": "Actualice el firmware de su Trezor para obtener las últimas mejoras de seguridad y funciones.",
+                    "cs": "Aktualizujte firmware svého zařízení Trezor pro nejnovější bezpečnostní vylepšení a funkce.",
+                    "ru": "Обновите прошивку вашего Trezor, чтобы получить последние улучшения безопасности и новые функции.",
+                    "ja": "Trezorのファームウェアをアップデートして、最新のセキュリティ改善と機能をご利用ください。",
+                    "hu": "Frissítse Trezor firmware-jét, hogy megkapja a legújabb biztonsági fejlesztéseket és funkciókat.",
+                    "it": "Aggiorna il firmware del tuo Trezor per ottenere gli ultimi miglioramenti di sicurezza e nuove funzionalità.",
+                    "fr": "Mettez à jour le firmware de votre Trezor pour bénéficier des dernières améliorations de sécurité et fonctionnalités.",
+                    "de": "Aktualisieren Sie Ihre Trezor-Firmware, um die neuesten Sicherheitsverbesserungen und Funktionen zu erhalten.",
+                    "tr": "En son güvenlik iyileştirmelerini ve özellikleri almak için Trezor donanım yazılımınızı güncelleyin.",
+                    "pt": "Atualize o firmware do seu Trezor para obter as mais recentes melhorias de segurança e recursos.",
+                    "uk": "Оновіть прошивку вашого Trezor, щоб отримати останні покращення безпеки та нові функції."
                 },
                 "cta": {
                     "action": "internal-link",

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2026-06-19T00:00:00+00:00",
-    "sequence": 145,
+    "timestamp": "2026-06-23T00:00:00+00:00",
+    "sequence": 146,
     "actions": [
         {
             "conditions": [
@@ -1539,46 +1539,6 @@
                     {
                         "domain": "security.entropyCheck",
                         "flag": false
-                    }
-                ]
-            }
-        },
-        {
-            "conditions": [
-                {
-                    "environment": {
-                        "desktop": ">=25.8.1",
-                        "mobile": "!",
-                        "web": "*"
-                    }
-                }
-            ],
-            "message": {
-                "id": "ab804171-6266-4618-be4f-a7c25d4c19ce",
-                "priority": 1,
-                "dismissible": true,
-                "variant": "info",
-                "category": "feature",
-                "content": {
-                    "en-GB": "Placehodler",
-                    "en": "Placehodler",
-                    "es": "Placehodler",
-                    "cs": "Placehodler",
-                    "de": "Placehodler",
-                    "fr": "Placehodler",
-                    "it": "Placehodler",
-                    "pt": "Placehodler",
-                    "tr": "Placehodler",
-                    "ru": "Placehodler",
-                    "ja": "Placehodler",
-                    "uk": "Placehodler",
-                    "hu": "Placehodler"
-                },
-                "feature": [
-                    {
-                        "domain": "dashboard.promoBanner",
-                        "visibleBanner": "tex",
-                        "flag": true
                     }
                 ]
             }


### PR DESCRIPTION
## Description

1. Updating text of message asking users to update FW.
2. Adding a message informing users about change in the min amount for SOL staking. <img width="1455" height="219" alt="Screenshot 2026-06-18 at 20 27 41" src="https://github.com/user-attachments/assets/c608b81f-f6dc-465f-b3b2-e855c61667ab" />
3. Updating text of the message informing users about change in the min amount for SOL staking.
4. Removing the TEX banner.
5. Display SOL min staking amount in versions of Suite before 26.7.1

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/message-system-update-2026-06-23/web/](https://dev.suite.sldev.cz/suite-web/chore/message-system-update-2026-06-23/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/message-system-update-2026-06-23&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/message-system-update-2026-06-23&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/message-system-update-2026-06-23&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-23T14:15:57.869Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-23T14:15:00.506Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `suite-common/message-system/config/config.v1.json`, which is a JSON configuration file for the message system (remote messaging, banners, notifications). No static test coverage mapping exists for this file, and none of the 112 candidate E2E tests appear to directly exercise message system configuration loading or rendering of remote messages. The `connectPopupWebextension.test.ts` test references `mockRemoteMessageSystem` but only as a setup utility to suppress remote messages, not to verify message system config behavior. This change is low-risk from an E2E perspective — it likely affects which banners or in-app messages are shown to users, but no existing E2E test validates that specific behavior. Manual or visual verification may be more appropriate.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/message-system/config/config.v1.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-common/message-system/config/config.v1.json`

_Updated: 2026-06-23T14:11:39.436Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->