### PR TITLE
Use turn on suite sync guard again

### DIFF
--- a/packages/suite-desktop-ui/tsconfig.json
+++ b/packages/suite-desktop-ui/tsconfig.json
@@ -2,9 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
         "outDir": "libDev",
-        "paths": {
-            "src/*": ["../suite/src/*"]
-        }
+        "paths": { "src/*": ["../suite/src/*"] }
     },
     "include": ["."],
     "references": [

--- a/packages/suite-web/tsconfig.json
+++ b/packages/suite-web/tsconfig.json
@@ -2,9 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
         "outDir": "./libDev",
-        "paths": {
-            "src/*": ["../suite/src/*"]
-        }
+        "paths": { "src/*": ["../suite/src/*"] }
     },
     "include": ["."],
     "references": [

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -8,9 +8,7 @@
             }
         ],
         "outDir": "./libDev",
-        "paths": {
-            "src/*": ["./src/*"]
-        }
+        "paths": { "src/*": ["./src/*"] }
     },
     "include": [".", "e2e", "**/*.json"],
     "references": [

--- a/suite-native/alerts/package.json
+++ b/suite-native/alerts/package.json
@@ -16,6 +16,7 @@
         "@trezor/env-utils": "workspace:*",
         "@trezor/styles-native": "workspace:*",
         "@trezor/theme": "workspace:*",
+        "@trezor/type-utils": "workspace:*",
         "jotai": "2.17.1",
         "react": "19.2.4",
         "react-native": "0.83.2",

--- a/suite-native/alerts/src/index.ts
+++ b/suite-native/alerts/src/index.ts
@@ -1,3 +1,4 @@
 export * from './components/AlertRenderer';
 export * from './useAlert';
+export * from './useShowAlertResult';
 export * from './alertsAtoms';

--- a/suite-native/alerts/src/useShowAlertResult.ts
+++ b/suite-native/alerts/src/useShowAlertResult.ts
@@ -1,0 +1,38 @@
+import { type Result, err, ok } from '@trezor/type-utils';
+
+import { type Alert } from './alertsAtoms';
+import { useAlert } from './useAlert';
+
+type AlertResult = Result<void, { type: 'cancelled' }>;
+
+type ShowAlertResultParams = Omit<Alert, 'onPressPrimaryButton' | 'onPressSecondaryButton'> & {
+    onPressPrimaryButton?: () => AlertResult | Promise<AlertResult> | void;
+    onPressSecondaryButton?: () => AlertResult | Promise<AlertResult> | void;
+};
+
+export const useShowAlertResult = () => {
+    const { showAlert } = useAlert();
+
+    const showAlertResult = ({
+        onPressPrimaryButton,
+        onPressSecondaryButton,
+        ...alert
+    }: ShowAlertResultParams): Promise<AlertResult> =>
+        new Promise(resolve =>
+            showAlert({
+                ...alert,
+                onPressPrimaryButton: () => {
+                    void Promise.resolve(onPressPrimaryButton?.()).then(result =>
+                        resolve(result ?? ok()),
+                    );
+                },
+                onPressSecondaryButton: () => {
+                    void Promise.resolve(onPressSecondaryButton?.()).then(result =>
+                        resolve(result ?? err({ type: 'cancelled' })),
+                    );
+                },
+            }),
+        );
+
+    return { showAlertResult };
+};

--- a/suite-native/alerts/tsconfig.json
+++ b/suite-native/alerts/tsconfig.json
@@ -8,6 +8,7 @@
         {
             "path": "../../packages/styles-native"
         },
-        { "path": "../../packages/theme" }
+        { "path": "../../packages/theme" },
+        { "path": "../../packages/type-utils" }
     ]
 }

--- a/suite-native/labeling/src/EditableLabelLayout.tsx
+++ b/suite-native/labeling/src/EditableLabelLayout.tsx
@@ -19,7 +19,7 @@ type EditableLabelLayoutParams = {
 export const EditableLabelLayout = ({ children, label, testID }: EditableLabelLayoutParams) => {
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
 
-    const { handleAddLabel } = useTurnOnSuiteSyncGuard();
+    const { handleAddLabel, isInProgress } = useTurnOnSuiteSyncGuard();
 
     const isLabellingAllowed = useSelector(selectIsLabellingAllowed);
 
@@ -35,6 +35,7 @@ export const EditableLabelLayout = ({ children, label, testID }: EditableLabelLa
                 iconRight="pencil"
                 testID={testID}
                 size="small"
+                isLoading={isInProgress}
             >
                 {label ?? <Translation id="suiteSync.addLabel" />}
             </TextButton>

--- a/suite-native/module-accounts-management/src/components/AccountRenameButton.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountRenameButton.tsx
@@ -16,7 +16,7 @@ export const AccountRenameButton = ({ accountKey }: AccountRenameModalProps) => 
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
 
     const isLabellingAllowed = useSelector(selectIsLabellingAllowed);
-    const { handleAddLabel } = useTurnOnSuiteSyncGuard();
+    const { handleAddLabel, isInProgress } = useTurnOnSuiteSyncGuard();
 
     const handleTriggerAccountRename = () => {
         if (isLabellingAllowed) {
@@ -32,8 +32,10 @@ export const AccountRenameButton = ({ accountKey }: AccountRenameModalProps) => 
                 intent="neutral"
                 priority="secondary"
                 iconName="pencilSimple"
+                size="medium"
                 onPress={handleTriggerAccountRename}
                 testID="@account-detail/settings/edit-button"
+                isLoading={isInProgress}
             />
             <BottomSheetModal
                 isCloseDisplayed

--- a/suite-native/suite-sync/src/useTurnOnSuiteSyncGuard.tsx
+++ b/suite-native/suite-sync/src/useTurnOnSuiteSyncGuard.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
@@ -14,7 +14,7 @@ import {
     selectEnsureWalletSuiteSyncOnDep,
     selectTurnOnSuiteSyncDep,
 } from '@suite-common/suite-sync-types';
-import { useAlert } from '@suite-native/alerts';
+import { useAlert, useShowAlertResult } from '@suite-native/alerts';
 import { Translation } from '@suite-native/intl';
 import {
     AuthorizeDeviceStackRoutes,
@@ -23,14 +23,18 @@ import {
     RootStackRoutes,
     type StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
-import { exhaustive } from '@trezor/type-utils';
+import { type Result, err, exhaustive, ok } from '@trezor/type-utils';
 
 import { useShowSuiteSyncEnabledToast } from './useShowSuiteSyncEnabledToast';
 import { useSuiteSyncErrorHandler } from './useSuiteSyncErrorHandler';
 
+type AddLabelSuiteSyncGuardResult = Result<void, { type: 'cancelled' }>;
+
 export const useTurnOnSuiteSyncGuard = () => {
     const { showAlert } = useAlert();
-    const isAddLabelRequestInProgressRef = useRef(false);
+    const { showAlertResult } = useShowAlertResult();
+
+    const [isInProgress, setIsInProgress] = useState(false);
 
     const { ensureWalletSuiteSyncOn, turnOnSuiteSync } = useServices(
         selectEnsureWalletSuiteSyncOnDep,
@@ -50,9 +54,8 @@ export const useTurnOnSuiteSyncGuard = () => {
     const deviceStaticSessionId = useSelector(selectDeviceStaticSessionId);
     const isDeviceConnected = useSelector(selectIsDeviceConnected);
 
-    const suiteSyncInteraction = useSelector(
-        (state: WithSuiteSyncAndDeviceState & MessageSystemRootState) =>
-            selectSuiteSyncInteraction(state, deviceStaticSessionId),
+    const interaction = useSelector((state: WithSuiteSyncAndDeviceState & MessageSystemRootState) =>
+        selectSuiteSyncInteraction(state, deviceStaticSessionId),
     );
 
     const showSuiteSyncFirmwareUpgradeAlert = () => {
@@ -76,80 +79,56 @@ export const useTurnOnSuiteSyncGuard = () => {
         });
     };
 
-    const handleTurnOnSuiteSync = async (onSuccess: () => void) => {
-        if (!deviceStaticSessionId) return;
+    const handleTurnOnSuiteSync = async (): Promise<AddLabelSuiteSyncGuardResult> => {
+        if (!deviceStaticSessionId) {
+            return err({ type: 'cancelled' });
+        }
 
         const result = await turnOnSuiteSync({ deviceStaticSessionId });
 
         if (!result.success) {
             handleSuiteSyncError(result.error);
 
-            return;
+            return err({ type: 'cancelled' });
         }
 
         showSuiteSyncEnabledToast();
 
-        onSuccess();
+        return ok();
     };
 
-    const showSuiteSyncEnableConfirmationAlert = ({
-        onSuccess,
-        onCancel,
-    }: {
-        onSuccess: () => void;
-        onCancel: () => void;
-    }) => {
+    const confirmSuiteSyncEnable = (): Promise<AddLabelSuiteSyncGuardResult> => {
         if (!isDeviceConnected) {
             navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
                 screen: AuthorizeDeviceStackRoutes.DeviceConnectionGuard,
             });
-            onCancel();
-        } else {
-            showAlert({
-                title: <Translation id="suiteSync.enableAlert.title" />,
-                description: <Translation id="suiteSync.enableAlert.description" />,
-                primaryButtonTitle: <Translation id="suiteSync.enableAlert.cta" />,
-                onPressPrimaryButton: () => handleTurnOnSuiteSync(onSuccess),
-                secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
-                onPressSecondaryButton: onCancel,
-            });
+
+            return Promise.resolve(err({ type: 'cancelled' }));
         }
+
+        return showAlertResult({
+            title: <Translation id="suiteSync.enableAlert.title" />,
+            description: <Translation id="suiteSync.enableAlert.description" />,
+            primaryButtonTitle: <Translation id="suiteSync.enableAlert.cta" />,
+            onPressPrimaryButton: handleTurnOnSuiteSync,
+            secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
+        });
     };
 
-    const handleAddLabel = async (onSuccess: () => void) => {
-        if (isAddLabelRequestInProgressRef.current) return;
-
-        isAddLabelRequestInProgressRef.current = true;
-
-        const releaseAddLabelRequest = () => {
-            isAddLabelRequestInProgressRef.current = false;
-        };
-
-        const handleSuccess = () => {
-            releaseAddLabelRequest();
-            onSuccess();
-        };
-
-        switch (suiteSyncInteraction) {
-            case 'suite-sync-off':
-                showSuiteSyncEnableConfirmationAlert({
-                    onSuccess: handleSuccess,
-                    onCancel: releaseAddLabelRequest,
-                });
-
-                return;
+    const ensureSuiteSyncReadyForAddLabel = async (): Promise<AddLabelSuiteSyncGuardResult> => {
+        switch (interaction) {
+            case 'suite-sync-off': {
+                return confirmSuiteSyncEnable();
+            }
 
             case 'firmware-upgrade-needed':
                 showSuiteSyncFirmwareUpgradeAlert();
-                releaseAddLabelRequest(); // Alert only informative, it then redirects user.
 
-                return;
+                return err({ type: 'cancelled' });
 
             case 'keys-needed': {
                 if (!deviceStaticSessionId) {
-                    releaseAddLabelRequest();
-
-                    return;
+                    return err({ type: 'cancelled' });
                 }
 
                 const result = await ensureWalletSuiteSyncOn({
@@ -160,26 +139,34 @@ export const useTurnOnSuiteSyncGuard = () => {
                 if (!result.success) {
                     handleSuiteSyncError(result.error);
 
-                    releaseAddLabelRequest();
-
-                    return;
+                    return err({ type: 'cancelled' });
                 }
 
-                handleSuccess();
-
-                return;
+                return ok();
             }
 
             case 'unsupported':
             case null:
-                handleSuccess();
-
-                return;
+                return ok();
 
             default:
-                return exhaustive(suiteSyncInteraction);
+                return exhaustive(interaction);
         }
     };
 
-    return { handleAddLabel };
+    const handleAddLabel = async (onSuccess: () => void) => {
+        if (isInProgress) return;
+
+        setIsInProgress(true);
+
+        const result = await ensureSuiteSyncReadyForAddLabel();
+
+        setIsInProgress(false);
+
+        if (result.success) {
+            onSuccess();
+        }
+    };
+
+    return { handleAddLabel, isInProgress };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11695,6 +11695,7 @@ __metadata:
     "@trezor/env-utils": "workspace:*"
     "@trezor/styles-native": "workspace:*"
     "@trezor/theme": "workspace:*"
+    "@trezor/type-utils": "workspace:*"
     jotai: "npm:2.17.1"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/28980#issuecomment-4800859449 and resolves https://github.com/trezor/trezor-suite/issues/28978

## Notes for QA
See issue and comment

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set is predominantly focused on suite-native code (alerts, labeling, suite-sync, accounts-management) and tsconfig adjustments for web/desktop packages. The suite-native changes are for the mobile/native app and have no direct E2E test coverage in the web/desktop Playwright test suite. The tsconfig.json changes are build configuration only and pose minimal runtime risk. The one directly changed E2E test (unsupported-device.test.ts) must be run. Suite Sync-related tests are recommended at medium priority since useTurnOnSuiteSyncGuard.tsx changes could conceptually affect shared Suite Sync logic, though the native and web implementations may be separate.

<details><summary><b>Changed files (11)</b></summary>

- `packages/suite-desktop-ui/tsconfig.json`
- `packages/suite-web/tsconfig.json`
- `packages/suite/tsconfig.json`
- `suite-native/alerts/package.json`
- `suite-native/alerts/src/index.ts`
- `suite-native/alerts/src/useShowAlertResult.ts`
- `suite-native/alerts/tsconfig.json`
- `suite-native/labeling/src/EditableLabelLayout.tsx`
- `suite-native/module-accounts-management/src/components/AccountRenameButton.tsx`
- `suite-native/suite-sync/src/useTurnOnSuiteSyncGuard.tsx`
- `suite/e2e/tests/metadata/suite-sync/unsupported-device.test.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/unsupported-device.test.ts` — This test file itself is listed as a changed file in the PR. It must be run to validate that the test changes are correct and pass.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — The changed file suite-native/suite-sync/src/useTurnOnSuiteSyncGuard.tsx modifies Suite Sync guard logic. This test exercises Suite Sync enablement flows across multiple wallets including the Suite Sync banner and device confirmation, which could be affected by changes to the sync guard.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test enables Suite Sync and creates labels (account, wallet, address, output), exercising the Suite Sync enablement path that useTurnOnSuiteSyncGuard.tsx may gate. Changes to the sync guard could affect whether Suite Sync can be turned on.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test sets up Suite Sync from the relay side and requires device confirmation for Suite Sync enablement. Changes to useTurnOnSuiteSyncGuard.tsx could affect the sync setup flow tested here.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test enables Suite Sync and removes previously synced labels. It exercises the Suite Sync enablement flow which could be affected by changes to the sync guard logic.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — This test migrates legacy labels to Suite Sync, which involves the Suite Sync enablement path. The EditableLabelLayout.tsx change in suite-native/labeling could share labeling infrastructure concepts, though the E2E tests target the web/desktop suite rather than native.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test migrates legacy Dropbox labels to Suite Sync. While the core migration logic is in shared packages, the Suite Sync guard change could affect the enablement flow tested here.

</details>

⚠️ **Changes with no test coverage (9)**
- `packages/suite-desktop-ui/tsconfig.json`
- `packages/suite-web/tsconfig.json`
- `packages/suite/tsconfig.json`
- `suite-native/alerts/package.json`
- `suite-native/alerts/src/index.ts`
- `suite-native/alerts/src/useShowAlertResult.ts`
- `suite-native/alerts/tsconfig.json`
- `suite-native/labeling/src/EditableLabelLayout.tsx`
- `suite-native/module-accounts-management/src/components/AccountRenameButton.tsx`

_Updated: 2026-06-29T15:41:43.249Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=useTurnOnSuiteSyncGuard-again&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=useTurnOnSuiteSyncGuard-again&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=useTurnOnSuiteSyncGuard-again&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-30T08:28:08.141Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-30T08:26:32.433Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/useTurnOnSuiteSyncGuard-again/web/](https://dev.suite.sldev.cz/suite-web/useTurnOnSuiteSyncGuard-again/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->