### PR TITLE
test(e2e): adds ignore to toast error in negative test

### DIFF
--- a/suite/e2e/support/common.ts
+++ b/suite/e2e/support/common.ts
@@ -1,3 +1,5 @@
+import { createIntl, createIntlCache } from 'react-intl';
+
 import test, { Locator, Page, TestInfo } from '@playwright/test';
 import { isEqual, omit } from 'lodash';
 import { readdirSync } from 'node:fs';
@@ -227,3 +229,12 @@ export const sanitizeAndStringifyLogFields = (fields: Record<string, unknown>) =
 
 export const toADA = (lovelace: number, options?: { maxDecimals?: number }) =>
     `${localizeNumber(lovelace / 1000000, 'en-US', 0, options?.maxDecimals ?? 6)} ADA`;
+
+export const replaceTemplatesInTranslation = (
+    template: string,
+    values: Record<string, string | number>,
+) => {
+    const intlEn = createIntl({ locale: 'en', messages: {} }, createIntlCache());
+
+    return intlEn.formatMessage({ id: template, defaultMessage: template }, values);
+};

--- a/suite/e2e/tests/passphrase/passphrase-cardano.test.ts
+++ b/suite/e2e/tests/passphrase/passphrase-cardano.test.ts
@@ -1,12 +1,21 @@
-import { formatAddress } from '../../support/common';
+import { messages } from '@suite/intl';
+
+import { formatAddress, replaceTemplatesInTranslation } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 const correctPassphraseAddr =
     'addr1qx3ufjpwcx30ee73a7r29surauze6yt0jvr7c3rnahw0hnppg7qp5xvslcfucsqqayrtjhm4u66xsw987ae6ugydlzzsqdsfz4';
 const passphrase = 'secret passphrase A';
+const toastErrorMessage = replaceTemplatesInTranslation(
+    messages.TOAST_VERIFY_ADDRESS_ERROR.defaultMessage,
+    { error: 'Passphrase is incorrect' },
+);
 
 test.describe('Passphrase with cardano', { tag: ['@nightlyOnly', '@T3W1', '@T3T1'] }, () => {
-    test.use({ deviceSetup: { mnemonic: 'mnemonic_all', passphrase_protection: true } });
+    test.use({
+        deviceSetup: { mnemonic: 'mnemonic_all', passphrase_protection: true },
+        ignoreToastErrors: [toastErrorMessage],
+    });
 
     test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();

--- a/suite/e2e/tests/wallet/send-doge.test.ts
+++ b/suite/e2e/tests/wallet/send-doge.test.ts
@@ -1,7 +1,13 @@
+import { messages } from '@suite/intl';
 import { localizeNumber } from '@suite-common/wallet-utils';
 
-import { formatAddressWithNewlines } from '../../support/common';
+import { formatAddressWithNewlines, replaceTemplatesInTranslation } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
+
+const signTxErrorMessage = replaceTemplatesInTranslation(
+    messages.TOAST_SIGN_TX_ERROR.defaultMessage,
+    { error: 'Invalid amount specified' },
+);
 
 test.describe('Doge Send', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({
@@ -9,7 +15,7 @@ test.describe('Doge Send', { tag: ['@T3W1', '@T3T1'] }, () => {
             mnemonic:
                 'fantasy auto fancy access ring spring patrol expect common tape talent annual',
         },
-        ignoreToastErrors: ['Invalid amount specified'],
+        ignoreToastErrors: [signTxErrorMessage],
     });
 
     const recipientAddress = 'DJk8vtoEuNGtT4YRNoqVxWyRh6kM3s8bzc';
@@ -65,8 +71,6 @@ test.describe('Doge Send', { tag: ['@T3W1', '@T3T1'] }, () => {
             await device.pressYes();
         });
 
-        await expect(page.getByTestId('@toast/sign-tx-error')).toHaveText(
-            'Transaction signing error: Invalid amount specified',
-        );
+        await expect(page.getByTestId('@toast/sign-tx-error')).toHaveText(signTxErrorMessage);
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Another cleanup of the new toast error tracking -> this test is nightly only and was in quarantine before.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-fixes-6-26&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-fixes-6-26&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-26T07:17:09.070Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |

</details>

_Updated: 2026-06-26T07:16:08.523Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-fixes-6-26/web/](https://dev.suite.sldev.cz/suite-web/test-fixes-6-26/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->