### PR TITLE
test(agent): finetune fix agent timeouts

### DIFF
--- a/.github/workflows/test-suite-nightly-fix-agent.yml
+++ b/.github/workflows/test-suite-nightly-fix-agent.yml
@@ -171,7 +171,7 @@ jobs:
     needs: [prepare-matrix, build-desktop, build-web]
     runs-on: ubuntu-24.04
     if: github.repository == 'trezor/trezor-suite' && needs.prepare-matrix.outputs.has-tasks == 'true'
-    timeout-minutes: 120
+    timeout-minutes: 210
     permissions:
       contents: write
       pull-requests: write

--- a/packages/e2e-utils/src/fixBot/fix.ts
+++ b/packages/e2e-utils/src/fixBot/fix.ts
@@ -8,7 +8,7 @@ import { processAgentOutput, runClaude } from './common';
 import { AnalysisReportSchema, FixResultJsonSchema, FixResultSchema } from './schemas';
 
 const MAX_BUDGET_USD = '10';
-const TIMEOUT_MS = 60 * 60 * 1000;
+const TIMEOUT_MS = 3 * 60 * 60 * 1000; // 3 hours
 
 function main(): void {
     const reportPath = process.env.REPORT_PATH;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix agent run is guarded by both price and time. I have seen a situation where its work was ended because of time and that is shame of loosing a already paid work -> increasing timeout and keeping the same price budget.

Dollar budge is 10$
Agent spawn process has 3 hours
GHA job has 3,5 hours

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=longer-timeout-gix-agent&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=longer-timeout-gix-agent&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/longer-timeout-gix-agent/web/](https://dev.suite.sldev.cz/suite-web/longer-timeout-gix-agent/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-26T09:09:55.603Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |

</details>

_Updated: 2026-06-26T09:08:21.241Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->