### PR TITLE
Feat(suite): Expand FW revision check to cover bootloader_hash

### DIFF
--- a/packages/connect-common/src/types/device.ts
+++ b/packages/connect-common/src/types/device.ts
@@ -83,6 +83,7 @@ export type UnavailableCapabilities = Partial<
 
 export type FirmwareRevisionCheckError =
     | 'revision-mismatch'
+    | 'bootloader-hash-mismatch'
     | 'firmware-version-unknown'
     | 'cannot-perform-check-offline' // suite offline & release version not found locally => we cannot check with `data.trezor.io`
     | 'other-error'; // incorrect URL, cannot parse JSON, etc.

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.0-bitcoinonly.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],
     "firmware_revision": "f4424ece1ccb7fc0d6cad00ff840fac287a34f07",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.10.0-bitcoinonly.bin",
     "fingerprint": "20a4068c34ff6dd7d8c510350409376cf7ea744ba668fdcf16da8f1d81fed289",

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.1-bitcoinonly.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],
     "firmware_revision": "3204fd682429eed23a82b748c05ae569c7f4481f",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.10.1-bitcoinonly.bin",
     "fingerprint": "74227362016a8763c4d5f5b06eeb7eabe5fbd7ed05798b586cc7f4bfef50d7fe",

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.2-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.2-bitcoinonly.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],
     "firmware_revision": "24bb4016388fca4b998285b95dcd408f4ed0bff6",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.10.2-bitcoinonly.bin",
     "fingerprint": "e597b6aef5a2e817f532d27b8501f99f189e432a887877bdd3498cd3a0afc431",

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.3-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.3-bitcoinonly.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],
     "firmware_revision": "9276b1702361f70e094286e2f89e919d8a230d5c",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.10.3-bitcoinonly.bin",
     "fingerprint": "d1143d2cba9c7dba4d57703d2b7da87859d8668472ffc651177ead6b94e89117",

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.4-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.4-bitcoinonly.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],
     "firmware_revision": "595b14254c1abb2be3f69e42c7932f1eca8cf1b1",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.10.4-bitcoinonly.bin",
     "fingerprint": "30d858b022e218f27854f071d568e5a696c937f1316d83b93aadcd178f3b0a38",

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.5-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.5-bitcoinonly.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],
     "firmware_revision": "3f12742669bd782cac374a1750d517f4fd88c43b",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.10.5-bitcoinonly.bin",
     "fingerprint": "1d319f643fe2ba5c247b178c7f73b989ab4e43d914a60468566ee7cc5bb9dde0",

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.11.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.11.1-bitcoinonly.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],
     "firmware_revision": "85a26d2c9593bcdf858c2d718d79951ca927a0c3",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.11.1-bitcoinonly.bin",
     "fingerprint": "8e17b95b5d302f203de3a8fe27959efd25e3d5140ac9b5e60412f1b3f624995d",

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.11.2-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.11.2-bitcoinonly.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 11, 0],
     "firmware_revision": "0d87b55ba4fed7eecc72bf2a94ee473830b095e9",
+    "bootloader_hash": "fa12a44fa05fd1d20539358b54f301cee4c3219c9f1bb3a5772ffd609af9e8e2",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.11.2-bitcoinonly.bin",
     "fingerprint": "7e51546f4411ecf44688c681ada72a18495fd08e91f3a0429ab91bc4415b362a",

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.12.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.12.1-bitcoinonly.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 12, 0],
     "bootloader_version": [1, 12, 1],
     "firmware_revision": "1eb0eb9d91b092e571aac63db4ebff2a07fd8a1f",
+    "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.12.1-bitcoinonly.bin",
     "fingerprint": "985fb6a8c87f7547fb810f6c4a8331ebf19c677445810358778eb21eca78a181",

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.13.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.13.0-bitcoinonly.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 12, 0],
     "bootloader_version": [1, 12, 1],
     "firmware_revision": "592590cf66a9b62dfeee7e4d2afb6e01005e5b2c",
+    "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.13.0-bitcoinonly.bin",
     "fingerprint": "253042fb209c78e02482c645b16cc9894c19124e9c9c0c1051b3c68b6e7c700b",

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.13.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.13.1-bitcoinonly.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 12, 0],
     "bootloader_version": [1, 12, 1],
     "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+    "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.13.1-bitcoinonly.bin",
     "fingerprint": "f27095f2e08278a209567e254b9921f6e34b28a9c0fc702a268f210e23057c27",

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.14.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.14.0-bitcoinonly.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 12, 0],
     "bootloader_version": [1, 12, 1],
     "firmware_revision": "de4b70e2e89a64f3894dba2124f6ec56e5cbd088",
+    "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.14.0-bitcoinonly.bin",
     "fingerprint": "0120fdb06e77b27f99e0466dffcde8f1441a00289249e8b628dee9c0f49e88a6",

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.8.3-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.8.3-bitcoinonly.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],
     "firmware_revision": "df0963ec48f01f3d07ffca556e21ff0070cab099",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.8.3-bitcoinonly.bin",
     "fingerprint": "13d6089cb935f453eaddbfe193e0ab37924a7aa66f684355a4fe5c660c18247a",

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.0-bitcoinonly.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],
     "firmware_revision": "0b7a8449f8dd003fc415262b05102d113247d3de",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.9.0-bitcoinonly.bin",
     "fingerprint": "93a670dd20d044bf76cfce6eecd2a85918acdebe616229dbb31250fd03a33870",

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.1-bitcoinonly.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],
     "firmware_revision": "c6b2580cd245ee924507f45e9675f857a3d78768",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.9.1-bitcoinonly.bin",
     "fingerprint": "ee743e3bd1e424ceb45a1d877a5422e7af449706f636c459cdd8bb0d4796cba5",

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.2-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.2-bitcoinonly.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],
     "firmware_revision": "cde8f31ec2ddcb7d35e36edbcf8a71dda983a9ea",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.9.2-bitcoinonly.bin",
     "fingerprint": "2762c0ff78c96e23d1d348330e0a3cdf45d83c8fc8c2d48853b7cb602ddc19bb",

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.3-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.3-bitcoinonly.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],
     "firmware_revision": "0d5f00668fb3d1c093ff3c879311a91d3a7175c8",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.9.3-bitcoinonly.bin",
     "fingerprint": "76f899d60ffd9685713cb420d017565c05c43aadaf0e62b645a50a8db69afef6",

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.4-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.4-bitcoinonly.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],
     "firmware_revision": "ffa96205fb5e22b43e7b08a3dbc3cdeee0931de3",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.9.4-bitcoinonly.bin",
     "fingerprint": "3f73dfbcfc48f66c8814f6562524d81888230e0acd1c19b52b6e8772c6c67e7f",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.0-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.0-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],
     "firmware_revision": "f4424ece1ccb7fc0d6cad00ff840fac287a34f07",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.10.0.bin",
     "fingerprint": "595ba3e8e887cba185e03098f9538e18164f72f9fc82445e691abcd03e5cf0a4",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.1-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.1-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],
     "firmware_revision": "3204fd682429eed23a82b748c05ae569c7f4481f",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.10.1.bin",
     "fingerprint": "36400becf1cdddec22b8150d56ff59eef76d37fef60dc465a6f82b4858903886",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.2-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.2-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],
     "firmware_revision": "24bb4016388fca4b998285b95dcd408f4ed0bff6",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.10.2.bin",
     "fingerprint": "99707b90a504f7e402f26c3d59cbbdacbc52754cebcce79cc47be528fc889338",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.3-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.3-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],
     "firmware_revision": "9276b1702361f70e094286e2f89e919d8a230d5c",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.10.3.bin",
     "fingerprint": "bf0cc936a9afbf0a4ae7b727a2817fb69fba432d7230a0ff7b79b4a73b845197",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.4-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.4-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],
     "firmware_revision": "595b14254c1abb2be3f69e42c7932f1eca8cf1b1",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.10.4.bin",
     "fingerprint": "74dfdfb9addb9d90fedb2c88794b7236af521d21ef0096f9080c25b597c8af86",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.5-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.5-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],
     "firmware_revision": "3f12742669bd782cac374a1750d517f4fd88c43b",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.10.5.bin",
     "fingerprint": "7619fcc73c43ca8a3e6aad3dc3eb6551fed05bb218340efe01a02bb96e9f346b",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.11.1-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.11.1-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],
     "firmware_revision": "85a26d2c9593bcdf858c2d718d79951ca927a0c3",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.11.1.bin",
     "fingerprint": "f7c60d0b8c2853afd576867c6562aba5ea52bdc2ce34d0dbb8751f52867c3665",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.11.2-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.11.2-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 11, 0],
     "firmware_revision": "0d87b55ba4fed7eecc72bf2a94ee473830b095e9",
+    "bootloader_hash": "fa12a44fa05fd1d20539358b54f301cee4c3219c9f1bb3a5772ffd609af9e8e2",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.11.2.bin",
     "fingerprint": "d8b55b68dfe8a8449ce7391e841073ef5d29349638d85b750508bbef5d2de5ec",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.12.1-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.12.1-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 12, 0],
     "bootloader_version": [1, 12, 1],
     "firmware_revision": "1eb0eb9d91b092e571aac63db4ebff2a07fd8a1f",
+    "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.12.1.bin",
     "fingerprint": "3c694191f5b66a65cb5bb209adbf113cb40209e644b77162ba996bb7ee8f382b",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.13.0-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.13.0-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 12, 0],
     "bootloader_version": [1, 12, 1],
     "firmware_revision": "592590cf66a9b62dfeee7e4d2afb6e01005e5b2c",
+    "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.13.0.bin",
     "fingerprint": "356433bd9de6cb564bf7778fc5de73c56197459523358f267e9235af9e1ce46d",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.13.1-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.13.1-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 12, 0],
     "bootloader_version": [1, 12, 1],
     "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+    "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.13.1.bin",
     "fingerprint": "f588657818ccf99b0046ede3f87eeaf17a0e6e6f1b7853344e18b846ca835328",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.14.0-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.14.0-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 12, 0],
     "bootloader_version": [1, 12, 1],
     "firmware_revision": "de4b70e2e89a64f3894dba2124f6ec56e5cbd088",
+    "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.14.0.bin",
     "fingerprint": "7b33c7d21aff9e2ca70e6667955380436b1e77d1886c15783d9c40031d1b44cb",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.0-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.0-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],
     "firmware_revision": "964a622bb512aa85cfcc3e451fc70729cc15bb4f",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.8.0.bin",
     "fingerprint": "d65f0c07a6a9c53d8b5287798eb53154b33f9e87cd38a3701970e3d0a750a659",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.1-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.1-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],
     "firmware_revision": "0a6a5f85729e663fbeae5ce9e5745918ff6f9d5d",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.8.1.bin",
     "fingerprint": "019e849c1eb285a03a92bbad6d18a328af3b4dc6999722ebb47677b403a4cd16",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.2-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.2-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],
     "firmware_revision": "3c19e3167d69902305a27f10e43abb5fc7a0254d",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.8.2.bin",
     "fingerprint": "909742eddcffdc72ca854557962ecad90e97585770f514170abe7a691b0c6eb1",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.3-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.3-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],
     "firmware_revision": "df0963ec48f01f3d07ffca556e21ff0070cab099",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.8.3.bin",
     "fingerprint": "496aecfab867504b2283a9f057a0b2fd9d17970a22c81f6ad74232e7b914ce68",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.0-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.0-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],
     "firmware_revision": "0b7a8449f8dd003fc415262b05102d113247d3de",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.9.0.bin",
     "fingerprint": "1f40d1e68f9d182888b5b60da5209eff047ec68fcc96a5c9b61b0e55dd07d458",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.1-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.1-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],
     "firmware_revision": "c6b2580cd245ee924507f45e9675f857a3d78768",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.9.1.bin",
     "fingerprint": "30cde253c46d4fc705f98634a35d06a494cf2a36824622a9c6a573e07f14292d",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.2-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.2-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],
     "firmware_revision": "cde8f31ec2ddcb7d35e36edbcf8a71dda983a9ea",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.9.2.bin",
     "fingerprint": "45b83acd1330ddfd5567edbae5ff8028df1c48a493f01d47cc5499ee0be9b991",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.3-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.3-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],
     "firmware_revision": "0d5f00668fb3d1c093ff3c879311a91d3a7175c8",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.9.3.bin",
     "fingerprint": "2589f456559f813d1149be1022e62f2d48fbe28f4d02de933bd888d91035cace",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.4-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.4-universal.json
@@ -6,6 +6,7 @@
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],
     "firmware_revision": "ffa96205fb5e22b43e7b08a3dbc3cdeee0931de3",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "translations": {},
     "url": "firmware/t1b1/trezor-t1b1-1.9.4.bin",
     "fingerprint": "867017bd784cc4e9ce6f0875c61ea86f89b19380d54045c34608b85472998000",

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -718,9 +718,11 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
 
         const result = await checkFirmwareRevision({
             internalModel: this.features.internal_model,
-            deviceRevision: this.features.revision,
             firmwareVersion,
+            deviceRevision: this.features.revision,
             expectedRevision: release?.firmware_revision,
+            deviceBootloaderHash: this.features.bootloader_hash,
+            expectedBootloaderHash: release?.bootloader_hash,
             firmwareType: this.firmwareType,
         });
         this.authenticityChecks = {

--- a/packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts
+++ b/packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts
@@ -11,6 +11,9 @@ jest.mock('../../utils/assets', () => ({
     httpRequest: jest.fn(jest.requireActual('../../utils/assets').httpRequest),
 }));
 
+const EXPECTED_BOOTLOADER_HASH = '94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0';
+const MISMATCHED_BOOTLOADER_HASH = '1234567890';
+
 const ONLINE_RELEASES_JSON_MOCK: FirmwareRelease = {
     required: false,
     version: [2, 7, 2],
@@ -31,14 +34,21 @@ const ONLINE_RELEASES_JSON_MOCK: FirmwareRelease = {
     changelog: '* A\n* B\n* C',
 };
 
+const ONLINE_RELEASES_JSON_WITH_BOOTLOADER_HASH_MOCK: FirmwareRelease = {
+    ...ONLINE_RELEASES_JSON_MOCK,
+    bootloader_hash: EXPECTED_BOOTLOADER_HASH,
+};
+
 const DeviceNames = Object.values(DeviceModelInternal);
 
 type CreateDeviceParams = Omit<CheckFirmwareRevisionParams, 'internalModel' | 'firmwareType'>;
 
 const createDeviceParams = (params: Partial<CreateDeviceParams>): CreateDeviceParams => ({
-    deviceRevision: '1eb0eb9d91b092e571aac63db4ebff2a07fd8a1f',
     firmwareVersion: [2, 7, 2],
+    deviceRevision: '1eb0eb9d91b092e571aac63db4ebff2a07fd8a1f',
     expectedRevision: '1eb0eb9d91b092e571aac63db4ebff2a07fd8a1f',
+    deviceBootloaderHash: null,
+    expectedBootloaderHash: undefined,
     ...params,
 });
 
@@ -70,6 +80,29 @@ describe.each(DeviceNames)(`${checkFirmwareRevision.name} for device %s`, intern
             expected: { success: false, error: 'revision-mismatch' },
         },
         {
+            it: 'errors when expected bootloader hash is provided in params, but device bootloader hash is missing',
+            params: createDeviceParams({
+                expectedBootloaderHash: EXPECTED_BOOTLOADER_HASH,
+            }),
+            expected: { success: false, error: 'bootloader-hash-mismatch' },
+        },
+        {
+            it: 'errors when expected bootloader hash is provided in params, but device bootloader hash does not match',
+            params: createDeviceParams({
+                deviceBootloaderHash: MISMATCHED_BOOTLOADER_HASH,
+                expectedBootloaderHash: EXPECTED_BOOTLOADER_HASH,
+            }),
+            expected: { success: false, error: 'bootloader-hash-mismatch' },
+        },
+        {
+            it: 'passes when matching bootloader hashes are provided in params',
+            params: createDeviceParams({
+                deviceBootloaderHash: EXPECTED_BOOTLOADER_HASH,
+                expectedBootloaderHash: EXPECTED_BOOTLOADER_HASH,
+            }),
+            expected: { success: true },
+        },
+        {
             it: 'passes when firmware version is not found locally, but found in the online release',
             httpRequestMock: () => Promise.resolve(ONLINE_RELEASES_JSON_MOCK),
             params: createDeviceParams({
@@ -85,6 +118,24 @@ describe.each(DeviceNames)(`${checkFirmwareRevision.name} for device %s`, intern
                 expectedRevision: undefined, // firmware not known by local releases.json file
             }),
             expected: { success: false, error: 'revision-mismatch' },
+        },
+        {
+            it: 'errors when bootloader hash is not provided in params, but online release provides a mismatched one',
+            httpRequestMock: () => Promise.resolve(ONLINE_RELEASES_JSON_WITH_BOOTLOADER_HASH_MOCK),
+            params: createDeviceParams({
+                deviceBootloaderHash: MISMATCHED_BOOTLOADER_HASH,
+                expectedRevision: undefined, // firmware not known by local releases.json file
+            }),
+            expected: { success: false, error: 'bootloader-hash-mismatch' },
+        },
+        {
+            it: 'passes when bootloader hash is not provided in params, but matches the online release',
+            httpRequestMock: () => Promise.resolve(ONLINE_RELEASES_JSON_WITH_BOOTLOADER_HASH_MOCK),
+            params: createDeviceParams({
+                deviceBootloaderHash: EXPECTED_BOOTLOADER_HASH,
+                expectedRevision: undefined, // firmware not known by local releases.json file
+            }),
+            expected: { success: true },
         },
         {
             it: 'errors when firmware version is not found locally, and also not in the online release',

--- a/packages/connect/src/device/checkFirmwareRevision.ts
+++ b/packages/connect/src/device/checkFirmwareRevision.ts
@@ -94,6 +94,8 @@ export type CheckFirmwareRevisionParams = {
     internalModel: PROTO.DeviceModelInternal;
     deviceRevision: string | null;
     expectedRevision: string | undefined;
+    deviceBootloaderHash: string | null;
+    expectedBootloaderHash: string | undefined;
     firmwareType: FirmwareType;
 };
 
@@ -125,8 +127,15 @@ export const checkFirmwareRevision = async ({
     internalModel,
     deviceRevision,
     expectedRevision,
+    deviceBootloaderHash,
+    expectedBootloaderHash,
     firmwareType,
 }: CheckFirmwareRevisionParams): Promise<FirmwareRevisionCheckResult> => {
+    // checking bootloader_hash is optional and only for T1B1, so check for failure first if available, or ignore and continue
+    if (expectedBootloaderHash && deviceBootloaderHash !== expectedBootloaderHash) {
+        return failFirmwareRevisionCheck('bootloader-hash-mismatch');
+    }
+
     if (expectedRevision === undefined) {
         if (!versionUtils.isVersionArray(firmwareVersion)) {
             return failFirmwareRevisionCheck('firmware-version-unknown');
@@ -141,6 +150,15 @@ export const checkFirmwareRevision = async ({
 
             if (onlineRelease?.firmware_revision === undefined) {
                 return failFirmwareRevisionCheck('firmware-version-unknown');
+            }
+
+            // again, check bootloader_hash in case it became available in the online release
+            const expectedOnlineBootloaderHash = onlineRelease.bootloader_hash;
+            if (
+                expectedOnlineBootloaderHash &&
+                deviceBootloaderHash !== expectedOnlineBootloaderHash
+            ) {
+                return failFirmwareRevisionCheck('bootloader-hash-mismatch');
             }
 
             if (

--- a/packages/device-utils/src/types.ts
+++ b/packages/device-utils/src/types.ts
@@ -96,6 +96,7 @@ export type FirmwareRelease = {
     min_bootloader_version: VersionArray;
     translations: Record<string, string>;
     firmware_revision?: string;
+    bootloader_hash?: string;
     fingerprint: string;
     changelog?: string;
 };

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareAuthenticityCheckBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareAuthenticityCheckBanner.tsx
@@ -19,6 +19,7 @@ const revisionCheckMessages: Record<
     TranslationKey
 > = {
     'cannot-perform-check-offline': 'TR_DEVICE_FIRMWARE_REVISION_CHECK_UNABLE_TO_PERFORM',
+    'bootloader-hash-mismatch': 'TR_FIRMWARE_REVISION_CHECK_FAILED',
     'revision-mismatch': 'TR_FIRMWARE_REVISION_CHECK_FAILED',
     'firmware-version-unknown': 'TR_FIRMWARE_REVISION_CHECK_FAILED',
 };

--- a/suite-common/firmware-authenticity/src/scenariosConfig.ts
+++ b/suite-common/firmware-authenticity/src/scenariosConfig.ts
@@ -41,6 +41,12 @@ export const revisionCheckErrorScenarios = {
         shouldNotify: false,
         isConclusive: true,
     },
+    'bootloader-hash-mismatch': {
+        type: 'hardModal',
+        shouldReport: true,
+        shouldNotify: false,
+        isConclusive: true,
+    },
     // Note that in native, a banner is displayed, but with special handling, see useIsOfflineBannerVisible
     'cannot-perform-check-offline': {
         type: 'softWarning',

--- a/suite-native/app/e2e/tests/deviceSettingsT1B1.test.ts
+++ b/suite-native/app/e2e/tests/deviceSettingsT1B1.test.ts
@@ -1,5 +1,6 @@
 import { Model } from '@trezor/trezor-user-env-link';
 
+import { deviceChecksDisabledState } from '../fixtures/deviceChecksDisabledState';
 import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
 import { regtestDiscoveryFinishedStateT1B1 } from '../fixtures/regtestDiscoveryFinishedStateT1B1';
 import { onDeviceManager } from '../pageObjects/deviceManagerActions';
@@ -10,6 +11,8 @@ import { waitForVisible } from '../support/utils';
 const preloadedStateT1B1 = preparePreloadedReduxState(
     onboardingCompletedState,
     regtestDiscoveryFinishedStateT1B1,
+    // Tenv T1B1 has correct FW revisions, but mismatched bootloader revisions, so it does not pass FW revision check.
+    deviceChecksDisabledState,
 );
 
 describe('Device Settings T1B1 [@androidOnly @T1B1]', () => {

--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -231,10 +231,14 @@ export class OnboardingPage {
     @step()
     async disableNecessaryFirmwareChecks(options?: { skipSuiteLoadedCheck?: boolean }) {
         await this.disableFirmwareHashCheck(options);
-        if (this.device.hasCanaryFirmware) {
+
+        // Canary firmware is not officialy released, so it cannot possibly pass FW revision check (unrecognized revision).
+        // Tenv T1B1 has correct FW revisions, but mismatched bootloader revisions, so it does not pass FW revision check.
+        if (this.device.hasCanaryFirmware || this.device.model === Model.T1B1) {
             await this.disableFirmwareRevisionCheck();
         }
 
+        // TODO https://github.com/trezor/trezor-suite/issues/22765
         if (this.device.model === Model.T3W1) {
             await this.disableAuthenticityCheck();
         }


### PR DESCRIPTION
## Description

- backfill `bootloader_hash` to local firmware info for T1B1 which are supported (1.9.0 and above)
  - duplicates [data#172](https://github.com/trezor/data/pull/172) – I copied the files as is from data, just ran prettier
- if `bootloader_hash`  is available in the firmware release info, make it compulsory in `features` response and fail the FW revision check if missing or mismatched
  - incl. the case when firmware release info is downloaded online on-the-fly 

:information_source: trezor-user-env has a special bootloader with a wrong hash, so all tenv T1B1 models now fail revision check.
→ Disable FW revision check in all E2E tests using T1B1.

## Notes for QA

See issue

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/209

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily modifies T1B1 firmware data files (JSON metadata for both bitcoin-only and universal variants across many versions), firmware revision checking logic (checkFirmwareRevision.ts), device type definitions (Device.ts, device types), firmware authenticity scenario configuration, and the firmware authenticity check banner component. The risk is concentrated around firmware validation and device onboarding flows, particularly for T1B1 devices. The recommended strategy focuses on T1B1-specific onboarding and recovery tests, firmware-related tests, and tests that explicitly handle firmware hash check errors. Most of the 121 statically-mapped tests are only transitively affected through broad shared infrastructure and do not need to run.

<details><summary><b>Changed files (46)</b></summary>

- `packages/connect-common/src/types/device.ts`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.2-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.3-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.4-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.5-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.11.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.11.2-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.12.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.13.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.13.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.14.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.8.3-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.2-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.3-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.4-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.0-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.2-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.3-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.4-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.5-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.11.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.11.2-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.12.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.13.0-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.13.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.14.0-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.0-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.2-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.3-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.0-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.2-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.3-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.4-universal.json`
- `packages/connect/src/device/Device.ts`
- `packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts`
- `packages/connect/src/device/checkFirmwareRevision.ts`
- `packages/device-utils/src/types.ts`
- `packages/suite/src/components/suite/banners/SuiteBanners/FirmwareAuthenticityCheckBanner.tsx`
- `suite-common/firmware-authenticity/src/scenariosConfig.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test directly exercises firmware readiness detection during onboarding across multiple device models including T1B1. Changes to checkFirmwareRevision.ts, firmware JSON data files for T1B1, and scenariosConfig.ts directly affect the firmware validation logic this test verifies.
- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` — This test creates a wallet on a T1B1 device during onboarding, which involves firmware checks. The bulk of changed files are T1B1 firmware data and the firmware revision check logic, making this the most directly affected T1B1 onboarding test.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts` — T1B1 recovery flow passes through firmware setup steps and uses the firmware check logic. With extensive T1B1 firmware data changes, this test validates that recovery still works correctly on T1B1 devices.
- `suite/e2e/tests/firmware/custom-firmware.test.ts` — This test installs custom firmware on a device through Settings > Device tab. Changes to Device.ts, checkFirmwareRevision.ts, and firmware authenticity scenariosConfig directly affect custom firmware installation and validation flows.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts` — Advanced recovery on T1B1 navigates through firmware steps. The T1B1 firmware data and firmware revision check changes could affect the firmware continuation step in this flow.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts` — T1B1 recovery failure test passes through firmware check steps during onboarding. Changes to T1B1 firmware data and firmware revision checking could affect the firmware continuation behavior.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test exercises firmware check and wallet creation flows, and explicitly references device compromised modals and firmware hash check errors. Changes to scenariosConfig.ts and FirmwareAuthenticityCheckBanner.tsx could affect the error handling paths tested here.
- `suite/e2e/tests/recovery/t1b1-dry-run.test.ts` — T1B1 dry run recovery test navigates through device settings and exercises firmware/device interaction. T1B1 firmware data changes and Device.ts modifications could affect device communication during the seed check flow.
- `suite/e2e/tests/settings/t1b1-device-settings.test.ts` — This test exercises T1B1 device settings including PIN setup and homescreen changes. Changes to Device.ts affect device communication, and T1B1 firmware data changes could affect how the device settings page interacts with the T1B1 model.
- `suite/e2e/tests/suite/initial-run.test.ts` — This test explicitly handles firmware hash check error modal dismissal during the initial run flow. Changes to FirmwareAuthenticityCheckBanner.tsx and scenariosConfig.ts could affect whether/how this modal appears.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/settings/autodetect.test.ts` — This test dismisses firmware hash check error modals during onboarding. Changes to scenariosConfig.ts and FirmwareAuthenticityCheckBanner.tsx could alter when these modals appear, potentially affecting the test flow.

</details>

⚠️ **Changes with no test coverage (41)**
- `packages/connect-common/src/types/device.ts`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.2-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.3-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.4-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.5-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.11.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.11.2-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.12.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.13.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.13.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.14.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.8.3-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.2-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.3-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.4-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.0-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.2-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.3-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.4-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.5-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.11.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.11.2-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.12.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.13.0-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.13.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.0-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.2-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.3-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.0-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.2-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.3-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.4-universal.json`
- `packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts`
- `packages/device-utils/src/types.ts`

_Updated: 2026-06-24T15:42:06.383Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/fw-revision-check-bootloader_hash&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/fw-revision-check-bootloader_hash&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/fw-revision-check-bootloader_hash&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/fw-revision-check-bootloader_hash/web/](https://dev.suite.sldev.cz/suite-web/feat/fw-revision-check-bootloader_hash/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-25T09:27:35.758Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-25T09:25:51.039Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->