### PR TITLE
fix(suite-native-23471): swap fee calculation sometimes fails on mobile blocking flow

### DIFF
--- a/suite-native/module-trading/src/components/general/TradeInfo/TradeInfo.tsx
+++ b/suite-native/module-trading/src/components/general/TradeInfo/TradeInfo.tsx
@@ -12,6 +12,7 @@ import { FeeSelectorRow } from '@suite-native/transaction-management';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { ProviderInfoRow } from './ProviderInfoRow';
+import { useComposeTradingTransaction } from '../../../hooks/general/useComposeTradingTransaction';
 import { updateTradingSelectedFeeLevelThunk } from '../../../thunks';
 
 const dividerStyle = prepareNativeStyle(utils => ({
@@ -27,6 +28,7 @@ type TradeInfoProps = {
 
 export const TradeInfo = ({ trade, accountKey, tradingType, children }: TradeInfoProps) => {
     const { applyStyle } = useNativeStyles();
+    const { composeTradingTransaction } = useComposeTradingTransaction({ tradeType: tradingType });
     const formDraftKey = getFormDraftKeyByTradeType(tradingType);
     const formDraft = useSelector((state: FormDraftRootState) =>
         selectDeepCopyOfFormDraft(state, formDraftKey),
@@ -43,6 +45,7 @@ export const TradeInfo = ({ trade, accountKey, tradingType, children }: TradeInf
                 selectedFeePerUnit={formDraft?.feePerUnit}
                 formDraft={formDraft}
                 formDraftKey={formDraftKey}
+                onFeeConfirmed={composeTradingTransaction}
             />
             {children}
         </Card>

--- a/suite-native/module-trading/src/components/general/TradeInfo/__tests__/TradeInfo.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeInfo/__tests__/TradeInfo.test.tsx
@@ -53,6 +53,7 @@ describe('TradeInfo', () => {
             expect.objectContaining({
                 accountKey: btc1AccountKey,
                 formDraftKey: expect.any(String),
+                onFeeConfirmed: expect.any(Function),
             }),
         );
     });

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.ts
@@ -119,8 +119,7 @@ export const useExchangeFlow = ({ flowType }: UseExchangeFlowProps = {}) => {
 
     const {
         txnErrorString,
-        composeRequest,
-        fetchFeesAndCompose,
+        composeTradingTransaction,
         signAndSendTransaction,
         serializedTx,
         resolveTransactionSendConsent,
@@ -226,8 +225,7 @@ export const useExchangeFlow = ({ flowType }: UseExchangeFlowProps = {}) => {
         confirmTrade,
         abortConfirmTrade,
         signDataAndConfirm,
-        composeRequest,
-        fetchFeesAndCompose,
+        composeTradingTransaction,
         signAndSendTransaction,
         serializedTx,
         resolveTransactionSendConsent,

--- a/suite-native/module-trading/src/hooks/general/__tests__/useComposeTradingTransaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useComposeTradingTransaction.test.ts
@@ -1,0 +1,120 @@
+import { formDraftActions } from '@suite-common/wallet-core';
+import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { type TestStore, act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+import {
+    getBtcAccount,
+    getInitializedTradingStateWithQuotes,
+} from '@suite-native/trading-fixtures';
+import { getFormDraftKeyByTradeType } from '@suite-native/trading-state';
+
+import { createTradingLightStore } from '../../../__tests__/tradingTestUtils';
+import { useComposeTradingTransaction } from '../useComposeTradingTransaction';
+
+const mockComposeTradingTransactionThunk = jest.fn(
+    (payload: unknown) => () =>
+        Object.assign(Promise.resolve({ type: 'composeTradingTransactionThunkMock', payload }), {
+            unwrap: () => Promise.resolve(true),
+        }),
+);
+
+jest.mock('../../../thunks', () => ({
+    composeTradingTransactionThunk: (payload: unknown) =>
+        mockComposeTradingTransactionThunk(payload),
+}));
+
+const btcAccount = getBtcAccount({ descriptor: asAccountDescriptor('btc1') });
+const exchangeFormDraftKey = getFormDraftKeyByTradeType('exchange');
+
+const btcFeeInfo = {
+    blockHeight: 100,
+    blockTime: 10,
+    minFee: 1,
+    maxFee: 100,
+    minPriorityFee: 0,
+    levels: [{ label: 'normal' as const, feePerUnit: '1', blocks: 1 }],
+};
+
+describe('useComposeTradingTransaction', () => {
+    const getInitializedStore = (): TestStore => {
+        const tradingState = getInitializedTradingStateWithQuotes();
+        tradingState.exchange.tradingAccountKey = btcAccount.key;
+        tradingState.exchange.selectedQuote = tradingState.exchange.quotes[0];
+
+        return createTradingLightStore({
+            tradeType: 'exchange',
+            overrides: {
+                wallet: {
+                    accounts: [btcAccount],
+                    fees: {
+                        btc: {
+                            status: 'loaded',
+                            data: btcFeeInfo,
+                        },
+                    },
+                    formDrafts: {
+                        [exchangeFormDraftKey]: {
+                            selectedFee: 'normal',
+                            feePerUnit: '1',
+                            feeLimit: '100',
+                        },
+                    },
+                    trading: tradingState,
+                },
+            },
+        });
+    };
+
+    const renderUseComposeTradingTransaction = (store: TestStore) =>
+        renderHookWithStoreProvider(() => useComposeTradingTransaction({ tradeType: 'exchange' }), {
+            store,
+        });
+
+    beforeEach(() => {
+        mockComposeTradingTransactionThunk.mockClear();
+    });
+
+    it('should compose transaction with latest draft fee values from store', async () => {
+        const store = getInitializedStore();
+
+        const { result } = renderUseComposeTradingTransaction(store);
+
+        act(() => {
+            store.dispatch(
+                formDraftActions.storeDraft({
+                    key: exchangeFormDraftKey,
+                    formDraft: {
+                        selectedFee: 'custom',
+                        feePerUnit: '42',
+                        feeLimit: '21000',
+                        maxPriorityFeePerGas: '2',
+                        maxFeePerGas: '100',
+                    },
+                }),
+            );
+        });
+
+        await act(async () => {
+            await result.current.composeTradingTransaction();
+        });
+
+        expect(mockComposeTradingTransactionThunk).toHaveBeenCalledWith(
+            expect.objectContaining({
+                tradeType: 'exchange',
+                account: expect.objectContaining({
+                    key: btcAccount.key,
+                }),
+                feeInfo: expect.objectContaining({
+                    blockHeight: btcFeeInfo.blockHeight,
+                    blockTime: btcFeeInfo.blockTime,
+                    minFee: btcFeeInfo.minFee,
+                    maxFee: btcFeeInfo.maxFee,
+                }),
+                selectedFeeLevel: 'custom',
+                feePerUnit: '42',
+                feeLimit: '21000',
+                maxPriorityFeePerGas: '2',
+                maxFeePerGas: '100',
+            }),
+        );
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTradingTransaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTradingTransaction.test.ts
@@ -11,6 +11,8 @@ import {
 } from '../../../__tests__/tradingTestUtils';
 import { useTradingTransaction } from '../useTradingTransaction';
 
+const mockComposeTradingTransaction = jest.fn();
+
 // Mock TrezorConnect to prevent errors during cleanup
 jest.mock('@trezor/connect', () => ({
     ...jest.requireActual('@trezor/connect'),
@@ -38,11 +40,6 @@ jest.mock('@suite-common/trading', () => ({
 
 // Mock the thunks
 jest.mock('../../../thunks', () => ({
-    composeTradingTransactionThunk: (payload: unknown) => ({
-        type: 'composeTradingTransactionThunkMock',
-        payload,
-        unwrap: () => Promise.resolve(true),
-    }),
     signAndPushSendFormTransactionThunk: (payload: unknown) => ({
         type: 'signAndPushSendFormTransactionThunkMock',
         payload,
@@ -50,14 +47,14 @@ jest.mock('../../../thunks', () => ({
     }),
 }));
 
-// Mock the wallet-core thunks
+jest.mock('../useComposeTradingTransaction', () => ({
+    useComposeTradingTransaction: () => ({
+        composeTradingTransaction: mockComposeTradingTransaction,
+    }),
+}));
+
 jest.mock('@suite-common/wallet-core', () => ({
     ...jest.requireActual('@suite-common/wallet-core'),
-    updateFeeInfoThunk: (payload: unknown) => ({
-        type: 'updateFeeInfoThunkMock',
-        payload,
-        unwrap: () => Promise.resolve(true),
-    }),
 }));
 
 const btc1Account = getBtcAccount({ descriptor: asAccountDescriptor('btc1') });
@@ -93,6 +90,7 @@ describe('useTradingTransaction', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        mockComposeTradingTransaction.mockResolvedValue(undefined);
 
         // Mock the serializedTx selector to return a proper value
         jest.spyOn(require('@suite-common/wallet-core'), 'selectSendSerializedTx').mockReturnValue({
@@ -123,116 +121,22 @@ describe('useTradingTransaction', () => {
     });
 
     describe('composeRequest', () => {
-        it('should call composeTradingTransactionThunk with correct parameters', async () => {
+        it('should call composeTradingTransaction', async () => {
             const store = getInitializedStore();
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-            // Mock the networkFeeInfo selector to return proper data
-            const mockNetworkFeeInfo = {
-                feePerUnit: '1000',
-                feeLimit: '21000',
-                estimatedFee: '21000000',
-            };
-
-            // Mock the selectConvertedNetworkFeeInfo selector
-            jest.spyOn(
-                require('@suite-common/wallet-core'),
-                'selectConvertedNetworkFeeInfo',
-            ).mockReturnValue(mockNetworkFeeInfo);
 
             const { result } = renderUseTradingTransaction({ store });
 
             await act(async () => {
-                await result.current.composeRequest({
-                    selectedFeeLevel: 'high',
-                    feePerUnit: '2000',
-                    feeLimit: '25000',
-                });
+                await result.current.composeRequest();
             });
 
-            expect(dispatchSpy).toHaveBeenCalledWith({
-                type: 'composeTradingTransactionThunkMock',
-                payload: {
-                    tradeType: 'exchange',
-                    account: expect.objectContaining({
-                        key: btc1Account.key,
-                    }),
-                    network: expect.any(Object),
-                    feeInfo: mockNetworkFeeInfo,
-                    selectedFeeLevel: 'high',
-                    feePerUnit: '2000',
-                    feeLimit: '25000',
-                },
-                unwrap: expect.any(Function),
-            });
-        });
-
-        it('should call composeTradingTransactionThunk with minimal parameters', async () => {
-            const store = getInitializedStore();
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-            // Mock the networkFeeInfo selector to return proper data
-            const mockNetworkFeeInfo = {
-                feePerUnit: '1000',
-                feeLimit: '21000',
-                estimatedFee: '21000000',
-            };
-
-            jest.spyOn(
-                require('@suite-common/wallet-core'),
-                'selectConvertedNetworkFeeInfo',
-            ).mockReturnValue(mockNetworkFeeInfo);
-
-            const { result } = renderUseTradingTransaction({ store });
-
-            await act(async () => {
-                await result.current.composeRequest({});
-            });
-
-            expect(dispatchSpy).toHaveBeenCalledWith({
-                type: 'composeTradingTransactionThunkMock',
-                payload: {
-                    tradeType: 'exchange',
-                    account: expect.objectContaining({
-                        key: btc1Account.key,
-                    }),
-                    network: expect.any(Object),
-                    feeInfo: mockNetworkFeeInfo,
-                    selectedFeeLevel: undefined,
-                    feePerUnit: undefined,
-                    feeLimit: undefined,
-                },
-                unwrap: expect.any(Function),
-            });
+            expect(mockComposeTradingTransaction).toHaveBeenCalledTimes(1);
         });
     });
 
     describe('fetchFeesAndCompose', () => {
-        it('should call updateFeeInfoThunk and then composeRequest with draft fee values', async () => {
+        it('should call composeTradingTransaction', async () => {
             const store = getInitializedStore();
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-            // Mock the networkFeeInfo selector to return proper data
-            const mockNetworkFeeInfo = {
-                feePerUnit: '1000',
-                feeLimit: '21000',
-                estimatedFee: '21000000',
-            };
-
-            jest.spyOn(
-                require('@suite-common/wallet-core'),
-                'selectConvertedNetworkFeeInfo',
-            ).mockReturnValue(mockNetworkFeeInfo);
-
-            // Mock the selectDeepCopyOfFormDraft selector to return draft fee values
-            jest.spyOn(
-                require('@suite-common/wallet-core'),
-                'selectDeepCopyOfFormDraft',
-            ).mockReturnValue({
-                selectedFee: 'high',
-                feePerUnit: '5000',
-                feeLimit: '30000',
-            });
 
             const { result } = renderUseTradingTransaction({ store });
 
@@ -240,86 +144,7 @@ describe('useTradingTransaction', () => {
                 await result.current.fetchFeesAndCompose();
             });
 
-            // Should call updateFeeInfoThunk first
-            expect(dispatchSpy).toHaveBeenCalledWith({
-                type: 'updateFeeInfoThunkMock',
-                payload: {
-                    networkSymbol: 'btc',
-                },
-                unwrap: expect.any(Function),
-            });
-
-            // Then should call composeRequest with draft fee values
-            expect(dispatchSpy).toHaveBeenCalledWith({
-                type: 'composeTradingTransactionThunkMock',
-                payload: {
-                    tradeType: 'exchange',
-                    account: expect.objectContaining({
-                        key: btc1Account.key,
-                    }),
-                    network: expect.any(Object),
-                    feeInfo: mockNetworkFeeInfo,
-                    selectedFeeLevel: 'high',
-                    feePerUnit: '5000',
-                    feeLimit: '30000',
-                },
-                unwrap: expect.any(Function),
-            });
-        });
-
-        it('should handle undefined draft values', async () => {
-            const store = getInitializedStore();
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-            // Mock the networkFeeInfo selector to return proper data
-            const mockNetworkFeeInfo = {
-                feePerUnit: '1000',
-                feeLimit: '21000',
-                estimatedFee: '21000000',
-            };
-
-            jest.spyOn(
-                require('@suite-common/wallet-core'),
-                'selectConvertedNetworkFeeInfo',
-            ).mockReturnValue(mockNetworkFeeInfo);
-
-            // Mock the selectDeepCopyOfFormDraft selector to return undefined
-            jest.spyOn(
-                require('@suite-common/wallet-core'),
-                'selectDeepCopyOfFormDraft',
-            ).mockReturnValue(undefined);
-
-            const { result } = renderUseTradingTransaction({ store });
-
-            await act(async () => {
-                await result.current.fetchFeesAndCompose();
-            });
-
-            // Should call updateFeeInfoThunk first
-            expect(dispatchSpy).toHaveBeenCalledWith({
-                type: 'updateFeeInfoThunkMock',
-                payload: {
-                    networkSymbol: 'btc',
-                },
-                unwrap: expect.any(Function),
-            });
-
-            // Then should call composeRequest with undefined values
-            expect(dispatchSpy).toHaveBeenCalledWith({
-                type: 'composeTradingTransactionThunkMock',
-                payload: {
-                    tradeType: 'exchange',
-                    account: expect.objectContaining({
-                        key: btc1Account.key,
-                    }),
-                    network: expect.any(Object),
-                    feeInfo: mockNetworkFeeInfo,
-                    selectedFeeLevel: undefined,
-                    feePerUnit: undefined,
-                    feeLimit: undefined,
-                },
-                unwrap: expect.any(Function),
-            });
+            expect(mockComposeTradingTransaction).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTradingTransaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTradingTransaction.test.ts
@@ -120,28 +120,14 @@ describe('useTradingTransaction', () => {
         });
     });
 
-    describe('composeRequest', () => {
+    describe('composeTradingTransaction', () => {
         it('should call composeTradingTransaction', async () => {
             const store = getInitializedStore();
 
             const { result } = renderUseTradingTransaction({ store });
 
             await act(async () => {
-                await result.current.composeRequest();
-            });
-
-            expect(mockComposeTradingTransaction).toHaveBeenCalledTimes(1);
-        });
-    });
-
-    describe('fetchFeesAndCompose', () => {
-        it('should call composeTradingTransaction', async () => {
-            const store = getInitializedStore();
-
-            const { result } = renderUseTradingTransaction({ store });
-
-            await act(async () => {
-                await result.current.fetchFeesAndCompose();
+                await result.current.composeTradingTransaction();
             });
 
             expect(mockComposeTradingTransaction).toHaveBeenCalledTimes(1);

--- a/suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.ts
+++ b/suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.ts
@@ -1,0 +1,65 @@
+import { useCallback } from 'react';
+import { useDispatch, useStore } from 'react-redux';
+
+import { selectTradingAccountKeyByTradeType } from '@suite-common/trading';
+import { getNetwork } from '@suite-common/wallet-config';
+import {
+    type AccountsRootState,
+    type FeesRootState,
+    type FormDraftRootState,
+    selectAccountByKey,
+    selectConvertedNetworkFeeInfo,
+    selectDeepCopyOfFormDraft,
+} from '@suite-common/wallet-core';
+import { type FeeLevelLabel } from '@suite-common/wallet-types';
+import { type TradingRootState, getFormDraftKeyByTradeType } from '@suite-native/trading-state';
+
+import { composeTradingTransactionThunk } from '../../thunks';
+
+type TradingTransactionRootState = TradingRootState &
+    AccountsRootState &
+    FeesRootState &
+    FormDraftRootState;
+
+type UseComposeTradingTransactionProps = {
+    tradeType: 'exchange' | 'sell';
+};
+
+export const useComposeTradingTransaction = ({ tradeType }: UseComposeTradingTransactionProps) => {
+    const dispatch = useDispatch();
+    const store = useStore<TradingTransactionRootState>();
+
+    const composeTradingTransaction = useCallback(async () => {
+        const state = store.getState();
+        const sendAccountKey = selectTradingAccountKeyByTradeType(state, tradeType);
+        const sendAccount = selectAccountByKey(state, sendAccountKey);
+        const draft = selectDeepCopyOfFormDraft(state, getFormDraftKeyByTradeType(tradeType));
+        const networkFeeInfo = selectConvertedNetworkFeeInfo(state, sendAccount?.symbol);
+
+        if (!sendAccount || !networkFeeInfo) {
+            console.error('Send account and networkFeeInfo are required for composing transaction');
+
+            return;
+        }
+
+        try {
+            await dispatch(
+                composeTradingTransactionThunk({
+                    tradeType,
+                    account: sendAccount,
+                    network: getNetwork(sendAccount.symbol),
+                    feeInfo: networkFeeInfo,
+                    selectedFeeLevel: draft?.selectedFee as FeeLevelLabel,
+                    feePerUnit: draft?.feePerUnit,
+                    feeLimit: draft?.feeLimit,
+                    maxPriorityFeePerGas: draft?.maxPriorityFeePerGas,
+                    maxFeePerGas: draft?.maxFeePerGas,
+                }),
+            ).unwrap();
+        } catch (error) {
+            console.error('Failed to compose trading transaction:', error);
+        }
+    }, [dispatch, store, tradeType]);
+
+    return { composeTradingTransaction };
+};

--- a/suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.ts
+++ b/suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import { useDispatch, useStore } from 'react-redux';
 
 import { selectTradingAccountKeyByTradeType } from '@suite-common/trading';
-import { getNetwork } from '@suite-common/wallet-config';
+import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type FeesRootState,
@@ -10,6 +10,7 @@ import {
     selectAccountByKey,
     selectConvertedNetworkFeeInfo,
     selectDeepCopyOfFormDraft,
+    updateFeeInfoThunk,
 } from '@suite-common/wallet-core';
 import { type FeeLevelLabel } from '@suite-common/wallet-types';
 import { type TradingRootState, getFormDraftKeyByTradeType } from '@suite-native/trading-state';
@@ -29,12 +30,31 @@ export const useComposeTradingTransaction = ({ tradeType }: UseComposeTradingTra
     const dispatch = useDispatch();
     const store = useStore<TradingTransactionRootState>();
 
+    const getNetworkFeeInfo = useCallback(
+        async (symbol: NetworkSymbol) => {
+            const networkFeeInfo = selectConvertedNetworkFeeInfo(store.getState(), symbol);
+
+            if (!networkFeeInfo) {
+                try {
+                    await dispatch(updateFeeInfoThunk({ networkSymbol: symbol })).unwrap();
+                } catch {
+                    console.error('Failed to re-fetch network fee info for composing transaction');
+
+                    return;
+                }
+            }
+
+            return networkFeeInfo ?? selectConvertedNetworkFeeInfo(store.getState(), symbol);
+        },
+        [store, dispatch],
+    );
+
     const composeTradingTransaction = useCallback(async () => {
         const state = store.getState();
         const sendAccountKey = selectTradingAccountKeyByTradeType(state, tradeType);
         const sendAccount = selectAccountByKey(state, sendAccountKey);
         const draft = selectDeepCopyOfFormDraft(state, getFormDraftKeyByTradeType(tradeType));
-        const networkFeeInfo = selectConvertedNetworkFeeInfo(state, sendAccount?.symbol);
+        const networkFeeInfo = await getNetworkFeeInfo(sendAccount?.symbol as NetworkSymbol);
 
         if (!sendAccount || !networkFeeInfo) {
             console.error('Send account and networkFeeInfo are required for composing transaction');
@@ -59,7 +79,7 @@ export const useComposeTradingTransaction = ({ tradeType }: UseComposeTradingTra
         } catch (error) {
             console.error('Failed to compose trading transaction:', error);
         }
-    }, [dispatch, store, tradeType]);
+    }, [dispatch, store, tradeType, getNetworkFeeInfo]);
 
     return { composeTradingTransaction };
 };

--- a/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
@@ -1,7 +1,7 @@
 import { type ReactNode, useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { isFulfilled, isRejected } from '@reduxjs/toolkit';
+import { isFulfilled } from '@reduxjs/toolkit';
 import type { ExchangeTrade, SellFiatTrade } from 'invity-api';
 
 import {
@@ -19,16 +19,13 @@ import {
 import { getNetwork } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
-    type FeesRootState,
     type FormDraftRootState,
     type SerializedTx,
     type WalletSettingsRootState,
     selectAccountByKey,
-    selectConvertedNetworkFeeInfo,
     selectDeepCopyOfFormDraft,
     selectIsAmountInSats,
     selectSendSerializedTx,
-    updateFeeInfoThunk,
 } from '@suite-common/wallet-core';
 import { type FeeLevelLabel, type TokenAddress } from '@suite-common/wallet-types';
 import { type TxKeyPath } from '@suite-native/intl';
@@ -36,26 +33,18 @@ import { type TokensRootState, selectAccountTokenDecimals } from '@suite-native/
 import { type TradingRootState, getFormDraftKeyByTradeType } from '@suite-native/trading-state';
 import {
     selectFeeLevels,
-    useFeesFetching,
     usePrecomposedTransactionError,
 } from '@suite-native/transaction-management';
 import TrezorConnect from '@trezor/connect';
 import { noop } from '@trezor/utils';
 
+import { useComposeTradingTransaction } from './useComposeTradingTransaction';
 import { useConsent } from './useConsent';
-import { composeTradingTransactionThunk, signAndPushSendFormTransactionThunk } from '../../thunks';
+import { signAndPushSendFormTransactionThunk } from '../../thunks';
 
 export type TradingTransactionSignAndSendProps = {
     nextStep: () => void;
     onError: (error: TradingSendRejectedProps<TxKeyPath>) => void;
-};
-
-export type TradingTransactionComposeProps = {
-    selectedFeeLevel?: FeeLevelLabel;
-    feePerUnit?: string;
-    feeLimit?: string;
-    maxFeePerGas?: string;
-    maxPriorityFeePerGas?: string;
 };
 
 export type UseTradingTransactionProps = {
@@ -67,7 +56,7 @@ export type UseTradingTransactionProps = {
 
 export type UseTradingTransactionReturnProps = {
     txnErrorString: ReactNode;
-    composeRequest: (props: TradingTransactionComposeProps) => Promise<unknown>;
+    composeRequest: () => Promise<unknown>;
     fetchFeesAndCompose: () => Promise<void>;
     signAndSendTransaction: (props: TradingTransactionSignAndSendProps) => Promise<boolean>;
     signAndPushSendFormTransaction: (
@@ -108,13 +97,7 @@ export const useTradingTransaction = ({
         selectDeepCopyOfFormDraft(state, getFormDraftKeyByTradeType(tradeType)),
     );
 
-    const {
-        selectedFee,
-        feePerUnit: feePerUnitDraft,
-        feeLimit: feeLimitDraft,
-        maxFeePerGas: maxFeePerGasDraft,
-        maxPriorityFeePerGas: maxPriorityFeePerGasDraft,
-    } = draft ?? {};
+    const { selectedFee } = draft ?? {};
 
     const { contractAddress } = cryptoIdToNetworkAndContractAddress(
         tradeType === 'exchange'
@@ -128,10 +111,6 @@ export const useTradingTransaction = ({
 
     const shouldSendInSats = useSelector((state: WalletSettingsRootState) =>
         selectIsAmountInSats(state, sendAccount?.symbol),
-    );
-
-    const networkFeeInfo = useSelector((state: FeesRootState) =>
-        selectConvertedNetworkFeeInfo(state, sendAccount?.symbol),
     );
 
     const serializedTx = useSelector(selectSendSerializedTx);
@@ -152,56 +131,12 @@ export const useTradingTransaction = ({
         resolveConsent: resolveTransactionSendConsent,
     } = useConsent();
 
-    useFeesFetching({
-        networkSymbol: sendAccount?.symbol,
-        isRefetchDisabled: selectedFee === 'custom',
-    });
-
     // TODO: slip24 - not implemented in mobile
     const isSlip24Active = false;
+    const { composeTradingTransaction } = useComposeTradingTransaction({ tradeType });
 
     // cancel txn signing on unmount
     useEffect(() => () => TrezorConnect.cancel(), []);
-
-    // this is called when we want to compose a transaction
-    const composeRequest = useCallback(
-        async ({
-            selectedFeeLevel,
-            feePerUnit,
-            feeLimit,
-            maxPriorityFeePerGas,
-            maxFeePerGas,
-        }: TradingTransactionComposeProps) => {
-            if (!sendAccount || !networkFeeInfo) {
-                console.error(
-                    'Send account and networkFeeInfo are required for composing transaction',
-                );
-
-                return;
-            }
-
-            try {
-                const levels = await dispatch(
-                    composeTradingTransactionThunk({
-                        tradeType,
-                        account: sendAccount,
-                        network: getNetwork(sendAccount.symbol),
-                        feeInfo: networkFeeInfo,
-                        selectedFeeLevel,
-                        feePerUnit,
-                        feeLimit,
-                        maxPriorityFeePerGas,
-                        maxFeePerGas,
-                    }),
-                ).unwrap();
-
-                return levels;
-            } catch (error) {
-                console.error('Failed to compose trading transaction:', error);
-            }
-        },
-        [dispatch, networkFeeInfo, sendAccount, tradeType],
-    );
 
     // this is called when we want to fetch fees and compose a transaction
     const fetchFeesAndCompose = useCallback(async () => {
@@ -211,30 +146,8 @@ export const useTradingTransaction = ({
             return;
         }
 
-        const feesResult = await dispatch(
-            updateFeeInfoThunk({ networkSymbol: sendAccount.symbol }),
-        );
-        if (isRejected(feesResult)) {
-            console.error('Failed to fetch fees for trading transaction');
-        }
-
-        await composeRequest({
-            selectedFeeLevel: selectedFee as FeeLevelLabel,
-            feePerUnit: feePerUnitDraft,
-            feeLimit: feeLimitDraft,
-            maxFeePerGas: maxFeePerGasDraft,
-            maxPriorityFeePerGas: maxPriorityFeePerGasDraft,
-        });
-    }, [
-        sendAccount,
-        dispatch,
-        composeRequest,
-        selectedFee,
-        feePerUnitDraft,
-        feeLimitDraft,
-        maxFeePerGasDraft,
-        maxPriorityFeePerGasDraft,
-    ]);
+        await composeTradingTransaction();
+    }, [sendAccount, composeTradingTransaction]);
 
     // this is the reusable signAndPushSendFormTransaction function
     // waitForPushApproval is used so that we can wait for the user to approve the transaction before sending it
@@ -336,30 +249,9 @@ export const useTradingTransaction = ({
         ],
     );
 
-    useEffect(() => {
-        if (selectedFee && networkFeeInfo) {
-            composeRequest({
-                selectedFeeLevel: selectedFee as FeeLevelLabel,
-                feePerUnit: feePerUnitDraft,
-                feeLimit: feeLimitDraft,
-                maxFeePerGas: maxFeePerGasDraft,
-                maxPriorityFeePerGas: maxPriorityFeePerGasDraft,
-            });
-        }
-    }, [
-        selectedFee,
-        composeRequest,
-        feePerUnitDraft,
-        feeLimitDraft,
-        networkFeeInfo,
-        selectedQuote,
-        maxFeePerGasDraft,
-        maxPriorityFeePerGasDraft,
-    ]);
-
     return {
         txnErrorString,
-        composeRequest,
+        composeRequest: composeTradingTransaction,
         fetchFeesAndCompose,
         signAndSendTransaction,
         signAndPushSendFormTransaction,

--- a/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
@@ -56,8 +56,7 @@ export type UseTradingTransactionProps = {
 
 export type UseTradingTransactionReturnProps = {
     txnErrorString: ReactNode;
-    composeRequest: () => Promise<unknown>;
-    fetchFeesAndCompose: () => Promise<void>;
+    composeTradingTransaction: () => Promise<unknown>;
     signAndSendTransaction: (props: TradingTransactionSignAndSendProps) => Promise<boolean>;
     signAndPushSendFormTransaction: (
         props: TradingSignAndPushSendFormTransactionProps,
@@ -137,17 +136,6 @@ export const useTradingTransaction = ({
 
     // cancel txn signing on unmount
     useEffect(() => () => TrezorConnect.cancel(), []);
-
-    // this is called when we want to fetch fees and compose a transaction
-    const fetchFeesAndCompose = useCallback(async () => {
-        if (!sendAccount) {
-            console.error('Send account is required to fetch fees and compose transaction');
-
-            return;
-        }
-
-        await composeTradingTransaction();
-    }, [sendAccount, composeTradingTransaction]);
 
     // this is the reusable signAndPushSendFormTransaction function
     // waitForPushApproval is used so that we can wait for the user to approve the transaction before sending it
@@ -251,8 +239,7 @@ export const useTradingTransaction = ({
 
     return {
         txnErrorString,
-        composeRequest: composeTradingTransaction,
-        fetchFeesAndCompose,
+        composeTradingTransaction,
         signAndSendTransaction,
         signAndPushSendFormTransaction,
         serializedTx,

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
@@ -55,8 +55,7 @@ jest.mock('expo-web-browser', () => {
 jest.mock('../../general/useTradingTransaction', () => ({
     useTradingTransaction: () => ({
         txnErrorString: null,
-        composeRequest: jest.fn(),
-        fetchFeesAndCompose: jest.fn(),
+        composeTradingTransaction: jest.fn(),
         signAndSendTransaction: jest.fn(),
         serializedTx: undefined,
         resolveTransactionSendConsent: jest.fn(),

--- a/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
@@ -58,8 +58,7 @@ export const useSellFlow = () => {
 
     const {
         txnErrorString,
-        composeRequest,
-        fetchFeesAndCompose,
+        composeTradingTransaction,
         signAndSendTransaction,
         serializedTx,
         resolveTransactionSendConsent,
@@ -150,8 +149,7 @@ export const useSellFlow = () => {
 
     return {
         txnErrorString,
-        composeRequest,
-        fetchFeesAndCompose,
+        composeTradingTransaction,
         signAndSendTransaction,
         serializedTx,
         resolveTransactionSendConsent,

--- a/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
@@ -69,7 +69,8 @@ const TradingExchangePreviewScreenContent = ({
 
     useSubscribeForSolanaBlockUpdates(fromAccount ?? null);
 
-    const { txnErrorString, confirmTrade, abortConfirmTrade, composeRequest } = useExchangeFlow();
+    const { txnErrorString, confirmTrade, abortConfirmTrade, composeTradingTransaction } =
+        useExchangeFlow();
     const store = useStore<TradingRootState>();
 
     const [isConfirmationErrorRequested, setIsConfirmationErrorRequested] =
@@ -96,7 +97,7 @@ const TradingExchangePreviewScreenContent = ({
             if (success) {
                 const currentFormStep = selectTradingExchangeFormStep(store.getState());
                 if (currentFormStep !== 'SIGN_DATA') {
-                    await composeRequest();
+                    await composeTradingTransaction();
                 }
             }
         } catch (e) {
@@ -106,7 +107,7 @@ const TradingExchangePreviewScreenContent = ({
 
             console.error('Failed to confirm trade', e);
         }
-    }, [confirmTrade, debounce, composeRequest, store, quote, toAccount]);
+    }, [confirmTrade, debounce, composeTradingTransaction, store, quote, toAccount]);
 
     useSlippageLifecycle(handleConfirmTrade);
 

--- a/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
@@ -69,8 +69,7 @@ const TradingExchangePreviewScreenContent = ({
 
     useSubscribeForSolanaBlockUpdates(fromAccount ?? null);
 
-    const { txnErrorString, confirmTrade, abortConfirmTrade, fetchFeesAndCompose } =
-        useExchangeFlow();
+    const { txnErrorString, confirmTrade, abortConfirmTrade, composeRequest } = useExchangeFlow();
     const store = useStore<TradingRootState>();
 
     const [isConfirmationErrorRequested, setIsConfirmationErrorRequested] =
@@ -97,7 +96,7 @@ const TradingExchangePreviewScreenContent = ({
             if (success) {
                 const currentFormStep = selectTradingExchangeFormStep(store.getState());
                 if (currentFormStep !== 'SIGN_DATA') {
-                    await fetchFeesAndCompose();
+                    await composeRequest();
                 }
             }
         } catch (e) {
@@ -107,7 +106,7 @@ const TradingExchangePreviewScreenContent = ({
 
             console.error('Failed to confirm trade', e);
         }
-    }, [confirmTrade, debounce, fetchFeesAndCompose, store, quote, toAccount]);
+    }, [confirmTrade, debounce, composeRequest, store, quote, toAccount]);
 
     useSlippageLifecycle(handleConfirmTrade);
 

--- a/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useEffectEvent, useState } from 'react';
+import { useCallback, useEffect, useEffectEvent } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
@@ -28,13 +28,19 @@ import { clearTradingStateThunk } from '../thunks';
 
 const TradingSellPreviewScreenContent = () => {
     const dispatch = useDispatch();
-    const { txnErrorString, doBankAccountVerificationCheck, fetchFeesAndCompose } = useSellFlow();
+    const { txnErrorString, doBankAccountVerificationCheck, composeTradingTransaction } =
+        useSellFlow();
     const { trade } = useTradingDetailData<TradingSellType>('sell');
     const selectedQuote = useSelector(selectTradingSellSelectedQuote);
-    const [shouldFetchFees, setShouldFetchFees] = useState(false);
 
     const currentQuote = trade?.data ? trade.data : selectedQuote;
     const isFinalized = isFinalStatus('sell', currentQuote?.status);
+
+    useWatchTrade({
+        accountKey: trade?.sendAccountKey,
+        orderId: currentQuote?.orderId,
+        isInProgress: true,
+    });
 
     const reportToAnalytics = useSellAnalyticReportCallback();
     const reportVisit = useEffectEvent(() => {
@@ -44,31 +50,19 @@ const TradingSellPreviewScreenContent = () => {
         reportVisit();
     }, []);
 
-    useWatchTrade({
-        accountKey: trade?.sendAccountKey,
-        orderId: currentQuote?.orderId,
-        isInProgress: true,
-    });
-
-    useEffect(() => {
+    const runBankAccountVerificationCheck = useEffectEvent(() => {
         doBankAccountVerificationCheck();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
+    });
+    useEffect(() => {
+        runBankAccountVerificationCheck();
     }, []);
 
-    // Fetch fees and compose when status is SEND_CRYPTO
+    // Compose transaction when status is SEND_CRYPTO
     useEffect(() => {
         if (currentQuote?.status === 'SEND_CRYPTO') {
-            setShouldFetchFees(true);
+            composeTradingTransaction();
         }
-    }, [currentQuote?.status, currentQuote?.orderId]);
-
-    // unfortunately fetchFeesAndCompose is too unstable to be used directly in above useEffect
-    useEffect(() => {
-        if (shouldFetchFees) {
-            setShouldFetchFees(false);
-            fetchFeesAndCompose();
-        }
-    }, [shouldFetchFees, fetchFeesAndCompose]);
+    }, [currentQuote?.status, composeTradingTransaction]);
 
     // clear trading state on unmount
     useEffect(

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.test.tsx
@@ -57,7 +57,7 @@ jest.mock('@suite-common/device', () => ({
 }));
 
 const mockConfirmTrade = jest.fn().mockResolvedValue(Promise.resolve());
-const mockFetchFeesAndCompose = jest.fn();
+const mockComposeTradingTransaction = jest.fn();
 const mockSignAndSendTransaction = jest.fn();
 const mockResolveConsent = jest.fn();
 const mockAbortConfirmTrade = jest.fn();
@@ -67,7 +67,7 @@ jest.mock('../../hooks/exchange/useExchangeFlow', () => ({
     useExchangeFlow: () => ({
         abortConfirmTrade: mockAbortConfirmTrade,
         confirmTrade: mockConfirmTrade,
-        fetchFeesAndCompose: mockFetchFeesAndCompose,
+        composeTradingTransaction: mockComposeTradingTransaction,
         signAndSendTransaction: mockSignAndSendTransaction,
         signDataAndConfirm: jest.fn(),
         isConsentRequested: false,

--- a/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.test.tsx
@@ -24,7 +24,7 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 const mockDoBankAccountVerificationCheck = jest.fn();
-const mockFetchFeesAndCompose = jest.fn();
+const mockComposeTradingTransaction = jest.fn();
 const mockTxnErrorString = null;
 const mockRetryDoSellTrade = jest.fn();
 
@@ -32,7 +32,7 @@ jest.mock('../../hooks/sell/useSellFlow', () => ({
     useSellFlow: () => ({
         txnErrorString: mockTxnErrorString,
         doBankAccountVerificationCheck: mockDoBankAccountVerificationCheck,
-        fetchFeesAndCompose: mockFetchFeesAndCompose,
+        composeTradingTransaction: mockComposeTradingTransaction,
         retryDoSellTrade: mockRetryDoSellTrade,
     }),
 }));
@@ -174,7 +174,7 @@ describe('TradingSellPreviewScreen', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should call fetchFeesAndCompose when quote has SEND_CRYPTO status on mount', async () => {
+    it('should call composeTradingTransaction when quote has SEND_CRYPTO status on mount', async () => {
         const quoteWithSendCryptoStatus = {
             ...banxaCreditCardSellQuote,
             status: 'SEND_CRYPTO' as const,
@@ -184,11 +184,11 @@ describe('TradingSellPreviewScreen', () => {
             wallet: { trading: { sell: { selectedQuote: quoteWithSendCryptoStatus } } },
         });
 
-        await waitFor(() => expect(mockFetchFeesAndCompose).toHaveBeenCalled());
-        expect(mockFetchFeesAndCompose).toHaveBeenCalledTimes(1);
+        await waitFor(() => expect(mockComposeTradingTransaction).toHaveBeenCalled());
+        expect(mockComposeTradingTransaction).toHaveBeenCalledTimes(1);
     });
 
-    it('should call fetchFeesAndCompose when trade data has SEND_CRYPTO status on mount', async () => {
+    it('should call composeTradingTransaction when trade data has SEND_CRYPTO status on mount', async () => {
         const trade = getSellTrade({ status: 'SEND_CRYPTO' });
         mockUseTradingDetailData.trade = trade;
 
@@ -201,11 +201,11 @@ describe('TradingSellPreviewScreen', () => {
             },
         });
 
-        await waitFor(() => expect(mockFetchFeesAndCompose).toHaveBeenCalled());
-        expect(mockFetchFeesAndCompose).toHaveBeenCalledTimes(1);
+        await waitFor(() => expect(mockComposeTradingTransaction).toHaveBeenCalled());
+        expect(mockComposeTradingTransaction).toHaveBeenCalledTimes(1);
     });
 
-    it('should not call fetchFeesAndCompose when status is not SEND_CRYPTO', async () => {
+    it('should not call composeTradingTransaction when status is not SEND_CRYPTO', async () => {
         const quoteWithOtherStatus = {
             ...banxaCreditCardSellQuote,
             status: 'SUBMITTED' as const,
@@ -215,10 +215,10 @@ describe('TradingSellPreviewScreen', () => {
             wallet: { trading: { sell: { selectedQuote: quoteWithOtherStatus } } },
         });
 
-        expect(mockFetchFeesAndCompose).not.toHaveBeenCalled();
+        expect(mockComposeTradingTransaction).not.toHaveBeenCalled();
     });
 
-    it('should call fetchFeesAndCompose only once per orderId', async () => {
+    it('should call composeTradingTransaction only once per orderId', async () => {
         const quoteWithSendCryptoStatus = {
             ...moonpayCreditCardSellQuote,
             status: 'SEND_CRYPTO' as const,
@@ -229,9 +229,9 @@ describe('TradingSellPreviewScreen', () => {
             wallet: { trading: { sell: { selectedQuote: quoteWithSendCryptoStatus } } },
         });
 
-        await waitFor(() => expect(mockFetchFeesAndCompose).toHaveBeenCalled());
+        await waitFor(() => expect(mockComposeTradingTransaction).toHaveBeenCalled());
         // Should be called exactly once for this orderId
-        expect(mockFetchFeesAndCompose).toHaveBeenCalledTimes(1);
+        expect(mockComposeTradingTransaction).toHaveBeenCalledTimes(1);
     });
 
     it('should render last error message', async () => {

--- a/suite-native/transaction-management/src/components/fees/FeesBottomSheet.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeesBottomSheet.tsx
@@ -42,7 +42,7 @@ type FeesBottomSheetProps = {
     formDraft: FormState | null | undefined;
     snapshotRef: RefObject<FeesFormValues | undefined>;
     confirmedRef: MutableRefObject<boolean>;
-    onConfirm: (feeLevel: FeeLevelLabel, customParams?: CustomFeeParams) => void;
+    onConfirm: (feeLevel: FeeLevelLabel, customParams?: CustomFeeParams) => void | Promise<void>;
     closeModal: () => void;
 };
 

--- a/suite-native/transaction-management/src/hooks/fees/useFeeSelection.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeeSelection.ts
@@ -30,7 +30,7 @@ export const useFeeSelection = ({
     const dispatch = useDispatch();
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const handleFeeLevelChange = useCallback(
-        (
+        async (
             feeLevel: FeeLevelLabel,
             {
                 customFeePerUnit,
@@ -65,7 +65,7 @@ export const useFeeSelection = ({
                 };
             }
 
-            dispatch(updateThunk(thunkParams));
+            await dispatch(updateThunk(thunkParams));
         },
         [analytics, dispatch, updateThunk, accountKey, tokenContract, formDraftKey],
     );
@@ -76,14 +76,13 @@ export const useFeeSelection = ({
             customFeeLimit,
             customMaxFeePerGas,
             customMaxPriorityFeePerGas,
-        }: CustomFeeParams) => {
+        }: CustomFeeParams) =>
             handleFeeLevelChange('custom', {
                 customFeePerUnit,
                 customFeeLimit,
                 customMaxFeePerGas,
                 customMaxPriorityFeePerGas,
-            });
-        },
+            }),
         [handleFeeLevelChange],
     );
 

--- a/suite-native/transaction-management/src/hooks/fees/useFeeSelector.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeeSelector.ts
@@ -9,13 +9,13 @@ import {
 } from '@suite-common/wallet-types';
 import { useBottomSheetModal } from '@suite-native/atoms';
 
+import { getFeeAvailability } from './feeAvailability';
+import { type CustomFeeParams } from './useFeeSelection';
+import { useFeesManagement } from './useFeesManagement';
 import { type FeesFormValues } from '../../feesFormSchema';
 import { updateFeeLimitThunk } from '../../thunks';
 import { type UpdateSelectedFeeLevelThunkParams } from '../../types';
 import { usePrecomposedTransactionError } from '../usePrecomposedTransactionError';
-import { getFeeAvailability } from './feeAvailability';
-import { type CustomFeeParams } from './useFeeSelection';
-import { useFeesManagement } from './useFeesManagement';
 
 export type UseFeeSelectorParams = {
     accountKey: AccountKey;
@@ -26,6 +26,7 @@ export type UseFeeSelectorParams = {
     selectedSetMaxOutputId?: number;
     formDraft: FormState | null | undefined;
     formDraftKey?: string;
+    onFeeConfirmed?: () => void | Promise<void>;
 };
 
 export const useFeeSelector = ({
@@ -37,6 +38,7 @@ export const useFeeSelector = ({
     selectedSetMaxOutputId,
     formDraft,
     formDraftKey,
+    onFeeConfirmed,
 }: UseFeeSelectorParams) => {
     const {
         form,
@@ -88,11 +90,14 @@ export const useFeeSelector = ({
     }, [form, openModal]);
 
     const handleConfirm = useCallback(
-        (feeLevel: FeeLevelLabel, customParams?: CustomFeeParams) => {
+        async (feeLevel: FeeLevelLabel, customParams?: CustomFeeParams) => {
             if (feeLevel === 'custom') {
-                if (!customParams) return;
+                if (!customParams) {
+                    return;
+                }
+
                 if (isTrc20 && customParams.customFeeLimit) {
-                    dispatch(
+                    await dispatch(
                         updateFeeLimitThunk({
                             accountKey,
                             tokenContract,
@@ -100,13 +105,23 @@ export const useFeeSelector = ({
                         }),
                     );
                 } else {
-                    handleCustomFeeSet(customParams);
+                    await handleCustomFeeSet(customParams);
                 }
             } else {
-                handleFeeLevelChange(feeLevel);
+                await handleFeeLevelChange(feeLevel);
             }
+
+            await onFeeConfirmed?.();
         },
-        [isTrc20, accountKey, tokenContract, dispatch, handleFeeLevelChange, handleCustomFeeSet],
+        [
+            isTrc20,
+            accountKey,
+            tokenContract,
+            dispatch,
+            handleFeeLevelChange,
+            handleCustomFeeSet,
+            onFeeConfirmed,
+        ],
     );
 
     const feeLimitSunOverride = isTrc20 ? form.watch('customFeeLimit') : undefined;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Extracts trading transaction composition into `useComposeTradingTransaction`.
- Removes duplicated fee fetching/composition from `useTradingTransaction`.
- Renames trading flow API from `composeRequest` / `fetchFeesAndCompose` to `composeTradingTransaction`.
- Reuses `composeTradingTransaction` from sell/exchange preview screens and fee selector confirmation.
- Ensures fee selection updates are awaited before recomposing with the selected fee.
- Updates related sell, exchange, fee selector, and hook tests.

<!--- Describe your changes in detail -->

## Notes for QA
* Test multiple swap and sell flows, to verify that the fees are calculated correctly and not stale. 

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/23471 🤞 

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/23471-swap-fee-calculation-sometimes-fails-on-mobile-blocking-flow&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->