### PR TITLE
fix(trading): correct fee limit for TRC20 swaps

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { type UseFormReturn } from 'react-hook-form';
 
 import { isTranslationKey, useTranslation } from '@suite/intl';
@@ -12,6 +12,7 @@ import {
 } from '@suite-common/trading';
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 import {
+    deriveTronColdRecipient,
     selectAccounts,
     selectAddressDisplayType,
     selectRawNetworkFeeInfo,
@@ -38,6 +39,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
     network,
     values,
     methods,
+    estimateFeeForUnknownRecipient,
     setShowReserveBanner,
 }: TradingUseComposeTransactionProps<T>): TradingUseComposeTransactionReturnProps => {
     const dispatch = useDispatch();
@@ -64,6 +66,55 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
     const outputAddress = values?.outputs?.[0]?.address;
     const [state, setState] = useState<TradingUseComposeTransactionStateProps>(initState);
 
+    // Tron: derive a cold recipient for the offers fee estimate, passed via compose context.
+    // Keyed on device?.state (not the device object) so signing doesn't re-fire the device call.
+    const accountsRef = useRef(accounts);
+    accountsRef.current = accounts;
+    const deviceRef = useRef(device);
+    deviceRef.current = device;
+    const [feeEstimationRecipient, setFeeEstimationRecipient] = useState<string | undefined>(
+        undefined,
+    );
+
+    useEffect(() => {
+        const currentDevice = deviceRef.current;
+        // deriving during sign/review would fire a device call that tears down the modal
+        if (!estimateFeeForUnknownRecipient || networkType !== 'tron' || !currentDevice) {
+            setFeeEstimationRecipient(undefined);
+
+            return;
+        }
+        let cancelled = false;
+        deriveTronColdRecipient({
+            account,
+            network,
+            accounts: accountsRef.current,
+            device: currentDevice,
+            chunkify,
+        }).then(recipient => {
+            if (!cancelled) setFeeEstimationRecipient(recipient);
+        });
+
+        return () => {
+            cancelled = true;
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [
+        account.descriptor,
+        account.symbol,
+        account.accountType,
+        networkType,
+        device?.state,
+        network,
+        chunkify,
+        estimateFeeForUnknownRecipient,
+    ]);
+
+    const composeContext = useMemo(
+        () => ({ ...state, feeEstimationRecipient }),
+        [state, feeEstimationRecipient],
+    );
+
     // sub-hook, Composing transaction
     const {
         isLoading: isComposing,
@@ -73,7 +124,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
         setComposedLevels,
     } = useCompose({
         ...methods,
-        state,
+        state: composeContext,
     });
 
     // sub-hook, FeeLevels handler

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -228,6 +228,7 @@ export const useTradingExchangeForm = ({
             network,
             values,
             methods,
+            estimateFeeForUnknownRecipient: isFormPage,
             setShowReserveBanner,
         });
 

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -173,6 +173,7 @@ export const useTradingSellForm = ({
         network,
         values: values as TradingSellFormProps,
         methods,
+        estimateFeeForUnknownRecipient: isFormPage,
         setShowReserveBanner,
     });
 

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -351,6 +351,7 @@ export interface TradingUseComposeTransactionProps<T extends TradingSellExchange
     network: Network;
     methods: UseFormReturn<T>;
     values: T;
+    estimateFeeForUnknownRecipient: boolean;
     setShowReserveBanner: (showReserveBanner: boolean) => void;
 }
 

--- a/packages/suite/src/utils/wallet/trading/__tests__/tradingUtils.test.ts
+++ b/packages/suite/src/utils/wallet/trading/__tests__/tradingUtils.test.ts
@@ -1,5 +1,6 @@
 import { type Network, networks } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { type Account } from 'src/types/wallet';
 import { FIXTURE_ACCOUNT_OPTIONS } from 'src/utils/wallet/trading/__fixtures__/tradingUtils';
@@ -138,7 +139,6 @@ describe('trading utils', () => {
             { networkType: 'solana', descriptor: 'SolanaAddress123' },
             { networkType: 'ripple', descriptor: 'rRippleAddress123' },
             { networkType: 'stellar', descriptor: 'GStellarAddress123' },
-            { networkType: 'tron', descriptor: 'TTronAddress123' },
         ] as const)('$networkType', ({ networkType, descriptor }) => {
             it('returns account descriptor', async () => {
                 const account = {
@@ -150,6 +150,17 @@ describe('trading utils', () => {
 
                 expect(result).toBe(descriptor);
             });
+        });
+
+        it('returns empty string for tron (fee uses compose context recipient)', async () => {
+            const account = mockWalletAccount({
+                symbol: 'trx',
+                descriptor: asAccountDescriptor('TTronAddress123'),
+            });
+
+            const result = await getComposeAddressPlaceholder(account, {} as Network);
+
+            expect(result).toBe('');
         });
     });
 });

--- a/packages/suite/src/utils/wallet/trading/tradingUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/tradingUtils.ts
@@ -106,8 +106,10 @@ export const getComposeAddressPlaceholder = async (
         case 'solana':
         case 'ripple':
         case 'stellar':
-        case 'tron':
             return account.descriptor;
+        case 'tron':
+            // keep the form address empty; the fee uses composeContext.feeEstimationRecipient
+            return '';
         default:
             return exhaustive(networkType);
     }

--- a/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
@@ -25,32 +25,39 @@ jest.mock('@suite-common/wallet-core', () => {
 
 const deviceReducer = prepareDeviceReducer(extraDependenciesCommonMock);
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
+const btcFeeData = {
+    blockHeight: 890366,
+    blockTime: 10,
+    minFee: 1,
+    maxFee: 100,
+    minPriorityFee: 0,
+    dustLimit: 546,
+    levels: [
+        {
+            label: 'economy' as const,
+            feePerUnit: '1',
+            blocks: 7,
+        },
+        {
+            label: 'normal' as const,
+            feePerUnit: '2',
+            blocks: 2,
+        },
+        {
+            label: 'high' as const,
+            feePerUnit: '3',
+            blocks: 1,
+        },
+    ],
+};
 const fees: FeesState = {
     [accountBtc.symbol]: {
-        data: {
-            blockHeight: 890366,
-            blockTime: 10,
-            minFee: 1,
-            maxFee: 100,
-            dustLimit: 546,
-            levels: [
-                {
-                    label: 'economy',
-                    feePerUnit: '1',
-                    blocks: 7,
-                },
-                {
-                    label: 'normal',
-                    feePerUnit: '2',
-                    blocks: 2,
-                },
-                {
-                    label: 'high',
-                    feePerUnit: '3',
-                    blocks: 1,
-                },
-            ],
-        },
+        status: 'loaded',
+        data: btcFeeData,
+    },
+    trx: {
+        status: 'loaded',
+        data: btcFeeData,
     },
 };
 
@@ -570,6 +577,113 @@ describe('recomposeAndSignTxThunk', () => {
             },
         });
         expect(mockSignAndPushSendFormTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should derive the Tron fee limit from the recomposed tx (real recipient), not the offers estimate', async () => {
+        const { store, tradingFormState } = getMocks({
+            composedTransactionInfo: {
+                selectedFee: 'normal',
+                composed: {
+                    feePerByte: '100',
+                    // offers-page estimate against a placeholder (warm) recipient
+                    estimatedFeeLimit: '6428500', // SUN
+                    feeLimit: '64285', // energy units
+                    token: { contract: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t' } as TokenInfo,
+                    fee: '6428500',
+                    outputs: [],
+                },
+            },
+        });
+
+        const account = { ...accountBtc, symbol: 'trx', networkType: 'tron' } as Account;
+
+        const mockSignAndPushSendFormTransaction = jest.fn().mockResolvedValueOnce({
+            success: true,
+            payload: { txid: 'txid' },
+        });
+
+        (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
+            createThunk(
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
+                (_, { fulfillWithValue }) =>
+                    fulfillWithValue({
+                        normal: {
+                            type: 'final',
+                            // recompose against the real (cold) recipient — higher energy
+                            feeLimit: '120000',
+                            estimatedFeeLimit: '12000000',
+                            fee: '12000000',
+                            outputs: [{ amount: '10000000' }],
+                        },
+                    }),
+            ),
+        );
+
+        const response = await store.dispatch(
+            tradingThunks.recomposeAndSignTxThunk({
+                account,
+                address: 'address',
+                amount: '0.1',
+                tradingFormState,
+                signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
+            }),
+        );
+
+        expect(response.meta.requestStatus).toBe('fulfilled');
+        expect(mockSignAndPushSendFormTransaction).toHaveBeenCalledTimes(1);
+        expect(mockSignAndPushSendFormTransaction.mock.calls[0][0].formState.feeLimit).toBe(
+            '12000000',
+        );
+    });
+
+    it('should keep the composed feeLimit for non-Tron networks', async () => {
+        const { store, account, tradingFormState } = getMocks({
+            composedTransactionInfo: {
+                selectedFee: 'normal',
+                composed: {
+                    feePerByte: '10',
+                    estimatedFeeLimit: '6428500',
+                    feeLimit: '64285',
+                    token: { contract: '0x123457' } as TokenInfo,
+                    fee: '1000',
+                    outputs: [],
+                },
+            },
+        });
+
+        const mockSignAndPushSendFormTransaction = jest.fn().mockResolvedValueOnce({
+            success: true,
+            payload: { txid: 'txid' },
+        });
+
+        (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
+            createThunk(
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
+                (_, { fulfillWithValue }) =>
+                    fulfillWithValue({
+                        normal: {
+                            type: 'final',
+                            outputs: [{ amount: '10000000' }],
+                        },
+                    }),
+            ),
+        );
+
+        const response = await store.dispatch(
+            tradingThunks.recomposeAndSignTxThunk({
+                account,
+                address: 'address',
+                amount: '0.1',
+                tradingFormState,
+                signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
+            }),
+        );
+
+        expect(response.meta.requestStatus).toBe('fulfilled');
+        expect(mockSignAndPushSendFormTransaction).toHaveBeenCalledTimes(1);
+        expect(mockSignAndPushSendFormTransaction.mock.calls[0][0].formState.feeLimit).toBe(
+            '64285',
+        );
     });
 
     it('should create payment requests when SLIP24 is active and conditions are met', async () => {

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -216,6 +216,11 @@ export const recomposeAndSignTxThunk = createThunk<
             });
         }
 
+        // Tron fee limit is SUN and recipient-dependent — use the recomposed (real recipient) estimate.
+        if (network.networkType === 'tron') {
+            formState.feeLimit = precomposedToSign.estimatedFeeLimit ?? precomposedToSign.fee ?? '';
+        }
+
         /*
             SLIP-24 to achieve the consistent trade data
             ---

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -50,6 +50,7 @@ export * from './send/sendFormSelectors';
 export * from './send/sendFormThunks';
 export type * from './send/sendFormTypes';
 export * from './send/sendFormEthereumThunks';
+export * from './send/tron/deriveColdRecipient';
 export * from './settings/useDisplayBaseCurrency';
 export * from './settings/walletSettingsActions';
 export * from './settings/walletSettingsConstants';

--- a/suite-common/wallet-core/src/send/tron/deriveColdRecipient.ts
+++ b/suite-common/wallet-core/src/send/tron/deriveColdRecipient.ts
@@ -1,0 +1,40 @@
+import { type TrezorDevice } from '@suite-common/suite-types';
+import { type Network } from '@suite-common/wallet-config';
+import { type Account } from '@suite-common/wallet-types';
+import { substituteBip43Path } from '@suite-common/wallet-utils';
+import TrezorConnect from '@trezor/connect';
+
+type DeriveTronColdRecipientParams = {
+    account: Account;
+    network: Network;
+    accounts?: Account[];
+    device?: TrezorDevice;
+    chunkify?: boolean;
+};
+
+export const deriveTronColdRecipient = async ({
+    account,
+    network,
+    accounts,
+    device,
+    chunkify,
+}: DeriveTronColdRecipientParams): Promise<string | undefined> => {
+    if (account.networkType !== 'tron' || !device) return undefined;
+
+    const bip43Path = network.accountTypes[account.accountType]?.bip43Path ?? network.bip43Path;
+    // highest existing index + 1 (not count) so a gap can't hit an existing warm account
+    const nextIndex =
+        (accounts ?? [])
+            .filter(a => a.symbol === account.symbol && a.accountType === account.accountType)
+            .reduce((max, a) => Math.max(max, a.index), -1) + 1;
+    const path = substituteBip43Path(bip43Path, nextIndex);
+
+    const result = await TrezorConnect.tronGetAddress({
+        device,
+        path,
+        showOnTrezor: false,
+        chunkify,
+    });
+
+    return result.success ? result.payload.address : undefined;
+};

--- a/suite-common/wallet-core/src/send/tron/sendFormTronThunks.ts
+++ b/suite-common/wallet-core/src/send/tron/sendFormTronThunks.ts
@@ -54,7 +54,10 @@ export const composeTronTransactionFeeLevelsThunk = createThunk<
         }
 
         const { output, tokenInfo: token, decimals } = composeOutputs;
-        const to = 'address' in output && output.address ? output.address : account.descriptor;
+        const to =
+            'address' in output && output.address
+                ? output.address
+                : (composeContext.feeEstimationRecipient ?? account.descriptor);
 
         const isSendMax = output.type === 'send-max' || output.type === 'send-max-noaddress';
         const fallbackAmount = token

--- a/suite-common/wallet-types/mocks/mockWalletAccount.ts
+++ b/suite-common/wallet-types/mocks/mockWalletAccount.ts
@@ -25,6 +25,14 @@ export const networkSpecificDefaultEthereum = {
     page: { index: 1, size: 25, total: 1 },
 };
 
+export const networkSpecificDefaultTron = {
+    networkType: 'tron' as const,
+    misc: {},
+    marker: undefined,
+    stellarCursor: undefined,
+    page: { index: 1, size: 25, total: 1 },
+};
+
 export const networkSpecificDefaultSolana = {
     networkType: 'solana' as const,
     marker: undefined,
@@ -67,6 +75,7 @@ export const networkSpecificDefaultStellar = {
 type NetworkSpecificDefault =
     | typeof networkSpecificDefaultBitcoin
     | typeof networkSpecificDefaultEthereum
+    | typeof networkSpecificDefaultTron
     | typeof networkSpecificDefaultSolana
     | typeof networkSpecificDefaultRipple
     | typeof networkSpecificDefaultCardano
@@ -106,8 +115,8 @@ const networkTypeMap: Record<NetworkSymbol, NetworkSpecificDefault> = {
     base: networkSpecificDefaultBitcoin,
     op: networkSpecificDefaultBitcoin,
     avax: networkSpecificDefaultBitcoin,
-    trx: networkSpecificDefaultBitcoin,
-    ttrx: networkSpecificDefaultBitcoin,
+    trx: networkSpecificDefaultTron,
+    ttrx: networkSpecificDefaultTron,
     txrp: networkSpecificDefaultBitcoin,
     txlm: networkSpecificDefaultBitcoin,
 };

--- a/suite-common/wallet-types/src/stakeTypes.ts
+++ b/suite-common/wallet-types/src/stakeTypes.ts
@@ -47,4 +47,5 @@ export interface ComposeActionContext {
     feeInfo: FeeInfo;
     excludedUtxos?: ExcludedUtxos;
     prison?: Record<string, unknown>;
+    feeEstimationRecipient?: string;
 }


### PR DESCRIPTION
## What

Fixes the network fee for TRC20 swaps on Tron (e.g. USDT → TRX).

## Problems

1. **Out of Energy on-chain** — the signed `fee_limit` was wrong. Tron signs `fee_limit` in SUN, but the flow used `composed.feeLimit` (energy units), and the offers estimate (against a placeholder recipient) instead of the real one.
2. **Wrong fee shown** — a cold recipient (first-time token holder) needs far more energy, but the offers/confirm estimate ran against the user's own (warm) address.

## Fix

- **Signing:** recompose derives the fee limit from the recomposed tx (real recipient) — SUN, like the Send flow.
- **Estimate:** `deriveTronColdRecipient` derives an unused (cold) address; it's passed on the compose context (`feeEstimationRecipient`) and the Tron compose uses it when the form has no recipient, so offers/confirm show the cold fee.
- The derivation runs only on the offers form, so it no longer fires a device call during signing (which was closing the review modal).

Send and other networks are unaffected (trading-only; Send always has a real recipient). Native already estimates against the real recipient.

## Notes for QA

Swap **USDT (Tron) → TRX** to a **fresh receive account** (no TRX/tokens/history):

- [ ] Broadcasts successfully (previously failed with *Out of Energy*).
- [ ] Fee matches across Trade form → Confirm & send → device (~13 TRX, not ~6.4).
- [ ] Review modal stays open after signing on the Trezor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in the trading/coinmarket subsystem: sell form hook, exchange (swap) form hook, compose transaction hook, recomposeAndSignTxThunk, and tradingUtils. These directly affect how trading transactions are composed, validated, signed, and displayed. The highest risk is in sell and swap flows where transaction composition and signing are modified. Buy flows share some utilities but are lower risk. The stakeTypes.ts change is a type definition file mapping to 121 tests but is unlikely to cause runtime regressions in E2E tests. Tron-related changes (deriveColdRecipient, sendFormTronThunks) have no E2E test coverage.

<details><summary><b>Changed files (13)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts`
- `packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts`
- `packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts`
- `packages/suite/src/types/trading/tradingForm.ts`
- `packages/suite/src/utils/wallet/trading/__tests__/tradingUtils.test.ts`
- `packages/suite/src/utils/wallet/trading/tradingUtils.ts`
- `suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts`
- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts`
- `suite-common/wallet-core/src/index.ts`
- `suite-common/wallet-core/src/send/tron/deriveColdRecipient.ts`
- `suite-common/wallet-core/src/send/tron/sendFormTronThunks.ts`
- `suite-common/wallet-types/mocks/mockWalletAccount.ts`
- `suite-common/wallet-types/src/stakeTypes.ts`

</details>

**Recommended tests (19)**

<details><summary>🔴 <b>High priority (10)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Directly exercises the sell trading flow including transaction composition, fee calculation, and device confirmation. Changes to useTradingSellForm.ts, useTradingComposeTransaction.ts, recomposeAndSignTxThunk.ts, and tradingUtils.ts all feed into this flow's core logic for composing and signing sell transactions.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests Ethereum sell flow with custom gas fees and transaction composition. The sell form hook, compose transaction hook, and recomposeAndSignTxThunk are all exercised when the user fills the sell form, sets custom fees, and confirms the transaction on device.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests the full Solana sell flow including form filling, transaction composition, device confirmation, and status polling. Changes to the sell form hook and compose transaction infrastructure directly affect how sell amounts and fees are calculated and sent.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Tests the swap (exchange) flow from SOL to BTC including transaction composition, device confirmation, and status tracking. The useTradingExchangeForm.ts and recomposeAndSignTxThunk.ts changes directly affect how swap transactions are composed and signed.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests swapping SOL to USDC token with transaction composition, device prompt verification, and toast notifications. The exchange form hook and compose transaction changes are directly in this code path.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping USDT token to BTC involving the exchange form hook for form state management and recomposeAndSignTxThunk for signing the swap transaction. Token-to-coin swaps may exercise different code paths in tradingUtils.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token (USDC) which exercises the sell form hook with token-specific logic and transaction composition for ERC-20 transfers. Changes to tradingUtils may affect how token amounts are formatted or validated.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Directly tests sell form input validation including decimal limits, insufficient funds, and percentage/max buttons. The useTradingSellForm and useTradingComposeTransaction hooks control this validation and amount calculation logic.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests custom Bitcoin fee settings during a swap transaction, directly exercising the compose transaction hook for fee calculation and the recomposeAndSignTxThunk for signing with custom fees.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests custom Ethereum gas fee settings during a swap, exercising the compose transaction hook for Ethereum fee calculation and the recomposeAndSignTxThunk for signing with custom gas parameters.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests token-to-token swap (USDT to USDC on Solana), exercising the exchange form hook and compose transaction logic for SPL token transfers. Different token swap path from coin swaps.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form input validation, fraction buttons, and amount calculations. The compose transaction hook and tradingUtils changes could affect how swap amounts are validated and calculated in the form.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — While buy flow doesn't use the sell/exchange form hooks directly, it shares tradingUtils for amount formatting and the compose transaction infrastructure. Changes to tradingUtils could affect how buy amounts are displayed.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Buy flow for Solana SPL token shares tradingUtils for crypto amount formatting and validation. Changes to tradingUtils could affect displayed amounts in the buy confirmation.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests buy form validation edge cases (min/max limits, empty quotes). tradingUtils changes could affect how validation limits are computed or displayed.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Ethereum buy flow shares tradingUtils and compose transaction infrastructure. Changes could affect amount formatting or account selection logic.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation to buy/sell/swap forms and verifies correct asset preselection. Changes to form hooks could affect form initialization when navigating from different entry points.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swap form behavior when the buy asset belongs to a disabled network. Exchange form hook changes could affect how quotes are displayed for disabled network assets.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-history.test.ts` — Tests swap trade history display. While it shares trading infrastructure, history viewing doesn't exercise the compose/sign transaction path. Only relevant if tradingUtils changes affect how historical trade data is formatted.

</details>

⚠️ **Changes with no test coverage (8)**
- `packages/suite/src/types/trading/tradingForm.ts`
- `packages/suite/src/utils/wallet/trading/__tests__/tradingUtils.test.ts`
- `suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts`
- `suite-common/wallet-core/src/index.ts`
- `suite-common/wallet-core/src/send/tron/deriveColdRecipient.ts`
- `suite-common/wallet-core/src/send/tron/sendFormTronThunks.ts`
- `suite-common/wallet-types/mocks/mockWalletAccount.ts`
- `suite-common/wallet-types/src/stakeTypes.ts`

_Updated: 2026-07-02T12:05:36.012Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tron-swap-fees/web/](https://dev.suite.sldev.cz/suite-web/fix/tron-swap-fees/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tron-swap-fees&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tron-swap-fees&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T12:11:14.090Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-02T12:08:38.349Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->