### PR TITLE
fix(suite): show legacy labels read-only on old Trezor with Suite Sync on

### DIFF
--- a/suite/metadata/src/__tests__/selectIsLegacyLabelingVisible.test.ts
+++ b/suite/metadata/src/__tests__/selectIsLegacyLabelingVisible.test.ts
@@ -1,0 +1,101 @@
+import { deviceReducerInitialState } from '@suite-common/device';
+import { messageSystemInitialState } from '@suite-common/message-system';
+import { type SuiteSyncState, initialSuiteSyncState } from '@suite-common/suite-sync';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { type StaticSessionId, type UnavailableCapabilities } from '@trezor/connect';
+
+import { initialMetadataState } from '../metadataReducer';
+import {
+    type LegacyLabelingVisibleRootState,
+    selectIsLegacyLabelingVisible,
+} from '../selectIsLegacyLabelingVisible';
+
+const DEVICE_STATIC_SESSION_ID: StaticSessionId = '1@2:3';
+
+const createMockState = ({
+    isMetadataEnabled,
+    isSuiteSyncEnabled,
+    unavailableCapabilities,
+}: {
+    isMetadataEnabled: boolean;
+    isSuiteSyncEnabled: boolean;
+    unavailableCapabilities: UnavailableCapabilities;
+}) => {
+    const device = mockSuiteDevice({
+        unavailableCapabilities,
+        state: { staticSessionId: DEVICE_STATIC_SESSION_ID },
+    });
+
+    return {
+        device: {
+            ...deviceReducerInitialState,
+            devices: [device],
+            selectedDevice: device,
+        },
+        suiteSync: {
+            ...initialSuiteSyncState,
+            settings: {
+                ...initialSuiteSyncState.settings,
+                isSuiteSyncEnabled,
+            },
+        } as SuiteSyncState,
+        metadata: {
+            ...initialMetadataState,
+            enabled: isMetadataEnabled,
+        },
+        messageSystem: messageSystemInitialState,
+    } as LegacyLabelingVisibleRootState;
+};
+
+describe(selectIsLegacyLabelingVisible.name, () => {
+    it('is not visible when legacy metadata is disabled', () => {
+        const state = createMockState({
+            isMetadataEnabled: false,
+            isSuiteSyncEnabled: false,
+            unavailableCapabilities: {},
+        });
+
+        expect(selectIsLegacyLabelingVisible(state)).toBe(false);
+    });
+
+    it('is visible when legacy metadata is enabled and Suite Sync is disabled', () => {
+        const state = createMockState({
+            isMetadataEnabled: true,
+            isSuiteSyncEnabled: false,
+            unavailableCapabilities: {},
+        });
+
+        expect(selectIsLegacyLabelingVisible(state)).toBe(true);
+    });
+
+    it('is not visible when Suite Sync is enabled and the device supports Suite Sync', () => {
+        const state = createMockState({
+            isMetadataEnabled: true,
+            isSuiteSyncEnabled: true,
+            unavailableCapabilities: {},
+        });
+
+        expect(selectIsLegacyLabelingVisible(state)).toBe(false);
+    });
+
+    it('stays visible when Suite Sync is enabled but the device only needs a firmware upgrade', () => {
+        const state = createMockState({
+            isMetadataEnabled: true,
+            isSuiteSyncEnabled: true,
+            unavailableCapabilities: { evolu: 'update-required' },
+        });
+
+        // update-required devices are still considered Suite Sync supported, so legacy labels hide.
+        expect(selectIsLegacyLabelingVisible(state)).toBe(false);
+    });
+
+    it('is visible (read-only) on an old Trezor without Suite Sync support even when Suite Sync is enabled', () => {
+        const state = createMockState({
+            isMetadataEnabled: true,
+            isSuiteSyncEnabled: true,
+            unavailableCapabilities: { evolu: 'no-capability' },
+        });
+
+        expect(selectIsLegacyLabelingVisible(state)).toBe(true);
+    });
+});

--- a/suite/metadata/src/selectIsLegacyLabelingVisible.ts
+++ b/suite/metadata/src/selectIsLegacyLabelingVisible.ts
@@ -1,15 +1,35 @@
+import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
 import { type MessageSystemRootState } from '@suite-common/message-system';
-import { type WithSuiteSyncState, selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
+import {
+    type WithSuiteSyncState,
+    isSuiteSyncSupportedByDevice,
+    selectIsSuiteSyncEnabled,
+} from '@suite-common/suite-sync';
 
 import { type MetadataRootState, selectIsMetadataEnabled } from './metadataReducer';
 
 export type LegacyLabelingVisibleRootState = MetadataRootState &
     WithSuiteSyncState &
-    MessageSystemRootState;
+    MessageSystemRootState &
+    DeviceRootState;
 
 export const selectIsLegacyLabelingVisible = (state: LegacyLabelingVisibleRootState) => {
-    const suiteSyncEnabled = selectIsSuiteSyncEnabled(state);
     const isMetadataEnabled = selectIsMetadataEnabled(state);
 
-    return !suiteSyncEnabled && isMetadataEnabled;
+    if (!isMetadataEnabled) {
+        return false;
+    }
+
+    const suiteSyncEnabled = selectIsSuiteSyncEnabled(state);
+
+    if (!suiteSyncEnabled) {
+        return true;
+    }
+
+    // Suite Sync is enabled, but old Trezor devices without the Evolu capability can't use it.
+    // For those, previously created legacy labels are still displayed (read-only — editing is
+    // blocked separately via getIsSuiteSyncLabelingActionEnabled('unsupported')).
+    const device = selectSelectedDevice(state);
+
+    return !isSuiteSyncSupportedByDevice(device);
 };


### PR DESCRIPTION
## Description

Old Trezor devices without the Evolu capability (`unavailableCapabilities.evolu === 'no-capability'`) cannot use Suite Sync. When Suite Sync was enabled globally, their previously-created **legacy labels were hidden entirely**, because `selectIsLegacyLabelingVisible` only returned `true` when Suite Sync was off.

This fixes `selectIsLegacyLabelingVisible` so legacy labels stay **visible (read-only)** on such devices even when Suite Sync is enabled.

## Notes for QA

**Happy paths**
- Model One / Model T (no secure element), Suite Sync ON, existing legacy labels → labels still displayed
- Same device → confirm labels are **read-only** (edit/add affordance disabled everywhere)
- Verify display across surfaces: account label, wallet label, receive/used addresses, transaction target, coin-control UTXOs, Settings → General

**Edge cases**
- Suite Sync–capable device (Safe 3 / Safe 5), Suite Sync ON → legacy labels stay **hidden** (unchanged)
- Device needing firmware upgrade (`update-required`), Suite Sync ON → labels **hidden**, editing still enabled (unchanged)
- Suite Sync OFF + metadata enabled, any device → labels visible **and editable** (unchanged)
- Metadata/labeling disabled → no labels shown at all
- Model One / Model T, Suite Sync ON, no prior legacy labels → empty, no edit option
- Reconnect / switch between old (Model T) and Suite-Sync-capable device → label visibility flips correctly per device

## Related Issue

Closes #28370

## Changes

- `selectIsLegacyLabelingVisible` now also returns `true` when Suite Sync is enabled but the selected device does not support Suite Sync (added `DeviceRootState` to the root-state type).
- Editing remains blocked for these devices via the existing `getIsSuiteSyncLabelingActionEnabled('unsupported')` path — no change needed there.
- Added a unit test covering the full visibility matrix (5 cases).

## Notes

- Scoped to `no-capability` ("old Trezor", matching the issue title). `update-required` devices are treated as Suite Sync supported and keep their existing edit-enabled behavior; the change is strictly additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change modifies selectIsLegacyLabelingVisible, a selector that controls whether the legacy labeling/metadata UI is visible to users, along with its unit test. This is a focused change but has broad impact across all legacy metadata/labeling E2E tests since they depend on the legacy labeling feature being accessible. The unit test file change is self-covering. The recommended strategy prioritizes tests that exercise the enable/disable/lifecycle of legacy labeling (high), then tests that use legacy labeling as a prerequisite for their flows (medium), and error-handling edge cases (low).

<details><summary><b>Changed files (2)</b></summary>

- `suite/metadata/src/__tests__/selectIsLegacyLabelingVisible.test.ts`
- `suite/metadata/src/selectIsLegacyLabelingVisible.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — This test directly exercises the legacy labeling lifecycle including enabling/disabling legacy labeling, which is the exact feature controlled by selectIsLegacyLabelingVisible. Changes to the visibility selector could affect whether the legacy labeling UI appears, persists across sessions, or can be toggled.
- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — This test enables/disables/disconnects legacy metadata labeling providers and verifies labels appear/disappear in the UI. The selectIsLegacyLabelingVisible selector likely controls whether legacy labeling UI elements are shown, directly impacting this test's assertions about label visibility after connect/disconnect cycles.
- `suite/e2e/tests/metadata/legacy/switching-providers.test.ts` — This test switches between legacy metadata providers (Dropbox/Google) and verifies provider disconnect/reconnect flows. The selectIsLegacyLabelingVisible selector determines whether the legacy labeling UI is visible, which directly impacts the connect/disconnect provider buttons and label editing flows tested here.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test enables legacy labeling with Dropbox and edits account labels. If selectIsLegacyLabelingVisible incorrectly returns false, the legacy labeling UI would not appear and label editing would fail.
- `suite/e2e/tests/metadata/legacy/interval-fetching.test.ts` — This test enables legacy labeling and verifies labels are periodically fetched from cloud providers. The visibility selector could gate whether the legacy labeling feature is active and fetching labels.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test uses legacy Dropbox labeling to label transaction outputs. The selectIsLegacyLabelingVisible selector likely controls whether legacy labeling UI is rendered, affecting the ability to add/edit output labels.
- `suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — This test enables legacy labeling with Dropbox for wallet labels. Changes to the visibility selector could prevent the legacy labeling UI from appearing for wallet-level label management.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test migrates from legacy Dropbox labeling to Suite Sync. The selectIsLegacyLabelingVisible selector likely determines whether the legacy labeling option is shown in the UI, which is a prerequisite for the migration flow.
- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — This test migrates legacy local file labels to Suite Sync. The visibility selector for legacy labeling affects whether the legacy labeling feature can be enabled as the starting point of the migration.
- `suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — This test enables legacy labeling with Google provider to label addresses. The visibility selector controls whether the legacy labeling option appears in settings, which is required for this test's flow.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts` — This test handles Dropbox API error scenarios during legacy labeling. While it depends on legacy labeling being visible/enabled, it primarily tests error handling rather than the visibility logic itself.
- `suite/e2e/tests/metadata/legacy/google-api-errors.test.ts` — This test handles Google API error scenarios during legacy labeling configuration. It depends on legacy labeling being accessible but primarily tests error handling paths.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/metadata/src/__tests__/selectIsLegacyLabelingVisible.test.ts`

_Updated: 2026-06-24T21:16:46.507Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/show-legacy-labels-for-older-devices&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/show-legacy-labels-for-older-devices&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-24T21:20:34.616Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-24T21:20:09.586Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/show-legacy-labels-for-older-devices/web/](https://dev.suite.sldev.cz/suite-web/fix/show-legacy-labels-for-older-devices/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->