### PR TITLE
fix(suite): align sorting of staking opportunities with mobile

### DIFF
--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingTable.tsx
@@ -55,14 +55,14 @@ export const EarnStakingTable = () => {
                                 {ethNotActivated && (
                                     <EarnStakingActivateRow symbol="eth" isCardLayout />
                                 )}
-                                {adaNotActivated && (
-                                    <EarnStakingActivateRow symbol="ada" isCardLayout />
-                                )}
                                 {solNotActivated && (
                                     <EarnStakingActivateRow symbol="sol" isCardLayout />
                                 )}
                                 {trxNotActivated && (
                                     <EarnStakingActivateRow symbol="trx" isCardLayout />
+                                )}
+                                {adaNotActivated && (
+                                    <EarnStakingActivateRow symbol="ada" isCardLayout />
                                 )}
                             </Column>
                         ) : (
@@ -87,12 +87,6 @@ export const EarnStakingTable = () => {
                                                 isCardLayout={false}
                                             />
                                         )}
-                                        {adaNotActivated && (
-                                            <EarnStakingActivateRow
-                                                symbol="ada"
-                                                isCardLayout={false}
-                                            />
-                                        )}
                                         {solNotActivated && (
                                             <EarnStakingActivateRow
                                                 symbol="sol"
@@ -102,6 +96,12 @@ export const EarnStakingTable = () => {
                                         {trxNotActivated && (
                                             <EarnStakingActivateRow
                                                 symbol="trx"
+                                                isCardLayout={false}
+                                            />
+                                        )}
+                                        {adaNotActivated && (
+                                            <EarnStakingActivateRow
+                                                symbol="ada"
                                                 isCardLayout={false}
                                             />
                                         )}


### PR DESCRIPTION
## Description

Align sorting of staking opportunities with mobile (ETH, SOL, TRX, ADA).

## Screenshots:

<img width="100%" alt="Screenshot 2026-06-26 at 12 11 01" src="https://github.com/user-attachments/assets/f80aa17b-11a2-4d84-8b28-4e3f7340a131" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to EarnStakingTable.tsx, a staking dashboard component within the earn/staking feature. This file maps to 121 tests via static analysis, indicating it's bundled into the main app and transitively imported everywhere — but only staking-related tests actually exercise its rendering. The highest risk is in ETH and SOL staking dashboard tests that directly verify staking amounts, progress indicators, dashboard cards, and action buttons rendered by this component. ADA staking tests are medium priority as they may use slightly different dashboard sub-components. All non-staking tests (onboarding, settings, trading, etc.) should be omitted as they don't exercise the staking dashboard UI.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/earn/dashboard/staking/EarnStakingTable.tsx`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — EarnStakingTable.tsx is a staking dashboard component. This test directly exercises the ETH staking dashboard, verifying staking amounts, progress indicators, and dashboard card visibility — all of which are rendered by or depend on staking table/dashboard components.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test verifies the ETH staking dashboard showing staked amounts, rewards, pending balances, and progress indicators — UI elements directly rendered by the EarnStakingTable component. It also tests the instant staking banner which is part of the staking dashboard.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test verifies the staking dashboard displaying pending, staked, rewards, and unstaking amounts, plus claim card visibility — all directly related to the EarnStakingTable dashboard component rendering staking state.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Tests the Solana staking dashboard empty state, staking card visibility, and staking amounts after staking — UI rendered by the staking dashboard/table component. Directly exercises the EarnStakingTable for SOL.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Directly tests the staking dashboard amounts panel (staked, rewards, unstaking, pending) and reward list display, which are core responsibilities of the EarnStakingTable component.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Tests the SOL staking dashboard showing staked amounts, action buttons (stake more, unstake), and progress indicators — all rendered by or dependent on the EarnStakingTable component.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Verifies the SOL staking dashboard state transitions including staked/unstaking amounts, claim card visibility, and empty state after claiming — all directly rendered by the staking dashboard component.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — Tests Cardano staking UI including reward amounts, claim rewards button, and staked balance indicators on the staking tab. While ADA staking may use different sub-components, the EarnStakingTable could be shared or involved in rendering the staking dashboard.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Tests the Cardano staking dashboard showing empty state and post-staking state with rewards and balances. The staking dashboard component EarnStakingTable may render parts of this view.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Tests Cardano unstaking flow and dashboard state changes (staked amounts, button states, start staking visibility). The EarnStakingTable may be involved in rendering the ADA staking dashboard.
- `suite/e2e/tests/staking/staking-form.test.ts` — Tests the ETH staking form including the stakeMoreButton which is part of the staking dashboard. While primarily a form validation test, it accesses the staking tab and interacts with dashboard elements that EarnStakingTable may render.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — Tests staking navigation analytics events from dashboard assets and account menu. If EarnStakingTable includes navigation entry points or stake buttons on the dashboard, changes could affect the analytics event triggers.

</details>

_Updated: 2026-06-26T10:14:57.004Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/sort-staking-opportunities/web/](https://dev.suite.sldev.cz/suite-web/fix/sort-staking-opportunities/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sort-staking-opportunities&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sort-staking-opportunities&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |

</details>

_Updated: 2026-06-26T10:17:48.959Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-26T10:17:46.242Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->