### PR TITLE
fix(suite): navigate back to correct route from Tron staking flows

### DIFF
--- a/packages/suite/src/components/earn/staking/tron/TronStakePageHeader.tsx
+++ b/packages/suite/src/components/earn/staking/tron/TronStakePageHeader.tsx
@@ -1,13 +1,13 @@
 import { AccountLabel } from '@suite/account';
 import { Translation, useTranslation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { goto } from '@suite/router';
+import { goto, selectSettingsBackRoute } from '@suite/router';
 import { type Account } from '@suite-common/wallet-types';
 import { Box, Button, Column, IconButton, Row, Text } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
 
 import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
-import { useDispatch } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 
 type TronStakePageHeaderProps = {
@@ -18,9 +18,10 @@ export const TronStakePageHeader = ({ account }: TronStakePageHeaderProps) => {
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
     const { isBelowMobile } = useLayoutSize();
+    const previousRoute = useSelector(selectSettingsBackRoute);
 
     const onBackClick = () => {
-        dispatch(goto({ routeName: 'suite-earn' }));
+        dispatch(goto({ routeName: previousRoute.name, params: previousRoute.params }));
     };
 
     const onHowItWorksClick = () => {


### PR DESCRIPTION
## Description

Navigate to previous route on back arrow click in Tron staking flows.

## Related Issue

Resolve #28915 

## Screenshots:

https://github.com/user-attachments/assets/345c5866-e8b9-466f-93ab-0da0d2876ac2

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is `TronStakePageHeader.tsx`, a Tron-specific staking page header component under the earn/staking path. No static test coverage mapping exists for this file. Reviewing the 101 candidate E2E tests, none of them cover Tron staking functionality — the staking tests focus on ETH, ADA, and SOL staking flows. While the general check-links test references `/earn/tron/stake` and other Tron earn routes, it only validates that links on those pages return HTTP 200 and does not exercise the TronStakePageHeader component in any meaningful way. There are no E2E tests available that would directly or indirectly validate changes to this Tron staking header component.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/earn/staking/tron/TronStakePageHeader.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/earn/staking/tron/TronStakePageHeader.tsx`

_Updated: 2026-06-23T11:34:04.485Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tron-staking-navigate-back&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tron-staking-navigate-back&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-23T11:38:07.475Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-23T11:35:43.619Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tron-staking-navigate-back/web/](https://dev.suite.sldev.cz/suite-web/fix/tron-staking-navigate-back/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->