### PR TITLE
refactor(suite): extract selectCustomBackends and reuse it in useCustomBackends

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/utils.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/utils.ts
@@ -1,11 +1,10 @@
-import { selectEnabledNetworks } from '@suite-common/wallet-core';
+import { selectCustomBackends, selectEnabledNetworks } from '@suite-common/wallet-core';
 
-import { useCustomBackends } from 'src/hooks/settings/backends';
 import { useSelector } from 'src/hooks/suite';
 
 export const useEnabledBackends = () => {
     const enabledNetworks = useSelector(selectEnabledNetworks);
-    const customBackends = useCustomBackends();
+    const customBackends = useSelector(selectCustomBackends);
 
     return customBackends.filter(backend => enabledNetworks.includes(backend.symbol));
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorModal.tsx
@@ -4,13 +4,12 @@ import { Translation } from '@suite/intl';
 import { isOnionUrl } from '@suite/tor';
 import { type UserContextPayload } from '@suite-common/suite-types';
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
-import { blockchainActions } from '@suite-common/wallet-core';
+import { blockchainActions, selectCustomBackends } from '@suite-common/wallet-core';
 import { Banner, Button, Card, Column, H3, Modal, Paragraph, Row } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
-import { useCustomBackends } from 'src/hooks/settings/backends';
-import { useDispatch } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { AdvancedCoinSettingsModal } from './AdvancedCoinSettingsModal/AdvancedCoinSettingsModal';
 
@@ -21,7 +20,8 @@ type DisableTorModalProps = Omit<Extract<UserContextPayload, { type: 'disable-to
 export const DisableTorModal = ({ onCancel, decision }: DisableTorModalProps) => {
     const dispatch = useDispatch();
     const [symbol, setSymbol] = useState<NetworkSymbol>();
-    const onionBackends = useCustomBackends().filter(({ urls }) => urls.every(isOnionUrl));
+    const customBackends = useSelector(selectCustomBackends);
+    const onionBackends = customBackends.filter(({ urls }) => urls.every(isOnionUrl));
 
     const onDisableTor = () => {
         onionBackends.forEach(({ symbol, type, urls }) =>

--- a/packages/suite/src/hooks/settings/backends/index.ts
+++ b/packages/suite/src/hooks/settings/backends/index.ts
@@ -1,5 +1,4 @@
 export { useDefaultUrls } from './useDefaultUrls';
 export { useBackendsForm } from './useBackendsForm';
-export { useCustomBackends } from './useCustomBackends';
 export { useBackendReconnection } from './useBackendReconnection';
 export type { BackendOption } from './useBackendsForm';

--- a/packages/suite/src/hooks/settings/backends/useCustomBackends.ts
+++ b/packages/suite/src/hooks/settings/backends/useCustomBackends.ts
@@ -1,5 +1,0 @@
-import { selectCustomBackends } from '@suite-common/wallet-core';
-
-import { useSelector } from 'src/hooks/suite';
-
-export const useCustomBackends = () => useSelector(selectCustomBackends);

--- a/packages/suite/src/hooks/settings/backends/useCustomBackends.ts
+++ b/packages/suite/src/hooks/settings/backends/useCustomBackends.ts
@@ -1,9 +1,5 @@
-import { getCustomBackends } from '@suite-common/wallet-utils';
+import { selectCustomBackends } from '@suite-common/wallet-core';
 
 import { useSelector } from 'src/hooks/suite';
 
-export const useCustomBackends = () => {
-    const blockchains = useSelector(state => state.wallet.blockchain);
-
-    return getCustomBackends(blockchains);
-};
+export const useCustomBackends = () => useSelector(selectCustomBackends);

--- a/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
@@ -233,10 +233,15 @@ export const selectIsCustomBackendConfigured = createMemoizedSelector(
 export const selectGapLimit = (state: BlockchainRootState, symbol: NetworkSymbol) =>
     state.wallet.blockchain[symbol]?.backends.gapLimit;
 
+export const selectCustomBackends = createMemoizedSelector(
+    [selectBlockchainState],
+    blockchainState => getCustomBackends(blockchainState),
+);
+
 export const selectEnabledCustomBackends = createMemoizedSelector(
-    [selectBlockchainState, selectEnabledNetworks],
-    (blockchainState, enabledNetworks) =>
-        getCustomBackends(blockchainState)
+    [selectCustomBackends, selectEnabledNetworks],
+    (customBackends, enabledNetworks) =>
+        customBackends
             .map(({ symbol }) => symbol)
             .filter(symbol => enabledNetworks.includes(symbol)),
 );


### PR DESCRIPTION
## Description

Extracts a `selectCustomBackends` memoized selector in `blockchainReducer.ts` and reuses it across the codebase, removing duplicated derivation of custom backends from the blockchain state.

### Changes

- **Add `selectCustomBackends`** — a memoized selector wrapping `getCustomBackends(selectBlockchainState)`, returning the full `CustomBackend[]` (`{ symbol, type, urls }`).
- **Rewire `selectEnabledCustomBackends`** to build on `selectCustomBackends` instead of calling `getCustomBackends` on raw state directly. Same output, one hop earlier, better cache stability.
- **Simplify `useCustomBackends`** to `useSelector(selectCustomBackends)` instead of reaching into `state.wallet.blockchain` and running `getCustomBackends` on every render.

### Why

`useCustomBackends` and `selectEnabledCustomBackends` both derived custom backends from the same blockchain slice independently. The hook re-ran `getCustomBackends` on every render and returned a fresh array reference each time (potential needless re-renders downstream). Consolidating onto one memoized selector removes the duplication and stabilizes the reference.

The output of `useCustomBackends` is unchanged (`selectBlockchainState` is literally `state => state.wallet.blockchain`, identical to the previous hook input), so consumers (`DisableTorModal`, `SuiteLayout/utils`) are unaffected.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch custom backend configuration hooks (useCustomBackends.ts, backends/index.ts), the blockchain state reducer (blockchainReducer.ts), a SuiteLayout utility, and the DisableTorModal component. The highest risk is in the backend configuration and blockchain state management, which directly affects custom backend setup, wallet discovery, and blockchain connections. The SuiteLayout utils and DisableTorModal map to 121 tests each, indicating they are broadly imported utilities — no specific test exercises DisableTorModal or Tor-related flows in the candidate list, so those are effectively uncovered. The recommended strategy focuses on the 4 tests that directly exercise custom backend configuration, plus 3 medium-priority tests that depend on blockchain state management.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/components/suite/layouts/SuiteLayout/utils.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorModal.tsx`
- `packages/suite/src/hooks/settings/backends/index.ts`
- `packages/suite/src/hooks/settings/backends/useCustomBackends.ts`
- `suite-common/wallet-core/src/blockchain/blockchainReducer.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test directly exercises custom backend configuration for coins (BTC, ETH), which is the core functionality of useCustomBackends.ts and related backend hooks. It tests enabling networks, configuring custom blockbook backend URLs, verifying connection success/failure, and the custom backend indicator — all of which depend on the changed backend hooks and potentially blockchainReducer.
- `suite/e2e/tests/settings/coins.test.ts` — This test configures custom backend servers (blockbook type for ETH), verifies custom backend indicators, and enables/disables coin networks — directly exercising the useCustomBackends hook and blockchainReducer state management for backend configuration.
- `suite/e2e/tests/settings/electrum.test.ts` — This test configures a custom Electrum backend server for the Regtest network and verifies discovery completes successfully. It directly exercises backend configuration logic in useCustomBackends.ts and the blockchainReducer for managing custom backend state.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends for BTC and LTC, then verifies wallet discovery completes and dashboard renders correctly. It directly tests the backend configuration flow handled by useCustomBackends and blockchainReducer.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test verifies that SuiteReady analytics events report customBackends correctly after configuring custom backend settings. Changes to useCustomBackends or blockchainReducer could affect how custom backend state is reported in analytics.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coin networks and verifies discovery completes after a page reload interruption. The blockchainReducer manages blockchain connection state critical to discovery, so changes there could cause discovery failures across multiple coins.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test enables regtest, sends BTC, and verifies balance updates in real-time. The blockchainReducer manages blockchain state including balance notifications, so changes could affect balance display updates.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/suite/layouts/SuiteLayout/utils.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorModal.tsx`

_Updated: 2026-06-26T01:16:16.713Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/select-custom-backends&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/select-custom-backends&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/select-custom-backends&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |

</details>

_Updated: 2026-06-26T01:21:33.799Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |

</details>

_Updated: 2026-06-26T01:19:13.067Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/select-custom-backends/web/](https://dev.suite.sldev.cz/suite-web/refactor/select-custom-backends/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->