### PR TITLE
perf(suite-native): stabilize graph point values

### DIFF
--- a/suite-native/graph/src/components/GraphBaseCurrencyBalance.tsx
+++ b/suite-native/graph/src/components/GraphBaseCurrencyBalance.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { type Atom, useAtomValue } from 'jotai';
@@ -14,12 +15,9 @@ import { BigNumber } from '@trezor/utils';
 import { GraphDateFormatter } from './GraphDateFormatter';
 import { PriceChangeIndicator } from './PriceChangeIndicator';
 
-type BalanceProps = {
-    selectedPointAtom: Atom<FiatGraphPoint | null>;
-    latestValue?: BaseCurrencyAmount;
-};
-
-type GraphFiatBalanceProps = BalanceProps & {
+type GraphFiatBalanceProps = {
+    selectedPointFiatValueAtom: Atom<string>;
+    selectedPointTimestampAtom: Atom<number | null>;
     referencePointAtom: Atom<FiatGraphPoint | null>;
     percentageChangeAtom: Atom<number>;
     showChange?: boolean;
@@ -40,26 +38,44 @@ const Skeleton = () => (
     </VStack>
 );
 
-const Balance = ({ selectedPointAtom, latestValue }: BalanceProps) => {
-    const point = useAtomValue(selectedPointAtom);
+const FormattedBalance = ({ value }: { value: BaseCurrencyAmount }) => (
+    <DiscreetTextTrigger testID="@home/portfolio/fiat-balance-header/discreet-trigger">
+        <BaseCurrencyAmountLargeFormatter
+            value={value}
+            testID="@home/portfolio/fiat-balance-header"
+        />
+    </DiscreetTextTrigger>
+);
 
-    const baseCurrencyValue =
-        latestValue ??
-        point?.valueLatestTotal ??
-        asBaseCurrencyAmount(new BigNumber(point?.value ? String(point.value) : '0'));
-
-    return (
-        <DiscreetTextTrigger testID="@home/portfolio/fiat-balance-header/discreet-trigger">
-            <BaseCurrencyAmountLargeFormatter
-                value={baseCurrencyValue}
-                testID="@home/portfolio/fiat-balance-header"
-            />
-        </DiscreetTextTrigger>
+const SelectedPointFiatBalance = ({
+    selectedPointFiatValueAtom,
+}: Pick<GraphFiatBalanceProps, 'selectedPointFiatValueAtom'>) => {
+    const selectedPointFiatValue = useAtomValue(selectedPointFiatValueAtom);
+    const selectedPointFiatBalance = useMemo(
+        () => asBaseCurrencyAmount(new BigNumber(selectedPointFiatValue)),
+        [selectedPointFiatValue],
     );
+
+    return <FormattedBalance value={selectedPointFiatBalance} />;
+};
+
+const Balance = ({
+    selectedPointFiatValueAtom,
+    latestValue,
+}: {
+    selectedPointFiatValueAtom: Atom<string>;
+    latestValue?: BaseCurrencyAmount;
+}) => {
+    if (latestValue !== undefined) {
+        return <FormattedBalance value={latestValue} />;
+    }
+
+    return <SelectedPointFiatBalance selectedPointFiatValueAtom={selectedPointFiatValueAtom} />;
 };
 
 export const GraphBaseCurrencyBalance = ({
-    selectedPointAtom,
+    selectedPointFiatValueAtom,
+    selectedPointTimestampAtom,
     referencePointAtom,
     percentageChangeAtom,
     showChange = true,
@@ -82,7 +98,7 @@ export const GraphBaseCurrencyBalance = ({
         return (
             <Box style={applyStyle(wrapperStyle)}>
                 <Balance
-                    selectedPointAtom={selectedPointAtom}
+                    selectedPointFiatValueAtom={selectedPointFiatValueAtom}
                     latestValue={totalBaseCurrencyBalance}
                 />
                 {showChange && (
@@ -103,12 +119,12 @@ export const GraphBaseCurrencyBalance = ({
 
     return (
         <Box style={applyStyle(wrapperStyle)}>
-            <Balance selectedPointAtom={selectedPointAtom} />
+            <Balance selectedPointFiatValueAtom={selectedPointFiatValueAtom} />
             {showChange && (
                 <HStack alignItems="center">
                     <GraphDateFormatter
                         firstPointDate={firstGraphPoint.date}
-                        selectedPointAtom={selectedPointAtom}
+                        selectedPointTimestampAtom={selectedPointTimestampAtom}
                     />
                     <PriceChangeIndicator percentageChangeAtom={percentageChangeAtom} />
                 </HStack>

--- a/suite-native/graph/src/components/GraphBaseCurrencyBalance.tsx
+++ b/suite-native/graph/src/components/GraphBaseCurrencyBalance.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { type Atom, useAtomValue } from 'jotai';
@@ -51,10 +50,7 @@ const SelectedPointFiatBalance = ({
     selectedPointFiatValueAtom,
 }: Pick<GraphFiatBalanceProps, 'selectedPointFiatValueAtom'>) => {
     const selectedPointFiatValue = useAtomValue(selectedPointFiatValueAtom);
-    const selectedPointFiatBalance = useMemo(
-        () => asBaseCurrencyAmount(new BigNumber(selectedPointFiatValue)),
-        [selectedPointFiatValue],
-    );
+    const selectedPointFiatBalance = asBaseCurrencyAmount(new BigNumber(selectedPointFiatValue));
 
     return <FormattedBalance value={selectedPointFiatBalance} />;
 };

--- a/suite-native/graph/src/components/GraphDateFormatter.tsx
+++ b/suite-native/graph/src/components/GraphDateFormatter.tsx
@@ -1,41 +1,48 @@
 import { type Atom, useAtomValue } from 'jotai';
 
 import { useFormatters } from '@suite-common/formatters';
-import { type FiatGraphPoint } from '@suite-common/graph';
 import { Text } from '@suite-native/atoms';
 
-type SelectedPointAtom = Atom<FiatGraphPoint | null>;
+type SelectedPointTimestampAtom = Atom<number | null>;
 
 type GraphDateFormatterProps = {
     firstPointDate: Date;
-    selectedPointAtom: SelectedPointAtom;
+    selectedPointTimestampAtom: SelectedPointTimestampAtom;
 };
 
-const WeekFormatter = ({ selectedPointAtom }: { selectedPointAtom: SelectedPointAtom }) => {
+const WeekFormatter = ({
+    selectedPointTimestampAtom,
+}: {
+    selectedPointTimestampAtom: SelectedPointTimestampAtom;
+}) => {
     const { DateTimeFormatter } = useFormatters();
-    const selectedPoint = useAtomValue(selectedPointAtom);
+    const selectedPointTimestamp = useAtomValue(selectedPointTimestampAtom);
 
     // Empty space to prevent layout shift
-    if (!selectedPoint) return <Text> </Text>;
+    if (selectedPointTimestamp === null) return <Text> </Text>;
 
-    return <DateTimeFormatter value={selectedPoint.date} />;
+    return <DateTimeFormatter value={new Date(selectedPointTimestamp)} />;
 };
 
-const OtherDateFormatter = ({ selectedPointAtom }: { selectedPointAtom: SelectedPointAtom }) => {
+const OtherDateFormatter = ({
+    selectedPointTimestampAtom,
+}: {
+    selectedPointTimestampAtom: SelectedPointTimestampAtom;
+}) => {
     const { DateFormatter } = useFormatters();
 
-    const selectedPoint = useAtomValue(selectedPointAtom);
+    const selectedPointTimestamp = useAtomValue(selectedPointTimestampAtom);
 
-    if (!selectedPoint) return null;
+    if (selectedPointTimestamp === null) return null;
 
-    return <DateFormatter value={selectedPoint.date} />;
+    return <DateFormatter value={new Date(selectedPointTimestamp)} />;
 };
 
 const millisecondsPerTwoWeek = 1209600000;
 
 export const GraphDateFormatter = ({
     firstPointDate,
-    selectedPointAtom,
+    selectedPointTimestampAtom,
 }: GraphDateFormatterProps) => {
     const millisecondElapsedFromFistPoint = new Date().getTime() - firstPointDate.getTime();
     // this check is significantly faster than using date-fns/differenceInWeeks(days)
@@ -45,7 +52,7 @@ export const GraphDateFormatter = ({
 
     return (
         <Text variant="body-sm" color="contentSecondary">
-            <Formatter selectedPointAtom={selectedPointAtom} />
+            <Formatter selectedPointTimestampAtom={selectedPointTimestampAtom} />
         </Text>
     );
 };

--- a/suite-native/graph/src/graphPointAtoms.ts
+++ b/suite-native/graph/src/graphPointAtoms.ts
@@ -1,0 +1,14 @@
+import { type Atom, atom } from 'jotai';
+
+import { type FiatGraphPoint } from '@suite-common/graph';
+
+export const createGraphPointDerivedAtoms = <TGraphPoint extends FiatGraphPoint>(
+    selectedPointAtom: Atom<TGraphPoint | null>,
+) => ({
+    selectedPointFiatValueAtom: atom(get => {
+        const selectedPoint = get(selectedPointAtom);
+
+        return selectedPoint?.valueLatestTotal?.toFixed() ?? String(selectedPoint?.value ?? 0);
+    }),
+    selectedPointTimestampAtom: atom(get => get(selectedPointAtom)?.date.getTime() ?? null),
+});

--- a/suite-native/graph/src/index.ts
+++ b/suite-native/graph/src/index.ts
@@ -2,6 +2,7 @@ export * from './components/Graph';
 export * from './components/TimeSwitch';
 export * from './utils';
 export * from './hooks';
+export * from './graphPointAtoms';
 export * from './slice';
 export * from './selectors';
 export * from './components/GraphBaseCurrencyBalance';

--- a/suite-native/module-accounts-management/src/accountDetailGraphAtoms.ts
+++ b/suite-native/module-accounts-management/src/accountDetailGraphAtoms.ts
@@ -1,9 +1,12 @@
 import { atom } from 'jotai';
 
 import { type FiatGraphPointWithCryptoBalance } from '@suite-common/graph';
-import { percentageDiff } from '@suite-native/graph';
+import { createGraphPointDerivedAtoms, percentageDiff } from '@suite-native/graph';
 
 export const selectedPointAtom = atom<FiatGraphPointWithCryptoBalance | null>(null);
+
+export const { selectedPointFiatValueAtom, selectedPointTimestampAtom } =
+    createGraphPointDerivedAtoms(selectedPointAtom);
 
 // reference is usually first point, same as Revolut does in their app
 export const referencePointAtom = atom<FiatGraphPointWithCryptoBalance | null>(null);

--- a/suite-native/module-accounts-management/src/components/AccountDetailHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailHeader.tsx
@@ -34,6 +34,8 @@ import {
     percentageChangeAtom,
     referencePointAtom,
     selectedPointAtom,
+    selectedPointFiatValueAtom,
+    selectedPointTimestampAtom,
 } from '../accountDetailGraphAtoms';
 
 type AccountBalanceProps = {
@@ -104,7 +106,8 @@ export const AccountDetailHeader = ({
             )}
 
             <GraphBaseCurrencyBalance
-                selectedPointAtom={selectedPointAtom}
+                selectedPointFiatValueAtom={selectedPointFiatValueAtom}
+                selectedPointTimestampAtom={selectedPointTimestampAtom}
                 referencePointAtom={referencePointAtom}
                 percentageChangeAtom={percentageChangeAtom}
                 showChange={isHistoryEnabledAccount}

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioHeader.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioHeader.tsx
@@ -10,7 +10,8 @@ import {
 import {
     percentageChangeAtom,
     referencePointAtom,
-    selectedPointAtom,
+    selectedPointFiatValueAtom,
+    selectedPointTimestampAtom,
 } from '../portfolioGraphAtoms';
 
 type PortfolioHeaderProps = {
@@ -25,7 +26,8 @@ export const PortfolioHeader = ({ isLoading, totalFiatBalance }: PortfolioHeader
         <Box testID="@home/portfolio/header">
             <VStack spacing="sp4" alignItems="center">
                 <GraphBaseCurrencyBalance
-                    selectedPointAtom={selectedPointAtom}
+                    selectedPointFiatValueAtom={selectedPointFiatValueAtom}
+                    selectedPointTimestampAtom={selectedPointTimestampAtom}
                     referencePointAtom={referencePointAtom}
                     percentageChangeAtom={percentageChangeAtom}
                     showChange={hasDeviceHistoryEnabledAccounts}

--- a/suite-native/module-home/src/screens/HomeScreen/portfolioGraphAtoms.ts
+++ b/suite-native/module-home/src/screens/HomeScreen/portfolioGraphAtoms.ts
@@ -1,11 +1,14 @@
 import { atom } from 'jotai';
 
 import { type FiatGraphPoint } from '@suite-common/graph';
-import { percentageDiff } from '@suite-native/graph';
+import { createGraphPointDerivedAtoms, percentageDiff } from '@suite-native/graph';
 
 // use atomic jotai structure for absolute minimum re-renders and maximum performance
 // otherwise graph will be freezing on slower device while point swipe gesture
 export const selectedPointAtom = atom<FiatGraphPoint | null>(null);
+
+export const { selectedPointFiatValueAtom, selectedPointTimestampAtom } =
+    createGraphPointDerivedAtoms(selectedPointAtom);
 
 // reference is usually first point, same as Revolut does in their app
 export const referencePointAtom = atom<FiatGraphPoint | null>(null);


### PR DESCRIPTION
## Description

Prevent the displayed graph balance from rerendering when swiping between graph points with the same fiat value. Graph point state now exposes derived primitive atoms for fiat value and timestamp, allowing balance and date consumers to update independently.

## Notes for QA

On the portfolio and account-detail graphs, swipe across consecutive points with the same displayed fiat value, especially $0.00 (all seed with bitcoin only for example). The amount should remain stable while the date continues to update. Verify the amount updates normally when moving to a point with a different value.

Also test it wasn't broken with non zero values. 

## Related Issue
Resolve https://github.com/trezor/trezor-suite/issues/28398

## Screenshots:
https://github.com/user-attachments/assets/0fa5b2c2-54b6-4f3f-a390-df03136898cb



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native-graph-point-value-rerenders&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->