### PR TITLE
chore(sentry): ignore unhandledrejection [object Object] events

### DIFF
--- a/suite/sentry/src/ignoreErrors.ts
+++ b/suite/sentry/src/ignoreErrors.ts
@@ -17,4 +17,7 @@ export const ignoreErrors = [
 
     // nodeJS deprecation errors
     /.*DEP0040.*punycode.*/, // used deep within tech stack, not much we can do about it atm
+
+    // browser-only Sentry global handler sends duplicated errors (in event.extra it wraps an error message that is also sent as a separate error event)
+    /.*unhandledrejection*object Object.*/,
 ] satisfies Options['ignoreErrors'];


### PR DESCRIPTION
## Description

Add an ignored Sentry error for Suite Web & Desktop  (matches a new inbound filters).  

Replaces #28745
- in that PR, I mistakenly thought that the error wrapped in `[global] unhandledrejection` swallowed the real error
- but the real error is sent alongside :heavy_check_mark: 
- it just wasn't visible for the current wave of `Aborted by timeout`, because there, the real error is ignored by current outbound filters

→ just ignore the `unhandledrejection` in outbound filters, it's pure spam.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `suite/sentry/src/ignoreErrors.ts`, which configures error filtering rules for Sentry (error reporting). This file has no static test coverage mapping, and none of the 85 candidate E2E tests exercise Sentry error filtering behavior — they focus on user-facing features like onboarding, trading, wallet operations, analytics, and device interactions. Since `ignoreErrors.ts` controls which errors are silently dropped by Sentry rather than affecting any user-visible behavior or application logic, no E2E tests are expected to be impacted by this change. The risk is very low; this change would only affect what gets reported to Sentry's error monitoring dashboard, not application functionality.

<details><summary><b>Changed files (1)</b></summary>

- `suite/sentry/src/ignoreErrors.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite/sentry/src/ignoreErrors.ts`

_Updated: 2026-06-26T13:06:39.127Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/ignore-unhandledrejection-in-sentry&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/ignore-unhandledrejection-in-sentry&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Trading - Sell Ethereum,Sell Ethereum" | 🙋 manual |
| Quarantine test: "Trading - Swap fees,Swap custom fees for Ethereum" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-26T13:11:26.151Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Send Eth,User can initiate ethereum sending" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |

</details>

_Updated: 2026-06-26T13:09:52.862Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/ignore-unhandledrejection-in-sentry/web/](https://dev.suite.sldev.cz/suite-web/chore/ignore-unhandledrejection-in-sentry/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->