### PR TITLE
fix(suite-native): replace APY with APR for Tron

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -3073,6 +3073,7 @@ export const messages = {
         notAvailable: 'Not available',
         apyNotAvailable: 'APY not available',
         apyPercentage: '~{apy}% APY',
+        aprPercentage: '~{apy}% APR',
         notAvailableShort: 'N/A',
         stakePendingCard: {
             totalStakePending: 'Total stake pending',

--- a/suite-native/module-earn/src/components/EarnAccountCard.tsx
+++ b/suite-native/module-earn/src/components/EarnAccountCard.tsx
@@ -168,7 +168,14 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
                             {isAdaStakedOutsideEverstake ? (
                                 <Translation id="earn.notAvailableShort" />
                             ) : (
-                                <Translation id="earn.apyPercentage" values={{ apy: apyValue }} />
+                                <Translation
+                                    id={
+                                        symbol === 'trx'
+                                            ? 'earn.aprPercentage'
+                                            : 'earn.apyPercentage'
+                                    }
+                                    values={{ apy: apyValue }}
+                                />
                             )}
                         </Text>
                     )}

--- a/suite-native/module-earn/src/components/EarnItemOverviewSection.tsx
+++ b/suite-native/module-earn/src/components/EarnItemOverviewSection.tsx
@@ -142,7 +142,14 @@ export const EarnItemOverviewSection = (item: EarnPromoItem) => {
                             {isAdaStakedOutsideEverstake ? (
                                 <Translation id="earn.notAvailableShort" />
                             ) : (
-                                <Translation id="earn.apyPercentage" values={{ apy: apyValue }} />
+                                <Translation
+                                    id={
+                                        symbol === 'trx'
+                                            ? 'earn.aprPercentage'
+                                            : 'earn.apyPercentage'
+                                    }
+                                    values={{ apy: apyValue }}
+                                />
                             )}
                         </Text>
                     )}


### PR DESCRIPTION
## Description

Replace `APY` with `APR` for Tron on Mobile.

## Screenshots:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-26 at 11 59 37" src="https://github.com/user-attachments/assets/3f480964-fade-4a5a-a0fe-2ee639d45ebf" />

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-26 at 11 59 26" src="https://github.com/user-attachments/assets/9de38c30-8691-4d5e-91ea-703bf6b4e14b" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All three changed files are in the `suite-native/` directory, which is the React Native mobile app codebase. The E2E tests in `suite/e2e/tests/` are all Playwright-based tests targeting the desktop/web Trezor Suite application, not the native mobile app. The changed files (`suite-native/intl/src/messages.ts`, `suite-native/module-earn/src/components/EarnAccountCard.tsx`, `suite-native/module-earn/src/components/EarnItemOverviewSection.tsx`) are mobile-specific components and intl messages that are not exercised by any of the 104 candidate E2E tests. No desktop/web E2E tests need to be run for these changes.

<details><summary><b>Changed files (3)</b></summary>

- `suite-native/intl/src/messages.ts`
- `suite-native/module-earn/src/components/EarnAccountCard.tsx`
- `suite-native/module-earn/src/components/EarnItemOverviewSection.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `suite-native/intl/src/messages.ts`
- `suite-native/module-earn/src/components/EarnAccountCard.tsx`
- `suite-native/module-earn/src/components/EarnItemOverviewSection.tsx`

_Updated: 2026-06-26T10:04:19.069Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/tron-apr-label&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/tron-apr-label&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/tron-apr-label&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-26T10:09:13.674Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |

</details>

_Updated: 2026-06-26T10:07:05.530Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/native/tron-apr-label/web/](https://dev.suite.sldev.cz/suite-web/fix/native/tron-apr-label/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->