### PR TITLE
fix(suite): do not chunk Tron voting address

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -572,6 +572,7 @@ const getOutputLines = ({
                     type: 'safe-address',
                     label: <Translation id="TR_ADDRESS" />,
                     value,
+                    isChunked: false,
                 },
                 {
                     id: 'votes',

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -100,9 +100,10 @@ type ValueProps = {
     isFiatVisible: boolean;
     state: TransactionReviewOutputElementProps['state'];
     token?: TokenInfo;
+    isChunked?: boolean;
 };
 
-const Value = ({ value, type, symbol, token, isFiatVisible, state }: ValueProps) => {
+const Value = ({ value, type, symbol, token, isFiatVisible, state, isChunked }: ValueProps) => {
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(symbol);
 
     switch (type) {
@@ -115,7 +116,7 @@ const Value = ({ value, type, symbol, token, isFiatVisible, state }: ValueProps)
                 <Address value={value} isDeviceRendered />
             );
         case 'safe-address':
-            return <Address value={value} isDeviceRendered />;
+            return <Address value={value} isDeviceRendered isChunked={isChunked} />;
         case 'note':
             return <Text>{value}</Text>;
         case 'data':
@@ -165,6 +166,7 @@ export type OutputElementLine = {
     token?: TokenInfo;
     type: 'default' | 'address' | 'safe-address' | 'note' | 'data' | 'amount';
     label?: ReactNode;
+    isChunked?: boolean;
 };
 
 export type TransactionReviewOutputElementProps = {
@@ -210,6 +212,7 @@ export const TransactionReviewOutputElement = ({
                             token={line.token}
                             isFiatVisible={fiatVisible}
                             state={state}
+                            isChunked={line.isChunked}
                         />
                     );
 


### PR DESCRIPTION
## Description

Disable address chunking in transaction review modal when doing Tron stake voting.

## Related Issue

Resolve #28981 

## Screenshots:

<img width="100%" alt="Screenshot 2026-06-26 at 13 17 06" src="https://github.com/user-attachments/assets/8abb193c-853d-47d6-9f0c-6f7d62219f8e" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files (TransactionReviewOutput.tsx and TransactionReviewOutputElement.tsx) are components within the transaction review modal that render output details (addresses, amounts, fees) during send/swap/sell/staking confirmation flows. Despite mapping to 121 tests via static analysis, only tests that actually exercise the transaction review/send confirmation modal are relevant. The highest priority tests are direct send flows (BTC regtest, LTC, DOGE, ETH, SOL) that assert on specific output values in the review modal. Medium priority covers trading (sell/swap) and staking flows that also trigger transaction review confirmation with device prompt assertions.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx`

</details>

**Recommended tests (21)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/wallet/send-doge.test.ts` — This test directly exercises the transaction review/confirmation modal by displaying amount, total, fee, and address on the device prompt modal during a send flow. Changes to TransactionReviewOutput and TransactionReviewOutputElement would directly affect how these values are rendered.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test verifies the transaction review modal for Ethereum sends, asserting on recipient address, gas limit, fee rate, priority fee rate, crypto amount, and maximum fee displayed via device prompt — all rendered through TransactionReviewOutput components.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test validates the Review & Send modal for Solana transactions, checking recipient address, total crypto amount, and fee display — outputs rendered by the TransactionReviewOutput components being changed.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test sends LTC via broadcast mode and confirms the transaction via device prompt, directly exercising the transaction review output rendering for LTC MimbleWimble peg-out transactions.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test submits BTC regtest transactions including OP_RETURN outputs and confirms them via device prompt. The transaction review modal renders these output details through the changed components.

</details>

<details><summary>🟡 <b>Medium priority (15)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — The sell BTC flow initiates a send transaction and verifies device prompt output values (address, crypto amount, fee). The transaction review modal is used to display these outputs before signing.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — The sell ETH flow triggers a send confirmation that displays destination address and crypto amount via the transaction review modal, making it sensitive to changes in the output rendering components.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test initiates a SOL sell send confirmation and verifies address, total crypto amount, and fee on the device prompt, which renders through the TransactionReviewOutput components.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Selling an ERC-20 token triggers a send transaction review showing destination address and USDC amount via the device prompt, exercising the changed output rendering components.
- `suite/e2e/tests/trading/swap-coins.test.ts` — The swap flow from SOL to BTC initiates a send confirmation and asserts on device prompt output values (address, amount, fee), which are rendered by the TransactionReviewOutput components.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test verifies custom BTC fee display (fee rate, total amount) in the transaction review modal during a swap, directly exercising TransactionReviewOutput rendering.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test verifies custom Ethereum gas parameters (gas limit, max fee per gas, priority fee) in the transaction review modal during a swap, directly testing output element rendering.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Swapping SOL to USDC initiates send confirmation and verifies device prompt output values (address, amount, fee), rendered through the changed TransactionReviewOutput components.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swapping USDT to BTC triggers send confirmation with token confirmation and verifies device prompt outputs (address, amount, fee), exercising the changed components.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Swapping USDT to USDC on Solana triggers a send confirmation displaying output values via the transaction review modal, directly relevant to the changed output components.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Cardano staking confirms stake key registration and delegation on the device, which may use the transaction review output components to display confirmation details like deposit and fee amounts.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Claiming ADA staking rewards shows withdrawal details (reward address, amount, fee) via device confirmation, potentially rendered through the transaction review output components.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — ADA unstaking displays stake key deregistration and transaction fee details on the device, which likely uses the transaction review output rendering path.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking shows device prompt with stake amount and fee, which may use the transaction review output components for rendering the confirmation modal.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL initial staking shows device prompt with stake amount, rent, and fee. The transaction review output components may render these confirmation details.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/without-device.test.ts` — This test clicks the send review button (which triggers the transaction review modal) and checks that a connection modal appears when device is disconnected. While the review modal is invoked, the assertions focus on the connection modal rather than output rendering.

</details>

_Updated: 2026-06-26T11:24:27.013Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tron-vote-address-chunking/web/](https://dev.suite.sldev.cz/suite-web/fix/tron-vote-address-chunking/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tron-vote-address-chunking&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tron-vote-address-chunking&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-26T11:28:39.226Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |

</details>

_Updated: 2026-06-26T11:27:18.027Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->