### PR TITLE
fix(suite): do not show tron votes when there are none

### DIFF
--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx
@@ -39,6 +39,7 @@ export const TronStakedCard = ({ account }: TronStakedCardProps) => {
     const remainingVotes = getTronAvailableVotingPower(account);
     const totalVotes = getTronTotalVotingPower(account);
     const hasRemainingVotes = new BigNumber(remainingVotes).gt(0);
+    const shouldShowRemainingVotes = new BigNumber(remainingVotes).plus(totalVotes).gt(0);
 
     const goToFlow = (routeName: 'earn-tron-stake' | 'earn-tron-unstake' | 'earn-tron-vote') =>
         dispatch(
@@ -131,12 +132,16 @@ export const TronStakedCard = ({ account }: TronStakedCardProps) => {
                         </Row>
                     </Tooltip>
                 ) : (
-                    <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
-                        <Translation
-                            id="TR_EARN_TRON_REMAINING_VOTES"
-                            values={{ remaining: remainingVotes, total: totalVotes }}
-                        />
-                    </Text>
+                    <>
+                        {shouldShowRemainingVotes && (
+                            <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                                <Translation
+                                    id="TR_EARN_TRON_REMAINING_VOTES"
+                                    values={{ remaining: remainingVotes, total: totalVotes }}
+                                />
+                            </Text>
+                        )}
+                    </>
                 )}
             </Row>
         </Card>


### PR DESCRIPTION
## Description

Hide `0/0 remaining votes`, instead show nothing in Tron staking dashboard.

## Related Issue

Resolve #29050 

## Screenshots:

<img width="100%" alt="Screenshot 2026-06-24 at 13 53 51" src="https://github.com/user-attachments/assets/10980713-d39e-4992-bfb6-a4051647239e" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is `TronStakedCard.tsx`, a component within the Tron Staking Dashboard. No existing E2E tests were found via static mapping, and reviewing the LLM analysis of all 131 candidate tests reveals no test that covers Tron staking dashboard functionality. The staking tests that exist cover ETH (initial-stake, stake-more, unstake, staking-form), ADA (claim, stake, unstake), and SOL (initial-stake, rewards, stake-more, unstake), but none exercise the Tron-specific staking UI. The `check-links.test.ts` does navigate to `/earn/tron/*` routes but only validates that links on those pages return HTTP 200 — it does not interact with the TronStakedCard component. This change has no meaningful E2E test coverage.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx`

_Updated: 2026-06-24T12:01:52.133Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tron-votes-empty-state&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tron-votes-empty-state&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-24T12:07:30.967Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-24T12:05:32.336Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tron-votes-empty-state/web/](https://dev.suite.sldev.cz/suite-web/fix/tron-votes-empty-state/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->