### PR TITLE
feat(suite-native-27781): refactor use isallowanceunlimited instead of ismaxallowancee

### DIFF
--- a/packages/suite/src/components/earn/yield/common/ApprovedAmountValue.tsx
+++ b/packages/suite/src/components/earn/yield/common/ApprovedAmountValue.tsx
@@ -26,7 +26,7 @@ export const ApprovedAmountValue = ({
         return <Text typographyStyle="body-md">-</Text>;
     }
 
-    if (isAllowanceUnlimited(amount, token.decimals)) {
+    if (isAllowanceUnlimited({ amount, decimals: token.decimals })) {
         return (
             <Text typographyStyle="body-md">
                 <Translation id="TR_APPROVE_AMOUNT_UNLIMITED" />

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -517,7 +517,8 @@ const getOutputLines = ({
         }
         case 'approve_data': {
             const isMaxApproval =
-                typeof token?.decimals === 'number' && isAllowanceUnlimited(value, token?.decimals);
+                typeof token?.decimals === 'number' &&
+                isAllowanceUnlimited({ amount: value, decimals: token.decimals, isSubunit: true });
             const isApprovalTx = evmTxType === 'approve';
             const type = isMaxApproval || !isApprovalTx ? 'data' : 'amount';
             const getValue = () => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -22,8 +22,8 @@ import {
     type EvmApprovalPurpose,
     findAccountsByAddress,
     getCardanoFingerprint,
+    isAllowanceUnlimited,
     isEvmApprovalTxByTextSignature,
-    isMaxAllowance,
     isTestnet,
     localizeNumber,
 } from '@suite-common/wallet-utils';
@@ -516,7 +516,8 @@ const getOutputLines = ({
             return output;
         }
         case 'approve_data': {
-            const isMaxApproval = isMaxAllowance(value);
+            const isMaxApproval =
+                typeof token?.decimals === 'number' && isAllowanceUnlimited(value, token?.decimals);
             const isApprovalTx = evmTxType === 'approve';
             const type = isMaxApproval || !isApprovalTx ? 'data' : 'amount';
             const getValue = () => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx
@@ -77,7 +77,8 @@ export const ApproveModal = (props: ApproveModalProps) => {
     const displaySymbol = getDisplaySymbol(token.symbol, token.contract);
     const hasPreapprovedAmount = !!preapprovedAmount && preapprovedAmount !== '0';
     const isPreapprovedAmountUnlimited =
-        hasPreapprovedAmount && isAllowanceUnlimited(preapprovedAmount, token.decimals);
+        hasPreapprovedAmount &&
+        isAllowanceUnlimited({ amount: preapprovedAmount, decimals: token.decimals });
 
     return (
         <FormProvider {...methods}>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx
@@ -88,7 +88,8 @@ export const RevokeModal = (props: RevokeModalProps) => {
     const displaySymbol = getDisplaySymbol(token.symbol, token.contract);
     const hasPreapprovedAmount = !!preapprovedAmount && preapprovedAmount !== '0';
     const isPreapprovedAmountUnlimited =
-        !!preapprovedAmount && isAllowanceUnlimited(preapprovedAmount, token.decimals);
+        !!preapprovedAmount &&
+        isAllowanceUnlimited({ amount: preapprovedAmount, decimals: token.decimals });
 
     const showRevokeBanner = shouldShowRevokeAllowanceBanner({
         followedByApproval,

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -29,11 +29,11 @@ import {
     getMevProtectedTxData,
     getPendingAccount,
     hasNetworkFeatures,
+    isAllowanceUnlimited,
     isCardanoTx,
     isEvmApprovalTxByTextSignature,
     isEvmYieldTxByTextSignature,
     isExchangeTradingForm,
-    isMaxAllowance,
     subunitsToUnits,
     tryGetAccountIdentity,
 } from '@suite-common/wallet-utils';
@@ -78,10 +78,6 @@ import {
     type SignTransactionError,
     type SignTransactionTimeoutError,
 } from './sendFormTypes';
-import {
-    composeTronTransactionFeeLevelsThunk,
-    signTronSendFormTransactionThunk,
-} from './tron/sendFormTronThunks';
 import { accountsActions } from '../accounts/accountsActions';
 import { selectAccountByKey } from '../accounts/accountsSelectors';
 import { syncAccountsWithBlockchainThunk } from '../blockchain/blockchainThunks';
@@ -95,6 +91,10 @@ import {
     addFakePendingEvmTxThunk,
     addFakePendingTxThunk,
 } from '../transactions/transactionsThunks';
+import {
+    composeTronTransactionFeeLevelsThunk,
+    signTronSendFormTransactionThunk,
+} from './tron/sendFormTronThunks';
 
 export const convertSendFormDraftsBtcAmountUnitsThunk = createThunk(
     `${SEND_MODULE_PREFIX}/convertSendFormDraftsBtcAmountUnitsThunk`,
@@ -366,7 +366,7 @@ export const pushSendFormTransactionThunk = createThunk<
 
             if (evmApprovalData && token) {
                 const amountString = evmApprovalData.amount.toString();
-                const isInfiniteApproval = isMaxAllowance(amountString);
+                const isInfiniteApproval = isAllowanceUnlimited(amountString, token.decimals);
                 const amount = subunitsToUnits({
                     value: asAmountSubunit(new BigNumber(amountString)),
                     decimals: token.decimals,

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -366,7 +366,11 @@ export const pushSendFormTransactionThunk = createThunk<
 
             if (evmApprovalData && token) {
                 const amountString = evmApprovalData.amount.toString();
-                const isInfiniteApproval = isAllowanceUnlimited(amountString, token.decimals);
+                const isInfiniteApproval = isAllowanceUnlimited({
+                    amount: amountString,
+                    decimals: token.decimals,
+                    isSubunit: true,
+                });
                 const amount = subunitsToUnits({
                     value: asAmountSubunit(new BigNumber(amountString)),
                     decimals: token.decimals,

--- a/suite-common/wallet-utils/src/__tests__/allowanceUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/allowanceUtils.test.ts
@@ -27,14 +27,35 @@ describe('tokenSupportsIncreasingAllowance', () => {
 });
 
 describe('isAllowanceUnlimited', () => {
-    it('treats values at or above half of UINT256_MAX as unlimited', () => {
-        expect(isAllowanceUnlimited('1000', 6)).toBe(false);
+    it('treats unit amounts at or above half of UINT256_MAX (in subunits) as unlimited', () => {
+        expect(isAllowanceUnlimited({ amount: '1000', decimals: 6 })).toBe(false);
         expect(
-            isAllowanceUnlimited(
-                '115792089237316195423570985008687907853269984665640564039457',
-                18,
-            ),
+            isAllowanceUnlimited({
+                amount: '115792089237316195423570985008687907853269984665640564039457',
+                decimals: 18,
+            }),
         ).toBe(true);
+    });
+
+    it('compares subunit amounts directly instead of scaling them again', () => {
+        // Unlimited approvals are decoded as UINT256_MAX subunits.
+        expect(
+            isAllowanceUnlimited({
+                amount: '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+                decimals: 18,
+                isSubunit: true,
+            }),
+        ).toBe(true);
+
+        // A large but finite approval (1e60 subunits) stays finite; without `isSubunit`
+        // it would be scaled by 10^18 again and mislabeled as unlimited.
+        expect(
+            isAllowanceUnlimited({
+                amount: `1${'0'.repeat(60)}`,
+                decimals: 18,
+                isSubunit: true,
+            }),
+        ).toBe(false);
     });
 });
 

--- a/suite-common/wallet-utils/src/__tests__/bigNumberUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/bigNumberUtils.test.ts
@@ -1,42 +1,8 @@
-import { UINT256_MAX } from '@suite-common/suite-constants';
 import { BigNumber } from '@trezor/utils';
 
-import { isMaxAllowance, roundToNonZeroFractionDigits } from '../bigNumberUtils';
+import { roundToNonZeroFractionDigits } from '../bigNumberUtils';
 
 describe('BigNumber utils', () => {
-    describe('isMaxAllowance', () => {
-        const maxDecimal =
-            '115792089237316195423570985008687907853269984665640564039457584007913129639935';
-        const formattedMaxDecimal =
-            '115792089237316195423570985008687907853269984665640564039457.584007913129639935';
-
-        it('returns true for uint256 max (hex constant and decimal string)', () => {
-            expect(isMaxAllowance(UINT256_MAX)).toBe(true);
-            expect(isMaxAllowance(maxDecimal)).toBe(true);
-        });
-
-        it('returns true for exact display-formatted uint256 max', () => {
-            expect(isMaxAllowance(formattedMaxDecimal)).toBe(true);
-        });
-
-        it('returns false for non-max values', () => {
-            expect(isMaxAllowance('0')).toBe(false);
-            // this number is one order smaller than max
-            expect(
-                isMaxAllowance(
-                    '15792089237316195423570985008687907853269984665640564039457584007913129639934',
-                ),
-            ).toBe(false);
-        });
-
-        it.each(['', 'abc', 'not-a-number', '12.34.56', '0xGG', ' '])(
-            'returns false when value is not a valid number (%j)',
-            invalid => {
-                expect(isMaxAllowance(invalid)).toBe(false);
-            },
-        );
-    });
-
     it('roundToNonZeroFractionDigits', () => {
         const cases = [
             {

--- a/suite-common/wallet-utils/src/allowanceUtils.ts
+++ b/suite-common/wallet-utils/src/allowanceUtils.ts
@@ -6,10 +6,24 @@ import { unitsToSubunits } from './amountUtils';
 
 const TOKEN_CONTRACTS_REQUIRING_APPROVAL_RESET = ['0xdAC17F958D2ee523a2206206994597C13D831ec7'];
 
-export const isAllowanceUnlimited = (amountUnits: string, decimals: number): boolean =>
-    new BigNumber(
-        unitsToSubunits({ value: asAmountUnit(new BigNumber(amountUnits)), decimals }),
-    ).gte(new BigNumber(UINT256_MAX).dividedBy(2).integerValue());
+type IsAllowanceUnlimitedParams = {
+    amount: string;
+    decimals: number;
+    // Set when `amount` is already in subunits (e.g. a decoded on-chain approval)
+    isSubunit?: boolean;
+};
+
+export const isAllowanceUnlimited = ({
+    amount,
+    decimals,
+    isSubunit = false,
+}: IsAllowanceUnlimitedParams): boolean => {
+    const subunits = isSubunit
+        ? new BigNumber(amount)
+        : new BigNumber(unitsToSubunits({ value: asAmountUnit(new BigNumber(amount)), decimals }));
+
+    return subunits.gte(new BigNumber(UINT256_MAX).dividedBy(2).integerValue());
+};
 
 export const tokenSupportsIncreasingAllowance = (contractAddress?: string): boolean => {
     if (!contractAddress) {

--- a/suite-common/wallet-utils/src/bigNumberUtils.ts
+++ b/suite-common/wallet-utils/src/bigNumberUtils.ts
@@ -1,5 +1,4 @@
-import { UINT256_MAX } from '@suite-common/suite-constants';
-import { BigNumber } from '@trezor/utils';
+import { type BigNumber } from '@trezor/utils';
 
 /**
  * Rounds a value to a given number of non-zero fractional digits.
@@ -42,27 +41,3 @@ export function roundToNonZeroFractionDigits(
     // Round *up* at the calculated decimal place
     return value.decimalPlaces(decimalPlaces);
 }
-
-/** Whether {@link value} equals EVM unlimited token allowance. */
-export const isMaxAllowance = (value: string | undefined): boolean => {
-    if (!value) {
-        return false;
-    }
-
-    const allowance = new BigNumber(value);
-    const maxAllowance = new BigNumber(UINT256_MAX).dividedBy(2).integerValue();
-
-    // Some callers pass the raw allowance value in base units.
-    if (allowance.gte(maxAllowance)) {
-        return true;
-    }
-
-    const [, fractionalPart] = value.split('.');
-
-    if (!fractionalPart) {
-        return false;
-    }
-
-    // Some DEX quote fields pass the same value formatted with token decimals.
-    return allowance.shiftedBy(fractionalPart.length).gte(maxAllowance);
-};

--- a/suite-native/module-earn/src/yieldApprovalUtils.ts
+++ b/suite-native/module-earn/src/yieldApprovalUtils.ts
@@ -130,5 +130,5 @@ export const isYieldApprovalAllowanceUnlimited = ({
         return false;
     }
 
-    return isAllowanceUnlimited(allowanceAmount, token.decimals);
+    return isAllowanceUnlimited({ amount: allowanceAmount, decimals: token.decimals });
 };

--- a/suite-native/module-trading/src/components/exchange/Approval/RevokeLimitInfoRow.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/RevokeLimitInfoRow.tsx
@@ -4,17 +4,19 @@ import {
     cryptoIdToNetworkAndContractAddress,
     selectTradingExchangeSelectedQuote,
 } from '@suite-common/trading';
-import { isMaxAllowance } from '@suite-common/wallet-utils';
+import { findToken, isAllowanceUnlimited } from '@suite-common/wallet-utils';
 import { HStack, Text } from '@suite-native/atoms';
 import { CryptoIcon, Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { TradeInfoRow } from '@suite-native/trading-atoms';
+import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
 
 import { UnlimitedAllowanceLabel } from './UnlimitedAllowanceLabel';
 import { TradingCoinAmountFormatter } from '../../general/TradingCoinAmountFormatter';
 
 export const RevokeLimitInfoRow = () => {
     const quote = useSelector(selectTradingExchangeSelectedQuote);
+    const sendAccount = useSelector(selectExchangeSelectedSendAccount);
 
     if (!quote?.send) {
         return null;
@@ -22,7 +24,12 @@ export const RevokeLimitInfoRow = () => {
 
     const { send, preapprovedStringAmount } = quote;
     const { network, contractAddress } = cryptoIdToNetworkAndContractAddress(send);
-    const isAllowanceUnlimited = isMaxAllowance(preapprovedStringAmount);
+    const { decimals } = findToken(sendAccount?.tokens, contractAddress) ?? {};
+
+    const showUnlimitedAllowanceLabel =
+        preapprovedStringAmount &&
+        typeof decimals === 'number' &&
+        isAllowanceUnlimited(preapprovedStringAmount, decimals);
 
     return (
         <TradeInfoRow testID="ExchangeApproval/LimitRevoke">
@@ -37,7 +44,7 @@ export const RevokeLimitInfoRow = () => {
                         size="extraSmall"
                     />
                 )}
-                {isAllowanceUnlimited ? (
+                {showUnlimitedAllowanceLabel ? (
                     <UnlimitedAllowanceLabel />
                 ) : (
                     <TradingCoinAmountFormatter

--- a/suite-native/module-trading/src/components/exchange/Approval/RevokeLimitInfoRow.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/RevokeLimitInfoRow.tsx
@@ -29,7 +29,7 @@ export const RevokeLimitInfoRow = () => {
     const showUnlimitedAllowanceLabel =
         preapprovedStringAmount &&
         typeof decimals === 'number' &&
-        isAllowanceUnlimited(preapprovedStringAmount, decimals);
+        isAllowanceUnlimited({ amount: preapprovedStringAmount, decimals });
 
     return (
         <TradeInfoRow testID="ExchangeApproval/LimitRevoke">

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/RevokeLimitInfoRow.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/RevokeLimitInfoRow.test.tsx
@@ -1,4 +1,6 @@
-import { mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
+import { UINT256_MAX } from '@suite-common/suite-constants';
+import { eth1NormalAccount, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
+import { BigNumber } from '@trezor/utils';
 
 import {
     type PreloadedStatePartial,
@@ -24,6 +26,7 @@ describe('RevokeLimitInfoRow', () => {
                         ...mercuryoFixedWorstQuote,
                         preapprovedStringAmount: '100',
                     },
+                    tradingAccountKey: eth1NormalAccount.key,
                 },
             },
         },
@@ -39,6 +42,30 @@ describe('RevokeLimitInfoRow', () => {
         const { getByText } = renderRevokeLimitInfoRow(withPreselectedQuote);
 
         expect(getByText('100 USDC')).toBeOnTheScreen();
+    });
+
+    it('should use token decimals to detect unlimited allowance', () => {
+        const amountUnlimitedOnlyWithEthDecimals = new BigNumber(UINT256_MAX)
+            .dividedBy(2)
+            .shiftedBy(-18)
+            .integerValue(BigNumber.ROUND_CEIL)
+            .toFixed();
+
+        const { queryByText } = renderRevokeLimitInfoRow({
+            wallet: {
+                trading: {
+                    exchange: {
+                        selectedQuote: {
+                            ...mercuryoFixedWorstQuote,
+                            preapprovedStringAmount: amountUnlimitedOnlyWithEthDecimals,
+                        },
+                        tradingAccountKey: eth1NormalAccount.key,
+                    },
+                },
+            },
+        });
+
+        expect(queryByText('Unlimited USDC')).toBeNull();
     });
 
     it('should render nothing when no quote is set', () => {

--- a/suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.tsx
@@ -1,5 +1,5 @@
-import { getApprovalStatus } from '@suite-common/trading';
-import { isMaxAllowance } from '@suite-common/wallet-utils';
+import { cryptoIdToNetworkAndContractAddress, getApprovalStatus } from '@suite-common/trading';
+import { findToken, isAllowanceUnlimited } from '@suite-common/wallet-utils';
 import { HStack, Text } from '@suite-native/atoms';
 import { DebugModeView } from '@suite-native/trading-debug';
 
@@ -8,14 +8,19 @@ import { useExchangeFormContext } from '../../hooks/exchange/useExchangeFormCont
 
 export const ExchangeFormQuoteDebugView = () => {
     const { watch } = useExchangeFormContext();
-    const quote = watch('quote');
+    const [quote, sendAccount] = watch(['quote', 'sendAccount']);
+
     const approvalStatus = getApprovalStatus(quote);
+    const { contractAddress } = cryptoIdToNetworkAndContractAddress(quote?.send);
+    const { decimals } = findToken(sendAccount?.tokens, contractAddress) ?? {};
 
     let preapproved = 'not defined';
     if (quote?.preapprovedStringAmount) {
-        preapproved = isMaxAllowance(quote.preapprovedStringAmount)
-            ? 'unlimited'
-            : quote.preapprovedStringAmount;
+        const isUnlimited =
+            typeof decimals === 'number' &&
+            isAllowanceUnlimited(quote.preapprovedStringAmount, decimals);
+
+        preapproved = isUnlimited ? 'unlimited' : quote.preapprovedStringAmount;
     }
 
     return (

--- a/suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.tsx
@@ -18,7 +18,7 @@ export const ExchangeFormQuoteDebugView = () => {
     if (quote?.preapprovedStringAmount) {
         const isUnlimited =
             typeof decimals === 'number' &&
-            isAllowanceUnlimited(quote.preapprovedStringAmount, decimals);
+            isAllowanceUnlimited({ amount: quote.preapprovedStringAmount, decimals });
 
         preapproved = isUnlimited ? 'unlimited' : quote.preapprovedStringAmount;
     }

--- a/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.tsx
@@ -32,7 +32,8 @@ export const ExchangeUsdcPresetButton = () => {
     const debugAccount = useSelector((state: AccountsRootState) =>
         selectAccounts(state).find(
             ({ symbol, tokens }) =>
-                symbol === 'eth' && tokens?.some(token => token.symbol === 'USDC'),
+                symbol === 'eth' &&
+                tokens?.some(token => token.symbol === 'USDC' && Number(token.balance) >= 1),
         ),
     );
 

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeFormQuoteDebugView.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeFormQuoteDebugView.test.tsx
@@ -7,12 +7,29 @@ import { renderWithBasicProvider, screen } from '@suite-native/test-utils';
 
 import { ExchangeFormQuoteDebugView } from '../ExchangeFormQuoteDebugView';
 
+const USDC_CONTRACT_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+const USDC_CRYPTO_ID = `ethereum--${USDC_CONTRACT_ADDRESS}` as CryptoId;
+
 let mockQuote: ExchangeTrade | undefined;
 let mockDebugMode: boolean;
+let mockSendAccount:
+    | {
+          tokens?: {
+              contract: string;
+              decimals: number;
+          }[];
+      }
+    | undefined;
 
 jest.mock('../../../hooks/exchange/useExchangeFormContext', () => ({
     useExchangeFormContext: () => ({
-        watch: () => mockQuote,
+        watch: (field: string | string[]) => {
+            if (Array.isArray(field)) {
+                return [mockQuote, mockSendAccount];
+            }
+
+            return mockQuote;
+        },
     }),
 }));
 
@@ -35,6 +52,7 @@ describe('ExchangeFormQuoteDebugView', () => {
 
     beforeEach(() => {
         mockQuote = undefined;
+        mockSendAccount = undefined;
         mockDebugMode = false;
     });
 
@@ -75,7 +93,7 @@ describe('ExchangeFormQuoteDebugView', () => {
     it('should render approval status "not_needed" for a non-DEX quote', () => {
         mockDebugMode = true;
         mockQuote = {
-            send: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CryptoId,
+            send: USDC_CRYPTO_ID,
             receive: 'bitcoin' as CryptoId,
             exchange: 'mercuryo',
             isDex: false,
@@ -89,7 +107,7 @@ describe('ExchangeFormQuoteDebugView', () => {
     it('should render approval status "needs_approval" for a DEX quote without pre-approval', () => {
         mockDebugMode = true;
         mockQuote = {
-            send: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CryptoId,
+            send: USDC_CRYPTO_ID,
             receive: 'bitcoin' as CryptoId,
             exchange: 'invity',
             isDex: true,
@@ -102,8 +120,16 @@ describe('ExchangeFormQuoteDebugView', () => {
 
     it('should display "unlimited" for pre-approved amount when preapprovedStringAmount is max uint256', () => {
         mockDebugMode = true;
+        mockSendAccount = {
+            tokens: [
+                {
+                    contract: USDC_CONTRACT_ADDRESS,
+                    decimals: 6,
+                },
+            ],
+        };
         mockQuote = {
-            send: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CryptoId,
+            send: USDC_CRYPTO_ID,
             receive: 'bitcoin' as CryptoId,
             exchange: 'invity',
             isDex: true,
@@ -120,7 +146,7 @@ describe('ExchangeFormQuoteDebugView', () => {
         mockDebugMode = true;
         const specificAmount = '1000000000000000000';
         mockQuote = {
-            send: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CryptoId,
+            send: USDC_CRYPTO_ID,
             receive: 'bitcoin' as CryptoId,
             exchange: 'invity',
             isDex: true,

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx
@@ -8,7 +8,7 @@ import {
     type TokenAddress,
     type TokenSymbol,
 } from '@suite-common/wallet-types';
-import { convertAmountSubunitsToUnits, isMaxAllowance } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits, isAllowanceUnlimited } from '@suite-common/wallet-utils';
 import { Box, HStack, Text, VStack } from '@suite-native/atoms';
 import { AddressFormatter, CryptoAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
@@ -135,7 +135,9 @@ export const ReviewOutputItemContent = ({
                 flowType === 'revoke-and-approve';
 
             const isApprovalTx = flowType === 'approve';
-            const isMaxApproval = isMaxAllowance(value);
+
+            const isMaxApproval =
+                typeof token?.decimals === 'number' && isAllowanceUnlimited(value, token?.decimals);
 
             const getPrimaryValue = () => {
                 if (!isApprovalTx && token?.symbol) {

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx
@@ -137,7 +137,8 @@ export const ReviewOutputItemContent = ({
             const isApprovalTx = flowType === 'approve';
 
             const isMaxApproval =
-                typeof token?.decimals === 'number' && isAllowanceUnlimited(value, token?.decimals);
+                typeof token?.decimals === 'number' &&
+                isAllowanceUnlimited({ amount: value, decimals: token.decimals, isSubunit: true });
 
             const getPrimaryValue = () => {
                 if (!isApprovalTx && token?.symbol) {

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItem.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItem.test.tsx
@@ -773,26 +773,5 @@ describe('ReviewOutputItem', () => {
 
             expect(within(content).getByText('123456789')).toBeOnTheScreen();
         });
-
-        it('should render unlimited label for revoke approve_data without token when value is max uint256', () => {
-            const maxUint256 = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
-            const { getByTestId } = renderReviewOutputItem({
-                reviewOutput: {
-                    state: undefined,
-                    type: 'approve_data',
-                    value: maxUint256,
-                    value2: 'Ethereum',
-                } as StatefulReviewOutput,
-                flowType: 'revoke',
-            });
-
-            const content = getByTestId('review-output-card/content');
-
-            expect(
-                within(content).getByText(
-                    getTranslation('transactionManagement.review.outputs.approveMaxAmount'),
-                ),
-            ).toBeOnTheScreen();
-        });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* replace isMaxAllowancee with isAllowanceUnlimited
* remove isMaxAllowancee from the codebase

<!--- Describe your changes in detail -->

## Notes for QA
* Verify that unlimited spending is shown in appropriate operations
* Verify normal finite approvals still render the numeric amount.
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/27781

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily affects allowance/approval modals (ApproveModal, RevokeModal), transaction review output rendering (TransactionReviewOutput), send form thunks, and utility functions (allowanceUtils, bigNumberUtils). The highest risk is in token swap flows where allowance approval is required before trading, and in transaction review confirmation screens where output rendering changes could break amount/fee/address display. Many changed files (12 of 17) are in suite-native or are unit test files with no E2E coverage, as they target the mobile app. The recommended strategy focuses on token swap and sell flows that exercise the allowance modals, plus send/staking flows that exercise the transaction review output changes.

<details><summary><b>Changed files (17)</b></summary>

- `packages/suite/src/components/earn/yield/common/ApprovedAmountValue.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx`
- `suite-common/wallet-core/src/send/sendFormThunks.ts`
- `suite-common/wallet-utils/src/__tests__/allowanceUtils.test.ts`
- `suite-common/wallet-utils/src/__tests__/bigNumberUtils.test.ts`
- `suite-common/wallet-utils/src/allowanceUtils.ts`
- `suite-common/wallet-utils/src/bigNumberUtils.ts`
- `suite-native/module-earn/src/yieldApprovalUtils.ts`
- `suite-native/module-trading/src/components/exchange/Approval/RevokeLimitInfoRow.tsx`
- `suite-native/module-trading/src/components/exchange/Approval/__tests__/RevokeLimitInfoRow.test.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.tsx`
- `suite-native/module-trading/src/components/exchange/__tests__/ExchangeFormQuoteDebugView.test.tsx`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItem.test.tsx`

</details>

**Recommended tests (16)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test exercises the full swap flow including transaction review and confirmation on the device. Changes to TransactionReviewOutput.tsx, sendFormThunks.ts, ApproveModal.tsx, and RevokeModal.tsx directly affect the swap confirmation path. The allowance modals (Approve/Revoke) are part of the token swap flow when ERC-20 approvals are needed.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Token-to-coin swaps involve token approval flows (ApproveModal/RevokeModal) and transaction review. Changes to allowanceUtils and the allowance modal components directly affect the token approval step that precedes sending tokens in a swap.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Token-to-token swaps (USDT to USDC) are the most likely flow to exercise token allowance/approval modals. Changes to ApproveModal, RevokeModal, allowanceUtils, and bigNumberUtils all feed into the token swap approval and amount calculation paths.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Ethereum swap with custom fees exercises TransactionReviewOutput for fee display and sendFormThunks for transaction composition. Changes to bigNumberUtils could affect fee calculations displayed in the review modal.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Sell ETH flow involves transaction review with custom fee parameters and send confirmation. TransactionReviewOutput changes affect the confirmation screen, and sendFormThunks changes affect transaction composition.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Selling an ERC-20 token (USDC) involves token allowance flows and transaction review. The ApproveModal/RevokeModal and allowanceUtils changes are directly relevant to the token sell approval step.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test verifies ETH send form with custom fees and device confirmation. TransactionReviewOutput.tsx changes directly affect the review modal displayed during send confirmation, and sendFormThunks.ts changes affect transaction composition.
- `suite/e2e/tests/wallet/send-base.test.ts` — Base network send test exercises the full transaction review flow including TransactionReviewOutput for address/amount/fee display and sendFormThunks for transaction composition and broadcasting.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking involves transaction review and uses bigNumberUtils for amount formatting. The ApprovedAmountValue component (changed) is used in yield/earn flows, and the staking flow confirms transactions through the review modal.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstaking exercises transaction review with amount/fee display and uses bigNumberUtils for balance calculations. Changes to TransactionReviewOutput affect the confirmation UI shown during unstake.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — BTC swap with custom fees exercises sendFormThunks for transaction composition and TransactionReviewOutput for fee display on the device prompt. bigNumberUtils changes could affect fee calculation logic.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Sell BTC flow includes transaction review confirmation showing address, amount, total, and fee. TransactionReviewOutput changes affect this confirmation UI, and sendFormThunks changes affect the send initiation.
- `suite/e2e/tests/staking/staking-form.test.ts` — The staking form validates amounts using bigNumberUtils for percentage calculations and min/max validation. Changes to bigNumberUtils could affect the fraction button calculations and amount validation logic.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/wallet/send-sol.test.ts` — SOL send flow exercises TransactionReviewOutput for displaying amounts and fees during review. While SOL doesn't use ERC-20 allowances, the review modal output changes could affect the confirmation display.
- `suite/e2e/tests/wallet/send-doge.test.ts` — DOGE send test verifies transaction review output display of amounts, fees, and addresses. Changes to TransactionReviewOutput could affect how these values are rendered in the confirmation modal.
- `suite/e2e/tests/trading/sell-solana.test.ts` — SOL sell flow includes transaction review and fee display. Changes to sendFormThunks and TransactionReviewOutput could affect the confirmation screen behavior.

</details>

⚠️ **Changes with no test coverage (12)**
- `packages/suite/src/components/earn/yield/common/ApprovedAmountValue.tsx`
- `suite-common/wallet-utils/src/__tests__/allowanceUtils.test.ts`
- `suite-common/wallet-utils/src/__tests__/bigNumberUtils.test.ts`
- `suite-common/wallet-utils/src/allowanceUtils.ts`
- `suite-native/module-earn/src/yieldApprovalUtils.ts`
- `suite-native/module-trading/src/components/exchange/Approval/RevokeLimitInfoRow.tsx`
- `suite-native/module-trading/src/components/exchange/Approval/__tests__/RevokeLimitInfoRow.test.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.tsx`
- `suite-native/module-trading/src/components/exchange/__tests__/ExchangeFormQuoteDebugView.test.tsx`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItem.test.tsx`

_Updated: 2026-07-02T11:35:51.114Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/27781-refactor-use-isallowanceunlimited-instead-of-ismaxallowancee&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/27781-refactor-use-isallowanceunlimited-instead-of-ismaxallowancee&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/27781-refactor-use-isallowanceunlimited-instead-of-ismaxallowancee&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T11:41:00.984Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-02T11:37:49.844Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/27781-refactor-use-isallowanceunlimited-instead-of-ismaxallowancee/web/](https://dev.suite.sldev.cz/suite-web/feat/27781-refactor-use-isallowanceunlimited-instead-of-ismaxallowancee/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->