### PR TITLE
style(suite): Fix guide nitpicks

### DIFF
--- a/packages/components/src/components/CardList/CardListItem.tsx
+++ b/packages/components/src/components/CardList/CardListItem.tsx
@@ -7,7 +7,7 @@ export type CardListItemPaddingType = (typeof cardListItemPaddingTypes)[number];
 
 const paddingMap: Record<CardListItemPaddingType, Padding> = {
     normal: { vertical: 16, horizontal: 20 },
-    medium: { vertical: 12, horizontal: 20 },
+    medium: { vertical: 12, horizontal: 16 },
     small: { vertical: 8, horizontal: 12 },
 };
 

--- a/packages/components/src/config/variables.ts
+++ b/packages/components/src/config/variables.ts
@@ -30,7 +30,7 @@ export const SCREEN_QUERY = {
 export const LAYOUT_SIZE = {
     GUIDE_PANEL_DEFAULT_WIDTH: 350,
     GUIDE_PANEL_MIN_WIDTH: 300,
-    GUIDE_PANEL_MAX_WIDTH: 500,
+    GUIDE_PANEL_MAX_WIDTH: 1200,
 } as const;
 
 export const ICONS = Object.keys(icons).sort();

--- a/packages/suite/src/components/guide/SupportConsentPopover.tsx
+++ b/packages/suite/src/components/guide/SupportConsentPopover.tsx
@@ -4,12 +4,12 @@ import { Translation } from '@suite/intl';
 import { selectIsAnalyticsEnabled } from '@suite-common/analytics-redux';
 import { selectSupportChatUrl } from '@suite-common/support';
 import { Button, Card, Checkbox, Column, Paragraph, Popover, variables } from '@trezor/components';
-import { spacingsPx, zIndices } from '@trezor/theme';
+import { zIndices } from '@trezor/theme';
 
 import { useSelector } from 'src/hooks/suite';
 
 // To match the width of the trigger button in the SupportFeedbackSelection component at minimum guide width.
-const POPOVER_WIDTH = `calc(${variables.LAYOUT_SIZE.GUIDE_PANEL_MIN_WIDTH - 1}px - 2 * ${spacingsPx.lg})`;
+const POPOVER_WIDTH = `calc(${variables.LAYOUT_SIZE.GUIDE_PANEL_DEFAULT_WIDTH}px - 33px)`;
 
 type SupportConsentPopoverProps = {
     children: ReactNode;

--- a/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
+++ b/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
@@ -1,6 +1,6 @@
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { UpdateState } from '@suite/desktop-update';
-import { Translation } from '@suite/intl';
+import { Translation, type TranslationKey } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { isDevEnv } from '@suite-common/suite-utils';
@@ -19,6 +19,12 @@ import {
 import { SupportConsentPopover } from 'src/components/guide/SupportConsentPopover';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
+const StatusText = ({ id }: { id: TranslationKey }) => (
+    <Text typographyStyle="body-sm" intent="neutral" priority="secondary" as="div">
+        <Translation id={id} />
+    </Text>
+);
+
 export const SupportFeedbackSelection = () => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const desktopUpdate = useSelector(state => state.desktopUpdate);
@@ -28,12 +34,18 @@ export const SupportFeedbackSelection = () => {
     const appUpToDate =
         isDesktop() &&
         [UpdateState.Checking, UpdateState.NotAvailable].includes(desktopUpdate.state);
+    const appUpdateAvailable =
+        isDesktop() &&
+        [UpdateState.Available, UpdateState.Downloading, UpdateState.Ready].includes(
+            desktopUpdate.state,
+        );
     const appVersion = `${process.env.VERSION}${isDevEnv ? '-dev' : ''}`;
 
+    const isDeviceConnected = !!device?.features;
     const firmwareUpToDate = device?.firmware === 'valid';
     const getFirmwareVersionLabel = () => {
         if (!device?.features) {
-            return <Translation id="TR_DEVICE_NOT_CONNECTED" />;
+            return '-/-';
         }
 
         const version = getFirmwareVersion(device);
@@ -44,6 +56,33 @@ export const SupportFeedbackSelection = () => {
 
         return <Translation id="TR_YOUR_CURRENT_VERSION" values={{ version }} />;
     };
+
+    const getAppStatusId = (): TranslationKey | null => {
+        if (appUpToDate) {
+            return 'TR_UP_TO_DATE';
+        }
+
+        if (appUpdateAvailable) {
+            return 'TR_UPDATE_AVAILABLE';
+        }
+
+        return null;
+    };
+
+    const getFirmwareStatusId = (): TranslationKey | null => {
+        if (firmwareUpToDate) {
+            return 'TR_UP_TO_DATE';
+        }
+
+        if (!isDeviceConnected) {
+            return 'TR_GUIDE_SUPPORT_DEVICE_DISCONNECTED';
+        }
+
+        return null;
+    };
+
+    const appStatusId = getAppStatusId();
+    const firmwareStatusId = getFirmwareStatusId();
 
     const goBack = () => dispatch(setView('GUIDE_DEFAULT'));
     const handleBugButtonClick = () => {
@@ -198,59 +237,45 @@ export const SupportFeedbackSelection = () => {
                     </Box>
                     <CardList margin={{ bottom: 16 }}>
                         <CardList.Item data-testid="@guide/support/version" paddingType="medium">
-                            <Column gap={4} alignItems="flex-start" overflow="hidden">
-                                <Text typographyStyle="body-md" as="div" maxWidth="100%">
-                                    <Translation id="TR_APPLICATION" />
-                                </Text>
-                                <Text
-                                    typographyStyle="body-sm"
-                                    intent="neutral"
-                                    priority="secondary"
-                                    as="div"
-                                    maxWidth="100%"
-                                >
-                                    <Translation
-                                        id="TR_YOUR_CURRENT_VERSION"
-                                        values={{ version: appVersion }}
-                                    />
-                                </Text>
-                            </Column>
-                            {appUpToDate && (
-                                <Text
-                                    typographyStyle="body-sm"
-                                    intent="neutral"
-                                    priority="secondary"
-                                    as="div"
-                                >
-                                    <Translation id="TR_UP_TO_DATE" />
-                                </Text>
-                            )}
+                            <Row justifyContent="space-between" width="100%" alignItems="flex-end">
+                                <Column gap={4} alignItems="flex-start" overflow="hidden">
+                                    <Text typographyStyle="body-md" as="div" maxWidth="100%">
+                                        <Translation id="TR_APPLICATION" />
+                                    </Text>
+                                    <Text
+                                        typographyStyle="body-sm"
+                                        intent="neutral"
+                                        priority="secondary"
+                                        as="div"
+                                        maxWidth="100%"
+                                    >
+                                        <Translation
+                                            id="TR_YOUR_CURRENT_VERSION"
+                                            values={{ version: appVersion }}
+                                        />
+                                    </Text>
+                                </Column>
+                                {!!appStatusId && <StatusText id={appStatusId} />}
+                            </Row>
                         </CardList.Item>
                         <CardList.Item data-testid="@guide/support/firmware" paddingType="medium">
-                            <Column gap={4} alignItems="flex-start" overflow="hidden">
-                                <Text typographyStyle="body-md" as="div" maxWidth="100%">
-                                    <Translation id="TR_FIRMWARE" />
-                                </Text>
-                                <Text
-                                    typographyStyle="body-sm"
-                                    intent="neutral"
-                                    priority="secondary"
-                                    as="div"
-                                    maxWidth="100%"
-                                >
-                                    {getFirmwareVersionLabel()}
-                                </Text>
-                            </Column>
-                            {firmwareUpToDate && (
-                                <Text
-                                    typographyStyle="body-sm"
-                                    intent="neutral"
-                                    priority="secondary"
-                                    as="div"
-                                >
-                                    <Translation id="TR_UP_TO_DATE" />
-                                </Text>
-                            )}
+                            <Row justifyContent="space-between" width="100%" alignItems="flex-end">
+                                <Column gap={4} alignItems="flex-start" overflow="hidden">
+                                    <Text typographyStyle="body-md" as="div" maxWidth="100%">
+                                        <Translation id="TR_FIRMWARE" />
+                                    </Text>
+                                    <Text
+                                        typographyStyle="body-sm"
+                                        intent="neutral"
+                                        priority="secondary"
+                                        as="div"
+                                        maxWidth="100%"
+                                    >
+                                        {getFirmwareVersionLabel()}
+                                    </Text>
+                                </Column>
+                                {!!firmwareStatusId && <StatusText id={firmwareStatusId} />}
+                            </Row>
                         </CardList.Item>
                     </CardList>
                 </Column>

--- a/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
+++ b/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
@@ -4,7 +4,7 @@ import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { isDevEnv } from '@suite-common/suite-utils';
-import { Box, Column, Icon, IconCircle, Paragraph, Row } from '@trezor/components';
+import { Box, CardList, Column, Icon, IconCircle, Row, Text } from '@trezor/components';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { isDesktop } from '@trezor/env-utils';
 import { TREZOR_FORUM_URL } from '@trezor/urls';
@@ -19,8 +19,6 @@ import {
 import { SupportConsentPopover } from 'src/components/guide/SupportConsentPopover';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
-import { GuideItem } from './GuideItem';
-
 export const SupportFeedbackSelection = () => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const desktopUpdate = useSelector(state => state.desktopUpdate);
@@ -30,13 +28,22 @@ export const SupportFeedbackSelection = () => {
     const appUpToDate =
         isDesktop() &&
         [UpdateState.Checking, UpdateState.NotAvailable].includes(desktopUpdate.state);
+    const appVersion = `${process.env.VERSION}${isDevEnv ? '-dev' : ''}`;
 
     const firmwareUpToDate = device?.firmware === 'valid';
-    const firmwareVersion = device?.features ? (
-        getFirmwareVersion(device) || <Translation id="TR_DEVICE_FW_UNKNOWN" />
-    ) : (
-        <Translation id="TR_DEVICE_NOT_CONNECTED" />
-    );
+    const getFirmwareVersionLabel = () => {
+        if (!device?.features) {
+            return <Translation id="TR_DEVICE_NOT_CONNECTED" />;
+        }
+
+        const version = getFirmwareVersion(device);
+
+        if (!version) {
+            return <Translation id="TR_DEVICE_FW_UNKNOWN" />;
+        }
+
+        return <Translation id="TR_YOUR_CURRENT_VERSION" values={{ version }} />;
+    };
 
     const goBack = () => dispatch(setView('GUIDE_DEFAULT'));
     const handleBugButtonClick = () => {
@@ -61,124 +68,192 @@ export const SupportFeedbackSelection = () => {
                 label={<Translation id="TR_GUIDE_VIEW_HEADLINES_SUPPORT_FEEDBACK_SELECTION" />}
             />
             <GuideContent>
-                <Box margin={{ bottom: 16 }}>
-                    <GuideSectionHeadline id="TR_GUIDE_VIEW_HEADLINE_HELP_US_IMPROVE" />
-                    <Column gap={12}>
-                        <GuideItem
-                            onClick={handleBugButtonClick}
-                            data-testid="@guide/feedback/bug"
-                            icon={<IconCircle name="lifebuoy" size={32} intent="neutral" />}
-                        >
-                            <Column gap={4} justifyContent="space-between">
-                                <Translation id="TR_BUG" />
-                                <Paragraph
+                <Column justifyContent="space-between" height="100%">
+                    <Box flex="1">
+                        <Box margin={{ bottom: 16 }}>
+                            <GuideSectionHeadline id="TR_GUIDE_VIEW_HEADLINE_HELP_US_IMPROVE" />
+                            <CardList>
+                                <CardList.Item
+                                    paddingType="medium"
+                                    onClick={handleBugButtonClick}
+                                    data-testid="@guide/feedback/bug"
+                                >
+                                    <Row gap={16} flex="1" overflow="hidden">
+                                        <IconCircle name="bugBeetle" size={32} intent="neutral" />
+                                        <Column gap={4} alignItems="flex-start" overflow="hidden">
+                                            <Text
+                                                typographyStyle="body-md"
+                                                as="div"
+                                                maxWidth="100%"
+                                            >
+                                                <Translation id="TR_BUG" />
+                                            </Text>
+                                            <Text
+                                                typographyStyle="body-sm"
+                                                intent="neutral"
+                                                priority="secondary"
+                                                as="div"
+                                                maxWidth="100%"
+                                            >
+                                                <Translation id="TR_GUIDE_BUG_LABEL" />
+                                            </Text>
+                                        </Column>
+                                    </Row>
+                                    <Icon
+                                        name="caretRight"
+                                        size={20}
+                                        intent="neutral"
+                                        priority="secondary"
+                                    />
+                                </CardList.Item>
+                                <CardList.Item
+                                    paddingType="medium"
+                                    onClick={handleFeedbackButtonClick}
+                                    data-testid="@guide/feedback/suggestion"
+                                >
+                                    <Row gap={16} flex="1" overflow="hidden">
+                                        <IconCircle name="megaphone" size={32} intent="neutral" />
+                                        <Column gap={4} alignItems="flex-start" overflow="hidden">
+                                            <Text
+                                                typographyStyle="body-md"
+                                                as="div"
+                                                maxWidth="100%"
+                                            >
+                                                <Translation id="TR_SUGGESTION" />
+                                            </Text>
+                                            <Text
+                                                typographyStyle="body-sm"
+                                                intent="neutral"
+                                                priority="secondary"
+                                                as="div"
+                                                maxWidth="100%"
+                                            >
+                                                <Translation id="TR_GUIDE_SUGGESTION_LABEL" />
+                                            </Text>
+                                        </Column>
+                                    </Row>
+                                    <Icon
+                                        name="caretRight"
+                                        size={20}
+                                        intent="neutral"
+                                        priority="secondary"
+                                    />
+                                </CardList.Item>
+                            </CardList>
+                        </Box>
+
+                        <Box>
+                            <GuideSectionHeadline id="TR_GUIDE_VIEW_HEADLINE_NEED_HELP" />
+                            <CardList>
+                                <SupportConsentPopover>
+                                    <CardList.Item
+                                        paddingType="medium"
+                                        onClick={() => {}}
+                                        data-testid="@guide/support"
+                                        width="100%"
+                                    >
+                                        <Row gap={16} flex="1" overflow="hidden">
+                                            <IconCircle
+                                                name="lifebuoy"
+                                                size={32}
+                                                intent="neutral"
+                                            />
+                                            <Text
+                                                typographyStyle="body-md"
+                                                as="div"
+                                                maxWidth="100%"
+                                            >
+                                                <Translation id="TR_GUIDE_SUPPORT" />
+                                            </Text>
+                                        </Row>
+                                        <Icon
+                                            name="arrowLineUpRight"
+                                            size={20}
+                                            intent="neutral"
+                                            priority="secondary"
+                                        />
+                                    </CardList.Item>
+                                </SupportConsentPopover>
+
+                                <CardList.Item
+                                    paddingType="medium"
+                                    onClick={() => window.open(TREZOR_FORUM_URL, '_blank')}
+                                    data-testid="@guide/forum"
+                                >
+                                    <Row gap={16} flex="1" overflow="hidden">
+                                        <IconCircle name="chats" size={32} intent="neutral" />
+                                        <Text typographyStyle="body-md" as="div" maxWidth="100%">
+                                            <Translation id="TR_GUIDE_FORUM" />
+                                        </Text>
+                                    </Row>
+                                    <Icon
+                                        name="arrowLineUpRight"
+                                        size={20}
+                                        intent="neutral"
+                                        priority="secondary"
+                                    />
+                                </CardList.Item>
+                            </CardList>
+                        </Box>
+                    </Box>
+                    <CardList margin={{ bottom: 16 }}>
+                        <CardList.Item data-testid="@guide/support/version" paddingType="medium">
+                            <Column gap={4} alignItems="flex-start" overflow="hidden">
+                                <Text typographyStyle="body-md" as="div" maxWidth="100%">
+                                    <Translation id="TR_APPLICATION" />
+                                </Text>
+                                <Text
                                     typographyStyle="body-sm"
                                     intent="neutral"
                                     priority="secondary"
+                                    as="div"
+                                    maxWidth="100%"
                                 >
-                                    <Translation id="TR_GUIDE_BUG_LABEL" />
-                                </Paragraph>
+                                    <Translation
+                                        id="TR_YOUR_CURRENT_VERSION"
+                                        values={{ version: appVersion }}
+                                    />
+                                </Text>
                             </Column>
-                        </GuideItem>
-                        <GuideItem
-                            onClick={handleFeedbackButtonClick}
-                            data-testid="@guide/feedback/suggestion"
-                            icon={<IconCircle name="megaphone" size={32} intent="neutral" />}
-                        >
-                            <Column gap={4} justifyContent="space-between">
-                                <Translation id="TR_SUGGESTION" />
-                                <Paragraph
+                            {appUpToDate && (
+                                <Text
                                     typographyStyle="body-sm"
                                     intent="neutral"
                                     priority="secondary"
+                                    as="div"
                                 >
-                                    <Translation id="TR_GUIDE_SUGGESTION_LABEL" />
-                                </Paragraph>
+                                    <Translation id="TR_UP_TO_DATE" />
+                                </Text>
+                            )}
+                        </CardList.Item>
+                        <CardList.Item data-testid="@guide/support/firmware" paddingType="medium">
+                            <Column gap={4} alignItems="flex-start" overflow="hidden">
+                                <Text typographyStyle="body-md" as="div" maxWidth="100%">
+                                    <Translation id="TR_FIRMWARE" />
+                                </Text>
+                                <Text
+                                    typographyStyle="body-sm"
+                                    intent="neutral"
+                                    priority="secondary"
+                                    as="div"
+                                    maxWidth="100%"
+                                >
+                                    {getFirmwareVersionLabel()}
+                                </Text>
                             </Column>
-                        </GuideItem>
-                    </Column>
-                </Box>
-
-                <Box>
-                    <GuideSectionHeadline id="TR_GUIDE_VIEW_HEADLINE_NEED_HELP" />
-                    <Column gap={12}>
-                        <SupportConsentPopover>
-                            <GuideItem onClick={() => {}} data-testid="@guide/support">
-                                <Row gap={8} justifyContent="space-between">
-                                    <Translation id="TR_GUIDE_SUPPORT" />
-                                    <Icon name="arrowLineUpRight" size={20} />
-                                </Row>
-                            </GuideItem>
-                        </SupportConsentPopover>
-
-                        <GuideItem
-                            onClick={() => window.open(TREZOR_FORUM_URL, '_blank')}
-                            data-testid="@guide/forum"
-                        >
-                            <Row gap={8} justifyContent="space-between">
-                                <Translation id="TR_GUIDE_FORUM" />
-                                <Icon name="arrowLineUpRight" size={20} />
-                            </Row>
-                        </GuideItem>
-                    </Column>
-                </Box>
-
-                <Row
-                    gap={16}
-                    margin={{ top: 20 }}
-                    alignItems="center"
-                    justifyContent="space-around"
-                >
-                    <Paragraph
-                        data-testid="@guide/support/version"
-                        typographyStyle="body-xs"
-                        intent="neutral"
-                        priority="secondary"
-                    >
-                        <Translation id="TR_APP" />
-                        :&nbsp;
-                        {!isDevEnv && appUpToDate ? (
-                            <>
-                                <Icon
-                                    size={12}
-                                    margin={{ horizontal: 4 }}
-                                    name="check"
+                            {firmwareUpToDate && (
+                                <Text
+                                    typographyStyle="body-sm"
                                     intent="neutral"
                                     priority="secondary"
-                                />
-                                <Translation id="TR_UP_TO_DATE" />
-                            </>
-                        ) : (
-                            <>
-                                {process.env.VERSION}
-                                {isDevEnv && '-dev'}
-                            </>
-                        )}
-                    </Paragraph>
-                    <Paragraph
-                        data-testid="@guide/support/firmware"
-                        typographyStyle="body-xs"
-                        intent="neutral"
-                        priority="secondary"
-                    >
-                        <Translation id="TR_FIRMWARE" />
-                        :&nbsp;
-                        {firmwareUpToDate ? (
-                            <>
-                                <Icon
-                                    size={12}
-                                    margin={{ horizontal: 4 }}
-                                    name="check"
-                                    intent="neutral"
-                                    priority="secondary"
-                                />
-                                <Translation id="TR_UP_TO_DATE" />
-                            </>
-                        ) : (
-                            firmwareVersion
-                        )}
-                    </Paragraph>
-                </Row>
+                                    as="div"
+                                >
+                                    <Translation id="TR_UP_TO_DATE" />
+                                </Text>
+                            )}
+                        </CardList.Item>
+                    </CardList>
+                </Column>
             </GuideContent>
         </GuideViewWrapper>
     );

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -7679,6 +7679,10 @@ export const messages = defineMessages({
         id: 'TR_GUIDE_SUPPORT_CONSENT_BUTTON',
         defaultMessage: 'Contact Trezor Support',
     },
+    TR_GUIDE_SUPPORT_DEVICE_DISCONNECTED: {
+        id: 'TR_GUIDE_SUPPORT_DEVICE_DISCONNECTED',
+        defaultMessage: 'Trezor disconnected',
+    },
     TR_GUIDE_FORUM: {
         id: 'TR_GUIDE_FORUM',
         defaultMessage: 'Trezor Forum',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="1498" height="1098" alt="image" src="https://github.com/user-attachments/assets/3d3a3d5e-705c-46a1-bb3b-055dbb4ed506" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch two guide-specific components (SupportFeedbackSelection.tsx and SupportConsentPopover.tsx), a broad shared UI component (CardListItem.tsx), a shared config file (variables.ts), and the global messages file. The guide components have a narrow blast radius — only the three guide/feedback-related tests directly exercise that functionality. The CardListItem, variables.ts, and messages.ts changes map to 121+ tests each, but since they are global shared utilities, only tests that specifically exercise the guide/feedback UI path warrant targeted execution. No other tests have concrete evidence of being affected by these changes beyond transitive imports.

<details><summary><b>Changed files (5)</b></summary>

- `packages/components/src/components/CardList/CardListItem.tsx`
- `packages/components/src/config/variables.ts`
- `packages/suite/src/components/guide/SupportConsentPopover.tsx`
- `packages/suite/src/components/guide/SupportFeedbackSelection.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/general/suite-guide.test.ts` — This test directly exercises the Suite Guide panel including bug report submission and article search. The changed files SupportFeedbackSelection.tsx and SupportConsentPopover.tsx are core components of the guide's Support and Feedback section, which this test interacts with when sending a bug report and looking up articles.
- `suite/e2e/tests/suite/bug-report-form.test.ts` — This test opens the Guide panel, navigates to Support and Feedback, and submits a bug report form. SupportFeedbackSelection.tsx renders the feedback selection UI that this test directly interacts with, and SupportConsentPopover.tsx may gate consent before submission.
- `suite/e2e/tests/suite/guide.test.ts` — This test extensively exercises the guide panel: opening/closing, navigating content, submitting feedback through the feedback form with suggestion rating, and searching articles. Both SupportFeedbackSelection.tsx (feedback form rendering) and SupportConsentPopover.tsx (consent before feedback) are directly in the test's code path.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/components/src/components/CardList/CardListItem.tsx`
- `packages/components/src/config/variables.ts`

_Updated: 2026-06-24T14:42:35.210Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=guide-nitpicks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=guide-nitpicks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-24T14:47:39.980Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-24T14:46:12.355Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/guide-nitpicks/web/](https://dev.suite.sldev.cz/suite-web/guide-nitpicks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->