### PR TITLE
fix(suite): settings locator fix

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/DustPhishing.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/DustPhishing.tsx
@@ -83,7 +83,7 @@ export const DustPhishing = () => {
                             <Switch
                                 isChecked={dustPhishingIsEnabled}
                                 onChange={onSwitchChange}
-                                data-testid="@settings/auto-eject-switch"
+                                data-testid="@settings/dust-phishing-switch"
                             />
                         </ActionColumn>
                     </SectionItem>

--- a/packages/suite/src/views/settings/SettingsGeneral/MevProtection.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/MevProtection.tsx
@@ -63,7 +63,7 @@ export const MevProtection = () => {
                         <Switch
                             isChecked={isMevProtectionEnabled}
                             onChange={handleSwitchChange}
-                            data-testid="@settings/auto-eject-switch"
+                            data-testid="@settings/mev-protection-switch"
                         />
                     </ActionColumn>
                 </SectionItem>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to two UI components (DustPhishing.tsx and MevProtection.tsx) within the SettingsGeneral view. Both files map to 91 tests via static coverage, which strongly indicates they are broad transitive dependencies through the settings page module rather than directly exercised by most tests. The only test that directly exercises the general settings page UI is settings/general.test.ts. The analytics/toggle.test.ts is included as medium priority since it also interacts with the application settings page. All other 89 tests are omitted as they have no specific interaction with dust phishing or MEV protection settings.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/views/settings/SettingsGeneral/DustPhishing.tsx`
- `packages/suite/src/views/settings/SettingsGeneral/MevProtection.tsx`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — This test directly exercises the Settings > Application (General) page where DustPhishing.tsx and MevProtection.tsx are rendered. It navigates to settingsPage.navigateTo('application') and interacts with various general settings components. Changes to these settings components could affect rendering or layout of the general settings page.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/analytics/toggle.test.ts` — This test navigates to the Settings > Application page and interacts with toggles and settings components. DustPhishing and MevProtection are sibling components on the same settings page, so a rendering error in either could break the analytics toggle interaction flow.

</details>

_Updated: 2026-06-26T07:45:31.494Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/settings-dataid&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/settings-dataid&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-26T07:50:05.122Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |

</details>

_Updated: 2026-06-26T07:47:46.315Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/settings-dataid/web/](https://dev.suite.sldev.cz/suite-web/fix/settings-dataid/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->