### PR TITLE
feat(suite): add representative tokens to networks list

### DIFF
--- a/packages/product-components/src/components/AssetLogo/AssetLogoWithId.tsx
+++ b/packages/product-components/src/components/AssetLogo/AssetLogoWithId.tsx
@@ -47,6 +47,7 @@ type AssetLogoBaseProps = AllowedFrameProps & {
 
 export type AssetLogoProps = AssetLogoBaseProps & {
     symbol: NetworkSymbolExtended;
+    coingeckoId?: string;
 };
 
 export type AssetLogoWithIdProps = AssetLogoBaseProps & {
@@ -67,11 +68,12 @@ const Logo = styled.img<{ $size: number; $isBordered: boolean }>`
     width: ${({ $size }) => $size}px;
     height: ${({ $size }) => $size}px;
     border-radius: ${borders.radii.full};
+    background-color: ${({ theme }) => theme.elementFillElevated};
+
     ${({ $isBordered }) =>
         $isBordered &&
         css`
             box-shadow: ${({ theme }) => theme.elementShadowElevated};
-            background-color: ${({ theme }) => theme.elementFillElevated};
         `}
 `;
 
@@ -159,6 +161,28 @@ export const AssetLogoWithId = ({
             });
 
             result.push({ address, src: url1x, srcSet: `${url1x} 1x, ${url2x} 2x` });
+        }
+
+        if (
+            !hasNative &&
+            !failedAddressesCache.has(makeAddressKey(coingeckoIdLogo, ZERO_ADDRESS))
+        ) {
+            const url1x = getAssetLogoUrl({
+                coingeckoId: coingeckoIdLogo,
+                density: 1,
+                size,
+            });
+            const url2x = getAssetLogoUrl({
+                coingeckoId: coingeckoIdLogo,
+                density: 2,
+                size,
+            });
+
+            result.push({
+                address: ZERO_ADDRESS,
+                src: url1x,
+                srcSet: `${url1x} 1x, ${url2x} 2x`,
+            });
         }
 
         return result;

--- a/packages/product-components/src/components/IconSet/IconSetBase.tsx
+++ b/packages/product-components/src/components/IconSet/IconSetBase.tsx
@@ -10,9 +10,9 @@ import { type AssetLogoSize } from '../AssetLogo/AssetLogoWithId';
 const mapSizeToTypographyStyle = (size: AssetLogoSize): TypographyStyle => {
     const typographyStyleMap: Record<AssetLogoSize, TypographyStyle> = {
         20: 'body-xs',
-        24: 'body-sm',
-        32: 'body-md',
-        40: 'headline-sm',
+        24: 'body-xs',
+        32: 'body-sm',
+        40: 'body-md',
     };
 
     return typographyStyleMap[size];
@@ -29,6 +29,8 @@ const Container = styled.div<{
     justify-content: center;
     display: flex;
     align-items: center;
+    filter: drop-shadow(0 2px 2px ${({ theme }) => theme.shadowKeyElevated})
+        drop-shadow(0 0 2px ${({ theme }) => theme.shadowAmbientElevated});
 
     ${({ $isCentered, $size, $gap, $length, $maxVisibleIcons, $isCountVisible }) => {
         const visibleCount =
@@ -57,36 +59,43 @@ const Container = styled.div<{
         `}
 `;
 
+const overlappingIconStyles = ($size: number, $gap: number, $length: number) =>
+    $length > 1 &&
+    css`
+        height: ${$size}px;
+
+        &:not(:first-child) {
+            mask: radial-gradient(
+                circle at calc(50% - ${$gap}px) 50%,
+                transparent ${$size / 2 + 1.5}px,
+                black ${$size / 2 + 1.5}px
+            );
+        }
+    `;
+
 export const IconWrapper = styled.div<{ $size: number; $gap: number; $length: number }>`
     border-radius: ${borders.radii.full};
 
-    ${({ $size, $gap, $length }) =>
-        $length > 1 &&
-        css`
-            height: ${$size}px;
-
-            &:not(:last-child) {
-                mask: radial-gradient(
-                    circle at calc(50% + ${$gap}px) 50%,
-                    transparent ${$size / 2 + 1}px,
-                    black ${$size / 2 + 1}px
-                );
-            }
-        `}
+    ${({ $size, $gap, $length }) => overlappingIconStyles($size, $gap, $length)}
 `;
 
-const CountContainer = styled.div<{ $size: AssetLogoSize }>`
+const CountContainer = styled.div<{
+    $size: AssetLogoSize;
+    $gap: SpacingValuesNew;
+    $length: number;
+}>`
     ${({ $size }) => css`
-        width: ${$size}px;
+        min-width: ${$size}px;
         height: ${$size}px;
     `}
 
-    position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: ${borders.radii.full};
+    border-radius: ${({ $size }) => $size / 2}px;
     background: ${({ theme }) => theme.elementFillNeutralSofter};
+
+    ${({ $size, $gap, $length }) => overlappingIconStyles($size, $gap, $length)}
 `;
 
 export type CommonIconSetProps = {
@@ -134,8 +143,12 @@ export const IconSetBase = ({
         >
             {orderedChildren}
             {count > effectiveMaxVisibleIcons && isCountVisible && (
-                <CountContainer $size={size}>
-                    <Text typographyStyle={mapSizeToTypographyStyle(size)} intent="neutral">
+                <CountContainer $size={size} $gap={gap} $length={count}>
+                    <Text
+                        typographyStyle={mapSizeToTypographyStyle(size)}
+                        intent="neutral"
+                        priority="secondary"
+                    >
                         +{count - effectiveMaxVisibleIcons}
                     </Text>
                 </CountContainer>

--- a/packages/product-components/src/components/TokenIconSet/TokenIconSet.tsx
+++ b/packages/product-components/src/components/TokenIconSet/TokenIconSet.tsx
@@ -1,13 +1,19 @@
 import { useMemo } from 'react';
 
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 
 import { AssetLogo } from '../AssetLogo/AssetLogo';
+import { CoinLogo } from '../CoinLogo/CoinLogo';
 import { type CommonIconSetProps, IconSetBase, IconWrapper } from '../IconSet/IconSetBase';
+
+export type TokenIconSetToken = {
+    contract?: string | null;
+    symbol?: string;
+};
 
 export type TokenIconSetProps = CommonIconSetProps & {
     symbol: NetworkSymbol;
-    tokens: { contract: string; symbol?: string }[]; // tokens represented by their contract addresses and symbols
+    tokens: readonly TokenIconSetToken[];
 };
 
 export const TokenIconSet = ({
@@ -18,24 +24,35 @@ export const TokenIconSet = ({
     maxVisibleIcons = 3,
     isCountVisible = false,
     isCentered = false,
-    isReversed = true,
+    isReversed = false,
 }: TokenIconSetProps) => {
     const { length } = tokens;
 
     const visibleTokensContent = useMemo(() => {
         const visibleTokens = maxVisibleIcons !== null ? tokens.slice(0, maxVisibleIcons) : tokens;
 
-        return visibleTokens.map(token => (
-            <IconWrapper key={token.contract} $size={size} $gap={gap} $length={length}>
-                <AssetLogo
-                    size={size}
-                    symbol={symbol}
-                    contractAddress={token.contract}
-                    placeholder={token.symbol ?? ''}
-                    placeholderWithTooltip={false}
-                />
-            </IconWrapper>
-        ));
+        return visibleTokens.map(token => {
+            const key = token.contract ?? token.symbol ?? symbol;
+            const nativeCoinSymbol = getNetwork(symbol).settlementLayer ?? symbol;
+
+            return (
+                <IconWrapper key={key} $size={size} $gap={gap} $length={length}>
+                    {token.contract ? (
+                        <AssetLogo
+                            size={size}
+                            symbol={symbol}
+                            contractAddress={token.contract ?? null}
+                            placeholder={token.symbol ?? ''}
+                            placeholderWithTooltip={false}
+                            shouldTryToFetch
+                            isBordered={false}
+                        />
+                    ) : (
+                        <CoinLogo size={size} symbol={nativeCoinSymbol} type="token" />
+                    )}
+                </IconWrapper>
+            );
+        });
     }, [tokens, maxVisibleIcons, symbol, size, gap, length]);
 
     return (

--- a/packages/suite-data/files/translations/en-US.json
+++ b/packages/suite-data/files/translations/en-US.json
@@ -731,6 +731,8 @@
   "TR_CUSTOM_BACKEND_INVALID_URL": "Invalid URL",
   "TR_CUSTOM_BACKEND_NETWORK_MISSING_CHAIN_ID": "Network doesn't have a chain ID configured",
   "TR_CUSTOM_BACKEND_VALIDATION_ERROR": "Failed to validate {url}",
+  "TR_MORE": "more",
+  "TR_REPRESENTATIVE_ASSETS_ON_NETWORK": "Representative assets on this network",
   "TR_CUSTOM_FEE_WARNING": "Setting a low fee might cause your transaction to fail or experience significant delays.",
   "TR_CUSTOM_FIRMWARE_GITHUB": "Find all official releases on",
   "TR_CUSTOM_FIRMWARE_TITLE_DOWNLOAD": "Select compatible firmware",

--- a/packages/suite/src/components/suite/NetworkList/NetworkCard.tsx
+++ b/packages/suite/src/components/suite/NetworkList/NetworkCard.tsx
@@ -5,6 +5,7 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Box, Card, Column, IconButton, Row, Text } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
 
+import { RepresentativeAssetIconSet } from './RepresentativeAssetIconSet';
 import { StatusIndicator } from './StatusIndicator';
 import { type BackendStatus } from './getBackendStatus';
 
@@ -38,12 +39,15 @@ export const NetworkCard = ({
             data-testid={`@settings/wallet/network/${symbol}`}
             onClick={isCardClickable && onClick ? () => onClick(symbol, !isEnabled) : undefined}
         >
-            <Row padding={{ vertical: 12, horizontal: 14 }} gap={12}>
+            <Row padding={{ vertical: 12, horizontal: 14 }} gap={12} maxWidth="100%">
                 <CoinLogo size={24} symbol={symbol} type="network" />
-                <Column flex="1" minHeight={32} justifyContent="center">
-                    <Text typographyStyle="body-sm-strong">{name}</Text>
+                <Column flex="1" minWidth={0} minHeight={32} justifyContent="center">
+                    <Text typographyStyle="body-sm-strong" ellipsisLineCount={1}>
+                        {name}
+                    </Text>
                 </Column>
-                <Row gap={12} onClick={e => e.stopPropagation()}>
+                <Row gap={12} onClick={e => e.stopPropagation()} flex="0 0 auto">
+                    <RepresentativeAssetIconSet symbol={symbol} />
                     {onSettings && (
                         // Make the clickable area bigger
                         <Box padding={8} margin={-8} onClick={() => onSettings(symbol)}>

--- a/packages/suite/src/components/suite/NetworkList/RepresentativeAssetIconSet.tsx
+++ b/packages/suite/src/components/suite/NetworkList/RepresentativeAssetIconSet.tsx
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+
+import { Translation } from '@suite/intl';
+import { type NetworkSymbol, getRepresentativeAssets } from '@suite-common/wallet-config';
+import { Row, Text, Tooltip } from '@trezor/components';
+import { TokenIconSet } from '@trezor/product-components';
+
+const ICON_SIZE = 24;
+
+const MoreBadge = styled.div`
+    height: ${ICON_SIZE}px;
+    min-width: ${ICON_SIZE}px;
+    width: fit-content;
+    padding: 0 0.5em;
+    margin-left: -8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: ${ICON_SIZE / 2}px;
+    background: ${({ theme }) => theme.elementFillNeutralSofter};
+`;
+
+type RepresentativeAssetIconSetProps = {
+    symbol: NetworkSymbol;
+};
+
+export const RepresentativeAssetIconSet = ({ symbol }: RepresentativeAssetIconSetProps) => {
+    const representativeAssets = getRepresentativeAssets(symbol);
+
+    if (representativeAssets.length === 0) {
+        return null;
+    }
+
+    return (
+        <Tooltip content={<Translation id="TR_REPRESENTATIVE_ASSETS_ON_NETWORK" />}>
+            <Row alignItems="center">
+                <TokenIconSet
+                    size={ICON_SIZE}
+                    gap={20}
+                    maxVisibleIcons={5}
+                    isReversed={false}
+                    isCountVisible={false}
+                    symbol={symbol}
+                    tokens={representativeAssets}
+                />
+                {representativeAssets.length > 1 && (
+                    <MoreBadge>
+                        <Text typographyStyle="body-xs" intent="neutral" priority="secondary">
+                            +<Translation id="TR_MORE" />
+                        </Text>
+                    </MoreBadge>
+                )}
+            </Row>
+        </Tooltip>
+    );
+};

--- a/packages/suite/src/components/wallet/TokenIconSetWrapper.tsx
+++ b/packages/suite/src/components/wallet/TokenIconSetWrapper.tsx
@@ -58,10 +58,11 @@ export const TokenIconSetWrapper = ({ accounts, symbol }: TokenIconSetWrapperPro
     );
 
     const sortedAggregatedTokens = aggregatedTokens.sort(sortTokensWithRates);
+    const size = sortedAggregatedTokens.length === 1 ? 24 : 20;
 
     return (
         <TokenIconSet
-            size={20}
+            size={size}
             gap={6}
             symbol={symbol}
             tokens={sortedAggregatedTokens}

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -304,7 +304,7 @@ export const SettingsCoins = () => {
                 </Anchor>
             </SettingsSection>
 
-            <Box position={{ type: 'fixed', bottom: 20 }}>
+            <Box position={{ type: 'fixed', bottom: 16 }}>
                 <AnimatePresence>
                     {isDiscoveryButtonVisible && (
                         <motion.div {...discoveryButtonAnimationConfig} key="discover-button">

--- a/suite-common/wallet-config/src/index.ts
+++ b/suite-common/wallet-config/src/index.ts
@@ -1,6 +1,7 @@
 export * from './backends';
 export * from './earnRewardsProvider';
 export * from './networksConfig';
+export * from './representativeAssets';
 export * from './stakingProviders';
 export * from './types';
 export * from './utils';

--- a/suite-common/wallet-config/src/representativeAssets.ts
+++ b/suite-common/wallet-config/src/representativeAssets.ts
@@ -1,0 +1,127 @@
+import { type NetworkSymbol } from './types';
+
+export type RepresentativeAsset = {
+    symbol: string;
+    contract?: string;
+};
+
+const representativeAssets: Partial<Record<NetworkSymbol, readonly RepresentativeAsset[]>> = {
+    btc: [{ symbol: 'BTC' }],
+    eth: [
+        { symbol: 'ETH' },
+        { symbol: 'USDC', contract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' },
+        { symbol: 'USDT', contract: '0xdac17f958d2ee523a2206206994597c13d831ec7' },
+        { symbol: 'LINK', contract: '0x514910771af9ca656af840dff83e8264ecf986ca' },
+        { symbol: 'UNI', contract: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984' },
+    ],
+    pol: [
+        { symbol: 'POL' },
+        { symbol: 'USDC', contract: '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359' },
+        { symbol: 'AAVE', contract: '0xd6df932a45c0f255f85145f286ea0b292b21c90b' },
+        { symbol: 'QUICK', contract: '0x831753dd7087cac61ab5644b308642cc1c33dc13' },
+        { symbol: 'WETH', contract: '0x7ceb23fd6bc0add59e62ac25578270cff1b9f619' },
+    ],
+    bsc: [
+        { symbol: 'BNB' },
+        { symbol: 'USDT', contract: '0x55d398326f99059ff775485246999027b3197955' },
+        { symbol: 'CAKE', contract: '0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82' },
+        { symbol: 'XRP', contract: '0x1d2f0da169ceb9fc7b3144628db156f3f6c60dbe' },
+        { symbol: 'BTCB', contract: '0x7130d2a12b9bcbfae4f2634d864a1ee1ce3ead9c' },
+    ],
+    arb: [
+        { symbol: 'ARB', contract: '0x912ce59144191c1204e64559fe8253a0e49e6548' },
+        { symbol: 'USDC', contract: '0xaf88d065e77c8cc2239327c5edb3a432268e5831' },
+        { symbol: 'GMX', contract: '0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a' },
+        { symbol: 'LINK', contract: '0xf97f4df75117a78c1a5a0dbb814af92458539fb4' },
+        { symbol: 'WETH', contract: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1' },
+    ],
+    base: [
+        { symbol: 'ETH' },
+        { symbol: 'USDC', contract: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913' },
+        { symbol: 'cbBTC', contract: '0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf' },
+        { symbol: 'AERO', contract: '0x940181a94a35a4569e4529a3cdfb74e38fd98631' },
+        { symbol: 'USDT', contract: '0xfde4c96c8593536e31f229ea8f37b2ada2699bb2' },
+    ],
+    op: [
+        { symbol: 'OP', contract: '0x4200000000000000000000000000000000000042' },
+        { symbol: 'USDC', contract: '0x0b2c639c533813f4aa9d7837caf62653d097ff85' },
+        { symbol: 'SNX', contract: '0x8700daec35af8ff88c16bdf0418774cb3d7599b4' },
+        { symbol: 'VELO', contract: '0x9560e827af36c94d2ac33a39bce1fe78631088db' },
+        { symbol: 'WETH', contract: '0x4200000000000000000000000000000000000006' },
+    ],
+    avax: [
+        { symbol: 'AVAX' },
+        { symbol: 'USDC', contract: '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e' },
+        { symbol: 'JOE', contract: '0x6e84a6216ea6dacc71ee8e6b0a5b7322eebc0fdd' },
+        { symbol: 'BTC.b', contract: '0x152b9d0fdc40c096757f570a51e494bd4b943e50' },
+        { symbol: 'QI', contract: '0x8729438eb15e2c8b576fcc6aecda6a148776c0f5' },
+    ],
+    sol: [
+        { symbol: 'SOL' },
+        { symbol: 'USDC', contract: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' },
+        { symbol: 'JUP', contract: 'JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN' },
+        { symbol: 'BONK', contract: 'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263' },
+        { symbol: 'PYTH', contract: 'HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3' },
+    ],
+    ada: [
+        { symbol: 'ADA' },
+        {
+            symbol: 'DJED',
+            contract:
+                '8db269c3ec630e06ae29f74bc39edd1f87c819f1056206e879a1cd61446a65644d6963726f555344',
+        },
+        {
+            symbol: 'SNEK',
+            contract: '279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f534e454b',
+        },
+        {
+            symbol: 'IAG',
+            contract: '5d16cc1a177b5d9ba9cfa9793b07e60f1fb70fea1f8aef064415d114494147',
+        },
+        {
+            symbol: 'WMTx',
+            contract:
+                'e5a42a1a1d3d1da71b0449663c32798725888d2eb0843c4dabeca05a576f726c644d6f62696c65546f6b656e58',
+        },
+    ],
+    etc: [
+        { symbol: 'ETC' },
+        { symbol: 'WETC', contract: '0x1953cab0e5bFa6D4a9BaD6E05fD46C1CC6527a5a' },
+        { symbol: 'USC', contract: '0xde093684c796204224bc081f937aa059d903c52a' },
+    ],
+    xlm: [
+        { symbol: 'XLM' },
+        {
+            symbol: 'USDC',
+            contract: 'USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+        },
+        {
+            symbol: 'AQUA',
+            contract: 'AQUA-GBNZILSTVQZ4R7IKQDGHYGY2QXL5QOFJYQMXPKWRRM5PAV7Y4M67AQUA',
+        },
+        {
+            symbol: 'yBTC',
+            contract: 'yBTC-GBUVRNH4RW4VLHP4C5MOF46RRIRZLAVHYGX45MVSTKA2F6TMR7E7L6NW',
+        },
+        {
+            symbol: 'EURC',
+            contract: 'EURC-GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4ITNPP2',
+        },
+    ],
+    trx: [
+        { symbol: 'TRX' },
+        { symbol: 'USDT', contract: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t' },
+        { symbol: 'BTT', contract: 'TAFjULxiVgT4qWk6UZwjqwZXTSaGaqnVp4' },
+        { symbol: 'JST', contract: 'TCFLL5dx5ZJdKnWuesXxi1VPwjLVmWZZy9' },
+        { symbol: 'USDD', contract: 'TXDk8mbtRbXeYuMNS83CfKPaYYT8XWv9Hz' },
+    ],
+    xrp: [{ symbol: 'XRP' }],
+    ltc: [{ symbol: 'LTC' }],
+    bch: [{ symbol: 'BCH' }],
+    doge: [{ symbol: 'DOGE' }],
+    zec: [{ symbol: 'ZEC' }],
+} as const;
+
+export const getRepresentativeAssets = (
+    networkSymbol: NetworkSymbol,
+): readonly RepresentativeAsset[] => representativeAssets[networkSymbol] ?? [];

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -6848,6 +6848,14 @@ export const messages = defineMessages({
         id: 'TR_CUSTOM_BACKEND',
         defaultMessage: 'Custom backend',
     },
+    TR_MORE: {
+        id: 'TR_MORE',
+        defaultMessage: 'more',
+    },
+    TR_REPRESENTATIVE_ASSETS_ON_NETWORK: {
+        id: 'TR_REPRESENTATIVE_ASSETS_ON_NETWORK',
+        defaultMessage: 'Representative assets on this network',
+    },
     TR_BACKEND_DEFAULT_SERVERS: {
         id: 'TR_BACKEND_DEFAULT_SERVERS',
         defaultMessage: 'Trezor (default)',


### PR DESCRIPTION
## Notes for QA
- added representative tokens to all networks lists 

## Screenshots:
<img width="697" height="847" alt="image" src="https://github.com/user-attachments/assets/915ef9fa-7dc8-47b5-8398-5c6f222de986" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes primarily affect the Settings Coins page (SettingsCoins.tsx), its sub-components (NetworkCard, RepresentativeAssetIconSet), icon/logo rendering components (TokenIconSet, AssetLogoWithId, IconSetBase), wallet-config representative assets data, and translation files. The core risk is visual/functional regression on the coins settings page and anywhere network cards or token icon sets are rendered. Since TokenIconSet and TokenIconSetWrapper map to 121+ tests (broad global components), most of those tests should be omitted unless they specifically exercise coin settings or asset display. The recommended strategy focuses on the settings/coins tests that directly render the changed components, plus the dashboard assets test that uses the Activate Assets modal with NetworkCard rendering.

<details><summary><b>Changed files (11)</b></summary>

- `packages/product-components/src/components/AssetLogo/AssetLogoWithId.tsx`
- `packages/product-components/src/components/IconSet/IconSetBase.tsx`
- `packages/product-components/src/components/TokenIconSet/TokenIconSet.tsx`
- `packages/suite-data/files/translations/en-US.json`
- `packages/suite/src/components/suite/NetworkList/NetworkCard.tsx`
- `packages/suite/src/components/suite/NetworkList/RepresentativeAssetIconSet.tsx`
- `packages/suite/src/components/wallet/TokenIconSetWrapper.tsx`
- `packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx`
- `suite-common/wallet-config/src/index.ts`
- `suite-common/wallet-config/src/representativeAssets.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — This test directly exercises the SettingsCoins view (SettingsCoins.tsx), which was changed. It verifies enabling/disabling mainnet and testnet networks, activating assets via the dashboard modal, and configuring custom backends — all UI rendered by the changed component. Changes to NetworkCard, RepresentativeAssetIconSet, and wallet-config representativeAssets would also be visually exercised here.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test enables coins from the SettingsCoins page and configures custom backends, directly exercising the SettingsCoins.tsx component and its network enable/disable UI. It also verifies the custom backend indicator, which relies on NetworkCard rendering.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test enables coins via the 'Activate Assets' modal on the dashboard, which uses the same NetworkList/NetworkCard components that were changed. It verifies asset contents in grid and table views, which would render TokenIconSet and AssetLogo components.
- `suite/e2e/tests/settings/electrum.test.ts` — This test navigates to the Coins settings tab to configure an Electrum backend for RegTest, directly exercising the SettingsCoins.tsx view and its coin network backend configuration UI.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test enables BTC/LTC from the Coins settings tab and opens advanced network settings to change backends, directly interacting with the SettingsCoins page and NetworkCard components.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test crawls all app routes including /settings/coins and validates that links return HTTP 200. Translation string changes in en-US.json and messages.ts could introduce broken links if new URLs were added, making this a lightweight validation of the translation changes.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/product-components/src/components/AssetLogo/AssetLogoWithId.tsx`
- `packages/product-components/src/components/IconSet/IconSetBase.tsx`
- `packages/suite/src/components/suite/NetworkList/RepresentativeAssetIconSet.tsx`
- `suite-common/wallet-config/src/representativeAssets.ts`

_Updated: 2026-07-02T09:03:23.903Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/add-network-representative-tokens&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/add-network-representative-tokens&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/add-network-representative-tokens&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T09:13:31.072Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |

</details>

_Updated: 2026-07-02T09:06:53.556Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/add-network-representative-tokens/web/](https://dev.suite.sldev.cz/suite-web/feat/add-network-representative-tokens/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->