### PR TITLE
fix(address): skip labeled used-like receive paths

### DIFF
--- a/suite-common/address/src/__tests__/getFirstFreshAddress.test.ts
+++ b/suite-common/address/src/__tests__/getFirstFreshAddress.test.ts
@@ -120,6 +120,67 @@ describe(getFirstFreshAddress.name, () => {
         });
     });
 
+    it('returns the next address after a labeled unused address', () => {
+        const account = mockWalletAccount({
+            symbol: 'test',
+            path: "m/84'/1'/0'",
+            descriptor: asAccountDescriptor('descriptorTest'),
+            history: { total: 13, tokens: 0, unconfirmed: 0 },
+            addresses: {
+                used: [],
+                unused: [
+                    {
+                        address: 'tb1q-skipped',
+                        path: "m/84'/1'/0'/0/138",
+                        balance: '0',
+                        sent: '0',
+                        received: '0',
+                        transfers: 0,
+                    },
+                    {
+                        address: 'tb1q-labeled',
+                        path: "m/84'/1'/0'/0/140",
+                        balance: '0',
+                        sent: '0',
+                        received: '0',
+                        transfers: 0,
+                    },
+                    {
+                        address: 'tb1q-fresh',
+                        path: "m/84'/1'/0'/0/141",
+                        balance: '0',
+                        sent: '0',
+                        received: '0',
+                        transfers: 0,
+                    },
+                ],
+                change: [],
+            },
+        });
+
+        expect(
+            getFirstFreshAddress(
+                account,
+                [
+                    {
+                        path: "m/84'/1'/0'/0/140",
+                        address: 'tb1q-labeled',
+                        isVerified: false,
+                    },
+                ],
+                [],
+                true,
+            ),
+        ).toEqual({
+            address: 'tb1q-fresh',
+            balance: '0',
+            path: "m/84'/1'/0'/0/141",
+            received: '0',
+            sent: '0',
+            transfers: 0,
+        });
+    });
+
     it('returns the descriptor-based receive address for non-utxo accounts', () => {
         const account = mockWalletAccount({
             symbol: 'xrp',

--- a/suite-common/address/src/getFirstFreshAddress.ts
+++ b/suite-common/address/src/getFirstFreshAddress.ts
@@ -1,4 +1,8 @@
 import { type Account, type ReceiveInfo } from '@suite-common/wallet-types';
+import { comparePath } from '@trezor/crypto-utils';
+
+const isPathLowerThanAnyUsedPath = (path: string, usedPaths: string[]) =>
+    usedPaths.some(usedPath => comparePath(path, usedPath) < 0);
 
 export const getFreshAddresses = (
     account: Account,
@@ -20,10 +24,13 @@ export const getFreshAddresses = (
         return unused;
     }
 
+    const usedPaths = alreadyUsedAddresses.map(address => address.path);
+
     return unused.filter(
         address =>
             !alreadyUsedAddresses.find(receiveAddress => receiveAddress.path === address.path) &&
-            !pendingAddresses.includes(address.address),
+            !pendingAddresses.includes(address.address) &&
+            !isPathLowerThanAnyUsedPath(address.path, usedPaths),
     );
 };
 

--- a/suite/receive/src/FreshAddress.tsx
+++ b/suite/receive/src/FreshAddress.tsx
@@ -110,16 +110,24 @@ export const FreshAddress = ({
     );
 
     useEffect(() => {
-        if (currentFreshAddress !== undefined) {
-            return;
-        }
+        const alreadyUsedAddressesExceptCurrentFresh = labeledAddresses
+            .concat(revealedAddresses)
+            .filter(address => address.path !== currentFreshAddress?.path);
 
         const firstFreshAddress = getFirstFreshAddress(
             account,
-            labeledAddresses.concat(revealedAddresses),
+            alreadyUsedAddressesExceptCurrentFresh,
             pendingAddresses,
             isAccountUtxoBased,
         );
+
+        const hasCurrentChanged =
+            currentFreshAddress?.path !== firstFreshAddress?.path ||
+            currentFreshAddress?.address !== firstFreshAddress?.address;
+
+        if (!hasCurrentChanged) {
+            return;
+        }
 
         dispatch(
             receiveActions.setCurrentFreshAddress({


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/pull/28782

## Notes for QA
See comment here: https://github.com/trezor/trezor-suite/pull/28782#issuecomment-4780693347


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes modify the core address selection logic (getFirstFreshAddress.ts) and its UI rendering component (FreshAddress.tsx), plus a unit test. These are central to the wallet receive flow across all supported cryptocurrencies. The highest risk is in the receive address display — showing the wrong address or failing to show one would be a critical user-facing bug. The recommended strategy prioritizes direct receive flow tests (single and global), then passphrase wallet receive scenarios which add complexity to address derivation, and finally Cardano-specific flows which may have distinct address handling.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/address/src/__tests__/getFirstFreshAddress.test.ts`
- `suite-common/address/src/getFirstFreshAddress.ts`
- `suite/receive/src/FreshAddress.tsx`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — The changed FreshAddress.tsx component is the UI for displaying fresh receive addresses, and getFirstFreshAddress.ts provides the logic for determining which address to show. The receive test directly exercises the receive flow across multiple coins (BTC, ETH, SOL, TRX), revealing addresses and copying them — this is the primary user-facing flow affected by these changes.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test exercises the global receive flow where a user opens the receive form, reveals an address, and verifies it on the device. The FreshAddress component and getFirstFreshAddress logic are directly exercised when displaying the fresh address to the user in this flow.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test exercises revealing receive addresses for passphrase wallets, including re-revealing after device reconnection. Changes to getFirstFreshAddress could affect which address is presented in passphrase wallet scenarios, and FreshAddress.tsx renders the address UI.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test reveals and verifies receive addresses across multiple passphrase wallets, checking that each wallet derives unique addresses. The getFirstFreshAddress logic determines which address is shown, and FreshAddress.tsx renders it.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test reveals a Cardano receive address behind a passphrase wallet. Changes to getFirstFreshAddress could affect Cardano address selection logic, and FreshAddress.tsx is the component rendering the address.
- `suite/e2e/tests/wallet/cardano.test.ts` — This test covers Cardano account receive flow including revealing an address and confirming it on the device. The getFirstFreshAddress function determines the fresh address for Cardano accounts, which may have different derivation logic than BTC/ETH.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — This test labels addresses in the receive view. While the primary focus is labeling, it still exercises the receive address display which uses FreshAddress.tsx and getFirstFreshAddress to determine which address to show.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/address/src/__tests__/getFirstFreshAddress.test.ts`

_Updated: 2026-07-01T08:54:44.999Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=lables-receuve&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=lables-receuve&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=lables-receuve&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/lables-receuve/web/](https://dev.suite.sldev.cz/suite-web/lables-receuve/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T08:59:34.414Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T08:58:10.859Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->