### PR TITLE
feat(suite): add Tron staking promo banner

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -8,7 +8,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
 import { getNetworkAdjustedStakingBalance } from '@suite-common/staking';
 import { type NetworkType, getDisplaySymbol } from '@suite-common/wallet-config';
-import { selectAccountIsStakingActive, selectPoolStatsApy } from '@suite-common/wallet-core';
+import { selectAccountIsStakingActive } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import {
     calculateRewards,
@@ -21,6 +21,7 @@ import { exhaustive } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
+import { useStakingYield } from 'src/hooks/earn/useStakingYield';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 type StakingBannerProps = {
@@ -31,10 +32,14 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const { CryptoAmountFormatter } = useFormatters();
-    const { stakeEthBannerClosed, stakeSolBannerClosed, stakeCardanoBannerClosed } =
-        useSelector(selectFlags);
+    const {
+        stakeEthBannerClosed,
+        stakeSolBannerClosed,
+        stakeCardanoBannerClosed,
+        stakeTronBannerClosed,
+    } = useSelector(selectFlags);
     const { route } = useSelector(state => state.router);
-    const apy = useSelector(state => selectPoolStatsApy(state, { account }));
+    const { apy } = useStakingYield({ symbol: account.symbol, accountKey: account.key });
     const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
 
     const displaySymbol = getDisplaySymbol(account.symbol);
@@ -71,6 +76,7 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
                 dispatch(setFlag({ key: 'stakeCardanoBannerClosed', value: true }));
                 break;
             case 'tron':
+                dispatch(setFlag({ key: 'stakeTronBannerClosed', value: true }));
                 break;
             default:
                 if (isSupportedStakingNetworkSymbol(account.symbol)) {
@@ -113,7 +119,7 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
             case 'cardano':
                 return stakeCardanoBannerClosed;
             case 'tron':
-                return true;
+                return stakeTronBannerClosed;
             default:
                 if (isSupportedStakingNetworkSymbol(account.symbol)) {
                     exhaustive(

--- a/packages/suite/src/support/tests/hooksHelper.tsx
+++ b/packages/suite/src/support/tests/hooksHelper.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from 'react';
 import { IntlProvider } from 'react-intl';
 import { Provider } from 'react-redux';
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
     type RenderResult,
     act,
@@ -19,6 +20,10 @@ import { ConnectedThemeProvider } from 'src/support/suite/ConnectedThemeProvider
 import { type SuiteServices } from '../extraDependencies';
 import { ResponsiveContextProvider } from '../suite/ResponsiveContext';
 
+const testQueryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+});
+
 // used in hooks tests
 export const renderWithProviders = (
     store: any,
@@ -26,17 +31,19 @@ export const renderWithProviders = (
     children: ReactNode,
 ): RenderResult =>
     render(
-        <Provider store={store}>
-            <ServicesProvider services={services}>
-                <ConnectedThemeProvider>
-                    <ResponsiveContextProvider>
-                        <IntlProvider locale="en">
-                            <MockedFormatterProvider>{children}</MockedFormatterProvider>
-                        </IntlProvider>
-                    </ResponsiveContextProvider>
-                </ConnectedThemeProvider>
-            </ServicesProvider>
-        </Provider>,
+        <QueryClientProvider client={testQueryClient}>
+            <Provider store={store}>
+                <ServicesProvider services={services}>
+                    <ConnectedThemeProvider>
+                        <ResponsiveContextProvider>
+                            <IntlProvider locale="en">
+                                <MockedFormatterProvider>{children}</MockedFormatterProvider>
+                            </IntlProvider>
+                        </ResponsiveContextProvider>
+                    </ConnectedThemeProvider>
+                </ServicesProvider>
+            </Provider>
+        </QueryClientProvider>,
     );
 
 export const waitForLoader = (text = /Loading/i) => {

--- a/suite/e2e/fixtures/remembered-wallet-db-lite.json
+++ b/suite/e2e/fixtures/remembered-wallet-db-lite.json
@@ -15611,6 +15611,7 @@
                         "stakeEthBannerClosed": false,
                         "stakeSolBannerClosed": false,
                         "stakeCardanoBannerClosed": false,
+                        "stakeTronBannerClosed": false,
                         "showDashboardStakingPromoBanner": true,
                         "suspiciousTransactionsTooltipClosed": false,
                         "showCopyAddressModal": true,

--- a/suite/flags/src/flagsSlice.ts
+++ b/suite/flags/src/flagsSlice.ts
@@ -19,6 +19,7 @@ export type FlagsState = {
     stakeEthBannerClosed: boolean;
     stakeSolBannerClosed: boolean;
     stakeCardanoBannerClosed: boolean;
+    stakeTronBannerClosed: boolean;
     showDashboardStakingPromoBanner: boolean;
     suspiciousTransactionsTooltipClosed: boolean;
     showUnhideTokenModal: boolean;
@@ -50,6 +51,7 @@ export const flagsInitialState: FlagsState = {
     stakeEthBannerClosed: false,
     stakeSolBannerClosed: false,
     stakeCardanoBannerClosed: false,
+    stakeTronBannerClosed: false,
     showDashboardStakingPromoBanner: true,
     suspiciousTransactionsTooltipClosed: false,
     showCopyAddressModal: true,


### PR DESCRIPTION
## Description

Show Tron staking promo banner in account detail.

## Related Issue

Resolve #29030 

## Screenshots:

<img width="100%" alt="Screenshot 2026-06-24 at 09 57 32" src="https://github.com/user-attachments/assets/7f9e1660-dd6b-48be-b2f8-e17f708782f7" />

<img width="100%" alt="Screenshot 2026-06-24 at 09 58 12" src="https://github.com/user-attachments/assets/ac4a0eac-5f22-4e5d-aa87-1d850d1e37a4" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-staking-promo-banner&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-staking-promo-banner&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-staking-promo-banner&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-26T08:24:15.616Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |

</details>

_Updated: 2026-06-26T08:21:59.244Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-staking-promo-banner/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-staking-promo-banner/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->