### PR TITLE
fix(sentry): disable profiling, tracing, timing in production

### DIFF
--- a/suite/sentry/src/config.ts
+++ b/suite/sentry/src/config.ts
@@ -79,6 +79,8 @@ const beforeBreadcrumb: Options['beforeBreadcrumb'] = breadcrumb => {
     return breadcrumb;
 };
 
+const isProd = isCodesignBuild();
+
 export const SENTRY_CONFIG = {
     dsn: 'https://6d91ca6e6a5d4de7b47989455858b5f6@o117836.ingest.sentry.io/5193825',
 
@@ -86,7 +88,7 @@ export const SENTRY_CONFIG = {
     enabled: !isDevEnv, // set to true to enable Sentry logging while testing locally
     maxValueLength: 500, // default 250 is not enough for some errors
     release: process.env.SENTRY_RELEASE,
-    environment: isCodesignBuild() ? 'production' : 'develop',
+    environment: isProd ? 'production' : 'develop',
     normalizeDepth: 4,
     maxBreadcrumbs: 40,
     beforeBreadcrumb,
@@ -100,13 +102,13 @@ export const SENTRY_CONFIG = {
 
 export const SENTRY_BROWSER_CONFIG = {
     ...SENTRY_CONFIG,
-    profileSessionSampleRate: isCodesignBuild() ? 0.1 : 1,
-    tracesSampleRate: isCodesignBuild() ? 0.1 : 1,
+    profileSessionSampleRate: isProd ? 0.1 : 1,
+    tracesSampleRate: isProd ? 0.1 : 1,
     profileLifecycle: 'trace',
     integrations: [
         captureConsoleIntegration({ levels: ['error'] }),
-        browserProfilingIntegration(),
-        browserTracingIntegration(),
-        elementTimingIntegration(),
-    ],
+        !isProd && browserProfilingIntegration(),
+        !isProd && browserTracingIntegration(),
+        !isProd && elementTimingIntegration(),
+    ].filter((item): item is Exclude<typeof item, false> => Boolean(item)),
 } satisfies BrowserOptions;


### PR DESCRIPTION
## Description

- Disable profiling, tracing, timing in production.
- This is only a hotfix. The proper fix is to gather those data but only if user approves telemetry (that's another issue #28998).

## Related Issue

Resolve #28874

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `suite/sentry/src/config.ts`, which is the Sentry error-reporting configuration. This file controls error monitoring/reporting setup (DSN, sample rates, ignored errors, etc.) and is not exercised by any of the 105 candidate E2E tests — none of them assert on Sentry behavior, error reporting, or monitoring configuration. There is no static coverage mapping, and none of the LLM-analyzed test behaviors, entry points, or source hints reference Sentry or error reporting infrastructure. The risk of this change causing user-facing regressions detectable by E2E tests is negligible. No E2E tests are recommended.

<details><summary><b>Changed files (1)</b></summary>

- `suite/sentry/src/config.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite/sentry/src/config.ts`

_Updated: 2026-06-23T13:40:16.797Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/sentry-integrations/web/](https://dev.suite.sldev.cz/suite-web/fix/sentry-integrations/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sentry-integrations&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sentry-integrations&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-23T13:45:19.449Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-23T13:44:04.672Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->