### PR TITLE
28815 mobile swap clear signing modal wrong trading partner casing address chunking and redundant amount row

### DIFF
--- a/suite-common/suite-constants/src/evm.ts
+++ b/suite-common/suite-constants/src/evm.ts
@@ -5,6 +5,7 @@
 export const EVM_SPENDER_LABELS: Record<string, string> = {
     '0x111111125421ca6dc452d289314280a0f8842a65': '1inch Aggregation Router V6',
     '0xe592427a0aece92de3edee1f18e0157c05861564': 'Uniswap V3 Router',
+    '0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45': 'Uniswap V3 Router',
     '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae': 'LiFI Diamond',
 };
 

--- a/suite-common/suite-constants/src/evm.ts
+++ b/suite-common/suite-constants/src/evm.ts
@@ -5,7 +5,7 @@
 export const EVM_SPENDER_LABELS: Record<string, string> = {
     '0x111111125421ca6dc452d289314280a0f8842a65': '1inch Aggregation Router V6',
     '0xe592427a0aece92de3edee1f18e0157c05861564': 'Uniswap V3 Router',
-    '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae': 'LiFi Diamond',
+    '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae': 'LiFI Diamond',
 };
 
 export const UINT256_MAX = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';

--- a/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsBody.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsBody.tsx
@@ -1,9 +1,6 @@
-import {
-    type AccountKey,
-    type FormDraftWithSendKeyPrefix,
-    type TokenAddress,
-} from '@suite-common/wallet-types';
+import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
 import { type ExchangeFlowType } from '@suite-native/navigation';
+import { getFormDraftKeyPrefixFromTradingType } from '@suite-native/trading-quote-utils';
 import { ReviewOutputItemList } from '@suite-native/transaction-management';
 
 import { ReviewOutputsSkeleton } from './ReviewOutputsSkeleton';
@@ -11,19 +8,19 @@ import { SignDataMessageReview } from './SignDataMessageReview';
 import { useTradingContentBuilder } from '../../hooks/reviewOutputs/useTradingContentBuilder';
 
 export type ReviewOutputsBodyProps = {
-    prefix: FormDraftWithSendKeyPrefix;
     accountKey: AccountKey;
     tokenContract?: TokenAddress;
     exchangeFlowType?: ExchangeFlowType;
     shouldDisplayReviewList: boolean;
+    tradingType: 'exchange' | 'sell';
 };
 
 export const ReviewOutputsBody = ({
-    prefix,
     accountKey,
     tokenContract,
     exchangeFlowType,
     shouldDisplayReviewList,
+    tradingType,
 }: ReviewOutputsBodyProps) => {
     const contentBuilder = useTradingContentBuilder();
 
@@ -32,6 +29,8 @@ export const ReviewOutputsBody = ({
     }
 
     if (shouldDisplayReviewList) {
+        const prefix = getFormDraftKeyPrefixFromTradingType(tradingType);
+
         return (
             <ReviewOutputItemList
                 prefix={prefix}

--- a/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsContent.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsContent.tsx
@@ -5,7 +5,6 @@ import { Box, VStack } from '@suite-native/atoms';
 import { ConfirmOnTrezorWrapper } from '@suite-native/confirm-on-trezor';
 import { Translation } from '@suite-native/intl';
 import { type ExchangeFlowType, ScreenHeader } from '@suite-native/navigation';
-import { getFormDraftKeyPrefixFromTradingType } from '@suite-native/trading-quote-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { ReviewOutputsBody } from './ReviewOutputsBody';
@@ -62,8 +61,6 @@ export const ReviewOutputsContent = memo(
             });
         const shouldDisplayReviewList = useDelayedReviewOutputListDisplayFlag();
 
-        const prefix = getFormDraftKeyPrefixFromTradingType(tradingType);
-
         return (
             <ConfirmOnTrezorWrapper
                 controlRef={confirmOnTrezorRef}
@@ -82,11 +79,11 @@ export const ReviewOutputsContent = memo(
                     testID="@trading/outputs-review"
                 >
                     <ReviewOutputsBody
-                        prefix={prefix}
                         accountKey={accountKey}
                         tokenContract={tokenContract}
                         exchangeFlowType={exchangeFlowType}
                         shouldDisplayReviewList={shouldDisplayReviewList}
+                        tradingType={tradingType}
                     />
                     {isTransactionAlreadySigned ? (
                         <ReviewOutputsFooter

--- a/suite-native/module-trading/src/components/reviewOutputs/__tests__/ReviewOutputsBody.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/__tests__/ReviewOutputsBody.test.tsx
@@ -6,7 +6,7 @@ import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
 import { ReviewOutputsBody, type ReviewOutputsBodyProps } from '../ReviewOutputsBody';
 
 const defaultProps: ReviewOutputsBodyProps = {
-    prefix: 'trading-exchange',
+    tradingType: 'exchange',
     accountKey: 'ACCOUNT_KEY' as AccountKey,
     tokenContract: 'TOKEN_CONTRACT' as TokenAddress,
     exchangeFlowType: 'swap',

--- a/suite-native/module-trading/src/hooks/reviewOutputs/useTradingContentBuilder.tsx
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/useTradingContentBuilder.tsx
@@ -4,7 +4,6 @@ import { useStore } from 'react-redux';
 import type { DeviceRootState } from '@suite-common/device';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { HStack, Text, VStack } from '@suite-native/atoms';
-import { AddressFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
 import { useReceiveAmountMultiplier } from '@suite-native/trading-quote-utils';
 import { type ReviewOutputItemListProps } from '@suite-native/transaction-management';
@@ -15,7 +14,7 @@ import { CryptoAmountRow } from '../../components/general/CryptoAmountRow';
 type ContentBuilderFunction = NonNullable<ReviewOutputItemListProps['contentBuilder']>;
 
 const flexStyle = prepareNativeStyle(() => ({
-    flex: 1,
+    flexShrink: 1,
 }));
 
 export const useTradingContentBuilder = (): ContentBuilderFunction => {
@@ -48,21 +47,17 @@ export const useTradingContentBuilder = (): ContentBuilderFunction => {
                             cryptoId={receive.cryptoId}
                         />
                         {!!account && (
-                            <HStack
-                                justifyContent="space-between"
-                                alignItems="flex-start"
-                                spacing="sp8"
-                            >
+                            <HStack justifyContent="space-between" spacing="sp16">
                                 <Text variant="body-sm" color="contentPrimary">
                                     <Translation id="moduleTrading.tradingReviewOutputs.tradedAssets.recipient" />
                                 </Text>
-                                <AddressFormatter
-                                    value={account.descriptor}
-                                    format="full"
-                                    variant="body-sm"
-                                    textAlign="right"
+                                <Text
+                                    variant="body-sm-strong"
+                                    color="contentPrimary"
                                     style={applyStyle(flexStyle)}
-                                />
+                                >
+                                    {account.descriptor}
+                                </Text>
                             </HStack>
                         )}
                     </VStack>

--- a/suite-native/transaction-management/src/__tests__/selectors.test.ts
+++ b/suite-native/transaction-management/src/__tests__/selectors.test.ts
@@ -1,12 +1,22 @@
 import { type FeeLevelLabel, type GeneralPrecomposedLevels } from '@suite-common/wallet-types';
+import { isClearSignedEvmTradingSwapTransaction } from '@suite-common/wallet-utils';
 
+import { ETH_ACCOUNT_KEY, getEthAccount, getWalletState } from '../__fixtures__/walletState';
 import {
+    type TransactionReviewOutputsState,
     selectCustomFeeLevel,
     selectFeeLevelTransactionBytes,
     selectFeeLevels,
+    selectFormDraftByPrefix,
+    selectIsClearSignedTradingSwap,
     selectIsTransactionAlreadySigned,
 } from '../selectors';
 import { type NativeSendRootState } from '../sendFormSlice';
+
+jest.mock('@suite-common/wallet-utils', () => ({
+    ...jest.requireActual('@suite-common/wallet-utils'),
+    isClearSignedEvmTradingSwapTransaction: jest.fn().mockReturnValue(false),
+}));
 
 const createMockState = (
     overrides: Partial<NativeSendRootState['wallet']['send']> = {},
@@ -164,6 +174,126 @@ describe('transaction-management selectors', () => {
             const state = createMockState({ serializedTx: { tx: 'tx_data', symbol: 'btc' } });
 
             expect(selectIsTransactionAlreadySigned(state)).toBe(true);
+        });
+    });
+
+    describe('selectIsClearSignedTradingSwap', () => {
+        const PREFIX = 'trading-exchange' as const;
+        const FORM_DRAFT_KEY = PREFIX + '/';
+
+        const buildClearSignedTradingSwapState = ({
+            includeAccount = true,
+            includeDevice = true,
+            includeFormDraft = true,
+            includePrecomposedTx = true,
+        } = {}): TransactionReviewOutputsState =>
+            ({
+                wallet: {
+                    ...getWalletState(),
+                    accounts: includeAccount ? [getEthAccount()] : [],
+                    send: {
+                        ...getWalletState().send,
+                        precomposedTx: includePrecomposedTx ? { outputs: [] } : undefined,
+                    },
+                    formDrafts: includeFormDraft
+                        ? { [FORM_DRAFT_KEY]: { transactionData: null, trading: null } }
+                        : {},
+                },
+                device: {
+                    selectedDevice: includeDevice ? { connected: true } : undefined,
+                },
+            }) as unknown as TransactionReviewOutputsState;
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('returns false when account is missing', () => {
+            const state = buildClearSignedTradingSwapState({ includeAccount: false });
+            const result = selectIsClearSignedTradingSwap(state, ETH_ACCOUNT_KEY, PREFIX);
+
+            expect(result).toBe(false);
+            expect(isClearSignedEvmTradingSwapTransaction).not.toHaveBeenCalled();
+        });
+
+        it('returns false when device is missing', () => {
+            const state = buildClearSignedTradingSwapState({ includeDevice: false });
+            const result = selectIsClearSignedTradingSwap(state, ETH_ACCOUNT_KEY, PREFIX);
+
+            expect(result).toBe(false);
+            expect(isClearSignedEvmTradingSwapTransaction).not.toHaveBeenCalled();
+        });
+
+        it('returns false when formDraft is missing for the prefix', () => {
+            const state = buildClearSignedTradingSwapState({ includeFormDraft: false });
+            const result = selectIsClearSignedTradingSwap(state, ETH_ACCOUNT_KEY, PREFIX);
+
+            expect(result).toBe(false);
+            expect(isClearSignedEvmTradingSwapTransaction).not.toHaveBeenCalled();
+        });
+
+        it('returns false when precomposedTx is missing', () => {
+            const state = buildClearSignedTradingSwapState({ includePrecomposedTx: false });
+            const result = selectIsClearSignedTradingSwap(state, ETH_ACCOUNT_KEY, PREFIX);
+
+            expect(result).toBe(false);
+            expect(isClearSignedEvmTradingSwapTransaction).not.toHaveBeenCalled();
+        });
+
+        it('returns true when all data is present and the transaction is clear-signed', () => {
+            (isClearSignedEvmTradingSwapTransaction as jest.Mock).mockReturnValueOnce(true);
+
+            const state = buildClearSignedTradingSwapState();
+            const result = selectIsClearSignedTradingSwap(state, ETH_ACCOUNT_KEY, PREFIX);
+
+            expect(result).toBe(true);
+            expect(isClearSignedEvmTradingSwapTransaction).toHaveBeenCalledTimes(1);
+        });
+
+        it('returns false when all data is present but the transaction is not clear-signed', () => {
+            const state = buildClearSignedTradingSwapState();
+            const result = selectIsClearSignedTradingSwap(state, ETH_ACCOUNT_KEY, PREFIX);
+
+            expect(result).toBe(false);
+            expect(isClearSignedEvmTradingSwapTransaction).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('selectFormDraftByPrefix', () => {
+        const MOCK_DRAFT = { outputs: [{ type: 'payment', address: '0x123' }] };
+
+        const buildState = (walletOverrides = {}): TransactionReviewOutputsState =>
+            ({
+                wallet: {
+                    ...getWalletState(),
+                    send: { ...getWalletState().send, drafts: {} },
+                    formDrafts: {},
+                    ...walletOverrides,
+                },
+                device: { selectedDevice: undefined },
+            }) as unknown as TransactionReviewOutputsState;
+
+        it('reads from send.drafts for the send prefix', () => {
+            const state = buildState({
+                send: { ...getWalletState().send, drafts: { [ETH_ACCOUNT_KEY]: MOCK_DRAFT } },
+            });
+            const result = selectFormDraftByPrefix(state, 'send', ETH_ACCOUNT_KEY);
+
+            expect(result).toEqual(MOCK_DRAFT);
+        });
+
+        it('reads from formDrafts keyed by prefix/accountKey for staking prefixes', () => {
+            const state = buildState({ formDrafts: { [`stake/${ETH_ACCOUNT_KEY}`]: MOCK_DRAFT } });
+            const result = selectFormDraftByPrefix(state, 'stake', ETH_ACCOUNT_KEY);
+
+            expect(result).toEqual(MOCK_DRAFT);
+        });
+
+        it('reads from formDrafts keyed by prefix/ for non-staking non-send prefixes', () => {
+            const state = buildState({ formDrafts: { 'trading-buy/': MOCK_DRAFT } });
+            const result = selectFormDraftByPrefix(state, 'trading-buy', ETH_ACCOUNT_KEY);
+
+            expect(result).toEqual(MOCK_DRAFT);
         });
     });
 });

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemList.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemList.tsx
@@ -85,6 +85,7 @@ export const ReviewOutputItemList = ({
                     {!isTron && (
                         <ReviewOutputSummaryItem
                             accountKey={accountKey}
+                            prefix={prefix}
                             summaryOutput={summaryOutput}
                             symbol={accountSymbol}
                             tokenContract={tokenContract}

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputSummaryItem.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputSummaryItem.tsx
@@ -1,7 +1,12 @@
 import { type LayoutChangeEvent, View } from 'react-native';
+import { useSelector } from 'react-redux';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
+import {
+    type AccountKey,
+    type FormDraftWithSendKeyPrefix,
+    type TokenAddress,
+} from '@suite-common/wallet-types';
 import { VStack } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 import type { ExchangeFlowType } from '@suite-native/navigation';
@@ -10,6 +15,10 @@ import { BigNumber } from '@trezor/utils';
 
 import { ReviewOutputCard } from './ReviewOutputCard';
 import { ReviewOutputItemValues } from './ReviewOutputItemValues';
+import {
+    type TransactionReviewOutputsState,
+    selectIsClearSignedTradingSwap,
+} from '../../selectors';
 import { type ReviewSummaryOutput } from '../../types';
 
 export type ReviewOutputSummaryItemProps = {
@@ -19,6 +28,7 @@ export type ReviewOutputSummaryItemProps = {
     tokenContract?: TokenAddress;
     summaryOutput?: ReviewSummaryOutput;
     flowType?: ExchangeFlowType;
+    prefix: FormDraftWithSendKeyPrefix;
 };
 
 type BitcoinValuesProps = {
@@ -30,6 +40,7 @@ type BitcoinValuesProps = {
 type TokenEnabledValuesProps = {
     tokenContract?: TokenAddress;
     flowType?: ExchangeFlowType;
+    isClearSignedTradingSwap: boolean;
 } & BitcoinValuesProps;
 
 const BitcoinValues = ({ accountKey, totalSpent, fee }: BitcoinValuesProps) => (
@@ -53,6 +64,7 @@ const TokenEnabledValues = ({
     fee,
     tokenContract,
     flowType,
+    isClearSignedTradingSwap,
 }: TokenEnabledValuesProps) => {
     let amount: string | undefined;
 
@@ -62,7 +74,7 @@ const TokenEnabledValues = ({
 
     return (
         <>
-            {!!amount && (
+            {!!amount && !isClearSignedTradingSwap && (
                 <ReviewOutputItemValues
                     accountKey={accountKey}
                     value={amount}
@@ -86,13 +98,18 @@ export const ReviewOutputSummaryItem = ({
     tokenContract,
     summaryOutput,
     flowType,
+    prefix,
 }: ReviewOutputSummaryItemProps) => {
     const { translate } = useTranslate();
 
-    if (!summaryOutput) return null;
+    const isClearSignedTradingSwap = useSelector((state: TransactionReviewOutputsState) =>
+        selectIsClearSignedTradingSwap(state, accountKey, prefix),
+    );
 
+    if (!summaryOutput) {
+        return null;
+    }
     const { state, totalSpent, fee } = summaryOutput;
-
     const isNetworkSupportingTokens = isNetworkWithTokens(symbol);
 
     return (
@@ -109,6 +126,7 @@ export const ReviewOutputSummaryItem = ({
                             fee={fee}
                             tokenContract={tokenContract}
                             flowType={flowType}
+                            isClearSignedTradingSwap={isClearSignedTradingSwap}
                         />
                     ) : (
                         <BitcoinValues accountKey={accountKey} totalSpent={totalSpent} fee={fee} />

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItemList.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItemList.test.tsx
@@ -26,6 +26,7 @@ jest.mock('../../../selectors', () => {
         selectReviewSummaryOutput: () => selectReviewSummaryOutputReturnValue,
         selectTransactionReviewOutputsFromDraft: () =>
             mockSelectTransactionReviewOutputsFromDraftReturnValue,
+        selectIsClearSignedTradingSwap: () => false,
     };
 });
 

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputSummaryItem.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputSummaryItem.test.tsx
@@ -1,13 +1,20 @@
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { Text as MockText } from '@suite-native/atoms';
 import { getTranslation } from '@suite-native/intl';
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
 import { ETH_ACCOUNT_KEY } from '../../../__fixtures__/walletState';
 import {
     ReviewOutputSummaryItem,
     type ReviewOutputSummaryItemProps,
 } from '../ReviewOutputSummaryItem';
+
+const mockSelectIsClearSignedTradingSwap = jest.fn();
+jest.mock('../../../selectors', () => ({
+    ...jest.requireActual('../../../selectors'),
+    selectIsClearSignedTradingSwap: (...args: unknown[]) =>
+        mockSelectIsClearSignedTradingSwap(...args),
+}));
 
 jest.mock('../ReviewOutputItemValues', () => ({
     ReviewOutputItemValues: ({
@@ -25,14 +32,20 @@ jest.mock('../ReviewOutputItemValues', () => ({
 
 describe('ReviewOutputSummaryItem', () => {
     const renderReviewOutputSummaryItem = (props: Partial<ReviewOutputSummaryItemProps>) =>
-        renderWithBasicProvider(
+        renderWithStoreProvider(
             <ReviewOutputSummaryItem
                 accountKey={ETH_ACCOUNT_KEY}
                 symbol="btc"
                 onLayout={jest.fn()}
+                prefix="trading-buy"
                 {...props}
             />,
         );
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockSelectIsClearSignedTradingSwap.mockReturnValue(false);
+    });
 
     it('should render nothing when summaryOutput is not specified', () => {
         const { toJSON } = renderReviewOutputSummaryItem({});
@@ -141,6 +154,30 @@ describe('ReviewOutputSummaryItem', () => {
                 'ReviewOutputItemValues: [transactionManagement.review.outputs.summary.amount]-[1000]',
             ),
         ).toBeTruthy();
+        expect(
+            getByText(
+                'ReviewOutputItemValues: [transactionManagement.review.outputs.summary.maxFee]-[10]',
+            ),
+        ).toBeTruthy();
+    });
+
+    it('should not render "amount" if transaction is clear-signed', () => {
+        mockSelectIsClearSignedTradingSwap.mockReturnValue(true);
+
+        const { queryByText, getByText } = renderReviewOutputSummaryItem({
+            summaryOutput: {
+                totalSpent: '1000',
+                fee: '10',
+                state: 'active',
+            },
+            symbol: 'eth',
+        });
+
+        expect(
+            queryByText(
+                /ReviewOutputItemValues: \[transactionManagement\.review\.outputs\.summary\.amount]/,
+            ),
+        ).toBeNull();
         expect(
             getByText(
                 'ReviewOutputItemValues: [transactionManagement.review.outputs.summary.maxFee]-[10]',

--- a/suite-native/transaction-management/src/selectors.ts
+++ b/suite-native/transaction-management/src/selectors.ts
@@ -26,6 +26,7 @@ import {
     getFormDraftKey,
     getIsUpdatedSendFlow,
     getTransactionReviewOutputState,
+    isClearSignedEvmTradingSwapTransaction,
     isRbfBumpFeeTransaction,
 } from '@suite-common/wallet-utils';
 import { BigNumber, isNotNullOrUndefined } from '@trezor/utils';
@@ -133,19 +134,26 @@ export const selectTransactionReviewOutputs = createSendMemoizedSelector(
     },
 );
 
+export const selectFormDraftByPrefix = (
+    state: TransactionReviewOutputsState,
+    prefix: FormDraftWithSendKeyPrefix,
+    accountKey: AccountKey,
+    tokenContract?: TokenAddress,
+) =>
+    prefix === 'send'
+        ? selectSendFormDraftByKey(state, accountKey, tokenContract)
+        : selectFormDraft<FormState>(
+              state,
+              getFormDraftKey(prefix, isStakingPrefix(prefix) ? accountKey : ''),
+          );
+
 export const selectTransactionReviewOutputsFromDraft = (
     state: TransactionReviewOutputsState,
     prefix: FormDraftWithSendKeyPrefix,
     accountKey: AccountKey,
     tokenContract?: TokenAddress,
 ) => {
-    const formDraft =
-        prefix === 'send'
-            ? selectSendFormDraftByKey(state, accountKey, tokenContract)
-            : selectFormDraft<FormState>(
-                  state,
-                  getFormDraftKey(prefix, isStakingPrefix(prefix) ? accountKey : ''),
-              );
+    const formDraft = selectFormDraftByPrefix(state, prefix, accountKey, tokenContract);
 
     return selectTransactionReviewOutputs(state, accountKey, tokenContract, formDraft);
 };
@@ -279,3 +287,29 @@ export const selectTransactionReviewActiveStepIndex = (
 
     return activeIndex === -1 ? reviewOutputs.length : activeIndex;
 };
+
+export const selectIsClearSignedTradingSwap = createSendMemoizedSelector(
+    [
+        selectAccountByKey,
+        selectSelectedDevice,
+        (
+            state: TransactionReviewOutputsState,
+            accountKey: AccountKey,
+            prefix: FormDraftWithSendKeyPrefix,
+        ) => selectFormDraftByPrefix(state, prefix, accountKey),
+        selectSendPrecomposedTx,
+    ],
+    (account, device, formDraft, precomposedTx) => {
+        if (account && device && formDraft && precomposedTx) {
+            return isClearSignedEvmTradingSwapTransaction({
+                account,
+                device,
+                precomposedTx,
+                transactionData: formDraft.transactionData,
+                trading: formDraft.trading,
+            });
+        }
+
+        return false;
+    },
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Update `EVM_SPENDER_LABELS` definitions
- Do not format recipient address as on trezor is not formatted as well.
- Do not display amount in summary for clear signing

<!--- Describe your changes in detail -->

## Notes for QA
Please test also signing of  sell and send form.

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #28815 

## Screenshots:

<img width="300" alt="clear-signing-review-outputs" src="https://github.com/user-attachments/assets/5888aded-bc12-42c5-8b21-ac2be4a53908" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The vast majority of changes (10 out of 11 files) are in `suite-native/` packages, which are React Native mobile components and have no E2E test coverage in the Playwright suite (these are desktop/web E2E tests). The only shared file is `suite-common/suite-constants/src/evm.ts`, which maps to 121 tests — indicating it is a broadly imported constant/utility module. Without knowing the specific nature of the change to `evm.ts`, and given that none of the 145 candidate E2E tests directly exercise EVM constant definitions in a way that would surface a regression from a constants change, no E2E tests are recommended. The mobile-specific changes are covered by their co-located unit tests (ReviewOutputsBody.test.tsx, ReviewOutputItemList.test.tsx, ReviewOutputSummaryItem.test.tsx, selectors.test.ts) rather than Playwright E2E tests.

<details><summary><b>Changed files (11)</b></summary>

- `suite-common/suite-constants/src/evm.ts`
- `suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsBody.tsx`
- `suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsContent.tsx`
- `suite-native/module-trading/src/components/reviewOutputs/__tests__/ReviewOutputsBody.test.tsx`
- `suite-native/module-trading/src/hooks/reviewOutputs/useTradingContentBuilder.tsx`
- `suite-native/transaction-management/src/__tests__/selectors.test.ts`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemList.tsx`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputSummaryItem.tsx`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItemList.test.tsx`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputSummaryItem.test.tsx`
- `suite-native/transaction-management/src/selectors.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (10)**
- `suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsBody.tsx`
- `suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsContent.tsx`
- `suite-native/module-trading/src/components/reviewOutputs/__tests__/ReviewOutputsBody.test.tsx`
- `suite-native/module-trading/src/hooks/reviewOutputs/useTradingContentBuilder.tsx`
- `suite-native/transaction-management/src/__tests__/selectors.test.ts`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemList.tsx`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputSummaryItem.tsx`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItemList.test.tsx`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputSummaryItem.test.tsx`
- `suite-native/transaction-management/src/selectors.ts`

_Updated: 2026-06-29T14:34:20.566Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/28815-mobile-swap-clear-signing-modal-wrong-trading-partner-casing-address-chunking-and-redundant-amount-row/web/](https://dev.suite.sldev.cz/suite-web/28815-mobile-swap-clear-signing-modal-wrong-trading-partner-casing-address-chunking-and-redundant-amount-row/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=28815-mobile-swap-clear-signing-modal-wrong-trading-partner-casing-address-chunking-and-redundant-amount-row&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=28815-mobile-swap-clear-signing-modal-wrong-trading-partner-casing-address-chunking-and-redundant-amount-row&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=28815-mobile-swap-clear-signing-modal-wrong-trading-partner-casing-address-chunking-and-redundant-amount-row&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T14:39:07.602Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T14:38:01.207Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->