### PR TITLE
fix(suite-native): correct bold tag typo in firmware installation message

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -3644,7 +3644,7 @@ export const messages = {
                     update: 'This firmware update may take some time to complete.',
                     install: 'This firmware installation may take some time to complete.',
                 },
-                item2: '</b> Keep the app open while installing</b> —closing it may corrupt the firmware.',
+                item2: '<b> Keep the app open while installing</b> —closing it may corrupt the firmware.',
                 item3: {
                     update: 'While the firmware is updating, leave your phone as is. It will remain on throughout the update.',
                     install:


### PR DESCRIPTION
### Description
Fixes a typo in the firmware installation message where a closing bold tag `</b>` was used instead of an opening bold tag `<b>`.

### Notes for QA
N/A