### PR TITLE
refactor(connect): adopt instance-form transports at DI-ready call sites

### DIFF
--- a/packages/connect-cli/src/transport.ts
+++ b/packages/connect-cli/src/transport.ts
@@ -1,5 +1,5 @@
 import { type ConnectSettingsTransport, type UiRequestThpPairing } from '@trezor/connect';
-import { NodeUsbTransport, UdpTransport } from '@trezor/transport';
+import { BridgeTransport, NodeUsbTransport, UdpTransport } from '@trezor/transport';
 import { BluetoothTransport, TrezorBluetooth } from '@trezor/transport-bluetooth';
 
 import { args } from './args';
@@ -145,10 +145,10 @@ export const getTransport = async (): Promise<ConnectSettingsTransport> => {
             logger: getLogger(),
         });
     } else if (transportName === 'bridge') {
-        return 'BridgeTransport';
+        return new BridgeTransport({ id: 'bridge', logger: getLogger() });
     } else if (transportName === 'udp') {
-        return 'UdpTransport';
+        return new UdpTransport({ id: 'udp', logger: getLogger() });
     }
 
-    return 'NodeUsbTransport';
+    return new NodeUsbTransport({ id: 'usb', logger: getLogger() });
 };

--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -2,6 +2,10 @@
 import TrezorConnect from '@trezor/connect';
 import { UI_REQUEST, UI_RESPONSE } from '@trezor/connect-common';
 import type { ApplySettings } from '@trezor/protobuf/src/definitions';
+// Deep import bypasses the `@trezor/transport` barrel so vitest's web project
+// does not pull node-only `usb`/`dgram` (imported by `NodeUsbTransport` /
+// `UdpTransport`, which the barrel re-exports) into the browser build.
+import { BridgeTransport } from '@trezor/transport/src/transports/bridge';
 import type { EmuStartOptsType, TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
 import { MNEMONICS, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 import { versionUtils } from '@trezor/utils';
@@ -225,7 +229,7 @@ export const initTrezorConnect = async (
             appUrl: 'tests.connect.trezor.io',
             email: 'tests@connect.trezor.io',
         },
-        transports: ['BridgeTransport'],
+        transports: [new BridgeTransport({ id: 'bridge', port: 21328 })],
         debug: true,
         pendingTransportEvent: true,
         transportReconnect: false,

--- a/packages/connect/e2e/tests/device/updateConnectSettings.test.ts
+++ b/packages/connect/e2e/tests/device/updateConnectSettings.test.ts
@@ -1,5 +1,9 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import TrezorConnect from '@trezor/connect';
+// Deep import bypasses the `@trezor/transport` barrel so vitest's web project
+// does not pull node-only `usb`/`dgram` (imported by `NodeUsbTransport` /
+// `UdpTransport`, which the barrel re-exports) into the browser build.
+import { BridgeTransport } from '@trezor/transport/src/transports/bridge';
 
 import { getController, initTrezorConnect, setup } from '../../common.setup';
 
@@ -24,7 +28,7 @@ describe('TrezorConnect.updateConnectSettings', () => {
             expect(before.success).toBe(true);
 
             const reconfig = await TrezorConnect.updateConnectSettings({
-                transports: ['BridgeTransport'],
+                transports: [new BridgeTransport({ id: 'bridge', port: 21328 })],
             });
             expect(reconfig).toMatchObject({ success: true, payload: { message: 'success' } });
 

--- a/suite/settings/package.json
+++ b/suite/settings/package.json
@@ -21,7 +21,6 @@
         "@suite-common/test-utils": "workspace:*",
         "@suite-common/trading": "workspace:*",
         "@suite/experimental": "workspace:*",
-        "@trezor/connect": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/suite-desktop-api": "workspace:*"
     }

--- a/suite/settings/src/settingsSlice.ts
+++ b/suite/settings/src/settingsSlice.ts
@@ -6,17 +6,25 @@ import { type OAuthServerEnvironment } from '@suite-common/metadata-types';
 import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
 import { type Locale } from '@suite-common/suite-types';
 import type { InvityServerEnvironment } from '@suite-common/trading';
-import { type ConnectSettings } from '@trezor/connect';
 import { isWeb } from '@trezor/env-utils';
 import { type SuiteThemeVariant } from '@trezor/suite-desktop-api';
 
 import { SIDEBAR_WIDTH_NUMERIC } from './suiteConstants';
 
+// String identifiers for the debug transport switcher UI, shared by the web and
+// desktop-renderer builds. Intentionally local to settings and NOT derived from
+// @trezor/connect's public types, so this package need not depend on @trezor/connect.
+export type DebugTransport =
+    | 'BridgeTransport'
+    | 'NodeUsbTransport'
+    | 'UdpTransport'
+    | 'WebUsbTransport';
+
 export interface DebugModeOptions {
     invityServerEnvironment?: InvityServerEnvironment;
     earnYieldWorkerBaseUrl?: EarnYieldWorkerBaseUrl;
     oauthServerEnvironment?: OAuthServerEnvironment;
-    transports: Extract<NonNullable<ConnectSettings['transports']>[number], string>[];
+    transports: DebugTransport[];
     isUnlockedBootloaderAllowed: boolean;
     showConnectLogs: boolean;
     isN4w1BackupEnabled: boolean;
@@ -30,7 +38,7 @@ export interface AutodetectSettings {
 
 export interface SuiteSettingsState {
     theme: {
-        variant: Exclude<SuiteThemeVariant, 'system'>;
+        variant: Exclude<SuiteThemeVariant, 'system'> | 'debug';
     };
     language: Locale;
     torOnionLinks: boolean;

--- a/suite/settings/tsconfig.json
+++ b/suite/settings/tsconfig.json
@@ -22,7 +22,6 @@
         },
         { "path": "../../suite-common/trading" },
         { "path": "../experimental" },
-        { "path": "../../packages/connect" },
         { "path": "../../packages/env-utils" },
         {
             "path": "../../packages/suite-desktop-api"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15062,7 +15062,6 @@ __metadata:
     "@suite-common/test-utils": "workspace:*"
     "@suite-common/trading": "workspace:*"
     "@suite/experimental": "workspace:*"
-    "@trezor/connect": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/suite-desktop-api": "workspace:*"
   languageName: unknown


### PR DESCRIPTION


## Description

Low-risk groundwork extracted from the upcoming pure-DI transports refactor (part of #27110), which narrows `ConnectSettingsTransport` to instance-only. Each call site changed here **already works on `develop` today** — `ConnectSettingsTransport` still accepts `Transport` instances and the `TransportList` resolver already has an `isTransportInstance` branch — so migrating them now is behavior-neutral and shrinks the follow-up breaking-change PR.

- **connect-cli** — `getTransport()` returns constructed `Transport` instances (`new BridgeTransport/UdpTransport/NodeUsbTransport(...)`) instead of string identifiers. Runtime is unchanged: on `develop`, connect already constructs exactly these instances from the equivalent strings.
- **connect e2e** — `init`/`updateConnectSettings` pass a `BridgeTransport` instance instead of `'BridgeTransport'`. The deep import (`@trezor/transport/src/transports/bridge`) bypasses the `@trezor/transport` barrel so the web vitest project does not pull node-only `usb`/`dgram`.
- **suite/settings** — `DebugModeOptions.transports` uses a local `DebugTransport` string union instead of a type derived from `@trezor/connect` (`Extract<NonNullable<ConnectSettings['transports']>[number], string>`). The two are type-equivalent on `develop` (both resolve to `'BridgeTransport' | 'NodeUsbTransport' | 'UdpTransport' | 'WebUsbTransport'`), so this drops the now-unused `@trezor/connect` dependency and project reference from the `@suite/settings` package.

Once this lands, the pure-DI refactor PR rebases on top and no longer needs to touch these files.

## Notes for QA

No functional change — this is behavior-neutral groundwork.

- **Blast radius:** `connect-cli` transport selection (runtime path identical to today), `@trezor/connect` e2e suite (test-only), and the `DebugModeOptions.transports` type used by the Suite debug transport switcher (type-only, equivalent set of values).
- **What to test:** nothing dedicated is required beyond green CI. If smoke-testing is desired: connect-cli still connects over bridge/udp/usb (`--transport` flag), and the Settings → Debug transport switcher in Suite behaves exactly as before.

## Related Issue

Part of #27110 (composition-root / pure-DI transports refactor).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mvarmuza/connect-transports-di-groundwork&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mvarmuza/connect-transports-di-groundwork&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mvarmuza/connect-transports-di-groundwork&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-24T14:13:48.370Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-24T14:12:35.380Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mvarmuza/connect-transports-di-groundwork/web/](https://dev.suite.sldev.cz/suite-web/mvarmuza/connect-transports-di-groundwork/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->