### PR TITLE
fix(wallet-core): guard removeAccount against deleting the wrong account

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -47,7 +47,11 @@ const update = (state: Account[], account: Account) => {
 const remove = (state: Account[], accounts: Account[]) => {
     accounts.forEach(a => {
         const index = state.findIndex(accountEqualTo(a));
-        state.splice(index, 1);
+        // a missing account yields index -1, and splice(-1, 1) would delete the
+        // last, unrelated account instead of being a no-op
+        if (index !== -1) {
+            state.splice(index, 1);
+        }
     });
 };
 


### PR DESCRIPTION
## Description

`accountsReducer.remove` removed accounts with:

```ts
const index = state.findIndex(accountEqualTo(a));
state.splice(index, 1);
```

When the account to remove is **not** in `state.wallet.accounts`, `findIndex` returns `-1`, and `splice(-1, 1)` deletes the **last** element — a different, unrelated account — instead of being a no-op. (`accountEqualTo` matches on `deviceState`, `symbol`, `accountType`, `index`.)

The fix guards the splice with `if (index !== -1)`. This is a single chokepoint that protects against every caller that can pass a stale or absent account.

### How it's reachable

Most `removeAccount` dispatchers build their payload synchronously from `state.wallet.accounts.filter(...)`, so their entries always match (forget-device, discovery cleanup, settings, native device middleware). The bug is reachable from the callers whose payload is a **drift-prone closure/singleton**, not a same-tick filter:

**1. connect-popup sign flows** (`bitcoin` / `ethereum` / `solanaSignTransaction` method hooks)
- Signing for a path with no real account creates a **placeholder** with a constant identity (`deviceState: 'placeholder@connect:0'`, `accountType: 'placeholder'`, `index: 0`) and pushes it into both state and a module-level `temporaryAccounts` array. `temporaryAccounts` is drained **only** in `postCallHook`.
- If the device disconnects mid-flow, the thunk throws `Device_Disconnected` **before** `postCallHook` runs, so `temporaryAccounts` is never cleared.
- The user reconnects and resumes; the lookup selector can't see the leftover placeholder (it filters by the real device's session), so a **second** placeholder with the same identity is created. `createAccount` dedups it, so state still holds one placeholder while `temporaryAccounts` now holds two equal references.
- On success, `postCallHook` dispatches `removeAccount([P1, P2])`. The first entry removes the placeholder; the second hits `findIndex === -1` → `splice(-1, 1)` deletes the **last real account** in the list.

**2. suite-native remove-coin confirmation** (`AccountSettingsRemoveCoinButton`)
- The confirm handler closes over the live `account` and is stored in a global alert atom that outlives the screen. If the account's device is forgotten while the dialog is open (auto on disconnect of a non-remembered device → `removeAccount` empties it from state), tapping Remove dispatches `removeAccount([account])` for an account that is already gone → `splice(-1, 1)` deletes another connected device's last account.

Both vectors were traced line-by-line against `develop`. Base rate is low (each needs a disconnect/error race plus a resume, or an open-dialog race), and **no funds are at risk** — keys live on-device and the account re-appears on the next discovery. But when triggered, a real account (balance, history, label) silently disappears from the list, and the *wrong* account is removed, with no error or confirmation.

### Tests

No test added. The guard is a one-line defensive chokepoint covering every drift-prone caller at once; a reducer-shaped regression test asserting the internal splice behaviour adds little durable signal in `develop`. The upstream causes (the `temporaryAccounts` leak on a thrown device error; the stale native closure) are separate latent issues, better exercised by their own follow-ups (#29181) than by a brittle end-to-end race test.

## Notes for QA

Hard to hit by hand: needs a device-disconnect race during a connect-popup sign followed by a resume, or forgetting a device while the suite-native remove-coin dialog is open. If you can stage it, watch for an **unrelated** account disappearing from the account list. No fund risk; the account returns after re-discovery / app restart.

---

Part of the small split-out series from #28977.

The two upstream causes referenced above (the `temporaryAccounts` leak on a thrown device error; the stale native remove-coin closure) are fixed in the stacked follow-up #29181.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to accountsReducer.ts is a core wallet state management file that maps to all 121 tests, indicating it is a foundational dependency. The highest risk areas are account discovery, account creation/management, balance tracking, and multi-wallet (passphrase) account isolation. The recommended strategy focuses on tests that directly exercise account CRUD operations, discovery flows, balance display, and multi-account scenarios rather than tests that merely transitively depend on account state (like analytics, backup, or onboarding tests). Running the high-priority discovery and account management tests first will catch most regressions, with medium-priority tests covering edge cases around specific coin types and custom backends.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/wallet-core/src/accounts/accountsReducer.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — This test directly exercises wallet account discovery across multiple coins (BTC, ETH, LTC, etc.), checking Redux store wallet.discovery status transitions and verifying account balances. The accountsReducer is central to how discovered accounts are stored and managed, making this a primary regression target.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test covers ejecting a wallet, adding a standard wallet, and verifying BTC account balance visibility after discovery. These operations directly depend on accountsReducer for account state management (adding/removing accounts during wallet switching).
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds different account types (normal, taproot, segwit, legacy) for multiple coins and verifies account counts increment correctly. The accountsReducer handles the state for adding new accounts and tracking account type groups, making this directly affected.
- `suite/e2e/tests/wallet/account-search.test.ts` — This test searches/filters accounts by name and verifies visibility toggling. Account search operates on the accounts state managed by accountsReducer, so changes to account data structure or selectors would directly break filtering behavior.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies account balance display and updates after receiving BTC on regtest. The accountsReducer stores account balance data, so changes could affect how balances are stored, updated, or displayed.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/wallet/public-keys.test.ts` — This test opens specific coin accounts and views their public keys (XPUBs) from account details. Account details data is stored in the accountsReducer, so structural changes could affect key display.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test verifies asset display in grid/table views and enabling new coins via the Activate Assets modal, relying on discovery completion and account state. The accountsReducer manages discovered accounts that populate the assets section.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Tests custom blockbook backend discovery for BTC and LTC, verifying discovery completes and the dashboard graph renders. Discovery results are stored in accountsReducer, so changes could affect account creation from custom backends.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test adds hidden (passphrase) wallets and verifies they derive unique accounts with correct receive addresses. The accountsReducer must correctly handle accounts across different wallet instances (standard vs passphrase), so changes could affect multi-wallet account management.
- `suite/e2e/tests/wallet/cardano.test.ts` — Tests opening a Cardano account and viewing account details (type, derivation path, xpub). Cardano accounts have unique properties in the accountsReducer, so changes could specifically affect ADA account handling.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test exports transactions across multiple coin types (BTC, LTC, ETH, ADA). Transaction export relies on account state from accountsReducer to identify the correct account and its transactions.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Tests configuring custom backends and verifying account discovery succeeds or fails with correct/wrong URLs. Account discovery results are managed by accountsReducer, and error states (TR_ACCOUNT_EXCEPTION_DISCOVERY_ERROR) depend on account state.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — Tests sequential numbering of passphrase wallets during add/eject cycles. Wallet numbering logic interacts with account management in accountsReducer, as each wallet instance has its own set of accounts.

</details>

_Updated: 2026-07-01T12:33:05.974Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/accounts-remove-guard&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/accounts-remove-guard&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/accounts-remove-guard&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T12:37:48.639Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T12:36:48.011Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/accounts-remove-guard/web/](https://dev.suite.sldev.cz/suite-web/mroz22/accounts-remove-guard/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->