### PR TITLE
refactor(wallet-core): move Account timestamp to separate reducer

### DIFF
--- a/packages/suite/src/actions/labels/__fixtures__/moveLabelsForRbfAccounts.fixture.ts
+++ b/packages/suite/src/actions/labels/__fixtures__/moveLabelsForRbfAccounts.fixture.ts
@@ -399,7 +399,6 @@ export const accountSpendingCoins: Account = {
     marker: undefined,
     stellarCursor: undefined,
     page: { index: 1, size: 25, total: 1 },
-    ts: 0,
 };
 
 export const accountReceivingCoins: Account = {
@@ -816,7 +815,6 @@ export const accountReceivingCoins: Account = {
     marker: undefined,
     stellarCursor: undefined,
     page: { index: 1, size: 25, total: 1 },
-    ts: 0,
 };
 
 export const moveLabelsForRbfAccountsFixture: AccountsRootState['wallet']['accounts'] = [

--- a/packages/suite/src/actions/wallet/trading/__fixtures__/tradingCommonActions/accounts.ts
+++ b/packages/suite/src/actions/wallet/trading/__fixtures__/tradingCommonActions/accounts.ts
@@ -52,7 +52,6 @@ export const BTC_ACCOUNT: Account = {
     misc: undefined,
     marker: undefined,
     stellarCursor: undefined,
-    ts: 0,
 };
 
 export const ETH_ACCOUNT: Account = {
@@ -95,7 +94,6 @@ export const ETH_ACCOUNT: Account = {
     misc: { nonce: '1' },
     marker: undefined,
     stellarCursor: undefined,
-    ts: 0,
 };
 
 export const XRP_ACCOUNT: Account = {
@@ -141,5 +139,4 @@ export const XRP_ACCOUNT: Account = {
     },
     marker: undefined,
     stellarCursor: undefined,
-    ts: 0,
 };

--- a/packages/suite/src/actions/wallet/trading/__fixtures__/tradingCommonActions/store.ts
+++ b/packages/suite/src/actions/wallet/trading/__fixtures__/tradingCommonActions/store.ts
@@ -52,5 +52,4 @@ export const ACCOUNT: Account = {
     misc: undefined,
     marker: undefined,
     stellarCursor: undefined,
-    ts: 0,
 };

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -39,7 +39,6 @@ import {
     type TokenDefinitionsState,
     prepareTokenDefinitionsReducer,
 } from '@suite-common/token-definitions';
-import { accountsActions } from '@suite-common/wallet-core';
 import { isCodesignBuild } from '@trezor/env-utils';
 import { mergeDeepObject } from '@trezor/utils';
 
@@ -119,7 +118,7 @@ const rootReducer = combineReducers({
     globalSendReceiveFilters: globalSendReceiveFiltersReducer,
 } satisfies ReducersMapObject<AppState, never, Record<keyof AppState, never>>);
 
-const loggerExcludedActions = [addLog.type, accountsActions.updateAccountRefreshTimestamp.type];
+const loggerExcludedActions = [addLog.type];
 
 const getCustomMiddleware = (getExtra: () => ExtraDependencies | null) => {
     const middleware = [

--- a/packages/suite/src/reducers/wallet/__fixtures__/transactionConstants.ts
+++ b/packages/suite/src/reducers/wallet/__fixtures__/transactionConstants.ts
@@ -104,7 +104,6 @@ export const accounts: CommonAccount[] = [
         misc: undefined,
         marker: undefined,
         stellarCursor: undefined,
-        ts: 0,
     },
     {
         deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
@@ -196,7 +195,6 @@ export const accounts: CommonAccount[] = [
         misc: undefined,
         marker: undefined,
         stellarCursor: undefined,
-        ts: 0,
     },
 ];
 

--- a/packages/suite/src/reducers/wallet/index.ts
+++ b/packages/suite/src/reducers/wallet/index.ts
@@ -4,6 +4,7 @@ import { selectedAccountReducer } from '@suite/account';
 import { type CoinjoinAction, type CoinjoinState, coinjoinReducer } from '@suite/coinjoin';
 import { type TradingState, prepareTradingReducer } from '@suite-common/trading';
 import {
+    type AccountsRefreshTimeState,
     type AccountsState,
     type ExplorerConfig,
     type FiatRatesState,
@@ -14,6 +15,7 @@ import {
     type StakeState,
     type TransactionsState,
     type TronStakeReducerState,
+    accountsRefreshTimeReducer,
     feesReducer,
     prepareAccountsReducer,
     prepareBlockchainReducer,
@@ -62,6 +64,7 @@ export type WalletState = {
     phishing: PhishingState;
     discovery: Discovery;
     accounts: AccountsState;
+    accountsRefreshTime: AccountsRefreshTimeState;
     selectedAccount: SelectedAccountStatus;
     fees: FeesState;
     blockchain: BlockchainNetworks;
@@ -88,6 +91,7 @@ export const walletReducers: Reducer<
     phishing: phishingReducer,
     discovery: discoveryReducer,
     accounts: accountsReducer,
+    accountsRefreshTime: accountsRefreshTimeReducer,
     selectedAccount: selectedAccountReducer,
     fees: feesReducer,
     blockchain: blockchainReducer,

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -194,7 +194,7 @@ export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteSer
         saveAs: (data: Blob, fileName: string) => saveAs(data, fileName),
         connectInitSettings,
         connectInitHooks,
-        accountRefreshThrottle: createAccountRefreshThrottle(),
+        accountRefreshThrottle: createAccountRefreshThrottle(deps.getState),
         createLogger: deps.createLogger,
         thpHostName: deps.thpHostName,
         createTransports,

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -64,6 +64,7 @@ import {
     type SendState,
     type TransactionsState,
     type WalletSettingsState,
+    createAccountRefreshThrottle,
     selectAccountsByDeviceState,
 } from '@suite-common/wallet-core';
 import { createAccountKey } from '@suite-common/wallet-types';
@@ -193,6 +194,7 @@ export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteSer
         saveAs: (data: Blob, fileName: string) => saveAs(data, fileName),
         connectInitSettings,
         connectInitHooks,
+        accountRefreshThrottle: createAccountRefreshThrottle(),
         createLogger: deps.createLogger,
         thpHostName: deps.thpHostName,
         createTransports,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/hooks/useAgregatedAccountsWithTokens.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/hooks/useAgregatedAccountsWithTokens.ts
@@ -23,7 +23,6 @@ import {
 function getAccountLight({
     utxo,
     addresses,
-    ts,
     page,
     history,
     metadata,

--- a/packages/utils/src/createKeyedThrottle.ts
+++ b/packages/utils/src/createKeyedThrottle.ts
@@ -1,0 +1,38 @@
+// Key defaults to string, but a branded key (e.g. AccountKey) can be enforced via the type param.
+export type KeyedThrottle<TKey extends string = string> = {
+    /** Has `interval` ms elapsed since this id last ran (or it never did)? */
+    canRun: (id: TKey) => boolean;
+    /** Record a run for this id now (starts a new interval). */
+    markRun: (id: TKey) => void;
+    /** Drop the id so the next canRun() returns true again (forced run / cleanup). */
+    reset: (id: TKey) => void;
+    /** Drop all ids so the next canRun() returns true for everything. */
+    resetAll: () => void;
+};
+
+/**
+ * Leading-edge throttle keyed by id. Answers "has `interval` ms elapsed since this id last ran?"
+ * without storing the timestamp on the caller's entity (which, in Redux, would churn its reference
+ * and re-render everything that reads it).
+ *
+ * Intentionally lazy - elapsed time is computed on read, so there is no background interval to run
+ * or clean up. A forgotten entry is just a number; `reset` removes it.
+ */
+export const createKeyedThrottle = <TKey extends string = string>(
+    interval: number,
+): KeyedThrottle<TKey> => {
+    const lastRunByKey = new Map<TKey, number>();
+
+    const canRun = (id: TKey) => Date.now() - (lastRunByKey.get(id) ?? 0) >= interval;
+    const markRun = (id: TKey) => {
+        lastRunByKey.set(id, Date.now());
+    };
+    const reset = (id: TKey) => {
+        lastRunByKey.delete(id);
+    };
+    const resetAll = () => {
+        lastRunByKey.clear();
+    };
+
+    return { canRun, markRun, reset, resetAll };
+};

--- a/packages/utils/src/createKeyedThrottle.ts
+++ b/packages/utils/src/createKeyedThrottle.ts
@@ -1,38 +1,18 @@
 // Key defaults to string, but a branded key (e.g. AccountKey) can be enforced via the type param.
 export type KeyedThrottle<TKey extends string = string> = {
-    /** Has `interval` ms elapsed since this id last ran (or it never did)? */
+    /** Has `interval` ms elapsed since this id last ran (per `getLastRun`), or it never did? */
     canRun: (id: TKey) => boolean;
-    /** Record a run for this id now (starts a new interval). */
-    markRun: (id: TKey) => void;
-    /** Drop the id so the next canRun() returns true again (forced run / cleanup). */
-    reset: (id: TKey) => void;
-    /** Drop all ids so the next canRun() returns true for everything. */
-    resetAll: () => void;
 };
 
 /**
- * Leading-edge throttle keyed by id. Answers "has `interval` ms elapsed since this id last ran?"
- * without storing the timestamp on the caller's entity (which, in Redux, would churn its reference
- * and re-render everything that reads it).
+ * Leading-edge throttle keyed by id. Answers "has `interval` ms elapsed since this id last ran?".
  *
- * Intentionally lazy - elapsed time is computed on read, so there is no background interval to run
- * or clean up. A forgotten entry is just a number; `reset` removes it.
+ * It does not store the timestamps itself - `getLastRun` reads them from wherever they live (e.g. a
+ * store slice), so the source of truth stays in one place and this stays a pure, testable predicate.
  */
 export const createKeyedThrottle = <TKey extends string = string>(
     interval: number,
-): KeyedThrottle<TKey> => {
-    const lastRunByKey = new Map<TKey, number>();
-
-    const canRun = (id: TKey) => Date.now() - (lastRunByKey.get(id) ?? 0) >= interval;
-    const markRun = (id: TKey) => {
-        lastRunByKey.set(id, Date.now());
-    };
-    const reset = (id: TKey) => {
-        lastRunByKey.delete(id);
-    };
-    const resetAll = () => {
-        lastRunByKey.clear();
-    };
-
-    return { canRun, markRun, reset, resetAll };
-};
+    getLastRun: (id: TKey) => number | undefined,
+): KeyedThrottle<TKey> => ({
+    canRun: (id: TKey) => Date.now() - (getLastRun(id) ?? 0) >= interval,
+});

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -21,6 +21,7 @@ export * from './countBytesInString';
 export * from './createCooldown';
 export * from './createDeferred';
 export * from './createDeferredManager';
+export * from './createKeyedThrottle';
 export * from './createLazy';
 export * from './extractUrlsFromText';
 export * from './formatBigUintToLE';

--- a/packages/utils/tests/createKeyedThrottle.test.ts
+++ b/packages/utils/tests/createKeyedThrottle.test.ts
@@ -1,0 +1,77 @@
+import { createKeyedThrottle } from '../src/createKeyedThrottle';
+
+describe('createKeyedThrottle', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    describe('canRun', () => {
+        it('is true for an id that never ran', () => {
+            const throttle = createKeyedThrottle(1000);
+            expect(throttle.canRun('a')).toBe(true);
+        });
+
+        it('is false right after markRun and until the interval elapses', () => {
+            const throttle = createKeyedThrottle(1000);
+            throttle.markRun('a');
+
+            expect(throttle.canRun('a')).toBe(false);
+            jest.advanceTimersByTime(999);
+            expect(throttle.canRun('a')).toBe(false);
+            jest.advanceTimersByTime(1); // exactly at the boundary
+            expect(throttle.canRun('a')).toBe(true);
+        });
+
+        it('tracks ids independently', () => {
+            const throttle = createKeyedThrottle(1000);
+            throttle.markRun('a');
+
+            expect(throttle.canRun('a')).toBe(false);
+            expect(throttle.canRun('b')).toBe(true);
+        });
+
+        it('re-marking extends the window', () => {
+            const throttle = createKeyedThrottle(1000);
+            throttle.markRun('a');
+            jest.advanceTimersByTime(800);
+            throttle.markRun('a');
+            jest.advanceTimersByTime(800); // 1600 since first mark, 800 since second
+
+            expect(throttle.canRun('a')).toBe(false);
+        });
+    });
+
+    describe('reset / resetAll', () => {
+        it('reset makes only that id runnable again', () => {
+            const throttle = createKeyedThrottle(1000);
+            throttle.markRun('a');
+            throttle.markRun('b');
+
+            throttle.reset('a');
+
+            expect(throttle.canRun('a')).toBe(true);
+            expect(throttle.canRun('b')).toBe(false);
+        });
+
+        it('reset on an unknown id is a no-op', () => {
+            const throttle = createKeyedThrottle(1000);
+            expect(() => throttle.reset('nope')).not.toThrow();
+            expect(throttle.canRun('nope')).toBe(true);
+        });
+
+        it('resetAll makes every id runnable again', () => {
+            const throttle = createKeyedThrottle(1000);
+            throttle.markRun('a');
+            throttle.markRun('b');
+
+            throttle.resetAll();
+
+            expect(throttle.canRun('a')).toBe(true);
+            expect(throttle.canRun('b')).toBe(true);
+        });
+    });
+});

--- a/packages/utils/tests/createKeyedThrottle.test.ts
+++ b/packages/utils/tests/createKeyedThrottle.test.ts
@@ -9,69 +9,38 @@ describe('createKeyedThrottle', () => {
         jest.useRealTimers();
     });
 
-    describe('canRun', () => {
-        it('is true for an id that never ran', () => {
-            const throttle = createKeyedThrottle(1000);
-            expect(throttle.canRun('a')).toBe(true);
-        });
-
-        it('is false right after markRun and until the interval elapses', () => {
-            const throttle = createKeyedThrottle(1000);
-            throttle.markRun('a');
-
-            expect(throttle.canRun('a')).toBe(false);
-            jest.advanceTimersByTime(999);
-            expect(throttle.canRun('a')).toBe(false);
-            jest.advanceTimersByTime(1); // exactly at the boundary
-            expect(throttle.canRun('a')).toBe(true);
-        });
-
-        it('tracks ids independently', () => {
-            const throttle = createKeyedThrottle(1000);
-            throttle.markRun('a');
-
-            expect(throttle.canRun('a')).toBe(false);
-            expect(throttle.canRun('b')).toBe(true);
-        });
-
-        it('re-marking extends the window', () => {
-            const throttle = createKeyedThrottle(1000);
-            throttle.markRun('a');
-            jest.advanceTimersByTime(800);
-            throttle.markRun('a');
-            jest.advanceTimersByTime(800); // 1600 since first mark, 800 since second
-
-            expect(throttle.canRun('a')).toBe(false);
-        });
+    it('canRun is true for an id that never ran (getLastRun returns undefined)', () => {
+        const throttle = createKeyedThrottle(1000, () => undefined);
+        expect(throttle.canRun('a')).toBe(true);
     });
 
-    describe('reset / resetAll', () => {
-        it('reset makes only that id runnable again', () => {
-            const throttle = createKeyedThrottle(1000);
-            throttle.markRun('a');
-            throttle.markRun('b');
+    it('canRun is false until the interval elapses since the last run', () => {
+        const lastRun: Record<string, number> = {};
+        const throttle = createKeyedThrottle(1000, id => lastRun[id]);
 
-            throttle.reset('a');
+        lastRun.a = Date.now();
 
-            expect(throttle.canRun('a')).toBe(true);
-            expect(throttle.canRun('b')).toBe(false);
-        });
+        expect(throttle.canRun('a')).toBe(false);
+        jest.advanceTimersByTime(999);
+        expect(throttle.canRun('a')).toBe(false);
+        jest.advanceTimersByTime(1); // exactly at the boundary
+        expect(throttle.canRun('a')).toBe(true);
+    });
 
-        it('reset on an unknown id is a no-op', () => {
-            const throttle = createKeyedThrottle(1000);
-            expect(() => throttle.reset('nope')).not.toThrow();
-            expect(throttle.canRun('nope')).toBe(true);
-        });
+    it('reads each id independently from getLastRun', () => {
+        const lastRun: Record<string, number> = { a: Date.now() };
+        const throttle = createKeyedThrottle(1000, id => lastRun[id]);
 
-        it('resetAll makes every id runnable again', () => {
-            const throttle = createKeyedThrottle(1000);
-            throttle.markRun('a');
-            throttle.markRun('b');
+        expect(throttle.canRun('a')).toBe(false);
+        expect(throttle.canRun('b')).toBe(true);
+    });
 
-            throttle.resetAll();
+    it('reflects live changes from getLastRun', () => {
+        const lastRun: Record<string, number> = {};
+        const throttle = createKeyedThrottle(1000, id => lastRun[id]);
 
-            expect(throttle.canRun('a')).toBe(true);
-            expect(throttle.canRun('b')).toBe(true);
-        });
+        expect(throttle.canRun('a')).toBe(true);
+        lastRun.a = Date.now(); // e.g. the store recorded a refresh
+        expect(throttle.canRun('a')).toBe(false);
     });
 });

--- a/suite-common/redux-utils/package.json
+++ b/suite-common/redux-utils/package.json
@@ -27,6 +27,7 @@
         "@trezor/connect": "workspace:*",
         "@trezor/connect-common": "workspace:*",
         "@trezor/transport-common": "workspace:*",
+        "@trezor/utils": "workspace:*",
         "lodash": "^4.18.1",
         "react": "19.2.3",
         "react-redux": "9.3.0",

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -33,6 +33,7 @@ import {
     type ThpSettings,
 } from '@trezor/connect';
 import type { Transport } from '@trezor/transport-common';
+import { type KeyedThrottle } from '@trezor/utils';
 
 import { type ConnectInitHooks } from './connectInitHooksType';
 import { type ActionType, type SuiteCompatibleSelector, type SuiteCompatibleThunk } from './types';
@@ -76,6 +77,7 @@ export type CommonServices = SuiteSyncDep &
         saveAs: (data: Blob, fileName: string) => void;
         connectInitSettings: ConnectInitSettings;
         connectInitHooks: ConnectInitHooks;
+        accountRefreshThrottle: KeyedThrottle<AccountKey>;
     } & ReportSecurityCheckDep &
     ReloadAppDep &
     MigrateSuiteSyncLabelsForRbfTransactionDep &

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -17,7 +17,11 @@ import {
     type UserContextPayload,
 } from '@suite-common/suite-types';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type Account, type SelectedAccountStatus } from '@suite-common/wallet-types';
+import {
+    type Account,
+    type AccountKey,
+    type SelectedAccountStatus,
+} from '@suite-common/wallet-types';
 import { type Analytics } from '@trezor/analytics-uploader';
 import {
     type BluetoothDeviceId,

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -17,11 +17,7 @@ import {
     type UserContextPayload,
 } from '@suite-common/suite-types';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import {
-    type Account,
-    type AccountKey,
-    type SelectedAccountStatus,
-} from '@suite-common/wallet-types';
+import { type Account, type SelectedAccountStatus } from '@suite-common/wallet-types';
 import { type Analytics } from '@trezor/analytics-uploader';
 import {
     type BluetoothDeviceId,
@@ -77,7 +73,7 @@ export type CommonServices = SuiteSyncDep &
         saveAs: (data: Blob, fileName: string) => void;
         connectInitSettings: ConnectInitSettings;
         connectInitHooks: ConnectInitHooks;
-        accountRefreshThrottle: KeyedThrottle<AccountKey>;
+        accountRefreshThrottle: KeyedThrottle<Account['key']>;
     } & ReportSecurityCheckDep &
     ReloadAppDep &
     MigrateSuiteSyncLabelsForRbfTransactionDep &

--- a/suite-common/redux-utils/tsconfig.json
+++ b/suite-common/redux-utils/tsconfig.json
@@ -25,6 +25,7 @@
         },
         {
             "path": "../../packages/transport-common"
-        }
+        },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/suite-common/test-utils/src/extraDependenciesCommonMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesCommonMock.ts
@@ -90,7 +90,7 @@ export const extraDependenciesCommonMock: ExtraDependencies = {
         connectInitSettings,
         connectInitHooks: { deviceEvent: {}, uiEvent: {} },
         createTransports: () => [],
-        accountRefreshThrottle: createKeyedThrottle(10_000),
+        accountRefreshThrottle: createKeyedThrottle(10_000, () => undefined),
         migrateSuiteSyncLabelsForRbfTransaction: () => Promise.resolve([[], []]),
     },
     selectors: {
@@ -105,6 +105,7 @@ export const extraDependenciesCommonMock: ExtraDependencies = {
         }),
         selectDesktopBinDir: notImplementedSelector('selectDesktopBinDir', '/bin'),
         selectLanguage: notImplementedSelector('selectLanguage', 'en'),
+
         selectSelectedAccount: notImplementedSelector('selectSelectedAccount', {
             status: 'loaded',
             account: mockWalletAccount({

--- a/suite-common/test-utils/src/extraDependenciesCommonMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesCommonMock.ts
@@ -21,6 +21,7 @@ import { type SelectedAccountLoaded, asAccountDescriptor } from '@suite-common/w
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { mockAnalytics } from '@trezor/analytics-uploader/mocks';
 import { err, ok } from '@trezor/type-utils';
+import { createKeyedThrottle } from '@trezor/utils';
 
 const suiteSyncMock: SuiteSync = {
     changeRelayUrl: () => Promise.resolve(),
@@ -89,6 +90,7 @@ export const extraDependenciesCommonMock: ExtraDependencies = {
         connectInitSettings,
         connectInitHooks: { deviceEvent: {}, uiEvent: {} },
         createTransports: () => [],
+        accountRefreshThrottle: createKeyedThrottle(10_000),
         migrateSuiteSyncLabelsForRbfTransaction: () => Promise.resolve([[], []]),
     },
     selectors: {

--- a/suite-common/trading/src/reducers/__fixtures__/account.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/account.ts
@@ -104,7 +104,6 @@ export const accounts: Account[] = [
         misc: undefined,
         marker: undefined,
         stellarCursor: undefined,
-        ts: 0,
     },
     {
         deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@C906E19794613145E3DF45F4:0',
@@ -196,7 +195,6 @@ export const accounts: Account[] = [
         misc: undefined,
         marker: undefined,
         stellarCursor: undefined,
-        ts: 0,
     },
 ];
 

--- a/suite-common/wallet-core/src/accounts/accountRefreshThrottle.ts
+++ b/suite-common/wallet-core/src/accounts/accountRefreshThrottle.ts
@@ -1,8 +1,17 @@
-import { type AccountKey } from '@suite-common/wallet-types';
+import { type Account } from '@suite-common/wallet-types';
 import { createKeyedThrottle } from '@trezor/utils';
 
-// Refresh the selected account on enter, at most once per this interval per account.
-export const ACCOUNT_REFRESH_INTERVAL = 10_000;
+import {
+    type AccountsRefreshTimeRootState,
+    selectAccountRefreshTime,
+} from './accountsRefreshTimeReducer';
 
-export const createAccountRefreshThrottle = () =>
-    createKeyedThrottle<AccountKey>(ACCOUNT_REFRESH_INTERVAL);
+// Refresh the selected account on enter, at most once per this interval per account.
+export const MIN_ACCOUNT_REFRESH_INTERVAL = 10_000;
+
+// The throttle reads the per-account timestamp from the store (accountsRefreshTime slice) rather
+// than keeping its own map, so there is a single source of truth.
+export const createAccountRefreshThrottle = (getState: () => AccountsRefreshTimeRootState) =>
+    createKeyedThrottle<Account['key']>(MIN_ACCOUNT_REFRESH_INTERVAL, accountKey =>
+        selectAccountRefreshTime(getState(), accountKey),
+    );

--- a/suite-common/wallet-core/src/accounts/accountRefreshThrottle.ts
+++ b/suite-common/wallet-core/src/accounts/accountRefreshThrottle.ts
@@ -1,0 +1,8 @@
+import { type AccountKey } from '@suite-common/wallet-types';
+import { createKeyedThrottle } from '@trezor/utils';
+
+// Refresh the selected account on enter, at most once per this interval per account.
+export const ACCOUNT_REFRESH_INTERVAL = 10_000;
+
+export const createAccountRefreshThrottle = () =>
+    createKeyedThrottle<AccountKey>(ACCOUNT_REFRESH_INTERVAL);

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -95,7 +95,6 @@ const createAccount = createAction(
                 }),
                 utxo: enhanceUtxo(utxo, networkType, index),
                 metadata: { key: metadataKey },
-                ts: Date.now(),
                 ...getAccountSpecific(accountInfo, networkType),
             };
 
@@ -143,23 +142,15 @@ const updateAccount = createAction(
                     utxo: enhanceUtxo(accountInfo.utxo, account.networkType, account.index),
                     addresses: enhanceAddresses(accountInfo, account),
                     tokens: enhanceTokens(accountInfo.tokens),
-                    ts: Date.now(),
                     ...getAccountSpecific(accountInfo, account.networkType),
                 },
             };
         }
 
         return {
-            payload: { ...account, ts: Date.now() },
+            payload: account,
         };
     },
-);
-
-const updateAccountRefreshTimestamp = createAction(
-    `${ACCOUNTS_MODULE_PREFIX}/updateAccountRefreshTimestamp`,
-    (account: Account): { payload: Account } => ({
-        payload: { ...account, ts: Date.now() },
-    }),
 );
 
 const renameAccount = createAction(
@@ -207,7 +198,6 @@ export const accountsActions = {
     createAccount,
     createAccountFromAccountInfo,
     updateAccount,
-    updateAccountRefreshTimestamp,
     renameAccount,
     updateSelectedAccount,
     changeAccountVisibility,

--- a/suite-common/wallet-core/src/accounts/accountsMiddleware.ts
+++ b/suite-common/wallet-core/src/accounts/accountsMiddleware.ts
@@ -3,12 +3,21 @@ import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { accountsActions } from './accountsActions';
 import { fetchAndUpdateAccountThunk } from './accountsThunks';
 
-const UPDATE_SELECTED_ACCOUNT_INTERVAL = 10_000;
-
 export const prepareAccountsMiddleware = createMiddlewareWithExtraDeps(
-    (action, { dispatch, next }) => {
-        // propagate action to reducers
+    (action, { dispatch, next, extra }) => {
+        const { accountRefreshThrottle } = extra.services;
 
+        // Mirror the old per-account `ts`: creating or updating an account restarts its refresh
+        // window. Marked BEFORE next() so the re-entrant updateSelectedAccount that syncSelectedAccount
+        // fires after an updateAccount sees the fresh mark and doesn't kick off a duplicate refresh.
+        if (
+            accountsActions.createAccount.match(action) ||
+            accountsActions.updateAccount.match(action)
+        ) {
+            accountRefreshThrottle.markRun(action.payload.key);
+        }
+
+        // propagate action to reducers
         next(action);
 
         if (
@@ -16,13 +25,17 @@ export const prepareAccountsMiddleware = createMiddlewareWithExtraDeps(
             action.payload.status === 'loaded'
         ) {
             const accountKey = action.payload.account.key;
-            const updatedAt = action.payload.account.ts || 0; // safety, old versions of Suite does not have this attribute
 
-            const shouldUpdateAccount = Date.now() - updatedAt >= UPDATE_SELECTED_ACCOUNT_INTERVAL; // update account on enter
-
-            if (shouldUpdateAccount) {
+            // Refresh the selected account on enter, throttled to once per interval per account.
+            // The timestamp lives in the throttle, not on the account entity, so this no longer
+            // mutates (and re-renders) the account every time.
+            if (accountRefreshThrottle.canRun(accountKey)) {
                 dispatch(fetchAndUpdateAccountThunk({ accountKey }));
             }
+        }
+
+        if (accountsActions.removeAccount.match(action)) {
+            action.payload.forEach(account => accountRefreshThrottle.reset(account.key));
         }
 
         return action;

--- a/suite-common/wallet-core/src/accounts/accountsMiddleware.ts
+++ b/suite-common/wallet-core/src/accounts/accountsMiddleware.ts
@@ -5,19 +5,8 @@ import { fetchAndUpdateAccountThunk } from './accountsThunks';
 
 export const prepareAccountsMiddleware = createMiddlewareWithExtraDeps(
     (action, { dispatch, next, extra }) => {
-        const { accountRefreshThrottle } = extra.services;
-
-        // Mirror the old per-account `ts`: creating or updating an account restarts its refresh
-        // window. Marked BEFORE next() so the re-entrant updateSelectedAccount that syncSelectedAccount
-        // fires after an updateAccount sees the fresh mark and doesn't kick off a duplicate refresh.
-        if (
-            accountsActions.createAccount.match(action) ||
-            accountsActions.updateAccount.match(action)
-        ) {
-            accountRefreshThrottle.markRun(action.payload.key);
-        }
-
-        // propagate action to reducers
+        // propagate action to reducers (the accountsRefreshTime slice records the refresh timestamp
+        // off the account entity, reacting to createAccount/updateAccount/removeAccount)
         next(action);
 
         if (
@@ -27,15 +16,11 @@ export const prepareAccountsMiddleware = createMiddlewareWithExtraDeps(
             const accountKey = action.payload.account.key;
 
             // Refresh the selected account on enter, throttled to once per interval per account.
-            // The timestamp lives in the throttle, not on the account entity, so this no longer
-            // mutates (and re-renders) the account every time.
-            if (accountRefreshThrottle.canRun(accountKey)) {
+            // canRun reads the timestamp from the store, so this no longer mutates (and re-renders)
+            // the account every time.
+            if (extra.services.accountRefreshThrottle.canRun(accountKey)) {
                 dispatch(fetchAndUpdateAccountThunk({ accountKey }));
             }
-        }
-
-        if (accountsActions.removeAccount.match(action)) {
-            action.payload.forEach(account => accountRefreshThrottle.reset(account.key));
         }
 
         return action;

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -1,10 +1,11 @@
-import { isAnyOf } from '@reduxjs/toolkit';
+import { current, isAnyOf } from '@reduxjs/toolkit';
 
 import { deviceActions } from '@suite-common/device';
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { networks } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { accountEqualTo, compareAccountsByCoin, enhanceHistory } from '@suite-common/wallet-utils';
+import { typedObjectKeys } from '@trezor/utils';
 
 import { accountsActions } from './accountsActions';
 
@@ -23,11 +24,33 @@ const findCoinjoinAccount =
     (account: Account): account is Extract<Account, { backendType: 'coinjoin' }> =>
         account.key === key && account.backendType === 'coinjoin';
 
+const isHistoryUnchanged = (prev: Account['history'], next: Account['history']) => {
+    const keys = typedObjectKeys(prev);
+    if (keys.length !== Object.keys(next).length) return false;
+
+    return keys.every(key => prev[key] === next[key]);
+};
+
+// `history` is the only field we rebuild here (enhanceHistory), so it's always a fresh object even
+// when the values are unchanged - compare it by its own keys. Every other field keeps the caller's
+// reference, so a shallow (reference) compare is enough to detect a real change.
+const isUnchangedAccount = (prev: Account, next: Account) => {
+    const keys = typedObjectKeys(prev);
+    if (keys.length !== Object.keys(next).length) return false;
+
+    return keys.every(key =>
+        key === 'history'
+            ? isHistoryUnchanged(prev.history, next.history)
+            : prev[key] === next[key],
+    );
+};
+
 const update = (state: Account[], account: Account) => {
     const accountIndex = state.findIndex(accountEqualTo(account));
+    const prev = state[accountIndex];
 
-    if (accountIndex !== -1) {
-        state[accountIndex] = {
+    if (prev) {
+        const next: Account = {
             ...account,
             // remove "transactions" field, they are stored in "transactionReducer"
             history: enhanceHistory(account.history),
@@ -35,8 +58,15 @@ const update = (state: Account[], account: Account) => {
 
         if (!account.marker) {
             // immer.js doesn't update fields that are set to undefined, so instead we delete the field
-            delete state[accountIndex].marker;
+            delete next.marker;
         }
+
+        // Skip the write when nothing changed, so the entity reference (and the components subscribed
+        // to it) stay stable. current() unwraps the immer draft, otherwise reads of nested fields
+        // return proxies and the reference compare would never match.
+        if (isUnchangedAccount(current(prev), next)) return;
+
+        state[accountIndex] = next;
     } else {
         console.warn(
             // do not log the descriptor: it is confidential and would leak into Sentry breadcrumbs

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -100,9 +100,6 @@ export const prepareAccountsReducer = createReducerWithExtraDeps(
             .addCase(accountsActions.updateAccount, (state, action) => {
                 update(state, action.payload);
             })
-            .addCase(accountsActions.updateAccountRefreshTimestamp, (state, action) => {
-                update(state, action.payload);
-            })
             .addCase(accountsActions.renameAccount, (state, action) => {
                 const { accountKey, accountLabel } = action.payload;
                 const accountByAccountKey = state.find(account => account.key === accountKey);

--- a/suite-common/wallet-core/src/accounts/accountsRefreshTimeReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsRefreshTimeReducer.ts
@@ -1,0 +1,53 @@
+import { type PayloadAction, createSlice } from '@reduxjs/toolkit';
+
+import { type Account } from '@suite-common/wallet-types';
+
+import { accountsActions } from './accountsActions';
+
+// Per-account "last refreshed at" timestamp, kept next to the accounts (but in its own slice, so
+// updating it does NOT churn the account entity reference). Used to throttle the selected-account
+// refresh. It reacts to the account lifecycle actions, so the timestamp lives in exactly one place
+// and is testable as a plain reducer. Keyed by the unique account key (descriptor-symbol-session),
+// not the descriptor alone, which can collide across devices/wallets.
+export type AccountsRefreshTimeState = Record<Account['key'], number>;
+
+export type AccountsRefreshTimeRootState = {
+    wallet: {
+        accountsRefreshTime: AccountsRefreshTimeState;
+    };
+};
+
+export const accountsRefreshTimeInitialState: AccountsRefreshTimeState = {};
+
+const accountsRefreshTimeSlice = createSlice({
+    name: 'accountsRefreshTime',
+    initialState: accountsRefreshTimeInitialState,
+    reducers: {
+        // Marks a refresh event that did not change the account – i.e. did not dispatch createAccount or updateAccount.
+        accountRefreshed: (state, action: PayloadAction<Account['key']>) => {
+            state[action.payload] = Date.now();
+        },
+    },
+    extraReducers: builder => {
+        builder
+            .addCase(accountsActions.createAccount, (state, action) => {
+                state[action.payload.key] = Date.now();
+            })
+            .addCase(accountsActions.updateAccount, (state, action) => {
+                state[action.payload.key] = Date.now();
+            })
+            .addCase(accountsActions.removeAccount, (state, action) => {
+                action.payload.forEach(account => {
+                    delete state[account.key];
+                });
+            });
+    },
+});
+
+export const { accountRefreshed } = accountsRefreshTimeSlice.actions;
+export const accountsRefreshTimeReducer = accountsRefreshTimeSlice.reducer;
+
+export const selectAccountRefreshTime = (
+    state: AccountsRefreshTimeRootState,
+    accountKey: Account['key'],
+): number | undefined => state.wallet.accountsRefreshTime[accountKey];

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -27,6 +27,7 @@ import {
     getAccountInfoAnalyticsPayload,
     isAccountActiveForAnalytics,
 } from './accountsInfoAnalytics';
+import { accountRefreshed } from './accountsRefreshTimeReducer';
 import { selectAccountByKey } from './accountsSelectors';
 import { selectBlockchainHeightBySymbol, selectGapLimit } from '../blockchain/blockchainReducer';
 import { selectBitcoinAmountUnit } from '../settings/walletSettingsReducer';
@@ -114,8 +115,7 @@ export const reportAccountInfoThunk = createThunk(
 // as we usually want to update all accounts for a single coin at once
 export const fetchAndUpdateAccountThunk = createThunk(
     `${ACCOUNTS_MODULE_PREFIX}/fetchAndUpdateAccountThunk`,
-    async ({ accountKey }: { accountKey: AccountKey }, { dispatch, getState, extra }) => {
-        const { accountRefreshThrottle } = extra.services;
+    async ({ accountKey }: { accountKey: AccountKey }, { dispatch, getState }) => {
         const account = selectAccountByKey(getState(), accountKey);
 
         if (!account || account.failed || account.accountType === 'placeholder') return;
@@ -153,7 +153,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
 
         if (!accountOutdated && !accountTxs.some(isPending)) {
             // refreshed, nothing changed - restart the throttle window (old code bumped account.ts)
-            accountRefreshThrottle.markRun(accountKey);
+            dispatch(accountRefreshed(accountKey));
 
             return;
         }
@@ -256,7 +256,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
                 dispatch(reportAccountInfoThunk(account.key));
             } else {
                 // refreshed, nothing changed - restart the throttle window directly
-                accountRefreshThrottle.markRun(accountKey);
+                dispatch(accountRefreshed(accountKey));
             }
 
             dispatch(reportWalletBalanceThunk());

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -114,7 +114,8 @@ export const reportAccountInfoThunk = createThunk(
 // as we usually want to update all accounts for a single coin at once
 export const fetchAndUpdateAccountThunk = createThunk(
     `${ACCOUNTS_MODULE_PREFIX}/fetchAndUpdateAccountThunk`,
-    async ({ accountKey }: { accountKey: AccountKey }, { dispatch, getState }) => {
+    async ({ accountKey }: { accountKey: AccountKey }, { dispatch, getState, extra }) => {
+        const { accountRefreshThrottle } = extra.services;
         const account = selectAccountByKey(getState(), accountKey);
 
         if (!account || account.failed || account.accountType === 'placeholder') return;
@@ -151,7 +152,8 @@ export const fetchAndUpdateAccountThunk = createThunk(
         // stop here if account is not outdated and there are no pending transactions
 
         if (!accountOutdated && !accountTxs.some(isPending)) {
-            dispatch(accountsActions.updateAccountRefreshTimestamp(account));
+            // refreshed, nothing changed - restart the throttle window (old code bumped account.ts)
+            accountRefreshThrottle.markRun(accountKey);
 
             return;
         }
@@ -249,10 +251,12 @@ export const fetchAndUpdateAccountThunk = createThunk(
                 isAccountOutdated(account, payload) ||
                 customTokens.length > 0
             ) {
+                // updateAccount restarts the throttle window via the middleware (mirrors old account.ts)
                 dispatch(accountsActions.updateAccount(account, payload));
                 dispatch(reportAccountInfoThunk(account.key));
             } else {
-                dispatch(accountsActions.updateAccountRefreshTimestamp(account));
+                // refreshed, nothing changed - restart the throttle window directly
+                accountRefreshThrottle.markRun(accountKey);
             }
 
             dispatch(reportWalletBalanceThunk());

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -251,7 +251,8 @@ export const fetchAndUpdateAccountThunk = createThunk(
                 isAccountOutdated(account, payload) ||
                 customTokens.length > 0
             ) {
-                // updateAccount restarts the throttle window via the middleware (mirrors old account.ts)
+                // updateAccount restarts the throttle window via the accountsRefreshTime slice
+                // (mirrors old account.ts)
                 dispatch(accountsActions.updateAccount(account, payload));
                 dispatch(reportAccountInfoThunk(account.key));
             } else {

--- a/suite-common/wallet-core/src/accounts/tests/accountsRefreshTimeReducer.test.ts
+++ b/suite-common/wallet-core/src/accounts/tests/accountsRefreshTimeReducer.test.ts
@@ -1,0 +1,71 @@
+import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+
+import { accountsActions } from '../accountsActions';
+import {
+    type AccountsRefreshTimeState,
+    accountRefreshed,
+    accountsRefreshTimeReducer,
+    selectAccountRefreshTime,
+} from '../accountsRefreshTimeReducer';
+
+const account = mockWalletAccount({
+    symbol: 'btc',
+    deviceState: '1@2:3',
+    descriptor: asAccountDescriptor('accA'),
+});
+const otherAccount = mockWalletAccount({
+    symbol: 'btc',
+    deviceState: '1@2:3',
+    descriptor: asAccountDescriptor('accB'),
+});
+
+const NOW = 1_700_000_000_000;
+
+describe('accountsRefreshTimeReducer', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(NOW);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('records the timestamp on accountRefreshed', () => {
+        const state = accountsRefreshTimeReducer({}, accountRefreshed(account.key));
+        expect(state[account.key]).toBe(NOW);
+    });
+
+    it('records the timestamp on createAccount and updateAccount', () => {
+        // createAccount payload is the account; the reducer only reads payload.key
+        const createdAccountAction: ReturnType<typeof accountsActions.createAccount> = {
+            type: accountsActions.createAccount.type,
+            payload: account,
+        };
+
+        const created = accountsRefreshTimeReducer({}, createdAccountAction);
+        expect(created[account.key]).toBe(NOW);
+
+        jest.setSystemTime(NOW + 5000);
+        const updated = accountsRefreshTimeReducer(created, accountsActions.updateAccount(account));
+        expect(updated[account.key]).toBe(NOW + 5000);
+    });
+
+    it('drops removed accounts', () => {
+        const state: AccountsRefreshTimeState = { [account.key]: NOW, [otherAccount.key]: NOW };
+        const next = accountsRefreshTimeReducer(
+            state,
+            accountsActions.removeAccount([account as Account]),
+        );
+
+        expect(next[account.key]).toBeUndefined();
+        expect(next[otherAccount.key]).toBe(NOW);
+    });
+
+    it('selector reads the timestamp for an account', () => {
+        const wallet = { accountsRefreshTime: { [account.key]: NOW } };
+        expect(selectAccountRefreshTime({ wallet }, account.key)).toBe(NOW);
+        expect(selectAccountRefreshTime({ wallet }, otherAccount.key)).toBeUndefined();
+    });
+});

--- a/suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts
+++ b/suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts
@@ -83,7 +83,6 @@ const mockState: AccountsRootState & DeviceRootState = {
                 },
                 networkType: 'bitcoin',
                 page: { index: 1, size: 25, total: 1 },
-                ts: 0,
             },
             {
                 symbol: 'eth',
@@ -120,7 +119,6 @@ const mockState: AccountsRootState & DeviceRootState = {
                 misc: { nonce: '1' },
                 marker: undefined,
                 stellarCursor: undefined,
-                ts: 0,
             },
         ],
     },

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -2,6 +2,7 @@
 export * from './accounts/accountRefreshThrottle';
 export * from './accounts/accountsActions';
 export * from './accounts/accountsConstants';
+export * from './accounts/accountsRefreshTimeReducer';
 export * from './accounts/accountsMiddleware';
 export * from './accounts/accountsReducer';
 export * from './accounts/accountsSelectors';

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -1,4 +1,5 @@
 // TODO: remove this file and prefer scoped imports or divide to smaller packages. Creating these huge export index files leads to circular ESM.
+export * from './accounts/accountRefreshThrottle';
 export * from './accounts/accountsActions';
 export * from './accounts/accountsConstants';
 export * from './accounts/accountsMiddleware';

--- a/suite-common/wallet-types/mocks/mockWalletAccount.ts
+++ b/suite-common/wallet-types/mocks/mockWalletAccount.ts
@@ -154,7 +154,6 @@ export const mockWalletAccount = (
         utxo: undefined,
         addresses: undefined,
         metadata: { key: 'xpub' },
-        ts: 0,
         ...account,
 
         // This is mandatory to pass to enforce consistency

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -204,8 +204,6 @@ export type AccountBase = {
      * IMPORTANT: This is relevant only for Mobile App.
      */
     accountLabel?: string;
-
-    ts: number;
 };
 
 export type Account = AccountBase &

--- a/suite-native/app/e2e/fixtures/btcDiscoveryFinishedStateT3T1.ts
+++ b/suite-native/app/e2e/fixtures/btcDiscoveryFinishedStateT3T1.ts
@@ -94,7 +94,6 @@ export const btcDiscoveryFinishedStateT3T1: PreloadedState = {
                 metadata: {
                     key: 'xpub6CEBKQ1jXhweie3b5UMEG7CSLcsyhWucYmiMdz1oPW55kkDhmizrAtThxdLFLKHCTWBhZeJY1G2XuFdgRLKkYssVbiLAxnTy6yM5Lzt5YMc',
                 },
-                ts: 1758031024091,
                 networkType: 'bitcoin',
                 page: {
                     index: 1,

--- a/suite-native/app/e2e/fixtures/btcDiscoveryFinishedStateT3W1.ts
+++ b/suite-native/app/e2e/fixtures/btcDiscoveryFinishedStateT3W1.ts
@@ -94,7 +94,6 @@ export const btcDiscoveryFinishedStateT3W1: PreloadedState = {
                 metadata: {
                     key: 'xpub6CEBKQ1jXhweie3b5UMEG7CSLcsyhWucYmiMdz1oPW55kkDhmizrAtThxdLFLKHCTWBhZeJY1G2XuFdgRLKkYssVbiLAxnTy6yM5Lzt5YMc',
                 },
-                ts: 1760446304591,
                 networkType: 'bitcoin',
                 page: {
                     index: 1,

--- a/suite-native/app/e2e/fixtures/regtestDiscoveryFinishedStateT1B1.ts
+++ b/suite-native/app/e2e/fixtures/regtestDiscoveryFinishedStateT1B1.ts
@@ -113,7 +113,6 @@ export const regtestDiscoveryFinishedStateT1B1: PreloadedState = {
                 metadata: {
                     key: 'tpubDCKpwiaxUvejaVwzGE9mjZQ5rHm2DwCTYDM3cYDYW5eG5V99uc34W4YZz1PYsWndPMD9PwcrBPV6C92zgP8Z1PHwrMEGFDeGp5YvFLxtP2P',
                 },
-                ts: 1758269690638,
                 networkType: 'bitcoin',
                 page: {
                     index: 1,

--- a/suite-native/app/e2e/fixtures/regtestDiscoveryFinishedStateT3T1.ts
+++ b/suite-native/app/e2e/fixtures/regtestDiscoveryFinishedStateT3T1.ts
@@ -113,7 +113,6 @@ export const regtestDiscoveryFinishedStateT3T1: PreloadedState = {
                 metadata: {
                     key: 'tpubDCKpwiaxUvejaVwzGE9mjZQ5rHm2DwCTYDM3cYDYW5eG5V99uc34W4YZz1PYsWndPMD9PwcrBPV6C92zgP8Z1PHwrMEGFDeGp5YvFLxtP2P',
                 },
-                ts: 1758269690638,
                 networkType: 'bitcoin',
                 page: {
                     index: 1,

--- a/suite-native/app/e2e/fixtures/regtestDiscoveryFinishedStateT3W1.ts
+++ b/suite-native/app/e2e/fixtures/regtestDiscoveryFinishedStateT3W1.ts
@@ -268,7 +268,6 @@ export const regtestDiscoveryFinishedStateT3W1: PreloadedState = {
                 metadata: {
                     key: 'tpubDCKpwiaxUvejaVwzGE9mjZQ5rHm2DwCTYDM3cYDYW5eG5V99uc34W4YZz1PYsWndPMD9PwcrBPV6C92zgP8Z1PHwrMEGFDeGp5YvFLxtP2P',
                 },
-                ts: 1760428935967,
                 networkType: 'bitcoin',
                 page: {
                     index: 1,

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListAddressItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListAddressItem.test.tsx
@@ -39,7 +39,6 @@ const createAccount = (
         addrTxCount: undefined,
     },
     metadata: { key: '' },
-    ts: 0,
     networkType: 'ripple',
     marker: undefined,
     stellarCursor: undefined,

--- a/suite-native/state/mocks/mockInitialAppState.ts
+++ b/suite-native/state/mocks/mockInitialAppState.ts
@@ -12,6 +12,7 @@ import { createNotificationsReducer } from '@suite-common/toast-notifications';
 import { tokenDefinitionsInitialState } from '@suite-common/token-definitions';
 import {
     accountsInitialState,
+    accountsRefreshTimeInitialState,
     blockchainInitialState,
     discoveryInitialState,
     explorerInitialState,
@@ -79,6 +80,7 @@ export const mockInitialAppState = (partialState?: Partial<FullAppState>): FullA
 
     wallet: {
         accounts: accountsInitialState,
+        accountsRefreshTime: accountsRefreshTimeInitialState,
         blockchain: blockchainInitialState,
         explorer: explorerInitialState,
         fiat: fiatRatesInitialState,

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -17,6 +17,7 @@ import {
 } from '@suite-common/redux-utils';
 import { createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot } from '@suite-common/suite-rbf-labels-migrations';
 import { selectAllLabelsForAccount, selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
+import { createAccountRefreshThrottle } from '@suite-common/wallet-core';
 import { analytics } from '@suite-native/analytics';
 import { forgetBluetoothDeviceThunk } from '@suite-native/bluetooth';
 import { selectTokenDefinitionsEnabledNetworks } from '@suite-native/discovery';
@@ -124,6 +125,7 @@ export const createNativeCompositionRoot = (deps: NativeAppDeps): NativeServices
                         return new NativeBluetoothTransport({ id: 'native-bluetooth', logger });
                 }
             }),
+        accountRefreshThrottle: createAccountRefreshThrottle(),
         migrateSuiteSyncLabelsForRbfTransaction:
             createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot({
                 dispatch: deps.dispatch,

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -125,7 +125,7 @@ export const createNativeCompositionRoot = (deps: NativeAppDeps): NativeServices
                         return new NativeBluetoothTransport({ id: 'native-bluetooth', logger });
                 }
             }),
-        accountRefreshThrottle: createAccountRefreshThrottle(),
+        accountRefreshThrottle: createAccountRefreshThrottle(deps.getState),
         migrateSuiteSyncLabelsForRbfTransaction:
             createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot({
                 dispatch: deps.dispatch,

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -18,6 +18,7 @@ import { prepareThpReducer } from '@suite-common/thp';
 import { createNotificationsReducer } from '@suite-common/toast-notifications';
 import { prepareTokenDefinitionsReducer } from '@suite-common/token-definitions';
 import {
+    accountsRefreshTimeReducer,
     feesReducer,
     formDraftReducer,
     prepareAccountsReducer,
@@ -221,6 +222,7 @@ export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
 
     const walletReducers = combineReducers({
         accounts: accountsReducer,
+        accountsRefreshTime: accountsRefreshTimeReducer,
         blockchain: blockchainPersistedReducer,
         explorer: explorerReducer,
         fiat: fiatRatesReducer,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10756,6 +10756,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/connect-common": "workspace:*"
     "@trezor/transport-common": "workspace:*"
+    "@trezor/utils": "workspace:*"
     lodash: "npm:^4.18.1"
     react: "npm:19.2.3"
     react-redux: "npm:9.3.0"
@@ -32949,7 +32950,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-parser@npm:3.3.1, jsonc-parser@npm:^3.2.0":
+"jsonc-parser@npm:3.3.1":
   version: 3.3.1
   resolution: "jsonc-parser@npm:3.3.1"
   checksum: 10/9b0dc391f20b47378f843ef1e877e73ec652a5bdc3c5fa1f36af0f119a55091d147a86c1ee86a232296f55c929bba174538c2bf0312610e0817a22de131cc3f4
@@ -32960,6 +32961,13 @@ __metadata:
   version: 2.3.1
   resolution: "jsonc-parser@npm:2.3.1"
   checksum: 10/a152a04049571e66cc065f0f5d5206f27242852b3e54d0d11a1303bb607cfdb144dce406bab215257b0c879fe1678e4f7f0eb9f21d813c149bfdaa84631f9feb
+  languageName: node
+  linkType: hard
+
+"jsonc-parser@npm:^3.2.0":
+  version: 3.2.1
+  resolution: "jsonc-parser@npm:3.2.1"
+  checksum: 10/fe2df6f39e21653781d52cae20c5b9e0ab62461918d97f9430b216cea9b6500efc1d8b42c6584cc0a7548b4c996055e9cdc39f09b9782fa6957af2f45306c530
   languageName: node
   linkType: hard
 
@@ -36698,7 +36706,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.1.3, nanoid@npm:^3.3.1, nanoid@npm:^3.3.11, nanoid@npm:^3.3.12, nanoid@npm:^3.3.6, nanoid@npm:^3.3.7, nanoid@npm:^3.3.8":
+"nanoid@npm:^3.1.3, nanoid@npm:^3.3.1, nanoid@npm:^3.3.11, nanoid@npm:^3.3.6, nanoid@npm:^3.3.7, nanoid@npm:^3.3.8":
+  version: 3.3.11
+  resolution: "nanoid@npm:3.3.11"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10/73b5afe5975a307aaa3c95dfe3334c52cdf9ae71518176895229b8d65ab0d1c0417dd081426134eb7571c055720428ea5d57c645138161e7d10df80815527c48
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.3.12":
   version: 3.3.12
   resolution: "nanoid@npm:3.3.12"
   bin:
@@ -39145,7 +39162,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.23, postcss@npm:^8.4.38, postcss@npm:^8.4.40, postcss@npm:^8.5.14, postcss@npm:^8.5.6, postcss@npm:^8.5.8, postcss@npm:^8.5.9":
+"postcss@npm:^8.4.23, postcss@npm:^8.4.38, postcss@npm:^8.4.40, postcss@npm:^8.5.6, postcss@npm:^8.5.8, postcss@npm:^8.5.9":
+  version: 8.5.9
+  resolution: "postcss@npm:8.5.9"
+  dependencies:
+    nanoid: "npm:^3.3.11"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10/b34661c6efca87f7bf747c6c943435e4bfef7617a238c3719103e607c605d16720682fb121b7ebd4f7f748228dfdf8711b82f7ffed80a5c4a9249c070ed5fd87
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.5.14":
   version: 8.5.15
   resolution: "postcss@npm:8.5.15"
   dependencies:
@@ -40012,7 +40040,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is-19@npm:react-is@^19.2.5, react-is@npm:^19.1.0, react-is@npm:^19.2.3":
+"react-is-19@npm:react-is@^19.2.5, react-is@npm:^19.2.3":
   version: 19.2.7
   resolution: "react-is@npm:19.2.7"
   checksum: 10/ae0d3ae7638aa2fa2a82a78a817daf2806e57fa0aef357d07e1e8d1e9a301902e5967168e9334b5816db0df8fa980a725cd57569ba5a9e6e76a71e117b18be04
@@ -40030,6 +40058,13 @@ __metadata:
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 10/73b36281e58eeb27c9cc6031301b6ae19ecdc9f18ae2d518bdb39b0ac564e65c5779405d623f1df9abf378a13858b79442480244bd579968afc1faf9a2ce5e05
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^19.1.0":
+  version: 19.2.4
+  resolution: "react-is@npm:19.2.4"
+  checksum: 10/3360fc50a38c23299c5003a709949f2439b2901e77962eea78d892f526f710d05a7777b600b302f853583d1861979b00d7a0a071c89c6562eac5740ac29b9665
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -32950,7 +32950,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-parser@npm:3.3.1":
+"jsonc-parser@npm:3.3.1, jsonc-parser@npm:^3.2.0":
   version: 3.3.1
   resolution: "jsonc-parser@npm:3.3.1"
   checksum: 10/9b0dc391f20b47378f843ef1e877e73ec652a5bdc3c5fa1f36af0f119a55091d147a86c1ee86a232296f55c929bba174538c2bf0312610e0817a22de131cc3f4
@@ -32961,13 +32961,6 @@ __metadata:
   version: 2.3.1
   resolution: "jsonc-parser@npm:2.3.1"
   checksum: 10/a152a04049571e66cc065f0f5d5206f27242852b3e54d0d11a1303bb607cfdb144dce406bab215257b0c879fe1678e4f7f0eb9f21d813c149bfdaa84631f9feb
-  languageName: node
-  linkType: hard
-
-"jsonc-parser@npm:^3.2.0":
-  version: 3.2.1
-  resolution: "jsonc-parser@npm:3.2.1"
-  checksum: 10/fe2df6f39e21653781d52cae20c5b9e0ab62461918d97f9430b216cea9b6500efc1d8b42c6584cc0a7548b4c996055e9cdc39f09b9782fa6957af2f45306c530
   languageName: node
   linkType: hard
 
@@ -36706,16 +36699,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.1.3, nanoid@npm:^3.3.1, nanoid@npm:^3.3.11, nanoid@npm:^3.3.6, nanoid@npm:^3.3.7, nanoid@npm:^3.3.8":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10/73b5afe5975a307aaa3c95dfe3334c52cdf9ae71518176895229b8d65ab0d1c0417dd081426134eb7571c055720428ea5d57c645138161e7d10df80815527c48
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.3.12":
+"nanoid@npm:^3.1.3, nanoid@npm:^3.3.1, nanoid@npm:^3.3.11, nanoid@npm:^3.3.12, nanoid@npm:^3.3.6, nanoid@npm:^3.3.7, nanoid@npm:^3.3.8":
   version: 3.3.12
   resolution: "nanoid@npm:3.3.12"
   bin:
@@ -39162,18 +39146,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.23, postcss@npm:^8.4.38, postcss@npm:^8.4.40, postcss@npm:^8.5.6, postcss@npm:^8.5.8, postcss@npm:^8.5.9":
-  version: 8.5.9
-  resolution: "postcss@npm:8.5.9"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10/b34661c6efca87f7bf747c6c943435e4bfef7617a238c3719103e607c605d16720682fb121b7ebd4f7f748228dfdf8711b82f7ffed80a5c4a9249c070ed5fd87
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.14":
+"postcss@npm:^8.4.23, postcss@npm:^8.4.38, postcss@npm:^8.4.40, postcss@npm:^8.5.14, postcss@npm:^8.5.6, postcss@npm:^8.5.8, postcss@npm:^8.5.9":
   version: 8.5.15
   resolution: "postcss@npm:8.5.15"
   dependencies:
@@ -40040,7 +40013,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is-19@npm:react-is@^19.2.5, react-is@npm:^19.2.3":
+"react-is-19@npm:react-is@^19.2.5, react-is@npm:^19.1.0, react-is@npm:^19.2.3":
   version: 19.2.7
   resolution: "react-is@npm:19.2.7"
   checksum: 10/ae0d3ae7638aa2fa2a82a78a817daf2806e57fa0aef357d07e1e8d1e9a301902e5967168e9334b5816db0df8fa980a725cd57569ba5a9e6e76a71e117b18be04
@@ -40058,13 +40031,6 @@ __metadata:
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 10/73b36281e58eeb27c9cc6031301b6ae19ecdc9f18ae2d518bdb39b0ac564e65c5779405d623f1df9abf378a13858b79442480244bd579968afc1faf9a2ce5e05
-  languageName: node
-  linkType: hard
-
-"react-is@npm:^19.1.0":
-  version: 19.2.4
-  resolution: "react-is@npm:19.2.4"
-  checksum: 10/3360fc50a38c23299c5003a709949f2439b2901e77962eea78d892f526f710d05a7777b600b302f853583d1861979b00d7a0a071c89c6562eac5740ac29b9665
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Stops the account refresh throttle from churning account entities (and re-rendering everything subscribed to them).

Previously the "last refreshed at" timestamp lived as a `ts` field **on the account entity**. Every throttle bump rewrote the account, swapping its reference and re-rendering all subscribers — even when nothing about the account actually changed.

### Changes

- **Remove `ts` from the `Account` entity.** The per-account refresh timestamp now lives in its own `accountsRefreshTime` slice, so recording a refresh no longer touches the account reference.
- **`createKeyedThrottle` is now a pure predicate.** It reads timestamps via a `getLastRun` callback instead of owning a map, keeping a single source of truth (the store) and staying trivially testable.
- **Skip no-op account updates.** `updateAccount` now compares the rebuilt account against the current one and skips the write when nothing changed, keeping the reference stable. The compare is shallow (reference) per field; only `history` — which we rebuild here — is compared by its own keys.

### Behavior note

Refresh timestamps are in-memory only (not persisted). After an app reload the selected account refreshes once on enter, since the 10s throttle window no longer survives a restart. This is intentional.


Relates #29027

### Testing

- New unit tests for `accountsRefreshTimeReducer` and the rewritten `createKeyedThrottle`.
- Typechecks pass for `@trezor/utils`, `redux-utils`, `wallet-core`, `suite-native/state`, and `packages/suite`.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily modifies the accounts subsystem: accountsReducer, accountsActions, accountsMiddleware, accountsThunks, and introduces a new accountRefreshThrottle/accountsRefreshTimeReducer for controlling account refresh timing. It also changes the Account type definition and the useAgregatedAccountsWithTokens trading hook. The highest risk is to wallet discovery and account management flows, where any regression in account creation, state updates, or refresh logic would be immediately visible. Trading/swap tests that use the asset picker hook are medium risk. Many files (store.ts, wallet/index.ts, etc.) map to 121+ tests but are structural/infra changes that should be validated through representative discovery and account tests rather than running everything.

<details><summary><b>Changed files (36)</b></summary>

- `packages/suite/src/actions/labels/__fixtures__/moveLabelsForRbfAccounts.fixture.ts`
- `packages/suite/src/actions/wallet/trading/__fixtures__/tradingCommonActions/accounts.ts`
- `packages/suite/src/actions/wallet/trading/__fixtures__/tradingCommonActions/store.ts`
- `packages/suite/src/reducers/store.ts`
- `packages/suite/src/reducers/wallet/__fixtures__/transactionConstants.ts`
- `packages/suite/src/reducers/wallet/index.ts`
- `packages/suite/src/support/extraDependencies.ts`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/hooks/useAgregatedAccountsWithTokens.ts`
- `packages/utils/src/createKeyedThrottle.ts`
- `packages/utils/src/index.ts`
- `packages/utils/tests/createKeyedThrottle.test.ts`
- `suite-common/redux-utils/package.json`
- `suite-common/redux-utils/src/extraDependenciesType.ts`
- `suite-common/redux-utils/tsconfig.json`
- `suite-common/test-utils/src/extraDependenciesCommonMock.ts`
- `suite-common/trading/src/reducers/__fixtures__/account.ts`
- `suite-common/wallet-core/src/accounts/accountRefreshThrottle.ts`
- `suite-common/wallet-core/src/accounts/accountsActions.ts`
- `suite-common/wallet-core/src/accounts/accountsMiddleware.ts`
- `suite-common/wallet-core/src/accounts/accountsReducer.ts`
- `suite-common/wallet-core/src/accounts/accountsRefreshTimeReducer.ts`
- `suite-common/wallet-core/src/accounts/accountsThunks.ts`
- `suite-common/wallet-core/src/accounts/tests/accountsRefreshTimeReducer.test.ts`
- `suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts`
- `suite-common/wallet-core/src/index.ts`
- `suite-common/wallet-types/mocks/mockWalletAccount.ts`
- `suite-common/wallet-types/src/account.ts`
- `suite-native/app/e2e/fixtures/btcDiscoveryFinishedStateT3T1.ts`
- `suite-native/app/e2e/fixtures/btcDiscoveryFinishedStateT3W1.ts`
- `suite-native/app/e2e/fixtures/regtestDiscoveryFinishedStateT1B1.ts`
- `suite-native/app/e2e/fixtures/regtestDiscoveryFinishedStateT3T1.ts`
- `suite-native/app/e2e/fixtures/regtestDiscoveryFinishedStateT3W1.ts`
- `suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListAddressItem.test.tsx`
- `suite-native/state/mocks/mockInitialAppState.ts`
- `suite-native/state/src/extraDependencies.ts`
- `suite-native/state/src/reducers.ts`

</details>

**Recommended tests (17)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — This test directly exercises account discovery across multiple coins, which is the core flow affected by changes to accountsReducer, accountsThunks, accountsMiddleware, and the new accountsRefreshTimeReducer. The discovery process creates and updates account objects whose shape is defined in the changed account.ts type file.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Tests custom blockbook backend discovery for BTC and LTC, directly exercising the accounts discovery pipeline (accountsThunks, accountsReducer, accountsMiddleware) which are core changed files. Discovery completion and dashboard graph visibility validate the full account creation flow.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies account balance updates after receiving BTC on regtest, directly exercising the account update/refresh flow in accountsThunks and accountsReducer. The new accountRefreshThrottle and accountsRefreshTimeReducer could affect how balance updates are processed.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Tests wallet discovery after ejecting and re-adding a standard wallet, verifying BTC account balance visibility. This directly exercises account creation, discovery, and state management via the changed accountsReducer, accountsThunks, and accountsActions.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Tests adding different account types (normal, taproot, segwit, legacy) for multiple coins, directly exercising accountsActions and accountsReducer for account creation. Changes to account type definitions in account.ts and the accounts middleware could break account addition.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Tests enabling new assets and verifying they appear correctly on the dashboard. This exercises the discovery pipeline (accountsThunks) and account state management (accountsReducer) when new networks are activated, which are directly changed.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Tests enabling coins with custom backends and verifying discovery completes and accounts load. Discovery success/failure depends on account creation flow in accountsThunks and proper state management in accountsReducer.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — Tests sending transactions and verifying pending/confirmed status, which involves account state updates via accountsReducer and accountsMiddleware. The new refresh throttle mechanism could affect how quickly account state reflects transaction status changes.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test uses a remembered wallet from IndexedDB and validates swap form behavior including account balance display and token interactions. It is directly affected by changes to useAgregatedAccountsWithTokens hook and account type definitions.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigating to buy/sell/swap forms from various entry points including token-level pages. The useAgregatedAccountsWithTokens hook change could affect how accounts with tokens are displayed and navigated in the trading asset picker.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests the buy flow for ETH including adding a new receive account via the asset picker. The useAgregatedAccountsWithTokens hook change could affect account listing in the trading form's asset picker component.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Tests SOL to BTC swap including asset selection through the trading form, which uses the changed useAgregatedAccountsWithTokens hook for account/token aggregation in the buy asset picker.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Tests various send form operations on regtest including adding outputs, setting locktime, and OP_RETURN. This exercises account state updates through accountsMiddleware after transactions are sent, which is directly changed.
- `suite/e2e/tests/trading/remembered-wallet-loading.test.ts` — Tests loading a remembered wallet from IndexedDB which involves deserializing account state. Changes to account.ts type definitions and accountsReducer could break deserialization or state hydration of remembered wallets.
- `suite/e2e/tests/settings/electrum.test.ts` — Tests Electrum backend configuration and subsequent discovery/balance display, directly exercising the accounts discovery and creation pipeline through accountsThunks and accountsReducer.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/suite/db-migration.test.ts` — Tests IndexedDB migration between Suite versions. Changes to the wallet reducer index and store structure could affect how the migrated state is read, though the migration test focuses on specific settings rather than account data.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Tests ETH staking which involves account state updates after staking transactions. The accountsReducer and accountsRefreshTimeReducer changes could affect how staking balance updates are reflected.

</details>

⚠️ **Changes with no test coverage (27)**
- `packages/suite/src/actions/labels/__fixtures__/moveLabelsForRbfAccounts.fixture.ts`
- `packages/suite/src/actions/wallet/trading/__fixtures__/tradingCommonActions/accounts.ts`
- `packages/suite/src/actions/wallet/trading/__fixtures__/tradingCommonActions/store.ts`
- `packages/suite/src/reducers/wallet/__fixtures__/transactionConstants.ts`
- `packages/utils/src/createKeyedThrottle.ts`
- `packages/utils/src/index.ts`
- `packages/utils/tests/createKeyedThrottle.test.ts`
- `suite-common/redux-utils/package.json`
- `suite-common/redux-utils/src/extraDependenciesType.ts`
- `suite-common/redux-utils/tsconfig.json`
- `suite-common/test-utils/src/extraDependenciesCommonMock.ts`
- `suite-common/trading/src/reducers/__fixtures__/account.ts`
- `suite-common/wallet-core/src/accounts/accountRefreshThrottle.ts`
- `suite-common/wallet-core/src/accounts/accountsRefreshTimeReducer.ts`
- `suite-common/wallet-core/src/accounts/tests/accountsRefreshTimeReducer.test.ts`
- `suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts`
- `suite-common/wallet-core/src/index.ts`
- `suite-common/wallet-types/mocks/mockWalletAccount.ts`
- `suite-native/app/e2e/fixtures/btcDiscoveryFinishedStateT3T1.ts`
- `suite-native/app/e2e/fixtures/btcDiscoveryFinishedStateT3W1.ts`
- `suite-native/app/e2e/fixtures/regtestDiscoveryFinishedStateT1B1.ts`
- `suite-native/app/e2e/fixtures/regtestDiscoveryFinishedStateT3T1.ts`
- `suite-native/app/e2e/fixtures/regtestDiscoveryFinishedStateT3W1.ts`
- `suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListAddressItem.test.tsx`
- `suite-native/state/mocks/mockInitialAppState.ts`
- `suite-native/state/src/extraDependencies.ts`
- `suite-native/state/src/reducers.ts`

_Updated: 2026-06-30T06:30:21.100Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/accoutn-ts-removal/web/](https://dev.suite.sldev.cz/suite-web/accoutn-ts-removal/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=accoutn-ts-removal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=accoutn-ts-removal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=accoutn-ts-removal&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-22T09:34:37.854Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| TrezorConnect > Error screen | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-22T09:33:00.382Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->