### PR TITLE
fix(suite-common): use smart fee levels for walletconnect bitcoin transfers

### DIFF
--- a/suite-common/walletconnect/src/adapters/bitcoin.ts
+++ b/suite-common/walletconnect/src/adapters/bitcoin.ts
@@ -143,7 +143,7 @@ const bitcoinRequestThunk = createThunk<
                 coin: account.symbol,
                 identity: getAccountIdentity(account),
                 request: {
-                    blocks: [1],
+                    feeLevels: 'smart',
                 },
             });
             if (!feeLevels.success) {


### PR DESCRIPTION
## Description

WalletConnect `sendTransfer` requests on the `bip122` (Bitcoin) namespace failed with `NOT-ENOUGH-FUNDS` even when the account had a sufficient balance.

Root cause: the bitcoin adapter called `blockchainEstimateFee` with `request: { blocks: [1] }`, which returns `feePerUnit` in **sat/kB** (raw Blockbook data). That value was passed straight into `composeTransaction`, which expects the fee rate in **sat/vB**. As a result the effective fee was inflated ~1000×, so even a small transfer required more than the whole balance and the compose step rejected it.

Fix: request `feeLevels: 'smart'` instead. This routes the estimate through `BitcoinFeeLevels` (`packages/connect/src/backend/fees/BitcoinFeeLevels.ts`), which converts sat/kB to sat/vB (`feePerKB / 1000`) — the unit `composeTransaction` actually expects. This matches how fees are already requested elsewhere in the app (`suite-common/wallet-core/src/fees/feesUtils.ts`).

Because the adapter lives in the shared `suite-common/walletconnect` package, this fixes the issue on desktop, web and mobile (suite-native) alike.

## Notes for QA

1. Pair Trezor Suite with a dapp via WalletConnect using the `bip122` namespace.
2. Submit a `sendTransfer` request for an amount well below the account balance (e.g. 10,000 sats from a ~115,000 sats account).
3. Before the fix: Suite rejects with a `composeTransaction error` / `NOT-ENOUGH-FUNDS`.
4. After the fix: the transaction composes with a realistic fee and can be signed and broadcast.

Worth checking that the computed fee looks sane (a few sat/vB, not thousands).

## Related Issue

Resolve #28605

## Screenshots:
Before:
<img width="1377" height="474" alt="Pasted Graphic 8" src="https://github.com/user-attachments/assets/8cd29f59-2db7-4304-8189-4ebc7875816f" />

After:
<img width="803" height="707" alt="Total amount" src="https://github.com/user-attachments/assets/05e4ab54-f7d8-42ba-8ee5-c87465aece39" />
