### PR TITLE
feat(suite): add tron staking to my assets on dashboard

### DIFF
--- a/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useDispatch } from 'react-redux';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
@@ -24,10 +23,10 @@ import {
 import { FiatHeader } from 'src/components/wallet/FiatHeader';
 import { useLoadingSkeleton, useSelector } from 'src/hooks/suite';
 
-import { AssetCardInfo, AssetCardInfoSkeleton } from './AssetCardInfo';
-import { AssetCardTokensAndStakingInfo } from './AssetCardTokensAndStakingInfo';
 import { AssetActionButton } from '../AssetActionButton';
 import { handleTokensAndStakingData } from '../assetsViewUtils';
+import { AssetCardInfo, AssetCardInfoSkeleton } from './AssetCardInfo';
+import { AssetCardTokensAndStakingInfo } from './AssetCardTokensAndStakingInfo';
 
 type AmountComponentProps = {
     failed: boolean;

--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -26,6 +26,7 @@ import {
     getFiatRateKey,
     isSupportedEthStakingNetworkSymbol,
     isSupportedSolStakingNetworkSymbol,
+    isSupportedTronStakingNetworkSymbol,
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode, TokenInfo } from '@trezor/blockchain-link-types';
@@ -154,7 +155,8 @@ export const AssetsView = () => {
             stakingAccounts: accounts.filter(
                 account =>
                     isSupportedEthStakingNetworkSymbol(account.symbol) ||
-                    isSupportedSolStakingNetworkSymbol(account.symbol),
+                    isSupportedSolStakingNetworkSymbol(account.symbol) ||
+                    isSupportedTronStakingNetworkSymbol(account.symbol),
             ),
             accounts,
             isStakeNetwork: getNetworkFeatures(symbol).includes('staking'),


### PR DESCRIPTION
## Description

Add Tron staking info to My Assets on Dashboard.

## Related Issue

Resolve #29049 

## Screenshots:

<img width="100%" alt="Screenshot 2026-06-24 at 13 41 02" src="https://github.com/user-attachments/assets/7b288b1e-ce15-490d-a786-af5634e30f08" />

<img width="100%" alt="Screenshot 2026-06-24 at 13 40 56" src="https://github.com/user-attachments/assets/a7e239ac-dea4-447c-8da5-7a80bf6997d3" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are scoped to two dashboard asset view components: AssetCard.tsx (individual asset card rendering) and AssetsView.tsx (the container/layout for the assets section). These are broadly imported across the app but only a handful of tests directly interact with asset cards, asset grid/table views, and dashboard-level asset actions. The highest risk is in tests that explicitly verify asset card content, layout toggling, and dashboard asset interactions (buy/stake buttons, discreet mode, asset activation). Most of the 99 statically-mapped tests only transitively import these files and don't exercise them meaningfully.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx`
- `packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test directly exercises the Assets section on the dashboard, including grid/table view toggling, buy buttons on asset cards, and enabling new assets via the Activate Assets modal. Both AssetCard.tsx and AssetsView.tsx are core components rendered by this test's interactions with the assetsSection (grid view, table view, asset contents verification).
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test verifies discreet mode hides balance values on asset cards and asset rows on the dashboard. It directly interacts with AssetCard fiat amounts and asset row fiat amounts, which are rendered by AssetCard.tsx within the AssetsView.tsx layout. Changes to these components could break the hidden/revealed balance display.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test navigates to staking from the dashboard assets section by clicking a stake button per coin. The stake button on the dashboard likely lives within the AssetCard or AssetsView components, so changes could affect the staking navigation entry point from the dashboard.
- `suite/e2e/tests/settings/coins.test.ts` — This test activates mainnet assets via the 'Activate Assets' modal from the dashboard empty state and verifies networks appear enabled. The empty state and asset activation flow are part of AssetsView.tsx, and changes there could affect the empty state rendering or the activation modal trigger.
- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates to the Buy trading form from the dashboard asset card (buyButton on dashboardPage). The buy button on the asset card is rendered by AssetCard.tsx, so changes could break the trading navigation entry point from the dashboard.

</details>

_Updated: 2026-06-24T11:47:27.007Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/dashboard-tron-staking&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/dashboard-tron-staking&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-24T11:52:15.610Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-24T11:50:48.824Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/dashboard-tron-staking/web/](https://dev.suite.sldev.cz/suite-web/feat/dashboard-tron-staking/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->