### PR TITLE
fix(suite): 25.11.0 migration when walletSettings store is empty

### DIFF
--- a/packages/suite/src/storage/migrations/versions/25.11.0.ts
+++ b/packages/suite/src/storage/migrations/versions/25.11.0.ts
@@ -1,4 +1,5 @@
 import { createMigration } from '@suite/idb-migration-utils';
+import { initialWalletSettingsState } from '@suite-common/wallet-core';
 
 import { type SuiteDBSchema } from 'src/storage/definitions';
 
@@ -18,6 +19,20 @@ export default createMigration<SuiteDBSchema>('25.11.0', async (db, tx) => {
 
     const suiteSettings = await getSuiteSettings();
     const prevAutoEjectValue = suiteSettings?.autoEject === true;
+    const walletSettingsStore = tx.objectStore('walletSettings');
+    const hasAnyWalletSettings = (await walletSettingsStore.count()) > 0;
+
+    if (!hasAnyWalletSettings) {
+        await walletSettingsStore.put(
+            {
+                ...initialWalletSettingsState,
+                isAutoEjectEnabled: prevAutoEjectValue,
+            },
+            'wallet',
+        );
+
+        return;
+    }
 
     await updateAll(tx, 'walletSettings', walletSettings => {
         delete (walletSettings as OldWalletSettingsType).autoForgetDeviceData;

--- a/packages/suite/src/storage/migrations/versions/__tests__/25.11.0.test.ts
+++ b/packages/suite/src/storage/migrations/versions/__tests__/25.11.0.test.ts
@@ -1,6 +1,8 @@
 import '@suite-common/test-utils/src/globalOverrides';
 import { type IDBPDatabase, deleteDB, openDB } from 'idb';
 
+import { initialWalletSettingsState } from '@suite-common/wallet-core';
+
 import { type SuiteDBSchema } from 'src/storage/definitions';
 
 import migration from '../25.11.0';
@@ -74,6 +76,27 @@ describe('migration 25.11.0', () => {
         const wallet = await migratedDb.get('walletSettings', 'wallet');
         expect(wallet).toBeDefined();
         expect(wallet?.isAutoEjectEnabled).toBe(false);
+
+        migratedDb.close();
+    });
+
+    test('creates walletSettings entry if the store is empty', async () => {
+        const db = await openDB(DB_NAME, INITIAL_VERSION, {
+            upgrade(db) {
+                db.createObjectStore('suiteSettings');
+                db.createObjectStore('walletSettings');
+            },
+        });
+        await db.put('suiteSettings', { settings: { autoEject: true } }, 'suite');
+        db.close();
+
+        const migratedDb = await runMigration();
+
+        const wallet = await migratedDb.get('walletSettings', 'wallet');
+        expect(wallet).toEqual({
+            ...initialWalletSettingsState,
+            isAutoEjectEnabled: true,
+        });
 
         migratedDb.close();
     });


### PR DESCRIPTION
## Description

Currently 25.11.0 only works if you have changed anything in `walletSettingsReducer` before. If not, then the autoEject is not migrated from `suiteSettings` to `walletSettings` because the latter doesn't exist in IDB.

→ in that case, populate it.

This should unblock #28702 which is stuck because of this problem

## Notes for QA

1. Visit https://dev.suite.sldev.cz/suite-web/release/25.10/web
2. Only enable AutoEject in settings
3. Visit https://dev.suite.sldev.cz/suite-web/fix/25.11-migration-with-empty-store/web/settings
4. AutoEject setting should be still on

This does not work if you visit develop in step 3.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies a storage migration version file (25.11.0.ts) and its unit test. Storage migrations are critical infrastructure that run when users upgrade Suite versions, transforming persisted IndexedDB data to match new schemas. The primary risk is data corruption or loss during migration. The recommended strategy focuses on the two dedicated DB migration E2E tests (which directly test version-to-version migration) and two tests that load from IndexedDB dumps (which exercise the migration pipeline indirectly). The unit test file has no E2E coverage but is self-contained. The 111 tests mapped via static coverage are transitively dependent through the migration module being part of the storage initialization chain, but most do not specifically exercise migration logic.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/storage/migrations/versions/25.11.0.ts`
- `packages/suite/src/storage/migrations/versions/__tests__/25.11.0.test.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/suite/db-migration.test.ts` — This test directly validates database migration from an old Suite version to the latest, preserving user data and settings. The changed file is a storage migration version (25.11.0.ts), making this the most directly relevant test for verifying that the migration logic works correctly end-to-end.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — This test verifies database migration between Suite versions preserves user settings like language preference. Since the change is to a storage migration version file, this test directly exercises the migration pipeline and could catch regressions in settings persistence across version upgrades.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trading/remembered-wallet-loading.test.ts` — This test loads a remembered wallet from IndexedDB, which exercises the storage/migration layer when Suite initializes with persisted state. A broken migration could prevent remembered wallets from loading correctly after an upgrade.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test seeds and loads from an IndexedDB dump (remembered-wallet-db-lite.json), which triggers the storage migration pipeline on initialization. A faulty migration version could corrupt the loaded wallet state.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/storage/migrations/versions/__tests__/25.11.0.test.ts`

_Updated: 2026-06-24T18:15:09.305Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/25.11-migration-with-empty-store&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/25.11-migration-with-empty-store&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/25.11-migration-with-empty-store/web/](https://dev.suite.sldev.cz/suite-web/fix/25.11-migration-with-empty-store/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-24T18:19:58.167Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-24T18:18:39.587Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->