### PR TITLE
fix(suite-native): debug view shared value

### DIFF
--- a/suite-native/atoms/src/DebugView.tsx
+++ b/suite-native/atoms/src/DebugView.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useRef } from 'react';
+import { forwardRef, useLayoutEffect, useRef } from 'react';
 import { View, type ViewProps } from 'react-native';
 import Animated, {
     interpolateColor,
@@ -62,7 +62,9 @@ export const DebugView = forwardRef<View, ViewProps>(({ style, children, ...prop
         }),
     );
 
-    flashState.value = flashState.value === 0 ? 1 : 0;
+    useLayoutEffect(() => {
+        flashState.value = flashState.value === 0 ? 1 : 0;
+    });
 
     const rStyle = useAnimatedStyle(() => {
         const backgroundColor = interpolateColor(


### PR DESCRIPTION
## Description

Fixes warning that was thrown for every render of DebugView (btw, that is any render 🦀 ). 

``` 
WARN  [Reanimated] Writing to `value` during component render. Please ensure that you don't access the `value` property nor use `set` method of a shared value while React is rendering a component.

If you don't want to see this message, you can disable the `strict` mode. Refer to:
https://docs.swmansion.com/react-native-reanimated/docs/debugging/logger-configuration for more details.
```

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/debug-view&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->