### PR TITLE
fix(wallet-utils): sum staked and free Tron bandwidth instead of taking max

### DIFF
--- a/suite-common/wallet-utils/src/__tests__/tronUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/tronUtils.test.ts
@@ -1,7 +1,7 @@
 import { type GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
 import { type TronAccountExtraData } from '@trezor/blockchain-link-types';
 
-import { calculateTronFeeBreakdown } from '../tronUtils';
+import { calculateTronFeeBreakdown, computeBandwidthFeeLevel } from '../tronUtils';
 
 const makeTrc20Tx = (overrides: Record<string, unknown> = {}): GeneralPrecomposedTransaction =>
     ({
@@ -61,6 +61,20 @@ describe(calculateTronFeeBreakdown.name, () => {
         );
         expect(result?.trxBurned.toString()).toBe('0.3');
         expect(result?.coveredBandwidth.toNumber()).toBe(0);
+    });
+
+    it('native TRX: combined staked + free bandwidth covers the tx — 0 TRX burned', () => {
+        // Tx: bandwidth: 300
+        // Account: staked 200 + free 200 = 400 (neither pool alone is enough)
+        // Expected: trxBurned: 0 TRX, coveredBandwidth: 300
+        // Regression: Math.max(200, 200) = 200 < 300 would wrongly burn 0.3 TRX.
+        const result = calculateTronFeeBreakdown(
+            makeNativeTrxTx(),
+            makeTronResources({ availableStakedBandwidth: 200, availableFreeBandwidth: 200 }),
+            'trx',
+        );
+        expect(result?.trxBurned.toNumber()).toBe(0);
+        expect(result?.coveredBandwidth.toNumber()).toBe(300);
     });
 
     it('TRC-20: has bandwidth, has energy — 0 TRX burned', () => {
@@ -157,5 +171,28 @@ describe(calculateTronFeeBreakdown.name, () => {
         expect(result?.trxBurned.toString()).toBe('1');
         expect(result?.coveredBandwidth.toNumber()).toBe(300);
         expect(result?.coveredEnergy.toNumber()).toBe(1000);
+    });
+});
+
+describe(computeBandwidthFeeLevel.name, () => {
+    it('sums staked and free bandwidth — no fee when the combined pools cover the tx', () => {
+        // staked 200 + free 200 = 400 >= 300 bytes.
+        // Regression: Math.max(200, 200) = 200 < 300 would charge a bandwidth fee.
+        const fee = computeBandwidthFeeLevel({
+            availableStakedBandwidth: 200,
+            availableFreeBandwidth: 200,
+            bytes: 300,
+        });
+        expect(fee.feePerTx).toBe('0');
+    });
+
+    it('charges the bandwidth cost when the combined pools fall short', () => {
+        // staked 100 + free 100 = 200 < 300 bytes -> 300 * 1000 sun
+        const fee = computeBandwidthFeeLevel({
+            availableStakedBandwidth: 100,
+            availableFreeBandwidth: 100,
+            bytes: 300,
+        });
+        expect(fee.feePerTx).toBe('300000');
     });
 });

--- a/suite-common/wallet-utils/src/tronUtils.ts
+++ b/suite-common/wallet-utils/src/tronUtils.ts
@@ -20,7 +20,7 @@ export const computeBandwidthFeeLevel = ({
     availableFreeBandwidth: number;
     bytes: number;
 }): TronFeeLevel => {
-    const availableBandwidth = Math.max(availableStakedBandwidth, availableFreeBandwidth);
+    const availableBandwidth = availableStakedBandwidth + availableFreeBandwidth;
     const feeInSun = availableBandwidth < bytes ? bytes * tronUtils.TRON_BANDWIDTH_SUN_PRICE : 0;
 
     return {
@@ -52,8 +52,7 @@ export const calculateTronFeeBreakdown = (
     const energyConsumed = 'energyConsumed' in tx ? (tx.energyConsumed ?? 0) : 0;
     const bandwidthBytes = tx.bytes ?? 0;
 
-    const isBandwidthCovered =
-        Math.max(availableStakedBandwidth, availableFreeBandwidth) >= bandwidthBytes;
+    const isBandwidthCovered = availableStakedBandwidth + availableFreeBandwidth >= bandwidthBytes;
     const coveredBandwidth = new BigNumber(isBandwidthCovered ? bandwidthBytes : 0);
     const coveredEnergy = new BigNumber(Math.min(availableEnergy, energyConsumed));
 


### PR DESCRIPTION
## Description

Tron bandwidth is consumed from **both** the free daily allowance and staked bandwidth, so the total available bandwidth is their **sum**. `computeBandwidthFeeLevel` and `calculateTronFeeBreakdown` used `Math.max(staked, free)`, which understates the total whenever both pools are non-zero.

Effect: a staker whose combined bandwidth covers the transaction (but neither pool alone does) was told the bandwidth wasn't covered, and was shown a phantom bandwidth fee / TRX burn that wouldn't actually be charged.

### Fix

`Math.max(staked, free)` → `staked + free` in both functions.

### Test

Extended `tronUtils.test.ts` with the combined-pool case (free 200 + staked 200 covering a 300-byte tx) for both functions — these fail on the old `Math.max` and pass on the fix. The existing cases all kept one pool at zero, so they couldn't catch this.

## Notes for QA

Affects Tron fee display for accounts that have **both** staked (frozen) and free bandwidth. Test: a Tron account where each pool alone is below the tx size but together they cover it should now show no bandwidth TRX burn. Non-stakers (free bandwidth only) are unaffected.

---

Part of the small split-out series from #28977.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change modifies tronUtils.ts and its unit test file. The tronUtils module is Tron-specific utility code, but it maps to 121 E2E tests via transitive imports through the wallet-utils barrel export. The vast majority of those 121 tests (analytics, backup, onboarding, metadata, trading, staking, etc.) have no Tron-related behavior and would not exercise tronUtils code paths. The only E2E test with concrete Tron-related behavior is the receive test, which explicitly tests TRX address receiving. The unit test file (tronUtils.test.ts) provides direct coverage of the utility itself. Overall risk is low — this is a narrowly scoped change to Tron-specific utilities.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-utils/src/__tests__/tronUtils.test.ts`
- `suite-common/wallet-utils/src/tronUtils.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — This test covers receiving TRX (Tron) transactions, including address reveal and format validation. Changes to tronUtils.ts could affect TRX address handling, formatting, or validation used in the receive flow.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-utils/src/__tests__/tronUtils.test.ts`

_Updated: 2026-06-24T13:41:15.229Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/tron-bandwidth-sum&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/tron-bandwidth-sum&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-24T13:45:57.034Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-24T13:44:49.707Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/tron-bandwidth-sum/web/](https://dev.suite.sldev.cz/suite-web/mroz22/tron-bandwidth-sum/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->