### PR TITLE
fix(trading): align trade page header navigation

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/__tests__/tradingPageHeaderUtils.test.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/__tests__/tradingPageHeaderUtils.test.ts
@@ -1,0 +1,145 @@
+import {
+    getBackRoute,
+    getTradingHeaderTitle,
+    isTradingTopLevelRoute,
+} from '../tradingPageHeaderUtils';
+
+describe('tradingPageHeaderUtils', () => {
+    describe('isTradingTopLevelRoute', () => {
+        it.each([
+            'wallet-trading-buy',
+            'wallet-trading-sell',
+            'wallet-trading-exchange',
+            'wallet-trading-concierge',
+        ] as const)('returns true for %s', route => {
+            expect(isTradingTopLevelRoute(route)).toBe(true);
+        });
+
+        it.each([
+            'wallet-trading-buy-detail',
+            'wallet-trading-buy-confirm',
+            'wallet-trading-transactions',
+            'suite-index',
+            undefined,
+        ] as const)('returns false for %s', route => {
+            expect(isTradingTopLevelRoute(route)).toBe(false);
+        });
+    });
+
+    describe('getBackRoute — trade history (transactions)', () => {
+        it.each([
+            'wallet-trading-buy',
+            'wallet-trading-sell',
+            'wallet-trading-exchange',
+            'wallet-trading-concierge',
+        ] as const)('returns the top-level tab %s the user opened it from', prevRoute => {
+            expect(getBackRoute('wallet-trading-transactions', prevRoute)).toBe(prevRoute);
+        });
+
+        it.each([
+            ['buy', 'wallet-trading-buy'],
+            ['exchange', 'wallet-trading-exchange'],
+        ] as const)(
+            'falls back to the %s section form when the previous route is not a top-level tab',
+            (activeSection, expected) => {
+                expect(
+                    getBackRoute(
+                        'wallet-trading-transactions',
+                        'wallet-trading-buy-detail',
+                        activeSection,
+                    ),
+                ).toBe(expected);
+            },
+        );
+
+        it.each([
+            ['buy', 'wallet-trading-buy'],
+            ['sell', 'wallet-trading-sell'],
+            ['exchange', 'wallet-trading-exchange'],
+        ] as const)(
+            'falls back to the %s section form when there is no previous route',
+            (activeSection, expected) => {
+                expect(getBackRoute('wallet-trading-transactions', undefined, activeSection)).toBe(
+                    expected,
+                );
+            },
+        );
+
+        it('defaults to the buy form when no active section is provided', () => {
+            expect(getBackRoute('wallet-trading-transactions')).toBe('wallet-trading-buy');
+        });
+    });
+
+    describe('getBackRoute — trade detail', () => {
+        it.each([
+            'wallet-trading-buy-detail',
+            'wallet-trading-sell-detail',
+            'wallet-trading-exchange-detail',
+        ] as const)('returns trade history when %s was opened from trade history', route => {
+            expect(getBackRoute(route, 'wallet-trading-transactions')).toBe(
+                'wallet-trading-transactions',
+            );
+        });
+
+        it.each([
+            ['wallet-trading-buy-detail', 'wallet-trading-buy-confirm', 'wallet-trading-buy'],
+            ['wallet-trading-sell-detail', 'wallet-trading-sell', 'wallet-trading-sell'],
+            [
+                'wallet-trading-exchange-detail',
+                'wallet-trading-exchange',
+                'wallet-trading-exchange',
+            ],
+        ] as const)(
+            'returns the section form when %s was reached from an active flow via %s',
+            (route, prevRoute, expected) => {
+                expect(getBackRoute(route, prevRoute)).toBe(expected);
+            },
+        );
+    });
+
+    describe('getBackRoute — confirm', () => {
+        it.each([
+            ['wallet-trading-buy-confirm', 'wallet-trading-transactions', 'wallet-trading-buy'],
+            ['wallet-trading-sell-confirm', undefined, 'wallet-trading-sell'],
+            ['wallet-trading-exchange-confirm', undefined, 'wallet-trading-exchange'],
+        ] as const)(
+            'returns the section form for %s regardless of the previous route',
+            (route, prevRoute, expected) => {
+                expect(getBackRoute(route, prevRoute)).toBe(expected);
+            },
+        );
+    });
+
+    describe('getBackRoute — fallback', () => {
+        it.each(['wallet-trading-redirect', undefined] as const)(
+            'returns suite-index for %s',
+            route => {
+                expect(getBackRoute(route)).toBe('suite-index');
+            },
+        );
+    });
+
+    describe('getTradingHeaderTitle', () => {
+        it.each([
+            'wallet-trading-buy-detail',
+            'wallet-trading-sell-detail',
+            'wallet-trading-exchange-detail',
+        ] as const)('returns TR_TRADING_TRADE_DETAIL for %s', route => {
+            expect(getTradingHeaderTitle(route)).toBe('TR_TRADING_TRADE_DETAIL');
+        });
+
+        it('returns the trade history title for the transactions route', () => {
+            expect(getTradingHeaderTitle('wallet-trading-transactions')).toBe(
+                'TR_TRADING_LAST_TRANSACTIONS',
+            );
+        });
+
+        it.each([
+            'wallet-trading-buy',
+            'wallet-trading-concierge',
+            'wallet-trading-buy-confirm',
+        ] as const)('returns TR_NAV_TRADE for %s', route => {
+            expect(getTradingHeaderTitle(route)).toBe('TR_NAV_TRADE');
+        });
+    });
+});

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/tradingPageHeaderUtils.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/tradingPageHeaderUtils.ts
@@ -1,0 +1,76 @@
+import { type TranslationKey } from '@suite/intl';
+import { type Route } from '@suite/router';
+import { type TradingType } from '@suite-common/trading';
+
+type TradingRoute = Route['name'];
+
+const TRANSACTIONS_ROUTE: TradingRoute = 'wallet-trading-transactions';
+
+type TradingSection = {
+    form: TradingRoute;
+    detail: TradingRoute;
+    confirm: TradingRoute;
+};
+
+const tradingSections = {
+    buy: {
+        form: 'wallet-trading-buy',
+        detail: 'wallet-trading-buy-detail',
+        confirm: 'wallet-trading-buy-confirm',
+    },
+    sell: {
+        form: 'wallet-trading-sell',
+        detail: 'wallet-trading-sell-detail',
+        confirm: 'wallet-trading-sell-confirm',
+    },
+    exchange: {
+        form: 'wallet-trading-exchange',
+        detail: 'wallet-trading-exchange-detail',
+        confirm: 'wallet-trading-exchange-confirm',
+    },
+} as const satisfies Record<TradingType, TradingSection>;
+
+const sections = Object.values(tradingSections);
+const topLevelRoutes: TradingRoute[] = [...sections.map(s => s.form), 'wallet-trading-concierge'];
+const detailRoutes: TradingRoute[] = sections.map(s => s.detail);
+
+const isDetailRoute = (route?: TradingRoute): boolean =>
+    route !== undefined && detailRoutes.includes(route);
+
+export const isTradingTopLevelRoute = (route?: TradingRoute): route is TradingRoute =>
+    route !== undefined && topLevelRoutes.includes(route);
+
+const getSectionFormRoute = (route?: TradingRoute): TradingRoute =>
+    sections.find(s => s.detail === route || s.confirm === route)?.form ?? 'suite-index';
+
+export const getBackRoute = (
+    route?: TradingRoute,
+    previousRoute?: TradingRoute,
+    activeSection: TradingType = 'buy',
+): TradingRoute => {
+    if (route === TRANSACTIONS_ROUTE) {
+        return isTradingTopLevelRoute(previousRoute)
+            ? previousRoute
+            : tradingSections[activeSection].form;
+    }
+
+    if (isDetailRoute(route)) {
+        return previousRoute === TRANSACTIONS_ROUTE
+            ? TRANSACTIONS_ROUTE
+            : getSectionFormRoute(route);
+    }
+
+    return getSectionFormRoute(route);
+};
+
+export const getTradingHeaderTitle = (route?: TradingRoute): TranslationKey => {
+    if (isDetailRoute(route)) {
+        return 'TR_TRADING_TRADE_DETAIL';
+    }
+
+    if (route === TRANSACTIONS_ROUTE) {
+        return 'TR_TRADING_LAST_TRANSACTIONS';
+    }
+
+    return 'TR_NAV_TRADE';
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/useTradingPageHeader.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/useTradingPageHeader.tsx
@@ -1,6 +1,6 @@
 import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
-import { type Route, goto, selectRouteName } from '@suite/router';
-import { type TradingType, selectTradingActiveSection } from '@suite-common/trading';
+import { type Route, goto, selectRouteName, selectSettingsBackRoute } from '@suite/router';
+import { selectTradingActiveSection } from '@suite-common/trading';
 import { Box, Button, IconButton, Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -8,30 +8,23 @@ import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
 import { BasicName } from 'src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/BasicName';
 import { useDispatch, useLayout, useSelector } from 'src/hooks/suite';
 
-const getBackRoute = (route?: Route['name'], activeSection?: TradingType): Route['name'] => {
-    const routePrefix = 'wallet-trading-';
-    const match = route?.match(new RegExp(`^${routePrefix}(exchange|buy|sell)-`));
-
-    if (route === `${routePrefix}transactions`) {
-        return activeSection === 'exchange' ? `${routePrefix}exchange` : `${routePrefix}buy`;
-    }
-
-    return match ? (`${routePrefix}${match[1]}` as Route['name']) : 'suite-index';
-};
+import {
+    getBackRoute,
+    getTradingHeaderTitle,
+    isTradingTopLevelRoute,
+} from './tradingPageHeaderUtils';
 
 type TradingPageHeaderProps = {
-    fallbackTitle: TranslationKey;
+    title: TranslationKey;
 };
 
-const TradingPageHeader = ({ fallbackTitle }: TradingPageHeaderProps) => {
+const TradingPageHeader = ({ title }: TradingPageHeaderProps) => {
     const dispatch = useDispatch();
     const currentRouteName = useSelector(selectRouteName);
+    const previousRoute = useSelector(selectSettingsBackRoute);
     const activeSection = useSelector(selectTradingActiveSection);
 
-    const isFormRoute =
-        currentRouteName === 'wallet-trading-buy' ||
-        currentRouteName === 'wallet-trading-sell' ||
-        currentRouteName === 'wallet-trading-exchange';
+    const isTopLevelRoute = isTradingTopLevelRoute(currentRouteName);
 
     const goToRoute = (route: Route['name']) => () => {
         dispatch(goto({ routeName: route, preserveParams: true }));
@@ -40,21 +33,23 @@ const TradingPageHeader = ({ fallbackTitle }: TradingPageHeaderProps) => {
     return (
         <PageHeader>
             <Row width="100%" gap={spacings.md}>
-                {!isFormRoute && (
+                {!isTopLevelRoute && (
                     <IconButton
                         icon="caretLeft"
                         intent="neutral"
                         priority="secondary"
                         size="large"
-                        onClick={goToRoute(getBackRoute(currentRouteName, activeSection))}
+                        onClick={goToRoute(
+                            getBackRoute(currentRouteName, previousRoute.name, activeSection),
+                        )}
                         data-testid="@account-subpage/back"
                         tooltip={{ content: <Translation id="TR_BACK" /> }}
                     />
                 )}
-                <BasicName>
-                    <Translation id={fallbackTitle} />
+                <BasicName data-testid="@trading/page-header/title">
+                    <Translation id={title} />
                 </BasicName>
-                {currentRouteName !== 'wallet-trading-transactions' && (
+                {isTopLevelRoute && (
                     <Box margin={{ left: 'auto' }}>
                         <Button
                             intent="neutral"
@@ -74,10 +69,10 @@ const TradingPageHeader = ({ fallbackTitle }: TradingPageHeaderProps) => {
 
 export const useTradingPageHeader = () => {
     const { translationString } = useTranslation();
-    const fallbackTitle: TranslationKey = 'TR_NAV_TRADE';
+    const currentRouteName = useSelector(selectRouteName);
 
-    const translatedTitle = translationString(fallbackTitle);
-    const pageTitle = `Trezor Suite | ${translatedTitle}`;
+    const title = getTradingHeaderTitle(currentRouteName);
+    const pageTitle = `Trezor Suite | ${translationString(title)}`;
 
-    useLayout(pageTitle, <TradingPageHeader fallbackTitle={fallbackTitle} />);
+    useLayout(pageTitle, <TradingPageHeader title={title} />);
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.tsx
@@ -5,7 +5,7 @@ import {
     selectTradingExchangeInfo,
     selectTradingSellInfo,
 } from '@suite-common/trading';
-import { Box, Column, H3, Paragraph, Text } from '@trezor/components';
+import { Box, Column, Paragraph, Text } from '@trezor/components';
 import { exhaustive } from '@trezor/type-utils';
 
 import { useSelector } from 'src/hooks/suite';
@@ -47,9 +47,6 @@ export const TradingTransactionsList = () => {
                 {!isEmpty && (
                     <>
                         <Column margin={{ bottom: 32 }}>
-                            <H3 data-testid="@trading/transactions/heading">
-                                <Translation id="TR_TRADING_LAST_TRANSACTIONS" />
-                            </H3>
                             <Text
                                 typographyStyle="body-sm"
                                 color="contentSecondary"

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/__tests__/TradingTransactionsList.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/__tests__/TradingTransactionsList.test.tsx
@@ -152,11 +152,10 @@ describe('TradingTransactionsList', () => {
 
         expect(screen.getByTestId('@trading/transactions/list')).toBeInTheDocument();
         expect(screen.getByTestId('@trading/transactions/no-transaction')).toBeInTheDocument();
-        expect(screen.queryByTestId('@trading/transactions/heading')).not.toBeInTheDocument();
         expect(screen.queryByTestId('@trading/transactions/count')).not.toBeInTheDocument();
     });
 
-    it('renders heading, correct transaction counts, and trade rows when there are trades', () => {
+    it('renders correct transaction counts and trade rows when there are trades', () => {
         const store = configureMockStore({
             preloadedState: buildState({ trades: [BUY_TRADE, SELL_TRADE, EXCHANGE_TRADE] }),
         });
@@ -167,7 +166,6 @@ describe('TradingTransactionsList', () => {
             <TradingTransactionsList />,
         );
 
-        expect(screen.getByTestId('@trading/transactions/heading')).toBeInTheDocument();
         expect(
             screen.queryByTestId('@trading/transactions/no-transaction'),
         ).not.toBeInTheDocument();

--- a/suite/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/suite/e2e/support/pageObjects/trading/tradingPage.ts
@@ -47,6 +47,7 @@ export class TradingPage {
     readonly setMax: Locator;
 
     // Transactions
+    readonly backButton: Locator;
     readonly transactionDetailStatus: Locator;
     readonly transactionDetail: Locator;
     readonly transactions: TradingTransactionsSection;
@@ -85,6 +86,7 @@ export class TradingPage {
         this.sendBalance = this.page.getByTestId('outputs.0.token');
         this.setMax = this.page.getByTestId('outputs.0.setMax');
 
+        this.backButton = this.page.getByTestId('@account-subpage/back');
         this.transactionDetailStatus = this.page.getByTestId('@trading/transaction/detail/status');
         this.transactionDetail = this.page.getByTestId('@trading/transaction/detail');
         this.transactions = new TradingTransactionsSection(page);

--- a/suite/e2e/support/pageObjects/trading/transactionsSection.ts
+++ b/suite/e2e/support/pageObjects/trading/transactionsSection.ts
@@ -11,7 +11,7 @@ export class TradingTransactionsSection {
 
     constructor(private page: Page) {
         this.menuButton = page.getByTestId('@trading/menu/wallet-trading-transactions');
-        this.heading = page.getByTestId('@trading/transactions/heading');
+        this.heading = page.getByTestId('@trading/page-header/title');
         this.count = page.getByTestId('@trading/transactions/count');
         this.list = page.getByTestId('@trading/transactions/list');
         this.allSwapRows = this.list.locator(

--- a/suite/e2e/tests/trading/swap-history.test.ts
+++ b/suite/e2e/tests/trading/swap-history.test.ts
@@ -166,7 +166,7 @@ test.describe('Trading - Swap history', { tag: ['@webOnly', '@T3T1', '@T3W1'] },
             });
 
             await test.step(`Navigate back to transaction list`, async () => {
-                await tradingPage.transactions.menuButton.click();
+                await tradingPage.backButton.click();
                 await expect(tradingPage.transactions.heading).toBeVisible();
             });
         }

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1093,6 +1093,10 @@ export const messages = defineMessages({
         defaultMessage: 'Trade history',
         id: 'TR_TRADING_LAST_TRANSACTIONS',
     },
+    TR_TRADING_TRADE_DETAIL: {
+        defaultMessage: 'Trade detail',
+        id: 'TR_TRADING_TRADE_DETAIL',
+    },
     TR_TRADING_PAYMENT_METHOD: {
         defaultMessage: 'Payment method',
         id: 'TR_TRADING_PAYMENT_METHOD',


### PR DESCRIPTION
## Description

- Remove the back button from top-level trading pages, including Concierge.
- Keep detail pages on contextual back navigation and show the Trade detail header title.
- Move the trade history heading into the page header and remove the duplicate detail-page action.

## Notes for QA

- In Trade home and Concierge, open the page and verify there is no back button; use Last transactions and verify the history page opens.
- In Trade > Last transactions, open a trade detail and verify the header says Trade detail, the top-right history action is gone, and Back returns to Last transactions.
- In Buy, Sell, and Swap preview flows, verify the back button is still shown and returns to the section form.

## Related Issue

Resolve #28970

## Screenshots:

<img width="953" height="646" alt="image" src="https://github.com/user-attachments/assets/367a7d6d-e74d-4af5-a1e6-5db09f6d93e0" />
<img width="961" height="540" alt="image" src="https://github.com/user-attachments/assets/8ff12b89-dba8-468b-b404-e5cf89dda5d6" />
<img width="961" height="567" alt="image" src="https://github.com/user-attachments/assets/c0454347-47a7-4161-bdea-6dcc39df451e" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/28970-trading-page-header/web/](https://dev.suite.sldev.cz/suite-web/fix/28970-trading-page-header/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/28970-trading-page-header&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/28970-trading-page-header&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-30T05:09:56.751Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-30T05:10:06.045Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->