### PR TITLE
feat(suite): add search to network settings

### DIFF
--- a/packages/suite/src/components/suite/NetworkList/NetworkCard.tsx
+++ b/packages/suite/src/components/suite/NetworkList/NetworkCard.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react';
 
-import { Translation, type TranslationKey } from '@suite/intl';
+import { Translation } from '@suite/intl';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Box, Card, Column, IconButton, Row, Text } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
@@ -11,7 +11,6 @@ import { type BackendStatus } from './getBackendStatus';
 type NetworkCardProps = {
     symbol: NetworkSymbol;
     name: string;
-    label?: TranslationKey;
     backendStatus?: BackendStatus;
     isEnabled: boolean;
     isDisabled: boolean;
@@ -24,7 +23,6 @@ type NetworkCardProps = {
 export const NetworkCard = ({
     symbol,
     name,
-    label,
     backendStatus,
     isEnabled,
     isDisabled,
@@ -44,11 +42,6 @@ export const NetworkCard = ({
                 <CoinLogo size={24} symbol={symbol} type="network" />
                 <Column flex="1" minHeight={32} justifyContent="center">
                     <Text typographyStyle="body-sm-strong">{name}</Text>
-                    {label && (
-                        <Text typographyStyle="body-xs" intent="neutral" priority="secondary">
-                            <Translation id={label} />
-                        </Text>
-                    )}
                 </Column>
                 <Row gap={12} onClick={e => e.stopPropagation()}>
                     {onSettings && (

--- a/packages/suite/src/components/suite/NetworkList/NetworkList.tsx
+++ b/packages/suite/src/components/suite/NetworkList/NetworkList.tsx
@@ -10,7 +10,6 @@ import { getFirmwareVersion, isDeviceInBootloaderMode } from '@trezor/device-uti
 import { versionUtils } from '@trezor/utils';
 
 import { useDiscovery, useSelector } from 'src/hooks/suite';
-import { getCoinLabel } from 'src/utils/suite/getCoinLabel';
 
 import { NetworkCard } from './NetworkCard';
 import { getBackendStatus } from './getBackendStatus';
@@ -59,7 +58,7 @@ export const NetworkList = ({
     return (
         <Column gap={12} width="100%">
             {networks.map(network => {
-                const { symbol, name, support, features, testnet: isTestnet } = network;
+                const { symbol, name, support } = network;
                 const blockchainInfo = blockchain[symbol];
                 const hasCustomBackend = !!blockchainInfo.backends.selected;
                 const backendStatus = getBackendStatus(blockchainInfo);
@@ -84,8 +83,6 @@ export const NetworkList = ({
                     getCoinUnavailabilityMessage(unavailableReason);
                 const tooltipString = discoveryTooltip || lockedTooltip || unavailabilityTooltip;
 
-                const label = getCoinLabel(features, isTestnet);
-
                 return (
                     <Tooltip
                         key={symbol}
@@ -105,7 +102,6 @@ export const NetworkList = ({
                         <NetworkCard
                             symbol={symbol}
                             name={name}
-                            label={label}
                             backendStatus={hasCustomBackend ? backendStatus : undefined}
                             isDisabled={isDisabled}
                             isEnabled={isEnabled}

--- a/packages/suite/src/hooks/settings/useNetworkSupport.ts
+++ b/packages/suite/src/hooks/settings/useNetworkSupport.ts
@@ -27,7 +27,7 @@ export const useNetworkSupport = () => {
         deviceSupportedNetworkSymbols.includes(network.symbol);
 
     const [supportedMainnets, unsupportedMainnets] = arrayPartition(mainnets, isNetworkSupported);
-    const supportedTestnets = testnets.filter(isNetworkSupported);
+    const [supportedTestnets, unsupportedTestnets] = arrayPartition(testnets, isNetworkSupported);
 
     const showUnsupportedCoins =
         device?.features?.internal_model === DeviceModelInternal.T1B1 &&
@@ -37,6 +37,7 @@ export const useNetworkSupport = () => {
         supportedMainnets,
         unsupportedMainnets,
         supportedTestnets,
+        unsupportedTestnets,
         showUnsupportedCoins,
     };
 };

--- a/packages/suite/src/views/settings/SettingsCoins/NetworkSettingsSearchInput.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/NetworkSettingsSearchInput.tsx
@@ -1,0 +1,31 @@
+import { useTranslation } from '@suite/intl';
+import { Icon, Input } from '@trezor/components';
+
+type NetworkSettingsSearchInputProps = {
+    searchQuery: string;
+    onSearchChange: (value: string) => void;
+    onSearchClear: () => void;
+};
+
+export const NetworkSettingsSearchInput = ({
+    searchQuery,
+    onSearchChange,
+    onSearchClear,
+}: NetworkSettingsSearchInputProps) => {
+    const { translationString } = useTranslation();
+
+    return (
+        <Input
+            value={searchQuery}
+            onChange={event => onSearchChange(event.target.value)}
+            onClear={onSearchClear}
+            placeholder={translationString('TR_SEARCH_NETWORK')}
+            showClearButton
+            width="100%"
+            data-testid="@settings-coins/network-search-input"
+            leftContent={
+                <Icon name="magnifyingGlass" intent="neutral" priority="secondary" size={16} />
+            }
+        />
+    );
+};

--- a/packages/suite/src/views/settings/SettingsCoins/NoNetworkSearchResults.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/NoNetworkSearchResults.tsx
@@ -1,0 +1,14 @@
+import { Translation } from '@suite/intl';
+import { Text } from '@trezor/components';
+
+export const NoNetworkSearchResults = () => (
+    <Text
+        typographyStyle="body-md"
+        intent="neutral"
+        priority="secondary"
+        align="center"
+        data-testid="@settings-coins/no-networks-found"
+    >
+        <Translation id="TR_NO_NETWORKS_FOUND" />
+    </Text>
+);

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { AnimatePresence, type MotionProps, motion } from 'framer-motion';
 import styled from 'styled-components';
 
@@ -8,7 +10,7 @@ import { openModal } from '@suite/modal';
 import { Anchor, SettingsAnchor } from '@suite/router';
 import { selectHasExperimentalFeature } from '@suite/settings';
 import { Context } from '@suite-common/message-system';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type Network, type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     changeCoinVisibility,
     selectDeviceSupportedNetworks,
@@ -16,9 +18,9 @@ import {
     selectShowRediscoverButton,
     startOrRestartDiscoveryThunk,
 } from '@suite-common/wallet-core';
-import { Button, Column, H4, Switch, Tooltip, motionEasing } from '@trezor/components';
+import { Box, Button, Column, Switch, Text, Tooltip, motionEasing } from '@trezor/components';
 import { hasBitcoinOnlyFirmware, isBitcoinOnlyDevice } from '@trezor/device-utils';
-import { SectionItem, SettingsSection } from '@trezor/product-components';
+import { OutlineHighlight, SectionItem, SettingsSection } from '@trezor/product-components';
 import { breakpoints, spacingsPx } from '@trezor/theme';
 
 import { SettingsLayout } from 'src/components/settings/SettingsLayout';
@@ -30,6 +32,9 @@ import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 import { isCoinjoinSupportedSymbol } from 'src/utils/wallet/coinjoinUtils';
 
 import { FirmwareTypeSuggestion } from './FirmwareTypeSuggestion';
+import { NetworkSettingsSearchInput } from './NetworkSettingsSearchInput';
+import { NoNetworkSearchResults } from './NoNetworkSearchResults';
+import { useNetworkSettingsSearch } from './useNetworkSettingsSearch';
 
 const DiscoveryButtonWrapper = styled.div`
     margin-top: ${spacingsPx.xl};
@@ -81,8 +86,13 @@ export const SettingsCoins = () => {
     const dispatch = useDispatch();
     const { firmwareTypeBannerClosed } = useSelector(selectFlags);
     const enabledNetworks = useSelector(selectEnabledNetworks);
-    const { showUnsupportedCoins, supportedMainnets, unsupportedMainnets, supportedTestnets } =
-        useNetworkSupport();
+    const {
+        showUnsupportedCoins,
+        supportedMainnets,
+        unsupportedMainnets,
+        supportedTestnets,
+        unsupportedTestnets,
+    } = useNetworkSupport();
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
     const { device, isLocked } = useDevice();
     const isDeviceLocked = !!device && isLocked();
@@ -91,6 +101,57 @@ export const SettingsCoins = () => {
         selectShowRediscoverButton(state, device),
     );
     const useTestnetNetworks = useSelector(selectHasExperimentalFeature('testnet-networks'));
+
+    const allSearchableNetworks = useMemo(
+        () => [
+            ...supportedMainnets,
+            ...(useTestnetNetworks ? supportedTestnets : []),
+            ...(showUnsupportedCoins ? unsupportedMainnets : []),
+            ...(showUnsupportedCoins && useTestnetNetworks ? unsupportedTestnets : []),
+        ],
+        [
+            showUnsupportedCoins,
+            supportedMainnets,
+            supportedTestnets,
+            unsupportedMainnets,
+            unsupportedTestnets,
+            useTestnetNetworks,
+        ],
+    );
+
+    const {
+        searchQuery,
+        hasActiveSearch,
+        hasNoSearchResults,
+        filterNetworks,
+        handleSearchChange,
+        handleSearchClear,
+    } = useNetworkSettingsSearch(allSearchableNetworks);
+
+    const filteredSupportedMainnets = filterNetworks(supportedMainnets);
+    const filteredSupportedTestnets = filterNetworks(supportedTestnets);
+    const filteredUnsupportedMainnets = filterNetworks(unsupportedMainnets);
+    const filteredUnsupportedTestnets = filterNetworks(unsupportedTestnets);
+
+    const showSupportedMainnets = !hasActiveSearch || filteredSupportedMainnets.length > 0;
+    const showSupportedTestnetsSection =
+        useTestnetNetworks &&
+        supportedTestnets.length > 0 &&
+        (!hasActiveSearch || filteredSupportedTestnets.length > 0);
+    const showUnsupportedSection =
+        showUnsupportedCoins &&
+        (unsupportedMainnets.length > 0 ||
+            (useTestnetNetworks && unsupportedTestnets.length > 0)) &&
+        (!hasActiveSearch ||
+            filteredUnsupportedMainnets.length > 0 ||
+            filteredUnsupportedTestnets.length > 0);
+    const showUnsupportedMainnets =
+        unsupportedMainnets.length > 0 &&
+        (!hasActiveSearch || filteredUnsupportedMainnets.length > 0);
+    const showUnsupportedTestnets =
+        useTestnetNetworks &&
+        unsupportedTestnets.length > 0 &&
+        (!hasActiveSearch || filteredUnsupportedTestnets.length > 0);
 
     const supportedEnabledNetworks = enabledNetworks.filter(enabledNetwork =>
         deviceSupportedNetworkSymbols.includes(enabledNetwork),
@@ -137,6 +198,21 @@ export const SettingsCoins = () => {
         />
     );
 
+    const renderNetworkList = (networks: Network[]) => (
+        <NetworkList
+            networks={networks}
+            enabledNetworks={enabledNetworks}
+            onClick={onToggle}
+            onSettings={onSettings}
+            renderRightContent={({ network, isEnabled }) =>
+                renderRightContent({
+                    networkSymbol: network.symbol,
+                    isEnabled,
+                })
+            }
+        />
+    );
+
     const startDiscovery = () => {
         dispatch(startOrRestartDiscoveryThunk());
     };
@@ -162,83 +238,99 @@ export const SettingsCoins = () => {
                             ref={anchorRef}
                             shouldHighlight={shouldHighlight}
                         >
-                            <NetworkList
-                                networks={supportedMainnets}
-                                enabledNetworks={enabledNetworks}
-                                onClick={onToggle}
-                                onSettings={onSettings}
-                                renderRightContent={({ network, isEnabled }) =>
-                                    renderRightContent({
-                                        networkSymbol: network.symbol,
-                                        isEnabled,
-                                    })
-                                }
-                            />
+                            <Column gap={24} width="100%">
+                                <NetworkSettingsSearchInput
+                                    searchQuery={searchQuery}
+                                    onSearchChange={handleSearchChange}
+                                    onSearchClear={handleSearchClear}
+                                />
+                                {hasNoSearchResults ? (
+                                    <NoNetworkSearchResults />
+                                ) : (
+                                    <Column gap={32} width="100%">
+                                        {showSupportedMainnets &&
+                                            renderNetworkList(filteredSupportedMainnets)}
+
+                                        {showSupportedTestnetsSection && (
+                                            <Anchor anchorId={SettingsAnchor.TestnetCrypto}>
+                                                {({
+                                                    anchorId: testnetAnchorId,
+                                                    anchorRef: testnetAnchorRef,
+                                                    shouldHighlight: testnetShouldHighlight,
+                                                }) => (
+                                                    <OutlineHighlight
+                                                        shouldHighlight={testnetShouldHighlight}
+                                                    >
+                                                        <Box
+                                                            ref={testnetAnchorRef}
+                                                            data-testid={testnetAnchorId}
+                                                            width="100%"
+                                                        >
+                                                            <Column gap={12} width="100%">
+                                                                <Text typographyStyle="body-md">
+                                                                    <Translation id="TR_TESTNET_COINS" />
+                                                                </Text>
+                                                                {renderNetworkList(
+                                                                    filteredSupportedTestnets,
+                                                                )}
+                                                            </Column>
+                                                        </Box>
+                                                    </OutlineHighlight>
+                                                )}
+                                            </Anchor>
+                                        )}
+
+                                        {showUnsupportedSection && (
+                                            <Anchor anchorId={SettingsAnchor.UnsupportedCrypto}>
+                                                {({
+                                                    anchorId: unsupportedAnchorId,
+                                                    anchorRef: unsupportedAnchorRef,
+                                                    shouldHighlight: unsupportedShouldHighlight,
+                                                }) => (
+                                                    <OutlineHighlight
+                                                        shouldHighlight={unsupportedShouldHighlight}
+                                                    >
+                                                        <Box
+                                                            ref={unsupportedAnchorRef}
+                                                            data-testid={unsupportedAnchorId}
+                                                            width="100%"
+                                                        >
+                                                            <Column gap={12} width="100%">
+                                                                <Text typographyStyle="headline-sm">
+                                                                    <Translation id="TR_UNSUPPORTED_COINS" />
+                                                                </Text>
+                                                                <Column gap={24} width="100%">
+                                                                    {showUnsupportedMainnets &&
+                                                                        renderNetworkList(
+                                                                            filteredUnsupportedMainnets,
+                                                                        )}
+                                                                    {showUnsupportedTestnets && (
+                                                                        <Column
+                                                                            gap={12}
+                                                                            width="100%"
+                                                                        >
+                                                                            <Text typographyStyle="body-md">
+                                                                                <Translation id="TR_TESTNET_COINS" />
+                                                                            </Text>
+                                                                            {renderNetworkList(
+                                                                                filteredUnsupportedTestnets,
+                                                                            )}
+                                                                        </Column>
+                                                                    )}
+                                                                </Column>
+                                                            </Column>
+                                                        </Box>
+                                                    </OutlineHighlight>
+                                                )}
+                                            </Anchor>
+                                        )}
+                                    </Column>
+                                )}
+                            </Column>
                         </SectionItem>
                     )}
                 </Anchor>
-                {showUnsupportedCoins && (
-                    <Anchor anchorId={SettingsAnchor.UnsupportedCrypto}>
-                        {({ anchorId, anchorRef, shouldHighlight }) => (
-                            <SectionItem
-                                data-testid={anchorId}
-                                ref={anchorRef}
-                                shouldHighlight={shouldHighlight}
-                            >
-                                <Column gap={12} width="100%">
-                                    <H4 typographyStyle="body-md">
-                                        <Translation id="TR_UNSUPPORTED_COINS" />
-                                    </H4>
-                                    <NetworkList
-                                        networks={unsupportedMainnets}
-                                        enabledNetworks={enabledNetworks}
-                                        onClick={onToggle}
-                                        onSettings={onSettings}
-                                        renderRightContent={({ network, isEnabled }) =>
-                                            renderRightContent({
-                                                networkSymbol: network.symbol,
-                                                isEnabled,
-                                            })
-                                        }
-                                    />
-                                </Column>
-                            </SectionItem>
-                        )}
-                    </Anchor>
-                )}
             </SettingsSection>
-
-            {useTestnetNetworks && (
-                <SettingsSection
-                    hasVerticalLayout={hasContentBelowTabletWidth}
-                    title={<Translation id="TR_TESTNET_COINS" />}
-                    icon="coin"
-                    hasContainer={false}
-                >
-                    <Anchor anchorId={SettingsAnchor.TestnetCrypto}>
-                        {({ anchorId, anchorRef, shouldHighlight }) => (
-                            <SectionItem
-                                data-testid={anchorId}
-                                ref={anchorRef}
-                                shouldHighlight={shouldHighlight}
-                            >
-                                <NetworkList
-                                    networks={supportedTestnets}
-                                    enabledNetworks={enabledNetworks}
-                                    onClick={onToggle}
-                                    onSettings={onSettings}
-                                    renderRightContent={({ network, isEnabled }) =>
-                                        renderRightContent({
-                                            networkSymbol: network.symbol,
-                                            isEnabled,
-                                        })
-                                    }
-                                />
-                            </SectionItem>
-                        )}
-                    </Anchor>
-                </SettingsSection>
-            )}
 
             <AnimatePresence>
                 {isDiscoveryButtonVisible && (

--- a/packages/suite/src/views/settings/SettingsCoins/useNetworkSettingsSearch.ts
+++ b/packages/suite/src/views/settings/SettingsCoins/useNetworkSettingsSearch.ts
@@ -1,0 +1,69 @@
+import { useCallback, useRef, useState } from 'react';
+
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
+import { events } from '@suite-common/analytics';
+import { useServices } from '@suite-common/dependency-injection';
+import { type Network } from '@suite-common/wallet-config';
+
+export const filterNetworksByName = (networks: Network[], searchQuery: string) => {
+    const normalizedQuery = searchQuery.trim().toLowerCase();
+
+    if (!normalizedQuery) {
+        return networks;
+    }
+
+    return networks.filter(({ name }) => name.toLowerCase().includes(normalizedQuery));
+};
+
+export const useNetworkSettingsSearch = (allNetworks: Network[]) => {
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const [searchQuery, setSearchQuery] = useState('');
+    const hasReportedSearchUsed = useRef(false);
+
+    const hasActiveSearch = searchQuery.trim().length > 0;
+
+    const filterNetworks = useCallback(
+        (networks: Network[]) => filterNetworksByName(networks, searchQuery),
+        [searchQuery],
+    );
+
+    const hasNoSearchResults = hasActiveSearch && filterNetworks(allNetworks).length === 0;
+
+    const handleSearchChange = useCallback(
+        (value: string) => {
+            setSearchQuery(value);
+
+            if (value.length === 0) {
+                hasReportedSearchUsed.current = false;
+
+                return;
+            }
+
+            if (value.length === 1 && !hasReportedSearchUsed.current) {
+                hasReportedSearchUsed.current = true;
+                analytics.report({
+                    type: events.settingsNetworkSearchUsedEvent.name,
+                    payload: {
+                        platform: 'desktop',
+                        origin: 'network-settings',
+                    },
+                });
+            }
+        },
+        [analytics],
+    );
+
+    const handleSearchClear = useCallback(() => {
+        setSearchQuery('');
+        hasReportedSearchUsed.current = false;
+    }, []);
+
+    return {
+        searchQuery,
+        hasActiveSearch,
+        hasNoSearchResults,
+        filterNetworks,
+        handleSearchChange,
+        handleSearchClear,
+    };
+};

--- a/suite-common/analytics/src/constants.ts
+++ b/suite-common/analytics/src/constants.ts
@@ -17,6 +17,7 @@ export enum EventType {
     SettingsDeviceChangeLabel = 'settings/device/change-label',
     SettingsDeviceWipe = 'settings/device/wipe',
     SettingsGeneralLabeling = 'settings/general/labeling',
+    SettingsNetworkSearchUsed = 'settings/network-search-used',
     // eslint-disable-next-line local-rules/analytics-event-name
     SuiteSyncLabelCreated = 'suite-sync/label',
     WalletConnectInit = 'wallet-connect/init',

--- a/suite-common/analytics/src/events/index.ts
+++ b/suite-common/analytics/src/events/index.ts
@@ -9,6 +9,7 @@ export { settingsAppLogExportedEvent } from './settingsAppLogExportedEvent';
 export { settingsDeviceChangeLabelEvent } from './settingsDeviceChangeLabelEvent';
 export { settingsDeviceWipeEvent } from './settingsDeviceWipeEvent';
 export { settingsGeneralLabelingEvent } from './settingsGeneralLabelingEvent';
+export { settingsNetworkSearchUsedEvent } from './settingsNetworkSearchUsedEvent';
 export { walletConnectInitEvent } from './walletConnectInitEvent';
 export { walletConnectPairedEvent } from './walletConnectPairedEvent';
 export { walletConnectProposalApprovedEvent } from './walletConnectProposalApprovedEvent';

--- a/suite-common/analytics/src/events/settingsNetworkSearchUsedEvent.ts
+++ b/suite-common/analytics/src/events/settingsNetworkSearchUsedEvent.ts
@@ -1,0 +1,30 @@
+import { EventType } from '../constants';
+import type { AnalyticsPlatform, AttributeDef, EventDef } from '../eventDefinition';
+
+type NetworkSettingsSearchOrigin = 'network-settings';
+
+type Attributes = {
+    platform: AttributeDef<AnalyticsPlatform>;
+    origin: AttributeDef<NetworkSettingsSearchOrigin>;
+};
+
+export const settingsNetworkSearchUsedEvent: EventDef<
+    Attributes,
+    EventType.SettingsNetworkSearchUsed
+> = {
+    name: EventType.SettingsNetworkSearchUsed,
+    descriptionTrigger:
+        'User enters the first character in the network search input on Settings > Coins (once per search session)',
+    changelog: [{ version: '26.7.0', notes: 'added' }],
+
+    attributes: {
+        platform: {
+            description: 'The platform where the search was used (`desktop` or `mobile`)',
+            changelog: [{ version: '26.7.0', notes: 'added' }],
+        },
+        origin: {
+            description: 'Where the search was used (`network-settings`)',
+            changelog: [{ version: '26.7.0', notes: 'added' }],
+        },
+    },
+};

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1788,6 +1788,14 @@ export const messages = defineMessages({
         defaultMessage: 'Coins',
         id: 'TR_COINS',
     },
+    TR_SEARCH_NETWORK: {
+        defaultMessage: 'Search networks',
+        id: 'TR_SEARCH_NETWORK',
+    },
+    TR_NO_NETWORKS_FOUND: {
+        defaultMessage: 'No networks found',
+        id: 'TR_NO_NETWORKS_FOUND',
+    },
     TR_HIDDEN: {
         defaultMessage: 'Hidden',
         id: 'TR_HIDDEN',
@@ -3456,7 +3464,7 @@ export const messages = defineMessages({
         id: 'TR_TAKE_ME_BACK_TO_WALLET',
     },
     TR_TESTNET_COINS: {
-        defaultMessage: 'Testnet',
+        defaultMessage: 'Testnet networks',
         id: 'TR_TESTNET_COINS',
     },
     TR_TESTNET_COINS_LABEL: {


### PR DESCRIPTION
## Notes for QA
Added search to network settings.

## Screenshots

<img width="1241" height="854" alt="image" src="https://github.com/user-attachments/assets/3a39e6f8-7212-4030-8ce5-b4fc68eb1ab7" />

<img width="1241" height="854" alt="image" src="https://github.com/user-attachments/assets/a413a9e5-1949-4960-ad42-abeb67f8dc88" />


<img width="1241" height="854" alt="image" src="https://github.com/user-attachments/assets/33e71a10-5fe5-4128-ad1d-d092d3887426" />



<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes primarily affect the Settings > Coins page UI (SettingsCoins view), introducing network search/filtering functionality (NetworkSettingsSearchInput, useNetworkSettingsSearch, NoNetworkSearchResults) and refactoring the NetworkList/NetworkCard components. A new analytics event (settingsNetworkSearchUsedEvent) is added. The highest risk is that the coin settings page breaks — preventing users from enabling/disabling networks and configuring backends. The coins.test.ts and coins-custom-backend.test.ts are critical since they directly exercise this page. Secondary risk is that shared network list components affect other views that use them (e.g., Activate Assets modal). The new search functionality and analytics event have no direct E2E test coverage.

<details><summary><b>Changed files (11)</b></summary>

- `packages/suite/src/components/suite/NetworkList/NetworkCard.tsx`
- `packages/suite/src/components/suite/NetworkList/NetworkList.tsx`
- `packages/suite/src/hooks/settings/useNetworkSupport.ts`
- `packages/suite/src/views/settings/SettingsCoins/NetworkSettingsSearchInput.tsx`
- `packages/suite/src/views/settings/SettingsCoins/NoNetworkSearchResults.tsx`
- `packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx`
- `packages/suite/src/views/settings/SettingsCoins/useNetworkSettingsSearch.ts`
- `suite-common/analytics/src/constants.ts`
- `suite-common/analytics/src/events/index.ts`
- `suite-common/analytics/src/events/settingsNetworkSearchUsedEvent.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — This test directly exercises the SettingsCoins view, including enabling/disabling networks, toggling testnet visibility, and configuring custom backends. The changes to SettingsCoins.tsx, NetworkList, NetworkCard, NetworkSettingsSearchInput, NoNetworkSearchResults, and useNetworkSettingsSearch all directly affect this page's rendering and behavior.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test enables coins from the Coins settings tab, opens advanced network settings, and changes backends — all of which render through the SettingsCoins view and NetworkCard/NetworkList components that were changed. It verifies network enable/disable toggles and the custom backend indicator, directly testing the changed UI.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test changes network settings (enabled networks, custom backends, testnet toggle) and verifies the SuiteReady analytics event reflects those changes. The new settingsNetworkSearchUsedEvent and changes to analytics constants/events could affect the analytics event definitions used in assertions.
- `suite/e2e/tests/settings/electrum.test.ts` — This test enables testnet networks and configures an Electrum backend through the Coins settings tab, directly exercising the SettingsCoins view and the network enable/backend configuration flow that uses the changed components.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test enables networks via the 'Activate Assets' modal which may share NetworkList/NetworkCard components, and navigates through the coins settings. Changes to how networks are listed and rendered could affect the activation flow.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test navigates to the Coins settings tab, enables networks, opens advanced network settings, and changes backends — all rendered through the changed SettingsCoins/NetworkList components.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test crawls all pages including /settings/coins and validates links return 200. New UI components (NoNetworkSearchResults, NetworkSettingsSearchInput) may introduce new links or change page structure that could affect link extraction.
- `suite/e2e/tests/settings/forget-device.test.ts` — This test enables networks from the coinsTab (enableNetwork, activateCoinsButton) during its setup, exercising the SettingsCoins view. While not focused on the search feature, it depends on the network enable flow working correctly.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/suite/src/views/settings/SettingsCoins/NetworkSettingsSearchInput.tsx`
- `packages/suite/src/views/settings/SettingsCoins/NoNetworkSearchResults.tsx`
- `packages/suite/src/views/settings/SettingsCoins/useNetworkSettingsSearch.ts`
- `suite-common/analytics/src/events/settingsNetworkSearchUsedEvent.ts`

_Updated: 2026-06-24T12:43:09.000Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/add-network-search/web/](https://dev.suite.sldev.cz/suite-web/feat/add-network-search/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/add-network-search&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/add-network-search&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/add-network-search&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-24T12:48:00.345Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-24T12:46:22.147Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->