### PR TITLE
chore(connect): `signTransaction` input.amount always required

### DIFF
--- a/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.paytoaddress.ts
+++ b/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.paytoaddress.ts
@@ -16,6 +16,7 @@ const btc = {
             ],
             prev_hash: '50f6f1209ca92d7359564be803cb2c932cde7d370f7cee50fd1fad6790f6206d',
             prev_index: 1,
+            amount: '50000',
         },
     ],
     outputs: [
@@ -153,6 +154,7 @@ const doge = {
             ],
             prev_index: 12,
             prev_hash: '0a4cb7d5c27455333701f0e53812e4be56a0272ad7f168279acfed7b065ee118',
+            amount: '622200000000',
         },
     ],
     outputs: [

--- a/packages/connect/e2e/__fixtures__/signTransactionZcash.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionZcash.ts
@@ -18,12 +18,14 @@ export default {
                         prev_hash:
                             '84533aa6244bcee68040d851dc4f502838ed3fd9ce838e2e48dbf440e7f4df2a',
                         prev_index: 0,
+                        amount: '13123',
                     },
                     {
                         address_n: "m/44'/133'/0'/1/0",
                         prev_hash:
                             '84533aa6244bcee68040d851dc4f502838ed3fd9ce838e2e48dbf440e7f4df2a',
                         prev_index: 1,
+                        amount: '3299',
                     },
                 ],
                 outputs: [
@@ -52,6 +54,7 @@ export default {
                         prev_hash:
                             '29d25589db4623d1a33c58745b8f95b131f49841c79dcd171847d0d7e9e2dc3a',
                         prev_index: 0,
+                        amount: '80000',
                     },
                 ],
                 outputs: [

--- a/packages/connect/src/api/bitcoin/__fixtures__/inputs.ts
+++ b/packages/connect/src/api/bitcoin/__fixtures__/inputs.ts
@@ -85,22 +85,9 @@ export const validateTrezorInputs = [
         params: [{ address_n: [0], amount: '1', prev_index: 1 }],
     },
     {
-        description: 'missing amount on non segwit path. valid only because of legacy reasons',
-        params: [{ address_n: [0], prev_index: 1, prev_hash: 'txid' }],
-        result: [{ prev_index: 1 }],
-    },
-    {
-        description: 'missing amount p2sh',
+        description: 'missing amount',
         params: [{ address_n: [49 | 0x80000000], prev_index: 1, prev_hash: 'txid' }],
     },
-    // {
-    //     description: 'missing amount p2wpkh',
-    //     params: [{ address_n: [84 | 0x80000000], prev_index: 1, prev_hash: 'txid' }],
-    // },
-    // {
-    //     description: 'missing amount p2tr',
-    //     params: [{ address_n: [86 | 0x80000000], prev_index: 1, prev_hash: 'txid' }],
-    // },
     {
         description: 'missing script_pubkey in EXTERNAL',
         params: [{ amount: '1', prev_index: 1, prev_hash: 'txid', script_type: 'EXTERNAL' }],

--- a/packages/connect/src/api/bitcoin/__fixtures__/signtxVerify.ts
+++ b/packages/connect/src/api/bitcoin/__fixtures__/signtxVerify.ts
@@ -7,7 +7,7 @@ const inputs = [
         address_n: PATH,
         prev_hash: '50f6f1209ca92d7359564be803cb2c932cde7d370f7cee50fd1fad6790f6206d',
         prev_index: 1,
-        amount: '1',
+        amount: '50000',
     },
 ];
 

--- a/packages/connect/src/api/bitcoin/inputs.ts
+++ b/packages/connect/src/api/bitcoin/inputs.ts
@@ -8,13 +8,7 @@ import type {
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 
 import { convertMultisigPubKey } from '../../utils/hdnodeUtils';
-import {
-    fixPath,
-    getHDPath,
-    getScriptType,
-    isSegwitPath,
-    validatePath,
-} from '../../utils/pathUtils';
+import { fixPath, getHDPath, getScriptType, validatePath } from '../../utils/pathUtils';
 import { validateParams } from '../common/paramsValidator';
 
 /** *****
@@ -28,14 +22,10 @@ export const validateTrezorInputs = (
         .map(i => fixPath(i))
         .map(i => convertMultisigPubKey(coinInfo.network, i))
         .map(input => {
-            const useAmount = input.script_type === 'EXTERNAL' || isSegwitPath(input.address_n);
-            // since 2.3.5 amount is required for all inputs.
-            // this change however is breaking 3rd party implementations
-            // missing amount will be delivered by refTx object
             validateParams(input, [
                 { name: 'prev_hash', type: 'string', required: true },
                 { name: 'prev_index', type: 'number', required: true },
-                { name: 'amount', type: 'uint', required: useAmount },
+                { name: 'amount', type: 'uint', required: true },
                 { name: 'script_type', type: 'string' },
                 { name: 'sequence', type: 'number' },
                 { name: 'multisig', type: 'object' },

--- a/packages/connect/src/utils/pathUtils.ts
+++ b/packages/connect/src/utils/pathUtils.ts
@@ -42,7 +42,7 @@ export const getHDPath = (path: string): number[] => {
     throw PATH_NOT_VALID;
 };
 
-export const isSegwitPath = (path: number[] | undefined) =>
+const isSegwitPath = (path: number[] | undefined) =>
     Array.isArray(path) && path[0] === toHardenedPathPart(49);
 
 const isBech32Path = (path: number[] | undefined) =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Followup for https://github.com/trezor/trezor-suite/pull/28587

since `enhanceTrezorInputs` was removed **amount is always required** but it was not reflected everywhere

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29166


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes primarily affect Bitcoin transaction signing infrastructure: input processing logic (inputs.ts), path utilities (pathUtils.ts), and test fixtures for signTransaction and Zcash signing. The highest risk is to TrezorConnect signTransaction flows, followed by any TrezorConnect API that relies on derivation path parsing. Since inputs.ts and pathUtils.ts map to 121+ tests each (broad global utilities), most of those tests are unrelated and should not be run. The recommended strategy focuses on the TrezorConnect integration tests that directly exercise transaction signing, path validation, and address derivation.

<details><summary><b>Changed files (6)</b></summary>

- `packages/connect-explorer/src/data/methods/bitcoin/signTransaction.paytoaddress.ts`
- `packages/connect/e2e/__fixtures__/signTransactionZcash.ts`
- `packages/connect/src/api/bitcoin/__fixtures__/inputs.ts`
- `packages/connect/src/api/bitcoin/__fixtures__/signtxVerify.ts`
- `packages/connect/src/api/bitcoin/inputs.ts`
- `packages/connect/src/utils/pathUtils.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — The changed files include Bitcoin signTransaction fixtures (signTransaction.paytoaddress.ts, signtxVerify.ts, inputs.ts) and the core inputs.ts processing logic. This test directly exercises TrezorConnect.signTransaction and verifies the multi-step device confirmation flow, making it the most directly affected test.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/error.test.ts` — This test validates TrezorConnect error handling for invalid derivation paths via ethereumGetAddress. Changes to pathUtils.ts (path validation/parsing) could affect how invalid paths are detected and reported, potentially altering the error message displayed.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This test exercises TrezorConnect.ethereumSignTransaction which relies on the inputs processing pipeline (inputs.ts) and path utilities (pathUtils.ts) for transaction construction and path validation. Changes to these could affect transaction signing flows.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — getAddress uses derivation path parsing from pathUtils.ts to resolve Bitcoin addresses. Changes to path utilities could affect address derivation for both single and bundled address exports.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises TrezorConnect.getAddress through the web popup flow, which uses pathUtils.ts for path handling. While path changes could theoretically affect it, the test primarily validates the popup UX flow rather than path logic.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Sign and verify for Bitcoin uses BIP84 address derivation paths which are processed by pathUtils.ts. A regression in path parsing could break the address selection dropdown or signing flow.
- `suite/e2e/tests/wallet/public-keys.test.ts` — This test verifies public key (XPUB) display for BTC, LTC, and ADA accounts by navigating to account details and showing the key via device prompt. Path utilities are used in derivation path handling for these accounts.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/connect/e2e/__fixtures__/signTransactionZcash.ts`
- `packages/connect/src/api/bitcoin/__fixtures__/inputs.ts`
- `packages/connect/src/api/bitcoin/__fixtures__/signtxVerify.ts`
- `packages/connect-explorer/src/data/methods/bitcoin/signTransaction.paytoaddress.ts`

_Updated: 2026-06-29T15:27:11.919Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/connect-signtx-input-amount/web/](https://dev.suite.sldev.cz/suite-web/fix/connect-signtx-input-amount/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-signtx-input-amount&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-signtx-input-amount&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-signtx-input-amount&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-30T07:19:24.533Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-30T07:17:52.742Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->