### PR TITLE
Fetch missing tx fiat rates on transaction detail

### DIFF
--- a/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
+++ b/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
@@ -23,6 +23,7 @@ import {
     InstantStakeBanner,
     TransactionName,
     getUnstakeTxAmount,
+    useFetchMissingTransactionFiatRates,
 } from '@suite-native/transactions';
 
 import { TransactionDetailData } from '../components/TransactionDetailData';
@@ -48,6 +49,8 @@ export const TransactionDetailScreen = ({
         navigation.dispatch(data.action);
         askForRating();
     });
+
+    useFetchMissingTransactionFiatRates({ accountKey, isEnabled: !!transaction });
 
     useEffect(() => {
         if (transaction) {

--- a/suite-native/transactions/src/components/TransactionList.tsx
+++ b/suite-native/transactions/src/components/TransactionList.tsx
@@ -11,10 +11,8 @@ import {
     fetchAndUpdateAccountThunk,
     fetchTransactionsPageThunk,
     selectAreAllAccountTransactionsLoaded,
-    selectBaseCurrency,
     selectIsLoadingAccountTransactions,
     selectIsPageAlreadyFetched,
-    updateMissingTxFiatRatesThunk,
 } from '@suite-common/wallet-core';
 import { type Account, type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
 import { type MonthKey, groupTransactionsByDate, isPending } from '@suite-common/wallet-utils';
@@ -35,6 +33,7 @@ import { TransactionListGroupTitle } from './TransactionListGroupTitle';
 import { TransactionListItem } from './TransactionListItem';
 import { TransactionsEmptyState } from './TransactionsEmptyState';
 import { TransactionsListFooter } from './TransactionsListFooter';
+import { useFetchMissingTransactionFiatRates } from '../hooks/useFetchMissingTransactionFiatRates';
 
 type AccountTransactionProps = {
     listHeaderComponent: JSX.Element;
@@ -140,7 +139,6 @@ export const TransactionList = ({
         utils: { colors },
     } = useNativeStyles();
 
-    const localCurrency = useSelector(selectBaseCurrency);
     const isLoadingTransactions = useSelector((state: TransactionsRootState) =>
         selectIsLoadingAccountTransactions(state, accountKey),
     );
@@ -247,11 +245,7 @@ export const TransactionList = ({
         ]) as TransactionListItem[];
     }, [transactions, tokenContract]);
 
-    useEffect(() => {
-        if (data.length > 0) {
-            dispatch(updateMissingTxFiatRatesThunk({ localCurrency, accountKey }));
-        }
-    }, [data, dispatch, localCurrency, accountKey]);
+    useFetchMissingTransactionFiatRates({ accountKey, isEnabled: data.length > 0 });
 
     const renderItem = useCallback(
         ({ item, index }: { item: TransactionListItem; index: number }) => {

--- a/suite-native/transactions/src/hooks/useFetchMissingTransactionFiatRates.ts
+++ b/suite-native/transactions/src/hooks/useFetchMissingTransactionFiatRates.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import {
+    type TransactionsRootState,
+    selectAccountTransactions,
+    selectBaseCurrency,
+    updateMissingTxFiatRatesThunk,
+} from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+
+type UseFetchMissingTransactionFiatRatesParams = {
+    accountKey?: AccountKey;
+    isEnabled?: boolean;
+};
+
+export const useFetchMissingTransactionFiatRates = ({
+    accountKey,
+    isEnabled = true,
+}: UseFetchMissingTransactionFiatRatesParams) => {
+    const dispatch = useDispatch();
+    const localCurrency = useSelector(selectBaseCurrency);
+    const transactions = useSelector((state: TransactionsRootState) =>
+        selectAccountTransactions(state, accountKey ?? null),
+    );
+
+    useEffect(() => {
+        if (isEnabled) {
+            dispatch(updateMissingTxFiatRatesThunk({ localCurrency, accountKey }));
+        }
+    }, [isEnabled, dispatch, localCurrency, accountKey, transactions]);
+};

--- a/suite-native/transactions/src/index.ts
+++ b/suite-native/transactions/src/index.ts
@@ -7,6 +7,7 @@ export * from './components/TransactionOutputLabelEditable';
 export * from './components/TokenTransferListItem';
 export * from './components/TransactionListItem';
 export * from './components/TransactionListItemContainer';
+export * from './hooks/useFetchMissingTransactionFiatRates';
 export * from './selectors';
 export type * from './types';
 export * from './utils';


### PR DESCRIPTION
## Description

The transaction detail screen now backfills missing historic fiat rates on its own, so the fiat value renders even when the screen is reached directly without the transaction list having loaded the rates first. The fetching logic is extracted into a reusable useFetchMissingTransactionFiatRates hook, which the transaction list now also consumes instead of duplicating the dispatch inline.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29092

## Screenshots:
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2026-06-25 at 15 29 12" src="https://github.com/user-attachments/assets/046d4dcf-007b-4eea-b07f-526a4584a78f" />
