### PR TITLE
perf(suite-desktop): tanstack query improvements

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
@@ -6,6 +6,7 @@ import { EarnAnchor, goto, useAnchor } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import {
     type YieldAccountRewards,
+    type YieldDto,
     useAllYieldOpportunities,
 } from '@suite-common/earn-stablecoin-api';
 import { Context } from '@suite-common/message-system';
@@ -27,6 +28,8 @@ import { useYieldTableData } from './hooks/useYieldTableData';
 import { useMerklRewards } from '../../yield/claim/hooks';
 import { EarnDashboardSection } from '../common/EarnDashboardSection';
 import { EarnDashboardTableHeader } from '../common/EarnDashboardTableHeader';
+
+const emptyVaults: YieldDto[] = [];
 
 export const EarnYieldTable = () => {
     const { anchorRef, shouldHighlight } = useAnchor(EarnAnchor.Yield);
@@ -60,7 +63,7 @@ export const EarnYieldTable = () => {
         isYieldActive,
         hasAnyRewardsData,
     } = useYieldTableData({
-        availableVaults,
+        availableVaults: availableVaults ?? emptyVaults,
         visibleAccounts,
         visibleAccountSymbols,
     });

--- a/suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewards.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewards.ts
@@ -70,7 +70,12 @@ export function useGetMerklRewards<Address extends string>(
     }, [queryClient, queryEntriesRef, chainsRewardsRef]);
 
     return {
-        ...queryResult,
+        data: queryResult.data,
+        error: queryResult.error,
+        isError: queryResult.isError,
+        isLoading: queryResult.isLoading,
+        isSuccess: queryResult.isSuccess,
+        refetch: queryResult.refetch,
         waitForMerklToResolveClaim,
     };
 }

--- a/suite-common/earn-stablecoin-api/src/hooks/useAllYieldOpportunities.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/useAllYieldOpportunities.ts
@@ -2,7 +2,7 @@ import { type YieldDto } from '@suite-common/earn-stablecoin-defs';
 import { commonQueryKeys, useQuery } from '@suite-common/react-query';
 
 import { YIELD_OPPORTUNITIES_DEFAULT_LIMIT, queriesStaleTime } from '../config';
-import { useGetYieldOpportunities } from './useGetYieldOpportunities';
+import { getYields } from '../services';
 
 type UseAllYieldOpportunitiesProps = {
     limit?: number;
@@ -15,14 +15,15 @@ export const useAllYieldOpportunities = ({
     limit = YIELD_OPPORTUNITIES_DEFAULT_LIMIT,
     enabled = true,
 }: UseAllYieldOpportunitiesProps = {}) => {
-    const { mutateAsync } = useGetYieldOpportunities({});
-
     const queryResult = useQuery({
         queryKey: commonQueryKeys.yieldOpportunities({ limit }),
-        queryFn: async () => {
-            const response = await mutateAsync({ offset: 0, limit });
+        queryFn: async ({ signal }) => {
+            const { items } = await getYields({
+                params: { offset: 0, limit, sort: 'statusEnterDesc' },
+                signal,
+            });
 
-            return response.items;
+            return items ?? stableEmptyArray;
         },
         enabled,
         staleTime: queriesStaleTime.getYieldOpportunities,

--- a/suite-common/earn-stablecoin-api/src/hooks/useAllYieldOpportunities.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/useAllYieldOpportunities.ts
@@ -14,9 +14,9 @@ const stableEmptyArray: YieldDto[] = [];
 export const useAllYieldOpportunities = ({
     limit = YIELD_OPPORTUNITIES_DEFAULT_LIMIT,
     enabled = true,
-}: UseAllYieldOpportunitiesProps = {}) => {
-    const queryResult = useQuery({
-        queryKey: commonQueryKeys.yieldOpportunities({ limit }),
+}: UseAllYieldOpportunitiesProps = {}) =>
+    useQuery({
+        queryKey: commonQueryKeys.yieldOpportunitiesList({ limit }),
         queryFn: async ({ signal }) => {
             const { items } = await getYields({
                 params: { offset: 0, limit, sort: 'statusEnterDesc' },
@@ -28,9 +28,3 @@ export const useAllYieldOpportunities = ({
         enabled,
         staleTime: queriesStaleTime.getYieldOpportunities,
     });
-
-    return {
-        ...queryResult,
-        data: queryResult.data ?? stableEmptyArray,
-    };
-};

--- a/suite-common/earn-stablecoin-api/src/hooks/useGetVaultByAddress.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/useGetVaultByAddress.ts
@@ -10,7 +10,7 @@ interface GetVaultByAddressProps {
 export function useGetVaultByAddress({ enabled, outputToken }: GetVaultByAddressProps) {
     return useQuery({
         enabled: Boolean(enabled && outputToken),
-        queryKey: commonQueryKeys.yieldOpportunities(outputToken),
+        queryKey: commonQueryKeys.yieldOpportunitiesByAddress(outputToken),
         async queryFn() {
             const { items } = await getYields({
                 params: {

--- a/suite-common/earn-stablecoin-api/src/hooks/useGetYieldOpportunities.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/useGetYieldOpportunities.ts
@@ -1,31 +1,34 @@
-import { type GetYieldsSort, type YieldsResponse } from '@suite-common/earn-stablecoin-defs';
-import { type MutationOptions, desktopMutationKeys, useMutation } from '@suite-common/react-query';
+import { type GetYieldsSort } from '@suite-common/earn-stablecoin-defs';
+import { commonQueryKeys, useInfiniteQuery } from '@suite-common/react-query';
 
+import { YIELD_OPPORTUNITIES_DEFAULT_LIMIT, queriesStaleTime } from '../config';
 import { getYields } from '../services';
 
-interface GetYieldOpportunitiesVariables {
-    offset?: number;
+export interface UseGetYieldOpportunitiesProps {
     limit?: number;
     sort?: GetYieldsSort;
-}
-
-export interface UseGetYieldOpportunitiesProps {
-    onSuccess?: MutationOptions<YieldsResponse, Error, GetYieldOpportunitiesVariables>['onSuccess'];
-    onError?: MutationOptions<YieldsResponse, Error, GetYieldOpportunitiesVariables>['onError'];
+    enabled?: boolean;
 }
 
 /**
- * Paginated list of Yield opportunities
+ * Paginated list of Yield opportunities — each `fetchNextPage()` loads the next offset.
  */
-export function useGetYieldOpportunities({ onError, onSuccess }: UseGetYieldOpportunitiesProps) {
-    return useMutation<YieldsResponse, Error, GetYieldOpportunitiesVariables>({
-        mutationKey: desktopMutationKeys.getYieldOpportunities,
-        mutationFn: ({ offset = 0, limit = 20, sort = 'statusEnterDesc' }) =>
-            getYields({
-                params: { offset, limit, sort },
-            }),
-        onError,
-        onSuccess: (data, variables, onMutateResult, context) =>
-            onSuccess?.(data, variables, onMutateResult, context),
+export function useGetYieldOpportunities({
+    limit = YIELD_OPPORTUNITIES_DEFAULT_LIMIT,
+    sort = 'statusEnterDesc',
+    enabled = true,
+}: UseGetYieldOpportunitiesProps = {}) {
+    return useInfiniteQuery({
+        queryKey: commonQueryKeys.yieldOpportunities('pages', { limit, sort }),
+        queryFn: ({ pageParam, signal }) =>
+            getYields({ params: { offset: pageParam, limit, sort }, signal }),
+        initialPageParam: 0,
+        getNextPageParam: lastPage => {
+            const nextOffset = lastPage.offset + (lastPage.items?.length ?? 0);
+
+            return nextOffset < lastPage.total ? nextOffset : undefined;
+        },
+        enabled,
+        staleTime: queriesStaleTime.getYieldOpportunities,
     });
 }

--- a/suite-common/earn-stablecoin-api/src/hooks/useGetYieldOpportunities.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/useGetYieldOpportunities.ts
@@ -19,7 +19,7 @@ export function useGetYieldOpportunities({
     enabled = true,
 }: UseGetYieldOpportunitiesProps = {}) {
     return useInfiniteQuery({
-        queryKey: commonQueryKeys.yieldOpportunities('pages', { limit, sort }),
+        queryKey: commonQueryKeys.yieldOpportunitiesPages({ limit, sort }),
         queryFn: ({ pageParam, signal }) =>
             getYields({ params: { offset: pageParam, limit, sort }, signal }),
         initialPageParam: 0,

--- a/suite-common/earn-stablecoin-api/src/hooks/useYieldOpportunity.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/useYieldOpportunity.ts
@@ -1,5 +1,3 @@
-import { useMemo, useRef } from 'react';
-
 import { type YieldDto } from '@suite-common/earn-stablecoin-defs';
 import { commonQueryKeys, useQuery } from '@suite-common/react-query';
 
@@ -9,32 +7,18 @@ interface UseYieldOpportunityProps<T extends YieldDto[keyof YieldDto] | YieldDto
     select?: (yieldOpportunity: YieldDto) => T;
 }
 
-const defaultSelect = <T extends YieldDto[keyof YieldDto] | YieldDto = YieldDto>(
-    yieldOpportunity: YieldDto,
-): T => yieldOpportunity as T;
-
 export function useYieldOpportunity<T extends YieldDto[keyof YieldDto] | YieldDto = YieldDto>(
     vaultId: string | undefined,
-    { select = defaultSelect }: UseYieldOpportunityProps<T> = {},
+    { select }: UseYieldOpportunityProps<T> = {},
 ) {
-    const queryResult = useQuery({
+    return useQuery({
         enabled: Boolean(vaultId),
-        queryKey: commonQueryKeys.yieldOpportunities(vaultId),
+        queryKey: commonQueryKeys.yieldOpportunity(vaultId),
         queryFn: ({ signal }) =>
             getYield({
                 routeParams: { vaultId: vaultId! },
                 signal,
             }),
+        select,
     });
-
-    const selectRef = useRef(select);
-    const selectedData = useMemo(
-        () => (queryResult.data ? selectRef.current(queryResult.data) : undefined),
-        [queryResult.data],
-    );
-
-    return {
-        ...queryResult,
-        data: selectedData,
-    };
 }

--- a/suite-common/react-query/src/constants/mutationKeys.ts
+++ b/suite-common/react-query/src/constants/mutationKeys.ts
@@ -1,5 +1,3 @@
 import { type AllowedMutationKey } from '../types';
 
-export const desktopMutationKeys = {
-    getYieldOpportunities: ['get-yield-opportunities'],
-} as const satisfies Record<string, AllowedMutationKey>;
+export const desktopMutationKeys = {} as const satisfies Record<string, AllowedMutationKey>;

--- a/suite-common/react-query/src/constants/queryKeys.ts
+++ b/suite-common/react-query/src/constants/queryKeys.ts
@@ -12,7 +12,18 @@ export const commonQueryKeys = {
     solanaRewards: (...args: any[]) => ['solana-rewards', ...args],
     solanaRewardsTotal: (address: string) => ['solana-rewards-total', address],
     tronStakingStats: () => ['tron-staking-stats'],
-    yieldOpportunities: (...args: any[]) => ['yield-opportunities', ...args],
+    yieldOpportunity: (vaultId: string | undefined) => ['yield-opportunities', 'single', vaultId],
+    yieldOpportunitiesList: (params: { limit: number }) => ['yield-opportunities', 'list', params],
+    yieldOpportunitiesByAddress: (outputToken: string | undefined) => [
+        'yield-opportunities',
+        'by-address',
+        outputToken,
+    ],
+    yieldOpportunitiesPages: (params: { limit: number; sort: string }) => [
+        'yield-opportunities',
+        'pages',
+        params,
+    ],
     merklRewards: (...args: any[]) => ['merkl-rewards', ...args],
     missingRateTickers: (...args: any[]) => ['missing-rate-tickers', ...args],
 } as const satisfies Record<string, AllowedQueryKey>;

--- a/suite-common/react-query/src/index.ts
+++ b/suite-common/react-query/src/index.ts
@@ -2,6 +2,7 @@ export {
     QueryClient,
     QueryClientProvider,
     useQuery,
+    useInfiniteQuery,
     useMutation,
     useQueryClient,
     type MutationOptions,

--- a/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts
+++ b/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts
@@ -215,6 +215,8 @@ export const resolveYieldFlowData = ({
     };
 };
 
+const emptyYieldOpportunities: YieldDto[] = [];
+
 export const useResolvedYieldFlowData = ({
     accountKey,
     tokenContract,
@@ -236,7 +238,7 @@ export const useResolvedYieldFlowData = ({
                 account,
                 tokenContract,
                 yieldId,
-                yieldOpportunities,
+                yieldOpportunities: yieldOpportunities ?? emptyYieldOpportunities,
             }),
         [account, tokenContract, yieldId, yieldOpportunities],
     );

--- a/suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts
+++ b/suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts
@@ -44,7 +44,7 @@ export const useStablecoinYieldListData = () => {
     const { data: yieldOpportunities, isLoading } = useAllYieldOpportunities();
 
     const listData = useMemo(() => {
-        if (isLoading) {
+        if (isLoading || !yieldOpportunities) {
             const promoListData: EarnPromoListDataItem[] = [
                 'stablecoin-yield',
                 ...STABLECOIN_SKELETON_ITEMS,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

During review of the separate branch I spotted some potential improvements to how TSQ is currently used and opening this PR to address issues:

```
3 + 4. A GET modeled as a mutation, then wrapped in a query
useGetYieldOpportunities.ts uses useMutation for a read (paginated list fetch). Docs: "mutations are typically used to create/update/delete data or perform server side-effects." Then useAllYieldOpportunities.ts calls that mutation's mutateAsync from inside a useQuery queryFn — a query driving a mutation driving the fetch. The mutationKey/mutation state is dead weight. Both should call getYields directly inside a query (and the paginated one is a textbook useInfiniteQuery).

5. Object-rest spreading the query result kills render optimization
return { ...queryResult, data: ... } in useYieldOpportunity.ts, useAllYieldOpportunities.ts, useGetMerklRewards.ts.

The result is a tracked proxy; rest-destructuring touches every property and disables the "only re-render on fields you use" optimization. TanStack ships a lint rule for exactly this (@tanstack/query/no-rest-destructuring). Consumers now re-render on every state transition (fetchStatus, etc.), not just the fields they read.

6. useYieldOpportunity reimplements select by hand
Same file — selectRef = useRef(select) + useMemo. This duplicates the built-in select option (which is memoized, integrates with structural sharing, and re-runs only when data or the selector ref changes). The hand-rolled version also captures only the first select (a changed selector is ignored). Use select and pass a stable reference (docs: render-optimizations → select).
```

## Notes for QA

Should work exactly like before

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily modifies earn/stablecoin yield hooks and a yield table UI component. Most changed files are in `suite-common/earn-stablecoin-api` and `suite-native/module-earn` which have no E2E test coverage — these are likely covered by unit tests or are mobile-only code paths. The `react-query` constants files (queryKeys, mutationKeys) and the `EarnYieldTable` component map to 121 tests each via transitive imports, but these are broad shared utilities unlikely to cause regressions in unrelated flows. The stablecoin/yield earn feature does not appear to have dedicated E2E tests in the suite. Risk is low for E2E regressions since the changes are concentrated in hooks and data-fetching layers rather than core navigation or transaction flows.

<details><summary><b>Changed files (11)</b></summary>

- `packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx`
- `suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewards.ts`
- `suite-common/earn-stablecoin-api/src/hooks/useAllYieldOpportunities.ts`
- `suite-common/earn-stablecoin-api/src/hooks/useGetVaultByAddress.ts`
- `suite-common/earn-stablecoin-api/src/hooks/useGetYieldOpportunities.ts`
- `suite-common/earn-stablecoin-api/src/hooks/useYieldOpportunity.ts`
- `suite-common/react-query/src/constants/mutationKeys.ts`
- `suite-common/react-query/src/constants/queryKeys.ts`
- `suite-common/react-query/src/index.ts`
- `suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts`
- `suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test crawls all application routes including /earn and /earn/yield/* paths. Changes to EarnYieldTable.tsx could cause rendering errors on earn pages that would break the link-checking crawl or produce broken links.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — The EarnYieldTable component is part of the earn/staking dashboard. ETH initial staking tests navigate to the staking tab which renders earn dashboard components. Changes to the yield table could affect the staking dashboard display.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — The stake-more test interacts with the staking dashboard which may render yield-related components. Changes to EarnYieldTable could affect the dashboard view where staking amounts and actions are displayed.

</details>

⚠️ **Changes with no test coverage (8)**
- `suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewards.ts`
- `suite-common/earn-stablecoin-api/src/hooks/useAllYieldOpportunities.ts`
- `suite-common/earn-stablecoin-api/src/hooks/useGetVaultByAddress.ts`
- `suite-common/earn-stablecoin-api/src/hooks/useGetYieldOpportunities.ts`
- `suite-common/earn-stablecoin-api/src/hooks/useYieldOpportunity.ts`
- `suite-common/react-query/src/index.ts`
- `suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts`
- `suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts`

_Updated: 2026-06-25T07:55:33.132Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=perf/tsq-destruct&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=perf/tsq-destruct&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=perf/tsq-destruct&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/perf/tsq-destruct/web/](https://dev.suite.sldev.cz/suite-web/perf/tsq-destruct/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-25T07:58:46.777Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-25T08:00:27.271Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->