### PR TITLE
feat(sentry): tracesSampler based on analytics confirmation

### DIFF
--- a/packages/suite-desktop-ui/tsconfig.json
+++ b/packages/suite-desktop-ui/tsconfig.json
@@ -2,9 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
         "outDir": "libDev",
-        "paths": {
-            "src/*": ["../suite/src/*"]
-        }
+        "paths": { "src/*": ["../suite/src/*"] }
     },
     "include": ["."],
     "references": [

--- a/packages/suite-web/tsconfig.json
+++ b/packages/suite-web/tsconfig.json
@@ -2,9 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
         "outDir": "./libDev",
-        "paths": {
-            "src/*": ["../suite/src/*"]
-        }
+        "paths": { "src/*": ["../suite/src/*"] }
     },
     "include": ["."],
     "references": [

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -108,6 +108,7 @@
         "@suite/receive": "workspace:*",
         "@suite/recovery": "workspace:*",
         "@suite/router": "workspace:*",
+        "@suite/sentry": "workspace:*",
         "@suite/settings": "workspace:*",
         "@suite/suite-sync": "workspace:*",
         "@suite/thp": "workspace:*",

--- a/packages/suite/src/utils/suite/sentry.ts
+++ b/packages/suite/src/utils/suite/sentry.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/core';
 
+import { setShouldCaptureBrowserTracing } from '@suite/sentry';
 import { selectAnalyticsInstanceId } from '@suite-common/analytics-redux';
 import { selectSelectedDevice } from '@suite-common/device';
 import { redactDevice, redactDiscovery, selectRedactedActionsLog } from '@suite-common/logger';
@@ -26,6 +27,8 @@ export const captureSentryMessage = Sentry.captureMessage;
  */
 export const allowSentryReport = (value: boolean) => {
     Sentry.setTag(ALLOW_REPORT_TAG, value);
+    // synchronize the newly set value to localStorage (`value` may have been also be retrieved from IDB, which effectively synces it)
+    setShouldCaptureBrowserTracing(value);
 };
 
 export const setSentryUser = (instanceId: string) => {

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -8,9 +8,7 @@
             }
         ],
         "outDir": "./libDev",
-        "paths": {
-            "src/*": ["./src/*"]
-        }
+        "paths": { "src/*": ["./src/*"] }
     },
     "include": [".", "e2e", "**/*.json"],
     "references": [
@@ -200,6 +198,7 @@
         { "path": "../../suite/receive" },
         { "path": "../../suite/recovery" },
         { "path": "../../suite/router" },
+        { "path": "../../suite/sentry" },
         { "path": "../../suite/settings" },
         { "path": "../../suite/suite-sync" },
         { "path": "../../suite/thp" },

--- a/suite/sentry/src/config.ts
+++ b/suite/sentry/src/config.ts
@@ -114,8 +114,8 @@ export const SENTRY_BROWSER_CONFIG = {
     profileLifecycle: 'trace',
     integrations: [
         captureConsoleIntegration({ levels: ['error'] }),
-        !isProd && browserProfilingIntegration(),
-        !isProd && browserTracingIntegration(),
-        !isProd && elementTimingIntegration(),
-    ].filter((item): item is Exclude<typeof item, false> => Boolean(item)),
+        browserProfilingIntegration(),
+        browserTracingIntegration(),
+        elementTimingIntegration(),
+    ],
 } satisfies BrowserOptions;

--- a/suite/sentry/src/config.ts
+++ b/suite/sentry/src/config.ts
@@ -18,6 +18,7 @@ import { isCodesignBuild } from '@trezor/env-utils';
 import { redactUserPathFromString } from '@trezor/utils';
 
 import { ignoreErrors } from './ignoreErrors';
+import { tracesSampler } from './traces';
 
 /**
  * Full user path could be part of reported error in some cases and we want to actively filter username out.
@@ -110,7 +111,8 @@ export const SENTRY_CONFIG = {
 export const SENTRY_BROWSER_CONFIG = {
     ...SENTRY_CONFIG,
     profileSessionSampleRate: isProd ? 0.1 : 1,
-    tracesSampleRate: isProd ? 0.1 : 1,
+    // In our case, `tracesSampler` is used only to drop traces based on arbitrary condition (similarly to `beforeSend` for error events)
+    tracesSampler,
     profileLifecycle: 'trace',
     integrations: [
         captureConsoleIntegration({ levels: ['error'] }),

--- a/suite/sentry/src/index.ts
+++ b/suite/sentry/src/index.ts
@@ -1,1 +1,2 @@
 export { SENTRY_CONFIG, SENTRY_BROWSER_CONFIG } from './config';
+export { getShouldCaptureBrowserTracing, setShouldCaptureBrowserTracing } from './traces';

--- a/suite/sentry/src/traces.ts
+++ b/suite/sentry/src/traces.ts
@@ -1,0 +1,36 @@
+import type { BrowserOptions } from '@sentry/browser';
+
+import { isCodesignBuild } from '@trezor/env-utils';
+
+const isProd = isCodesignBuild();
+const DEFAULT_TRACES_SAMPLE_RATE = isProd ? 0.1 : 1;
+
+const STORAGE_KEY = 'analytics-confirmed-and-enabled';
+
+/**
+ * Persist the analytics confirmed & enabled decision also in localStorage, because in order to use it for traces filtering, it must be readable synchronously.
+ * That's because Sentry.init() starts synchronously right away when module is loaded, but IDB is retrieved async much later (preloadStore when react app renders).
+ * Note that this is different from `redactSentryEvent`, because error events are a discrete events. There we don't mind
+ * that the confirmed & enabled decision may not yet be available for error events sent early before IDB loads,
+ * because those events are merely sent redacted, that's OK. While traces are continuously running from Sentry.init(),
+ * and if we don't have the decision available at that point, we have to drop them entirely, so it would not be possible to collect them.
+ *
+ * Known issue: the first fresh app load will not emit trace, that is due to design (need to confirm analytics first).
+ */
+export const setShouldCaptureBrowserTracing = (newValue: boolean) => {
+    localStorage.setItem(STORAGE_KEY, String(newValue));
+};
+
+export const getShouldCaptureBrowserTracing = (): boolean =>
+    localStorage.getItem(STORAGE_KEY) === 'true';
+
+/**
+ * Drop Sentry tracing & profiling when analytics are not explicitly enabled, by dynamically setting the sample rate.
+ * As per Sentry docs, that is the recommended way for arbitrary traces filtering.
+ */
+export const tracesSampler: NonNullable<BrowserOptions['tracesSampler']> = samplingContext => {
+    const shouldCaptureBrowserTracing = getShouldCaptureBrowserTracing();
+    if (shouldCaptureBrowserTracing !== true) return 0;
+
+    return samplingContext.inheritOrSampleWith(DEFAULT_TRACES_SAMPLE_RATE);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -17028,6 +17028,7 @@ __metadata:
     "@suite/receive": "workspace:*"
     "@suite/recovery": "workspace:*"
     "@suite/router": "workspace:*"
+    "@suite/sentry": "workspace:*"
     "@suite/settings": "workspace:*"
     "@suite/suite-sync": "workspace:*"
     "@suite/thp": "workspace:*"


### PR DESCRIPTION
## Description

Followup to https://github.com/trezor/trezor-suite/pull/28887 and https://github.com/trezor/trezor-suite/pull/29046:

- Enable Sentry tracing and profiling in production
- Do not send unless analytics are **confirmed & enabled**
  - That's a difference from error events, where we send them redacted until confirmed.
- Use `localStorage` to persist the information about confirming analytics (duplicates the redux in IDB)
  - that's necessary for it to work, see comment in [traces.ts‎](https://github.com/trezor/trezor-suite/pull/29168/changes#diff-8dee16b421d0f9334af128eecadbf63e6f483c6d93b129182ad7f46d3838830e)
  - btw such a single-use `localStorage` is precedented, we have a few like that, [for example dark/light theme](https://github.com/trezor/trezor-suite/blob/32383ee4b76a0c3240f6222d8d6ac10e5343807d/packages/analytics-docs/src/contexts/ThemeContext.tsx#L25) 

## Notes for QA

Most important case that no sentry trace is sent before analytics confirmation, and none after rejecting the analytics.
 
On Suite Web you may open devtools → network tab → Fetch/XHR → filter for `sentry`
~Only the initial handshake is sent when loading the page, but nothing shall be sent after rejecting analytics, and before confirmation only errror events.~ nope that was a mistake, that definitely should **never** send!!

On Suite Desktop Sentry network traffic is not observable in devtools, [only on Sentry dashboard](https://satoshilabs.sentry.io/explore/profiles/?environment=develop&project=5193825&statsPeriod=1h). There you can find your session in traces, if they are enabled.

## Related Issue

Resolve #28998

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sentry-traces-only-when-analytics-confirmed&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sentry-traces-only-when-analytics-confirmed&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T10:54:06.036Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T10:53:23.771Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to Sentry error-tracking configuration (suite/sentry/src/config.ts, index.ts, traces.ts), the Sentry utility in Suite (packages/suite/src/utils/suite/sentry.ts), and TypeScript/package configuration files (tsconfig.json files and package.json). The sentry.ts utility is a global dependency imported by 121 tests but none of those tests directly exercise Sentry functionality — they merely transitively import it as part of the Suite application bootstrap. The Sentry config/traces changes and tsconfig changes are infrastructure-level and do not alter any user-facing behavior that E2E tests would validate. There is no E2E test that specifically tests Sentry error reporting, so no tests are recommended. The risk is low: if Sentry is misconfigured, error reporting may silently fail but no user-facing functionality would break.

<details><summary><b>Changed files (8)</b></summary>

- `packages/suite-desktop-ui/tsconfig.json`
- `packages/suite-web/tsconfig.json`
- `packages/suite/package.json`
- `packages/suite/src/utils/suite/sentry.ts`
- `packages/suite/tsconfig.json`
- `suite/sentry/src/config.ts`
- `suite/sentry/src/index.ts`
- `suite/sentry/src/traces.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (8)**
- `packages/suite-desktop-ui/tsconfig.json`
- `packages/suite-web/tsconfig.json`
- `packages/suite/package.json`
- `packages/suite/src/utils/suite/sentry.ts`
- `packages/suite/tsconfig.json`
- `suite/sentry/src/config.ts`
- `suite/sentry/src/index.ts`
- `suite/sentry/src/traces.ts`

_Updated: 2026-06-29T10:50:39.542Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/sentry-traces-only-when-analytics-confirmed/web/](https://dev.suite.sldev.cz/suite-web/fix/sentry-traces-only-when-analytics-confirmed/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->