### PR TITLE
fix(utils): cap bytesToHumanReadable at the largest unit instead of looping forever

### DIFF
--- a/packages/utils/src/bytesToHumanReadable.ts
+++ b/packages/utils/src/bytesToHumanReadable.ts
@@ -9,7 +9,8 @@ export const bytesToHumanReadable = (bytes: number): string => {
     let size = Math.abs(bytes);
     let i = 0;
 
-    while (size >= 1024 || i >= units.length) {
+    // divide down until the value fits, but stop at the largest unit ('TB')
+    while (size >= 1024 && i < units.length - 1) {
         size /= 1024;
         i++;
     }

--- a/packages/utils/tests/bytesToHumanReadable.test.ts
+++ b/packages/utils/tests/bytesToHumanReadable.test.ts
@@ -1,0 +1,23 @@
+import { bytesToHumanReadable } from '../src/bytesToHumanReadable';
+
+describe(bytesToHumanReadable.name, () => {
+    it('formats sizes using the appropriate unit', () => {
+        expect(bytesToHumanReadable(0)).toBe('0.0 B');
+        expect(bytesToHumanReadable(512)).toBe('512.0 B');
+        expect(bytesToHumanReadable(1024)).toBe('1.0 KB');
+        expect(bytesToHumanReadable(1536)).toBe('1.5 KB');
+        expect(bytesToHumanReadable(1024 ** 2)).toBe('1.0 MB');
+        expect(bytesToHumanReadable(1024 ** 3)).toBe('1.0 GB');
+        expect(bytesToHumanReadable(1024 ** 4)).toBe('1.0 TB');
+    });
+
+    it('uses the absolute value for negative input', () => {
+        expect(bytesToHumanReadable(-2048)).toBe('2.0 KB');
+    });
+
+    it('caps at the largest unit instead of looping forever for >= 1 PB', () => {
+        // on the previous implementation these inputs caused an infinite loop
+        expect(bytesToHumanReadable(1024 ** 5)).toBe('1024.0 TB');
+        expect(bytesToHumanReadable(1024 ** 6)).toBe('1048576.0 TB');
+    });
+});


### PR DESCRIPTION
## Description

`bytesToHumanReadable` had a safety-cap clause written with the wrong operator: `while (size >= 1024 || i >= units.length)`. Once `i` reached `units.length`, the `|| i >= units.length` part stayed permanently true, so the loop never terminated — an infinite loop (process/UI hang) for inputs `>= 1 PB`.

### Fix

`while (size >= 1024 && i < units.length - 1)` — stop at the largest available unit (`TB`) instead of running off the end of the array.

### Test

Added a unit test (the function had none): normal units, negative input, and the `>= 1 PB` cap case — the last one hung forever on the previous implementation.

## Notes for QA

No QA needed. The three real call sites (`os.totalmem()`, app-update download progress) never produce `>= 1 PB`, so this is a latent-only fix with no observable change for real inputs. Pure-function unit test only.

---

Part of the small split-out series from #28977.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to `packages/utils/src/bytesToHumanReadable.ts` and its corresponding unit test file. This is a pure utility function that converts byte counts to human-readable strings (e.g., "1.5 MB"). None of the 43 candidate E2E tests reference or exercise `bytesToHumanReadable` in their behaviors, assertions, or source hints. The function is likely used in niche UI contexts (e.g., displaying file sizes) that are not covered by any of the analyzed E2E tests. The unit test file itself provides direct coverage of the changed logic, so the risk of undetected regression via E2E tests is very low. No E2E tests are recommended.

<details><summary><b>Changed files (2)</b></summary>

- `packages/utils/src/bytesToHumanReadable.ts`
- `packages/utils/tests/bytesToHumanReadable.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/utils/src/bytesToHumanReadable.ts`
- `packages/utils/tests/bytesToHumanReadable.test.ts`

_Updated: 2026-06-24T13:59:26.105Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/byteshumanreadable-overflow-cap/web/](https://dev.suite.sldev.cz/suite-web/mroz22/byteshumanreadable-overflow-cap/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/byteshumanreadable-overflow-cap&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/byteshumanreadable-overflow-cap&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-24T14:05:24.229Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-24T14:03:23.482Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->