### PR TITLE
fix firebase installation in EAS post-success hook and update to latest firebase CLI

### DIFF
--- a/suite-native/app/eas-post-success.sh
+++ b/suite-native/app/eas-post-success.sh
@@ -1,23 +1,37 @@
 #!/bin/bash
+set -euo pipefail
 
-FIREBASE_VERSION="${FIREBASE_VERSION:-v13.16.0}"
+FIREBASE_VERSION="${FIREBASE_VERSION:-v15.22.3}"
+FIREBASE_BINARY_SHA256="${FIREBASE_BINARY_SHA256:-27d7b37280b98e7250dae5f552f21f0ecfdf63968c43d80313cf38a41e491f96}"
+FIREBASE_BINARY_PATH="/tmp/firebase-tools-linux-${FIREBASE_VERSION}"
+FIREBASE_DOWNLOAD_URL="https://github.com/firebase/firebase-tools/releases/download/${FIREBASE_VERSION}/firebase-tools-linux"
+
+install_firebase_cli() {
+    curl -fsSL "$FIREBASE_DOWNLOAD_URL" -o "$FIREBASE_BINARY_PATH"
+
+    if ! printf '%s  %s\n' "$FIREBASE_BINARY_SHA256" "$FIREBASE_BINARY_PATH" | sha256sum -c -; then
+        echo "Firebase CLI checksum verification failed." >&2
+        exit 1
+    fi
+
+    chmod +x "$FIREBASE_BINARY_PATH"
+}
 
 distribute_develop_apk() {
-    # Install Firebase CLI
-    curl -sL https://firebase.tools | sed "s/latest/$FIREBASE_VERSION/" | bash
+    install_firebase_cli
 
     release_notes="Last commit hash: $EAS_BUILD_GIT_COMMIT_HASH"
     echo "$EAS_BUILD_GIT_COMMIT_HASH"
-    # Distribute APK to develop-testers group using Firebase CLI
-    firebase appdistribution:distribute "$EAS_BUILD_WORKINGDIR"/suite-native/app/android/app/build/outputs/apk/release/app-release.apk \
+
+    "$FIREBASE_BINARY_PATH" appdistribution:distribute "$EAS_BUILD_WORKINGDIR"/suite-native/app/android/app/build/outputs/apk/release/app-release.apk \
         --project pc-api-4710771878548015996-769 \
         --app 1:191883890128:android:625bcdab76b3b3a644bdd5 \
         --groups "develop-testers" \
         --release-notes "$release_notes"
 }
 
-if [[ "$EAS_BUILD_PLATFORM" == "android" && "$EAS_BUILD_PROFILE" == "develop" ]]; then
+if [[ "${EAS_BUILD_PLATFORM:-}" == "android" && "${EAS_BUILD_PROFILE:-}" == "develop" ]]; then
     distribute_develop_apk
-elif [[ "$EAS_BUILD_PLATFORM" == "ios" ]]; then
+elif [[ "${EAS_BUILD_PLATFORM:-}" == "ios" ]]; then
     exit 0
 fi


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

## Description

There were some changes in the firebase installation hook recently and it broke the hacky version pinning so I decided to delete that hack and download the binary directly together with checking the hash every time.

First failing pipeline https://expo.dev/accounts/trezorcompany/projects/trezor-suite-develop/builds/e6ef5409-e954-496b-9610-ea470a2225e7

## Notes for QA

Just verify that latest develop android build is shipped via App Tester



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/fix-eas-post-success-hook-firebase-installation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->