### PR TITLE
fix(trading): add sentry logging for fee estimation fallback

### DIFF
--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -14,6 +14,7 @@
     "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
         "@reduxjs/toolkit": "2.12.0",
+        "@sentry/core": "10.53.1",
         "@suite-common/analytics": "workspace:*",
         "@suite-common/bluetooth": "workspace:*",
         "@suite-common/calldata": "workspace:*",

--- a/suite-common/wallet-core/src/send/reportEthereumFeeEstimationError.ts
+++ b/suite-common/wallet-core/src/send/reportEthereumFeeEstimationError.ts
@@ -1,0 +1,65 @@
+import { captureException, withScope } from '@sentry/core';
+
+import { type Account, type FormState } from '@suite-common/wallet-types';
+import { isEvmApprovalTx } from '@suite-common/wallet-utils';
+import { type TokenInfo } from '@trezor/connect';
+import { type SerializedError } from '@trezor/connect-common/src/constants/errors';
+
+interface ReportEthereumFeeEstimationFailedParams {
+    account: Account;
+    formState: FormState;
+    tokenInfo: TokenInfo | undefined;
+    estimateTarget: string;
+    error: SerializedError;
+}
+
+const reportedSignatures = new Set<string>();
+
+/**
+ * Reports an error when Ethereum fee estimation fails.
+ */
+export const reportEthereumFeeEstimationFailed = ({
+    account,
+    formState,
+    tokenInfo,
+    estimateTarget,
+    error,
+}: ReportEthereumFeeEstimationFailedParams): void => {
+    const isApproveTx = isEvmApprovalTx(formState.transactionData);
+    const isTokenTransfer = !!tokenInfo;
+    const isDexFlow = !!formState.ethereumAdjustGasLimit;
+    const toIsSelf = estimateTarget === account.descriptor;
+    const connectErrorCode = error.code ?? 'unknown';
+
+    const signature = [
+        account.symbol,
+        isTokenTransfer,
+        isApproveTx,
+        isDexFlow,
+        toIsSelf,
+        connectErrorCode,
+    ].join('|');
+    if (reportedSignatures.has(signature)) {
+        return;
+    }
+    reportedSignatures.add(signature);
+
+    withScope(scope => {
+        scope.setTag('error.code', 'eth_fee_estimation_failed');
+        scope.setTag('fee.network', account.symbol);
+        scope.setTag('fee.accountType', account.accountType);
+        scope.setTag('fee.isApproveTx', isApproveTx);
+        scope.setTag('fee.isTokenTransfer', isTokenTransfer);
+        scope.setTag('fee.isDexFlow', isDexFlow);
+        scope.setTag('fee.toIsSelf', toIsSelf);
+        scope.setTag('fee.hasTransactionData', !!formState.transactionData);
+        scope.setTag('fee.selectedFee', formState.selectedFee ?? 'unknown');
+        scope.setTag('fee.connectErrorCode', connectErrorCode);
+        scope.setExtra('connectErrorMessage', error.message);
+        captureException(
+            new Error(
+                `Ethereum fee estimation failed, using backup gas limit [${connectErrorCode}]`,
+            ),
+        );
+    });
+};

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -42,6 +42,7 @@ import {
 import TrezorConnect, { type FeeLevel, type TokenInfo } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
+import { reportEthereumFeeEstimationFailed } from './reportEthereumFeeEstimationError';
 import { SEND_MODULE_PREFIX } from './sendFormConstants';
 import {
     type ComposeFeeLevelsError,
@@ -263,6 +264,15 @@ export const composeEthereumTransactionFeeLevelsThunk = createThunk<
                     ? ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT
                     : ETH_TRANSFER_BACKUP_GAS_LIMIT,
             );
+
+            reportEthereumFeeEstimationFailed({
+                account,
+                formState,
+                tokenInfo,
+                estimateTarget: ethereumEstimateFeeParams.to,
+                error: estimatedFee.error,
+            });
+
             dispatch(
                 notificationsActions.addToast({
                     type: 'estimated-fee-error',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11199,6 +11199,7 @@ __metadata:
   dependencies:
     "@mobily/ts-belt": "npm:^3.13.1"
     "@reduxjs/toolkit": "npm:2.12.0"
+    "@sentry/core": "npm:10.53.1"
     "@suite-common/analytics": "workspace:*"
     "@suite-common/bluetooth": "workspace:*"
     "@suite-common/calldata": "workspace:*"


### PR DESCRIPTION
## Description

- Report Ethereum fee estimation failures to Sentry when the backup gas limit path is used.
- Attach network and transaction context tags so repeated failures can be grouped and diagnosed.
- Keep the existing backup gas limit fallback and toast flow unchanged.

## Notes for QA

Just a DEV thing.  Ping @sherpaPSX when you see the error ;)

## Related Issue
https://github.com/trezor/trezor-suite/issues/18060

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on Ethereum send form logic: sendFormEthereumThunks.ts handles Ethereum transaction composition and fee calculation, while reportEthereumFeeEstimationError.ts is a new or modified utility for reporting fee estimation errors. The highest risk is in any E2E flow that composes and sends Ethereum transactions with fee parameters (ETH send, ETH sell/swap with custom fees, ETH staking). The package.json change is likely a dependency version bump with minimal behavioral impact. Testing strategy should prioritize direct Ethereum send and fee-related flows.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/wallet-core/package.json`
- `suite-common/wallet-core/src/send/reportEthereumFeeEstimationError.ts`
- `suite-common/wallet-core/src/send/sendFormEthereumThunks.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — This test directly exercises the Ethereum send form with custom gas fee parameters (gas limit, max fee per gas, max priority fee per gas), which is the core functionality of sendFormEthereumThunks.ts. The reportEthereumFeeEstimationError change could affect fee estimation error handling in this exact flow.
- `suite/e2e/tests/wallet/send-base.test.ts` — This test sends a transaction on the Base (EVM L2) network with custom Ethereum fees and verifies gas limit, max fee per gas, and max priority fee per gas on the device. It directly exercises the Ethereum send thunks for an EVM-compatible chain.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test exercises the Ethereum sell flow including custom gas fee parameters (gas limit, max fee per gas, max priority fee per gas) and initiating a send transaction, which directly invokes the Ethereum send form thunks.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test specifically validates custom Ethereum fee settings (gas limit, max fee per gas, max priority fee per gas) during a swap transaction. The composedTransactionInfo Redux state it checks is populated by sendFormEthereumThunks.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — This test sells an ERC-20 token (USDC) through the Ethereum send flow, exercising Ethereum transaction composition including fee calculation. Changes to sendFormEthereumThunks could affect token send behavior.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking transactions go through the Ethereum send form thunks for transaction composition and fee estimation. The fee display and device prompt confirmation directly depend on sendFormEthereumThunks output.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstaking and claiming involve Ethereum transactions with fee estimation that flows through sendFormEthereumThunks. The test verifies fee amounts and transaction confirmation on device.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Staking more ETH composes an Ethereum transaction via sendFormEthereumThunks and verifies the fee and amount on the device prompt. Changes to fee estimation error reporting could affect this flow.
- `suite/e2e/tests/staking/staking-form.test.ts` — The ETH staking form validates amounts and displays fee information that depends on Ethereum transaction composition from sendFormEthereumThunks. Max staking amount calculation involves fee estimation.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/send-doge.test.ts` — While DOGE is not an Ethereum network, this test uses the broadcast send form and verifies toast error handling for signing failures. The package.json change could theoretically affect shared send infrastructure, though impact is unlikely.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/wallet-core/package.json`
- `suite-common/wallet-core/src/send/reportEthereumFeeEstimationError.ts`

_Updated: 2026-06-24T11:22:37.362Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/18060-sentry-fee-estimation-logging/web/](https://dev.suite.sldev.cz/suite-web/fix/18060-sentry-fee-estimation-logging/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/18060-sentry-fee-estimation-logging&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/18060-sentry-fee-estimation-logging&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/18060-sentry-fee-estimation-logging&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-24T11:27:27.255Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-24T11:25:43.504Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->