### PR TITLE
fix(connect-popup): tear down placeholder accounts when a sign call throws

### DIFF
--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -53,7 +53,13 @@ import {
     type SelectAccountCandidate,
     isUtxoNetwork,
 } from './connectPopupTypes';
-import { compatibilityHooks, postCallHooks, preCallHooks, validateCallHooks } from './methodHooks';
+import {
+    cleanupHooks,
+    compatibilityHooks,
+    postCallHooks,
+    preCallHooks,
+    validateCallHooks,
+} from './methodHooks';
 import type { DistributiveOmit } from './methodHooks/types';
 import {
     deriveCardanoEnabledNetworks,
@@ -296,6 +302,9 @@ export const connectPopupCallInnerThunk = createThunk<
                 error: serializeError(error),
             });
         } finally {
+            // Tear down any placeholder accounts created in preCallHooks even if the call threw
+            // before postCallHooks ran, so they cannot leak into a later removeAccount payload.
+            cleanupHooks(dispatch);
             dispatch(extra.actions.lockDevice(false));
         }
     },

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -54,7 +54,7 @@ import {
     isUtxoNetwork,
 } from './connectPopupTypes';
 import {
-    cleanupHooks,
+    cleanupAllTemporaryAccounts,
     compatibilityHooks,
     postCallHooks,
     preCallHooks,
@@ -304,7 +304,7 @@ export const connectPopupCallInnerThunk = createThunk<
         } finally {
             // Tear down any placeholder accounts created in preCallHooks even if the call threw
             // before postCallHooks ran, so they cannot leak into a later removeAccount payload.
-            cleanupHooks(dispatch);
+            cleanupAllTemporaryAccounts(dispatch);
             dispatch(extra.actions.lockDevice(false));
         }
     },

--- a/suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts
@@ -1,3 +1,5 @@
+import { type Dispatch } from '@reduxjs/toolkit/react';
+
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import {
     accountsActions,
@@ -87,12 +89,17 @@ const preCallHook = async <M extends CallMethodKeys>({
     }
 };
 
-export function postCallHook<M extends CallMethodKeys>({ dispatch }: PostCallHookParams<M>) {
+const cleanupHook = (dispatch: Dispatch) => {
     if (temporaryAccounts.length) {
-        // Remove temporary accounts
-        dispatch(accountsActions.removeAccount(temporaryAccounts));
+        // Dispatch a copy: temporaryAccounts is cleared below and Redux carries the payload by
+        // reference, so mutating it would mutate the already-dispatched action's payload.
+        dispatch(accountsActions.removeAccount([...temporaryAccounts]));
         temporaryAccounts.length = 0;
     }
+};
+
+export function postCallHook<M extends CallMethodKeys>({ dispatch }: PostCallHookParams<M>) {
+    cleanupHook(dispatch);
 
     return false;
 }
@@ -100,4 +107,5 @@ export function postCallHook<M extends CallMethodKeys>({ dispatch }: PostCallHoo
 export const bitcoinSignTransaction = {
     preCallHook,
     postCallHook,
+    cleanupHook,
 };

--- a/suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts
@@ -1,21 +1,15 @@
-import { type Dispatch } from '@reduxjs/toolkit/react';
-
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
-import {
-    accountsActions,
-    selectAccountForNetworkSymbolAndPath,
-    sendFormActions,
-} from '@suite-common/wallet-core';
-import { type Account, type FormOptions } from '@suite-common/wallet-types';
+import { selectAccountForNetworkSymbolAndPath, sendFormActions } from '@suite-common/wallet-core';
+import { type FormOptions } from '@suite-common/wallet-types';
 import type { CallMethodKeys, SignTransaction } from '@trezor/connect';
 import { getSerializedPath } from '@trezor/connect-common';
 import type { Bip43Path } from '@trezor/crypto-utils';
 
 import { connectPopupActions } from '../connectPopupActions';
 import { type PostCallHookParams, type PreCallHookParams } from './types';
-import { createPlaceholderAccount } from './utils';
+import { createPlaceholderAccount, createTemporaryAccountsRegistry } from './utils';
 
-const temporaryAccounts: Account[] = [];
+const temporaryAccounts = createTemporaryAccountsRegistry();
 
 const preCallHook = async <M extends CallMethodKeys>({
     method,
@@ -45,7 +39,7 @@ const preCallHook = async <M extends CallMethodKeys>({
             if (!selectedAccount) {
                 // Create a new placeholder account
                 const createdAccount = await dispatch(createPlaceholderAccount(network, path));
-                temporaryAccounts.push(createdAccount.payload);
+                temporaryAccounts.track(createdAccount.payload);
                 selectedAccount = createdAccount.payload;
             }
             if (!selectedAccount) {
@@ -89,17 +83,8 @@ const preCallHook = async <M extends CallMethodKeys>({
     }
 };
 
-const cleanupHook = (dispatch: Dispatch) => {
-    if (temporaryAccounts.length) {
-        // Dispatch a copy: temporaryAccounts is cleared below and Redux carries the payload by
-        // reference, so mutating it would mutate the already-dispatched action's payload.
-        dispatch(accountsActions.removeAccount([...temporaryAccounts]));
-        temporaryAccounts.length = 0;
-    }
-};
-
 export function postCallHook<M extends CallMethodKeys>({ dispatch }: PostCallHookParams<M>) {
-    cleanupHook(dispatch);
+    temporaryAccounts.cleanup(dispatch);
 
     return false;
 }
@@ -107,5 +92,4 @@ export function postCallHook<M extends CallMethodKeys>({ dispatch }: PostCallHoo
 export const bitcoinSignTransaction = {
     preCallHook,
     postCallHook,
-    cleanupHook,
 };

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -1,3 +1,5 @@
+import { type Dispatch } from '@reduxjs/toolkit/react';
+
 import { selectSelectedDevice } from '@suite-common/device';
 import { getNetworkByEvmChainId } from '@suite-common/wallet-config';
 import {
@@ -175,12 +177,17 @@ const preCallHook = async <M extends CallMethodKeys>({
     }
 };
 
-const postCallHook = <M extends CallMethodKeys>({ dispatch }: PostCallHookParams<M>) => {
+const cleanupHook = (dispatch: Dispatch) => {
     if (temporaryAccounts.length) {
-        // Remove temporary accounts
-        dispatch(accountsActions.removeAccount(temporaryAccounts));
+        // Dispatch a copy: temporaryAccounts is cleared below and Redux carries the payload by
+        // reference, so mutating it would mutate the already-dispatched action's payload.
+        dispatch(accountsActions.removeAccount([...temporaryAccounts]));
         temporaryAccounts.length = 0;
     }
+};
+
+const postCallHook = <M extends CallMethodKeys>({ dispatch }: PostCallHookParams<M>) => {
+    cleanupHook(dispatch);
 
     return false;
 };
@@ -188,4 +195,5 @@ const postCallHook = <M extends CallMethodKeys>({ dispatch }: PostCallHookParams
 export const ethereumSignTransaction = {
     preCallHook,
     postCallHook,
+    cleanupHook,
 };

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -1,13 +1,7 @@
-import { type Dispatch } from '@reduxjs/toolkit/react';
-
 import { selectSelectedDevice } from '@suite-common/device';
 import { getNetworkByEvmChainId } from '@suite-common/wallet-config';
-import {
-    accountsActions,
-    selectAccountForNetworkSymbolAndPath,
-    sendFormActions,
-} from '@suite-common/wallet-core';
-import { type Account, type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import { selectAccountForNetworkSymbolAndPath, sendFormActions } from '@suite-common/wallet-core';
+import { type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import TrezorConnect from '@trezor/connect';
 import type {
     CallMethodKeys,
@@ -19,12 +13,12 @@ import { getSerializedPath, validatePath } from '@trezor/connect-common';
 import type { Bip43Path } from '@trezor/crypto-utils';
 
 import { connectPopupActions } from '../connectPopupActions';
-import { createPlaceholderAccount } from './utils';
+import { createPlaceholderAccount, createTemporaryAccountsRegistry } from './utils';
 import { getPermissionDeferred } from '../connectPopupPromiseManager';
 import { selectConnectPopupCall } from '../connectPopupReducer';
 import { type PostCallHookParams, type PreCallHookParams } from './types';
 
-const temporaryAccounts: Account[] = [];
+const temporaryAccounts = createTemporaryAccountsRegistry();
 
 const _storePrecomposedTransaction = ({
     typedPayload,
@@ -99,7 +93,7 @@ const preCallHook = async <M extends CallMethodKeys>({
         if (!selectedAccount) {
             // Create a new placeholder account
             const createdAccount = await dispatch(createPlaceholderAccount(network, path));
-            temporaryAccounts.push(createdAccount.payload);
+            temporaryAccounts.track(createdAccount.payload);
             selectedAccount = createdAccount.payload;
         }
         if (!selectedAccount) {
@@ -177,17 +171,8 @@ const preCallHook = async <M extends CallMethodKeys>({
     }
 };
 
-const cleanupHook = (dispatch: Dispatch) => {
-    if (temporaryAccounts.length) {
-        // Dispatch a copy: temporaryAccounts is cleared below and Redux carries the payload by
-        // reference, so mutating it would mutate the already-dispatched action's payload.
-        dispatch(accountsActions.removeAccount([...temporaryAccounts]));
-        temporaryAccounts.length = 0;
-    }
-};
-
 const postCallHook = <M extends CallMethodKeys>({ dispatch }: PostCallHookParams<M>) => {
-    cleanupHook(dispatch);
+    temporaryAccounts.cleanup(dispatch);
 
     return false;
 };
@@ -195,5 +180,4 @@ const postCallHook = <M extends CallMethodKeys>({ dispatch }: PostCallHookParams
 export const ethereumSignTransaction = {
     preCallHook,
     postCallHook,
-    cleanupHook,
 };

--- a/suite-common/connect-popup/src/methodHooks/index.ts
+++ b/suite-common/connect-popup/src/methodHooks/index.ts
@@ -1,5 +1,3 @@
-import { type Dispatch } from '@reduxjs/toolkit/react';
-
 import type { CallMethodKeys } from '@trezor/connect';
 
 import { addressConfirmationModalHooks } from './addressConfirmation';
@@ -68,13 +66,7 @@ export async function postCallHooks<M extends CallMethodKeys>(params: PostCallHo
     return hooks.some(Boolean);
 }
 
-// Sign hooks may create placeholder accounts in preCallHook that are normally torn down in
-// postCallHook. If the call throws between the two (e.g. Device_Disconnected), postCallHook never
-// runs and the module-level placeholder leaks, later causing a stale removeAccount payload. This is
-// the unconditional safety net invoked from the thunk's finally so the leak cannot survive a call.
-export const cleanupHooks = (dispatch: Dispatch) => {
-    bitcoinSignTransaction.cleanupHook(dispatch);
-    ethereumSignTransaction.cleanupHook(dispatch);
-    solanaSignTransaction.cleanupHook(dispatch);
-    stellarSignTransaction.cleanupHook(dispatch);
-};
+// Unconditional safety net invoked from the thunk's finally: tears down every sign hook's
+// placeholder accounts (registered via createTemporaryAccountsRegistry) so the leak cannot survive a
+// call even when it throws between preCallHook and postCallHook.
+export { cleanupAllTemporaryAccounts } from './utils';

--- a/suite-common/connect-popup/src/methodHooks/index.ts
+++ b/suite-common/connect-popup/src/methodHooks/index.ts
@@ -1,3 +1,5 @@
+import { type Dispatch } from '@reduxjs/toolkit/react';
+
 import type { CallMethodKeys } from '@trezor/connect';
 
 import { addressConfirmationModalHooks } from './addressConfirmation';
@@ -65,3 +67,14 @@ export async function postCallHooks<M extends CallMethodKeys>(params: PostCallHo
 
     return hooks.some(Boolean);
 }
+
+// Sign hooks may create placeholder accounts in preCallHook that are normally torn down in
+// postCallHook. If the call throws between the two (e.g. Device_Disconnected), postCallHook never
+// runs and the module-level placeholder leaks, later causing a stale removeAccount payload. This is
+// the unconditional safety net invoked from the thunk's finally so the leak cannot survive a call.
+export const cleanupHooks = (dispatch: Dispatch) => {
+    bitcoinSignTransaction.cleanupHook(dispatch);
+    ethereumSignTransaction.cleanupHook(dispatch);
+    solanaSignTransaction.cleanupHook(dispatch);
+    stellarSignTransaction.cleanupHook(dispatch);
+};

--- a/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
@@ -1,3 +1,5 @@
+import { type Dispatch } from '@reduxjs/toolkit/react';
+
 import { selectSelectedDevice } from '@suite-common/device';
 import { getNetwork } from '@suite-common/wallet-config';
 import {
@@ -105,12 +107,17 @@ const preCallHook = async <M extends CallMethodKeys>({
     }
 };
 
-export function postCallHook<M extends CallMethodKeys>({ dispatch }: PostCallHookParams<M>) {
+const cleanupHook = (dispatch: Dispatch) => {
     if (temporaryAccounts.length) {
-        // Remove temporary accounts
-        dispatch(accountsActions.removeAccount(temporaryAccounts));
+        // Dispatch a copy: temporaryAccounts is cleared below and Redux carries the payload by
+        // reference, so mutating it would mutate the already-dispatched action's payload.
+        dispatch(accountsActions.removeAccount([...temporaryAccounts]));
         temporaryAccounts.length = 0;
     }
+};
+
+export function postCallHook<M extends CallMethodKeys>({ dispatch }: PostCallHookParams<M>) {
+    cleanupHook(dispatch);
 
     return false;
 }
@@ -118,4 +125,5 @@ export function postCallHook<M extends CallMethodKeys>({ dispatch }: PostCallHoo
 export const solanaSignTransaction = {
     preCallHook,
     postCallHook,
+    cleanupHook,
 };

--- a/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
@@ -1,13 +1,6 @@
-import { type Dispatch } from '@reduxjs/toolkit/react';
-
 import { selectSelectedDevice } from '@suite-common/device';
 import { getNetwork } from '@suite-common/wallet-config';
-import {
-    accountsActions,
-    selectAccountForNetworkSymbolAndPath,
-    sendFormActions,
-} from '@suite-common/wallet-core';
-import { type Account } from '@suite-common/wallet-types';
+import { selectAccountForNetworkSymbolAndPath, sendFormActions } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 import type { CallMethodKeys, SolanaSignTransaction } from '@trezor/connect';
 import { getSerializedPath, validatePath } from '@trezor/connect-common';
@@ -16,9 +9,9 @@ import type { Bip43Path } from '@trezor/crypto-utils';
 import { connectPopupActions } from '../connectPopupActions';
 import { getPermissionDeferred } from '../connectPopupPromiseManager';
 import { type PostCallHookParams, type PreCallHookParams } from './types';
-import { createPlaceholderAccount } from './utils';
+import { createPlaceholderAccount, createTemporaryAccountsRegistry } from './utils';
 
-const temporaryAccounts: Account[] = [];
+const temporaryAccounts = createTemporaryAccountsRegistry();
 
 const preCallHook = async <M extends CallMethodKeys>({
     method,
@@ -42,7 +35,7 @@ const preCallHook = async <M extends CallMethodKeys>({
             if (!selectedAccount) {
                 // Create a new placeholder account
                 const createdAccount = await dispatch(createPlaceholderAccount(network, path));
-                temporaryAccounts.push(createdAccount.payload);
+                temporaryAccounts.track(createdAccount.payload);
                 selectedAccount = createdAccount.payload;
             }
             if (!selectedAccount) {
@@ -107,17 +100,8 @@ const preCallHook = async <M extends CallMethodKeys>({
     }
 };
 
-const cleanupHook = (dispatch: Dispatch) => {
-    if (temporaryAccounts.length) {
-        // Dispatch a copy: temporaryAccounts is cleared below and Redux carries the payload by
-        // reference, so mutating it would mutate the already-dispatched action's payload.
-        dispatch(accountsActions.removeAccount([...temporaryAccounts]));
-        temporaryAccounts.length = 0;
-    }
-};
-
 export function postCallHook<M extends CallMethodKeys>({ dispatch }: PostCallHookParams<M>) {
-    cleanupHook(dispatch);
+    temporaryAccounts.cleanup(dispatch);
 
     return false;
 }
@@ -125,5 +109,4 @@ export function postCallHook<M extends CallMethodKeys>({ dispatch }: PostCallHoo
 export const solanaSignTransaction = {
     preCallHook,
     postCallHook,
-    cleanupHook,
 };

--- a/suite-common/connect-popup/src/methodHooks/stellarSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/stellarSignTransaction.ts
@@ -1,9 +1,6 @@
-import { type Dispatch } from '@reduxjs/toolkit/react';
-
 import { selectSelectedDevice } from '@suite-common/device';
 import { getNetwork } from '@suite-common/wallet-config';
-import { accountsActions, selectAccountForNetworkSymbolAndPath } from '@suite-common/wallet-core';
-import { type Account } from '@suite-common/wallet-types';
+import { selectAccountForNetworkSymbolAndPath } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 import type { CallMethodKeys, StellarSignTransaction } from '@trezor/connect';
 import { getSerializedPath, validatePath } from '@trezor/connect-common';
@@ -12,9 +9,9 @@ import type { Bip43Path } from '@trezor/crypto-utils';
 import { connectPopupActions } from '../connectPopupActions';
 import { getPermissionDeferred } from '../connectPopupPromiseManager';
 import { type PostCallHookParams, type PreCallHookParams } from './types';
-import { createPlaceholderAccount } from './utils';
+import { createPlaceholderAccount, createTemporaryAccountsRegistry } from './utils';
 
-const temporaryAccounts: Account[] = [];
+const temporaryAccounts = createTemporaryAccountsRegistry();
 
 const preCallHook = async <M extends CallMethodKeys>({
     method,
@@ -45,7 +42,7 @@ const preCallHook = async <M extends CallMethodKeys>({
         );
         if (!selectedAccount) {
             const createdAccount = await dispatch(createPlaceholderAccount(network, path));
-            temporaryAccounts.push(createdAccount.payload);
+            temporaryAccounts.track(createdAccount.payload);
             selectedAccount = createdAccount.payload;
         }
         if (!selectedAccount) {
@@ -87,17 +84,8 @@ const preCallHook = async <M extends CallMethodKeys>({
     }
 };
 
-const cleanupHook = (dispatch: Dispatch) => {
-    if (temporaryAccounts.length) {
-        // Dispatch a copy: temporaryAccounts is cleared below and Redux carries the payload by
-        // reference, so mutating it would mutate the already-dispatched action's payload.
-        dispatch(accountsActions.removeAccount([...temporaryAccounts]));
-        temporaryAccounts.length = 0;
-    }
-};
-
 export function postCallHook<M extends CallMethodKeys>({ dispatch }: PostCallHookParams<M>) {
-    cleanupHook(dispatch);
+    temporaryAccounts.cleanup(dispatch);
 
     return false;
 }
@@ -105,5 +93,4 @@ export function postCallHook<M extends CallMethodKeys>({ dispatch }: PostCallHoo
 export const stellarSignTransaction = {
     preCallHook,
     postCallHook,
-    cleanupHook,
 };

--- a/suite-common/connect-popup/src/methodHooks/stellarSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/stellarSignTransaction.ts
@@ -1,3 +1,5 @@
+import { type Dispatch } from '@reduxjs/toolkit/react';
+
 import { selectSelectedDevice } from '@suite-common/device';
 import { getNetwork } from '@suite-common/wallet-config';
 import { accountsActions, selectAccountForNetworkSymbolAndPath } from '@suite-common/wallet-core';
@@ -85,11 +87,17 @@ const preCallHook = async <M extends CallMethodKeys>({
     }
 };
 
-export function postCallHook<M extends CallMethodKeys>({ dispatch }: PostCallHookParams<M>) {
+const cleanupHook = (dispatch: Dispatch) => {
     if (temporaryAccounts.length) {
-        dispatch(accountsActions.removeAccount(temporaryAccounts));
+        // Dispatch a copy: temporaryAccounts is cleared below and Redux carries the payload by
+        // reference, so mutating it would mutate the already-dispatched action's payload.
+        dispatch(accountsActions.removeAccount([...temporaryAccounts]));
         temporaryAccounts.length = 0;
     }
+};
+
+export function postCallHook<M extends CallMethodKeys>({ dispatch }: PostCallHookParams<M>) {
+    cleanupHook(dispatch);
 
     return false;
 }
@@ -97,4 +105,5 @@ export function postCallHook<M extends CallMethodKeys>({ dispatch }: PostCallHoo
 export const stellarSignTransaction = {
     preCallHook,
     postCallHook,
+    cleanupHook,
 };

--- a/suite-common/connect-popup/src/methodHooks/utils/index.ts
+++ b/suite-common/connect-popup/src/methodHooks/utils/index.ts
@@ -2,6 +2,12 @@ import { type Network } from '@suite-common/wallet-config';
 import { accountsActions } from '@suite-common/wallet-core';
 import type { Bip43Path } from '@trezor/crypto-utils';
 
+export {
+    createTemporaryAccountsRegistry,
+    cleanupAllTemporaryAccounts,
+    type TemporaryAccountsRegistry,
+} from './temporaryAccountsRegistry';
+
 export const createPlaceholderAccount = (
     network: Pick<Network, 'networkType' | 'symbol' | 'name'>,
     path: Bip43Path,

--- a/suite-common/connect-popup/src/methodHooks/utils/temporaryAccountsRegistry.ts
+++ b/suite-common/connect-popup/src/methodHooks/utils/temporaryAccountsRegistry.ts
@@ -1,0 +1,46 @@
+import { type Dispatch } from '@reduxjs/toolkit/react';
+
+import { accountsActions } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+
+export type TemporaryAccountsRegistry = {
+    /** Remember a placeholder account created in preCallHook so it can be torn down later. */
+    track: (account: Account) => void;
+    /** Drain the tracked placeholders via a single removeAccount dispatch (no-op if empty). */
+    cleanup: (dispatch: Dispatch) => void;
+};
+
+// Every drain registered by a sign hook, so cleanupAllTemporaryAccounts can tear all of them down
+// without a hand-maintained list — a new coin cannot forget to wire itself into the safety net.
+const registeredCleanups: Array<(dispatch: Dispatch) => void> = [];
+
+// A sign hook creates a placeholder account in preCallHook that is normally torn down in
+// postCallHook. If the call throws between the two (e.g. Device_Disconnected), postCallHook never
+// runs and the placeholder leaks, later causing a stale removeAccount payload. Each hook owns one
+// registry; the thunk's finally calls cleanupAllTemporaryAccounts so the leak cannot survive a call
+// regardless of how it ends.
+export const createTemporaryAccountsRegistry = (): TemporaryAccountsRegistry => {
+    const temporaryAccounts: Account[] = [];
+
+    const cleanup = (dispatch: Dispatch) => {
+        if (temporaryAccounts.length) {
+            // Dispatch a copy: temporaryAccounts is cleared below and Redux carries the payload by
+            // reference, so mutating it would mutate the already-dispatched action's payload.
+            dispatch(accountsActions.removeAccount([...temporaryAccounts]));
+            temporaryAccounts.length = 0;
+        }
+    };
+
+    registeredCleanups.push(cleanup);
+
+    return {
+        track: account => {
+            temporaryAccounts.push(account);
+        },
+        cleanup,
+    };
+};
+
+export const cleanupAllTemporaryAccounts = (dispatch: Dispatch) => {
+    registeredCleanups.forEach(cleanup => cleanup(dispatch));
+};


### PR DESCRIPTION
## Description

Follow-up to #29082. That PR added a defensive guard in `accountsReducer.remove` so a stale or absent `removeAccount` payload becomes a no-op instead of deleting the wrong account. This PR fixes the two **upstream causes** that produce such stale payloads in the first place, so the guard becomes a safety net rather than the only thing standing between a race and a wrong deletion.

### 1. connect-popup placeholder account leak

`bitcoin` / `ethereum` / `solanaSignTransaction` sign hooks create a placeholder account in `preCallHook` and push it into a module-level `temporaryAccounts` array. That array is drained **only** in `postCallHook`.

If the call throws between the two hooks — e.g. `Device_Disconnected`, which `connectPopupThunks` can raise right after `preCallHooks` (`if (!device) throw TypedError('Device_Disconnected')`) or from `TrezorConnect.call` itself — `postCallHook` never runs and the placeholder leaks across calls. On a later resume a second equal placeholder is created (`createAccount` dedups it in state, but `temporaryAccounts` now holds two equal references), and the eventual `removeAccount([P, P])` carries a stale entry.

Fix: extract the drain into a shared `cleanupTemporaryAccounts` and call it unconditionally from the thunk's `finally`, so the placeholder cannot survive a call regardless of how it ends. `postCallHook` keeps draining on the success path (unchanged behaviour); `finally` is the safety net for every throw path. The two drains are idempotent — at most one real `removeAccount` dispatch per call.

## Notes for QA

Same hard-to-stage races as #29082, now fixed at the source. Not testable imho.

---

Part of the small split-out series from #29735. Stacked on #29082.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/accounts-remove-followups&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/accounts-remove-followups&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/accounts-remove-followups&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly focused on the suite-common/connect-popup package, specifically popup thunk orchestration and transaction signing method hooks for Bitcoin, Ethereum, Solana, and Stellar. The highest risk is to third-party TrezorConnect flows that sign transactions or show permission popups. The recommended strategy is to run the targeted trezor-connect tests for Bitcoin/Ethereum signing and the general popup lifecycle; note that the Solana and Stellar signTransaction hooks have no direct E2E coverage in the available test inventory.

<details><summary><b>Changed files (8)</b></summary>

- `suite-common/connect-popup/src/connectPopupThunks.ts`
- `suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/index.ts`
- `suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/stellarSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/utils/index.ts`
- `suite-common/connect-popup/src/methodHooks/utils/temporaryAccountsRegistry.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Exercises the core TrezorConnect popup lifecycle (permissions modal, address confirmation, cancellation, popup close/reopen, popup blocking) that is orchestrated by the changed connectPopupThunks.ts. A regression here would directly break third-party app integrations and the Connect popup UX.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Directly exercises the Ethereum signTransaction Connect method handled by the changed ethereumSignTransaction.ts method hook and connectPopupThunks.ts, including device prompts, transaction confirmation, and the shared methodHooks utilities (inferred coverage for temporaryAccountsRegistry.ts).
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Directly exercises the Bitcoin signTransaction Connect method handled by the changed bitcoinSignTransaction.ts method hook and connectPopupThunks.ts, including the full permission-to-device-confirmation flow and shared methodHooks utilities (inferred coverage for temporaryAccountsRegistry.ts).

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Tests the same Connect popup thunk lifecycle and permissions flow as connectPopupWeb.test.ts but in a webextension context, providing confidence that connectPopupThunks.ts changes work across different host environments.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Exercises the Connect popup flow for address export, which uses the same popup thunk infrastructure and method hook registration (methodHooks/index.ts) as the changed signTransaction flows. It covers permissions, device confirmation, and verification states.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests permission grant, remembrance, and revocation flows that are managed by connectPopupThunks.ts. Changes to thunk logic could break remembered permissions or the connected apps list.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests silent mode permission behavior and focus suppression, which relies on connectPopupThunks.ts permission state and popup handling. A regression could cause unwanted Suite window focus during Connect calls.
- `suite/e2e/tests/trezor-connect/upfrontPermissions.test.ts` — Tests the upfront declared permissions feature that flows through connectPopupThunks.ts and the permissions modal, ensuring batch permission grants still work after thunk changes.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/stellarSignTransaction.ts`

_Updated: 2026-09-05T17:58:32.003Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/accounts-remove-followups/web/](https://dev.suite.sldev.cz/suite-web/mroz22/accounts-remove-followups/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-05T18:00:29.811Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-05T18:00:49.497Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->