### PR TITLE
Remove `ADDRESS_VALIDATION` event from Connect

### DIFF
--- a/packages/connect-common/src/events/call.ts
+++ b/packages/connect-common/src/events/call.ts
@@ -42,12 +42,9 @@ type CallApi = {
 };
 type TrezorConnectCoreMethods = keyof TrezorConnectCore;
 
-// necessary part of CallMethod which shouldn't be exposed to the consumers
-type SupportParams = { useEventListener?: boolean };
-
 export type CallMethodKeys = Exclude<keyof CallApi, TrezorConnectCoreMethods>;
 export type CallMethodUnion = CallApi[CallMethodKeys];
-export type CallMethodPayload = Parameters<CallMethodUnion>[0] & SupportParams;
+export type CallMethodPayload = Parameters<CallMethodUnion>[0];
 export type CallMethodParams<M extends CallMethodKeys> = Parameters<CallApi[M]>[0];
 export type CallMethodResponse<M extends CallMethodKeys> = UnwrappedResponse<
     ReturnType<CallApi[M]>

--- a/packages/connect-common/src/events/ui-request.ts
+++ b/packages/connect-common/src/events/ui-request.ts
@@ -52,7 +52,6 @@ export const UI_REQUEST = {
     REQUEST_WORD: 'ui-request_word',
 
     BUNDLE_PROGRESS: 'ui-bundle_progress',
-    ADDRESS_VALIDATION: 'ui-address_validation',
     REQUEST_DISCOVERY_ACCOUNTS: 'ui-request_discovery_accounts',
 } as const;
 
@@ -141,11 +140,6 @@ export interface UiRequestButton {
     payload: DeviceButtonRequest['payload'] & {
         data?: UiRequestButtonData;
     };
-}
-
-export interface UiRequestAddressValidation {
-    type: typeof UI_REQUEST.ADDRESS_VALIDATION;
-    payload: UiRequestButtonData | undefined;
 }
 
 export interface UiRequestConfirmation {
@@ -310,7 +304,6 @@ export type UiEvent =
     | FirmwareException
     | FirmwareReconnect
     | FirmwareDisconnect
-    | UiRequestAddressValidation
     | UiRequestFirmwareDownloaded
     | UiRequestDiscoveryAccounts;
 

--- a/packages/connect-common/src/factory.ts
+++ b/packages/connect-common/src/factory.ts
@@ -1,5 +1,4 @@
 import { connectCallableMethods } from './callableMethods';
-import { UI_REQUEST } from './events';
 import type { CallMethod } from './events/call';
 import { type Manifest, type TrezorConnect } from './types';
 import type { ConnectEmitter } from './types/emitter';
@@ -39,14 +38,7 @@ export const factory = <
     const callableMethods = Object.fromEntries(
         connectCallableMethods.map(method => [
             method,
-            (params: any) =>
-                call({
-                    ...params,
-                    method,
-                    useEventListener: method.toLowerCase().endsWith('getaddress')
-                        ? eventEmitter.listenerCount(UI_REQUEST.ADDRESS_VALIDATION) > 0
-                        : undefined,
-                }),
+            (params: any) => call({ ...params, method }),
         ]),
     ) as Pick<TrezorConnect, (typeof connectCallableMethods)[number]>;
 

--- a/packages/connect-explorer/src/pages/methods/bitcoin/getAddress.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/getAddress.mdx
@@ -71,23 +71,6 @@ TrezorConnect.getAddress({
 });
 ```
 
-Validate address using custom UI inside of your application:
-
-```javascript
-import TrezorConnect, { UI } from '@trezor/connect';
-
-TrezorConnect.on(UI.ADDRESS_VALIDATION, data => {
-    console.log('Handle button request', data.address, data.serializedPath);
-    // here you can display custom UI inside of your app
-});
-
-const result = await TrezorConnect.getAddress({
-    path: "m/49'/0'/0'/0/0",
-    address: '3L6TyTisPBmrDAj6RoKmDzNnj4eQi54gD2',
-});
-// dont forget to hide your custom UI after you get the result!
-```
-
 ### Result
 
 [Address type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/types/params.ts)

--- a/packages/connect-explorer/src/pages/methods/cardano/cardanoGetAddress.mdx
+++ b/packages/connect-explorer/src/pages/methods/cardano/cardanoGetAddress.mdx
@@ -260,28 +260,6 @@ TrezorConnect.cardanoGetAddress({
 });
 ```
 
-Validate address using custom UI inside of your application:
-
-```javascript
-import TrezorConnect, { UI } from '@trezor/connect';
-
-TrezorConnect.on(UI.ADDRESS_VALIDATION, data => {
-    console.log('Handle button request', data.address, data.serializedPath);
-    // here you can display custom UI inside of your app
-});
-
-const result = await TrezorConnect.cardanoGetAddress({
-    addressParameters: {
-        addressType: 8,
-        path: "m/44'/1815'/0'/0/0",
-    },
-    protocolMagic: 764824073,
-    networkId: 0,
-    address: 'Ae2tdPwUPEZ5YUb8sM3eS8JqKgrRLzhiu71crfuH2MFtqaYr5ACNRdsswsZ',
-});
-// don't forget to hide your custom UI after you get the result!
-```
-
 ### Result
 
 [CardanoAddress type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/types/api/cardano/common.ts)

--- a/packages/connect-explorer/src/pages/methods/ethereum/ethereumGetAddress.mdx
+++ b/packages/connect-explorer/src/pages/methods/ethereum/ethereumGetAddress.mdx
@@ -68,23 +68,6 @@ TrezorConnect.ethereumGetAddress({
 });
 ```
 
-Validate address using custom UI inside of your application:
-
-```javascript
-import TrezorConnect, { UI } from '@trezor/connect';
-
-TrezorConnect.on(UI.ADDRESS_VALIDATION, data => {
-    console.log('Handle button request', data.address, data.serializedPath);
-    // here you can display custom UI inside of your app
-});
-
-const result = await TrezorConnect.ethereumGetAddress({
-    path: "m/44'/60'/0'/0/0",
-    address: '0x73d0385F4d8E00C5e6504C6030F47BF6212736A8',
-});
-// dont forget to hide your custom UI after you get the result!
-```
-
 ### Result
 
 [Address type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/types/params.ts)

--- a/packages/connect-explorer/src/pages/methods/ripple/rippleGetAddress.mdx
+++ b/packages/connect-explorer/src/pages/methods/ripple/rippleGetAddress.mdx
@@ -67,23 +67,6 @@ TrezorConnect.rippleGetAddress({
 });
 ```
 
-Validate address using custom UI inside of your application:
-
-```javascript
-import TrezorConnect, { UI } from '@trezor/connect';
-
-TrezorConnect.on(UI.ADDRESS_VALIDATION, data => {
-    console.log('Handle button request', data.address, data.serializedPath);
-    // here you can display custom UI inside of your app
-});
-
-const result = await TrezorConnect.rippleGetAddress({
-    path: "m/44'/144'/0'/0/0",
-    address: 'rNaqKtKrMSwpwZSzRckPf7S96DkimjkF4H',
-});
-// dont forget to hide your custom UI after you get the result!
-```
-
 ### Result
 
 [Address type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/types/params.ts)

--- a/packages/connect-explorer/src/pages/methods/stellar/stellarGetAddress.mdx
+++ b/packages/connect-explorer/src/pages/methods/stellar/stellarGetAddress.mdx
@@ -67,23 +67,6 @@ TrezorConnect.stellarGetAddress({
 });
 ```
 
-Validate address using custom UI inside of your application:
-
-```javascript
-import TrezorConnect, { UI } from '@trezor/connect';
-
-TrezorConnect.on(UI.ADDRESS_VALIDATION, data => {
-    console.log('Handle button request', data.address, data.serializedPath);
-    // here you can display custom UI inside of your app
-});
-
-const result = await TrezorConnect.stellarGetAddress({
-    path: "m/44'/148'/0'/0/0",
-    address: 'GAXSFOOGF4ELO5HT5PTN23T5XE6D5QWL3YBHSVQ2HWOFEJNYYMRJENBV',
-});
-// dont forget to hide your custom UI after you get the result!
-```
-
 ### Result
 
 [Address type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/types/params.ts)

--- a/packages/connect-explorer/src/pages/methods/tezos/tezosGetAddress.mdx
+++ b/packages/connect-explorer/src/pages/methods/tezos/tezosGetAddress.mdx
@@ -67,23 +67,6 @@ TrezorConnect.tezosGetAddress({
 });
 ```
 
-Validate address using custom UI inside of your application:
-
-```javascript
-import TrezorConnect, { UI } from '@trezor/connect';
-
-TrezorConnect.on(UI.ADDRESS_VALIDATION, data => {
-    console.log('Handle button request', data.address, data.serializedPath);
-    // here you can display custom UI inside of your app
-});
-
-const result = await TrezorConnect.tezosGetAddress({
-    path: "m/44'/1729'/0'",
-    address: 'tz1Kef7BSg6fo75jk37WkKRYSnJDs69KVqt9',
-});
-// dont forget to hide your custom UI after you get the result!
-```
-
 ### Result
 
 [Address type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/types/params.ts)

--- a/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
@@ -60,7 +60,6 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
         super(message, params);
 
         this.hasBundle = hasBundle;
-        this.useUi = this.getUseUi(this.params, payload.useEventListener);
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Cardano'];
         this.requiredFirmwareCoins = [getMiscNetwork('Cardano')];

--- a/packages/connect/src/api/common/AbstractMiscGetAddress.ts
+++ b/packages/connect/src/api/common/AbstractMiscGetAddress.ts
@@ -55,7 +55,6 @@ export abstract class AbstractMiscGetAddress<
         super(message, params);
 
         this.hasBundle = hasBundle;
-        this.useUi = this.getUseUi(this.params, payload.useEventListener);
         this.confirmMissingBackup = true;
     }
 

--- a/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
@@ -60,7 +60,6 @@ export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddre
 
         this.requiredFirmwareCoins = params.map(({ network }) => network);
         this.hasBundle = hasBundle;
-        this.useUi = this.getUseUi(this.params, payload.useEventListener);
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Ethereum'];
     }

--- a/packages/connect/src/api/getAddress.ts
+++ b/packages/connect/src/api/getAddress.ts
@@ -80,7 +80,6 @@ export default class GetAddress extends AbstractMethod<'getAddress', Params[]> {
         super(message, params);
 
         this.hasBundle = hasBundle;
-        this.useUi = this.getUseUi(this.params, payload.useEventListener);
         this.requiredFirmwareCoins = params.map(({ coinInfo }) => coinInfo);
         this.confirmMissingBackup = true;
     }

--- a/packages/connect/src/api/monero/api/moneroGetAddress.ts
+++ b/packages/connect/src/api/monero/api/moneroGetAddress.ts
@@ -54,7 +54,6 @@ export default class MoneroGetAddress extends AbstractMethod<'moneroGetAddress',
         super(message, params);
 
         this.hasBundle = hasBundle;
-        this.useUi = this.getUseUi(this.params, payload.useEventListener);
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Monero'];
         this.requiredFirmwareCoins = [getMiscNetwork('Monero')];

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -211,22 +211,6 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         this.confirmMissingBackup = false;
     }
 
-    // Used in *getAddress methods
-    protected getUseUi(
-        params: { address?: string; proto: { show_display?: boolean } }[],
-        useEventListener: boolean | undefined,
-    ) {
-        // @ts-expect-error: indexing with noUncheckedIndexedAccess
-        const firstParam: (typeof params)[number] = params[0];
-        const notUseUi =
-            useEventListener &&
-            params.length === 1 &&
-            typeof firstParam.address === 'string' &&
-            firstParam.proto.show_display;
-
-        return !notUseUi;
-    }
-
     public setDevice(device: Device) {
         this.device = device;
     }

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -456,7 +456,6 @@ const onDeviceButtonHandler =
     (device: Device, context: CoreContext, method?: AbstractMethod<any>) =>
     ({ payload: request }: DeviceEvents['button']) => {
         const { sendCoreMessage } = context;
-        const addressRequest = request.code === 'ButtonRequest_Address';
         const data =
             typeof method?.getButtonRequestData === 'function' && request.code
                 ? method?.getButtonRequestData(request.code, request.name)
@@ -472,9 +471,6 @@ const onDeviceButtonHandler =
                 data,
             }),
         );
-        if (addressRequest && !method?.useUi) {
-            sendCoreMessage(createUiMessage(UI_REQUEST.ADDRESS_VALIDATION, data));
-        }
     };
 
 const onDevicePinHandler =


### PR DESCRIPTION
## Description

This PR removes the alternative flow for `getAddress` methods where, instead of showing Suite's UI, `ADDRESS_VALIDATION` event is emitted for implementers to show their own UI. The reasoning is following:
- we don't use this flow, neither in Suite nor anywhere else
- event emitting doesn't work in connect-web/connect-webextension/connect-mobile anyway
- we may presume that no 3rd party uses this directly with @trezor/connect
- it allows to remove `AbstractMethod.getUseUi` method and `useEventListener` param in every single method call

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/connect-address-event-removal&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/connect-address-event-removal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/connect-address-event-removal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes span the TrezorConnect core infrastructure (AbstractMethod, core/index, event types) and specific address-related API methods (getAddress, ethereumGetAddress, cardanoGetAddress, moneroGetAddress). The highest risk is in the address retrieval flows — any regression would directly break receive address functionality across multiple coin types. The TrezorConnect popup and permissions tests are medium risk since they exercise the core method lifecycle and event infrastructure. The AbstractMethod and core/index changes touch 121+ tests but most of those tests (analytics, backup, settings, staking, trading, etc.) don't exercise the address or method lifecycle paths being changed, so they are omitted. Monero address functionality has no E2E test coverage.

<details><summary><b>Changed files (10)</b></summary>

- `packages/connect-common/src/events/call.ts`
- `packages/connect-common/src/events/ui-request.ts`
- `packages/connect-common/src/factory.ts`
- `packages/connect/src/api/cardano/api/cardanoGetAddress.ts`
- `packages/connect/src/api/common/AbstractMiscGetAddress.ts`
- `packages/connect/src/api/ethereum/api/ethereumGetAddress.ts`
- `packages/connect/src/api/getAddress.ts`
- `packages/connect/src/api/monero/api/moneroGetAddress.ts`
- `packages/connect/src/core/AbstractMethod.ts`
- `packages/connect/src/core/index.ts`

</details>

**Recommended tests (17)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — Directly exercises cardanoGetAddress which was changed. This test reveals a Cardano receive address, confirms it on device, and verifies address display — all core behaviors of the changed cardanoGetAddress API.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — Directly exercises cardanoGetAddress with passphrase protection. Changes to cardanoGetAddress could affect passphrase-based address derivation and the reveal address flow tested here.
- `suite/e2e/tests/wallet/receive.test.ts` — Tests receive address reveal for BTC, ETH, SOL, and TRX. Changes to both ethereumGetAddress and getAddress are directly exercised. The ETH flow uses ethereumGetAddress and the BTC flow uses getAddress.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — Tests the global receive flow which reveals an ETH address and verifies it on-device. Directly exercises the changed ethereumGetAddress API path.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Tests BTC address reveal with passphrase wallets, directly exercising the changed getAddress API. Verifies address derivation, device confirmation, and passphrase mismatch handling.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Tests BTC receive address reveal with passphrase caching across device reconnection, directly exercising the changed getAddress API including re-confirmation after reconnect.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Directly tests TrezorConnect.getAddress API including single address export, bundle export, on-device verification, and device rejection — all core flows affected by the changed getAddress implementation and AbstractMethod.
- `suite/e2e/tests/trezor-connect/error.test.ts` — Tests TrezorConnect.ethereumGetAddress with an invalid path, exercising error handling in the changed ethereumGetAddress API. Changes to AbstractMethod or event handling could alter error display behavior.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Tests TrezorConnect.getAddress through the web popup flow including permissions, address confirmation, cancellation, and popup lifecycle. Changes to getAddress, AbstractMethod, and connect-common events/factory affect this flow.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Tests TrezorConnect.getAddress through the webextension popup flow. Changes to getAddress and the core connect infrastructure (AbstractMethod, events, factory) could affect address export in this context.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests connect permissions flow using getAddress as the underlying API call. Changes to AbstractMethod, core/index, and event infrastructure could affect the permissions grant and revocation flow.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Tests TrezorConnect.getAccountInfo which goes through AbstractMethod and core/index. Changes to the core method infrastructure could affect account info retrieval and the permissions/account selection modal flow.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Tests TrezorConnect.ethereumSignMessage which shares AbstractMethod infrastructure and connect-common events. Changes to core method processing or UI events could affect the sign message confirmation flow.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Tests TrezorConnect.ethereumSignTransaction using the core connect infrastructure. Changes to AbstractMethod and core/index affect the multi-step device confirmation flow tested here.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Tests TrezorConnect.signTransaction which exercises AbstractMethod and core/index. The multi-step device confirmation flow could be affected by changes to the core method infrastructure.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests TrezorConnect silent mode with signMessage API calls. Changes to AbstractMethod, core/index, and event handling could affect how permissions and silent mode interact during API calls.
- `suite/e2e/tests/wallet/public-keys.test.ts` — Tests showing public keys (XPUBs) for BTC, LTC, and ADA accounts via device prompts. This exercises getAddress-adjacent connect flows and AbstractMethod for key derivation that could be affected by the changes.

</details>

⚠️ **Changes with no test coverage (5)**
- `packages/connect/src/api/monero/api/moneroGetAddress.ts`
- `packages/connect-common/src/events/call.ts`
- `packages/connect-common/src/events/ui-request.ts`
- `packages/connect-common/src/factory.ts`
- `packages/connect/src/api/common/AbstractMiscGetAddress.ts`

_Updated: 2026-06-26T07:50:03.666Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-26T07:54:43.123Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |

</details>

_Updated: 2026-06-26T07:51:48.286Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/connect-address-event-removal/web/](https://dev.suite.sldev.cz/suite-web/chore/connect-address-event-removal/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->