### PR TITLE
fix(suite-native): add solana kit to exports map workaround

### DIFF
--- a/suite-native/app/metro.config.js
+++ b/suite-native/app/metro.config.js
@@ -72,6 +72,7 @@ const config = {
                 '@evolu/common/local-first': `${rootNodeModulesPath}/@evolu/common/dist/src/local-first/index.js`,
                 '@evolu/common/polyfills': `${rootNodeModulesPath}/@evolu/common/dist/src/Polyfills.js`,
                 '@evolu/react-native/polyfills': `${rootNodeModulesPath}/@evolu/react-native/dist/src/Polyfills.js`,
+                '@solana/kit/program-client-core': `${rootNodeModulesPath}/@solana/kit/dist/program-client-core.native.mjs`,
                 'crc/calculators/crc32': `${rootNodeModulesPath}/crc/cjs-default-unwrap/calculators/crc32.js`,
                 'crc/calculators/crc16xmodem': `${rootNodeModulesPath}/crc/cjs-default-unwrap/calculators/crc16xmodem.js`,
                 'bignumber.js': `${rootNodeModulesPath}/bignumber.js/dist/bignumber.cjs`,


### PR DESCRIPTION
## Description

Fix Metro build error after #28962
Metro currently requires adding manual workarounds for module subpaths/aliases
Waiting for better solution with #20733

```
error Unable to resolve module @solana/kit/program-client-core from /home/runner/work/trezor-suite/trezor-suite/node_modules/@solana-program/compute-budget/dist/src/index.js: @solana/kit/program-client-core could not be found within the project or in these directories:
  ../../node_modules
  node_modules
  ../../node_modules
  2 |
  3 | var kit = require('@solana/kit');
> 4 | var programClientCore = require('@solana/kit/program-client-core');
```

## Notes for QA

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/solana-program-import&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->