### PR TITLE
feat(suite): change staking KB links to Guide links

### DIFF
--- a/packages/suite/src/components/earn/utils/getStakingGuideLink.ts
+++ b/packages/suite/src/components/earn/utils/getStakingGuideLink.ts
@@ -1,0 +1,14 @@
+import { type NetworkType } from '@suite-common/wallet-config';
+
+export const getStakingGuideLink = (networkType?: NetworkType) => {
+    switch (networkType) {
+        case 'ethereum':
+            return '/earn/staking/ethereum-eth-staking.md';
+        case 'solana':
+            return '/earn/staking/solana-sol-staking.md';
+        case 'cardano':
+            return '/earn/staking/cardano-ada-staking.md';
+        default:
+            return undefined;
+    }
+};

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EverstakeFooter.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EverstakeFooter.tsx
@@ -3,10 +3,13 @@ import { useMemo } from 'react';
 import styled from 'styled-components';
 
 import { selectSelectedAccount } from '@suite/account';
-import { LearnMoreButton } from '@suite/external-links';
+import { Translation } from '@suite/intl';
+import { Button } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 
-import { PoweredByBadge, getStakingHelpCenterLink } from 'src/components/earn';
+import { PoweredByBadge } from 'src/components/earn';
+import { getStakingGuideLink } from 'src/components/earn/utils/getStakingGuideLink';
+import { useGuideOpenNode } from 'src/hooks/guide';
 import { useSelector } from 'src/hooks/suite';
 
 const Wrapper = styled.div`
@@ -21,16 +24,27 @@ const Wrapper = styled.div`
 
 export const EverstakeFooter = () => {
     const account = useSelector(selectSelectedAccount);
+    const { openNodeById } = useGuideOpenNode();
 
-    const learnMoreLink = useMemo(
-        () => getStakingHelpCenterLink(account?.networkType),
+    const moreInfoLink = useMemo(
+        () => getStakingGuideLink(account?.networkType),
         [account?.networkType],
     );
 
     return (
         <Wrapper>
             <PoweredByBadge provider="everstake" />
-            {learnMoreLink && <LearnMoreButton url={learnMoreLink} />}
+
+            {moreInfoLink && (
+                <Button
+                    onClick={() => openNodeById(moreInfoLink)}
+                    intent="neutral"
+                    priority="secondary"
+                    size="small"
+                >
+                    <Translation id="TR_LEARN_MORE" />
+                </Button>
+            )}
         </Wrapper>
     );
 };


### PR DESCRIPTION
## Description

Change staking links from KB articles to Guide.

## Related Issue

Resolve #28991 

## Screenshots:

<img width="100%" alt="Screenshot 2026-06-23 at 14 30 57" src="https://github.com/user-attachments/assets/ade0d4d8-854a-4d6c-af7d-f5356e1ea3be" />

<img width="100%" alt="Screenshot 2026-06-23 at 14 31 04" src="https://github.com/user-attachments/assets/ffff384e-b8b2-4bd2-a9ed-95c2737c2f51" />

<img width="100%" alt="Screenshot 2026-06-23 at 14 31 11" src="https://github.com/user-attachments/assets/4dc8da69-8d06-48ba-bf97-81f679075aa8" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect EverstakeFooter (a component within the StakingDashboard) and getStakingGuideLink (a utility that likely generates network-specific staking guide URLs used by the footer). These are relatively contained UI changes within the staking feature. The highest risk is a rendering regression in the staking dashboard or broken guide links per network. Testing should focus on verifying the staking dashboard renders correctly across ETH (primary), SOL, and ADA networks, with ETH initial-stake and stake-more being the most critical since they thoroughly exercise the dashboard view states.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/earn/utils/getStakingGuideLink.ts`
- `packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EverstakeFooter.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the full ETH staking dashboard flow including the StakingDashboard component where EverstakeFooter is rendered. Changes to EverstakeFooter (which likely contains a staking guide link from getStakingGuideLink) could affect the staking dashboard UI visible during this test's assertions on dashboard card visibility and staking flow.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test validates the ETH staking dashboard with existing staked amounts, where EverstakeFooter is rendered as part of the StakingDashboard. It verifies staking dashboard card visibility and staking amounts, which could be affected by layout/rendering changes in EverstakeFooter.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — Tests the ETH unstaking and claiming flow on the staking dashboard where EverstakeFooter is a child component. While the test focuses on unstake/claim actions, the footer is part of the rendered dashboard view.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Tests SOL initial staking including the staking dashboard empty and active states. EverstakeFooter renders on the staking dashboard and getStakingGuideLink may produce different links per network, so SOL-specific behavior should be verified.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Tests ADA staking flow which renders the staking dashboard including EverstakeFooter. getStakingGuideLink may have ADA-specific logic, making this a reasonable cross-network verification point.
- `suite/e2e/tests/staking/staking-form.test.ts` — Tests the ETH staking form accessed via the staking dashboard. While focused on form validation, it navigates through the staking tab where EverstakeFooter is rendered, and a broken footer could affect page layout.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/earn/utils/getStakingGuideLink.ts`

_Updated: 2026-06-26T08:32:27.511Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/staking-guide-links/web/](https://dev.suite.sldev.cz/suite-web/feat/staking-guide-links/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/staking-guide-links&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/staking-guide-links&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-26T07:44:19.748Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |

</details>

_Updated: 2026-06-26T08:35:06.390Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->