### PR TITLE
fix(trading): prefill buy account from header action

### DIFF
--- a/packages/suite/src/middlewares/wallet/__tests__/tradingMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/tradingMiddleware.test.ts
@@ -266,6 +266,29 @@ describe('tradingMiddleware', () => {
         },
     );
 
+    it('should set buy trading and receive account keys from prefilled account on buy route', () => {
+        const accountKey = mockAccountKey({ descriptor: 'prefilledaccountkey' });
+        const store = initStore(
+            getInitialState({
+                trading: {
+                    ...initialState,
+                    prefilledFromAccount: {
+                        cryptoId: 'bitcoin' as CryptoId,
+                        key: accountKey,
+                    },
+                },
+                router: {
+                    ...getInitialState().router,
+                },
+            }),
+        );
+
+        store.dispatch(routerLocationChange({ ...tradingMiddlewareFixtures.TRADING_BUY_ROUTE }));
+
+        expect(store.getState().wallet.trading.buy.tradingAccountKey).toEqual(accountKey);
+        expect(store.getState().wallet.trading.buy.receiveAccountKey).toEqual(accountKey);
+    });
+
     it.each([
         [tradingExchangeActions.setTradingAccountKey.type, 'exchange' as const],
         [tradingSellActions.setTradingAccountKey.type, 'sell' as const],

--- a/packages/suite/src/middlewares/wallet/tradingMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/tradingMiddleware.ts
@@ -58,6 +58,7 @@ export const tradingMiddleware =
                 api.dispatch(tradingBuyActions.saveTransactionId(undefined));
                 if (prefilledFromAccount.key) {
                     api.dispatch(tradingBuyActions.setTradingAccountKey(prefilledFromAccount.key));
+                    api.dispatch(tradingBuyActions.setReceiveAccountKey(prefilledFromAccount.key));
                 } else {
                     // When switching from sell tab, carry over the sell account key
                     const sellAccountKey = selectTradingAccountKeyByTradeType(nextState, 'sell');


### PR DESCRIPTION
## Description

- Set the Buy receive account key from `prefilledFromAccount` when the header Buy action opens the trading form with correct receive account

- In Accounts, open the header Buy action from a non-default account and verify the Buy form preselects that same account.
## Related Issue

Resolve #28141

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect tradingMiddleware.ts and its unit test file. The middleware is a Redux middleware that handles trading/coinmarket operations (buy, sell, swap) including trade orchestration, quote processing, watch polling, and composed transaction state management. While it maps to 121 E2E tests via static analysis, this is because it's loaded as part of the global middleware stack — only the ~20 trading-specific tests actually exercise its core functionality. The recommended strategy focuses on trading E2E tests that directly exercise buy/sell/swap flows, with high priority on the most common paths (BTC buy, BTC sell, coin swap, navigation) and medium priority on variant flows (tokens, other coins, fee customization, history). The unit test file has no E2E coverage (as expected for a unit test).

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/middlewares/wallet/__tests__/tradingMiddleware.test.ts`
- `packages/suite/src/middlewares/wallet/tradingMiddleware.ts`

</details>

**Recommended tests (20)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test directly exercises the trading/coinmarket buy flow end-to-end, including trade requests, quote handling, and transaction status updates — all of which are orchestrated through the tradingMiddleware. Changes to tradingMiddleware could break buy trade confirmation, watch polling, or redirect handling.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test covers the full sell BTC flow including quote display, trade confirmation, and send initiation — core trading flows that route through tradingMiddleware. A regression in middleware dispatch or state management would directly impact this test.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test exercises the complete swap flow (SOL→BTC) including quote selection, device confirmation, transaction sending, and status polling through SENDING→CONFIRMING→CONVERTING→SUCCESS states. The tradingMiddleware handles swap trade orchestration and watch polling.
- `suite/e2e/tests/trading/navigation.test.ts` — This test validates trading form navigation from multiple entry points (dashboard, account, global header, sidebar, tokens). The tradingMiddleware likely handles route-based state initialization for buy/sell/swap forms, making this test critical for verifying navigation-triggered middleware behavior.

</details>

<details><summary>🟡 <b>Medium priority (13)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests SOL→USDC cross-network swap with receive account selection and transaction confirmation. This exercises tradingMiddleware's handling of token-based swap trades and cross-network receive account logic.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests USDT→BTC swap including token confirmation flow and success toast. Exercises the tradingMiddleware's handling of token-to-coin swap trades which may have different middleware logic than coin-to-coin swaps.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests the sell flow for Solana including trade confirmation, transaction sending, and status polling (Sending→Processing/Success). Exercises tradingMiddleware's handling of non-BTC/ETH sell flows and watch endpoint integration.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests buying ETH via asset picker search and new account addition. Exercises tradingMiddleware's handling of buy trades for non-BTC coins and account creation during the buy flow.
- `suite/e2e/tests/trading/swap-history.test.ts` — Tests viewing swap trade order history and detail pages. The tradingMiddleware handles swap watch endpoint interception and trade status management, which directly affects how historical trades are displayed and updated.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests buy form validation edge cases (max/min limits, empty quotes). The tradingMiddleware may handle quote response processing and error state management that affects how validation errors are surfaced.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation and fraction buttons for BTC and SOL. The tradingMiddleware may process composed transaction info that affects fee calculations and max amount computation in the sell form.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form inputs, fraction buttons, asset selection, and provider display. The tradingMiddleware handles swap quote syncing and fee computation that directly affects the swap form's displayed values.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests custom BTC fee settings during swap, including composedTransactionInfo Redux state. The tradingMiddleware manages the composed transaction info state that this test directly asserts against.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests custom ETH fee settings during swap with gas limit, max fee, and priority fee. Asserts that wallet.trading.composedTransactionInfo Redux state is populated, which is managed by tradingMiddleware.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests the ETH sell flow with custom gas fees. Exercises tradingMiddleware's handling of EVM-specific sell trades and fee parameter management.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token (USDC) through the trading flow. Exercises tradingMiddleware's handling of token-specific sell trades which may differ from native coin sells.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Tests buying a Solana SPL token (Jupiter/JUP) via asset picker and crypto amount input. Exercises tradingMiddleware's handling of token-level buy trades on non-EVM networks.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests SPL token-to-token swap (USDT→USDC on Solana). While it exercises trading middleware, the core swap logic is largely the same as swap-coins; included for token-specific edge case coverage.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swapping to an asset on a disabled network. The tradingMiddleware may handle quote display logic differently when the target network is not enabled, making this a specific edge case worth covering.
- `suite/e2e/tests/trading/remembered-wallet-loading.test.ts` — Tests loading a remembered wallet state from IndexedDB. The tradingMiddleware initializes when the app loads, and this test verifies the app works correctly in a device-disconnected state that may affect middleware initialization.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/middlewares/wallet/__tests__/tradingMiddleware.test.ts`

_Updated: 2026-06-25T05:39:36.292Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/28141-buy-prefills-selected-account&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/28141-buy-prefills-selected-account&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-25T05:44:13.522Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-25T05:42:37.700Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/28141-buy-prefills-selected-account/web/](https://dev.suite.sldev.cz/suite-web/fix/28141-buy-prefills-selected-account/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->