### PR TITLE
Remove Solana staking from debug mode on mobile

### DIFF
--- a/suite-native/app/.env.development
+++ b/suite-native/app/.env.development
@@ -15,7 +15,6 @@ EXPO_PUBLIC_ENVIRONMENT=debug
 # EXPO_PUBLIC_FF_IS_CONNECT_POPUP_ENABLED=true
 # EXPO_PUBLIC_FF_IS_TRADING_ENABLED=true
 # EXPO_PUBLIC_FF_IS_WALLET_CONNECT_ENABLED=true
-# EXPO_PUBLIC_FF_IS_SOLANA_STAKING_ENABLED=true
 
 
 ### Possibility to disable device checks, see suite-native/settings/src/settingsSlice.ts

--- a/suite-native/config/src/types.ts
+++ b/suite-native/config/src/types.ts
@@ -15,6 +15,5 @@ export type LaunchArguments = {
     isTradingDebugEnabled?: boolean;
     isN4w1BackupEnabled?: boolean;
     isStablecoinYieldEnabled?: boolean;
-    isSolanaStakingEnabled?: boolean;
     isN4W1BackupEnabled?: boolean;
 };

--- a/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
+++ b/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
@@ -23,7 +23,6 @@ describe('featureFlagsSlice', () => {
                 isTradingDebugEnabled: false,
                 isN4w1BackupEnabled: false,
                 isStablecoinYieldEnabled: false,
-                isSolanaStakingEnabled: false,
             });
         });
 
@@ -42,7 +41,6 @@ describe('featureFlagsSlice', () => {
                 isTradingDebugEnabled: false,
                 isN4w1BackupEnabled: false,
                 isStablecoinYieldEnabled: false,
-                isSolanaStakingEnabled: false,
             });
         });
     });

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -10,7 +10,6 @@ export const FeatureFlag = {
     IsTradingResidenceCheckEnabled: 'isTradingResidenceCheckEnabled',
     IsTradingDebugEnabled: 'isTradingDebugEnabled',
     IsStablecoinYieldEnabled: 'isStablecoinYieldEnabled',
-    IsSolanaStakingEnabled: 'isSolanaStakingEnabled',
     IsN4w1BackupEnabled: 'isN4w1BackupEnabled',
 } as const;
 
@@ -37,8 +36,6 @@ export const featureFlagsInitialState: FeatureFlagsState = {
         process.env.EXPO_PUBLIC_FF_IS_TRADING_DEBUG_ENABLED === 'true',
     [FeatureFlag.IsStablecoinYieldEnabled]:
         process.env.EXPO_PUBLIC_FF_IS_STABLECOIN_YIELD_DEBUG_ENABLED === 'true',
-    [FeatureFlag.IsSolanaStakingEnabled]:
-        process.env.EXPO_PUBLIC_FF_IS_SOLANA_STAKING_ENABLED === 'true',
     [FeatureFlag.IsN4w1BackupEnabled]: process.env.EXPO_PUBLIC_FF_IS_N4W1_BACKUP_ENABLED === 'true',
 };
 
@@ -49,7 +46,6 @@ export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsTradingResidenceCheckEnabled,
     FeatureFlag.IsTradingDebugEnabled,
     FeatureFlag.IsStablecoinYieldEnabled,
-    FeatureFlag.IsSolanaStakingEnabled,
     FeatureFlag.IsN4w1BackupEnabled,
 ];
 

--- a/suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx
@@ -14,7 +14,6 @@ const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsTradingResidenceCheckEnabled]: '💰 Trading Residence Check',
     [FeatureFlagEnum.IsTradingDebugEnabled]: '💰 Trading Debug Mode',
     [FeatureFlagEnum.IsStablecoinYieldEnabled]: 'Stablecoin Yield',
-    [FeatureFlagEnum.IsSolanaStakingEnabled]: 'Solana Staking',
     [FeatureFlagEnum.IsN4w1BackupEnabled]: 'N4W1 Backup',
 } as const satisfies Record<FeatureFlagEnum, string>;
 

--- a/suite-native/module-earn/src/components/EarnAccountCard.tsx
+++ b/suite-native/module-earn/src/components/EarnAccountCard.tsx
@@ -7,10 +7,7 @@ import {
     useTronStakingStats,
 } from '@suite-common/earn-staking-api';
 import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
-import {
-    isSupportedSolStakingNetworkSymbol,
-    isSupportedStakingNetworkSymbol,
-} from '@suite-common/wallet-utils';
+import { isSupportedStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import { AccountTypeBadge } from '@suite-native/accounts';
 import { Box, Card, PressableOpacity, Text, VStack } from '@suite-native/atoms';
 import { CryptoIconWithNetwork, Icon } from '@suite-native/icons';
@@ -28,10 +25,9 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { CRYPTO_BALANCE_DECIMALS } from '../constants';
 import { EarnClaimAlert } from './EarnClaimAlert';
-import { useMessageSystemStaking } from '../hooks/useMessageSystemStaking';
-import { useSolanaStakingFlag } from '../hooks/useSolanaStakingFlag';
-import { type EarnDepositsCardActiveItem } from '../types';
 import { EarnTronVotingAlert } from './EarnTronVotingAlert';
+import { useMessageSystemStaking } from '../hooks/useMessageSystemStaking';
+import { type EarnDepositsCardActiveItem } from '../types';
 
 const itemCardStyle = prepareNativeStyle(utils => ({
     marginBottom: utils.spacings.sp16,
@@ -78,9 +74,7 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
     const isStakingItem = item.type === 'staking';
     const isStablecoinYieldItem = item.type === 'stablecoin-yield';
     const isSupportedStaking = isStakingItem && isSupportedStakingNetworkSymbol(item.symbol);
-    const isSolStaking = isStakingItem && isSupportedSolStakingNetworkSymbol(item.symbol);
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
-    const isSolanaStakingEnabled = useSolanaStakingFlag();
 
     const symbol = isStakingItem ? item.symbol : item.networkSymbol;
 
@@ -127,10 +121,7 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
 
     const { isClaimingDisabled } = useMessageSystemStaking(isStakingItem ? item.symbol : null);
 
-    const isSolClaimHidden = isSolStaking && !isSolanaStakingEnabled;
-
-    const showClaimAlert =
-        canClaim && !isClaimingDisabled && !isPortfolioTrackerDevice && !isSolClaimHidden;
+    const showClaimAlert = canClaim && !isClaimingDisabled && !isPortfolioTrackerDevice;
 
     const showTronVotingAlert =
         isStakingItem && item.symbol === 'trx' && availableTronVotingPower !== '0';

--- a/suite-native/module-earn/src/hooks/__tests__/useStakingDetailNavigation.test.tsx
+++ b/suite-native/module-earn/src/hooks/__tests__/useStakingDetailNavigation.test.tsx
@@ -2,7 +2,6 @@ import { type AccountKey } from '@suite-common/wallet-types';
 import { RootStackRoutes } from '@suite-native/navigation';
 import { renderHook } from '@suite-native/test-utils';
 
-import { useSolanaStakingFlag } from '../useSolanaStakingFlag';
 import { useStakingDetailNavigation } from '../useStakingDetailNavigation';
 
 const mockNavigate = jest.fn();
@@ -12,12 +11,6 @@ jest.mock('@react-navigation/native', () => ({
     useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
-jest.mock('../useSolanaStakingFlag', () => ({
-    useSolanaStakingFlag: jest.fn(),
-}));
-
-const mockUseSolanaStakingFlag = jest.mocked(useSolanaStakingFlag);
-
 const accountKey = 'account-key' as AccountKey;
 
 describe('useStakingDetailNavigation', () => {
@@ -25,9 +18,7 @@ describe('useStakingDetailNavigation', () => {
         jest.clearAllMocks();
     });
 
-    it('navigates a Solana account to staking management when the feature flag is enabled', () => {
-        mockUseSolanaStakingFlag.mockReturnValue(true);
-
+    it('navigates a Solana account to staking management', () => {
         const { result } = renderHook(() => useStakingDetailNavigation());
         result.current.navigateToStakingDetail({ accountKey, symbol: 'sol' });
 
@@ -36,20 +27,7 @@ describe('useStakingDetailNavigation', () => {
         });
     });
 
-    it('falls back to the read-only staking detail page when the Solana flag is disabled', () => {
-        mockUseSolanaStakingFlag.mockReturnValue(false);
-
-        const { result } = renderHook(() => useStakingDetailNavigation());
-        result.current.navigateToStakingDetail({ accountKey, symbol: 'sol' });
-
-        expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.StakingDetail, {
-            accountKey,
-        });
-    });
-
-    it('never gates Ethereum staking regardless of the Solana flag', () => {
-        mockUseSolanaStakingFlag.mockReturnValue(false);
-
+    it('navigates an Ethereum account to staking management', () => {
         const { result } = renderHook(() => useStakingDetailNavigation());
         result.current.navigateToStakingDetail({ accountKey, symbol: 'eth' });
 

--- a/suite-native/module-earn/src/hooks/useSolanaStakingFlag.ts
+++ b/suite-native/module-earn/src/hooks/useSolanaStakingFlag.ts
@@ -1,3 +1,0 @@
-import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
-
-export const useSolanaStakingFlag = () => useFeatureFlag(FeatureFlag.IsSolanaStakingEnabled);

--- a/suite-native/module-earn/src/hooks/useStakingDetailNavigation.ts
+++ b/suite-native/module-earn/src/hooks/useStakingDetailNavigation.ts
@@ -4,14 +4,12 @@ import { useNavigation } from '@react-navigation/native';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
-import {
-    type RootStackParamList,
+import type {
+    RootStackParamList,
     RootStackRoutes,
-    type StackNavigationProps,
+    StackNavigationProps,
 } from '@suite-native/navigation';
 
-import { useSolanaStakingFlag } from './useSolanaStakingFlag';
 import { resolveStakingTargetRoute } from '../utils/resolveStakingTargetRoute';
 
 type NavigationProp = StackNavigationProps<RootStackParamList, RootStackRoutes.StakingManagement>;
@@ -23,19 +21,12 @@ export type NavigateToStakingDetail = (params: {
 
 export const useStakingDetailNavigation = () => {
     const navigation = useNavigation<NavigationProp>();
-    const isSolanaStakingEnabled = useSolanaStakingFlag();
 
     const navigateToStakingDetail = useCallback<NavigateToStakingDetail>(
         ({ accountKey, symbol }) => {
-            if (isSupportedSolStakingNetworkSymbol(symbol) && !isSolanaStakingEnabled) {
-                navigation.navigate(RootStackRoutes.StakingDetail, { accountKey });
-
-                return;
-            }
-
             navigation.navigate(resolveStakingTargetRoute(symbol), { accountKey });
         },
-        [navigation, isSolanaStakingEnabled],
+        [navigation],
     );
 
     return { navigateToStakingDetail };

--- a/suite-native/module-earn/src/hooks/useStakingPromoNavigation.ts
+++ b/suite-native/module-earn/src/hooks/useStakingPromoNavigation.ts
@@ -8,7 +8,6 @@ import { selectIsDeviceInViewOnlyMode } from '@suite-common/device';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectVisibleDeviceAccounts } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
-import { isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import { useAccountAlerts } from '@suite-native/accounts';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { useBottomSheetModal } from '@suite-native/atoms';
@@ -21,8 +20,6 @@ import {
 
 import { useEarnPortfolioTrackerGuard } from '../components/EarnPortfolioTrackerGuard';
 import { type StakingEarnItem } from '../types';
-import { useSolanaStakingFlag } from './useSolanaStakingFlag';
-import { useStakingDetailNavigation } from './useStakingDetailNavigation';
 import { useStakingNavigateAnalytics } from './useStakingNavigateAnalytics';
 import { isStakeFlowSupportedSymbol } from '../utils';
 import { navigateByAccountState } from '../utils/navigateByAccountState';
@@ -37,8 +34,6 @@ export const useStakingPromoNavigation = () => {
     const { showViewOnlyAddAccountAlert } = useAccountAlerts();
     const { isPortfolioTrackerDevice, openPortfolioTrackerSheet } = useEarnPortfolioTrackerGuard();
     const { analytics } = useServices(selectNativeAnalyticsDep);
-    const isSolanaStakingEnabled = useSolanaStakingFlag();
-    const { navigateToStakingDetail } = useStakingDetailNavigation();
 
     const reportStakingNavigate = useStakingNavigateAnalytics();
 
@@ -64,28 +59,15 @@ export const useStakingPromoNavigation = () => {
     const chooseAccountSymbolRef = useRef<NetworkSymbol | null>(null);
     const pendingEnableSymbolRef = useRef<NetworkSymbol | null>(null);
 
-    const chooseAccountModeRef = useRef<'stake' | 'detail'>('stake');
-
     const handleAccountSelected = useCallback(
         (account: Account) => {
             chooseAccountContinuedRef.current = true;
             closeChooseAccountModal();
             reportStakingNavigate(account);
 
-            if (chooseAccountModeRef.current === 'detail') {
-                navigateToStakingDetail({ accountKey: account.key, symbol: account.symbol });
-
-                return;
-            }
-
             navigateByAccountState(account, navigation.navigate);
         },
-        [
-            closeChooseAccountModal,
-            navigation.navigate,
-            reportStakingNavigate,
-            navigateToStakingDetail,
-        ],
+        [closeChooseAccountModal, navigation.navigate, reportStakingNavigate],
     );
 
     const handleChooseAccountDismiss = useCallback(() => {
@@ -159,15 +141,6 @@ export const useStakingPromoNavigation = () => {
 
             const accountsForSymbol = accounts.filter(acc => acc.symbol === item.symbol);
 
-            const isSolStakingViewOnly =
-                isSupportedSolStakingNetworkSymbol(item.symbol) && !isSolanaStakingEnabled;
-
-            if (isSolStakingViewOnly && accountsForSymbol.length === 0) {
-                openInfoModal();
-
-                return;
-            }
-
             if (isPortfolioTrackerDevice) {
                 openPortfolioTrackerSheet();
 
@@ -186,13 +159,6 @@ export const useStakingPromoNavigation = () => {
             const singleAccount = accountsForSymbol[0];
             if (accountsForSymbol.length === 1 && singleAccount) {
                 reportStakingNavigate(singleAccount);
-
-                if (isSolStakingViewOnly) {
-                    navigateToStakingDetail({ accountKey: singleAccount.key, symbol: item.symbol });
-
-                    return;
-                }
-
                 navigateByAccountState(singleAccount, navigation.navigate);
 
                 return;
@@ -201,20 +167,17 @@ export const useStakingPromoNavigation = () => {
             setChosenAccounts(accountsForSymbol);
             chooseAccountSymbolRef.current = item.symbol;
             chooseAccountContinuedRef.current = false;
-            chooseAccountModeRef.current = isSolStakingViewOnly ? 'detail' : 'stake';
             openChooseAccountModal();
         },
         [
             accounts,
             navigation.navigate,
-            isSolanaStakingEnabled,
             isPortfolioTrackerDevice,
             openPortfolioTrackerSheet,
             openInfoModal,
             openChooseAccountModal,
             openEnableNetworkModal,
             reportStakingNavigate,
-            navigateToStakingDetail,
         ],
     );
 


### PR DESCRIPTION
## Description

Removes the `IsSolanaStakingEnabled` feature flag that previously gated Solana staking management in the mobile app. With the flag gone, Solana accounts now go through the regular native staking flow, unstake and claim instead of being redirected to the desktop app. The flag definition, its dev-utils toggle, environment override, and the read-only fallback paths have all been removed.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29149
