### PR TITLE
Refactor/stablecoin yield api 2

### DIFF
--- a/packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react';
 
-import { type TokenDto } from '@suite-common/earn-stablecoin-api';
+import { type TokenDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { Column, Row } from '@trezor/components';
@@ -12,7 +12,7 @@ import { type EarnTokenBalance } from './types';
 type EarnAccountCellProps = {
     account?: Account;
     symbol?: NetworkSymbol;
-    iconToken?: TokenDto;
+    iconToken?: TokenDtoV2;
     showAssetNetworkIcon?: boolean;
     tokenBalance?: EarnTokenBalance;
     subtitle?: ReactNode;

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
@@ -1,7 +1,7 @@
 import { Translation, type TranslationKey } from '@suite/intl';
 import {
-    type RewardDto,
-    type TokenDto,
+    type RewardDtoV2,
+    type TokenDtoV2,
     sortRewardsByUnderlyingToken,
 } from '@suite-common/earn-stablecoin-api';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
@@ -10,15 +10,15 @@ import { Column, Icon, Row, Text } from '@trezor/components';
 import { AssetLogo } from '@trezor/product-components';
 
 type EarnYieldApyBreakdownProps = {
-    rewards: RewardDto[];
+    rewards: RewardDtoV2[];
     networkSymbol: NetworkSymbol;
-    underlyingToken: TokenDto | undefined;
+    underlyingToken: TokenDtoV2 | undefined;
 };
 
 // Translatable explainer rendered as the secondary text of a reward row. Unknown sources return
 // null so we never render the raw, untranslated description coming from the API.
 const getYieldSourceDescriptionId = (
-    yieldSource: RewardDto['yieldSource'],
+    yieldSource: RewardDtoV2['yieldSource'],
 ): TranslationKey | null => {
     switch (yieldSource) {
         case 'lending':

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
-import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Tooltip } from '@trezor/components';
 
@@ -22,7 +22,7 @@ const Abbr = styled.abbr`
 `;
 
 type EarnYieldApyTooltipProps = {
-    vault: YieldDto;
+    vault: YieldDtoV2;
     apyPercentage: number | null;
     networkSymbol: NetworkSymbol;
     children?: ReactNode;

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
@@ -6,7 +6,7 @@ import { EarnAnchor, goto, useAnchor } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import {
     type YieldAccountRewards,
-    type YieldDto,
+    type YieldDtoV2,
     useAllYieldOpportunities,
 } from '@suite-common/earn-stablecoin-api';
 import { Context } from '@suite-common/message-system';
@@ -29,7 +29,7 @@ import { useMerklRewards } from '../../yield/claim/hooks';
 import { EarnDashboardSection } from '../common/EarnDashboardSection';
 import { EarnDashboardTableHeader } from '../common/EarnDashboardTableHeader';
 
-const emptyVaults: YieldDto[] = [];
+const emptyVaults: YieldDtoV2[] = [];
 
 export const EarnYieldTable = () => {
     const { anchorRef, shouldHighlight } = useAnchor(EarnAnchor.Yield);

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { type TokenDto, type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type TokenDtoV2, type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type NetworkSymbol, getNetworkByYieldXyzId } from '@suite-common/wallet-config';
 import {
     doTokensMatch,
@@ -36,7 +36,7 @@ const getMatchedAccountToken = ({
 }: {
     account: Account;
     networkSymbol: NetworkSymbol;
-    token?: Pick<TokenDto, 'address' | 'symbol' | 'decimals'>;
+    token?: Pick<TokenDtoV2, 'address' | 'symbol' | 'decimals'>;
 }): TokenInfoBranded | undefined => {
     if (!account.tokens?.length || !token) {
         return undefined;
@@ -64,7 +64,7 @@ const getYieldOpportunityData = ({
 }: {
     account: Account;
     networkSymbol: NetworkSymbol;
-    vault: YieldDto;
+    vault: YieldDtoV2;
 }): YieldOpportunityData => {
     const matchedInputToken = getMatchedAccountToken({
         account,
@@ -113,7 +113,7 @@ const toNetworkTokenSortKey = (opportunity: YieldAccountOpportunity) =>
     };
 
 type UseYieldTableDataProps = {
-    availableVaults: YieldDto[];
+    availableVaults: YieldDtoV2[];
     visibleAccounts: Account[];
     visibleAccountSymbols: Set<NetworkSymbol>;
 };

--- a/packages/suite/src/components/earn/dashboard/yield/types.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/types.ts
@@ -1,4 +1,4 @@
-import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, type TokenInfoBranded, type TokenSymbol } from '@suite-common/wallet-types';
 
@@ -6,7 +6,7 @@ export type YieldAccountOpportunity = {
     key: string;
     account?: Account;
     networkSymbol: NetworkSymbol;
-    vault: YieldDto;
+    vault: YieldDtoV2;
     matchedInputToken: TokenInfoBranded | undefined;
     hasVaultPosition: boolean;
     hasRewardsData: boolean;

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldDepositingInfo.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldDepositingInfo.tsx
@@ -1,5 +1,5 @@
 import { Translation } from '@suite/intl';
-import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { StepList } from '@trezor/components';
 
@@ -10,7 +10,7 @@ import { EarnInfoRow } from './EarnInfoRow';
 
 type YieldDepositingInfoProps = {
     apy: number | null;
-    vault: YieldDto | undefined;
+    vault: YieldDtoV2 | undefined;
     networkSymbol: NetworkSymbol;
     depositSymbol: string;
     vaultSymbol: string | undefined;

--- a/packages/suite/src/components/earn/yield/common/YieldFlowCompleteDeposit.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowCompleteDeposit.tsx
@@ -1,5 +1,5 @@
 import { Translation } from '@suite/intl';
-import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type YieldFlowCompleteValue } from '@suite-common/wallet-core';
 import { Divider, Row, Text } from '@trezor/components';
@@ -13,7 +13,7 @@ type YieldFlowCompleteDepositProps = {
     input: YieldFlowCompleteValue;
     output: YieldFlowCompleteValue;
     apy?: number | null;
-    vault: YieldDto;
+    vault: YieldDtoV2;
     networkSymbol: NetworkSymbol;
 };
 

--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -4,7 +4,7 @@ import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { type EarnParams, goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
-import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import {
     type EarnAnalyticsStep,
     EarnFlow,
@@ -23,7 +23,7 @@ interface YieldPageHeaderProps {
     fallbackTitleId: TranslationKey;
     account?: Account;
     routeParams?: EarnParams;
-    vault?: YieldDto;
+    vault?: YieldDtoV2;
     isInvalid?: boolean;
 }
 

--- a/packages/suite/src/components/earn/yield/deposit/YieldDeposit.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDeposit.tsx
@@ -1,7 +1,7 @@
 import { FormProvider } from 'react-hook-form';
 
 import { type EarnParams } from '@suite/router';
-import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { Context } from '@suite-common/message-system';
 import { getYieldVaultContractAddress } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
@@ -20,7 +20,7 @@ import { YieldDisabledBanner } from '../common/YieldDisabledBanner';
 type YieldDepositProps = {
     account: Account;
     routeParams: EarnParams;
-    vault: YieldDto;
+    vault: YieldDtoV2;
 };
 
 export const YieldDeposit = ({ account, routeParams, vault }: YieldDepositProps) => {

--- a/packages/suite/src/components/earn/yield/deposit/useYieldDeposit.ts
+++ b/packages/suite/src/components/earn/yield/deposit/useYieldDeposit.ts
@@ -1,5 +1,5 @@
 import { type EarnParams } from '@suite/router';
-import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type Account } from '@suite-common/wallet-types';
 
 import { type YieldFlowContextValues, useYieldFlow } from '../hooks/useYieldFlow';
@@ -7,7 +7,7 @@ import { type YieldFlowContextValues, useYieldFlow } from '../hooks/useYieldFlow
 type UseYieldDepositProps = {
     account: Account;
     routeParams: EarnParams;
-    vault: YieldDto;
+    vault: YieldDtoV2;
 };
 
 export const useYieldDeposit = ({

--- a/packages/suite/src/components/earn/yield/hooks/useResolvedYieldFlowData.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useResolvedYieldFlowData.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { type EarnParams } from '@suite/router';
-import { type TokenDto, type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type TokenDtoV2, type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
     type YieldFlowDisplayToken,
@@ -23,7 +23,7 @@ const getMatchedAccountToken = ({
     token,
 }: {
     account: Account;
-    token?: Pick<TokenDto, 'address' | 'symbol' | 'decimals'>;
+    token?: Pick<TokenDtoV2, 'address' | 'symbol' | 'decimals'>;
 }) => {
     if (!account.tokens?.length || !token) {
         return undefined;
@@ -57,7 +57,7 @@ type UseResolvedYieldFlowDataResult = {
 type UseResolvedYieldFlowDataProps = {
     account: Account;
     routeParams: EarnParams;
-    vault: YieldDto;
+    vault: YieldDtoV2;
 };
 
 export const useResolvedYieldFlowData = ({

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -7,7 +7,7 @@ import { type TranslationKey } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { type EarnParams } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
-import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import {
     type YieldAllowanceStatus,
     type YieldApproveModalState,
@@ -50,7 +50,7 @@ import {
 type UseYieldFlowProps = {
     account: Account;
     routeParams: EarnParams;
-    vault: YieldDto;
+    vault: YieldDtoV2;
     flowType: YieldPositionFlowType;
 };
 
@@ -62,7 +62,7 @@ type UseYieldFlowStepsResult = {
 
 export type UseYieldFlowResult = {
     account: Account;
-    vault: YieldDto;
+    vault: YieldDtoV2;
     token: YieldFlowToken | null;
     receiptToken: YieldFlowDisplayToken | null;
     apy: number | null;
@@ -111,7 +111,7 @@ export type YieldFlowContextValues = Omit<
 > & {
     token: YieldFlowToken;
     receiptToken: YieldFlowDisplayToken;
-    vault: YieldDto;
+    vault: YieldDtoV2;
 };
 
 export const useYieldFlow = ({

--- a/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 
 import { type AnalyticsDesktopEvents, events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
-import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import {
     type YieldFlowType,
     type YieldPendingTransactionState,
@@ -65,7 +65,7 @@ const getResolutionEventType = (
 
 type ReportContext = {
     networkSymbol: string;
-    vault?: YieldDto | null;
+    vault?: YieldDtoV2 | null;
     durationMs?: number;
 };
 
@@ -148,7 +148,7 @@ type UseYieldPendingTransactionTrackingProps = {
     flowType: YieldFlowType;
     flowKey: string;
     waitForMerklToResolveClaim?: () => Promise<unknown>;
-    vault?: YieldDto | null;
+    vault?: YieldDtoV2 | null;
 };
 
 const stablePlaceholderPromise = () => Promise.resolve();

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdraw.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdraw.tsx
@@ -1,7 +1,7 @@
 import { FormProvider } from 'react-hook-form';
 
 import { type EarnParams } from '@suite/router';
-import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { Context } from '@suite-common/message-system';
 import { getYieldVaultContractAddress } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
@@ -20,7 +20,7 @@ import { YieldDisabledBanner } from '../common/YieldDisabledBanner';
 type YieldWithdrawProps = {
     account: Account;
     routeParams: EarnParams;
-    vault: YieldDto;
+    vault: YieldDtoV2;
 };
 
 export const YieldWithdraw = ({ account, routeParams, vault }: YieldWithdrawProps) => {

--- a/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
+++ b/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 
 import { type EarnParams } from '@suite/router';
-import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import {
     type YieldFlowCompleteValue,
     type YieldWithdrawFlowType,
@@ -14,7 +14,7 @@ import { type YieldFlowContextValues, useYieldFlow } from '../hooks/useYieldFlow
 type UseYieldWithdrawProps = {
     account: Account;
     routeParams: EarnParams;
-    vault: YieldDto;
+    vault: YieldDtoV2;
 };
 
 export type YieldWithdrawContextValues = Omit<YieldFlowContextValues, 'flowType'> & {

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
@@ -1,4 +1,4 @@
-import { type RewardDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { YIELD_FLOW_STEPS, type YieldFlowStepId } from '@suite-common/wallet-core';
 import { getApyPercent } from '@suite-common/wallet-utils';
 import type { StepListItemState } from '@trezor/components';
@@ -38,7 +38,9 @@ export const getYieldModifyAmountInput = ({
  * component is emitted as-is — symbols repeating across components are not
  * merged. Returns an empty string when there are no usable components.
  */
-export const getApyBreakdown = (components: RewardDto[] | undefined): string =>
+export const getApyBreakdown = (
+    components: YieldDtoV2['rewardRate']['components'] | undefined,
+): string =>
     (components ?? [])
         .map(component => {
             if (!Number.isFinite(component.rate)) return null;

--- a/packages/suite/src/types/earn/earnLayout.ts
+++ b/packages/suite/src/types/earn/earnLayout.ts
@@ -1,5 +1,5 @@
 import { type EarnParams } from '@suite/router';
-import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type Account } from '@suite-common/wallet-types';
 
 export type EarnLayoutInvalidReason =
@@ -14,6 +14,6 @@ export type EarnLayoutInvalidReason =
 export type EarnLayoutState =
     | { status: 'loading' }
     | { status: 'invalid'; reason: EarnLayoutInvalidReason }
-    | { status: 'valid'; account: Account; routeParams: EarnParams; vault: YieldDto };
+    | { status: 'valid'; account: Account; routeParams: EarnParams; vault: YieldDtoV2 };
 
 export type EarnLayoutFallbackState = Exclude<EarnLayoutState, { status: 'valid' }>;

--- a/packages/suite/src/views/earn/yield/useEarnLayout.tsx
+++ b/packages/suite/src/views/earn/yield/useEarnLayout.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { type TranslationKey } from '@suite/intl';
 import { type EarnParams, goto } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
-import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { useYieldOpportunity } from '@suite-common/earn-stablecoin-api';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { type EarnAnalyticsStep } from '@suite-common/suite-types/src/staking';
@@ -28,7 +28,7 @@ type GetEarnLayoutResultParams = {
     account?: Account;
     device?: TrezorDevice;
     routeParams?: EarnParams;
-    vault?: YieldDto;
+    vault?: YieldDtoV2;
     type: YieldPositionFlowType;
     isYieldOpportunitiesLoading: boolean;
     isYieldOpportunitiesSuccess: boolean;
@@ -37,7 +37,7 @@ type GetEarnLayoutResultParams = {
 
 type VaultValidationParams = {
     account: Account;
-    vault?: YieldDto;
+    vault?: YieldDtoV2;
 };
 
 type VaultTokenValidationParams = VaultValidationParams & {

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { selectSelectedDevice } from '@suite-common/device';
-import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import {
     type EnhancedTokenInfo,
     type TokenManagementAction,
@@ -36,7 +36,7 @@ type TokenRowProps = {
     hideRates?: boolean;
     isUnverifiedTable?: boolean;
     isCollapsed?: boolean;
-    yieldOpportunities?: YieldDto[];
+    yieldOpportunities?: YieldDtoV2[];
 };
 
 export const TokenRow = ({

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -12,7 +12,7 @@ import { showAddressThunk } from '@suite/receive';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
-import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import {
     DefinitionType,
     type EnhancedTokenInfo,
@@ -62,7 +62,7 @@ interface TokenRowBasicActionsProps {
     account: Account;
     network: Network;
     isUnverifiedTable?: boolean;
-    yieldOpportunities?: YieldDto[];
+    yieldOpportunities?: YieldDtoV2[];
     setShowDeactivateModal: (value: boolean) => void;
 }
 
@@ -567,7 +567,7 @@ interface TokenRowActionsProps {
     tokenStatusType: TokenManagementAction;
     account: Account;
     network: Network;
-    yieldOpportunities?: YieldDto[];
+    yieldOpportunities?: YieldDtoV2[];
     isUnverifiedTable?: boolean;
     setShowDeactivateModal: (value: boolean) => void;
 }

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { Translation } from '@suite/intl';
-import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import {
     type EnhancedTokenInfo,
     type TokenManagementAction,
@@ -40,7 +40,7 @@ interface TokensTableProps {
     hideRates?: boolean;
     searchQuery?: string;
     isUnverifiedTable?: boolean;
-    yieldOpportunities?: YieldDto[];
+    yieldOpportunities?: YieldDtoV2[];
 }
 
 export const TokensTable = ({

--- a/suite-common/earn-stablecoin-api/src/hooks/useAllYieldOpportunities.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/useAllYieldOpportunities.ts
@@ -1,4 +1,4 @@
-import { type YieldDto } from '@suite-common/earn-stablecoin-defs';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-defs';
 import { commonQueryKeys, useQuery } from '@suite-common/react-query';
 
 import { YIELD_OPPORTUNITIES_DEFAULT_LIMIT, queriesStaleTime } from '../config';
@@ -9,7 +9,7 @@ type UseAllYieldOpportunitiesProps = {
     enabled?: boolean;
 };
 
-const stableEmptyArray: YieldDto[] = [];
+const stableEmptyArray: YieldDtoV2[] = [];
 
 export const useAllYieldOpportunities = ({
     limit = YIELD_OPPORTUNITIES_DEFAULT_LIMIT,

--- a/suite-common/earn-stablecoin-api/src/hooks/useYieldOpportunity.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/useYieldOpportunity.ts
@@ -1,16 +1,17 @@
-import { type YieldDto } from '@suite-common/earn-stablecoin-defs';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-defs';
 import { commonQueryKeys, useQuery } from '@suite-common/react-query';
 
 import { getYield } from '../services';
 
-interface UseYieldOpportunityProps<T extends YieldDto[keyof YieldDto] | YieldDto = YieldDto> {
-    select?: (yieldOpportunity: YieldDto) => T;
+interface UseYieldOpportunityProps<
+    T extends YieldDtoV2[keyof YieldDtoV2] | YieldDtoV2 = YieldDtoV2,
+> {
+    select?: (yieldOpportunity: YieldDtoV2) => T;
 }
 
-export function useYieldOpportunity<T extends YieldDto[keyof YieldDto] | YieldDto = YieldDto>(
-    vaultId: string | undefined,
-    { select }: UseYieldOpportunityProps<T> = {},
-) {
+export function useYieldOpportunity<
+    T extends YieldDtoV2[keyof YieldDtoV2] | YieldDtoV2 = YieldDtoV2,
+>(vaultId: string | undefined, { select }: UseYieldOpportunityProps<T> = {}) {
     return useQuery({
         enabled: Boolean(vaultId),
         queryKey: commonQueryKeys.yieldOpportunity(vaultId),

--- a/suite-common/earn-stablecoin-api/src/services/yieldxyz.ts
+++ b/suite-common/earn-stablecoin-api/src/services/yieldxyz.ts
@@ -1,4 +1,4 @@
-import { GetYieldResponse, GetYieldsResponse } from '@suite-common/earn-stablecoin-defs';
+import { YieldResponseV2, YieldsResponseV2 } from '@suite-common/earn-stablecoin-defs';
 import { createHttpClient } from '@suite-common/http-client';
 import { getSuiteVersion } from '@trezor/env-utils';
 
@@ -8,17 +8,17 @@ export const yieldXyzApi = createHttpClient({
     async baseUrl() {
         const baseUrl = await earnYieldWorkerBaseUrl.get();
 
-        return `${baseUrl}/yieldxyz/v1`;
+        return `${baseUrl}/yieldxyz/v2`;
     },
     headers: { 'X-Suite-Version': getSuiteVersion() },
 });
 
 export const getYields = yieldXyzApi('/yields', {
     method: 'GET',
-    schema: GetYieldsResponse,
+    schema: YieldsResponseV2,
 });
 
 export const getYield = yieldXyzApi('/yields/:vaultId', {
     method: 'GET',
-    schema: GetYieldResponse,
+    schema: YieldResponseV2,
 });

--- a/suite-common/earn-stablecoin-api/src/tests/utils/sortRewardsByUnderlyingToken.test.ts
+++ b/suite-common/earn-stablecoin-api/src/tests/utils/sortRewardsByUnderlyingToken.test.ts
@@ -1,8 +1,8 @@
-import { type RewardDto, type TokenDto } from '@suite-common/earn-stablecoin-defs';
+import { type RewardDtoV2, type TokenDtoV2 } from '@suite-common/earn-stablecoin-defs';
 
 import { sortRewardsByUnderlyingToken } from '../../utils/sortRewardsByUnderlyingToken';
 
-const USDC: TokenDto = {
+const USDC: TokenDtoV2 = {
     symbol: 'USDC',
     name: 'USD Coin',
     decimals: 6,
@@ -10,7 +10,7 @@ const USDC: TokenDto = {
     address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
 };
 
-const MORPHO: TokenDto = {
+const MORPHO: TokenDtoV2 = {
     symbol: 'MORPHO',
     name: 'Morpho',
     decimals: 18,
@@ -18,7 +18,7 @@ const MORPHO: TokenDto = {
     address: '0x58d97b57bb95320f9a05dc918aef65434969c2b2',
 };
 
-const ARB: TokenDto = {
+const ARB: TokenDtoV2 = {
     symbol: 'ARB',
     name: 'Arbitrum',
     decimals: 18,
@@ -27,10 +27,10 @@ const ARB: TokenDto = {
 };
 
 const reward = (
-    token: TokenDto,
-    yieldSource: RewardDto['yieldSource'],
+    token: TokenDtoV2,
+    yieldSource: RewardDtoV2['yieldSource'],
     rate: number,
-): RewardDto => ({ token, yieldSource, rate, rateType: 'APY' });
+): RewardDtoV2 => ({ token, yieldSource, rate, rateType: 'APY' });
 
 describe('sortRewardsByUnderlyingToken', () => {
     it('puts the underlying-asset reward first', () => {
@@ -44,7 +44,7 @@ describe('sortRewardsByUnderlyingToken', () => {
     });
 
     it('matches underlying token by address case-insensitively', () => {
-        const underlyingToken: TokenDto = { ...USDC, address: USDC.address!.toUpperCase() };
+        const underlyingToken: TokenDtoV2 = { ...USDC, address: USDC.address!.toUpperCase() };
         const underlying = reward(USDC, 'lending', 0.04);
         const incentive = reward(MORPHO, 'protocol_incentive', 0.5);
 

--- a/suite-common/earn-stablecoin-api/src/utils/sortRewardsByUnderlyingToken.ts
+++ b/suite-common/earn-stablecoin-api/src/utils/sortRewardsByUnderlyingToken.ts
@@ -1,6 +1,6 @@
-import { type RewardDto, type TokenDto } from '@suite-common/earn-stablecoin-defs';
+import { type RewardDtoV2, type TokenDtoV2 } from '@suite-common/earn-stablecoin-defs';
 
-const isSameToken = (a: TokenDto, b: TokenDto) => {
+const isSameToken = (a: TokenDtoV2, b: TokenDtoV2) => {
     if (a.address && b.address) {
         return a.address.toLowerCase() === b.address.toLowerCase();
     }
@@ -13,8 +13,8 @@ const isSameToken = (a: TokenDto, b: TokenDto) => {
 };
 
 export const sortRewardsByUnderlyingToken = (
-    rewards: RewardDto[],
-    underlyingToken: TokenDto | undefined,
+    rewards: RewardDtoV2[],
+    underlyingToken: TokenDtoV2 | undefined,
 ) =>
     rewards.toSorted((a, b) => {
         if (underlyingToken) {

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -1,4 +1,4 @@
-import { type TokenDto } from '@suite-common/earn-stablecoin-defs';
+import { type TokenDtoV2 } from '@suite-common/earn-stablecoin-defs';
 import { type DeviceModelInternal } from '@trezor/device-utils';
 
 export type NetworkSymbol =
@@ -149,7 +149,7 @@ type NetworkWithSpecificKey<TKey extends NetworkSymbol> = {
      * Network ID used by Yield.xyz
      * @url https://yield.xyz
      */
-    yieldXyzId: TokenDto['network'] | null;
+    yieldXyzId: TokenDtoV2['network'] | null;
 };
 export type Network = NetworkWithSpecificKey<NetworkSymbol>;
 

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -1,4 +1,4 @@
-import { type TokenDto } from '@suite-common/earn-stablecoin-defs';
+import { type TokenDtoV2 } from '@suite-common/earn-stablecoin-defs';
 import { exhaustive } from '@trezor/type-utils';
 
 import { networks } from './networksConfig';
@@ -162,5 +162,5 @@ export const getNetworkDecimals = (symbol: NetworkSymbolExtended) => {
     return undefined;
 };
 
-export const getNetworkByYieldXyzId = (yieldXyzId: TokenDto['network']) =>
+export const getNetworkByYieldXyzId = (yieldXyzId: TokenDtoV2['network']) =>
     networksCollection.find(n => n.yieldXyzId === yieldXyzId) ?? null;

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
@@ -1,4 +1,4 @@
-import type { YieldDto } from '@suite-common/earn-stablecoin-api';
+import type { YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import type { EvmHexString } from '@suite-common/schemas/src/evm';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { Account } from '@suite-common/wallet-types';
@@ -29,7 +29,7 @@ export type YieldFlowToken = YieldFlowDisplayToken & {
 
 export type YieldFlowResolvedData = {
     account: Account;
-    vault: YieldDto;
+    vault: YieldDtoV2;
     token: YieldFlowToken;
     receiptToken: YieldFlowDisplayToken;
 };

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -1,5 +1,5 @@
 import { Calldata, type EvmAddress } from '@suite-common/calldata';
-import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey, type EvmSelectedFee } from '@suite-common/wallet-types';
 import {
@@ -376,7 +376,7 @@ export const getConvertedOutputTokenBalanceToInputTokenAmount = ({
 const getVaultAddressFromYieldId = (yieldId: string) =>
     yieldId.match(/0x[a-fA-F0-9]{40}/)?.[0] ?? null;
 
-export const getYieldVaultContractAddress = (vault: Pick<YieldDto, 'id' | 'outputToken'>) =>
+export const getYieldVaultContractAddress = (vault: Pick<YieldDtoV2, 'id' | 'outputToken'>) =>
     vault.outputToken?.address ?? getVaultAddressFromYieldId(vault.id);
 
 export const getAllowanceSpender = (flowData: YieldFlowResolvedData) =>

--- a/suite-native/module-accounts-management/src/components/StablecoinYieldApyBreakdown.tsx
+++ b/suite-native/module-accounts-management/src/components/StablecoinYieldApyBreakdown.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 
 import {
-    type RewardDto,
-    type TokenDto,
+    type RewardDtoV2,
+    type TokenDtoV2,
     sortRewardsByUnderlyingToken,
 } from '@suite-common/earn-stablecoin-api';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
@@ -16,13 +16,13 @@ import { getApyBreakdownDescriptionKey } from '../utils';
 
 type StablecoinYieldApyBreakdownProps = {
     networkSymbol: NetworkSymbol;
-    rewards: RewardDto[];
-    underlyingToken: TokenDto | undefined;
+    rewards: RewardDtoV2[];
+    underlyingToken: TokenDtoV2 | undefined;
     tokenSymbol: string;
 };
 
 type RewardRowProps = {
-    reward: RewardDto;
+    reward: RewardDtoV2;
     networkSymbol: NetworkSymbol;
     tokenSymbol: string;
 };

--- a/suite-native/module-accounts-management/src/utils.ts
+++ b/suite-native/module-accounts-management/src/utils.ts
@@ -1,8 +1,8 @@
-import { type RewardDto } from '@suite-common/earn-stablecoin-api';
+import { type RewardDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type TxKeyPath } from '@suite-native/intl';
 
 export const getApyBreakdownDescriptionKey = (
-    yieldSource: RewardDto['yieldSource'],
+    yieldSource: RewardDtoV2['yieldSource'],
 ): TxKeyPath | null => {
     switch (yieldSource) {
         case 'protocol_incentive':

--- a/suite-native/module-earn/src/hooks/__tests__/useResolvedYieldFlowData.test.ts
+++ b/suite-native/module-earn/src/hooks/__tests__/useResolvedYieldFlowData.test.ts
@@ -1,4 +1,4 @@
-import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import { type TokenInfo } from '@trezor/connect';
 
@@ -35,13 +35,8 @@ const vault = {
     providerId: 'morpho',
     metadata: {
         name: 'Steakhouse USDC Prime',
-        description: '',
         underMaintenance: false,
         deprecated: false,
-        logoURI: '',
-        documentation: '',
-        supportedStandards: [],
-        supportsCampaigns: false,
     },
     token: {
         address: underlyingTokenAddress,
@@ -59,7 +54,6 @@ const vault = {
         network: 'ethereum',
         coinGeckoId: 'usd-coin',
     },
-    inputTokens: [],
     rewardRate: {
         total: 0.05,
         rateType: 'APY',
@@ -69,7 +63,7 @@ const vault = {
         enter: true,
         exit: true,
     },
-} satisfies Omit<YieldDto, 'tokens' | 'mechanics' | 'prime'> as unknown as YieldDto;
+} satisfies YieldDtoV2 as unknown as YieldDtoV2;
 
 const resolve = ({
     tokenContract,

--- a/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts
+++ b/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { type YieldDto, useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2, useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
 import { getNetworkByYieldXyzId } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
@@ -38,7 +38,7 @@ type UnresolvedYieldFlowData = {
     depositedSharesAmount: string | null;
     token: YieldFlowToken | null;
     tokenSymbol: TokenSymbol | null;
-    vault: YieldDto | null;
+    vault: YieldDtoV2 | null;
     vaultTokenName: string | null;
     vaultTokenSymbol: string | null;
 };
@@ -54,7 +54,7 @@ type YieldFlowDataResolved = {
     depositedSharesAmount: string;
     token: YieldFlowToken;
     tokenSymbol: TokenSymbol;
-    vault: YieldDto;
+    vault: YieldDtoV2;
     vaultTokenName: string;
     vaultTokenSymbol: string;
 };
@@ -65,7 +65,7 @@ type ResolveYieldFlowDataParams = {
     account: Account | null;
     tokenContract: string;
     yieldId?: string;
-    yieldOpportunities: YieldDto[];
+    yieldOpportunities: YieldDtoV2[];
 };
 
 type GetMatchingTokenParams = {
@@ -220,7 +220,7 @@ export const resolveYieldFlowData = ({
     };
 };
 
-const emptyYieldOpportunities: YieldDto[] = [];
+const emptyYieldOpportunities: YieldDtoV2[] = [];
 
 export const useResolvedYieldFlowData = ({
     accountKey,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Upgrade `/yield/v2` and rename respective types (no migration required – the v2 was specially design for Suite, no redundant data).  
- ~~This PR can be merged after [this Cloudflare worker PR](https://github.com/trezor/cloudflare-workers/pull/78)~~ Done.

## Notes for QA

Stablecoin Yield still load available vaults.

## Related Issue

Resolve #29126

## Screenshots:

<img width="2727" height="1574" alt="Snímek obrazovky 2026-06-26 v 12 25 54" src="https://github.com/user-attachments/assets/d68992cf-6f7a-4af4-a4b3-63a432ad2665" />

<img width="2722" height="914" alt="Snímek obrazovky 2026-06-26 v 15 58 14" src="https://github.com/user-attachments/assets/dd0715e0-fd08-4252-9880-a39253a7ad9d" />



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/stablecoin-yield-api-2&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/stablecoin-yield-api-2&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/stablecoin-yield-api-2&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in the earn/yield/staking feature area: yield deposit/withdraw flows, staking dashboard table components, APY breakdown UI, nutshell modal, and stablecoin yield API utilities. There are also changes to token table components (TokenRow, TokenRowActions, TokensTable) and foundational wallet-config types/utils. The wallet-config changes map to 121+ tests but are likely type-level changes that won't affect runtime behavior. The primary risk is in the ETH/SOL/ADA staking E2E flows which directly exercise the changed deposit, withdraw, dashboard, and modal components. Secondary risk exists for token table navigation and earn route rendering.

<details><summary><b>Changed files (35)</b></summary>

- `packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx`
- `packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts`
- `packages/suite/src/components/earn/dashboard/yield/types.ts`
- `packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldDepositingInfo.tsx`
- `packages/suite/src/components/earn/yield/common/YieldFlowCompleteDeposit.tsx`
- `packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx`
- `packages/suite/src/components/earn/yield/deposit/YieldDeposit.tsx`
- `packages/suite/src/components/earn/yield/deposit/useYieldDeposit.ts`
- `packages/suite/src/components/earn/yield/hooks/useResolvedYieldFlowData.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts`
- `packages/suite/src/components/earn/yield/withdraw/YieldWithdraw.tsx`
- `packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts`
- `packages/suite/src/components/earn/yield/yieldFlowUtils.ts`
- `packages/suite/src/types/earn/earnLayout.ts`
- `packages/suite/src/views/earn/yield/useEarnLayout.tsx`
- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx`
- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx`
- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx`
- `suite-common/earn-stablecoin-api/src/hooks/useAllYieldOpportunities.ts`
- `suite-common/earn-stablecoin-api/src/hooks/useYieldOpportunity.ts`
- `suite-common/earn-stablecoin-api/src/services/yieldxyz.ts`
- `suite-common/earn-stablecoin-api/src/tests/utils/sortRewardsByUnderlyingToken.test.ts`
- `suite-common/earn-stablecoin-api/src/utils/sortRewardsByUnderlyingToken.ts`
- `suite-common/wallet-config/src/types.ts`
- `suite-common/wallet-config/src/utils.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts`
- `suite-native/module-accounts-management/src/components/StablecoinYieldApyBreakdown.tsx`
- `suite-native/module-accounts-management/src/utils.ts`
- `suite-native/module-earn/src/hooks/__tests__/useResolvedYieldFlowData.test.ts`
- `suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the ETH staking flow including the 'Staking in a Nutshell' modal and deposit form, which directly uses the changed EarnInANutshell/YieldDepositingInfo component, YieldDeposit, useYieldDeposit, and useYieldFlow hooks. Changes to yield deposit logic and the nutshell modal could break this flow.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test covers the ETH 'Stake More' flow including staking dashboard display, staking form, and pending transaction tracking. It directly exercises EarnYieldTable, useYieldTableData for the dashboard view, and the deposit/staking flow components that were changed.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test covers the ETH unstaking and claiming flow, directly exercising the changed YieldWithdraw component, useYieldWithdraw hook, and the staking dashboard components (EarnYieldTable, useYieldTableData) for displaying staked/unstaking amounts.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates the ETH staking form input validation, percentage/max buttons, and crypto/fiat switching. The staking form uses useYieldDeposit and YieldDeposit components that were changed, and form behavior depends on useResolvedYieldFlowData and yieldFlowUtils.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL initial staking exercises the staking nutshell modal and deposit flow. While SOL staking has its own specific components, the shared EarnInANutshell modal with YieldDepositingInfo was changed, and the earn layout/page header changes could affect navigation.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — SOL stake-more flow shows the staking dashboard and deposit form. Changes to the yield table components and deposit hooks could affect how staking amounts are displayed and the staking form behavior for SOL.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstaking exercises the withdraw flow and staking dashboard. The changed YieldWithdraw and useYieldWithdraw components handle the unstaking form, and dashboard components show staking amounts.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — SOL rewards test displays staking dashboard with staked amounts and reward data. The changed EarnYieldTable and useYieldTableData directly control how these amounts are rendered.
- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking flow uses the staking nutshell modal which includes the changed YieldDepositingInfo component. The staking dashboard display also uses earn dashboard components that were modified.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — ADA unstaking exercises the withdraw flow. While ADA has specific staking components, the shared withdraw UI components (YieldWithdraw) were changed and could affect the unstake modal and confirmation flow.
- `suite/e2e/tests/staking/ada/claim.test.ts` — ADA claim rewards test interacts with the staking dashboard and reward display components. Changes to EarnAccountCell and the yield table could affect how staked balances and rewards are shown.
- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates through token pages (TrueUSD, USDC on Ethereum) which render TokenRow and TokensTable components that were directly changed. Changes to token row actions could break navigation to buy/sell/swap from token views.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test crawls all routes including /earn/yield/deposit and /earn/yield/withdraw pages. Changes to earn layout (useEarnLayout), page headers (YieldPageHeader), and yield flow components could cause rendering failures on these routes, breaking the link check.
- `suite/e2e/tests/analytics/staking-events.test.ts` — This test navigates to staking from account menu and dashboard for ETH/ADA. Changes to earn dashboard components (EarnAccountCell, EarnYieldTable) could affect the staking navigation entry points that trigger the StakingNavigate analytics event.

</details>

⚠️ **Changes with no test coverage (16)**
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx`
- `packages/suite/src/components/earn/dashboard/yield/types.ts`
- `packages/suite/src/components/earn/yield/common/YieldFlowCompleteDeposit.tsx`
- `packages/suite/src/types/earn/earnLayout.ts`
- `suite-common/earn-stablecoin-api/src/hooks/useAllYieldOpportunities.ts`
- `suite-common/earn-stablecoin-api/src/hooks/useYieldOpportunity.ts`
- `suite-common/earn-stablecoin-api/src/services/yieldxyz.ts`
- `suite-common/earn-stablecoin-api/src/tests/utils/sortRewardsByUnderlyingToken.test.ts`
- `suite-common/earn-stablecoin-api/src/utils/sortRewardsByUnderlyingToken.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts`
- `suite-native/module-accounts-management/src/components/StablecoinYieldApyBreakdown.tsx`
- `suite-native/module-accounts-management/src/utils.ts`
- `suite-native/module-earn/src/hooks/__tests__/useResolvedYieldFlowData.test.ts`
- `suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts`

_Updated: 2026-06-26T15:48:27.919Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/stablecoin-yield-api-2/web/](https://dev.suite.sldev.cz/suite-web/refactor/stablecoin-yield-api-2/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-26T15:51:41.159Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->