### PR TITLE
Connect settings revamp

### DIFF
--- a/packages/connect-common/src/data/connectSettings.ts
+++ b/packages/connect-common/src/data/connectSettings.ts
@@ -1,7 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/data/ConnectSettings.js
 
 import { parseThpSettings } from './thpSettings';
-import { DEFAULT_DOMAIN, VERSION } from './version';
+import { VERSION } from './version';
 import type { ConnectSettings, LocalFirmwares, Manifest } from '../types/settings';
 
 /*
@@ -9,18 +9,10 @@ import type { ConnectSettings, LocalFirmwares, Manifest } from '../types/setting
  * It could be changed by passing values into TrezorConnect.init(...) method
  */
 
-export const DEFAULT_PRIORITY = 2;
-
 const initialSettings: ConnectSettings = {
-    configSrc: './data/config.json', // constant
-    version: VERSION, // constant
     debug: false,
-    priority: DEFAULT_PRIORITY,
-    popupSrc: `${DEFAULT_DOMAIN}popup.html`,
     transports: undefined,
     pendingTransportEvent: true,
-    env: 'node',
-    timestamp: new Date().getTime(),
     transportReconnect: true,
 };
 
@@ -40,8 +32,7 @@ export const parseManifest = (manifest?: Manifest) => {
     };
 };
 
-export const parseVersion = (version?: string) =>
-    typeof version === 'string' ? version : initialSettings.version;
+export const parseVersion = (version?: string) => (typeof version === 'string' ? version : VERSION);
 
 export const parseLocalFirmwares = (localFirmwares: LocalFirmwares) => {
     if (!localFirmwares) return;
@@ -107,27 +98,8 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
         settings.pendingTransportEvent = input.pendingTransportEvent;
     }
 
-    if (typeof input.extension === 'string') {
-        settings.extension = input.extension;
-    }
-
-    if (typeof input.env === 'string') {
-        settings.env = input.env;
-    }
-
-    if (typeof input.timestamp === 'number') {
-        settings.timestamp = input.timestamp;
-    }
-
     if (typeof input.manifest === 'object') {
         settings.manifest = parseManifest(input.manifest);
-    }
-
-    if (
-        typeof input.coreMode === 'string' &&
-        ['auto', 'suite-desktop', 'suite-web'].includes(input.coreMode)
-    ) {
-        settings.coreMode = input.coreMode;
     }
 
     if (typeof input.binFilesBaseUrl === 'string') {
@@ -144,14 +116,6 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
         input.firmwareHashCheckTimeouts !== null
     ) {
         settings.firmwareHashCheckTimeouts = input.firmwareHashCheckTimeouts;
-    }
-
-    if (typeof input.npmVersion === 'string') {
-        settings.npmVersion = input.npmVersion;
-    }
-
-    if (typeof input.version === 'string') {
-        settings.version = input.version;
     }
 
     if (Array.isArray(input.enabledNetworks)) {

--- a/packages/connect-common/src/data/version.ts
+++ b/packages/connect-common/src/data/version.ts
@@ -2,13 +2,7 @@ export const VERSION = '10.0.0-alpha.1';
 
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 
-const isBeta = VERSION.includes('beta');
-
 export const DEFAULT_DOMAIN_MAJOR_VER = `https://connect.trezor.io/${versionN[0]}/`;
-
-export const DEFAULT_DOMAIN = isBeta
-    ? `https://connect.trezor.io/${VERSION}/`
-    : DEFAULT_DOMAIN_MAJOR_VER;
 
 // Increment with deeplink protocol changes
 export const DEEPLINK_VERSION = 1;

--- a/packages/connect-common/src/events/popup.ts
+++ b/packages/connect-common/src/events/popup.ts
@@ -1,6 +1,6 @@
 import type { TransportInfo } from './transport';
 import { UI_EVENT } from './ui-request';
-import type { ConnectSettings, Manifest } from '../types/settings';
+import type { ConnectDynamicSettings, Manifest } from '../types/settings';
 import type { MessageFactoryFn } from '../types/utils';
 
 export const POPUP = {
@@ -19,7 +19,7 @@ export const POPUP = {
 export interface PopupInit {
     type: typeof POPUP.INIT;
     payload: {
-        settings: ConnectSettings; // settings from window.opener (sent by @trezor/connect-web)
+        settings: ConnectDynamicSettings; // settings from window.opener (sent by @trezor/connect-web)
         useBroadcastChannel: boolean;
         useCore?: boolean;
     };

--- a/packages/connect-common/src/events/transport.ts
+++ b/packages/connect-common/src/events/transport.ts
@@ -4,7 +4,7 @@
 import type { TRANSPORT, Transport } from '@trezor/transport-common';
 
 import { serializeError } from '../constants/errors';
-import type { ConnectSettings } from '../types/settings';
+import type { ConnectSettingsTransport } from '../types/settings';
 import type { MessageFactoryFn } from '../types/utils';
 
 export const TRANSPORT_EVENT = 'TRANSPORT_EVENT';
@@ -27,7 +27,7 @@ export type TransportEvent =
 
 export interface TransportSetTransports {
     type: typeof TRANSPORT.SET_TRANSPORTS;
-    payload: Pick<ConnectSettings, 'transports'>;
+    payload: { transports?: ConnectSettingsTransport[] };
 }
 
 export interface TransportRequestWebUSBDevice {

--- a/packages/connect-common/src/impl/dynamic.ts
+++ b/packages/connect-common/src/impl/dynamic.ts
@@ -4,24 +4,10 @@ import { ERRORS } from '../constants';
 import { parseManifest, parseVersion } from '../data/connectSettings';
 import { type CallMethodPayload, createErrorMessage } from '../events';
 import type { ConnectFactoryDependencies } from '../factory';
-import type { ConnectSettings } from '../types';
+import type { ConnectDynamicSettings, ConnectImplSettings } from '../types';
 import type { UpdateConnectSettings } from '../types/api/core/updateConnectSettings';
 import { ConnectEmitter } from '../types/emitter';
 import { type CancelParams } from '../utils/cancelParams';
-
-export type ConnectImplSettings = {
-    manifest: NonNullable<ConnectSettings['manifest']>;
-    version: NonNullable<ConnectSettings['version']>;
-    env?: ConnectSettings['env'];
-    debug?: ConnectSettings['debug'];
-    enabledNetworks?: ConnectSettings['enabledNetworks'];
-};
-
-type CoreMode = 'auto' | 'suite-desktop' | 'suite-web';
-
-export type ConnectDynamicSettings = Partial<ConnectImplSettings> & {
-    coreMode?: CoreMode;
-};
 
 type ImplType = 'core-in-suite-desktop' | 'core-in-suite-web';
 
@@ -46,7 +32,7 @@ export class TrezorConnectDynamic implements ConnectFactoryDependencies<Record<n
     private currentTarget: ImplType;
     private readonly implementations: Record<ImplType, ConnectImpl>;
 
-    private coreMode?: CoreMode;
+    private coreMode?: ConnectDynamicSettings['coreMode'];
     private implSettings?: ConnectImplSettings;
     private callPending = 0;
     private beforeCallSynchronize = getSynchronize();

--- a/packages/connect-common/src/types/settings.ts
+++ b/packages/connect-common/src/types/settings.ts
@@ -102,3 +102,23 @@ export type ConnectSettings = ConnectSettingsPublic &
     ConnectSettingsInternal &
     // coreMode is a common parameter between these, so it is explicitly handled here for correct handling
     { coreMode?: 'auto' | 'suite-desktop' | 'suite-web' | 'deeplink' };
+
+export type ConnectImplSettings = {
+    manifest: Manifest;
+    version: string;
+    env?: 'node' | 'web' | 'webextension' | 'electron' | 'react-native';
+    debug?: boolean;
+    enabledNetworks?: EnabledNetwork[];
+};
+
+export type ConnectDynamicSettings = Partial<ConnectImplSettings> & {
+    coreMode?: 'auto' | 'suite-desktop' | 'suite-web';
+};
+
+export interface ConnectMobileSettings {
+    manifest: Manifest;
+    coreMode?: 'deeplink';
+    connectSrc?: string;
+    deeplinkOpen: (url: string) => void;
+    deeplinkCallbackUrl: string;
+}

--- a/packages/connect-common/src/types/settings.ts
+++ b/packages/connect-common/src/types/settings.ts
@@ -117,7 +117,6 @@ export type ConnectDynamicSettings = Partial<ConnectImplSettings> & {
 
 export interface ConnectMobileSettings {
     manifest: Manifest;
-    coreMode?: 'deeplink';
     connectSrc?: string;
     deeplinkOpen: (url: string) => void;
     deeplinkCallbackUrl: string;

--- a/packages/connect-common/src/types/settings.ts
+++ b/packages/connect-common/src/types/settings.ts
@@ -78,6 +78,8 @@ export interface ConnectSettingsPublic {
     // enable firmware hash check automatically when device connects. Requires binFilesBaseUrl to be set.
     enableFirmwareHashCheck?: boolean;
     firmwareHashCheckTimeouts?: FirmwareHashCheckTimeouts;
+    firmwareChannel?: FirmwareChannel;
+    localFirmwares?: LocalFirmwares;
     thp?: ThpSettings;
     enabledNetworks?: EnabledNetwork[];
 }
@@ -94,8 +96,6 @@ export interface ConnectSettingsInternal {
     env: 'node' | 'web' | 'webextension' | 'electron' | 'react-native';
     timestamp: number;
     proxy?: Proxy;
-    localFirmwares?: LocalFirmwares;
-    firmwareChannel?: FirmwareChannel;
 }
 
 export type ConnectSettings = ConnectSettingsPublic &

--- a/packages/connect-common/src/types/settings.ts
+++ b/packages/connect-common/src/types/settings.ts
@@ -56,7 +56,7 @@ export interface EnabledNetwork {
     coin: CoinSymbol;
 }
 
-export interface ConnectSettingsPublic {
+export interface ConnectSettings {
     manifest?: Manifest;
     // Enables connect logs. NOTE: connect core no longer uses this to gate its COMPONENT loggers
     // (Core/Device/DeviceCommands/@trezor/transport) — those are driven by `createLogger`. It is still
@@ -83,25 +83,6 @@ export interface ConnectSettingsPublic {
     thp?: ThpSettings;
     enabledNetworks?: EnabledNetwork[];
 }
-
-// internal part, not to be accepted from .init()
-export interface ConnectSettingsInternal {
-    origin?: string;
-    configSrc: string;
-    popupSrc: string;
-    version: string;
-    npmVersion?: string;
-    priority: number;
-    extension?: string;
-    env: 'node' | 'web' | 'webextension' | 'electron' | 'react-native';
-    timestamp: number;
-    proxy?: Proxy;
-}
-
-export type ConnectSettings = ConnectSettingsPublic &
-    ConnectSettingsInternal &
-    // coreMode is a common parameter between these, so it is explicitly handled here for correct handling
-    { coreMode?: 'auto' | 'suite-desktop' | 'suite-web' | 'deeplink' };
 
 export type ConnectImplSettings = {
     manifest: Manifest;

--- a/packages/connect-explorer/src/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/actions/trezorConnectActions.ts
@@ -69,7 +69,6 @@ export const init =
             if (connectOptions.coreMode === 'deeplink') {
                 await TrezorConnectMobile.init({
                     ...connectOptions,
-                    coreMode: 'deeplink',
                     deeplinkOpen(url) {
                         window.open(url, '_blank');
                     },

--- a/packages/connect-explorer/src/types/actions.ts
+++ b/packages/connect-explorer/src/types/actions.ts
@@ -1,7 +1,6 @@
 import type { TSchema } from '@sinclair/typebox';
 
-import type TrezorConnectMobile from '@trezor/connect-mobile';
-import type TrezorConnect from '@trezor/connect-web';
+import type { ConnectDynamicSettings, ConnectMobileSettings } from '@trezor/connect-common';
 import type { TrezorConnect as TrezorConnectType } from '@trezor/connect-web';
 
 import type { Field } from './common';
@@ -37,7 +36,7 @@ export type MethodAction =
 
 // TrezorConnect action types
 export type ConnectOptions = Partial<
-    Parameters<(typeof TrezorConnect | typeof TrezorConnectMobile)['init']>[0]
+    (ConnectMobileSettings & { coreMode: 'deeplink' }) | ConnectDynamicSettings
 >;
 
 export type TrezorConnectAction =

--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -7,7 +7,11 @@ import {
 import { type CallMethodPayload } from '@trezor/connect-common/src/events';
 import { createErrorMessage } from '@trezor/connect-common/src/events';
 import { type ConnectFactoryDependencies, factory } from '@trezor/connect-common/src/factory';
-import { type Manifest, type UpdateConnectSettings } from '@trezor/connect-common/src/types';
+import type {
+    ConnectMobileSettings,
+    Manifest,
+    UpdateConnectSettings,
+} from '@trezor/connect-common/src/types';
 import { ConnectEmitter } from '@trezor/connect-common/src/types/emitter';
 import {
     type CancelParams,
@@ -39,15 +43,7 @@ const buildUrl = ({ method, id, params, connectSrc, callbackUrl, manifest }: Bui
     );
 };
 
-interface ConnectSettingsMobile {
-    manifest: Manifest;
-    coreMode?: 'deeplink';
-    connectSrc?: string;
-    deeplinkOpen: (url: string) => void;
-    deeplinkCallbackUrl: string;
-}
-
-export class TrezorConnectDeeplink implements ConnectFactoryDependencies<ConnectSettingsMobile> {
+export class TrezorConnectDeeplink implements ConnectFactoryDependencies<ConnectMobileSettings> {
     public eventEmitter = new ConnectEmitter();
     private messages = createDeferredManager({ generateId: (): string => crypto.randomUUID() });
 
@@ -66,7 +62,7 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies<Connect
         connectSrc,
         deeplinkOpen,
         deeplinkCallbackUrl,
-    }: ConnectSettingsMobile) {
+    }: ConnectMobileSettings) {
         this.manifest = parseManifest(manifest);
 
         if (!this.manifest) {
@@ -179,7 +175,7 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies<Connect
 }
 
 const impl = new TrezorConnectDeeplink();
-const TrezorConnect = factory<ConnectSettingsMobile, { handleDeeplink: (url: string) => void }>(
+const TrezorConnect = factory<ConnectMobileSettings, { handleDeeplink: (url: string) => void }>(
     {
         eventEmitter: impl.eventEmitter,
         init: impl.init.bind(impl),

--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -6,8 +6,8 @@ import {
     type CallMethodPayload,
     POPUP,
 } from '@trezor/connect-common/src/events';
-import type { ConnectImpl, ConnectImplSettings } from '@trezor/connect-common/src/impl/dynamic';
-import type { Manifest } from '@trezor/connect-common/src/types/settings';
+import type { ConnectImpl } from '@trezor/connect-common/src/impl/dynamic';
+import type { ConnectImplSettings, Manifest } from '@trezor/connect-common/src/types/settings';
 import {
     type CancelParams,
     normalizeCancelParams,

--- a/packages/connect-web/src/impl/core-in-suite-web.ts
+++ b/packages/connect-web/src/impl/core-in-suite-web.ts
@@ -6,7 +6,8 @@ import {
     type CallMethodPayload,
     createErrorMessage,
 } from '@trezor/connect-common/src/events';
-import type { ConnectImpl, ConnectImplSettings } from '@trezor/connect-common/src/impl/dynamic';
+import type { ConnectImpl } from '@trezor/connect-common/src/impl/dynamic';
+import type { ConnectImplSettings } from '@trezor/connect-common/src/types/settings';
 import {
     type CancelParams,
     normalizeCancelParams,

--- a/packages/connect-web/src/popup/abstract.ts
+++ b/packages/connect-web/src/popup/abstract.ts
@@ -6,13 +6,16 @@ import {
     type AbstractMessageChannel,
     type Message,
 } from '@trezor/connect-common/src/messageChannel/abstract';
-import type { ConnectSettings } from '@trezor/connect-common/src/types';
+import type { Manifest } from '@trezor/connect-common/src/types';
 import { type Log } from '@trezor/connect-common/src/utils/debug';
 import { getOrigin } from '@trezor/connect-common/src/utils/urlUtils';
 import type { IntervalId } from '@trezor/type-utils';
 import { type Deferred, createDeferred } from '@trezor/utils';
 
-export type Params = Pick<ConnectSettings, 'manifest' | 'popupSrc' | 'version'> & {
+export type Params = {
+    manifest: Manifest;
+    popupSrc: string;
+    version: string;
     logger: Log;
 };
 

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -2,10 +2,10 @@
 // these targeted imports
 import { CORE_CALL_CANCEL, POPUP } from '@trezor/connect-common/src/events';
 import { factory } from '@trezor/connect-common/src/factory';
-import { type ConnectDynamicSettings } from '@trezor/connect-common/src/impl/dynamic';
 import { TrezorConnectDynamic } from '@trezor/connect-common/src/impl/dynamic';
 // Import as src not lib due to webpack issues with inlining content script later
 import { ServiceWorkerWindowChannel } from '@trezor/connect-common/src/messageChannel/serviceworker-window';
+import { type ConnectDynamicSettings } from '@trezor/connect-common/src/types/settings';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports -- intra-tier wiring: connect-webextension composes implementations from connect-web (see #27376)
 import { CoreInSuiteDesktop } from '@trezor/connect-web/src/impl/core-in-suite-desktop';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports -- intra-tier wiring: connect-webextension composes implementations from connect-web (see #27376)

--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -7,9 +7,11 @@ import {
 } from '@trezor/connect-common/src/events';
 import { createErrorMessage } from '@trezor/connect-common/src/events';
 import { factory } from '@trezor/connect-common/src/factory';
-import { type ConnectDynamicSettings } from '@trezor/connect-common/src/impl/dynamic';
 import { WindowServiceWorkerChannel } from '@trezor/connect-common/src/messageChannel/window-serviceworker';
-import type { UpdateConnectSettings } from '@trezor/connect-common/src/types';
+import type {
+    ConnectDynamicSettings,
+    UpdateConnectSettings,
+} from '@trezor/connect-common/src/types';
 import { ConnectEmitter } from '@trezor/connect-common/src/types/emitter';
 import {
     type CancelParams,

--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -229,7 +229,6 @@ export const initTrezorConnect = async (
         debug: true,
         pendingTransportEvent: true,
         transportReconnect: false,
-        coreMode: 'auto', // for connect-web
         thp: {
             appName: 'TrezorConnect',
             hostName: 'tests:e2e',

--- a/packages/connect/e2e/tests/device/thpPairing.test.ts
+++ b/packages/connect/e2e/tests/device/thpPairing.test.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect, { type ConnectSettings, type Device, type UiEvent } from '@trezor/connect';
+import TrezorConnect, { type Device, type ThpSettings, type UiEvent } from '@trezor/connect';
 
 import { getController, initTrezorConnect, restartEmu, setup } from '../../common.setup';
 
@@ -16,7 +16,7 @@ describe('THP pairing', () => {
         TrezorConnect.dispose();
     });
 
-    const waitForDevice = async (settings: Partial<ConnectSettings['thp']>) => {
+    const waitForDevice = async (settings: Partial<ThpSettings>) => {
         await initTrezorConnect(controller, {
             pendingTransportEvent: false,
             thp: {

--- a/packages/connect/src/api/requestLogin.ts
+++ b/packages/connect/src/api/requestLogin.ts
@@ -1,13 +1,12 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/RequestLogin.js
 
-import type { ConnectSettings, PermissionRequest } from '@trezor/connect-common';
+import type { PermissionRequest } from '@trezor/connect-common';
 import { RequestLoginSchema } from '@trezor/connect-common';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import * as settingsStore from '../data/settingsStore';
 
 export default class RequestLogin extends AbstractMethod<'requestLogin', PROTO.SignIdentity> {
     constructor(message: MethodMessage<'requestLogin'>) {
@@ -17,9 +16,8 @@ export default class RequestLogin extends AbstractMethod<'requestLogin', PROTO.S
         Assert(RequestLoginSchema, payload);
 
         const identity: PROTO.IdentityType = {};
-        const settings: ConnectSettings = settingsStore.get();
 
-        const origin = payload.origin || settings.origin;
+        const { origin } = payload;
 
         if (origin) {
             const originParts = origin.split(':');

--- a/packages/connect/src/backend/BackendManager.ts
+++ b/packages/connect/src/backend/BackendManager.ts
@@ -1,7 +1,8 @@
 import { BLOCKCHAIN, createBlockchainMessage } from '@trezor/connect-common';
-import type { BlockchainLink, CoinInfo } from '@trezor/connect-common';
+import type { BlockchainLink, CoinInfo, Proxy } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import type { TimerId } from '@trezor/type-utils';
+import { deepEqual } from '@trezor/utils';
 
 import type { BlockchainOptions } from './Blockchain';
 import { Blockchain } from './Blockchain';
@@ -16,6 +17,8 @@ type BackendParams = Pick<BlockchainOptions, 'coinInfo' | 'postMessage' | 'ident
 const DEFAULT_IDENTITY = 'default';
 
 export class BackendManager {
+    private proxy?: Proxy;
+
     private readonly instances: { [shortcut: CoinShortcutIdentity]: Blockchain } = {};
     private readonly reconnect: { [shortcut: CoinShortcutIdentity]: Reconnect } = {};
     private readonly custom: { [shortcut: CoinShortcut]: BlockchainLink } = {};
@@ -33,7 +36,7 @@ export class BackendManager {
                 coinInfo: this.patchCoinInfo(coinInfo),
                 identity,
                 debug: settingsStore.get('debug'),
-                proxy: settingsStore.get('proxy'),
+                proxy: this.proxy,
                 postMessage,
                 onDisconnected: pendingSubscriptions => {
                     const reconnectAttempts = pendingSubscriptions ? 0 : undefined;
@@ -88,6 +91,13 @@ export class BackendManager {
             this.custom[shortcut] = blockchainLink;
         } else {
             delete this.custom[shortcut];
+        }
+    }
+
+    async updateProxy(proxy: Proxy | undefined) {
+        if (proxy !== undefined && !deepEqual(this.proxy, proxy)) {
+            this.proxy = proxy;
+            await this.reconnectAll();
         }
     }
 

--- a/packages/connect/src/backend/BlockchainLink.ts
+++ b/packages/connect/src/backend/BlockchainLink.ts
@@ -1,4 +1,4 @@
-import type { CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo, Proxy } from '@trezor/connect-common';
 
 import { BackendManager } from './BackendManager';
 import type { BlockchainOptions as Options } from './Blockchain';
@@ -24,5 +24,7 @@ export const initBlockchain = (
 ) => backends.getOrConnect({ coinInfo, identity, postMessage });
 
 export const reconnectAllBackends = (coinInfo?: CoinInfo) => backends.reconnectAll(coinInfo);
+
+export const updateProxy = (proxy?: Proxy) => backends.updateProxy(proxy);
 
 export const dispose = () => backends.dispose();

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -975,10 +975,9 @@ export class Core extends EventEmitter {
                 localFirmwareStore.set(localFirmwares);
             }
             await loadProtobufModules();
-            const { priority, manifest } = settingsStore.get();
+            const { manifest } = settingsStore.get();
 
             this._deviceList = new DeviceList({
-                priority,
                 manifest,
                 createLogger: this.createLogger,
             });

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -268,7 +268,7 @@ const onCallDevice = async (
 ): Promise<void> => {
     const { deviceList, callMethods, sendCoreMessage, logger } = context;
     const responseID = message.id;
-    const { env, transports, pendingTransportEvent } = settingsStore.get();
+    const { transports, pendingTransportEvent } = settingsStore.get();
 
     if (!deviceList.isConnected() && !deviceList.pendingConnection()) {
         // transport is missing try to initialize it once again
@@ -276,31 +276,20 @@ const onCallDevice = async (
     }
     await deviceList.pendingConnection();
 
-    const shouldRetry = ['web', 'webextension'].includes(env);
     // find device
     let tempDevice: Device | undefined;
-    while (!tempDevice) {
-        try {
-            tempDevice = selectDevice(context, message.payload.device);
-        } catch (error) {
-            if (error.code === 'Transport_Missing') {
-                // show message about transport
-                sendCoreMessage(createUiMessage(UI_REQUEST.TRANSPORT));
-
-                // Retry selectDevice again
-                // NOTE: this should change after multi-transports refactor, where transport will be always alive
-                if (deviceList.pendingConnection() && shouldRetry) {
-                    while (deviceList.pendingConnection()) {
-                        await deviceList.pendingConnection();
-                    }
-                    continue;
-                }
-            }
-            // TODO: this should not be returned here before user agrees on "read" perms...
-            sendCoreMessage(createResponseMessage(responseID, false, { error }));
-            throw error;
+    try {
+        tempDevice = selectDevice(context, message.payload.device);
+    } catch (error) {
+        if (error.code === 'Transport_Missing') {
+            // show message about transport
+            sendCoreMessage(createUiMessage(UI_REQUEST.TRANSPORT));
         }
+        // TODO: this should not be returned here before user agrees on "read" perms...
+        sendCoreMessage(createResponseMessage(responseID, false, { error }));
+        throw error;
     }
+
     const device = tempDevice;
 
     method.setDevice(device);

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -1003,8 +1003,7 @@ export class Core extends EventEmitter {
             throw error;
         }
 
-        const { transports, pendingTransportEvent, transportReconnect, coreMode } =
-            settingsStore.get();
+        const { transports, pendingTransportEvent, transportReconnect } = settingsStore.get();
 
         try {
             this.deviceList.init({ transports, pendingTransportEvent, transportReconnect });
@@ -1014,8 +1013,7 @@ export class Core extends EventEmitter {
             throw error;
         }
 
-        // in auto core mode, we have to wait to check if transport is available
-        if (!transportReconnect || coreMode === 'auto') {
+        if (!transportReconnect) {
             await this.deviceList.pendingConnection();
         }
 

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -10,7 +10,7 @@ import type {
     TransportInfo,
 } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
-import type { CreateLogger } from '@trezor/connect-common/src/types/settings';
+import type { CreateLogger, Manifest } from '@trezor/connect-common/src/types/settings';
 import { parseStaticSessionId } from '@trezor/device-utils';
 import {
     type Descriptor,
@@ -33,7 +33,8 @@ import { createTransportList } from './TransportList';
 import { TransportManager } from './TransportManager';
 import { trezorPushNotificationHandler } from './workflow/trezorPushNotification';
 
-const createAuthPenaltyManager = (priority: number) => {
+// TODO probably scheduled for deletion, given that priority is now always 2
+const createAuthPenaltyManager = (priority = 2) => {
     const penalizedDevices: { [deviceID: string]: number } = {};
 
     const get = () =>
@@ -98,7 +99,8 @@ export const assertDeviceListConnected: (
     }
 };
 
-type ConstructorParams = Pick<ConnectSettings, 'priority' | 'manifest'> & {
+type ConstructorParams = {
+    manifest?: Manifest;
     createLogger: CreateLogger;
 };
 type InitParams = Pick<
@@ -142,12 +144,12 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         return this.getConnectedTransports().map(getTransportInfo);
     }
 
-    constructor({ priority, manifest, createLogger }: ConstructorParams) {
+    constructor({ manifest, createLogger }: ConstructorParams) {
         super();
 
         this.createLogger = createLogger;
         this.handshakeLock = getSynchronize();
-        this.authPenaltyManager = createAuthPenaltyManager(priority);
+        this.authPenaltyManager = createAuthPenaltyManager();
         this.updateTransports = createTransportList({
             logger: createLogger('@trezor/transport'),
             id: manifest?.appName || manifest?.appUrl || 'unknown app',

--- a/packages/connect/src/device/__tests__/DeviceList.test.ts
+++ b/packages/connect/src/device/__tests__/DeviceList.test.ts
@@ -39,7 +39,6 @@ describe('DeviceList', () => {
     beforeEach(() => {
         list = new DeviceList({
             ...parseConnectSettings({}),
-            priority: 0,
             createLogger: noopCreateLogger,
         });
         eventsSpy = jest.fn();
@@ -67,7 +66,6 @@ describe('DeviceList', () => {
         const createLogger = jest.fn(() => noopLogger);
         const local = new DeviceList({
             ...parseConnectSettings({}),
-            priority: 0,
             createLogger,
         });
 

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -13,7 +13,6 @@ import type {
     CallMethodPayload,
     ConnectFactoryDependencies,
     ConnectSettings,
-    ConnectSettingsPublic,
     ConnectSettingsTransport,
     CoreEventMessage,
     CoreRequestMessage,
@@ -34,7 +33,7 @@ import { type Logger, cloneObject, createDeferredManager } from '@trezor/utils';
 
 import { initCoreState } from '../core';
 
-export abstract class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsPublic> {
+export abstract class CoreInModule implements ConnectFactoryDependencies<ConnectSettings> {
     public readonly eventEmitter = new ConnectEmitter();
 
     private settings;

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,9 +1,7 @@
 import type { UpdateConnectSettings } from '@trezor/connect-common';
 import { factory } from '@trezor/connect-common';
-import { deepEqual } from '@trezor/utils';
 
-import { reconnectAllBackends } from './backend/BlockchainLink';
-import * as settingsStore from './data/settingsStore';
+import { updateProxy } from './backend/BlockchainLink';
 import { CoreInModule } from './impl/core-in-module';
 
 class CoreInModuleNode extends CoreInModule {
@@ -12,13 +10,7 @@ class CoreInModuleNode extends CoreInModule {
     }
 
     protected async updateProxy(proxy: UpdateConnectSettings['proxy']) {
-        // updateConnectSettings() may be called before init() — nothing to do yet.
-        if (!settingsStore.isLoaded()) return;
-        const settings = settingsStore.get();
-        if (proxy !== undefined && !deepEqual(settings.proxy, proxy)) {
-            settingsStore.update({ proxy });
-            await reconnectAllBackends();
-        }
+        await updateProxy(proxy);
     }
 }
 

--- a/packages/suite-desktop-core/src/index.d.ts
+++ b/packages/suite-desktop-core/src/index.d.ts
@@ -135,7 +135,7 @@ declare type TraySettings = {
     showOnTray: boolean;
 };
 
-declare type ConnectSettings = {
+declare type ElectronConnectSettings = {
     disableWs: boolean;
     autoStartDontAskAgain: boolean;
     hasUsedConnectWs: boolean;

--- a/packages/suite-desktop-core/src/libs/store.ts
+++ b/packages/suite-desktop-core/src/libs/store.ts
@@ -21,7 +21,7 @@ export class Store {
         torSettings: TorSettings;
         bridgeSettings: BridgeSettings;
         traySettings: TraySettings;
-        connectSettings: ConnectSettings;
+        connectSettings: ElectronConnectSettings;
         bioAuthSettings: BioAuthSettings;
         mcpSettings: McpSettings;
     }>;
@@ -117,7 +117,7 @@ export class Store {
         });
     }
 
-    public setConnectSettings(connectSettings: Partial<ConnectSettings>) {
+    public setConnectSettings(connectSettings: Partial<ElectronConnectSettings>) {
         this.store.set('connectSettings', {
             ...this.store.get('connectSettings'),
             ...connectSettings,

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -1,13 +1,12 @@
 import { ipcMain } from 'electron';
 
 import TrezorConnect, {
-    type ConnectSettings,
     type LocalFirmwares,
     UI_EVENT,
     UI_REQUEST,
     UI_RESPONSE,
 } from '@trezor/connect';
-import { initLog } from '@trezor/connect-common';
+import { type ConnectSettingsTransport, initLog } from '@trezor/connect-common';
 import { type IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
 import { parseElectrumUrl } from '@trezor/utils';
 
@@ -52,8 +51,8 @@ const emitOnSetCustomBackendToMainThreadToAllowDomains = ({
 // override TrezorConnect.init and TrezorConnect.updateConnectSettings params
 // add BluetoothTransport if bluetooth module is enabled
 const getTransportsParam = (
-    transports?: ConnectSettings['transports'],
-): ConnectSettings['transports'] => {
+    transports?: ConnectSettingsTransport[],
+): ConnectSettingsTransport[] | undefined => {
     const bluetooth = bluetoothModuleState.getTransport();
     if (!bluetooth) return transports;
 

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -21,10 +21,11 @@ import {
 import { type Analytics } from '@trezor/analytics-uploader';
 import {
     type BluetoothDeviceId,
-    type ConnectSettings,
+    type ConnectSettingsPublic,
     type CreateLoggerDep,
     type Manifest,
     type StaticSessionId,
+    type ThpSettings,
 } from '@trezor/connect';
 
 import { type ConnectInitHooks } from './connectInitHooksType';
@@ -36,7 +37,7 @@ type StorageLoadTransactionsReducer = (state: any, action: { type: any; payload:
 
 export type ConnectInitSettings = {
     manifest: Manifest;
-} & Partial<ConnectSettings>;
+} & Partial<ConnectSettingsPublic>;
 
 export type CommonServices = SuiteSyncDep &
     Bip329Dep &
@@ -82,7 +83,7 @@ export type ExtraDependenciesStatic = {
         >;
         selectTradedAccountKeys: SuiteCompatibleSelector<AccountKey[]>;
         selectIsViewOnlyByDefaultEnabled: SuiteCompatibleSelector<boolean>;
-        selectThpSettings: SuiteCompatibleSelector<NonNullable<ConnectSettings['thp']>>;
+        selectThpSettings: SuiteCompatibleSelector<ThpSettings>;
         selectAllowPrerelease: SuiteCompatibleSelector<boolean>;
     };
     // You should only use ActionCreatorWithPayload from redux-toolkit!

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -21,7 +21,7 @@ import {
 import { type Analytics } from '@trezor/analytics-uploader';
 import {
     type BluetoothDeviceId,
-    type ConnectSettingsPublic,
+    type ConnectSettings,
     type CreateLoggerDep,
     type Manifest,
     type StaticSessionId,
@@ -37,7 +37,7 @@ type StorageLoadTransactionsReducer = (state: any, action: { type: any; payload:
 
 export type ConnectInitSettings = {
     manifest: Manifest;
-} & Partial<ConnectSettingsPublic>;
+} & Partial<ConnectSettings>;
 
 export type CommonServices = SuiteSyncDep &
     Bip329Dep &

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -95,7 +95,6 @@ export const createNativeCompositionRoot = (deps: NativeAppDeps): NativeServices
         connectInitSettings: {
             transportReconnect: false,
             debug: false,
-            env: 'react-native',
             manifest: {
                 email: 'info@trezor.io',
                 appName: 'Trezor Suite',

--- a/suite/settings/package.json
+++ b/suite/settings/package.json
@@ -21,7 +21,7 @@
         "@suite-common/test-utils": "workspace:*",
         "@suite-common/trading": "workspace:*",
         "@suite/experimental": "workspace:*",
-        "@trezor/connect": "workspace:*",
+        "@trezor/connect-common": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/suite-desktop-api": "workspace:*"
     }

--- a/suite/settings/src/settingsSlice.ts
+++ b/suite/settings/src/settingsSlice.ts
@@ -6,7 +6,7 @@ import { type OAuthServerEnvironment } from '@suite-common/metadata-types';
 import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
 import { type Locale } from '@suite-common/suite-types';
 import type { InvityServerEnvironment } from '@suite-common/trading';
-import { type ConnectSettings } from '@trezor/connect';
+import type { ConnectSettingsTransport } from '@trezor/connect-common';
 import { isWeb } from '@trezor/env-utils';
 import { type SuiteThemeVariant } from '@trezor/suite-desktop-api';
 
@@ -16,7 +16,7 @@ export interface DebugModeOptions {
     invityServerEnvironment?: InvityServerEnvironment;
     earnYieldWorkerBaseUrl?: EarnYieldWorkerBaseUrl;
     oauthServerEnvironment?: OAuthServerEnvironment;
-    transports: Extract<NonNullable<ConnectSettings['transports']>[number], string>[];
+    transports: Extract<ConnectSettingsTransport, string>[];
     isUnlockedBootloaderAllowed: boolean;
     showConnectLogs: boolean;
     isN4w1BackupEnabled: boolean;

--- a/suite/settings/tsconfig.json
+++ b/suite/settings/tsconfig.json
@@ -22,7 +22,9 @@
         },
         { "path": "../../suite-common/trading" },
         { "path": "../experimental" },
-        { "path": "../../packages/connect" },
+        {
+            "path": "../../packages/connect-common"
+        },
         { "path": "../../packages/env-utils" },
         {
             "path": "../../packages/suite-desktop-api"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15332,7 +15332,7 @@ __metadata:
     "@suite-common/test-utils": "workspace:*"
     "@suite-common/trading": "workspace:*"
     "@suite/experimental": "workspace:*"
-    "@trezor/connect": "workspace:*"
+    "@trezor/connect-common": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/suite-desktop-api": "workspace:*"
   languageName: unknown


### PR DESCRIPTION
## Description

Restructuralization of all the different kinds of Connect settings and removing unused settings.

- desktop app connect settings renamed to `ElectronConnectSettings` so they don't get mixed up
- stop reusing `ConnectSettings` for every possible subset in different implementations
- some configurable fields (`firmwareChannel` and `localFirmwares` specifically) moved from `ConnectSettingsInternal` to `ConnectSettingsPublic`
- the rest of `ConnectSettingsInternal` can be removed completely:
  - some fields were used but irrelevant for Connect core
    - `coreMode` - used only in dynamic and not passed to core; `deeplink` variant relevant only for mobile
    - `env` - used only in dynamic and not passed to core
  - some fields were never passed to Connect
    - `priority` - not passed, `DeviceList` always used default value 2
    - `origin` - not passed, used from `requestLogin` where it's a param anyway
  - some fields were unused (`configSrc`, `popupSrc`, `version`, `npmVersion`, `extension`, `timestamp`)
  - `proxy` was moved directly to its only consumer `BackendManager`

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This changeset primarily affects the TrezorConnect integration layer: popup handling, transport events, device list management, backend connections, desktop core mode, and webextension proxy. The highest risk is in the trezor-connect E2E tests which directly exercise these code paths via TrezorConnect API calls in both suite-desktop and suite-web modes. Secondary risk exists in discovery/backend tests (BackendManager, BlockchainLink changes) and settings tests (settingsSlice changes). The broad utility files (connect core, DeviceList, BackendManager) map to 121+ tests each but most tests only transitively depend on them — targeted testing of TrezorConnect popup flows, desktop core mode, and backend discovery provides the best risk coverage.

<details><summary><b>Changed files (32)</b></summary>

- `packages/connect-common/src/data/connectSettings.ts`
- `packages/connect-common/src/data/version.ts`
- `packages/connect-common/src/events/popup.ts`
- `packages/connect-common/src/events/transport.ts`
- `packages/connect-common/src/impl/dynamic.ts`
- `packages/connect-common/src/types/settings.ts`
- `packages/connect-explorer/src/actions/trezorConnectActions.ts`
- `packages/connect-explorer/src/types/actions.ts`
- `packages/connect-mobile/src/index.ts`
- `packages/connect-web/src/impl/core-in-suite-desktop.ts`
- `packages/connect-web/src/impl/core-in-suite-web.ts`
- `packages/connect-web/src/popup/abstract.ts`
- `packages/connect-webextension/src/index.ts`
- `packages/connect-webextension/src/proxy/index.ts`
- `packages/connect/e2e/common.setup.ts`
- `packages/connect/e2e/tests/device/thpPairing.test.ts`
- `packages/connect/src/api/requestLogin.ts`
- `packages/connect/src/backend/BackendManager.ts`
- `packages/connect/src/backend/BlockchainLink.ts`
- `packages/connect/src/core/index.ts`
- `packages/connect/src/device/DeviceList.ts`
- `packages/connect/src/device/__tests__/DeviceList.test.ts`
- `packages/connect/src/impl/core-in-module.ts`
- `packages/connect/src/index.ts`
- `packages/suite-desktop-core/src/index.d.ts`
- `packages/suite-desktop-core/src/libs/store.ts`
- `packages/suite-desktop-core/src/modules/trezor-connect.ts`
- `suite-common/redux-utils/src/extraDependenciesType.ts`
- `suite-native/state/src/extraDependencies.ts`
- `suite/settings/package.json`
- `suite/settings/src/settingsSlice.ts`
- `suite/settings/tsconfig.json`

</details>

**Recommended tests (19)**

<details><summary>🔴 <b>High priority (10)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test directly exercises TrezorConnect popup flow via core-in-suite-web, which is changed in connect-web/src/impl/core-in-suite-web.ts and connect-web/src/popup/abstract.ts. It also tests Connect Explorer (connect-explorer actions changed) and permissions modal flow affected by connect-common/src/events/popup.ts changes.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test exercises the webextension TrezorConnect flow. Changes to connect-webextension/src/index.ts, connect-webextension/src/proxy/index.ts, and connect-web/src/popup/abstract.ts directly affect this code path. Connect Explorer actions are also changed.
- `suite/e2e/tests/trezor-connect/error.test.ts` — This test uses TrezorConnect.init with coreMode 'suite-desktop', directly exercising connect-web/src/impl/core-in-suite-desktop.ts and suite-desktop-core/src/modules/trezor-connect.ts, both of which are changed.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Uses TrezorConnect.init with coreMode 'suite-desktop' and exercises the connect permissions flow. Directly affected by changes to core-in-suite-desktop.ts, suite-desktop-core trezor-connect module, and popup event handling.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Tests Ethereum transaction signing via TrezorConnect with suite-desktop core mode. Directly exercises core-in-suite-desktop.ts, the connect core module, and suite-desktop trezor-connect integration.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Tests TrezorConnect.getAccountInfo with suite-desktop core mode and account selection. Directly exercises core-in-suite-desktop.ts, BackendManager (account info retrieval), and permissions modal flow.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Tests TrezorConnect.getAddress with suite-desktop core mode including address verification, bundle export, and device rejection. Directly exercises core-in-suite-desktop.ts, DeviceList, and connect core.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests TrezorConnect permissions grant/revoke/remember flow with suite-desktop core mode. Directly affected by changes to popup events, connect settings, core-in-suite-desktop, and suite-desktop trezor-connect module.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Tests Bitcoin transaction signing via TrezorConnect with suite-desktop core mode. Directly exercises core-in-suite-desktop.ts, connect core, and device communication paths.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests TrezorConnect silent mode with suite-desktop core mode, permissions modal, and IPC focus behavior. Directly affected by changes to core-in-suite-desktop.ts, suite-desktop-core trezor-connect module, popup events, and connect settings.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Tests bridge spawning and device reconnection in the Electron desktop app. Changes to suite-desktop-core modules (trezor-connect.ts, store.ts, index.d.ts) could affect how the desktop app initializes and manages bridge connections.
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — Tests bridge daemon mode in Electron. Changes to suite-desktop-core (trezor-connect module, store, index.d.ts) could affect daemon app lifecycle and bridge management.
- `suite/e2e/tests/settings/general.test.ts` — Changes to suite/settings/src/settingsSlice.ts directly affect the settings Redux state. This test verifies fiat currency, theme, language changes and their analytics events — all managed by the settings slice.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Tests Bridge session management across multiple tabs/windows. Changes to DeviceList.ts and transport events (connect-common/src/events/transport.ts) could affect session acquisition and device status handling.
- `suite/e2e/tests/analytics/events.test.ts` — Tests TransportType and DeviceConnect events which are directly related to transport event changes (connect-common/src/events/transport.ts) and DeviceList changes. Also verifies suite settings which are affected by settingsSlice.ts changes.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Tests custom blockbook backend configuration and discovery. Changes to BackendManager.ts and BlockchainLink.ts directly affect how custom backends are connected and accounts discovered.
- `suite/e2e/tests/wallet/discovery.test.ts` — Tests account discovery across multiple coins with page reload resilience. Changes to BackendManager.ts, BlockchainLink.ts, DeviceList.ts, and core/index.ts could affect discovery stability and device reconnection after reload.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Tests custom Blockbook backend discovery for BTC and LTC. Directly affected by BackendManager.ts and BlockchainLink.ts changes which manage backend connections.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/settings/autodetect.test.ts` — Tests autodetection of theme and locale. Changes to settingsSlice.ts could affect how autodetect settings are stored/read, though the test primarily verifies CSS colors and translations.

</details>

⚠️ **Changes with no test coverage (13)**
- `packages/connect-common/src/data/connectSettings.ts`
- `packages/connect-common/src/impl/dynamic.ts`
- `packages/connect-common/src/types/settings.ts`
- `packages/connect-mobile/src/index.ts`
- `packages/connect/e2e/common.setup.ts`
- `packages/connect/e2e/tests/device/thpPairing.test.ts`
- `packages/connect/src/api/requestLogin.ts`
- `packages/connect/src/device/__tests__/DeviceList.test.ts`
- `packages/connect/src/index.ts`
- `packages/connect-explorer/src/types/actions.ts`
- `suite-common/redux-utils/src/extraDependenciesType.ts`
- `suite-native/state/src/extraDependencies.ts`
- `suite/settings/tsconfig.json`

_Updated: 2026-07-01T09:11:06.246Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/connect-settings-revamp/web/](https://dev.suite.sldev.cz/suite-web/chore/connect-settings-revamp/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/connect-settings-revamp&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/connect-settings-revamp&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/connect-settings-revamp&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T09:15:56.995Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T09:13:58.926Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->