### PR TITLE
Cleanup smoke

### DIFF
--- a/packages/e2e-utils/src/grepUtils.ts
+++ b/packages/e2e-utils/src/grepUtils.ts
@@ -2,8 +2,10 @@ import { Model } from '@trezor/trezor-user-env-link';
 
 /**
  * Returns a regex fragment of negative lookaheads for every device model except T3T1.
- * Combine with a positive T3T1 assertion to detect tests that are T3T1-only
- * (i.e. not shared with any other device model).
+ * Combine with a positive T3T1 assertion to select tests that are T3T1-only
+ * (i.e. not shared with any other device model). Used by the PR configs so that the
+ * T3T1 project runs only its exclusive tests — shared T3W1/T3T1 tests are covered by
+ * the representative T3W1 project on PR and by the full nightly run.
  * The caller is responsible for anchoring the resulting regex (e.g. prefixing with `^`).
  */
 export function noOtherDevice(): string {

--- a/suite-native/app/e2e/tests/deviceOnboarding.test.ts
+++ b/suite-native/app/e2e/tests/deviceOnboarding.test.ts
@@ -30,7 +30,7 @@ const preloadedState = preparePreloadedReduxState(
 
 const LONG_RUNNING_TEST_TIMEOUT = 7 * 60 * 1000; // [ms]
 
-describe('Device onboarding [@androidOnly @smoke @T3T1 @T3W1]', () => {
+describe('Device onboarding [@androidOnly @T3T1 @T3W1]', () => {
     beforeEach(async () => {
         await prepareTrezorEmulator({ seed: '' });
         await openApp({ args: { preloadedState } });

--- a/suite-native/app/e2e/tests/passphraseFlow.test.ts
+++ b/suite-native/app/e2e/tests/passphraseFlow.test.ts
@@ -55,7 +55,7 @@ const preloadedState = preparePreloadedReduxState(
         : regtestDiscoveryFinishedStateT3W1,
 );
 
-describe('passphrase flow [@androidOnly @smoke @T3T1 @T3W1]', () => {
+describe('passphrase flow [@androidOnly @T3T1 @T3W1]', () => {
     beforeAll(async () => {
         // wallet without passphrase
         await TrezorUserEnvLink.sendToAddressAndMineBlock({

--- a/suite-native/app/e2e/tests/receive.test.ts
+++ b/suite-native/app/e2e/tests/receive.test.ts
@@ -19,7 +19,7 @@ const preloadedState = preparePreloadedReduxState(
         : btcDiscoveryFinishedStateT3T1,
 );
 
-describe('Receive [@androidOnly @smoke @T3T1 @T3W1]', () => {
+describe('Receive [@androidOnly @T3T1 @T3W1]', () => {
     beforeEach(async () => {
         await prepareTrezorEmulator();
         await openApp({ args: { preloadedState } });

--- a/suite-native/app/e2e/tests/send.test.ts
+++ b/suite-native/app/e2e/tests/send.test.ts
@@ -59,7 +59,7 @@ const preloadedState = preparePreloadedReduxState(
         : regtestDiscoveryFinishedStateT3W1,
 );
 
-describe('Send transaction flow. [@androidOnly @smoke @T3T1 @T3W1]', () => {
+describe('Send transaction flow. [@androidOnly @T3T1 @T3W1]', () => {
     beforeAll(async () => {
         await TrezorUserEnvLink.sendToAddressAndMineBlock({
             address: 'bcrt1q34up3cga3fkmph47t22mpk5d0xxj3ppghph9da',

--- a/suite-native/app/e2e/tests/suiteSync.test.ts
+++ b/suite-native/app/e2e/tests/suiteSync.test.ts
@@ -75,7 +75,7 @@ const preloadedState = preparePreloadedReduxState(
     deviceChecksDisabledState,
 );
 
-describe.skip('Suite Sync - Labelling [@androidOnly @T3T1 @smoke]', () => {
+describe.skip('Suite Sync - Labelling [@androidOnly @T3T1]', () => {
     let evoluClient: NativeEvoluClient;
 
     beforeEach(async () => {

--- a/suite-native/app/e2e/trezorDetoxRunner/config/runner-android-release-nightly.config.js
+++ b/suite-native/app/e2e/trezorDetoxRunner/config/runner-android-release-nightly.config.js
@@ -2,7 +2,7 @@ const target = 'android.emu.release';
 
 /*
  * Android Release Nightly config
- * This config is used to run all tests nightly, including non-smoke T3T1 tests.
+ * This config is used to run all tests nightly, including the full T3T1 set (PR runs only T3T1-only tests).
  * There are projects for all supported device models with the latest firmware versions
  */
 /** @type {import('../types').RunnerConfig} */

--- a/suite-native/app/e2e/trezorDetoxRunner/config/runner-android-release.config.js
+++ b/suite-native/app/e2e/trezorDetoxRunner/config/runner-android-release.config.js
@@ -22,7 +22,7 @@ module.exports = {
             target,
             model: 'T3T1',
             firmwareVersion: '2-latest',
-            grep: `^(?=.*@T3T1)((?=.*@smoke)|${noOtherDevice()})(?!.*@iosOnly)`,
+            grep: `^(?=.*@T3T1)${noOtherDevice()}(?!.*@iosOnly)`,
         },
         {
             projectName: 'T1B1',

--- a/suite/e2e/docs/e2e-playwright-suite.md
+++ b/suite/e2e/docs/e2e-playwright-suite.md
@@ -86,16 +86,21 @@ Each test must be assigned a tag according to what device model it is supported 
 
 At the moment, there are these additional tags:
 
-- @smoke
 - @desktopOnly
 - @webOnly
 - @nightlyOnly
 - @specificFirmware
 - @firmware-ready
 
-#### @smoke
+#### Device coverage on PR
 
-Tests belonging to a smoke set are executed on all supported devices in PR pipelines. Otherwise only T3W1 is used.
+Most E2E tests are specified to cover T3T1 and T3W1, the two flagship models.
+But to save Currents quota, T3T1 is skipped on PR test runs, and only T3W1 is covered, unless the test is exclusive (T3T1-only) test. Meanwhile, nightly tests provide full coverage, i.e. they run both flagship models. This is configured entirely in the Playwright project configs.
+To summarize:
+
+- in PR run, if a test specifies T3T1 alongside any other models, T3T1 is skipped, and only other models are covered (usually just T3W1)
+- in PR run, if a test specifies T3T1 as its only model, it is covered
+- in nightly run, all models specified in the test are covered
 
 #### @desktopOnly or @webOnly
 

--- a/suite/e2e/playwright-config/playwright-desktop-nightly-canary.config.ts
+++ b/suite/e2e/playwright-config/playwright-desktop-nightly-canary.config.ts
@@ -23,9 +23,8 @@ const definition: PlaywrightProjectDefinition[] = [
     },
     {
         model: Model.T3T1,
-        nameSuffix: 'fw_canary_smoke',
+        nameSuffix: 'fw_canary',
         firmware: '2-main',
-        grep: /^(?=.*@T3T1)(?=.*@smoke)/,
         additionalGrepInvert: /@specificFirmware/,
         currentsTags: tagsCanary,
     },

--- a/suite/e2e/playwright-config/playwright-desktop-pr.config.ts
+++ b/suite/e2e/playwright-config/playwright-desktop-pr.config.ts
@@ -13,7 +13,8 @@ import { PlaywrightTarget } from '../support/testExtends/suiteTestOptions';
  * Desktop PR config
  * This config is used to run tests on each PR
  * There are projects for all supported device models with the latest firmware version
- * Additionally we only run smoke tests on T3T1 model to reduce the total number of tests executed on each PR
+ * To save Currents quota, T3W1 acts as the representative flagship and runs the full set; T3T1 runs only
+ * its exclusive (T3T1-only) tests on PR. Shared T3W1/T3T1 tests get full T3T1 coverage in nightly instead.
  */
 const target = PlaywrightTarget.Desktop;
 const definition: PlaywrightProjectDefinition[] = [
@@ -22,8 +23,7 @@ const definition: PlaywrightProjectDefinition[] = [
         model: Model.T3T1,
         additionalGrepInvert: /@nightlyOnly/,
         currentsTags: tagsPr,
-        nameSuffix: 'smoke',
-        grep: new RegExp(`^(?=.*@T3T1)((?=.*@smoke)|${noOtherDevice()})`),
+        grep: new RegExp(`^(?=.*@T3T1)${noOtherDevice()}`),
     },
     { model: Model.T3B1, additionalGrepInvert: /@nightlyOnly/, currentsTags: tagsPr },
     { model: Model.T2T1, additionalGrepInvert: /@nightlyOnly/, currentsTags: tagsPr },

--- a/suite/e2e/playwright-config/playwright-web-nightly-canary.config.ts
+++ b/suite/e2e/playwright-config/playwright-web-nightly-canary.config.ts
@@ -11,7 +11,7 @@ import { PlaywrightTarget } from '../support/testExtends/suiteTestOptions';
 /*
  * Web Canary config
  * This config runs only the canary FW projects once a week (Fridays).
- * With the canary FW, we only run smoke tests on T3T1 model and tests tagged as @webOnly to reduce the total number of tests executed.
+ * With the canary FW we run the full @webOnly set.
  */
 const target = PlaywrightTarget.Web;
 const definition: PlaywrightProjectDefinition[] = [
@@ -25,9 +25,9 @@ const definition: PlaywrightProjectDefinition[] = [
     },
     {
         model: Model.T3T1,
-        nameSuffix: 'fw_canary_smoke',
+        nameSuffix: 'fw_canary',
         firmware: '2-main',
-        grep: /^(?=.*@T3T1)(?=.*@smoke)(?=.*@webOnly)/,
+        grep: /^(?=.*@T3T1)(?=.*@webOnly)/,
         additionalGrepInvert: /@specificFirmware/,
         currentsTags: tagsCanary,
     },

--- a/suite/e2e/playwright-config/playwright-web-pr.config.ts
+++ b/suite/e2e/playwright-config/playwright-web-pr.config.ts
@@ -13,7 +13,9 @@ import { PlaywrightTarget } from '../support/testExtends/suiteTestOptions';
  * Web PR config
  * This config is used to run tests on each PR
  * There are projects for all supported device models with the latest firmware version
- * Additionally we only run smoke tests on T3T1 model and tests tagged as @webOnly to reduce the total number of tests executed on each PR
+ * To save Currents quota, T3W1 acts as the representative flagship and runs the full set; T3T1 runs only
+ * its exclusive (T3T1-only) tests on PR. Shared T3W1/T3T1 tests get full T3T1 coverage in nightly instead.
+ * Only @webOnly tests run on web.
  */
 const target = PlaywrightTarget.Web;
 const definition: PlaywrightProjectDefinition[] = [
@@ -27,8 +29,7 @@ const definition: PlaywrightProjectDefinition[] = [
         model: Model.T3T1,
         additionalGrepInvert: /@nightlyOnly/,
         currentsTags: tagsPr,
-        nameSuffix: 'smoke',
-        grep: new RegExp(`^(?=.*@T3T1)(?=.*@webOnly)((?=.*@smoke)|${noOtherDevice()})`),
+        grep: new RegExp(`^(?=.*@T3T1)(?=.*@webOnly)${noOtherDevice()}`),
     },
     {
         model: Model.T3B1,

--- a/suite/e2e/skills/tagging.md
+++ b/suite/e2e/skills/tagging.md
@@ -23,7 +23,6 @@
 
 ### Execution Context Tags
 
-- `@smoke` — Without this tag, `T3T1` test will be run only in nightly. So **critical tests** must be paired `@T3T1` with `@smoke`. Without `@T3T1`, this tag has no effect.
 - `@nightlyOnly` — runs only in nightly config; excluded from PR. **Required for slow/resource-intensive tests or tests with live currencies**. Combine with single platform (`@webOnly` or `@desktopOnly`) to conserve resources.
 - `@specificFirmware` — **required when using `test.use({ firmwareVersion: '2.10' })`**. Excluded from canary FW projects to prevent mismatched firmware runs.
 - `@group=manual` — excluded from all automated runs, reserved for manual test definitions

--- a/suite/e2e/tests/analytics/events.test.ts
+++ b/suite/e2e/tests/analytics/events.test.ts
@@ -7,101 +7,97 @@ import { expect, test } from '../../support/fixtures';
 import { Language, Theme } from '../../support/pageObjects/settings/settingsPage';
 import { ExtractByEventType } from '../../support/types';
 
-test.describe(
-    'Analytics Events',
-    { tag: ['@webOnly', '@specificFirmware', '@T3T1', '@smoke'] },
-    () => {
-        const firmwareVersion = findLatestVersionForModel(Model.T3T1); // Specific firmware is needed to have predictable firmware version in analytics and unfortunately I can't get the PW project defined device model here, so this test is limited to T3T1 only.
-        test.use({ firmwareVersion });
+test.describe('Analytics Events', { tag: ['@webOnly', '@specificFirmware', '@T3T1'] }, () => {
+    const firmwareVersion = findLatestVersionForModel(Model.T3T1); // Specific firmware is needed to have predictable firmware version in analytics and unfortunately I can't get the PW project defined device model here, so this test is limited to T3T1 only.
+    test.use({ firmwareVersion });
 
-        test.beforeEach(async ({ analytics, onboardingPage }) => {
-            await analytics.interceptAnalytics();
-            await onboardingPage.completeOnboarding();
-        });
+    test.beforeEach(async ({ analytics, onboardingPage }) => {
+        await analytics.interceptAnalytics();
+        await onboardingPage.completeOnboarding();
+    });
 
-        test(
-            'Analytics captures important events when started enabled by default',
-            {
-                annotation: createTestAnnotation({
-                    testCase:
-                        'Verify that analytics captures SuiteReady, DeviceConnect, TransportType, and DeviceDisconnect events when analytics is enabled by default',
-                    category: TestCategory.General,
-                    priority: TestPriority.High,
-                    stream: TestStream.Foundation,
-                }),
-            },
-            async ({ device, analytics }) => {
-                await analytics.waitForAnalyticsRequests(3);
+    test(
+        'Analytics captures important events when started enabled by default',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Verify that analytics captures SuiteReady, DeviceConnect, TransportType, and DeviceDisconnect events when analytics is enabled by default',
+                category: TestCategory.General,
+                priority: TestPriority.High,
+                stream: TestStream.Foundation,
+            }),
+        },
+        async ({ device, analytics }) => {
+            await analytics.waitForAnalyticsRequests(3);
 
-                await test.step('Validate SuiteReady event', () => {
-                    const suiteReadyEvent = analytics.findAnalyticsEventByType<
-                        ExtractByEventType<(typeof events.suiteReadyEvent)['name']>
-                    >(events.suiteReadyEvent.name);
-                    expect(suiteReadyEvent).toMatchObject({
-                        language: 'en-US',
-                        enabledNetworks: '',
-                        customBackends: '',
-                        localCurrency: 'usd',
-                        bitcoinUnit: 'BTC',
-                        discreetMode: 'false',
-                        screenWidth: '1280',
-                        screenHeight: '720',
-                        platformLanguages: 'en-US',
-                        tor: 'false',
-                        labeling: 'off',
-                        rememberedStandardWallets: '0',
-                        rememberedHiddenWallets: '0',
-                        theme: 'light',
-                        earlyAccessProgram: 'false',
-                        experimentalFeatures: '',
-                        autodetectLanguage: 'true',
-                        autodetectTheme: 'true',
-                        isAutomaticUpdateEnabled: 'false',
-                    });
+            await test.step('Validate SuiteReady event', () => {
+                const suiteReadyEvent = analytics.findAnalyticsEventByType<
+                    ExtractByEventType<(typeof events.suiteReadyEvent)['name']>
+                >(events.suiteReadyEvent.name);
+                expect(suiteReadyEvent).toMatchObject({
+                    language: 'en-US',
+                    enabledNetworks: '',
+                    customBackends: '',
+                    localCurrency: 'usd',
+                    bitcoinUnit: 'BTC',
+                    discreetMode: 'false',
+                    screenWidth: '1280',
+                    screenHeight: '720',
+                    platformLanguages: 'en-US',
+                    tor: 'false',
+                    labeling: 'off',
+                    rememberedStandardWallets: '0',
+                    rememberedHiddenWallets: '0',
+                    theme: 'light',
+                    earlyAccessProgram: 'false',
+                    experimentalFeatures: '',
+                    autodetectLanguage: 'true',
+                    autodetectTheme: 'true',
+                    isAutomaticUpdateEnabled: 'false',
                 });
+            });
 
-                await test.step('Validate DeviceConnect event', () => {
-                    const deviceConnectEvent = analytics.findAnalyticsEventByType<
-                        ExtractByEventType<(typeof events.deviceConnectEvent)['name']>
-                    >(events.deviceConnectEvent.name);
-                    expect(deviceConnectEvent).toMatchObject({
-                        mode: 'normal',
-                        firmware: firmwareVersion,
-                        bootloaderHash: '',
-                        backup_type: 'Bip39',
-                        pin_protection: 'false',
-                        passphrase_protection: 'false',
-                        totalInstances: '1',
-                        isBitcoinOnly: 'false',
-                        isBitcoinOnlyDevice: 'false',
-                        totalDevices: '1',
-                        language: 'en-US',
-                        model: Model.T3T1,
-                        optiga_sec: '0',
-                    });
+            await test.step('Validate DeviceConnect event', () => {
+                const deviceConnectEvent = analytics.findAnalyticsEventByType<
+                    ExtractByEventType<(typeof events.deviceConnectEvent)['name']>
+                >(events.deviceConnectEvent.name);
+                expect(deviceConnectEvent).toMatchObject({
+                    mode: 'normal',
+                    firmware: firmwareVersion,
+                    bootloaderHash: '',
+                    backup_type: 'Bip39',
+                    pin_protection: 'false',
+                    passphrase_protection: 'false',
+                    totalInstances: '1',
+                    isBitcoinOnly: 'false',
+                    isBitcoinOnlyDevice: 'false',
+                    totalDevices: '1',
+                    language: 'en-US',
+                    model: Model.T3T1,
+                    optiga_sec: '0',
                 });
+            });
 
-                await test.step('Validate TransportType event', () => {
-                    const transportTypeEvent = analytics.findAnalyticsEventByType<
-                        ExtractByEventType<(typeof events.transportTypeEvent)['name']>
-                    >(events.transportTypeEvent.name);
-                    expect(transportTypeEvent.type).toBe('BridgeTransport');
-                    expect(parseInt(transportTypeEvent.version, 10)).not.toBeNaN();
-                });
+            await test.step('Validate TransportType event', () => {
+                const transportTypeEvent = analytics.findAnalyticsEventByType<
+                    ExtractByEventType<(typeof events.transportTypeEvent)['name']>
+                >(events.transportTypeEvent.name);
+                expect(transportTypeEvent.type).toBe('BridgeTransport');
+                expect(parseInt(transportTypeEvent.version, 10)).not.toBeNaN();
+            });
 
-                await test.step('Stop emulator and validate DeviceDisconnect event', async () => {
-                    await device.powerOff();
-                    await analytics.waitForAnalyticsRequests(1); // Poll to prevent race condition
-                    expect(
-                        analytics.findLatestRequestByLegacyType(events.deviceDisconnectEvent.name),
-                    ).toBeDefined();
-                });
-            },
-        );
-    },
-);
+            await test.step('Stop emulator and validate DeviceDisconnect event', async () => {
+                await device.powerOff();
+                await analytics.waitForAnalyticsRequests(1); // Poll to prevent race condition
+                expect(
+                    analytics.findLatestRequestByLegacyType(events.deviceDisconnectEvent.name),
+                ).toBeDefined();
+            });
+        },
+    );
+});
 
-test.describe('Analytics Events', { tag: ['@webOnly', '@T3W1', '@T3T1', '@smoke'] }, () => {
+test.describe('Analytics Events', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
     test.use({ startEmulator: false });
 
     test.beforeEach(async ({ onboardingPage }) => {

--- a/suite/e2e/tests/analytics/toggle.test.ts
+++ b/suite/e2e/tests/analytics/toggle.test.ts
@@ -2,177 +2,168 @@ import { events } from '@suite/analytics';
 
 import { expect, test } from '../../support/fixtures';
 
-test.describe(
-    'Analytics Toggle - Enabling and Disabling',
-    { tag: ['@T3W1', '@T3T1', '@smoke'] },
-    () => {
-        test.beforeEach(async ({ analytics, onboardingPage }) => {
-            await analytics.interceptAnalytics();
-            await onboardingPage.disableNecessaryFirmwareChecks();
-            await onboardingPage.disableAuthenticityCheck();
+test.describe('Analytics Toggle - Enabling and Disabling', { tag: ['@T3W1', '@T3T1'] }, () => {
+    test.beforeEach(async ({ analytics, onboardingPage }) => {
+        await analytics.interceptAnalytics();
+        await onboardingPage.disableNecessaryFirmwareChecks();
+        await onboardingPage.disableAuthenticityCheck();
+    });
+
+    test('should respect disabled analytics in onboarding with following enabling in settings', async ({
+        analytics,
+        page,
+        device,
+        analyticsSection,
+        onboardingPage,
+        dashboardPage,
+        settingsPage,
+        devicePrompt,
+    }) => {
+        await test.step('Disable analytics in onboarding', async () => {
+            await expect(settingsPage.analyticsSwitchInput).toBeChecked();
+            await settingsPage.analyticsSwitch.click();
+            await expect(settingsPage.analyticsSwitchInput).not.toBeChecked();
         });
 
-        test('should respect disabled analytics in onboarding with following enabling in settings', async ({
-            analytics,
-            page,
-            device,
-            analyticsSection,
-            onboardingPage,
-            dashboardPage,
-            settingsPage,
-            devicePrompt,
-        }) => {
-            await test.step('Disable analytics in onboarding', async () => {
-                await expect(settingsPage.analyticsSwitchInput).toBeChecked();
-                await settingsPage.analyticsSwitch.click();
-                await expect(settingsPage.analyticsSwitchInput).not.toBeChecked();
-            });
-
-            const disposeRequest =
-                await test.step('Continue onboarding and check analytics dispose event', async () => {
-                    await analyticsSection.continueButton.click();
-                    await analytics.waitForAnalyticsRequests();
-                    // assert that only "analytics/dispose" event was fired
-                    const request = analytics.findLatestRequestByLegacyType(
-                        events.settingsAnalyticsEvent.name,
-                    );
-                    expect(request).toHaveProperty('c_type', events.settingsAnalyticsEvent.name);
-                    expect(request).toHaveProperty('value', 'false');
-                    expect(request).toHaveProperty('c_session_id');
-                    expect(request).toHaveProperty('c_instance_id');
-                    expect(request).toHaveProperty('c_timestamp');
-                    expect(request?.c_timestamp).toMatch(/^\d+$/);
-
-                    return request;
-                });
-
-            await test.step('Finish onboarding', async () => {
-                if (device.hasTHP) {
-                    await devicePrompt.allowConnectToTrezor();
-                    await onboardingPage.enterTHPPairingCode();
-                    await onboardingPage.enableAutoconnect();
-                }
-
-                await onboardingPage.completeOnboardingButton.click();
-            });
-
-            await test.step('Reload app and check analytics state', async () => {
-                // app needs time to save initialRun flag into storage to change session id
-                await page.getByTestId('@suite/loading').waitFor({ state: 'hidden' });
-                await page.discoveryShouldFinish();
-                await page.reload();
-                await settingsPage.navigateTo('application');
-                await expect(settingsPage.analyticsSwitchInput).not.toBeChecked();
-            });
-
-            await test.step('Enable analytics in settings and check enable event', async () => {
-                await settingsPage.analyticsSwitch.click();
-                await expect(settingsPage.analyticsSwitchInput).toBeChecked();
-                await analytics.waitForAnalyticsRequests();
-
-                const enableRequest = analytics.findLatestRequestByLegacyType(
-                    events.settingsAnalyticsEvent.name,
-                );
-                expect(enableRequest).toHaveProperty('c_type', events.settingsAnalyticsEvent.name);
-                expect(enableRequest).toHaveProperty('c_session_id');
-                expect(enableRequest).toHaveProperty('c_instance_id');
-                expect(enableRequest).toHaveProperty('c_timestamp');
-                expect(enableRequest?.c_timestamp).toMatch(/^\d+$/);
-
-                // check that timestamps are different
-                expect(disposeRequest?.c_timestamp).not.toEqual(enableRequest?.c_timestamp);
-
-                // check that session ids changed after reload
-                expect(disposeRequest?.c_session_id).not.toEqual(enableRequest?.c_session_id);
-
-                // check that instance ids are the same after reload
-                expect(disposeRequest?.c_instance_id).toEqual(enableRequest?.c_instance_id);
-            });
-
-            await test.step('Change fiat and check analytics event', async () => {
-                const enableRequest = analytics.findLatestRequestByLegacyType(
-                    events.settingsAnalyticsEvent.name,
-                );
-                await settingsPage.changeFiatCurrency('huf');
-                await analytics.waitForAnalyticsRequests();
-                const changeFiatRequest = analytics.findLatestRequestByLegacyType(
-                    events.settingsGeneralChangeFiatEvent.name,
-                );
-                expect(changeFiatRequest).toHaveProperty(
-                    'c_type',
-                    events.settingsGeneralChangeFiatEvent.name,
-                );
-                expect(changeFiatRequest).toHaveProperty('fiat', 'huf');
-                expect(changeFiatRequest).toHaveProperty(
-                    'c_instance_id',
-                    enableRequest?.c_instance_id,
-                );
-            });
-
-            await test.step('Open device modal and check analytics event', async () => {
-                await dashboardPage.openDeviceSwitcher();
-                await analytics.waitForAnalyticsRequests();
-
-                const deviceModalRequest = analytics.findLatestRequestByType(
-                    events.routerLocationChangeEvent.name,
-                );
-                expect(deviceModalRequest).toHaveProperty(
-                    'c_type',
-                    events.routerLocationChangeEvent.name,
-                );
-            });
-        });
-
-        test('should respect enabled analytics in onboarding with following disabling in settings', async ({
-            device,
-            analytics,
-            analyticsSection,
-            onboardingPage,
-            settingsPage,
-            devicePrompt,
-        }) => {
-            await test.step('Pass through onboarding with enabled analytics', async () => {
-                await expect(settingsPage.analyticsSwitchInput).toBeChecked();
+        const disposeRequest =
+            await test.step('Continue onboarding and check analytics dispose event', async () => {
                 await analyticsSection.continueButton.click();
-                await analytics.waitForAnalyticsRequests(3);
-
-                expect(analytics.requests.length).toBeGreaterThan(1);
-                expect(
-                    analytics.findLatestRequestByLegacyType(events.suiteReadyEvent.name),
-                ).toBeDefined();
-                expect(
-                    analytics.findLatestRequestByLegacyType(events.settingsAnalyticsEvent.name),
-                ).toBeDefined();
-            });
-
-            await test.step('Finish onboarding', async () => {
-                if (device.hasTHP) {
-                    await devicePrompt.allowConnectToTrezor();
-                    await onboardingPage.enterTHPPairingCode();
-                }
-                await onboardingPage.completeOnboardingButton.click();
-            });
-
-            await test.step('Go to settings and disable analytics', async () => {
-                await settingsPage.navigateTo('application');
-                await expect(settingsPage.analyticsSwitchInput).toBeChecked();
-
-                await settingsPage.analyticsSwitch.click();
-                await expect(settingsPage.analyticsSwitchInput).not.toBeChecked();
-            });
-
-            await test.step('Change fiat and check "settings/general/change-fiat" event was not fired', async () => {
-                await settingsPage.changeFiatCurrency('huf');
                 await analytics.waitForAnalyticsRequests();
-                expect(
-                    analytics.findLatestRequestByLegacyType(events.settingsAnalyticsEvent.name),
-                ).toBeDefined();
-                expect(
-                    analytics.findLatestRequestByLegacyType(
-                        events.settingsGeneralChangeFiatEvent.name,
-                    ),
-                ).not.toBeDefined();
+                // assert that only "analytics/dispose" event was fired
+                const request = analytics.findLatestRequestByLegacyType(
+                    events.settingsAnalyticsEvent.name,
+                );
+                expect(request).toHaveProperty('c_type', events.settingsAnalyticsEvent.name);
+                expect(request).toHaveProperty('value', 'false');
+                expect(request).toHaveProperty('c_session_id');
+                expect(request).toHaveProperty('c_instance_id');
+                expect(request).toHaveProperty('c_timestamp');
+                expect(request?.c_timestamp).toMatch(/^\d+$/);
+
+                return request;
             });
+
+        await test.step('Finish onboarding', async () => {
+            if (device.hasTHP) {
+                await devicePrompt.allowConnectToTrezor();
+                await onboardingPage.enterTHPPairingCode();
+                await onboardingPage.enableAutoconnect();
+            }
+
+            await onboardingPage.completeOnboardingButton.click();
         });
-    },
-);
+
+        await test.step('Reload app and check analytics state', async () => {
+            // app needs time to save initialRun flag into storage to change session id
+            await page.getByTestId('@suite/loading').waitFor({ state: 'hidden' });
+            await page.discoveryShouldFinish();
+            await page.reload();
+            await settingsPage.navigateTo('application');
+            await expect(settingsPage.analyticsSwitchInput).not.toBeChecked();
+        });
+
+        await test.step('Enable analytics in settings and check enable event', async () => {
+            await settingsPage.analyticsSwitch.click();
+            await expect(settingsPage.analyticsSwitchInput).toBeChecked();
+            await analytics.waitForAnalyticsRequests();
+
+            const enableRequest = analytics.findLatestRequestByLegacyType(
+                events.settingsAnalyticsEvent.name,
+            );
+            expect(enableRequest).toHaveProperty('c_type', events.settingsAnalyticsEvent.name);
+            expect(enableRequest).toHaveProperty('c_session_id');
+            expect(enableRequest).toHaveProperty('c_instance_id');
+            expect(enableRequest).toHaveProperty('c_timestamp');
+            expect(enableRequest?.c_timestamp).toMatch(/^\d+$/);
+
+            // check that timestamps are different
+            expect(disposeRequest?.c_timestamp).not.toEqual(enableRequest?.c_timestamp);
+
+            // check that session ids changed after reload
+            expect(disposeRequest?.c_session_id).not.toEqual(enableRequest?.c_session_id);
+
+            // check that instance ids are the same after reload
+            expect(disposeRequest?.c_instance_id).toEqual(enableRequest?.c_instance_id);
+        });
+
+        await test.step('Change fiat and check analytics event', async () => {
+            const enableRequest = analytics.findLatestRequestByLegacyType(
+                events.settingsAnalyticsEvent.name,
+            );
+            await settingsPage.changeFiatCurrency('huf');
+            await analytics.waitForAnalyticsRequests();
+            const changeFiatRequest = analytics.findLatestRequestByLegacyType(
+                events.settingsGeneralChangeFiatEvent.name,
+            );
+            expect(changeFiatRequest).toHaveProperty(
+                'c_type',
+                events.settingsGeneralChangeFiatEvent.name,
+            );
+            expect(changeFiatRequest).toHaveProperty('fiat', 'huf');
+            expect(changeFiatRequest).toHaveProperty('c_instance_id', enableRequest?.c_instance_id);
+        });
+
+        await test.step('Open device modal and check analytics event', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await analytics.waitForAnalyticsRequests();
+
+            const deviceModalRequest = analytics.findLatestRequestByType(
+                events.routerLocationChangeEvent.name,
+            );
+            expect(deviceModalRequest).toHaveProperty(
+                'c_type',
+                events.routerLocationChangeEvent.name,
+            );
+        });
+    });
+
+    test('should respect enabled analytics in onboarding with following disabling in settings', async ({
+        device,
+        analytics,
+        analyticsSection,
+        onboardingPage,
+        settingsPage,
+        devicePrompt,
+    }) => {
+        await test.step('Pass through onboarding with enabled analytics', async () => {
+            await expect(settingsPage.analyticsSwitchInput).toBeChecked();
+            await analyticsSection.continueButton.click();
+            await analytics.waitForAnalyticsRequests(3);
+
+            expect(analytics.requests.length).toBeGreaterThan(1);
+            expect(
+                analytics.findLatestRequestByLegacyType(events.suiteReadyEvent.name),
+            ).toBeDefined();
+            expect(
+                analytics.findLatestRequestByLegacyType(events.settingsAnalyticsEvent.name),
+            ).toBeDefined();
+        });
+
+        await test.step('Finish onboarding', async () => {
+            if (device.hasTHP) {
+                await devicePrompt.allowConnectToTrezor();
+                await onboardingPage.enterTHPPairingCode();
+            }
+            await onboardingPage.completeOnboardingButton.click();
+        });
+
+        await test.step('Go to settings and disable analytics', async () => {
+            await settingsPage.navigateTo('application');
+            await expect(settingsPage.analyticsSwitchInput).toBeChecked();
+
+            await settingsPage.analyticsSwitch.click();
+            await expect(settingsPage.analyticsSwitchInput).not.toBeChecked();
+        });
+
+        await test.step('Change fiat and check "settings/general/change-fiat" event was not fired', async () => {
+            await settingsPage.changeFiatCurrency('huf');
+            await analytics.waitForAnalyticsRequests();
+            expect(
+                analytics.findLatestRequestByLegacyType(events.settingsAnalyticsEvent.name),
+            ).toBeDefined();
+            expect(
+                analytics.findLatestRequestByLegacyType(events.settingsGeneralChangeFiatEvent.name),
+            ).not.toBeDefined();
+        });
+    });
+});

--- a/suite/e2e/tests/dashboard/assets.test.ts
+++ b/suite/e2e/tests/dashboard/assets.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '../../support/fixtures';
 
-test.describe('Assets', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
+test.describe('Assets', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.beforeEach(async ({ onboardingPage, settingsPage, dashboardPage }) => {
         await onboardingPage.completeOnboarding();
         await settingsPage.changeNetworks({ enableNetworks: ['btc'] });

--- a/suite/e2e/tests/metadata/legacy/account-metadata.test.ts
+++ b/suite/e2e/tests/metadata/legacy/account-metadata.test.ts
@@ -4,7 +4,7 @@ import { MetadataProvider } from '../../../support/mocks/metadataMock';
 
 // Metadata is by default disabled, this means, that application does not try to generate master key and connect to cloud.
 // Hovering over fields that may be labeled shows "add label" button upon which is clicked, Suite initiates metadata flow
-test.describe('Account metadata', { tag: ['@webOnly', '@T3W1', '@T3T1', '@smoke'] }, () => {
+test.describe('Account metadata', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
     test.use({ deviceSetup: { mnemonic: 'mnemonic_all' } });
 
     test.beforeEach(async ({ metadataMock }) => {

--- a/suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts
+++ b/suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts
@@ -4,130 +4,126 @@ import { MetadataProvider } from '../../../support/mocks/metadataMock';
 const standardWalletIndex = 0;
 const hiddenWalletIndex = 1;
 
-test.describe(
-    'Metadata - wallet labeling',
-    { tag: ['@webOnly', '@T3W1', '@T3T1', '@smoke'] },
-    () => {
-        test.beforeEach(async ({ onboardingPage, metadataMock, metadataPage, settingsPage }) => {
-            await metadataMock.start(MetadataProvider.DROPBOX);
-            await onboardingPage.completeOnboarding();
-            await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
-            await metadataPage.enableLegacyLabeling(MetadataProvider.DROPBOX);
+test.describe('Metadata - wallet labeling', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+    test.beforeEach(async ({ onboardingPage, metadataMock, metadataPage, settingsPage }) => {
+        await metadataMock.start(MetadataProvider.DROPBOX);
+        await onboardingPage.completeOnboarding();
+        await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
+        await metadataPage.enableLegacyLabeling(MetadataProvider.DROPBOX);
+    });
+
+    test.use({
+        deviceSetup: {
+            mnemonic: 'mnemonic_all',
+            passphrase_protection: true,
+        },
+    });
+
+    test('persists wallet labels', async ({
+        page,
+        device,
+        dashboardPage,
+        metadataPage,
+        devicePrompt,
+        metadataMock,
+    }) => {
+        await test.step('Setup standard wallet and enable labels', async () => {
+            await dashboardPage.openDeviceSwitcher();
         });
 
-        test.use({
-            deviceSetup: {
-                mnemonic: 'mnemonic_all',
-                passphrase_protection: true,
-            },
+        await test.step('Add and Edit label of standard wallet', async () => {
+            await metadataPage.wallet.clickEditLabel(standardWalletIndex);
+            await metadataPage.wallet.fillLabelInput('label for standard wallet');
+
+            await metadataPage.wallet.successIconIsVisible(standardWalletIndex);
+            await expect(metadataPage.wallet.walletLabel(standardWalletIndex)).toHaveText(
+                'label for standard wallet',
+            );
+
+            await metadataPage.wallet.clickEditLabel(standardWalletIndex);
+            await metadataPage.wallet.fillLabelInput('wallet for drugs');
+            await metadataPage.wallet.successIconIsVisible(standardWalletIndex);
         });
 
-        test('persists wallet labels', async ({
-            page,
-            device,
-            dashboardPage,
-            metadataPage,
-            devicePrompt,
-            metadataMock,
-        }) => {
-            await test.step('Setup standard wallet and enable labels', async () => {
-                await dashboardPage.openDeviceSwitcher();
-            });
+        await test.step('Add hidden wallet and enable labeling', async () => {
+            await dashboardPage.addUnusedHiddenWallet('abc');
 
-            await test.step('Add and Edit label of standard wallet', async () => {
-                await metadataPage.wallet.clickEditLabel(standardWalletIndex);
-                await metadataPage.wallet.fillLabelInput('label for standard wallet');
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await device.pressYes();
 
-                await metadataPage.wallet.successIconIsVisible(standardWalletIndex);
-                await expect(metadataPage.wallet.walletLabel(standardWalletIndex)).toHaveText(
-                    'label for standard wallet',
-                );
-
-                await metadataPage.wallet.clickEditLabel(standardWalletIndex);
-                await metadataPage.wallet.fillLabelInput('wallet for drugs');
-                await metadataPage.wallet.successIconIsVisible(standardWalletIndex);
-            });
-
-            await test.step('Add hidden wallet and enable labeling', async () => {
-                await dashboardPage.addUnusedHiddenWallet('abc');
-
-                await devicePrompt.confirmOnDevicePromptIsShown();
-                await device.pressYes();
-
-                await dashboardPage.openDeviceSwitcher();
-                await metadataPage.wallet.clickEditLabel(hiddenWalletIndex);
-                await metadataPage.wallet.fillLabelInput('wallet not for drugs');
-                await metadataPage.wallet.successIconIsVisible(hiddenWalletIndex);
-            });
-
-            await test.step('Verify wallet labels', async () => {
-                await expect(metadataPage.wallet.walletLabel(standardWalletIndex)).toHaveText(
-                    'wallet for drugs',
-                );
-                await expect(metadataPage.wallet.walletLabel(hiddenWalletIndex)).toHaveText(
-                    'wallet not for drugs',
-                );
-            });
-
-            await test.step('Reload app', async () => {
-                await page.waitForTimeout(1000); // wait for changes to db
-                await page.reload();
-                await metadataMock.setupWindowStubs();
-            });
-
-            await test.step('Verify wallet labels after reload', async () => {
-                await dashboardPage.openDeviceSwitcher();
-
-                await expect(metadataPage.wallet.walletLabel(standardWalletIndex)).toHaveText(
-                    'wallet for drugs',
-                );
-                await expect(metadataPage.wallet.walletLabel(hiddenWalletIndex)).toHaveText(
-                    'wallet not for drugs',
-                );
-            });
+            await dashboardPage.openDeviceSwitcher();
+            await metadataPage.wallet.clickEditLabel(hiddenWalletIndex);
+            await metadataPage.wallet.fillLabelInput('wallet not for drugs');
+            await metadataPage.wallet.successIconIsVisible(hiddenWalletIndex);
         });
 
-        test('labels can be enabled and edited when different wallet is open', async ({
-            device,
-            dashboardPage,
-            metadataPage,
-            devicePrompt,
-        }) => {
-            await test.step('Setup standard wallet with label and edit it', async () => {
-                await dashboardPage.openDeviceSwitcher();
-                await metadataPage.wallet.clickEditLabel(standardWalletIndex);
-                await metadataPage.wallet.fillLabelInput('label for standard wallet');
-                await metadataPage.wallet.successIconIsVisible(standardWalletIndex);
-            });
-
-            await test.step('Add passphrase wallet C and switch back to first wallet', async () => {
-                await dashboardPage.addUnusedHiddenWallet('C');
-                await devicePrompt.confirmOnDevicePromptIsShown();
-                await device.pressNo();
-                await dashboardPage.openDeviceSwitcher();
-                await dashboardPage.walletAtIndex(standardWalletIndex).click();
-            });
-
-            await test.step('Enable labeling for wallet C', async () => {
-                await dashboardPage.openDeviceSwitcher();
-                await metadataPage.wallet.clickEditLabel(hiddenWalletIndex);
-                await devicePrompt.confirmOnDevicePromptIsShown();
-                await device.pressYes();
-                await metadataPage.wallet.clickEditLabel(hiddenWalletIndex);
-                await metadataPage.wallet.fillLabelInput(
-                    'still works, metadata enabled for currently not selected device',
-                );
-                await metadataPage.wallet.successIconIsVisible(hiddenWalletIndex);
-            });
-
-            await test.step('Verify wallet labels', async () => {
-                await expect(metadataPage.wallet.walletLabel(standardWalletIndex)).toHaveText(
-                    'label for standard wallet',
-                );
-                await expect(metadataPage.wallet.walletLabel(hiddenWalletIndex)).toHaveText(
-                    'still works, metadata enabled for currently not selected device',
-                );
-            });
+        await test.step('Verify wallet labels', async () => {
+            await expect(metadataPage.wallet.walletLabel(standardWalletIndex)).toHaveText(
+                'wallet for drugs',
+            );
+            await expect(metadataPage.wallet.walletLabel(hiddenWalletIndex)).toHaveText(
+                'wallet not for drugs',
+            );
         });
-    },
-);
+
+        await test.step('Reload app', async () => {
+            await page.waitForTimeout(1000); // wait for changes to db
+            await page.reload();
+            await metadataMock.setupWindowStubs();
+        });
+
+        await test.step('Verify wallet labels after reload', async () => {
+            await dashboardPage.openDeviceSwitcher();
+
+            await expect(metadataPage.wallet.walletLabel(standardWalletIndex)).toHaveText(
+                'wallet for drugs',
+            );
+            await expect(metadataPage.wallet.walletLabel(hiddenWalletIndex)).toHaveText(
+                'wallet not for drugs',
+            );
+        });
+    });
+
+    test('labels can be enabled and edited when different wallet is open', async ({
+        device,
+        dashboardPage,
+        metadataPage,
+        devicePrompt,
+    }) => {
+        await test.step('Setup standard wallet with label and edit it', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await metadataPage.wallet.clickEditLabel(standardWalletIndex);
+            await metadataPage.wallet.fillLabelInput('label for standard wallet');
+            await metadataPage.wallet.successIconIsVisible(standardWalletIndex);
+        });
+
+        await test.step('Add passphrase wallet C and switch back to first wallet', async () => {
+            await dashboardPage.addUnusedHiddenWallet('C');
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await device.pressNo();
+            await dashboardPage.openDeviceSwitcher();
+            await dashboardPage.walletAtIndex(standardWalletIndex).click();
+        });
+
+        await test.step('Enable labeling for wallet C', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await metadataPage.wallet.clickEditLabel(hiddenWalletIndex);
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await device.pressYes();
+            await metadataPage.wallet.clickEditLabel(hiddenWalletIndex);
+            await metadataPage.wallet.fillLabelInput(
+                'still works, metadata enabled for currently not selected device',
+            );
+            await metadataPage.wallet.successIconIsVisible(hiddenWalletIndex);
+        });
+
+        await test.step('Verify wallet labels', async () => {
+            await expect(metadataPage.wallet.walletLabel(standardWalletIndex)).toHaveText(
+                'label for standard wallet',
+            );
+            await expect(metadataPage.wallet.walletLabel(hiddenWalletIndex)).toHaveText(
+                'still works, metadata enabled for currently not selected device',
+            );
+        });
+    });
+});

--- a/suite/e2e/tests/onboarding/firmware-check.test.ts
+++ b/suite/e2e/tests/onboarding/firmware-check.test.ts
@@ -5,7 +5,7 @@ import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe(
     'Firmware - check readiness',
-    { tag: ['@firmware-ready', '@T1B1', '@T2T1', '@T3B1', '@T3T1', '@smoke'] },
+    { tag: ['@firmware-ready', '@T1B1', '@T2T1', '@T3B1', '@T3T1'] },
     () => {
         test.use({
             setupEmulator: false,

--- a/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts
+++ b/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts
@@ -4,7 +4,7 @@ import { TestCategory, TestPriority } from '@trezor/e2e-utils';
 import { expect, test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
-test.describe('Onboarding - create wallet', { tag: ['@desktopOnly', '@T3T1', '@smoke'] }, () => {
+test.describe('Onboarding - create wallet', { tag: ['@desktopOnly', '@T3T1'] }, () => {
     test.use({
         setupEmulator: false,
         electronConf: { offlineMode: true },

--- a/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
@@ -3,7 +3,7 @@ import { TestCategory, TestPriority } from '@trezor/e2e-utils';
 import { test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
-test.describe('Onboarding - create wallet', { tag: ['@T3T1', '@smoke'] }, () => {
+test.describe('Onboarding - create wallet', { tag: ['@T3T1'] }, () => {
     test.use({
         setupEmulator: false,
     });

--- a/suite/e2e/tests/recovery/dry-run.test.ts
+++ b/suite/e2e/tests/recovery/dry-run.test.ts
@@ -7,7 +7,7 @@ import { createTestAnnotation } from '../../support/reporters/annotations';
 
 const pin = '1';
 
-test.describe('Recovery - dry run', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
+test.describe('Recovery - dry run', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({
         deviceSetup: { mnemonic: 'mnemonic_all', pin },
     });

--- a/suite/e2e/tests/settings/coins-custom-backend.test.ts
+++ b/suite/e2e/tests/settings/coins-custom-backend.test.ts
@@ -11,7 +11,7 @@ type Coin = {
     customBackendUrlWrong: string;
 };
 
-test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
+test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({
         deviceSetup: {
             mnemonic:

--- a/suite/e2e/tests/settings/coins.test.ts
+++ b/suite/e2e/tests/settings/coins.test.ts
@@ -4,7 +4,7 @@ import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
-test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
+test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
         await settingsPage.navigateTo('coins');

--- a/suite/e2e/tests/settings/forget-device.test.ts
+++ b/suite/e2e/tests/settings/forget-device.test.ts
@@ -259,7 +259,7 @@ test.describe('Device Settings - Forget TS7', { tag: ['@T3W1'] }, () => {
     );
 });
 
-test.describe('Device Settings - Forget TS5', { tag: ['@T3T1', '@smoke'] }, () => {
+test.describe('Device Settings - Forget TS5', { tag: ['@T3T1'] }, () => {
     test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
         await settingsPage.navigateTo('device');

--- a/suite/e2e/tests/settings/general.test.ts
+++ b/suite/e2e/tests/settings/general.test.ts
@@ -11,7 +11,7 @@ export enum Currency {
     USD = 'usd',
 }
 
-test.describe('General settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
+test.describe('General settings', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.beforeEach(async ({ analytics, onboardingPage, settingsPage, dashboardPage }) => {
         await onboardingPage.completeOnboarding();
         await analytics.interceptAnalytics();

--- a/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
+++ b/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
@@ -34,7 +34,7 @@ async function gotoConnectExplorer(page: Page, method: string) {
     }
 }
 
-test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] }, () => {
+test.describe('TrezorConnect popup web', { tag: ['@T3T1', '@webOnly'] }, () => {
     test.beforeEach(async ({ onboardingPage, context }) => {
         await onboardingPage.completeOnboarding();
         await context.grantPermissions(['storage-access']);
@@ -323,37 +323,32 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
     );
 });
 
-test.describe(
-    'TrezorConnect popup web - no onboarding',
-    { tag: ['@smoke', '@T3T1', '@webOnly'] },
-    () => {
-        test(
-            'popup blocked by browser returns popup-blocked error',
-            {
-                annotation: createTestAnnotation({
-                    testCase:
-                        'Suite Web Connect: When popup is blocked, returns popup-blocked error',
-                }),
-            },
-            async ({ page }) => {
-                // When window.open returns null (popup blocked), the error is
-                // returned immediately as { success: false, error: "popup-blocked" }.
+test.describe('TrezorConnect popup web - no onboarding', { tag: ['@T3T1', '@webOnly'] }, () => {
+    test(
+        'popup blocked by browser returns popup-blocked error',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Suite Web Connect: When popup is blocked, returns popup-blocked error',
+            }),
+        },
+        async ({ page }) => {
+            // When window.open returns null (popup blocked), the error is
+            // returned immediately as { success: false, error: "popup-blocked" }.
 
-                await gotoConnectExplorer(page, 'bitcoin/getAddress');
-                await page.getByTestId('@api-playground/collapsible-box').click();
+            await gotoConnectExplorer(page, 'bitcoin/getAddress');
+            await page.getByTestId('@api-playground/collapsible-box').click();
 
-                // Block popups
-                await page.evaluate(() => {
-                    window.open = () => null;
-                });
+            // Block popups
+            await page.evaluate(() => {
+                window.open = () => null;
+            });
 
-                await page.getByTestId('@submit-button').click();
-                const response = page.getByTestId('@response');
-                // todo: there is quite big  timeout before handshake failed appears. Maybe we could detect that popup
-                // did not open earlier and return error faster?
-                await expect(response).toHaveText(/success: false/, { timeout: 15_000 });
-                await expect(response).toHaveText(/popup-blocked/i);
-            },
-        );
-    },
-);
+            await page.getByTestId('@submit-button').click();
+            const response = page.getByTestId('@response');
+            // todo: there is quite big  timeout before handshake failed appears. Maybe we could detect that popup
+            // did not open earlier and return error faster?
+            await expect(response).toHaveText(/success: false/, { timeout: 15_000 });
+            await expect(response).toHaveText(/popup-blocked/i);
+        },
+    );
+});

--- a/suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts
+++ b/suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts
@@ -142,291 +142,284 @@ async function setupWebextensionTest(
     return { context, page, suite, connectPermissionsModal };
 }
 
-test.describe(
-    'TrezorConnect webextension -> Suite Web',
-    { tag: ['@smoke', '@T3T1', '@webOnly'] },
-    () => {
-        test(
-            'TrezorConnect.getAddress',
-            {
-                annotation: createTestAnnotation({
-                    testCase:
-                        'Suite Web Connect (webextension): Happy path scenario with getAddress',
-                }),
-            },
-            async ({ model, device, context: defaultContext }) => {
-                const { context, page, suite } = await setupWebextensionTest(
-                    model,
-                    device,
-                    defaultContext,
-                    'connect-explorer-webextension',
-                );
+test.describe('TrezorConnect webextension -> Suite Web', { tag: ['@T3T1', '@webOnly'] }, () => {
+    test(
+        'TrezorConnect.getAddress',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Suite Web Connect (webextension): Happy path scenario with getAddress',
+            }),
+        },
+        async ({ model, device, context: defaultContext }) => {
+            const { context, page, suite } = await setupWebextensionTest(
+                model,
+                device,
+                defaultContext,
+                'connect-explorer-webextension',
+            );
 
-                try {
-                    await suite.getByTestId('@connect-address-confirmation/confirm-button').click();
+            try {
+                await suite.getByTestId('@connect-address-confirmation/confirm-button').click();
 
-                    await expect(
-                        suite.getByTestId('@connect-address-confirmation/verify-button/0'),
-                    ).toBeDisabled();
-                    await suite.waitForTimeout(1000);
-                    await device.pressYes();
+                await expect(
+                    suite.getByTestId('@connect-address-confirmation/verify-button/0'),
+                ).toBeDisabled();
+                await suite.waitForTimeout(1000);
+                await device.pressYes();
 
-                    await expect(
-                        suite.getByTestId('@connect-address-confirmation/verified-badge/0'),
-                    ).toBeVisible();
+                await expect(
+                    suite.getByTestId('@connect-address-confirmation/verified-badge/0'),
+                ).toBeVisible();
 
-                    await suite.getByTestId('@connect-address-confirmation/close-button').click();
+                await suite.getByTestId('@connect-address-confirmation/close-button').click();
 
-                    const response = page.getByTestId('@response');
-                    await expect(response).toHaveText(/success: true/);
-                } finally {
-                    await context.close();
-                }
-            },
-        );
+                const response = page.getByTestId('@response');
+                await expect(response).toHaveText(/success: true/);
+            } finally {
+                await context.close();
+            }
+        },
+    );
 
-        test(
-            'call cancellation',
-            {
-                annotation: createTestAnnotation({
-                    testCase: 'Suite Web Connect (webextension): Call cancelled by user',
-                }),
-            },
-            async ({ model, device, context: defaultContext }) => {
-                // --- Cancel on Grant Permissions modal ---
-                const {
-                    context,
-                    page,
-                    connectPermissionsModal: modal1,
-                } = await setupWebextensionTest(
-                    model,
-                    device,
-                    defaultContext,
-                    'connect-explorer-webextension-cancellation',
-                    { skipPermissionConfirm: true },
-                );
+    test(
+        'call cancellation',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Suite Web Connect (webextension): Call cancelled by user',
+            }),
+        },
+        async ({ model, device, context: defaultContext }) => {
+            // --- Cancel on Grant Permissions modal ---
+            const {
+                context,
+                page,
+                connectPermissionsModal: modal1,
+            } = await setupWebextensionTest(
+                model,
+                device,
+                defaultContext,
+                'connect-explorer-webextension-cancellation',
+                { skipPermissionConfirm: true },
+            );
 
-                try {
-                    await modal1.cancelButton.click();
+            try {
+                await modal1.cancelButton.click();
 
-                    const response1 = page.getByTestId('@response');
-                    await expect(response1).toHaveText(/success: false/);
+                const response1 = page.getByTestId('@response');
+                await expect(response1).toHaveText(/success: false/);
 
-                    // --- Cancel after confirming permissions (on address confirmation) ---
-                    const [suite2] = await Promise.all([
-                        context.waitForEvent('page', { timeout: 10_000 }),
-                        page.getByTestId('@submit-button').click(),
-                    ]);
+                // --- Cancel after confirming permissions (on address confirmation) ---
+                const [suite2] = await Promise.all([
+                    context.waitForEvent('page', { timeout: 10_000 }),
+                    page.getByTestId('@submit-button').click(),
+                ]);
 
-                    await suite2.waitForLoadState('domcontentloaded', { timeout: 10_000 });
-                    await suite2
-                        .getByTestId('@suite/menu/suite-index')
-                        .waitFor({ state: 'visible', timeout: 15_000 });
+                await suite2.waitForLoadState('domcontentloaded', { timeout: 10_000 });
+                await suite2
+                    .getByTestId('@suite/menu/suite-index')
+                    .waitFor({ state: 'visible', timeout: 15_000 });
 
-                    const modal2 = new ConnectPermissionsModal(suite2);
-                    await expect(modal2.appName).toHaveText('Trezor Connect Explorer', {
-                        timeout: 15_000,
-                    });
-                    await modal2.confirmButton.click();
+                const modal2 = new ConnectPermissionsModal(suite2);
+                await expect(modal2.appName).toHaveText('Trezor Connect Explorer', {
+                    timeout: 15_000,
+                });
+                await modal2.confirmButton.click();
 
-                    await expect(modal2.loadingHeader).toHaveText('Export Bitcoin address');
-                    await suite2.getByTestId('@connect-address-confirmation/close-button').click();
+                await expect(modal2.loadingHeader).toHaveText('Export Bitcoin address');
+                await suite2.getByTestId('@connect-address-confirmation/close-button').click();
 
-                    const response2 = page.getByTestId('@response');
-                    await expect(response2).toHaveText(/success: false/);
-                } finally {
-                    await context.close();
-                }
-            },
-        );
+                const response2 = page.getByTestId('@response');
+                await expect(response2).toHaveText(/success: false/);
+            } finally {
+                await context.close();
+            }
+        },
+    );
 
-        test(
-            'call cancelled from calling application',
-            {
-                annotation: createTestAnnotation({
-                    testCase:
-                        'Suite Web Connect (webextension): Call cancelled via TrezorConnect.cancel() from the calling app',
-                }),
-            },
-            async ({ model, device, context: defaultContext }) => {
-                const { context, page, suite } = await setupWebextensionTest(
-                    model,
-                    device,
-                    defaultContext,
-                    'connect-explorer-webextension-cancel-from-app',
-                );
+    test(
+        'call cancelled from calling application',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Suite Web Connect (webextension): Call cancelled via TrezorConnect.cancel() from the calling app',
+            }),
+        },
+        async ({ model, device, context: defaultContext }) => {
+            const { context, page, suite } = await setupWebextensionTest(
+                model,
+                device,
+                defaultContext,
+                'connect-explorer-webextension-cancel-from-app',
+            );
 
-                try {
-                    // Switch back to connect-explorer and click the cancel "x" button
-                    // that appears next to the submit button while a call is in progress.
-                    await page.bringToFront();
-                    const cancelButton = page.getByTestId('@cancel-button');
-                    await cancelButton.click();
+            try {
+                // Switch back to connect-explorer and click the cancel "x" button
+                // that appears next to the submit button while a call is in progress.
+                await page.bringToFront();
+                const cancelButton = page.getByTestId('@cancel-button');
+                await cancelButton.click();
 
-                    const response = page.getByTestId('@response');
-                    await expect(response).toHaveText(/success: false/);
-                    await expect(response).toHaveText(/Method_Interrupted/);
+                const response = page.getByTestId('@response');
+                await expect(response).toHaveText(/success: false/);
+                await expect(response).toHaveText(/Method_Interrupted/);
 
-                    // The popup (suite tab) should show a cancellation message.
-                    await expect(suite.getByText('Request was canceled by the user')).toBeVisible({
-                        timeout: 15_000,
-                    });
-                } finally {
-                    await context.close();
-                }
-            },
-        );
+                // The popup (suite tab) should show a cancellation message.
+                await expect(suite.getByText('Request was canceled by the user')).toBeVisible({
+                    timeout: 15_000,
+                });
+            } finally {
+                await context.close();
+            }
+        },
+    );
 
-        test(
-            'closing popup window',
-            {
-                annotation: createTestAnnotation({
-                    testCase:
-                        'Suite Web Connect (webextension): Closing the popup window (not close button) returns a proper error',
-                }),
-            },
-            async ({ model, device, context: defaultContext }) => {
-                const { context, page, suite } = await setupWebextensionTest(
-                    model,
-                    device,
-                    defaultContext,
-                    'connect-explorer-webextension-interrupted',
-                );
+    test(
+        'closing popup window',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Suite Web Connect (webextension): Closing the popup window (not close button) returns a proper error',
+            }),
+        },
+        async ({ model, device, context: defaultContext }) => {
+            const { context, page, suite } = await setupWebextensionTest(
+                model,
+                device,
+                defaultContext,
+                'connect-explorer-webextension-interrupted',
+            );
 
-                try {
-                    // Close the browser popup window directly (simulates user clicking X)
-                    await suite.close();
+            try {
+                // Close the browser popup window directly (simulates user clicking X)
+                await suite.close();
 
-                    const response = page.getByTestId('@response');
-                    await expect(response).toHaveText(/success: false/);
-                    await expect(response).toHaveText(/Method_Interrupted/);
-                } finally {
-                    await context.close();
-                }
-            },
-        );
+                const response = page.getByTestId('@response');
+                await expect(response).toHaveText(/success: false/);
+                await expect(response).toHaveText(/Method_Interrupted/);
+            } finally {
+                await context.close();
+            }
+        },
+    );
 
-        test(
-            'second call after popup was closed by user should work',
-            {
-                annotation: createTestAnnotation({
-                    testCase:
-                        'Suite Web Connect (webextension): After popup is force-closed, next call should still work',
-                }),
-            },
-            async ({ model, device, context: defaultContext }) => {
-                const {
-                    context,
-                    page,
-                    suite: suite1,
-                } = await setupWebextensionTest(
-                    model,
-                    device,
-                    defaultContext,
-                    'connect-explorer-webextension-recovery',
-                );
+    test(
+        'second call after popup was closed by user should work',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Suite Web Connect (webextension): After popup is force-closed, next call should still work',
+            }),
+        },
+        async ({ model, device, context: defaultContext }) => {
+            const {
+                context,
+                page,
+                suite: suite1,
+            } = await setupWebextensionTest(
+                model,
+                device,
+                defaultContext,
+                'connect-explorer-webextension-recovery',
+            );
 
-                try {
-                    // Close the Suite popup directly (simulates user clicking X)
-                    await suite1.close();
+            try {
+                // Close the Suite popup directly (simulates user clicking X)
+                await suite1.close();
 
-                    const response1 = page.getByTestId('@response');
-                    await expect(response1).toHaveText(/success: false/);
-                    await expect(response1).toHaveText(/Method_Interrupted/);
+                const response1 = page.getByTestId('@response');
+                await expect(response1).toHaveText(/success: false/);
+                await expect(response1).toHaveText(/Method_Interrupted/);
 
-                    // Second call — register page listener before clicking to
-                    // avoid a race where the tab opens before waitForEvent.
-                    const [suite2] = await Promise.all([
-                        context.waitForEvent('page', { timeout: 10_000 }),
-                        page.getByTestId('@submit-button').click(),
-                    ]);
-                    await suite2.waitForLoadState('domcontentloaded', { timeout: 10_000 });
-                    await suite2
-                        .getByTestId('@suite/menu/suite-index')
-                        .waitFor({ state: 'visible', timeout: 15_000 });
+                // Second call — register page listener before clicking to
+                // avoid a race where the tab opens before waitForEvent.
+                const [suite2] = await Promise.all([
+                    context.waitForEvent('page', { timeout: 10_000 }),
+                    page.getByTestId('@submit-button').click(),
+                ]);
+                await suite2.waitForLoadState('domcontentloaded', { timeout: 10_000 });
+                await suite2
+                    .getByTestId('@suite/menu/suite-index')
+                    .waitFor({ state: 'visible', timeout: 15_000 });
 
-                    const modal2 = new ConnectPermissionsModal(suite2);
-                    await expect(modal2.appName).toHaveText('Trezor Connect Explorer', {
-                        timeout: 15_000,
-                    });
-                    await modal2.confirmButton.click();
+                const modal2 = new ConnectPermissionsModal(suite2);
+                await expect(modal2.appName).toHaveText('Trezor Connect Explorer', {
+                    timeout: 15_000,
+                });
+                await modal2.confirmButton.click();
 
-                    await expect(modal2.loadingHeader).toHaveText('Export Bitcoin address');
-                    await suite2
-                        .getByTestId('@connect-address-confirmation/confirm-button')
-                        .click();
+                await expect(modal2.loadingHeader).toHaveText('Export Bitcoin address');
+                await suite2.getByTestId('@connect-address-confirmation/confirm-button').click();
 
-                    await expect(
-                        suite2.getByTestId('@connect-address-confirmation/verify-button/0'),
-                    ).toBeDisabled();
-                    await suite2.waitForTimeout(1000);
-                    await device.pressYes();
+                await expect(
+                    suite2.getByTestId('@connect-address-confirmation/verify-button/0'),
+                ).toBeDisabled();
+                await suite2.waitForTimeout(1000);
+                await device.pressYes();
 
-                    await expect(
-                        suite2.getByTestId('@connect-address-confirmation/verified-badge/0'),
-                    ).toBeVisible();
-                    await suite2.getByTestId('@connect-address-confirmation/close-button').click();
-                    const response2 = page.getByTestId('@response');
-                    await expect(response2).toHaveText(/success: true/);
-                } finally {
-                    await context.close();
-                }
-            },
-        );
+                await expect(
+                    suite2.getByTestId('@connect-address-confirmation/verified-badge/0'),
+                ).toBeVisible();
+                await suite2.getByTestId('@connect-address-confirmation/close-button').click();
+                const response2 = page.getByTestId('@response');
+                await expect(response2).toHaveText(/success: true/);
+            } finally {
+                await context.close();
+            }
+        },
+    );
 
-        test(
-            'focuses existing popup if already open',
-            {
-                annotation: createTestAnnotation({
-                    testCase:
-                        'Suite Web Connect (webextension): If popup is already open, it should be focused instead of opening a new one',
-                }),
-            },
-            async ({ model, device, context: defaultContext }) => {
-                const { context, page, suite } = await setupWebextensionTest(
-                    model,
-                    device,
-                    defaultContext,
-                    'connect-explorer-webextension-focus',
-                );
+    test(
+        'focuses existing popup if already open',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Suite Web Connect (webextension): If popup is already open, it should be focused instead of opening a new one',
+            }),
+        },
+        async ({ model, device, context: defaultContext }) => {
+            const { context, page, suite } = await setupWebextensionTest(
+                model,
+                device,
+                defaultContext,
+                'connect-explorer-webextension-focus',
+            );
 
-                try {
-                    // Start the address flow but don't finish it
-                    await suite.getByTestId('@connect-address-confirmation/confirm-button').click();
+            try {
+                // Start the address flow but don't finish it
+                await suite.getByTestId('@connect-address-confirmation/confirm-button').click();
 
-                    await expect(
-                        suite.getByTestId('@connect-address-confirmation/verify-button/0'),
-                    ).toBeDisabled();
-                    await suite.waitForTimeout(1000);
-                    await device.pressYes();
+                await expect(
+                    suite.getByTestId('@connect-address-confirmation/verify-button/0'),
+                ).toBeDisabled();
+                await suite.waitForTimeout(1000);
+                await device.pressYes();
 
-                    await expect(
-                        suite.getByTestId('@connect-address-confirmation/verified-badge/0'),
-                    ).toBeVisible();
+                await expect(
+                    suite.getByTestId('@connect-address-confirmation/verified-badge/0'),
+                ).toBeVisible();
 
-                    // Switch focus back to the extension and click submit again
-                    await page.bringToFront();
+                // Switch focus back to the extension and click submit again
+                await page.bringToFront();
 
-                    // Count pages before second click
-                    const pageCountBefore = context.pages().length;
+                // Count pages before second click
+                const pageCountBefore = context.pages().length;
 
-                    await page.getByTestId('@submit-button').click();
+                await page.getByTestId('@submit-button').click();
 
-                    // Wait a bit and verify no new page was opened
-                    await page.waitForTimeout(2000);
-                    const pageCountAfter = context.pages().length;
+                // Wait a bit and verify no new page was opened
+                await page.waitForTimeout(2000);
+                const pageCountAfter = context.pages().length;
 
-                    expect(pageCountAfter).toBe(pageCountBefore);
+                expect(pageCountAfter).toBe(pageCountBefore);
 
-                    // The original Suite popup should still be open
-                    expect(suite.isClosed()).toBe(false);
+                // The original Suite popup should still be open
+                expect(suite.isClosed()).toBe(false);
 
-                    // Clean up
-                    await suite.close();
-                } finally {
-                    await context.close();
-                }
-            },
-        );
-    },
-);
+                // Clean up
+                await suite.close();
+            } finally {
+                await context.close();
+            }
+        },
+    );
+});

--- a/suite/e2e/tests/wallet/add-account-types.test.ts
+++ b/suite/e2e/tests/wallet/add-account-types.test.ts
@@ -6,7 +6,7 @@ import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 import { ExtractByEventType } from '../../support/types';
 
-test.describe('Account types suite', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
+test.describe('Account types suite', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({
         deviceSetup: {
             mnemonic: 'town grace cat forest dress dust trick practice hair survey pupil regular',

--- a/suite/e2e/tests/wallet/cardano.test.ts
+++ b/suite/e2e/tests/wallet/cardano.test.ts
@@ -10,7 +10,7 @@ const receiveAddress =
 // todo: setup emu with 24 words mnemonic so that we can test different cardano derivation and its 'auto-discovery; feature
 //mnemonic: 'clot trim improve bag pigeon party wave mechanic beyond clean cake maze protect left assist carry guitar bridge nest faith critic excuse tooth dutch',
 
-test.describe('Cardano', { tag: ['@nightlyOnly', '@T3W1', '@T3T1', '@smoke'] }, () => {
+test.describe('Cardano', { tag: ['@nightlyOnly', '@T3W1', '@T3T1'] }, () => {
     test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
         await settingsPage.changeNetworks({ enableNetworks: ['ada'] });

--- a/suite/e2e/tests/wallet/discovery.test.ts
+++ b/suite/e2e/tests/wallet/discovery.test.ts
@@ -19,7 +19,7 @@ const coinsToActivate: NetworkSymbol[] = [
     'zec',
 ];
 
-test.describe('Discovery', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
+test.describe('Discovery', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
     });

--- a/suite/e2e/tests/wallet/receive.test.ts
+++ b/suite/e2e/tests/wallet/receive.test.ts
@@ -5,7 +5,7 @@ import { DEVICE_RENDERED_EVM_INDENT } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
-test.describe('Receive transaction', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
+test.describe('Receive transaction', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({
         contextOptions: {
             permissions: ['clipboard-read', 'clipboard-write'],

--- a/suite/e2e/tests/wallet/send-eth.test.ts
+++ b/suite/e2e/tests/wallet/send-eth.test.ts
@@ -19,7 +19,7 @@ const maxPriorityFeePerGasRounded = new BigNumber(maxPriorityFeePerGas).decimalP
     BigNumber.ROUND_UP,
 );
 
-test.describe('Send Eth', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
+test.describe('Send Eth', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({ deviceSetup: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
 
     test.beforeEach(async ({ onboardingPage, dashboardPage, walletPage, settingsPage }) => {

--- a/suite/e2e/tests/wallet/send-sol.test.ts
+++ b/suite/e2e/tests/wallet/send-sol.test.ts
@@ -14,7 +14,7 @@ const FORMATTED_ADDRESS = formatAddressWithNewlines(RECIPIENT_ADDRESS);
 const TRANSFORMED_ADDRESS = transformAddress(RECIPIENT_ADDRESS, 'fullLine');
 const SOL_DECIMALS = getNetwork('sol').decimals;
 
-test.describe('Send - Solana', { tag: ['@webOnly', '@T3T1', '@T3W1', '@smoke'] }, () => {
+test.describe('Send - Solana', { tag: ['@webOnly', '@T3T1', '@T3W1'] }, () => {
     test.use({
         deviceSetup: {
             mnemonic: 'mnemonic_academic',

--- a/suite/e2e/tests/wallet/sign-and-verify.test.ts
+++ b/suite/e2e/tests/wallet/sign-and-verify.test.ts
@@ -8,7 +8,7 @@ const SIGNATURE =
 const ELECTRUM_SIGNATURE =
     'HxpInbBQH8LYgBBnRt4/QCV+HBW3hL1o1Yg85biWX1DdBTbfN96pyLL7tLQdYn+VtjvuZWJhEYbUCasjZLmih6w=';
 
-test.describe('Sign and verify', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
+test.describe('Sign and verify', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({ deviceSetup: { mnemonic: 'mnemonic_all' } });
 
     test.beforeEach(async ({ page, walletPage, onboardingPage, settingsPage }) => {

--- a/suite/e2e/tests/wallet/transactions.test.ts
+++ b/suite/e2e/tests/wallet/transactions.test.ts
@@ -11,7 +11,7 @@ const rangeData: { range: graphRangeOptions; label: string }[] = [
     { range: 'all', label: messages['TR_ALL'].defaultMessage },
 ];
 
-test.describe('Account transactions overview', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
+test.describe('Account transactions overview', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({ deviceSetup: { mnemonic: 'mnemonic_all' } });
 
     test.beforeEach(async ({ onboardingPage, settingsPage }) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

TLDR: @smoke tag was confusing and didn't bring the intended value -> this PR removes it.

Our original concept @smoke tag was a way how to optimize test runs and save currents quota. The system was not easy to understand. I brainstormed how to improve it and make it more clear but ultimately I failed. So I questioned its value and did following analysis. As result of that, this PR remove the functionality completely

# T3T1-on-PR value analysis (Currents, 90 days, ~2,400–2,700 paired runs/test)

**Question:** does running `@smoke` tests on **T3T1** on PR catch any failure the **T3W1** run doesn't?
**W** = failed only on T3W1, **T** = failed only on T3T1 (the value-case). Both pipelines (PR + nightly), canary excluded.

### Desktop (project 4ytF0E)

| Test | bothFail | W | T | flake W:T | Verdict |
|---|--:|--:|--:|--:|---|
| toggle · enabled | 8 | 2 | 0 | 52:6 | clean |
| toggle · disabled | 8 | 0 | 0 | 50:0 | clean |
| sign-verify · verify-btc | 0 | 0 | 0 | 52:1 | clean |
| sign-verify · electrum | 5 | 2 | 0 | 42:2 | clean |
| sign-verify · signs-btc | 1 | 1 | 0 | 97:0 | clean |
| transactions | 11 | 0 | 0 | 68:0 | clean |
| discovery | 501 | 97 | 98 | 156:36 | Caused by instable cardano |
| recovery · partial | 9 | 4 | 0 | 48:1 | clean |
| recovery · standard | 8 | 3 | 1 | 146:1 | T3T1-only = timeout flake |
| recovery · reconnection | 9 | 4 | 0 | 65:0 | clean |
| send-eth | 37 | 0 | 0 | 56:1 | clean (deep-dived) |
| assets · new | 5 | 1 | 0 | 50:3 | clean |
| assets · buy-grid | 5 | 1 | 0 | 83:10 | clean |
| assets · buy-table | 5 | 0 | 0 | 71:0 | clean |
| receive · TRX | 8 | 1 | 0 | 67:0 | clean |
| receive · ETH | 12 | 2 | 1 | 56:2 | T3T1-only = timeout flake |
| receive · BTC | 4 | 1 | 0 | 119:0 | clean |
| receive · SOL | 5 | 2 | 0 | 59:16 | clean |
| add-account · btc-like | 0 | 0 | 0 | 73:11 | clean |
| add-account · ada | 3 | 0 | 0 | 5:0 | clean (few runs) |
| add-account · non-BTC | 1081 | 69 | 57 | 48:19 | Caused by instable cardano |
| coins | 101 | 8 | 0 | 57:5 | clean (T3W1-skewed) |
| coins-backend · btc-ok | 6 | 0 | 0 | 117:1 | clean |
| coins-backend · eth-wrong | 8 | 0 | 0 | 63:0 | clean |
| coins-backend · eth-ok | 12 | 0 | 0 | 66:0 | clean |
| coins-backend · btc-wrong | 2 | 0 | 0 | 61:0 | clean |
| general | 1 | 0 | 0 | 59:0 | clean |

### Web (project Og0NOQ, @webOnly tests)

| Test | bothFail | W | T | flake W:T | Verdict |
|---|--:|--:|--:|--:|---|
| send-sol | 2 | 2 | 2 | 50:41 | symmetric + timeouts → flaky |
| analytics/events | 5 | 1 | 0 | 5:2 | clean |
| account-metadata | 716 | 0 | 1 | 4:2 | ⚠️ quarantined; load flake |
| wallet-metadata · labels | 541 | 12 | 3 | 6:32 | ⚠️ quarantined; device/load flakes |
| wallet-metadata · persists | 544 | 12 | 2 | 13:31 | ⚠️ quarantined; device/load flakes |

### Bottom line

- **20 of 32 tests have zero T3T1-only failures.** Every remaining T3T1-only failure is either **symmetric** with T3W1 inside a heavily-quarantined test (flaky instability) or an **isolated generic timeout / Suite-load / device-prompt flake**.
- **No test shows a T3T1-skewed failure pattern** — the fingerprint of T3T1 catching a unique regression. Globally T3W1 is the *flakier* model (one-sided W:T ≈ 225:165, and the T3T1 excess lives entirely in quarantined-test symmetry).
- Over 90 days, **running `@smoke` tests on T3T1 on PR caught no T3T1-specific product regression** — matching the product-side analysis (Suite/connect send identical instructions to both flagships; the only divergence is firmware-rendered display, which a Suite PR can't change).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=cleanup-smoke&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=cleanup-smoke&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=cleanup-smoke&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-26T09:53:31.653Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |

</details>

_Updated: 2026-06-26T09:51:36.357Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/cleanup-smoke/web/](https://dev.suite.sldev.cz/suite-web/cleanup-smoke/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->