### PR TITLE
chore(suite): move Tron staking out of debug mode

### DIFF
--- a/packages/suite/src/components/wallet/Fees/TronFreezeFeeBanner.tsx
+++ b/packages/suite/src/components/wallet/Fees/TronFreezeFeeBanner.tsx
@@ -1,5 +1,4 @@
 import { selectSelectedAccount } from '@suite/account';
-import { selectIsDebugModeActive } from '@suite/debug';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { type PrecomposedLevels, type PrecomposedLevelsCardano } from '@suite-common/wallet-types';
@@ -21,11 +20,10 @@ export const TronFreezeFeeBanner = ({
 }: TronFreezeFeeBannerProps) => {
     const dispatch = useDispatch();
     const account = useSelector(selectSelectedAccount);
-    const isDebugModeActive = useSelector(selectIsDebugModeActive);
 
     const freezeAmount = calculateTronFreezeSuggestion(composedLevels?.normal, tronResources);
 
-    if (!account || !isDebugModeActive || !freezeAmount) {
+    if (!account || !freezeAmount) {
         return null;
     }
 

--- a/packages/suite/src/views/earn/tron/EarnTronStake.tsx
+++ b/packages/suite/src/views/earn/tron/EarnTronStake.tsx
@@ -1,29 +1,12 @@
-import { useEffect } from 'react';
-
-import { selectIsDebugModeActive } from '@suite/debug';
-import { goto } from '@suite/router';
-
 import { TronStake, TronStakePageHeader } from 'src/components/earn';
 import { useEarnRouteAccount } from 'src/components/earn/utils/useEarnRouteAccount';
 import { AccountNotExists } from 'src/components/wallet/WalletLayout/AccountException/AccountNotExists';
-import { useDispatch, useLayout, useSelector } from 'src/hooks/suite';
+import { useLayout } from 'src/hooks/suite';
 
 export const EarnTronStake = () => {
-    const dispatch = useDispatch();
-    const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const { account } = useEarnRouteAccount();
 
     useLayout('Earn', <TronStakePageHeader account={account} />);
-
-    useEffect(() => {
-        if (!isDebugModeActive) {
-            dispatch(goto({ routeName: 'suite-earn' }));
-        }
-    }, [isDebugModeActive, dispatch]);
-
-    if (!isDebugModeActive) {
-        return null;
-    }
 
     if (!account) {
         return <AccountNotExists />;

--- a/packages/suite/src/views/earn/tron/EarnTronUnstake.tsx
+++ b/packages/suite/src/views/earn/tron/EarnTronUnstake.tsx
@@ -1,29 +1,12 @@
-import { useEffect } from 'react';
-
-import { selectIsDebugModeActive } from '@suite/debug';
-import { goto } from '@suite/router';
-
 import { TronStakePageHeader, TronUnstake } from 'src/components/earn';
 import { useEarnRouteAccount } from 'src/components/earn/utils/useEarnRouteAccount';
 import { AccountNotExists } from 'src/components/wallet/WalletLayout/AccountException/AccountNotExists';
-import { useDispatch, useLayout, useSelector } from 'src/hooks/suite';
+import { useLayout } from 'src/hooks/suite';
 
 export const EarnTronUnstake = () => {
-    const dispatch = useDispatch();
-    const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const { account } = useEarnRouteAccount();
 
     useLayout('Earn', <TronStakePageHeader account={account} />);
-
-    useEffect(() => {
-        if (!isDebugModeActive) {
-            dispatch(goto({ routeName: 'suite-earn' }));
-        }
-    }, [isDebugModeActive, dispatch]);
-
-    if (!isDebugModeActive) {
-        return null;
-    }
 
     if (!account) {
         return <AccountNotExists />;

--- a/packages/suite/src/views/earn/tron/EarnTronVote.tsx
+++ b/packages/suite/src/views/earn/tron/EarnTronVote.tsx
@@ -1,29 +1,12 @@
-import { useEffect } from 'react';
-
-import { selectIsDebugModeActive } from '@suite/debug';
-import { goto } from '@suite/router';
-
 import { TronStakePageHeader, TronVote } from 'src/components/earn';
 import { useEarnRouteAccount } from 'src/components/earn/utils/useEarnRouteAccount';
 import { AccountNotExists } from 'src/components/wallet/WalletLayout/AccountException/AccountNotExists';
-import { useDispatch, useLayout, useSelector } from 'src/hooks/suite';
+import { useLayout } from 'src/hooks/suite';
 
 export const EarnTronVote = () => {
-    const dispatch = useDispatch();
-    const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const { account } = useEarnRouteAccount();
 
     useLayout('Earn', <TronStakePageHeader account={account} />);
-
-    useEffect(() => {
-        if (!isDebugModeActive) {
-            dispatch(goto({ routeName: 'suite-earn' }));
-        }
-    }, [isDebugModeActive, dispatch]);
-
-    if (!isDebugModeActive) {
-        return null;
-    }
 
     if (!account) {
         return <AccountNotExists />;

--- a/packages/suite/src/views/earn/tron/EarnTronWithdraw.tsx
+++ b/packages/suite/src/views/earn/tron/EarnTronWithdraw.tsx
@@ -1,29 +1,12 @@
-import { useEffect } from 'react';
-
-import { selectIsDebugModeActive } from '@suite/debug';
-import { goto } from '@suite/router';
-
 import { TronStakePageHeader, TronWithdraw } from 'src/components/earn';
 import { useEarnRouteAccount } from 'src/components/earn/utils/useEarnRouteAccount';
 import { AccountNotExists } from 'src/components/wallet/WalletLayout/AccountException/AccountNotExists';
-import { useDispatch, useLayout, useSelector } from 'src/hooks/suite';
+import { useLayout } from 'src/hooks/suite';
 
 export const EarnTronWithdraw = () => {
-    const dispatch = useDispatch();
-    const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const { account } = useEarnRouteAccount();
 
     useLayout('Earn', <TronStakePageHeader account={account} />);
-
-    useEffect(() => {
-        if (!isDebugModeActive) {
-            dispatch(goto({ routeName: 'suite-earn' }));
-        }
-    }, [isDebugModeActive, dispatch]);
-
-    if (!isDebugModeActive) {
-        return null;
-    }
 
     if (!account) {
         return <AccountNotExists />;


### PR DESCRIPTION
## Description

Move Tron staking out of debug mode.

## Related Issue

Resolve #28899 

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on Tron staking/earn views (Stake, Unstake, Vote, Withdraw) and a TronFreezeFeeBanner component. None of the 131 candidate E2E tests directly cover Tron staking flows — the test suite appears to lack dedicated Tron staking E2E tests. The only tangentially relevant test is the link checker which crawls all routes including the /earn/tron/* paths. The risk is moderate for Tron-specific functionality but low for the rest of the application since these are isolated view components.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/components/wallet/Fees/TronFreezeFeeBanner.tsx`
- `packages/suite/src/views/earn/tron/EarnTronStake.tsx`
- `packages/suite/src/views/earn/tron/EarnTronUnstake.tsx`
- `packages/suite/src/views/earn/tron/EarnTronVote.tsx`
- `packages/suite/src/views/earn/tron/EarnTronWithdraw.tsx`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test crawls all application routes including /earn/tron/stake, /earn/tron/vote, /earn/tron/unstake, and /earn/tron/withdraw, which are the exact views modified. It validates that these pages load correctly and all links return HTTP 200. Changes to these Tron earn views could break page rendering or introduce broken links.

</details>

⚠️ **Changes with no test coverage (5)**
- `packages/suite/src/components/wallet/Fees/TronFreezeFeeBanner.tsx`
- `packages/suite/src/views/earn/tron/EarnTronStake.tsx`
- `packages/suite/src/views/earn/tron/EarnTronUnstake.tsx`
- `packages/suite/src/views/earn/tron/EarnTronVote.tsx`
- `packages/suite/src/views/earn/tron/EarnTronWithdraw.tsx`

_Updated: 2026-06-23T11:46:44.128Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/tron-staking-out-of-debug-mode/web/](https://dev.suite.sldev.cz/suite-web/chore/tron-staking-out-of-debug-mode/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/tron-staking-out-of-debug-mode&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/tron-staking-out-of-debug-mode&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-23T11:50:02.126Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-23T11:49:33.277Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->