### PR TITLE
chore(analytics): add onboarding feedback banner event

### DIFF
--- a/suite-common/analytics/src/constants.ts
+++ b/suite-common/analytics/src/constants.ts
@@ -29,5 +29,6 @@ export enum EventType {
     CoinDiscovery = 'coin_discovery',
     AccountsBalance = 'accounts/balance',
     OnboardingStepViewed = 'onboarding/step-viewed',
+    OnboardingFeedbackBannerClicked = 'onboarding/feedback-banner',
     PromoNoDeviceEshopCta = 'promo/no-device-eshop-cta',
 }

--- a/suite-common/analytics/src/events/index.ts
+++ b/suite-common/analytics/src/events/index.ts
@@ -20,6 +20,10 @@ export {
     onboardingStepViewedEvent,
     type DeviceOnboardingStepName,
 } from './onboardingStepViewedEvent';
+export {
+    onboardingFeedbackBannerClickedEvent,
+    type OnboardingFeedbackBannerOrigin,
+} from './onboardingFeedbackBannerClickedEvent';
 export { suiteSyncLabelCreatedEvent } from './suiteSyncLabelCreatedEvent';
 export { walletBalanceEvent } from './walletBalanceEvent';
 export {

--- a/suite-common/analytics/src/events/onboardingFeedbackBannerClickedEvent.ts
+++ b/suite-common/analytics/src/events/onboardingFeedbackBannerClickedEvent.ts
@@ -1,0 +1,40 @@
+import { EventType } from '../constants';
+import type { AnalyticsPlatform, AttributeDef, EventDef } from '../eventDefinition';
+
+export type OnboardingFeedbackBannerOrigin = 'postOnboardingDashboard';
+type OnboardingFeedbackBannerAction = 'cta' | 'close';
+
+type Attributes = {
+    platform: AttributeDef<AnalyticsPlatform>;
+    origin: AttributeDef<OnboardingFeedbackBannerOrigin>;
+    action: AttributeDef<OnboardingFeedbackBannerAction>;
+};
+
+export const onboardingFeedbackBannerClickedEvent: EventDef<
+    Attributes,
+    EventType.OnboardingFeedbackBannerClicked
+> = {
+    name: EventType.OnboardingFeedbackBannerClicked,
+    descriptionTrigger:
+        'Fired when the user interacts with the one-time onboarding feedback banner shown on the first post-onboarding dashboard — either by opening the survey (`cta`) or dismissing the banner (`close`). Emitted by both desktop and mobile app.',
+    description:
+        'Measures engagement with the post-onboarding feedback ask. The banner opens a survey about the setup experience; this event tracks how many freshly-onboarded users open it versus dismiss it.',
+    changelog: [{ version: '26.7.1', notes: 'added' }],
+
+    attributes: {
+        platform: {
+            changelog: [{ version: '26.7.1', notes: 'added' }],
+            description: '`desktop` or `mobile`, identifying which app emitted the event.',
+        },
+        origin: {
+            changelog: [{ version: '26.7.1', notes: 'added' }],
+            description:
+                'Where the banner was shown. Currently always `postOnboardingDashboard` (first dashboard after completing device onboarding).',
+        },
+        action: {
+            changelog: [{ version: '26.7.1', notes: 'added' }],
+            description:
+                'What action was taken: `cta` (opened the feedback survey) or `close` (dismissed the banner).',
+        },
+    },
+};


### PR DESCRIPTION
## Description

Adds the cross-platform analytics event `onboarding/feedback-banner` to `suite-common/analytics` so it can be reused by both Desktop and Mobile.

The event fires when the user interacts with the one-time post-onboarding feedback banner:
- `action: 'cta'` — opened the feedback survey
- `action: 'close'` — dismissed the banner

Attributes:
- `platform` — `desktop` or `mobile` (not auto-injected; both apps report under `app: 'suite'`, so it must be explicit to split reporting)
- `origin` — currently always `postOnboardingDashboard`
- `action` — `cta` | `close`

This PR is analytics-only; the Mobile banner UI that emits the event is implemented separately.

## Notes for QA

No user-facing changes in this PR — it only defines the analytics event. Nothing to test in the app.

## Related Issue

Relates to  #28960 and #28959 

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes add a new analytics event (onboardingFeedbackBannerClickedEvent) and modify the analytics constants and events index. The primary risk is breaking existing analytics event type definitions or event registration. Analytics-focused tests should be prioritized since they directly validate event types and payloads. The new event file itself likely lacks direct E2E test coverage, so the guide/feedback test is recommended as the closest proxy for validating onboarding feedback-related analytics.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/analytics/src/constants.ts`
- `suite-common/analytics/src/events/index.ts`
- `suite-common/analytics/src/events/onboardingFeedbackBannerClickedEvent.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test directly validates analytics event constants and event definitions (suiteReadyEvent, deviceConnectEvent, transportTypeEvent, settingsAnalyticsEvent, etc.) from @suite/analytics. The changed files modify the analytics constants and events index, which this test imports and asserts against. Any new or modified event constant would be exercised here.
- `suite/e2e/tests/analytics/toggle.test.ts` — This test exercises the analytics event infrastructure including settingsAnalyticsEvent, suiteReadyEvent, and routerLocationChangeEvent from the analytics events module. Changes to the events index or constants could affect event payload structure or event type matching that this test validates.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — This test asserts on EventType.PromoDashboardBanner from @suite/analytics constants. Changes to the constants file could affect the event type enumeration used in assertions.
- `suite/e2e/tests/analytics/staking-events.test.ts` — This test validates EventType.StakingNavigate from @suite-common/analytics. Changes to the analytics constants or events index could affect the event type definitions this test relies on.
- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — This test validates multiple EventType constants (WalletConnectInit, WalletConnectPaired, etc.) from @suite-common/analytics. Changes to the constants or events index could impact these event type definitions.
- `suite/e2e/tests/suite/guide.test.ts` — The new file onboardingFeedbackBannerClickedEvent.ts suggests a new analytics event related to onboarding feedback. The guide test covers feedback form submission during onboarding and could exercise feedback-related analytics events. This is the closest test to validating a new onboarding feedback banner click event.
- `suite/e2e/tests/settings/general.test.ts` — This test validates analytics events for settings changes (settingsGeneralChangeFiatEvent, settingsGeneralChangeThemeEvent, settingsGeneralChangeLanguageEvent, settingsAnalyticsEvent) which are defined in the analytics events module being changed.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — The new onboardingFeedbackBannerClickedEvent suggests a UI element (feedback banner) during onboarding. This test covers the onboarding analytics consent flow and could indirectly surface issues if the new event affects the onboarding page structure.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/analytics/src/events/onboardingFeedbackBannerClickedEvent.ts`

_Updated: 2026-06-26T08:45:16.431Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/suite/promo-banner-analytics&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/suite/promo-banner-analytics&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/suite/promo-banner-analytics&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-26T08:50:26.891Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |

</details>

_Updated: 2026-06-26T08:47:51.469Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/suite/promo-banner-analytics/web/](https://dev.suite.sldev.cz/suite-web/chore/suite/promo-banner-analytics/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->