### PR TITLE
test(e2e): fix labeling tests

### DIFF
--- a/suite/e2e/support/pageObjects/metadata/outputMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/outputMetadata.ts
@@ -21,6 +21,7 @@ export class OutputMetadata extends MetadataBase {
     async clickAddLabelButton(outputId: string, txNumber: number) {
         await this.page.resetMousePosition();
         await expect(this.outputLabel(outputId, txNumber)).toHaveText(/[A-Za-z]+/);
+        await this.outputLabel(outputId, txNumber).scrollIntoViewIfNeeded();
         await this.outputLabel(outputId, txNumber).hover();
         await this.page.waitForTimeout(500); // edit button is unstable without this wait
         await this.outputLabel(outputId, txNumber).getByTestId(this.editButtonId).click();

--- a/suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts
+++ b/suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts
@@ -27,7 +27,7 @@ test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] },
 
     test('Migration from local file', async ({
         page,
-        devicePrompt,
+        dashboardPage,
         walletPage,
         metadataPage,
         evoluClient,
@@ -81,7 +81,6 @@ test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] },
 
         await test.step('Switch to Suite Sync labeling and confirm legacy label is migrated', async () => {
             await metadataPage.enableSuiteSync();
-            await devicePrompt.waitForPromptAndConfirm();
             await expect(
                 page.getByTestId('@toast/legacy-labeling-migration-success'),
             ).toHaveTranslation('TR_LABELING_MIGRATION_SUCCESS', {
@@ -92,6 +91,17 @@ test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] },
             await expect(
                 walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
             ).toHaveText(localLabel);
+        });
+
+        await test.step('Change wallet label to trigger device prompt for Suite Sync keys', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await metadataPage.wallet.changeLabel({
+                index: 0,
+                label: 'label4key',
+                confirmSuiteSync: true,
+            });
+            await expect.soft(metadataPage.wallet.walletLabel(0)).toHaveText('label4key');
+            await dashboardPage.deviceSwitchingCloseButton.click();
         });
 
         await test.step('Verify output label is synced', async () => {

--- a/suite/e2e/tests/metadata/legacy/output-labeling.test.ts
+++ b/suite/e2e/tests/metadata/legacy/output-labeling.test.ts
@@ -35,6 +35,8 @@ test.describe('Metadata - Output labeling', { tag: ['@webOnly', '@T3W1', '@T3T1'
             await page.keyboard.press('Enter');
 
             await test.step('Go to legacy account 6, it has txs with multiple outputs', async () => {
+                // Close "Turn on Suite Sync" notification
+                await metadataPage.closeLegacyNotificationButton.click();
                 await page.getByTestId('@account-menu/legacy').click();
                 await walletPage.openAccount({ symbol: 'btc', type: 'legacy', atIndex: 5 });
             });


### PR DESCRIPTION
- stabilize output lablel change
- add missing trigger for obtaining keys in migration test

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-fixes-25-6&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-fixes-25-6&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |

</details>

_Updated: 2026-06-25T15:01:14.798Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |

</details>

_Updated: 2026-06-25T15:00:13.617Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-fixes-25-6/web/](https://dev.suite.sldev.cz/suite-web/test-fixes-25-6/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->