### PR TITLE
refactor(sentry): consistent beforeSend callback typing

### DIFF
--- a/suite-common/sentry/src/index.ts
+++ b/suite-common/sentry/src/index.ts
@@ -1,3 +1,4 @@
 export * from './constants';
 export { ignoreErrorsCommon } from './ignoreErrors';
 export { redactSentryEvent } from './redactSentryEvent';
+export type { ChainableBeforeSend } from './types';

--- a/suite-common/sentry/src/redactSentryEvent.ts
+++ b/suite-common/sentry/src/redactSentryEvent.ts
@@ -1,6 +1,5 @@
-import type { ErrorEvent } from '@sentry/core';
-
 import { ALLOW_REPORT_TAG, MAX_EVENTS_INTERVAL_LENGTH, MAX_EVENTS_PER_INTERVAL } from './constants';
+import { type ChainableBeforeSend } from './types';
 
 let eventCountThisSession = 0;
 let countingStartTimestamp = Date.now();
@@ -18,7 +17,9 @@ const incrementOrResetCounter = () => {
  * Note that in case of Desktop & Mobile, the SDKs share tags and userId between processes
  * (it consistently handles events e.g. from Electron Main vs. Renderer)
  */
-export const redactSentryEvent = (event: ErrorEvent): ErrorEvent | null => {
+export const redactSentryEvent: ChainableBeforeSend = event => {
+    if (event === null) return null;
+
     incrementOrResetCounter();
     // hard limit the number of events sent this session (app instance), to prevent a flurry of events sent in a loop
     if (eventCountThisSession > MAX_EVENTS_PER_INTERVAL) {

--- a/suite-common/sentry/src/types.ts
+++ b/suite-common/sentry/src/types.ts
@@ -1,0 +1,7 @@
+import type { ErrorEvent } from '@sentry/core';
+
+/**
+ * Allows to to compose a Sentry beforeSend from smaller atomic functions, because
+ * Sentry's beforeSend type can return null, but doesn't accept it.
+ */
+export type ChainableBeforeSend = (event: ErrorEvent | null) => ErrorEvent | null;

--- a/suite/sentry/src/config.ts
+++ b/suite/sentry/src/config.ts
@@ -5,9 +5,14 @@ import {
     captureConsoleIntegration,
     elementTimingIntegration,
 } from '@sentry/browser';
-import type { ErrorEvent, Options } from '@sentry/core';
+import type { Options } from '@sentry/core';
 
-import { COINJOIN_NETWORK_TAG, COINJOIN_REPORT_TAG, redactSentryEvent } from '@suite-common/sentry';
+import {
+    COINJOIN_NETWORK_TAG,
+    COINJOIN_REPORT_TAG,
+    type ChainableBeforeSend,
+    redactSentryEvent,
+} from '@suite-common/sentry';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { isCodesignBuild } from '@trezor/env-utils';
 import { redactUserPathFromString } from '@trezor/utils';
@@ -25,7 +30,8 @@ import { ignoreErrors } from './ignoreErrors';
  *
  * This is relevant only on Desktop.
  */
-const redactUserPath = (event: ErrorEvent): ErrorEvent => {
+const redactUserPath: ChainableBeforeSend = event => {
+    if (event === null) return null;
     try {
         const eventAsString = JSON.stringify(event);
         const redactedString = redactUserPathFromString(eventAsString);
@@ -43,7 +49,8 @@ const redactUserPath = (event: ErrorEvent): ErrorEvent => {
 };
 
 // Leaves only what is really necessary on a coinjoin error event
-const redactCoinjoinData = (event: ErrorEvent): ErrorEvent => {
+const redactCoinjoinData: ChainableBeforeSend = event => {
+    if (event === null) return null;
     if (event.tags?.[COINJOIN_REPORT_TAG]) {
         return {
             type: event.type,
@@ -60,7 +67,7 @@ const redactCoinjoinData = (event: ErrorEvent): ErrorEvent => {
     return event;
 };
 
-const beforeSend = (event: ErrorEvent) =>
+const beforeSend: ChainableBeforeSend = event =>
     redactSentryEvent(redactUserPath(redactCoinjoinData(event)));
 
 const beforeBreadcrumb: Options['beforeBreadcrumb'] = breadcrumb => {


### PR DESCRIPTION
## Description

Small leftover from #28745
to make `beforeSend` in Sentry easier to work with – you will be able to chain them any way you want, currently TS needlessly enforces one specific order.

## Notes for QA

N/A, if TS is satisfied then this is safe

The new `if (event === null)` branches are never invoked (if they were, TS would fail at current develop). 

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all within the Sentry error-reporting infrastructure (suite-common/sentry and suite/sentry). These changes affect error redaction logic, Sentry types, and Sentry configuration — none of which are directly exercised by any E2E test. Sentry is a background error-reporting service that doesn't affect user-visible application behavior tested by E2E tests. The redactSentryEvent.ts file maps to 121 tests only because it's transitively imported as part of the global app bundle, not because any test specifically validates Sentry behavior. No E2E test in the candidate list checks Sentry event payloads, redaction logic, or error reporting configuration. Unit tests for the sentry package itself (not in this E2E test list) would be the appropriate validation mechanism. Running E2E tests for this change would provide no meaningful signal beyond confirming the app still boots without crashing, which any single smoke test would cover.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/sentry/src/index.ts`
- `suite-common/sentry/src/redactSentryEvent.ts`
- `suite-common/sentry/src/types.ts`
- `suite/sentry/src/config.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (4)**
- `suite-common/sentry/src/index.ts`
- `suite-common/sentry/src/redactSentryEvent.ts`
- `suite-common/sentry/src/types.ts`
- `suite/sentry/src/config.ts`

_Updated: 2026-06-26T13:14:27.563Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/sentry-beforeSend-interfaces&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/sentry-beforeSend-interfaces&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/sentry-beforeSend-interfaces&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Trading - Sell Ethereum,Sell Ethereum" | 🙋 manual |
| Quarantine test: "Trading - Swap fees,Swap custom fees for Ethereum" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-26T13:19:23.054Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Send Eth,User can initiate ethereum sending" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |

</details>

_Updated: 2026-06-26T13:18:01.340Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/sentry-beforeSend-interfaces/web/](https://dev.suite.sldev.cz/suite-web/refactor/sentry-beforeSend-interfaces/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->