### PR TITLE
fix: better SuiteSync error sentry format

### DIFF
--- a/packages/utils/src/serializeError.ts
+++ b/packages/utils/src/serializeError.ts
@@ -1,19 +1,23 @@
+const serializeErrorReplacer = (_key: string, value: unknown): unknown => {
+    // Error instances are objects, but have no JSON printable properties.
+    // Instead, .toString() is their standard string representation. Though stack trace must be included separately
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/toString
+    if (value instanceof Error) {
+        return { message: value.toString(), stackTrace: value.stack };
+    }
+
+    return value;
+};
+
 /**
  * Serialize an error of unknown type to a string.
  */
 export const serializeError = (error: unknown): string => {
-    // Error instances are objects, but have no JSON printable properties.
-    // Instead, .toString() is their standard string representation. Though stack trace must be included separately
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/toString
-    if (error instanceof Error) {
-        return JSON.stringify({ message: error.toString(), stackTrace: error.stack });
-    }
-
-    // plain javascript object is not a conventional error type, but we have to count with it
+    // Plain JavaScript object is not a conventional error type, but we have to count with it.
     if (typeof error === 'object') {
-        return JSON.stringify(error);
+        return JSON.stringify(error, serializeErrorReplacer);
     }
 
-    // assumed to be a primitive type; exotic types such as function will also be simply stringified
+    // Assumed to be a primitive type; exotic types such as function will also be simply stringified.
     return `${error}`;
 };

--- a/packages/utils/tests/serializeError.test.ts
+++ b/packages/utils/tests/serializeError.test.ts
@@ -37,6 +37,66 @@ describe(serializeError.name, () => {
         expect(serializeError(error)).toBe(JSON.stringify(error));
     });
 
+    it('serializes an Error instance nested inside a plain object', () => {
+        const caused = new Error('Goverment is mafia');
+        caused.stack = 'Mock Stack Trace';
+
+        expect(
+            JSON.parse(
+                serializeError({
+                    type: 'TaxationIsTheft',
+                    caused,
+                }),
+            ),
+        ).toMatchObject({
+            type: 'TaxationIsTheft',
+            caused: {
+                message: 'Error: Goverment is mafia',
+                stackTrace: 'Mock Stack Trace',
+            },
+        });
+    });
+
+    it('serializes an Error instance nested deeply inside a plain object', () => {
+        const caused = new Error('Goverment is mafia');
+        caused.stack = 'Mock Stack Trace';
+
+        expect(
+            JSON.parse(
+                serializeError({
+                    type: 'TaxationIsTheft',
+                    details: {
+                        level1: {
+                            level2: {
+                                level3: {
+                                    level4: {
+                                        caused,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                }),
+            ),
+        ).toMatchObject({
+            type: 'TaxationIsTheft',
+            details: {
+                level1: {
+                    level2: {
+                        level3: {
+                            level4: {
+                                caused: {
+                                    message: 'Error: Goverment is mafia',
+                                    stackTrace: 'Mock Stack Trace',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        });
+    });
+
     it('serializes a primitive', () => {
         expect(serializeError('test')).toBe('test');
         expect(serializeError(123)).toBe('123');

--- a/suite/suite-sync/src/suiteSyncErrorHandler.ts
+++ b/suite/suite-sync/src/suiteSyncErrorHandler.ts
@@ -7,6 +7,7 @@ import { type EnsureWalletSuiteSyncOnErrors } from '@suite-common/suite-sync-typ
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { type StaticSessionId } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
+import { serializeError } from '@trezor/utils';
 
 import { suiteSyncErrorTranslationKeyMap } from './suiteSyncErrorTranslationKeyMap';
 import { updateShowEnableSuiteSyncModal } from './suiteSyncSlice';
@@ -31,7 +32,7 @@ export const suiteSyncErrorHandler = ({
     //       It unfortunately can happen, if we are not able to map OwnerId to the Device
     //       See: https://github.com/trezor/trezor-suite/issues/27049
     if (deviceStaticSessionId === null) {
-        console.error('Unexpected SuiteSync error', error);
+        console.error('Unexpected SuiteSync error', serializeError(error));
 
         dispatch(
             notificationsActions.addToast({
@@ -91,7 +92,7 @@ export const suiteSyncErrorHandler = ({
         // We want those errors to come to Sentry
         case 'SuiteSyncUpdateError':
         case 'QuotaManagerCommunicationFailed':
-            console.error('Unexpected SuiteSync error', error);
+            console.error('Unexpected SuiteSync error', serializeError(error));
 
             dispatch(
                 notificationsActions.addToast({


### PR DESCRIPTION
Better log for Sentry

## Description

Resolves: https://github.com/trezor/trezor-suite/issues/29164

## Notes for QA

Non, its just log improvement

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies `serializeError` (a very broad utility used by 121+ tests) and `suiteSyncErrorHandler.ts` (Suite Sync error handling). The `serializeError` change is extremely low risk for E2E tests since it's a deep utility for error serialization that wouldn't manifest in user-visible behavior unless something breaks catastrophically — and it has its own unit test. The `suiteSyncErrorHandler.ts` change is more targeted and could affect Suite Sync labeling flows, so the recommended strategy focuses on Suite Sync E2E tests. No tests need to be run at high priority since the changes are in error-handling infrastructure rather than happy-path logic.

<details><summary><b>Changed files (3)</b></summary>

- `packages/utils/src/serializeError.ts`
- `packages/utils/tests/serializeError.test.ts`
- `suite/suite-sync/src/suiteSyncErrorHandler.ts`

</details>

**Recommended tests (6)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — The suiteSyncErrorHandler.ts change directly affects Suite Sync error handling logic. This test exercises Suite Sync label creation and syncing to the Evolu Relay backend, which is the primary user-facing flow where Suite Sync error handling would be triggered.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test covers multi-wallet Suite Sync flows including enabling/declining Suite Sync, setting labels on passphrase wallets, and syncing to Evolu Relay. Changes to suiteSyncErrorHandler.ts could affect error handling during these complex sync operations.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — Tests Suite Sync label removal and null-value syncing to the Evolu relay. The suiteSyncErrorHandler.ts change could affect how errors during label removal/sync are handled.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — Tests syncing labels from the Evolu relay server to Suite, which is a core Suite Sync flow. Changes to suiteSyncErrorHandler.ts directly impact error handling in this sync pathway.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — Tests migration from legacy labeling to Suite Sync, which involves Suite Sync initialization and relay syncing. The suiteSyncErrorHandler.ts change could affect error handling during migration flows.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — Tests migrating Dropbox labels to Suite Sync. While less directly related, the suiteSyncErrorHandler.ts change could affect the error handling path when Suite Sync encounters issues during label migration.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/utils/tests/serializeError.test.ts`
- `suite/suite-sync/src/suiteSyncErrorHandler.ts`

_Updated: 2026-06-29T09:53:46.408Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=sentry-fix&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=sentry-fix&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T09:58:13.140Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T09:57:10.478Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/sentry-fix/web/](https://dev.suite.sldev.cz/suite-web/sentry-fix/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->