### PR TITLE
chore(suite): clarify discovery selectors

### DIFF
--- a/packages/suite/src/utils/suite/sentry.ts
+++ b/packages/suite/src/utils/suite/sentry.ts
@@ -36,6 +36,7 @@ export const reportToSentry = (error: any) => (_: Dispatch, getState: GetState) 
     const instanceId = selectAnalyticsInstanceId(getState());
     const enabledNetworks = selectEnabledNetworks(getState());
     const device = selectSelectedDevice(getState());
+    // Although discoveryReducer contains sensitive information (staticSessionId), this is a discovery status selected for a particular device (no id there)
     const discovery = selectDiscoveryForSelectedDevice(getState());
     const redactedActionsLog = selectRedactedActionsLog(getState(), true);
 

--- a/suite-common/wallet-core/src/discovery/discoverySelectors.ts
+++ b/suite-common/wallet-core/src/discovery/discoverySelectors.ts
@@ -7,7 +7,9 @@ import { type DiscoveryRootState } from './discoveryReducer';
 export const selectDiscoveryByDevicePath = (state: DiscoveryRootState, path?: DeviceUniquePath) =>
     path !== undefined ? state.wallet.discovery[path] : undefined;
 
-export const selectDiscoveryForSelectedDevice = (state: DiscoveryRootState & DeviceRootState) => {
+export const selectDiscoveryForSelectedDevice = (
+    state: DiscoveryRootState & DeviceRootState,
+): DiscoveryStatus | undefined => {
     const selectedDevice = selectSelectedDevice(state);
 
     return selectDiscoveryByDevicePath(state, selectedDevice?.path);
@@ -34,7 +36,7 @@ export function isDiscoveryInProgress(
     );
 }
 
-export const selectHasRunningDiscovery = (state: DiscoveryRootState & DeviceRootState) => {
+export const selectHasRunningDiscovery = (state: DiscoveryRootState & DeviceRootState): boolean => {
     const discovery = selectDiscoveryForSelectedDevice(state);
 
     return isDiscoveryInProgress(discovery);
@@ -46,12 +48,12 @@ export const selectHasRunningDiscovery = (state: DiscoveryRootState & DeviceRoot
 export const selectIsDiscoveryStatusConfirmEmptyPassphrase = (
     state: DiscoveryRootState & DeviceRootState,
     path?: DeviceUniquePath,
-) => selectDiscoveryByDevicePath(state, path)?.status === 'confirm-empty-passphrase';
+): boolean => selectDiscoveryByDevicePath(state, path)?.status === 'confirm-empty-passphrase';
 
 export const selectIsCreatingNewPassphraseWallet = (
     state: DiscoveryRootState & DeviceRootState,
-) => {
+): boolean => {
     const discovery = selectDiscoveryForSelectedDevice(state);
 
-    return discovery?.isAddingHiddenWallet;
+    return discovery?.isAddingHiddenWallet === true;
 };

--- a/suite-native/passphrase/src/components/PassphraseScreenHeader.tsx
+++ b/suite-native/passphrase/src/components/PassphraseScreenHeader.tsx
@@ -5,7 +5,10 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
-import { cancelDiscoveryThunk } from '@suite-common/wallet-core';
+import {
+    cancelDiscoveryThunk,
+    selectIsCreatingNewPassphraseWallet,
+} from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { IconButton, ScreenHeaderWrapper } from '@suite-native/atoms';
@@ -22,8 +25,6 @@ import {
     useNavigateToInitialScreen,
 } from '@suite-native/navigation';
 import TrezorConnect from '@trezor/connect';
-
-import { selectIsCreatingNewPassphraseWallet } from '../passphraseSelectors';
 
 type NavigationProp = StackToTabCompositeProps<
     AuthorizeDeviceStackParamList,

--- a/suite-native/passphrase/src/passphraseSelectors.ts
+++ b/suite-native/passphrase/src/passphraseSelectors.ts
@@ -1,9 +1,5 @@
 import type { DeviceRootState } from '@suite-common/device';
-import {
-    type DiscoveryRootState,
-    selectDiscoveryByDevicePath,
-    selectIsCreatingNewPassphraseWallet,
-} from '@suite-common/wallet-core';
+import { type DiscoveryRootState, selectDiscoveryByDevicePath } from '@suite-common/wallet-core';
 
 /**
  * Returns true if discovery failed due to passphrase flow (cancelled, wrong passphrase, modal dismissed).
@@ -38,8 +34,6 @@ export const selectHasPassphraseIncorrectError = (state: DiscoveryRootState & De
 
     return discovery?.status === 'failed' && discovery?.error === 'Passphrase is incorrect';
 };
-
-export { selectIsCreatingNewPassphraseWallet };
 
 export const selectPassphraseDeviceNotEmpty = (state: DiscoveryRootState & DeviceRootState) => {
     const discovery = selectDiscoveryByDevicePath(state, state.device.selectedDevice?.path);


### PR DESCRIPTION
## Description

A little cleanup around some selectors related to discovery:
- especially make it clear in Sentry code that we are not sending anything sensitive
  - i.e. **not** the whole map of staticSessionId => discoveryStatus
- add explicit typing to make selectors understandable when name doesn't make it clear
- remove useless reexport

## Notes for QA

N/A, just comments and typescript

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies four files: two broad shared utilities (sentry.ts and discoverySelectors.ts each mapped to 121+ tests) and two suite-native mobile-only files with no E2E coverage. The sentry.ts change is an error-reporting utility unlikely to affect any specific test behavior, so no tests are recommended for it. The discoverySelectors.ts change has the highest risk since discovery status is explicitly checked in several tests. The two suite-native passphrase files are mobile-only components with no web/desktop E2E test coverage. The recommended strategy focuses on tests that explicitly assert on discovery state transitions or gate UI behavior on discovery completion.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/utils/suite/sentry.ts`
- `suite-common/wallet-core/src/discovery/discoverySelectors.ts`
- `suite-native/passphrase/src/components/PassphraseScreenHeader.tsx`
- `suite-native/passphrase/src/passphraseSelectors.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — This test directly exercises the wallet discovery process including checking Redux state 'wallet.discovery' status transitions (starting → complete). Changes to discoverySelectors.ts could break discovery status reporting, which this test explicitly asserts on.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test verifies discovery completes successfully after configuring custom backends, using page.discoveryShouldFinish() which likely depends on discovery selectors to determine completion status.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test exercises the wallet discovery flow (eject wallet, add standard wallet, verify balance appears), which relies on discovery state managed by the changed discoverySelectors.
- `suite/e2e/tests/settings/coins.test.ts` — This test activates coin networks and verifies discovery finishes (page.discoveryShouldFinish), and checks the dashboard empty discovery state — both of which depend on discovery selectors for status determination.
- `suite/e2e/tests/settings/forget-device.test.ts` — This test explicitly checks that the Forget button is disabled during active discovery and enabled after discovery finishes, directly testing UI behavior gated by discovery state from discoverySelectors.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-native/passphrase/src/components/PassphraseScreenHeader.tsx`
- `suite-native/passphrase/src/passphraseSelectors.ts`

_Updated: 2026-06-24T13:24:19.832Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/clarify-discovery-selectors/web/](https://dev.suite.sldev.cz/suite-web/chore/clarify-discovery-selectors/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/clarify-discovery-selectors&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/clarify-discovery-selectors&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/clarify-discovery-selectors&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-24T13:29:25.616Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-24T13:27:52.477Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->