### PR TITLE
chore(suite-native): extract hardcoded strings to translations

### DIFF
--- a/suite-native/address/src/AddressQRCode.tsx
+++ b/suite-native/address/src/AddressQRCode.tsx
@@ -46,7 +46,7 @@ export const AddressQRCode = ({
                 message: address,
             });
         } catch (error) {
-            Alert.alert('Something went wrong.', error.message);
+            Alert.alert(translate('generic.unknownError'), error.message);
         }
     };
 

--- a/suite-native/graph/src/components/TransactionEventTooltip.tsx
+++ b/suite-native/graph/src/components/TransactionEventTooltip.tsx
@@ -14,6 +14,7 @@ import {
     SignValueFormatter,
     TokenAmountFormatter,
 } from '@suite-native/formatters';
+import { useTranslate } from '@suite-native/intl';
 import { type EventTooltipComponentProps } from '@suite-native/react-native-graph';
 import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
@@ -140,6 +141,7 @@ export const TransactionEventTooltip = ({
     },
 }: TransactionEventTooltipProps) => {
     const { applyStyle } = useNativeStyles();
+    const { translate } = useTranslate();
 
     const totalAmount = received && sent ? received - sent : null;
 
@@ -155,7 +157,7 @@ export const TransactionEventTooltip = ({
             <Card style={applyStyle(TooltipCardStyle)}>
                 {isSentDisplayed && (
                     <EventTooltipRow
-                        title={`Sent · ${sentTransactionsCount}`}
+                        title={translate('graph.tooltip.sent', { count: sentTransactionsCount })}
                         signValue="negative"
                         value={sent}
                         symbol={symbol}
@@ -165,7 +167,9 @@ export const TransactionEventTooltip = ({
                 )}
                 {isReceivedDisplayed && (
                     <EventTooltipRow
-                        title={`Received · ${receivedTransactionsCount}`}
+                        title={translate('graph.tooltip.received', {
+                            count: receivedTransactionsCount,
+                        })}
                         signValue="positive"
                         value={received}
                         symbol={symbol}
@@ -175,7 +179,7 @@ export const TransactionEventTooltip = ({
                 )}
                 {isNotNullOrUndefined(totalAmount) && (
                     <EventTooltipRow
-                        title="In total"
+                        title={translate('graph.tooltip.inTotal')}
                         signValue={totalAmount}
                         value={Math.abs(totalAmount)}
                         symbol={symbol}

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -24,6 +24,7 @@ export const messages = {
             copy: 'Copy',
             understand: 'I understand',
             goBack: 'Go back',
+            moreInfo: 'More info',
         },
         validateForm: 'Validate form',
         savedToClipboard: 'Saved to clipboard',
@@ -2183,6 +2184,11 @@ export const messages = {
             sixMonths: '6M',
             year: '1Y',
             all: 'ALL',
+        },
+        tooltip: {
+            sent: 'Sent · {count}',
+            received: 'Received · {count}',
+            inTotal: 'In total',
         },
     },
     modulePassphrase: {

--- a/suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx
+++ b/suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx
@@ -34,7 +34,7 @@ import {
     TokenToFiatAmountFormatter,
 } from '@suite-native/formatters';
 import { CryptoIcon } from '@suite-native/icons';
-import { Translation } from '@suite-native/intl';
+import { Translation, useTranslate } from '@suite-native/intl';
 import {
     type TokensRootState as NativeTokensRootState,
     selectAccountTokenInfo,
@@ -83,6 +83,7 @@ export const TokenSettingsBottomSheet = forwardRef(
         ref: Ref<BottomSheetModalMethods>,
     ) => {
         const { applyStyle } = useNativeStyles();
+        const { translate } = useTranslate();
         const dispatch = useDispatch();
 
         const token = useSelector((state: NativeTokensRootState) =>
@@ -172,7 +173,7 @@ export const TokenSettingsBottomSheet = forwardRef(
                     </Card>
                     <TouchableSwitchRow
                         icon="eyeSlash"
-                        accessibilityLabel="Hide token"
+                        accessibilityLabel={translate('moduleAccountManagement.tokenSettings.hideToken')}
                         text={<Translation id="moduleAccountManagement.tokenSettings.hideToken" />}
                         isChecked={isHidden}
                         onChange={handleToggleHide}

--- a/suite-native/module-settings/src/components/ToggleMevProtectionCard.tsx
+++ b/suite-native/module-settings/src/components/ToggleMevProtectionCard.tsx
@@ -4,9 +4,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import { networksCollection } from '@suite-common/wallet-config';
 import { selectIsMevProtectionEnabled, setMevProtection } from '@suite-common/wallet-core';
 import { TouchableSwitchRow } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
+import { Translation, useTranslate } from '@suite-native/intl';
 
 export const ToggleMevProtectionCard = () => {
+    const { translate } = useTranslate();
     const isMevProtectionEnabled = useSelector(selectIsMevProtectionEnabled);
     const dispatch = useDispatch();
 
@@ -27,7 +28,7 @@ export const ToggleMevProtectionCard = () => {
         <TouchableSwitchRow
             isChecked={isMevProtectionEnabled}
             onChange={handleToggle}
-            accessibilityLabel="MEV protection"
+            accessibilityLabel={translate('moduleSettings.advanced.mevProtection.title')}
             text={<Translation id="moduleSettings.advanced.mevProtection.title" />}
             description={
                 <Translation

--- a/suite-native/module-settings/src/components/ToggleSuiteSyncCard.tsx
+++ b/suite-native/module-settings/src/components/ToggleSuiteSyncCard.tsx
@@ -12,11 +12,12 @@ import {
 import { useAlert } from '@suite-native/alerts';
 import { events as nativeEvents, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { TouchableSwitchRow } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
+import { Translation, useTranslate } from '@suite-native/intl';
 import { StorageContext } from '@suite-native/storage';
 import { useShowSuiteSyncEnabledToast, useSuiteSyncErrorHandler } from '@suite-native/suite-sync';
 
 export const ToggleSuiteSyncCard = () => {
+    const { translate } = useTranslate();
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const storageContext = useContext(StorageContext);
     const { showAlert } = useAlert();
@@ -90,7 +91,7 @@ export const ToggleSuiteSyncCard = () => {
                 description={
                     <Translation id="moduleSettings.items.features.suiteSync.toggleDescription" />
                 }
-                accessibilityLabel="Secure sync toggle"
+                accessibilityLabel={translate('moduleSettings.items.features.suiteSync.title')}
                 testID="settings/suite-sync-touchable-row"
             />
         </>

--- a/suite-native/module-settings/src/components/ToggleTestnetsCard.tsx
+++ b/suite-native/module-settings/src/components/ToggleTestnetsCard.tsx
@@ -3,10 +3,11 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useServices } from '@suite-common/dependency-injection';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { TouchableSwitchRow } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
+import { Translation, useTranslate } from '@suite-native/intl';
 import { selectAreTestnetsEnabled, toggleAreTestnetsEnabled } from '@suite-native/settings';
 
 export const ToggleTestnetsCard = () => {
+    const { translate } = useTranslate();
     const dispatch = useDispatch();
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const areTestnetsEnabled = useSelector(selectAreTestnetsEnabled);
@@ -27,7 +28,7 @@ export const ToggleTestnetsCard = () => {
             onChange={handleToggleTestnets}
             text={<Translation id="moduleSettings.experimental.testnets.title" />}
             description={<Translation id="moduleSettings.experimental.testnets.description" />}
-            accessibilityLabel="Testnets toggle"
+            accessibilityLabel={translate('moduleSettings.experimental.testnets.title')}
             testID="settings/testnets-touchable-row"
         />
     );

--- a/suite-native/module-settings/src/screens/SettingsExperimentalScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsExperimentalScreen.tsx
@@ -1,5 +1,5 @@
 import { IconButton, VStack } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
+import { Translation, useTranslate } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
 import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
 import { EXPERIMENTAL_FEATURES_KB_URL } from '@trezor/urls';
@@ -7,6 +7,7 @@ import { EXPERIMENTAL_FEATURES_KB_URL } from '@trezor/urls';
 import { ToggleTestnetsCard } from '../components/ToggleTestnetsCard';
 
 export const SettingsExperimentalScreen = () => {
+    const { translate } = useTranslate();
     const openLink = useOpenLink();
 
     const onInfoPress = () => {
@@ -26,7 +27,7 @@ export const SettingsExperimentalScreen = () => {
                             priority="secondary"
                             onPress={onInfoPress}
                             accessibilityRole="button"
-                            accessibilityLabel="More info"
+                            accessibilityLabel={translate('generic.buttons.moreInfo')}
                         />
                     }
                 />

--- a/suite-native/navigation/src/components/GoBackIcon.tsx
+++ b/suite-native/navigation/src/components/GoBackIcon.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { useNavigation } from '@react-navigation/native';
 
 import { IconButton } from '@suite-native/atoms';
+import { useTranslate } from '@suite-native/intl';
 
 import { type CloseActionType } from '../navigators';
 
@@ -14,6 +15,7 @@ type GoBackIconProps = {
 
 export const GoBackIcon = ({ closeActionType = 'back', closeAction, testID }: GoBackIconProps) => {
     const navigation = useNavigation();
+    const { translate } = useTranslate();
 
     const handleGoBack = useCallback(() => {
         if (closeAction) {
@@ -32,7 +34,7 @@ export const GoBackIcon = ({ closeActionType = 'back', closeAction, testID }: Go
             size="medium"
             onPress={handleGoBack}
             accessibilityRole="button"
-            accessibilityLabel="Go back"
+            accessibilityLabel={translate('generic.buttons.goBack')}
         />
     );
 };

--- a/suite-native/swipeable-walkthrough/src/components/SwipeableWalkthroughCloseButton.tsx
+++ b/suite-native/swipeable-walkthrough/src/components/SwipeableWalkthroughCloseButton.tsx
@@ -6,6 +6,7 @@ import Animated, {
 } from 'react-native-reanimated';
 
 import { IconButton } from '@suite-native/atoms';
+import { useTranslate } from '@suite-native/intl';
 
 type SwipeableWalkthroughCloseButtonProps = {
     onPressBack: () => void;
@@ -18,6 +19,8 @@ export const SwipeableWalkthroughCloseButton = ({
     onPressBack,
     currentStepIndex,
 }: SwipeableWalkthroughCloseButtonProps) => {
+    const { translate } = useTranslate();
+
     const xOpacity = useDerivedValue(() =>
         withTiming(currentStepIndex.value === 0 ? 1 : 0, {
             duration: ANIMATION_DURATION / (currentStepIndex.value === 0 ? 4 : 1),
@@ -45,7 +48,7 @@ export const SwipeableWalkthroughCloseButton = ({
                 priority="secondary"
                 onPress={onPressBack}
                 accessibilityRole="button"
-                accessibilityLabel="Go back"
+                accessibilityLabel={translate('generic.buttons.goBack')}
                 style={animatedCaretStyle}
             />
             <IconButton
@@ -55,7 +58,7 @@ export const SwipeableWalkthroughCloseButton = ({
                 priority="secondary"
                 onPress={onPressBack}
                 accessibilityRole="button"
-                accessibilityLabel="Go back"
+                accessibilityLabel={translate('generic.buttons.goBack')}
             />
         </Animated.View>
     );

--- a/suite-native/swipeable-walkthrough/src/components/SwipeableWalkthroughScreenHeader.tsx
+++ b/suite-native/swipeable-walkthrough/src/components/SwipeableWalkthroughScreenHeader.tsx
@@ -3,6 +3,7 @@ import Animated, { type SharedValue, useAnimatedStyle, withTiming } from 'react-
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Box, IconButton } from '@suite-native/atoms';
+import { useTranslate } from '@suite-native/intl';
 import { ScreenHeader, useOverrideBackNavigation } from '@suite-native/navigation';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
@@ -37,6 +38,8 @@ const SwipeableWalkthroughBackButton = ({
     onPressBack,
     currentStepIndex,
 }: SwipeableWalkthroughBackButtonProps) => {
+    const { translate } = useTranslate();
+
     const animatedButtonStyle = useAnimatedStyle(() => ({
         transform: [
             {
@@ -56,7 +59,7 @@ const SwipeableWalkthroughBackButton = ({
                 size="medium"
                 onPress={onPressBack}
                 accessibilityRole="button"
-                accessibilityLabel="Go back"
+                accessibilityLabel={translate('generic.buttons.goBack')}
             />
         </Animated.View>
     );


### PR DESCRIPTION
## Description

A few user-facing strings in `suite-native` were still hardcoded in English instead of going through the intl system. This PR routes them through `Translation` / `useTranslate` so they get localized like the rest of the app.

## Changes

**Reused existing keys** (no new strings):
- `accessibilityLabel="Go back"` → `generic.buttons.goBack` (GoBackIcon, SwipeableWalkthrough close button ×2 + screen header)
- `accessibilityLabel="MEV protection"` → `moduleSettings.advanced.mevProtection.title`
- `accessibilityLabel="Testnets toggle"` → `moduleSettings.experimental.testnets.title`
- `accessibilityLabel="Secure sync toggle"` → `moduleSettings.items.features.suiteSync.title`
- `accessibilityLabel="Hide token"` → `moduleAccountManagement.tokenSettings.hideToken`
- `Alert.alert('Something went wrong.')` → `generic.unknownError` (AddressQRCode share error)

**New keys added to `messages.ts`:**
- `generic.buttons.moreInfo` — "More info" (experimental settings info button)
- `graph.tooltip.sent` — "Sent · {count}"
- `graph.tooltip.received` — "Received · {count}"
- `graph.tooltip.inTotal` — "In total"

(The last three replace hardcoded template literals in the transaction graph tooltip.)

## Notes

- Dev/debug-only screens (dev-utils, trading debug views) were intentionally left untouched.
- Translations are managed via Crowdin; this PR only adds the English source keys to `messages.ts`.
- `yarn workspace @suite-native/intl translations:verify-structure` passes (no key-structure collisions).