### PR TITLE
fix(suite): redact discovery edge cases error data

### DIFF
--- a/packages/suite/src/utils/suite/sentry.ts
+++ b/packages/suite/src/utils/suite/sentry.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/core';
 
 import { selectAnalyticsInstanceId } from '@suite-common/analytics-redux';
 import { selectSelectedDevice } from '@suite-common/device';
-import { redactDevice, selectRedactedActionsLog } from '@suite-common/logger';
+import { redactDevice, redactDiscovery, selectRedactedActionsLog } from '@suite-common/logger';
 import { ALLOW_REPORT_TAG } from '@suite-common/sentry';
 import { type ReportSecurityCheckParams } from '@suite-common/suite-types';
 import { selectDiscoveryForSelectedDevice, selectEnabledNetworks } from '@suite-common/wallet-core';
@@ -43,7 +43,7 @@ export const reportToSentry = (error: any) => (_: Dispatch, getState: GetState) 
         scope.setUser({ id: instanceId });
         scope.setContext('suiteState', {
             device: redactDevice(device) ?? null,
-            discovery,
+            discovery: redactDiscovery(discovery) ?? null,
             enabledCoins: enabledNetworks,
             suiteLog: redactedActionsLog?.slice(-30), // send only the last 30 actions to avoid "413 Request Entity Too Large" response from Sentry
         });

--- a/suite-common/logger/src/__tests__/utils.test.ts
+++ b/suite-common/logger/src/__tests__/utils.test.ts
@@ -1,8 +1,9 @@
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
-import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { type DiscoveryStatus, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { type StaticSessionId } from '@trezor/connect';
 
-import { REDACTED_REPLACEMENT, redactAccount, redactDevice } from '../utils';
+import { REDACTED_REPLACEMENT, redactAccount, redactDevice, redactDiscovery } from '../utils';
 
 describe('logsUtils', () => {
     const account = mockWalletAccount({
@@ -48,6 +49,35 @@ describe('logsUtils', () => {
                     label: REDACTED_REPLACEMENT,
                 },
             });
+        });
+    });
+
+    describe(redactDiscovery.name, () => {
+        it('redacts duplicate static session id for duplicate passphrase discovery', () => {
+            const duplicateDeviceStaticSessionId: StaticSessionId = 'session@device-id:1';
+            const discovery: DiscoveryStatus = {
+                status: 'passphrase-duplicate',
+                duplicateDeviceStaticSessionId,
+            };
+
+            expect(redactDiscovery(discovery)).toEqual({
+                ...discovery,
+                duplicateDeviceStaticSessionId: REDACTED_REPLACEMENT,
+            });
+        });
+
+        it('keeps other discovery statuses unchanged', () => {
+            const discovery: DiscoveryStatus = {
+                status: 'progress',
+                progress: 1,
+                total: 3,
+            };
+
+            expect(redactDiscovery(discovery)).toEqual(discovery);
+        });
+
+        it('keeps undefined value', () => {
+            expect(redactDiscovery(undefined)).toEqual(undefined);
         });
     });
 });

--- a/suite-common/logger/src/utils.ts
+++ b/suite-common/logger/src/utils.ts
@@ -2,7 +2,7 @@ import { deviceActions } from '@suite-common/device';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { getBrowserName, getBrowserVersion, getOsVersion } from '@suite-common/suite-utils';
 import { accountsActions } from '@suite-common/wallet-core';
-import { type Account } from '@suite-common/wallet-types';
+import { type Account, type DiscoveryStatus } from '@suite-common/wallet-types';
 import { DEVICE } from '@trezor/connect';
 import {
     getCommitHash,
@@ -82,6 +82,30 @@ export const redactDevice = (device: DeepPartial<TrezorDevice> | undefined) => {
               }
             : undefined,
         metadata: device.metadata ? REDACTED_REPLACEMENT : undefined,
+    };
+};
+
+type RedactedPassphraseDuplicateDiscoveryStatus = Omit<
+    Extract<DiscoveryStatus, { status: 'passphrase-duplicate' }>,
+    'duplicateDeviceStaticSessionId'
+> & {
+    duplicateDeviceStaticSessionId: string;
+};
+
+export type RedactedDiscoveryStatus =
+    | Exclude<DiscoveryStatus, { status: 'passphrase-duplicate' }>
+    | RedactedPassphraseDuplicateDiscoveryStatus;
+
+export const redactDiscovery = (
+    discovery: DiscoveryStatus | undefined,
+): RedactedDiscoveryStatus | undefined => {
+    if (discovery?.status !== 'passphrase-duplicate') {
+        return discovery;
+    }
+
+    return {
+        ...discovery,
+        duplicateDeviceStaticSessionId: REDACTED_REPLACEMENT,
     };
 };
 

--- a/suite-common/wallet-core/src/discovery/discoverySelectors.ts
+++ b/suite-common/wallet-core/src/discovery/discoverySelectors.ts
@@ -7,7 +7,9 @@ import { type DiscoveryRootState } from './discoveryReducer';
 export const selectDiscoveryByDevicePath = (state: DiscoveryRootState, path?: DeviceUniquePath) =>
     path !== undefined ? state.wallet.discovery[path] : undefined;
 
-export const selectDiscoveryForSelectedDevice = (state: DiscoveryRootState & DeviceRootState) => {
+export const selectDiscoveryForSelectedDevice = (
+    state: DiscoveryRootState & DeviceRootState,
+): DiscoveryStatus | undefined => {
     const selectedDevice = selectSelectedDevice(state);
 
     return selectDiscoveryByDevicePath(state, selectedDevice?.path);
@@ -34,7 +36,7 @@ export function isDiscoveryInProgress(
     );
 }
 
-export const selectHasRunningDiscovery = (state: DiscoveryRootState & DeviceRootState) => {
+export const selectHasRunningDiscovery = (state: DiscoveryRootState & DeviceRootState): boolean => {
     const discovery = selectDiscoveryForSelectedDevice(state);
 
     return isDiscoveryInProgress(discovery);
@@ -46,12 +48,12 @@ export const selectHasRunningDiscovery = (state: DiscoveryRootState & DeviceRoot
 export const selectIsDiscoveryStatusConfirmEmptyPassphrase = (
     state: DiscoveryRootState & DeviceRootState,
     path?: DeviceUniquePath,
-) => selectDiscoveryByDevicePath(state, path)?.status === 'confirm-empty-passphrase';
+): boolean => selectDiscoveryByDevicePath(state, path)?.status === 'confirm-empty-passphrase';
 
 export const selectIsCreatingNewPassphraseWallet = (
     state: DiscoveryRootState & DeviceRootState,
-) => {
+): boolean => {
     const discovery = selectDiscoveryForSelectedDevice(state);
 
-    return discovery?.isAddingHiddenWallet;
+    return discovery?.isAddingHiddenWallet === true;
 };

--- a/suite-native/passphrase/src/components/PassphraseScreenHeader.tsx
+++ b/suite-native/passphrase/src/components/PassphraseScreenHeader.tsx
@@ -5,7 +5,10 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
-import { cancelDiscoveryThunk } from '@suite-common/wallet-core';
+import {
+    cancelDiscoveryThunk,
+    selectIsCreatingNewPassphraseWallet,
+} from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { IconButton, ScreenHeaderWrapper } from '@suite-native/atoms';
@@ -22,8 +25,6 @@ import {
     useNavigateToInitialScreen,
 } from '@suite-native/navigation';
 import TrezorConnect from '@trezor/connect';
-
-import { selectIsCreatingNewPassphraseWallet } from '../passphraseSelectors';
 
 type NavigationProp = StackToTabCompositeProps<
     AuthorizeDeviceStackParamList,

--- a/suite-native/passphrase/src/passphraseSelectors.ts
+++ b/suite-native/passphrase/src/passphraseSelectors.ts
@@ -1,9 +1,5 @@
 import type { DeviceRootState } from '@suite-common/device';
-import {
-    type DiscoveryRootState,
-    selectDiscoveryByDevicePath,
-    selectIsCreatingNewPassphraseWallet,
-} from '@suite-common/wallet-core';
+import { type DiscoveryRootState, selectDiscoveryByDevicePath } from '@suite-common/wallet-core';
 
 /**
  * Returns true if discovery failed due to passphrase flow (cancelled, wrong passphrase, modal dismissed).
@@ -38,8 +34,6 @@ export const selectHasPassphraseIncorrectError = (state: DiscoveryRootState & De
 
     return discovery?.status === 'failed' && discovery?.error === 'Passphrase is incorrect';
 };
-
-export { selectIsCreatingNewPassphraseWallet };
 
 export const selectPassphraseDeviceNotEmpty = (state: DiscoveryRootState & DeviceRootState) => {
     const discovery = selectDiscoveryByDevicePath(state, state.device.selectedDevice?.path);


### PR DESCRIPTION
## Description

- redact sensitive data that might have been sent in error cases of discovery (only for duplicate wallet, which is rare edge-case)
- some small cleanup from #29071

## Notes for QA

Duplicate passphrase bug not reproducible AFAIK.

The context that we redact is only sent for erros sent _during React render cycle_, not other errors..
Which means very specific setup to test it – I tested that the context is still sent as it should be
https://satoshilabs.sentry.io/issues/7572771879/events/a9e90a82e9ce4f2299c10b8e9977ad8e/

The cleanup is only comments and typescript (no-op).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies broadly-used infrastructure (sentry, logger utils, discovery selectors) plus suite-native passphrase components. The sentry.ts and logger/utils.ts changes map to 121+ tests each but are global utilities unlikely to cause test-specific regressions. The discovery selectors change is the highest-risk item since it directly affects discovery state management used by many wallet/dashboard flows. The suite-native passphrase files only affect the mobile app and have no web E2E test coverage. The logger unit test file is a standalone test with no E2E mapping. Recommended strategy: focus on tests that explicitly check discovery state transitions and completion, plus one test covering log output to validate logger changes.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/utils/suite/sentry.ts`
- `suite-common/logger/src/__tests__/utils.test.ts`
- `suite-common/logger/src/utils.ts`
- `suite-common/wallet-core/src/discovery/discoverySelectors.ts`
- `suite-native/passphrase/src/components/PassphraseScreenHeader.tsx`
- `suite-native/passphrase/src/passphraseSelectors.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — This test directly exercises the wallet discovery flow, checking Redux state 'wallet.discovery' status transitions (starting → complete). Changes to discoverySelectors.ts could break discovery status detection, causing this test to fail on its core assertions about discovery completion.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test verifies wallet discovery after ejecting and re-adding a standard wallet, directly relying on discovery completion logic. Changes to discoverySelectors.ts could affect the discoveryShouldFinish helper and account balance visibility assertions.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends and verifies discovery completes successfully via page.discoveryShouldFinish(). Discovery selector changes could affect the completion detection mechanism used in this test.
- `suite/e2e/tests/settings/coins.test.ts` — This test activates networks and verifies discovery finishes (page.discoveryShouldFinish), and checks dashboard empty discovery state. Discovery selector changes could affect the empty state detection or discovery completion checks.
- `suite/e2e/tests/settings/forget-device.test.ts` — This test explicitly checks that the Forget button is disabled during active discovery and enabled after discovery finishes (page.discoveryShouldFinish). Changes to discovery selectors could break the discovery-in-progress state detection.
- `suite/e2e/tests/settings/application-log.test.ts` — This test exports and verifies application log content. Changes to logger/utils.ts could affect how log entries are formatted or generated, potentially changing the log content displayed in the modal.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/logger/src/__tests__/utils.test.ts`
- `suite-native/passphrase/src/components/PassphraseScreenHeader.tsx`
- `suite-native/passphrase/src/passphraseSelectors.ts`

_Updated: 2026-06-24T14:35:55.297Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/redact-discovery-edge-cases/web/](https://dev.suite.sldev.cz/suite-web/fix/redact-discovery-edge-cases/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/redact-discovery-edge-cases&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/redact-discovery-edge-cases&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/redact-discovery-edge-cases&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-24T14:41:02.694Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-24T14:39:14.551Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->