### PR TITLE
test(suite): stabilize sol unstake test

### DIFF
--- a/suite/e2e/support/pageObjects/staking/stakingSection.ts
+++ b/suite/e2e/support/pageObjects/staking/stakingSection.ts
@@ -193,13 +193,23 @@ export class StakingSection {
     }
 
     @step()
-    async expectStakingAmounts(expected: {
-        pending: string | 'hidden';
-        staked: string | 'hidden';
-        rewards: string | 'hidden';
-        unstaking: string | 'hidden';
+    async expectStakingAmounts({
+        expected,
+        options,
+    }: {
+        expected: {
+            pending: string | 'hidden';
+            staked: string | 'hidden';
+            rewards: string | 'hidden';
+            unstaking: string | 'hidden';
+        };
+        options?: { fastForward?: string; timeout?: number };
     }) {
         await expect(async () => {
+            if (options?.fastForward) {
+                await this.page.clock.fastForward(options.fastForward);
+            }
+
             const getStatus = async (locator: Locator) =>
                 (await locator.isVisible()) ? locator.innerText() : 'hidden';
 
@@ -214,6 +224,6 @@ export class StakingSection {
                 { pending, staked, rewards, unstaking },
                 'expected Staking dashboard to show correct values',
             ).toEqual(expected);
-        }).toPass();
+        }).toPass({ timeout: options?.timeout ?? 15_000 });
     }
 }

--- a/suite/e2e/tests/staking/eth/initial-stake.test.ts
+++ b/suite/e2e/tests/staking/eth/initial-stake.test.ts
@@ -159,10 +159,12 @@ test.describe('ETH staking', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await stakingSection.expectProgressIndicatorsToMatchPhase('pendingTransaction');
                 await expect(stakingSection.speedUpButton).toBeEnabled();
                 await stakingSection.expectStakingAmounts({
-                    pending: '0.100204158497493752',
-                    staked: '0',
-                    rewards: '0',
-                    unstaking: 'hidden',
+                    expected: {
+                        pending: '0.100204158497493752',
+                        staked: '0',
+                        rewards: '0',
+                        unstaking: 'hidden',
+                    },
                 });
             });
 
@@ -188,10 +190,12 @@ test.describe('ETH staking', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await expect(stakingSection.transactionStatus).toHaveTranslation('TR_TX_CONFIRMED');
                 await stakingSection.expectProgressIndicatorsToMatchPhase('addingToPool');
                 await stakingSection.expectStakingAmounts({
-                    pending: '0.100204158497493752',
-                    staked: '0',
-                    rewards: '0',
-                    unstaking: 'hidden',
+                    expected: {
+                        pending: '0.100204158497493752',
+                        staked: '0',
+                        rewards: '0',
+                        unstaking: 'hidden',
+                    },
                 });
                 await expect(stakingSection.pendingTransactionText).toBeHidden();
                 await expect(stakingSection.speedUpButton).toBeHidden();
@@ -215,10 +219,12 @@ test.describe('ETH staking', { tag: ['@T3W1', '@T3T1'] }, () => {
                 });
                 await page.clock.fastForward(stakingSection.watchPeriod);
                 await stakingSection.expectStakingAmounts({
-                    pending: 'hidden',
-                    staked: '0.100204158497493752',
-                    rewards: '0',
-                    unstaking: 'hidden',
+                    expected: {
+                        pending: 'hidden',
+                        staked: '0.100204158497493752',
+                        rewards: '0',
+                        unstaking: 'hidden',
+                    },
                 });
                 await stakingSection.expectProgressIndicatorsToMatchPhase('receivingRewards');
                 await expect(stakingSection.stakeMoreButton).toBeEnabled();

--- a/suite/e2e/tests/staking/eth/stake-more.test.ts
+++ b/suite/e2e/tests/staking/eth/stake-more.test.ts
@@ -99,10 +99,12 @@ test.describe('ETH staking', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await walletPage.openAccount({ symbol: 'eth', type: 'normal', atIndex: 0 });
                 await stakingSection.stakingTabButton.click();
                 await stakingSection.expectStakingAmounts({
-                    pending: 'hidden',
-                    staked: '3,000',
-                    rewards: '234',
-                    unstaking: 'hidden',
+                    expected: {
+                        pending: 'hidden',
+                        staked: '3,000',
+                        rewards: '234',
+                        unstaking: 'hidden',
+                    },
                 });
                 // TODO: Highly unstable. Disappears after first sync of data. Needs investigation.
                 // await stakingSection.expectProgressIndicatorsToMatchPhase('receivingRewards');
@@ -190,10 +192,12 @@ test.describe('ETH staking', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await stakingSection.expectProgressIndicatorsToMatchPhase('pendingTransaction');
                 await expect(stakingSection.speedUpButton).toBeEnabled();
                 await stakingSection.expectStakingAmounts({
-                    pending: '0.100204158497493752',
-                    staked: '3,000',
-                    rewards: '234',
-                    unstaking: 'hidden',
+                    expected: {
+                        pending: '0.100204158497493752',
+                        staked: '3,000',
+                        rewards: '234',
+                        unstaking: 'hidden',
+                    },
                 });
             });
 
@@ -219,10 +223,12 @@ test.describe('ETH staking', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await expect(stakingSection.transactionStatus).toHaveTranslation('TR_TX_CONFIRMED');
                 await stakingSection.expectProgressIndicatorsToMatchPhase('addingToPool');
                 await stakingSection.expectStakingAmounts({
-                    pending: '0.100204158497493752',
-                    staked: '3,000',
-                    rewards: '234',
-                    unstaking: 'hidden',
+                    expected: {
+                        pending: '0.100204158497493752',
+                        staked: '3,000',
+                        rewards: '234',
+                        unstaking: 'hidden',
+                    },
                 });
                 await expect(stakingSection.pendingTransactionText).toBeHidden();
                 await expect(stakingSection.speedUpButton).toBeHidden();
@@ -246,10 +252,12 @@ test.describe('ETH staking', { tag: ['@T3W1', '@T3T1'] }, () => {
                 });
                 await page.clock.fastForward(stakingSection.watchPeriod);
                 await stakingSection.expectStakingAmounts({
-                    pending: 'hidden',
-                    staked: '3,000.100204158497493752',
-                    rewards: '234',
-                    unstaking: 'hidden',
+                    expected: {
+                        pending: 'hidden',
+                        staked: '3,000.100204158497493752',
+                        rewards: '234',
+                        unstaking: 'hidden',
+                    },
                 });
                 await stakingSection.expectProgressIndicatorsToMatchPhase('receivingRewards');
             });

--- a/suite/e2e/tests/staking/eth/unstake.test.ts
+++ b/suite/e2e/tests/staking/eth/unstake.test.ts
@@ -47,10 +47,12 @@ test.describe('ETH unstaking and claim', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await walletPage.openAccount({ symbol: 'eth', type: 'normal', atIndex: 0 });
                 await stakingSection.stakingTabButton.click();
                 await stakingSection.expectStakingAmounts({
-                    pending: '300',
-                    staked: '3,000',
-                    rewards: '234',
-                    unstaking: 'hidden',
+                    expected: {
+                        pending: '300',
+                        staked: '3,000',
+                        rewards: '234',
+                        unstaking: 'hidden',
+                    },
                 });
             });
 
@@ -113,10 +115,12 @@ test.describe('ETH unstaking and claim', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await expect(stakingSection.pendingTransactionText).toBeVisible();
                 await expect(stakingSection.speedUpButton).toBeEnabled();
                 await stakingSection.expectStakingAmounts({
-                    pending: '300',
-                    staked: '3,000',
-                    rewards: '234',
-                    unstaking: 'hidden',
+                    expected: {
+                        pending: '300',
+                        staked: '3,000',
+                        rewards: '234',
+                        unstaking: 'hidden',
+                    },
                 });
             });
 
@@ -140,10 +144,12 @@ test.describe('ETH unstaking and claim', { tag: ['@T3W1', '@T3T1'] }, () => {
                 });
                 await page.clock.fastForward(stakingSection.watchPeriod);
                 await stakingSection.expectStakingAmounts({
-                    pending: '300',
-                    staked: '0',
-                    rewards: '0',
-                    unstaking: '3,234',
+                    expected: {
+                        pending: '300',
+                        staked: '0',
+                        rewards: '0',
+                        unstaking: '3,234',
+                    },
                 });
                 await expect(stakingSection.unstakeToClaimButton).toBeDisabled();
                 await expect(stakingSection.pendingTransactionText).toBeHidden();
@@ -170,10 +176,12 @@ test.describe('ETH unstaking and claim', { tag: ['@T3W1', '@T3T1'] }, () => {
                 });
                 await page.clock.fastForward(stakingSection.watchPeriod);
                 await stakingSection.expectStakingAmounts({
-                    pending: '300',
-                    staked: '0',
-                    rewards: '0',
-                    unstaking: 'hidden',
+                    expected: {
+                        pending: '300',
+                        staked: '0',
+                        rewards: '0',
+                        unstaking: 'hidden',
+                    },
                 });
                 await expect(stakingSection.claimBalanceWithSymbol).toHaveText('3,234 ETH');
                 await stakingSection.claimButton.click();

--- a/suite/e2e/tests/staking/sol/initial-stake.test.ts
+++ b/suite/e2e/tests/staking/sol/initial-stake.test.ts
@@ -113,10 +113,12 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
 
             await test.step('Verify pending on dashboard', async () => {
                 await stakingSection.expectStakingAmounts({
-                    pending: stakedAmount,
-                    staked: '0',
-                    rewards: '0',
-                    unstaking: 'hidden',
+                    expected: {
+                        pending: stakedAmount,
+                        staked: '0',
+                        rewards: '0',
+                        unstaking: 'hidden',
+                    },
                 });
                 await expect(stakingSection.stakeMoreButton).toBeEnabled();
                 await expect(stakingSection.unstakeToClaimButton).toBeDisabled();
@@ -127,10 +129,12 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                 await solanaStakingMock.advanceEpoch();
                 await page.clock.fastForward(stakingSection.solanaEpochCachePeriod);
                 await stakingSection.expectStakingAmounts({
-                    pending: 'hidden',
-                    staked: stakedAmount,
-                    rewards: '0',
-                    unstaking: 'hidden',
+                    expected: {
+                        pending: 'hidden',
+                        staked: stakedAmount,
+                        rewards: '0',
+                        unstaking: 'hidden',
+                    },
                 });
                 await expect(stakingSection.stakeMoreButton).toBeEnabled();
                 await expect(stakingSection.unstakeToClaimButton).toBeEnabled();

--- a/suite/e2e/tests/staking/sol/rewards.test.ts
+++ b/suite/e2e/tests/staking/sol/rewards.test.ts
@@ -56,10 +56,12 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                 await walletPage.openAccount({ symbol: 'sol', type: 'normal', atIndex: 0 });
                 await stakingSection.stakingTabButton.click();
                 await stakingSection.expectStakingAmounts({
-                    pending: 'hidden',
-                    staked: stakedTotal,
-                    rewards: '0',
-                    unstaking: unstakingTotal,
+                    expected: {
+                        pending: 'hidden',
+                        staked: stakedTotal,
+                        rewards: '0',
+                        unstaking: unstakingTotal,
+                    },
                 });
 
                 await expect(
@@ -102,10 +104,12 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
 
             await test.step('Verify rewards are displayed correctly', async () => {
                 await stakingSection.expectStakingAmounts({
-                    pending: 'hidden',
-                    staked: stakedTotal,
-                    rewards: totalRewardsInSol,
-                    unstaking: unstakingTotal,
+                    expected: {
+                        pending: 'hidden',
+                        staked: stakedTotal,
+                        rewards: totalRewardsInSol,
+                        unstaking: unstakingTotal,
+                    },
                 });
                 await expect(
                     walletPage.balanceOfAccountWithSymbol({

--- a/suite/e2e/tests/staking/sol/stake-more.test.ts
+++ b/suite/e2e/tests/staking/sol/stake-more.test.ts
@@ -53,10 +53,12 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                 await walletPage.openAccount({ symbol: 'sol', type: 'normal', atIndex: 0 });
                 await stakingSection.stakingTabButton.click();
                 await stakingSection.expectStakingAmounts({
-                    pending: 'hidden',
-                    staked: stakedAmount,
-                    rewards: '0',
-                    unstaking: 'hidden',
+                    expected: {
+                        pending: 'hidden',
+                        staked: stakedAmount,
+                        rewards: '0',
+                        unstaking: 'hidden',
+                    },
                 });
                 await expect(stakingSection.unstakeToClaimButton).toBeEnabled();
                 await expect(stakingSection.stakeMoreButton).toBeEnabled();
@@ -133,10 +135,12 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
 
             await test.step('Verify pending on dashboard', async () => {
                 await stakingSection.expectStakingAmounts({
-                    pending: stakeMoreAmount,
-                    staked: stakedAmount,
-                    rewards: '0',
-                    unstaking: 'hidden',
+                    expected: {
+                        pending: stakeMoreAmount,
+                        staked: stakedAmount,
+                        rewards: '0',
+                        unstaking: 'hidden',
+                    },
                 });
                 await expect(stakingSection.stakeMoreButton).toBeEnabled();
                 await expect(stakingSection.unstakeToClaimButton).toBeEnabled();
@@ -147,10 +151,12 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                 await solanaStakingMock.advanceEpoch();
                 await page.clock.fastForward(stakingSection.solanaEpochCachePeriod);
                 await stakingSection.expectStakingAmounts({
-                    pending: 'hidden',
-                    staked: totalStakedAmount,
-                    rewards: '0',
-                    unstaking: 'hidden',
+                    expected: {
+                        pending: 'hidden',
+                        staked: totalStakedAmount,
+                        rewards: '0',
+                        unstaking: 'hidden',
+                    },
                 });
                 await expect(stakingSection.stakeMoreButton).toBeEnabled();
                 await expect(stakingSection.unstakeToClaimButton).toBeEnabled();

--- a/suite/e2e/tests/staking/sol/unstake.test.ts
+++ b/suite/e2e/tests/staking/sol/unstake.test.ts
@@ -54,10 +54,12 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                 await walletPage.openAccount({ symbol: 'sol', type: 'normal', atIndex: 0 });
                 await stakingSection.stakingTabButton.click();
                 await stakingSection.expectStakingAmounts({
-                    pending: 'hidden',
-                    staked: stakedAmount,
-                    rewards: '0',
-                    unstaking: 'hidden',
+                    expected: {
+                        pending: 'hidden',
+                        staked: stakedAmount,
+                        rewards: '0',
+                        unstaking: 'hidden',
+                    },
                 });
                 await expect(stakingSection.claimCard).toBeHidden();
             });
@@ -121,12 +123,14 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                     stakedAmountFormatted,
                 );
                 await solanaStakingMock.setupUnstakingAccount();
-                await page.clock.fastForward(stakingSection.solanaEpochCachePeriod);
                 await stakingSection.expectStakingAmounts({
-                    pending: 'hidden',
-                    staked: '0',
-                    rewards: '0',
-                    unstaking: unstakingAmount,
+                    expected: {
+                        pending: 'hidden',
+                        staked: '0',
+                        rewards: '0',
+                        unstaking: unstakingAmount,
+                    },
+                    options: { fastForward: stakingSection.solanaEpochCachePeriod },
                 });
                 await expect(stakingSection.unstakeToClaimButton).toBeDisabled();
                 await expect(stakingSection.stakeMoreButton).toBeEnabled();
@@ -143,12 +147,14 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
 
             await test.step('Wait few epochs for claim to be available', async () => {
                 await solanaStakingMock.advanceEpoch();
-                await page.clock.fastForward(stakingSection.solanaEpochCachePeriod);
                 await stakingSection.expectStakingAmounts({
-                    pending: 'hidden',
-                    staked: '0',
-                    rewards: '0',
-                    unstaking: 'hidden',
+                    expected: {
+                        pending: 'hidden',
+                        staked: '0',
+                        rewards: '0',
+                        unstaking: 'hidden',
+                    },
+                    options: { fastForward: stakingSection.solanaEpochCachePeriod },
                 });
                 await expect(stakingSection.unstakeToClaimButton).toBeDisabled();
                 await expect(stakingSection.stakeMoreButton).toBeEnabled();
@@ -214,10 +220,12 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
 
             await test.step('Verify dashboard is back to initial state', async () => {
                 await solanaStakingMock.advanceEpoch();
-                await page.clock.fastForward(stakingSection.solanaEpochCachePeriod);
-                await expect(stakingSection.stakingEmptyCard).toBeVisible();
-                await expect(stakingSection.claimCard).toBeHidden();
-                await expect(stakingSection.startStakingButton).toBeVisible();
+                await expect(async () => {
+                    await page.clock.fastForward(stakingSection.solanaEpochCachePeriod);
+                    await expect(stakingSection.stakingEmptyCard).toBeVisible();
+                    await expect(stakingSection.claimCard).toBeHidden();
+                    await expect(stakingSection.startStakingButton).toBeVisible();
+                }).toPass({ timeout: 10_000 });
             });
         },
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There is very small race window for automation flakyness ~200ms. In this window, product is not yet checking clock for when it should refresh dashboard. If our clock.fastForwards hits this window, then product does not register the time change and dashboard is not changed. It affects only unstake solana. But the fix is general one ready to be adjusted for any staking verification. 

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-tests-6-28/web/](https://dev.suite.sldev.cz/suite-web/fix-tests-6-28/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-tests-6-28&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-tests-6-28&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-28T11:31:30.580Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |

</details>

_Updated: 2026-06-28T11:29:51.696Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->