### PR TITLE
refactor(suite): use server address example & validation from suite-common

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/BackendTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/BackendTypeSelect.tsx
@@ -4,11 +4,10 @@ import styled from 'styled-components';
 
 import { selectIsDebugModeActive } from '@suite/debug';
 import { Translation } from '@suite/intl';
-import { type Network } from '@suite-common/wallet-config';
+import { type Network, type ServerType } from '@suite-common/wallet-config';
 import { Select } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
 
-import type { BackendOption } from 'src/hooks/settings/backends';
 import { useSelector } from 'src/hooks/suite';
 
 const Capitalize = styled.span`
@@ -63,8 +62,8 @@ const useBackendOptions = (network: Network, isDebugModeActive: boolean) => {
 
 type BackendTypeSelectProps = {
     network: Network;
-    value: BackendOption;
-    onChange: (type: BackendOption) => void;
+    value: ServerType;
+    onChange: (type: ServerType) => void;
 };
 
 export const BackendTypeSelect = ({ network, value, onChange }: BackendTypeSelectProps) => {

--- a/packages/suite/src/hooks/settings/backends/index.ts
+++ b/packages/suite/src/hooks/settings/backends/index.ts
@@ -2,4 +2,3 @@ export { useDefaultUrls } from './useDefaultUrls';
 export { useBackendsForm } from './useBackendsForm';
 export { useCustomBackends } from './useCustomBackends';
 export { useBackendReconnection } from './useBackendReconnection';
-export type { BackendOption } from './useBackendsForm';

--- a/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
+++ b/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
@@ -5,63 +5,25 @@ import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useTranslation } from '@suite/intl';
 import { isOnionUrl } from '@suite/tor';
 import { useServices } from '@suite-common/dependency-injection';
-import { type BackendType, type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import {
+    type NetworkSymbol,
+    type ServerType,
+    getNetwork,
+    getServerAddressExample,
+    validateServerAddress,
+} from '@suite-common/wallet-config';
 import { blockchainActions } from '@suite-common/wallet-core';
 import { type BackendSettings } from '@suite-common/wallet-types';
-import { isElectrumUrl } from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
-import { isUrlWithQuery } from '@trezor/utils';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
-export type BackendOption = BackendType | 'default';
-
 type BackendsFormData = {
-    type: BackendOption;
+    type: ServerType;
     urls: string[];
 };
 
-const validateUrl = (type: BackendOption, value: string) => {
-    switch (type) {
-        case 'blockbook':
-            return isUrlWithQuery(value);
-        case 'blockfrost':
-            return isUrlWithQuery(value);
-        case 'electrum':
-            return isElectrumUrl(value);
-        case 'solana':
-            return isUrlWithQuery(value);
-        case 'ripple':
-            return isUrlWithQuery(value);
-        case 'stellar':
-            return isUrlWithQuery(value);
-        case 'evm-rpc':
-            return isUrlWithQuery(value);
-        default:
-            return false;
-    }
-};
-
-const getUrlPlaceholder = (symbol: NetworkSymbol, type: BackendOption) => {
-    switch (type) {
-        case 'blockbook':
-            return `https://${symbol}.trezor.io/`;
-        case 'blockfrost':
-            return `wss://${symbol}.trezor.io/`;
-        case 'electrum':
-            return `electrum.example.com:50001:t`;
-        case 'solana':
-        case 'stellar':
-        case 'evm-rpc':
-            return 'https://';
-        case 'ripple':
-            return 'wss://';
-        default:
-            return '';
-    }
-};
-
-const useBackendUrlInput = (symbol: NetworkSymbol, type: BackendOption, currentUrls: string[]) => {
+const useBackendUrlInput = (symbol: NetworkSymbol, type: ServerType, currentUrls: string[]) => {
     const {
         register,
         watch,
@@ -74,19 +36,16 @@ const useBackendUrlInput = (symbol: NetworkSymbol, type: BackendOption, currentU
 
     const name = 'url' as const;
     const validate = (value: string) => {
-        // Check if URL is valid
-        if (!validateUrl(type, value)) {
+        if (!validateServerAddress(type, value)) {
             return translationString('TR_CUSTOM_BACKEND_INVALID_URL');
         }
-
-        // Check if already exists
         if (currentUrls.includes(value)) {
             return translationString('TR_CUSTOM_BACKEND_BACKEND_ALREADY_ADDED');
         }
     };
 
     const placeholder = translationString('SETTINGS_ADV_COIN_URL_INPUT_PLACEHOLDER', {
-        url: getUrlPlaceholder(symbol, type),
+        url: getServerAddressExample(symbol, type),
     });
 
     return {
@@ -102,7 +61,7 @@ const useBackendUrlInput = (symbol: NetworkSymbol, type: BackendOption, currentU
 
 const getStoredState = (
     symbol: NetworkSymbol,
-    type?: BackendOption,
+    type?: ServerType,
     urls?: BackendSettings['urls'],
 ): BackendsFormData => ({
     type: type ?? (symbol === 'regtest' ? 'blockbook' : 'default'),
@@ -126,7 +85,7 @@ export const useBackendsForm = (symbol: NetworkSymbol) => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [symbol]);
 
-    const changeType = (type: BackendOption) => {
+    const changeType = (type: ServerType) => {
         setCurrentValues(getStoredState(symbol, type, backends.urls));
         setValidationError(null);
     };


### PR DESCRIPTION
## Description

🖥️ Suite refactored to use server address example & validation from `suite-common`.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on the custom backend configuration UI: the BackendTypeSelect component, the useBackendsForm hook, and its barrel export. These are specifically used when users configure custom blockchain backends (Blockbook, Electrum, Blockfrost) in the coin settings. The highest-risk tests are those that directly exercise custom backend configuration (coins-custom-backend, coins, blockbook-discovery, electrum). Medium-priority tests are those that rely on setting up custom backends as a prerequisite for other functionality (staking tests with mocked backends, send tests with custom backends, analytics events that verify custom backend state). The remaining 121 tests mapped via static coverage are false positives from broad transitive imports and should not be run.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/BackendTypeSelect.tsx`
- `packages/suite/src/hooks/settings/backends/index.ts`
- `packages/suite/src/hooks/settings/backends/useBackendsForm.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test directly exercises custom backend configuration for coins (BTC, ETH), including selecting backend type and entering URLs via the advanced coin settings modal. The changed BackendTypeSelect component and useBackendsForm hook are the core of this functionality.
- `suite/e2e/tests/settings/coins.test.ts` — This test configures a custom blockbook backend for ETH via advanced coin settings, directly exercising the BackendTypeSelect component and useBackendsForm hook. It verifies backend type selection, URL input, and the custom backend indicator.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backend URLs for BTC and LTC via the coins settings tab advanced settings and changeBackend flow, directly using the backend configuration UI components that were changed.
- `suite/e2e/tests/settings/electrum.test.ts` — This test configures an Electrum backend for Regtest via the coins tab advanced settings, exercising the backend type selection (changing to electrum) and URL configuration that uses BackendTypeSelect and useBackendsForm.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test configures custom backends as part of changing application settings before verifying analytics events. The SuiteReady event specifically checks 'customBackends: eth', which requires the backend configuration flow to work correctly.
- `suite/e2e/tests/staking/ada/claim.test.ts` — This test enables ADA with a mocked Blockfrost backend via openNetworkAdvanceSettings and changeBackend, exercising the backend configuration UI to set up the custom backend before testing staking.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This test configures a custom Blockfrost backend for ADA via the coins tab advanced settings before testing staking, directly using the backend type selection and URL configuration flow.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — This test sets up a custom Blockfrost backend for ADA via advanced coin settings before testing unstaking functionality, using the backend configuration components that were changed.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test enables ETH with a custom blockbook backend via coinsTab.changeBackend before testing staking, exercising the backend configuration flow.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test configures a custom blockbook backend for ETH via the coins tab settings before testing the staking form, using the backend type selection and URL input.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test enables DOGE and configures a custom blockbook backend via openNetworkAdvanceSettings and changeBackend before testing send functionality, directly using the changed backend configuration components.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test configures a custom blockbook backend for LTC via the coins tab settings before testing the send form with MimbleWimble peg-out transactions.

</details>

_Updated: 2026-06-26T11:10:37.227Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/suite/backend-server-address/web/](https://dev.suite.sldev.cz/suite-web/refactor/suite/backend-server-address/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/suite/backend-server-address&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/suite/backend-server-address&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-26T11:14:48.347Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |

</details>

_Updated: 2026-06-26T11:13:51.404Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->