### PR TITLE
Mobile Trade debug: introduce ExchangeUsdcPresetButton

### DIFF
--- a/suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.tsx
@@ -3,6 +3,7 @@ import { isMaxAllowance } from '@suite-common/wallet-utils';
 import { HStack, Text } from '@suite-native/atoms';
 import { DebugModeView } from '@suite-native/trading-debug';
 
+import { ExchangeUsdcPresetButton } from './ExchangeUsdcPresetButton';
 import { useExchangeFormContext } from '../../hooks/exchange/useExchangeFormContext';
 
 export const ExchangeFormQuoteDebugView = () => {
@@ -30,6 +31,9 @@ export const ExchangeFormQuoteDebugView = () => {
                 <Text variant="body-xs" color="contentSecondary">
                     {preapproved}
                 </Text>
+            </HStack>
+            <HStack>
+                <ExchangeUsdcPresetButton />
             </HStack>
         </DebugModeView>
     );

--- a/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.tsx
@@ -1,0 +1,60 @@
+import { useDispatch, useSelector } from 'react-redux';
+
+import { tradingExchangeActions } from '@suite-common/trading';
+import { type AccountsRootState, selectAccounts } from '@suite-common/wallet-core';
+import { type TokenAddress } from '@suite-common/wallet-types';
+import { Text, TextButton } from '@suite-native/atoms';
+import { type TradeableAsset } from '@suite-native/trading-types';
+
+import { useExchangeFormContext } from '../../hooks/exchange/useExchangeFormContext';
+
+const USDC_ETH: TradeableAsset = {
+    symbol: 'USDC',
+    name: 'USDC',
+    coingeckoId: 'usd-coin',
+    cryptoId: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TradeableAsset['cryptoId'],
+    networkId: 'ethereum',
+    contractAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress,
+};
+
+const USDT_ETH: TradeableAsset = {
+    symbol: 'USDT',
+    name: 'Tether USDT',
+    coingeckoId: 'tether',
+    cryptoId: 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as TradeableAsset['cryptoId'],
+    networkId: 'ethereum',
+    contractAddress: '0xdac17f958d2ee523a2206206994597c13d831ec7' as TokenAddress,
+};
+
+export const ExchangeUsdcPresetButton = () => {
+    const { setValue } = useExchangeFormContext();
+    const dispatch = useDispatch();
+    const debugAccount = useSelector((state: AccountsRootState) =>
+        selectAccounts(state).find(
+            ({ symbol, tokens }) =>
+                symbol === 'eth' && tokens?.some(token => token.symbol === 'USDC'),
+        ),
+    );
+
+    if (!debugAccount) {
+        return (
+            <Text variant="body-xs" color="contentCritical">
+                No account with USDC found.
+            </Text>
+        );
+    }
+
+    const handlePress = () => {
+        setValue('sendAsset', USDC_ETH);
+        setValue('sendAccount', debugAccount);
+        dispatch(tradingExchangeActions.setTradingAccountKey(debugAccount.key));
+        setValue('sendCryptoAmount', '1');
+        setValue('receiveAsset', USDT_ETH);
+    };
+
+    return (
+        <TextButton size="small" onPress={handlePress} intent="accentViolet">
+            Prefill 1 USDC → USDT
+        </TextButton>
+    );
+};

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeFormQuoteDebugView.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeFormQuoteDebugView.test.tsx
@@ -1,3 +1,5 @@
+import { Text } from 'react-native';
+
 import type { CryptoId, ExchangeTrade } from 'invity-api';
 
 import { UINT256_MAX } from '@suite-common/suite-constants';
@@ -23,6 +25,10 @@ jest.mock('@suite-native/trading-debug', () => {
             mockDebugMode ? children : null,
     };
 });
+
+jest.mock('../ExchangeUsdcPresetButton', () => ({
+    ExchangeUsdcPresetButton: () => <Text>PRESET BUTTON MOCK</Text>,
+}));
 
 describe('ExchangeFormQuoteDebugView', () => {
     const renderDebugView = () => renderWithBasicProvider(<ExchangeFormQuoteDebugView />);

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeUsdcPresetButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeUsdcPresetButton.test.tsx
@@ -1,0 +1,85 @@
+import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { type TestStore, fireEvent, screen } from '@suite-native/test-utils-store';
+
+import {
+    createTradingLightStore,
+    createTradingPreloadedState,
+    renderWithTradingProvider,
+} from '../../../__tests__/tradingTestUtils';
+import { ExchangeUsdcPresetButton } from '../ExchangeUsdcPresetButton';
+
+const mockSetValue = jest.fn();
+
+jest.mock('../../../hooks/exchange/useExchangeFormContext', () => ({
+    useExchangeFormContext: () => ({ setValue: mockSetValue }),
+}));
+
+const ethAccountWithUsdc = mockWalletAccount({
+    symbol: 'eth',
+    accountType: 'normal',
+    descriptor: asAccountDescriptor('ethusdc'),
+    tokens: [
+        {
+            standard: 'ERC20',
+            name: 'USD Coin',
+            contract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            symbol: 'USDC',
+            decimals: 6,
+            balance: '1',
+        },
+    ],
+    visible: true,
+});
+
+describe('ExchangeUsdcPresetButton', () => {
+    beforeEach(() => {
+        mockSetValue.mockClear();
+    });
+
+    afterEach(() => {
+        screen.unmount();
+    });
+
+    it('without a matching account shows an error message', () => {
+        const store = createTradingLightStore({ tradeType: 'exchange' });
+        renderWithTradingProvider(<ExchangeUsdcPresetButton />, { store });
+
+        expect(screen.getByText('No account with USDC found.')).toBeOnTheScreen();
+    });
+
+    describe('with a matching ETH account that has a USDC token', () => {
+        let store: TestStore;
+
+        beforeEach(() => {
+            const preloadedState = createTradingPreloadedState({
+                tradeType: 'exchange',
+                overrides: { wallet: { accounts: [ethAccountWithUsdc] } },
+            });
+            store = createTradingLightStore({ tradeType: 'exchange', overrides: preloadedState });
+            renderWithTradingProvider(<ExchangeUsdcPresetButton />, { store });
+        });
+
+        it('renders the preset button', () => {
+            expect(screen.getByText('Prefill 1 USDC → USDT')).toBeOnTheScreen();
+        });
+
+        it('fills form for 1 USDC -> USDT trade', () => {
+            fireEvent.press(screen.getByText(/1 USDC.*USDT/));
+
+            expect(mockSetValue).toHaveBeenCalledWith(
+                'sendAsset',
+                expect.objectContaining({ symbol: 'USDC', networkId: 'ethereum' }),
+            );
+            expect(mockSetValue).toHaveBeenCalledWith('sendAccount', ethAccountWithUsdc);
+            expect(mockSetValue).toHaveBeenCalledWith('sendCryptoAmount', '1');
+            expect(mockSetValue).toHaveBeenCalledWith(
+                'receiveAsset',
+                expect.objectContaining({ symbol: 'USDT', networkId: 'ethereum' }),
+            );
+
+            const tradingState = store.getState().wallet.trading.exchange;
+            expect(tradingState.tradingAccountKey).toBe(ethAccountWithUsdc.key);
+        });
+    });
+});


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Utility for faster testing of exchange form.
<!--- Describe your changes in detail -->

## Notes for QA
Just dev tool. Nothing that should be affect production.

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

https://github.com/user-attachments/assets/96e7cb69-b627-40cc-9ed3-4b941fbb619f



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=trading-debug-form-prefill&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->