### PR TITLE
chore(connect-data): sync FW release files with upstream

### DIFF
--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.0-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 10, 0],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.1-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 10, 1],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.2-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.2-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 10, 2],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.3-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.3-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 10, 3],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.4-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.4-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 10, 4],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.5-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.5-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 10, 5],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.11.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.11.1-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 11, 1],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.11.2-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.11.2-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 11, 2],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 11, 0],

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.12.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.12.1-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 12, 1],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 12, 0],
     "min_firmware_version": [1, 12, 0],
     "bootloader_version": [1, 12, 1],

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.13.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.13.0-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 13, 0],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 12, 0],
     "min_firmware_version": [1, 12, 0],
     "bootloader_version": [1, 12, 1],

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.13.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.13.1-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 13, 1],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 12, 0],
     "min_firmware_version": [1, 12, 0],
     "bootloader_version": [1, 12, 1],

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.14.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.14.0-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 14, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [1, 12, 0],
     "min_firmware_version": [1, 12, 0],
     "bootloader_version": [1, 12, 1],

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.8.3-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.8.3-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 8, 3],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.0-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": true,
     "version": [1, 9, 0],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.1-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 9, 1],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.2-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.2-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 9, 2],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.3-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.3-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 9, 3],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],

--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.4-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.4-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 9, 4],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.0-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.0-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 10, 0],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.1-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 10, 1],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.2-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.2-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 10, 2],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.3-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.3-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 10, 3],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.4-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.4-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 10, 4],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.5-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.5-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 10, 5],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.11.1-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.11.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 11, 1],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 10, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.11.2-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.11.2-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 11, 2],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 11, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.12.1-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.12.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 12, 1],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 12, 0],
     "min_firmware_version": [1, 12, 0],
     "bootloader_version": [1, 12, 1],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.13.0-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.13.0-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 13, 0],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 12, 0],
     "min_firmware_version": [1, 12, 0],
     "bootloader_version": [1, 12, 1],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.13.1-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.13.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 13, 1],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 12, 0],
     "min_firmware_version": [1, 12, 0],
     "bootloader_version": [1, 12, 1],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.14.0-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.14.0-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 14, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [1, 12, 0],
     "min_firmware_version": [1, 12, 0],
     "bootloader_version": [1, 12, 1],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.3.6-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.3.6-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 3, 6],
-    "min_bridge_version": [1, 1, 5],
     "min_bootloader_version": [1, 0, 0],
     "min_firmware_version": [1, 0, 0],
     "firmware_revision": "36b9d80120348700264bba518a533d4f82d79cbd",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.4.0-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.4.0-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 4, 0],
-    "min_bridge_version": [1, 1, 5],
     "min_bootloader_version": [1, 0, 0],
     "min_firmware_version": [1, 0, 0],
     "firmware_revision": "e0e190b3dc29bcb0f6ab9699c439fe7bfbcde370",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.4.1-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.4.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 4, 1],
-    "min_bridge_version": [1, 1, 5],
     "min_bootloader_version": [1, 0, 0],
     "min_firmware_version": [1, 0, 0],
     "firmware_revision": "ae37ea8a9a2ab96e60714451a7a9502e0ef1ffc9",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.4.2-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.4.2-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 4, 2],
-    "min_bridge_version": [1, 1, 5],
     "min_bootloader_version": [1, 0, 0],
     "min_firmware_version": [1, 0, 0],
     "firmware_revision": "14399f100e862608c24a7e214e9ce971c4d32457",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.5.0-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.5.0-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 5, 0],
-    "min_bridge_version": [1, 1, 5],
     "min_bootloader_version": [1, 0, 0],
     "min_firmware_version": [1, 0, 0],
     "firmware_revision": "6b74139b4530a4687b4a317b8b08f4329704efc4",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.5.1-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.5.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 5, 1],
-    "min_bridge_version": [1, 1, 5],
     "min_bootloader_version": [1, 0, 0],
     "min_firmware_version": [1, 0, 0],
     "firmware_revision": "f0d2e7a37142a6d4c7f7e45a6e4427e53123d614",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.5.2-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.5.2-universal.json
@@ -1,7 +1,6 @@
 {
     "required": true,
     "version": [1, 5, 2],
-    "min_bridge_version": [1, 1, 5],
     "min_bootloader_version": [1, 0, 0],
     "min_firmware_version": [1, 0, 0],
     "firmware_revision": "e4cc08775fc9c204f295442f930326eb7877f2d4",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.6.0-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.6.0-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 6, 0],
-    "min_bridge_version": [1, 1, 5],
     "min_bootloader_version": [1, 0, 0],
     "min_firmware_version": [1, 0, 0],
     "firmware_revision": "723cf295a72ce07b96047901bb8c2e461a2488f8",

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.6.1-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.6.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": true,
     "version": [1, 6, 1],
-    "min_bridge_version": [1, 1, 5],
     "min_bootloader_version": [1, 0, 0],
     "min_firmware_version": [1, 0, 0],
     "bootloader_version": [1, 4, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.6.2-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.6.2-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 6, 2],
-    "min_bridge_version": [1, 1, 5],
     "min_bootloader_version": [1, 0, 0],
     "min_firmware_version": [1, 0, 0],
     "bootloader_version": [1, 5, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.6.3-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.6.3-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 6, 3],
-    "min_bridge_version": [1, 1, 5],
     "min_bootloader_version": [1, 0, 0],
     "min_firmware_version": [1, 0, 0],
     "bootloader_version": [1, 5, 1],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.7.1-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.7.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 7, 1],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 6, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.7.2-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.7.2-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 7, 2],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 6, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.7.3-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.7.3-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 7, 3],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 6, 1],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.0-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.0-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 8, 0],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.1-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": true,
     "version": [1, 8, 1],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.2-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.2-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 8, 2],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.3-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.3-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 8, 3],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.0-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.0-universal.json
@@ -1,7 +1,6 @@
 {
     "required": true,
     "version": [1, 9, 0],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.1-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 9, 1],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.2-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.2-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 9, 2],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.3-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.3-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 9, 3],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.4-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.4-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [1, 9, 4],
-    "min_bridge_version": [2, 0, 25],
     "min_bootloader_version": [1, 5, 0],
     "min_firmware_version": [1, 6, 2],
     "bootloader_version": [1, 8, 0],

--- a/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.12.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.12.0-bitcoinonly.json
@@ -1,19 +1,18 @@
 {
     "required": false,
     "version": [2, 12, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 16],
     "firmware_revision": "4d89c11df37355bd2cb0f3b8e28cfc661b65f743",
+    "url": "firmware/t2b1/trezor-t2b1-2.12.0-bitcoinonly.bin",
+    "fingerprint": "94047a99eb571790038608e73459240af018ce514d8a086c8eb0fe4af75d94a7",
+    "changelog": "",
     "translations": {
         "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.12.0.bin",
         "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.12.0.bin",
         "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.12.0.bin",
         "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.12.0.bin",
         "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.12.0.bin"
-    },
-    "url": "firmware/t2b1/trezor-t2b1-2.12.0-bitcoinonly.bin",
-    "fingerprint": "94047a99eb571790038608e73459240af018ce514d8a086c8eb0fe4af75d94a7",
-    "changelog": ""
+    }
 }

--- a/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.6.3-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.6.3-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 6, 3],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 4],

--- a/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.6.4-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.6.4-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 6, 4],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 4],

--- a/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.7.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.7.0-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 7, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 4],

--- a/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.7.2-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.7.2-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 7, 2],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 4],

--- a/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.8.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.8.0-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 4],

--- a/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.8.10-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.8.10-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 10],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.8.7-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.8.7-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 7],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.8.9-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.8.9-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 9],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.9.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.9.1-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 9, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.12.0-universal.json
+++ b/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.12.0-universal.json
@@ -1,19 +1,18 @@
 {
     "required": false,
     "version": [2, 12, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 16],
     "firmware_revision": "4d89c11df37355bd2cb0f3b8e28cfc661b65f743",
+    "url": "firmware/t2b1/trezor-t2b1-2.12.0.bin",
+    "fingerprint": "caaaebc46fca7b286c6aedf51392d3f242ed3e8c0c7bb5832f56ed3109fd985d",
+    "changelog": "* Added UI flows for some ERC-4626 vault interactions.\n* Improved EVM address chunking.\n* Updated translations in Cardano flow.\n* Re-introduced initial blob confirmation layout for Ethereum.\n* Fixed out-of-memory failure when confirming large input data.\n* Cached confirmed EIP-712 domain.\n* Fixed Solana ALT recipient account parsing.\n* Fixed bug in Solana account type identification.",
     "translations": {
         "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.12.0.bin",
         "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.12.0.bin",
         "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.12.0.bin",
         "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.12.0.bin",
         "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.12.0.bin"
-    },
-    "url": "firmware/t2b1/trezor-t2b1-2.12.0.bin",
-    "fingerprint": "caaaebc46fca7b286c6aedf51392d3f242ed3e8c0c7bb5832f56ed3109fd985d",
-    "changelog": "* Added UI flows for some ERC-4626 vault interactions.\n* Improved EVM address chunking.\n* Updated translations in Cardano flow.\n* Re-introduced initial blob confirmation layout for Ethereum.\n* Fixed out-of-memory failure when confirming large input data.\n* Cached confirmed EIP-712 domain.\n* Fixed Solana ALT recipient account parsing.\n* Fixed bug in Solana account type identification."
+    }
 }

--- a/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.6.3-universal.json
+++ b/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.6.3-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 6, 3],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 4],

--- a/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.6.4-universal.json
+++ b/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.6.4-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 6, 4],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 4],

--- a/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.7.0-universal.json
+++ b/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.7.0-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 7, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 4],

--- a/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.7.2-universal.json
+++ b/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.7.2-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 7, 2],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 4],

--- a/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.8.0-universal.json
+++ b/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.8.0-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 4],

--- a/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.8.10-universal.json
+++ b/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.8.10-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 10],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.8.7-universal.json
+++ b/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.8.7-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 7],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.8.9-universal.json
+++ b/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.8.9-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 9],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.9.1-universal.json
+++ b/packages/connect-data/files/firmware/t2b1/universal/t2b1-2.9.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 9, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 1],
     "min_firmware_version": [2, 6, 1],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.1.5-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.1.5-bitcoinonly.json
@@ -1,9 +1,8 @@
 {
     "required": false,
     "version": [2, 1, 5],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
-    "min_firmware_version": [2, 1, 0],
+    "min_firmware_version": [2, 0, 8],
     "firmware_revision": "df0963ec48f01f3d07ffca556e21ff0070cab099",
     "translations": {},
     "url": "firmware/t2t1/trezor-t2t1-2.1.5-bitcoinonly.bin",

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.1.6-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.1.6-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 1, 6],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "629fa58d396e732f230866ebe733d268370d7879",

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.1.7-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.1.7-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 1, 7],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "2cabc8b40ce237ee8a7e1926b6269040519d447a",

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.1.8-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.1.8-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 1, 8],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "8eb6ce08995514c67d175b7197feeadeccc48ff0",

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.12.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.12.0-bitcoinonly.json
@@ -1,19 +1,18 @@
 {
     "required": false,
     "version": [2, 12, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 16],
     "firmware_revision": "4d89c11df37355bd2cb0f3b8e28cfc661b65f743",
+    "url": "firmware/t2t1/trezor-t2t1-2.12.0-bitcoinonly.bin",
+    "fingerprint": "dae2742ff0edf8cedba4fcd6fd81840215d682889fe1bd2c32c904f4ede03503",
+    "changelog": "",
     "translations": {
         "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.12.0.bin",
         "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.12.0.bin",
         "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.12.0.bin",
         "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.12.0.bin",
         "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.12.0.bin"
-    },
-    "url": "firmware/t2t1/trezor-t2t1-2.12.0-bitcoinonly.bin",
-    "fingerprint": "dae2742ff0edf8cedba4fcd6fd81840215d682889fe1bd2c32c904f4ede03503",
-    "changelog": ""
+    }
 }

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.0-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": true,
     "version": [2, 3, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "0b7a8449f8dd003fc415262b05102d113247d3de",

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.1-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 3, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "c6b2580cd245ee924507f45e9675f857a3d78768",

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.2-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.2-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 3, 2],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "63ebb8ccb56fc17a72eef91db36a37ff3176519d",

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.3-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.3-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 3, 3],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "0d5f00668fb3d1c093ff3c879311a91d3a7175c8",

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.4-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.4-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 3, 4],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "50854b9210f7674262c1541272a8c7fd1767b7a9",

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.5-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.5-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 3, 5],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "ffa96205fb5e22b43e7b08a3dbc3cdeee0931de3",

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.6-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.6-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 3, 6],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "b19cbf67c6c7c38513947b703df6d4409c59bc98",

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.4.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.4.0-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 4, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "ea3596ad89a7993ad7b9d62798de94325ad1717a",

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.4.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.4.1-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 4, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "24bb4016388fca4b998285b95dcd408f4ed0bff6",

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.4.2-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.4.2-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 4, 2],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "9276b1702361f70e094286e2f89e919d8a230d5c",

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.4.3-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.4.3-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 4, 3],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "595b14254c1abb2be3f69e42c7932f1eca8cf1b1",

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.5.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.5.1-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 5, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "85a26d2c9593bcdf858c2d718d79951ca927a0c3",

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.5.2-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.5.2-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 5, 2],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "0d87b55ba4fed7eecc72bf2a94ee473830b095e9",

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.5.3-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.5.3-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 5, 3],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "2f03ace311584988d5aeab58fd1acf24ef54711a",

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.6.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.6.0-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 6, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 0],

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.6.3-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.6.3-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 6, 3],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 4],

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.6.4-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.6.4-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 6, 4],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 4],

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.7.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.7.0-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 7, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 4],

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.7.2-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.7.2-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 7, 2],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 4],

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.8.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.8.1-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 6],

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.8.10-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.8.10-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 10],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.8.7-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.8.7-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 7],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.8.8-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.8.8-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 8],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.8.9-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.8.9-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 9],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.9.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.9.1-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 9, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.0.10-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.0.10-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 0, 10],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 5],
     "bootloader_version": [2, 0, 2],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.0.5-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.0.5-universal.json
@@ -1,7 +1,6 @@
 {
     "required": true,
     "version": [2, 0, 5],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 5],
     "bootloader_version": [2, 0, 0],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.0.6-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.0.6-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 0, 6],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 5],
     "bootloader_version": [2, 0, 0],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.0.7-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.0.7-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 0, 7],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 5],
     "bootloader_version": [2, 0, 0],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.0.8-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.0.8-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 0, 8],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 5],
     "bootloader_version": [2, 0, 0],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.0.9-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.0.9-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 0, 9],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 5],
     "bootloader_version": [2, 0, 0],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.0-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.0-universal.json
@@ -1,7 +1,6 @@
 {
     "required": true,
     "version": [2, 1, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 5],
     "bootloader_version": [2, 0, 3],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.1-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 1, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 5],
     "firmware_revision": "7af1d5859458e87efd6957885566aed890a9f781",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.4-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.4-universal.json
@@ -1,9 +1,8 @@
 {
     "required": false,
     "version": [2, 1, 4],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
-    "min_firmware_version": [2, 1, 0],
+    "min_firmware_version": [2, 0, 8],
     "firmware_revision": "6a1a02ca3c595067ed02a78f2d6c36eb58eaa9ed",
     "translations": {},
     "url": "firmware/t2t1/trezor-t2t1-2.1.4.bin",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.5-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.5-universal.json
@@ -1,9 +1,8 @@
 {
     "required": false,
     "version": [2, 1, 5],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
-    "min_firmware_version": [2, 1, 0],
+    "min_firmware_version": [2, 0, 8],
     "firmware_revision": "df0963ec48f01f3d07ffca556e21ff0070cab099",
     "translations": {},
     "url": "firmware/t2t1/trezor-t2t1-2.1.5.bin",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.6-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.6-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 1, 6],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "629fa58d396e732f230866ebe733d268370d7879",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.7-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.7-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 1, 7],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "2cabc8b40ce237ee8a7e1926b6269040519d447a",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.8-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.8-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 1, 8],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "8eb6ce08995514c67d175b7197feeadeccc48ff0",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.12.0-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.12.0-universal.json
@@ -1,19 +1,18 @@
 {
     "required": false,
     "version": [2, 12, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 16],
     "firmware_revision": "4d89c11df37355bd2cb0f3b8e28cfc661b65f743",
+    "url": "firmware/t2t1/trezor-t2t1-2.12.0.bin",
+    "fingerprint": "3bef5f94d9f4bef90f3362ffff5a04026eea467f7b9798f38d87b27afd703161",
+    "changelog": "* Added UI flows for some ERC-4626 vault interactions.\n* Improved EVM address chunking.\n* Updated translations in Cardano flow.\n* Re-introduced initial blob confirmation layout for Ethereum.\n* Fixed out-of-memory failure when confirming large input data.\n* Cached confirmed EIP-712 domain.\n* Fixed Solana ALT recipient account parsing.\n* Fixed bug in Solana account type identification.",
     "translations": {
         "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.12.0.bin",
         "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.12.0.bin",
         "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.12.0.bin",
         "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.12.0.bin",
         "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.12.0.bin"
-    },
-    "url": "firmware/t2t1/trezor-t2t1-2.12.0.bin",
-    "fingerprint": "3bef5f94d9f4bef90f3362ffff5a04026eea467f7b9798f38d87b27afd703161",
-    "changelog": "* Added UI flows for some ERC-4626 vault interactions.\n* Improved EVM address chunking.\n* Updated translations in Cardano flow.\n* Re-introduced initial blob confirmation layout for Ethereum.\n* Fixed out-of-memory failure when confirming large input data.\n* Cached confirmed EIP-712 domain.\n* Fixed Solana ALT recipient account parsing.\n* Fixed bug in Solana account type identification."
+    }
 }

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.0-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.0-universal.json
@@ -1,7 +1,6 @@
 {
     "required": true,
     "version": [2, 3, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "0b7a8449f8dd003fc415262b05102d113247d3de",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.1-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 3, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "c6b2580cd245ee924507f45e9675f857a3d78768",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.2-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.2-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 3, 2],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "63ebb8ccb56fc17a72eef91db36a37ff3176519d",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.3-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.3-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 3, 3],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "0d5f00668fb3d1c093ff3c879311a91d3a7175c8",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.4-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.4-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 3, 4],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "50854b9210f7674262c1541272a8c7fd1767b7a9",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.5-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.5-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 3, 5],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "ffa96205fb5e22b43e7b08a3dbc3cdeee0931de3",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.6-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.6-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 3, 6],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "b19cbf67c6c7c38513947b703df6d4409c59bc98",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.4.0-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.4.0-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 4, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "ea3596ad89a7993ad7b9d62798de94325ad1717a",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.4.1-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.4.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 4, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "24bb4016388fca4b998285b95dcd408f4ed0bff6",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.4.2-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.4.2-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 4, 2],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "9276b1702361f70e094286e2f89e919d8a230d5c",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.4.3-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.4.3-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 4, 3],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "595b14254c1abb2be3f69e42c7932f1eca8cf1b1",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.5.1-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.5.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 5, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "85a26d2c9593bcdf858c2d718d79951ca927a0c3",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.5.2-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.5.2-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 5, 2],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "0d87b55ba4fed7eecc72bf2a94ee473830b095e9",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.5.3-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.5.3-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 5, 3],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "firmware_revision": "2f03ace311584988d5aeab58fd1acf24ef54711a",

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.6.0-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.6.0-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 6, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 0],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.6.3-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.6.3-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 6, 3],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 4],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.6.4-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.6.4-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 6, 4],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 4],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.7.0-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.7.0-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 7, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 4],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.7.2-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.7.2-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 7, 2],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 4],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.8.1-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.8.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 6],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.8.10-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.8.10-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 10],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.8.7-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.8.7-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 7],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.8.8-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.8.8-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 8],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.8.9-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.8.9-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 9],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.9.1-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.9.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 9, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t3b1/bitcoinonly/t3b1-2.12.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t3b1/bitcoinonly/t3b1-2.12.0-bitcoinonly.json
@@ -1,19 +1,18 @@
 {
     "required": false,
     "version": [2, 12, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 7],
     "min_firmware_version": [2, 8, 3],
     "bootloader_version": [2, 1, 16],
     "firmware_revision": "4d89c11df37355bd2cb0f3b8e28cfc661b65f743",
+    "url": "firmware/t3b1/trezor-t3b1-2.12.0-bitcoinonly.bin",
+    "fingerprint": "439bb92154f3a88811464795670b1b0610ad73785361780d22d32e6789e33b80",
+    "changelog": "",
     "translations": {
         "cs-CZ": "firmware/translations/t3b1/translation-T3B1-cs-CZ-2.12.0.bin",
         "de-DE": "firmware/translations/t3b1/translation-T3B1-de-DE-2.12.0.bin",
         "es-ES": "firmware/translations/t3b1/translation-T3B1-es-ES-2.12.0.bin",
         "fr-FR": "firmware/translations/t3b1/translation-T3B1-fr-FR-2.12.0.bin",
         "pt-BR": "firmware/translations/t3b1/translation-T3B1-pt-BR-2.12.0.bin"
-    },
-    "url": "firmware/t3b1/trezor-t3b1-2.12.0-bitcoinonly.bin",
-    "fingerprint": "439bb92154f3a88811464795670b1b0610ad73785361780d22d32e6789e33b80",
-    "changelog": ""
+    }
 }

--- a/packages/connect-data/files/firmware/t3b1/bitcoinonly/t3b1-2.8.10-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t3b1/bitcoinonly/t3b1-2.8.10-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 10],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 7],
     "min_firmware_version": [2, 8, 3],
     "bootloader_version": [2, 1, 10],

--- a/packages/connect-data/files/firmware/t3b1/bitcoinonly/t3b1-2.8.3-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t3b1/bitcoinonly/t3b1-2.8.3-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 3],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 7],
     "min_firmware_version": [2, 8, 3],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t3b1/bitcoinonly/t3b1-2.8.7-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t3b1/bitcoinonly/t3b1-2.8.7-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 7],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 7],
     "min_firmware_version": [2, 8, 3],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t3b1/bitcoinonly/t3b1-2.8.9-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t3b1/bitcoinonly/t3b1-2.8.9-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 9],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 7],
     "min_firmware_version": [2, 8, 3],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t3b1/bitcoinonly/t3b1-2.9.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t3b1/bitcoinonly/t3b1-2.9.1-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 9, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 7],
     "min_firmware_version": [2, 8, 3],
     "bootloader_version": [2, 1, 10],

--- a/packages/connect-data/files/firmware/t3b1/universal/t3b1-2.12.0-universal.json
+++ b/packages/connect-data/files/firmware/t3b1/universal/t3b1-2.12.0-universal.json
@@ -1,19 +1,18 @@
 {
     "required": false,
     "version": [2, 12, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 7],
     "min_firmware_version": [2, 8, 3],
     "bootloader_version": [2, 1, 16],
     "firmware_revision": "4d89c11df37355bd2cb0f3b8e28cfc661b65f743",
+    "url": "firmware/t3b1/trezor-t3b1-2.12.0.bin",
+    "fingerprint": "9ae80e212f8933fc13f017d4e27ece52f44b8b0f738f4400a17e4e3ad3d184d4",
+    "changelog": "* Added UI flows for some ERC-4626 vault interactions.\n* Improved EVM address chunking.\n* Updated translations in Cardano flow.\n* Re-introduced initial blob confirmation layout for Ethereum.\n* Fixed out-of-memory failure when confirming large input data.\n* Cached confirmed EIP-712 domain.\n* Fixed Solana ALT recipient account parsing.\n* Fixed bug in Solana account type identification.",
     "translations": {
         "cs-CZ": "firmware/translations/t3b1/translation-T3B1-cs-CZ-2.12.0.bin",
         "de-DE": "firmware/translations/t3b1/translation-T3B1-de-DE-2.12.0.bin",
         "es-ES": "firmware/translations/t3b1/translation-T3B1-es-ES-2.12.0.bin",
         "fr-FR": "firmware/translations/t3b1/translation-T3B1-fr-FR-2.12.0.bin",
         "pt-BR": "firmware/translations/t3b1/translation-T3B1-pt-BR-2.12.0.bin"
-    },
-    "url": "firmware/t3b1/trezor-t3b1-2.12.0.bin",
-    "fingerprint": "9ae80e212f8933fc13f017d4e27ece52f44b8b0f738f4400a17e4e3ad3d184d4",
-    "changelog": "* Added UI flows for some ERC-4626 vault interactions.\n* Improved EVM address chunking.\n* Updated translations in Cardano flow.\n* Re-introduced initial blob confirmation layout for Ethereum.\n* Fixed out-of-memory failure when confirming large input data.\n* Cached confirmed EIP-712 domain.\n* Fixed Solana ALT recipient account parsing.\n* Fixed bug in Solana account type identification."
+    }
 }

--- a/packages/connect-data/files/firmware/t3b1/universal/t3b1-2.8.10-universal.json
+++ b/packages/connect-data/files/firmware/t3b1/universal/t3b1-2.8.10-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 10],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 7],
     "min_firmware_version": [2, 8, 3],
     "bootloader_version": [2, 1, 10],

--- a/packages/connect-data/files/firmware/t3b1/universal/t3b1-2.8.3-universal.json
+++ b/packages/connect-data/files/firmware/t3b1/universal/t3b1-2.8.3-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 3],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 7],
     "min_firmware_version": [2, 8, 3],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t3b1/universal/t3b1-2.8.7-universal.json
+++ b/packages/connect-data/files/firmware/t3b1/universal/t3b1-2.8.7-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 7],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 7],
     "min_firmware_version": [2, 8, 3],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t3b1/universal/t3b1-2.8.9-universal.json
+++ b/packages/connect-data/files/firmware/t3b1/universal/t3b1-2.8.9-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 9],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 7],
     "min_firmware_version": [2, 8, 3],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t3b1/universal/t3b1-2.9.1-universal.json
+++ b/packages/connect-data/files/firmware/t3b1/universal/t3b1-2.9.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 9, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 7],
     "min_firmware_version": [2, 8, 3],
     "bootloader_version": [2, 1, 10],

--- a/packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.12.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.12.0-bitcoinonly.json
@@ -1,19 +1,18 @@
 {
     "required": false,
     "version": [2, 12, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 6],
     "min_firmware_version": [2, 7, 2],
     "bootloader_version": [2, 1, 16],
     "firmware_revision": "4d89c11df37355bd2cb0f3b8e28cfc661b65f743",
+    "url": "firmware/t3t1/trezor-t3t1-2.12.0-bitcoinonly.bin",
+    "fingerprint": "1e14f60f37eaf0e7778fbe3ffdb1e18258b9334b1974f824879c159492e5b274",
+    "changelog": "* Introduced font kerning.",
     "translations": {
         "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.12.0.bin",
         "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.12.0.bin",
         "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.12.0.bin",
         "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.12.0.bin",
         "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.12.0.bin"
-    },
-    "url": "firmware/t3t1/trezor-t3t1-2.12.0-bitcoinonly.bin",
-    "fingerprint": "1e14f60f37eaf0e7778fbe3ffdb1e18258b9334b1974f824879c159492e5b274",
-    "changelog": "* Introduced font kerning."
+    }
 }

--- a/packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.7.2-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.7.2-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 7, 2],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 6],
     "min_firmware_version": [2, 7, 2],
     "bootloader_version": [2, 1, 6],

--- a/packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.8.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.8.0-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 6],
     "min_firmware_version": [2, 7, 2],
     "bootloader_version": [2, 1, 6],

--- a/packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.8.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.8.1-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 6],
     "min_firmware_version": [2, 7, 2],
     "bootloader_version": [2, 1, 6],

--- a/packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.8.10-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.8.10-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 10],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 6],
     "min_firmware_version": [2, 7, 2],
     "bootloader_version": [2, 1, 10],

--- a/packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.8.3-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.8.3-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 3],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 6],
     "min_firmware_version": [2, 7, 2],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.8.7-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.8.7-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 7],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 6],
     "min_firmware_version": [2, 7, 2],
     "bootloader_version": [2, 1, 9],

--- a/packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.8.9-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.8.9-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 9],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 6],
     "min_firmware_version": [2, 7, 2],
     "bootloader_version": [2, 1, 10],

--- a/packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.9.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.9.1-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 9, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 6],
     "min_firmware_version": [2, 7, 2],
     "bootloader_version": [2, 1, 10],

--- a/packages/connect-data/files/firmware/t3t1/universal/t3t1-2.12.0-universal.json
+++ b/packages/connect-data/files/firmware/t3t1/universal/t3t1-2.12.0-universal.json
@@ -1,19 +1,18 @@
 {
     "required": false,
     "version": [2, 12, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 6],
     "min_firmware_version": [2, 7, 2],
     "bootloader_version": [2, 1, 16],
     "firmware_revision": "4d89c11df37355bd2cb0f3b8e28cfc661b65f743",
+    "url": "firmware/t3t1/trezor-t3t1-2.12.0.bin",
+    "fingerprint": "eb774f47e73d983b2b1def8b8816af66fb9b3a407767269b8991ba79d07c9928",
+    "changelog": "* Added UI flows for some ERC-4626 vault interactions.\n* Introduced font kerning.\n* Improved EVM address chunking.\n* Updated translations in Cardano flow.\n* Re-introduced initial blob confirmation layout for Ethereum.\n* Fixed out-of-memory failure when confirming large input data.\n* Cached confirmed EIP-712 domain.\n* Fixed Solana ALT recipient account parsing.\n* Fixed bug in Solana account type identification.",
     "translations": {
         "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.12.0.bin",
         "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.12.0.bin",
         "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.12.0.bin",
         "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.12.0.bin",
         "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.12.0.bin"
-    },
-    "url": "firmware/t3t1/trezor-t3t1-2.12.0.bin",
-    "fingerprint": "eb774f47e73d983b2b1def8b8816af66fb9b3a407767269b8991ba79d07c9928",
-    "changelog": "* Added UI flows for some ERC-4626 vault interactions.\n* Introduced font kerning.\n* Improved EVM address chunking.\n* Updated translations in Cardano flow.\n* Re-introduced initial blob confirmation layout for Ethereum.\n* Fixed out-of-memory failure when confirming large input data.\n* Cached confirmed EIP-712 domain.\n* Fixed Solana ALT recipient account parsing.\n* Fixed bug in Solana account type identification."
+    }
 }

--- a/packages/connect-data/files/firmware/t3t1/universal/t3t1-2.7.2-universal.json
+++ b/packages/connect-data/files/firmware/t3t1/universal/t3t1-2.7.2-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 7, 2],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 6],
     "min_firmware_version": [2, 7, 2],
     "bootloader_version": [2, 1, 6],

--- a/packages/connect-data/files/firmware/t3t1/universal/t3t1-2.8.0-universal.json
+++ b/packages/connect-data/files/firmware/t3t1/universal/t3t1-2.8.0-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 6],
     "min_firmware_version": [2, 7, 2],
     "bootloader_version": [2, 1, 6],

--- a/packages/connect-data/files/firmware/t3t1/universal/t3t1-2.8.1-universal.json
+++ b/packages/connect-data/files/firmware/t3t1/universal/t3t1-2.8.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 6],
     "min_firmware_version": [2, 7, 2],
     "bootloader_version": [2, 1, 6],

--- a/packages/connect-data/files/firmware/t3t1/universal/t3t1-2.8.10-universal.json
+++ b/packages/connect-data/files/firmware/t3t1/universal/t3t1-2.8.10-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 10],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 6],
     "min_firmware_version": [2, 7, 2],
     "bootloader_version": [2, 1, 10],

--- a/packages/connect-data/files/firmware/t3t1/universal/t3t1-2.8.3-universal.json
+++ b/packages/connect-data/files/firmware/t3t1/universal/t3t1-2.8.3-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 3],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 6],
     "min_firmware_version": [2, 7, 2],
     "bootloader_version": [2, 1, 8],

--- a/packages/connect-data/files/firmware/t3t1/universal/t3t1-2.8.7-universal.json
+++ b/packages/connect-data/files/firmware/t3t1/universal/t3t1-2.8.7-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 7],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 6],
     "min_firmware_version": [2, 7, 2],
     "bootloader_version": [2, 1, 9],

--- a/packages/connect-data/files/firmware/t3t1/universal/t3t1-2.8.9-universal.json
+++ b/packages/connect-data/files/firmware/t3t1/universal/t3t1-2.8.9-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 8, 9],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 6],
     "min_firmware_version": [2, 7, 2],
     "bootloader_version": [2, 1, 10],

--- a/packages/connect-data/files/firmware/t3t1/universal/t3t1-2.9.1-universal.json
+++ b/packages/connect-data/files/firmware/t3t1/universal/t3t1-2.9.1-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 9, 1],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 6],
     "min_firmware_version": [2, 7, 2],
     "bootloader_version": [2, 1, 10],

--- a/packages/connect-data/files/firmware/t3w1/bitcoinonly/t3w1-2.12.0-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t3w1/bitcoinonly/t3w1-2.12.0-bitcoinonly.json
@@ -1,19 +1,18 @@
 {
     "required": false,
     "version": [2, 12, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 13],
     "min_firmware_version": [2, 9, 3],
     "bootloader_version": [2, 1, 17],
     "firmware_revision": "4d89c11df37355bd2cb0f3b8e28cfc661b65f743",
+    "url": "firmware/t3w1/trezor-t3w1-2.12.0-bitcoinonly.bin",
+    "fingerprint": "4b5abd6da9844d655709b54e35daf4f1b74bf79ba916d759d4a36e6650bf60b3",
+    "changelog": "* Prolonged minimal auto-suspend time during backup and recovery to 2 minutes.\n* Introduced font kerning.\n* Made cancel option consistent across screens.\n* Truncated device name on BLE pairing.",
     "translations": {
         "cs-CZ": "firmware/translations/t3w1/translation-T3W1-cs-CZ-2.12.0.bin",
         "de-DE": "firmware/translations/t3w1/translation-T3W1-de-DE-2.12.0.bin",
         "es-ES": "firmware/translations/t3w1/translation-T3W1-es-ES-2.12.0.bin",
         "fr-FR": "firmware/translations/t3w1/translation-T3W1-fr-FR-2.12.0.bin",
         "pt-BR": "firmware/translations/t3w1/translation-T3W1-pt-BR-2.12.0.bin"
-    },
-    "url": "firmware/t3w1/trezor-t3w1-2.12.0-bitcoinonly.bin",
-    "fingerprint": "4b5abd6da9844d655709b54e35daf4f1b74bf79ba916d759d4a36e6650bf60b3",
-    "changelog": "* Prolonged minimal auto-suspend time during backup and recovery to 2 minutes.\n* Introduced font kerning.\n* Made cancel option consistent across screens.\n* Truncated device name on BLE pairing."
+    }
 }

--- a/packages/connect-data/files/firmware/t3w1/bitcoinonly/t3w1-2.9.3-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t3w1/bitcoinonly/t3w1-2.9.3-bitcoinonly.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 9, 3],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 13],
     "min_firmware_version": [2, 9, 3],
     "bootloader_version": [2, 1, 14],

--- a/packages/connect-data/files/firmware/t3w1/universal/t3w1-2.12.0-universal.json
+++ b/packages/connect-data/files/firmware/t3w1/universal/t3w1-2.12.0-universal.json
@@ -1,19 +1,18 @@
 {
     "required": false,
     "version": [2, 12, 0],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 13],
     "min_firmware_version": [2, 9, 3],
     "bootloader_version": [2, 1, 17],
     "firmware_revision": "4d89c11df37355bd2cb0f3b8e28cfc661b65f743",
+    "url": "firmware/t3w1/trezor-t3w1-2.12.0.bin",
+    "fingerprint": "ed862539d6a6b4e67a2717149d458b188231b512257ca9e449ba4b076358b648",
+    "changelog": "* Added UI flows for some ERC-4626 vault interactions.\n* Prolonged minimal auto-suspend time during backup and recovery to 2 minutes.\n* Introduced font kerning.\n* Improved EVM address chunking.\n* Made cancel option consistent across screens.\n* Updated translations in Cardano flow.\n* Re-introduced initial blob confirmation layout for Ethereum.\n* Truncated device name on BLE pairing.\n* Fixed out-of-memory failure when confirming large input data.\n* Cached confirmed EIP-712 domain.\n* Fixed Solana ALT recipient account parsing.\n* Fixed bug in Solana account type identification.",
     "translations": {
         "cs-CZ": "firmware/translations/t3w1/translation-T3W1-cs-CZ-2.12.0.bin",
         "de-DE": "firmware/translations/t3w1/translation-T3W1-de-DE-2.12.0.bin",
         "es-ES": "firmware/translations/t3w1/translation-T3W1-es-ES-2.12.0.bin",
         "fr-FR": "firmware/translations/t3w1/translation-T3W1-fr-FR-2.12.0.bin",
         "pt-BR": "firmware/translations/t3w1/translation-T3W1-pt-BR-2.12.0.bin"
-    },
-    "url": "firmware/t3w1/trezor-t3w1-2.12.0.bin",
-    "fingerprint": "ed862539d6a6b4e67a2717149d458b188231b512257ca9e449ba4b076358b648",
-    "changelog": "* Added UI flows for some ERC-4626 vault interactions.\n* Prolonged minimal auto-suspend time during backup and recovery to 2 minutes.\n* Introduced font kerning.\n* Improved EVM address chunking.\n* Made cancel option consistent across screens.\n* Updated translations in Cardano flow.\n* Re-introduced initial blob confirmation layout for Ethereum.\n* Truncated device name on BLE pairing.\n* Fixed out-of-memory failure when confirming large input data.\n* Cached confirmed EIP-712 domain.\n* Fixed Solana ALT recipient account parsing.\n* Fixed bug in Solana account type identification."
+    }
 }

--- a/packages/connect-data/files/firmware/t3w1/universal/t3w1-2.9.3-universal.json
+++ b/packages/connect-data/files/firmware/t3w1/universal/t3w1-2.9.3-universal.json
@@ -1,7 +1,6 @@
 {
     "required": false,
     "version": [2, 9, 3],
-    "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 13],
     "min_firmware_version": [2, 9, 3],
     "bootloader_version": [2, 1, 14],


### PR DESCRIPTION
## Description

Sync the FW release files with upstream in data.trezor.io, which effectively means:

- https://github.com/trezor/data/commit/6a98bcd6d223df171bef18edc09fc84ba6351800 delete unused `min_bridge_version`
  - actually, in Suite, that was [deleted long time ago in connect-common](https://github.com/trezor/trezor-suite/blob/e91fb637e2e3a627d12cea571085de0cd30cb9a7/packages/connect-common/CHANGELOG.md#0032), but reintroduced when the FW release distribution was reworked in 2025
- https://github.com/trezor/data/commit/6a98bcd6d223df171bef18edc09fc84ba6351800
- https://github.com/trezor/data/commit/5d03d4d4ad740ba629f09d24ffb46f8ed8f4e5f1
- reorder some lines (noop)

## Notes for QA

Just smoke test that offline onboarding still works for all models, can be done as part of the release checks.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are exclusively to firmware metadata JSON files across all Trezor device models (t1b1, t2t1, t2b1, t3t1, t3b1, t3w1) in the connect-data package. These are data files that describe firmware releases (versions, checksums, URLs, etc.) and are consumed by firmware check/update logic. The risk is relatively low since these are typically additive metadata updates, but tests that directly interact with firmware detection, firmware update modals, or report firmware version information should be validated. Most E2E tests pass through onboarding firmware checks but typically disable or bypass them, limiting blast radius.

<details><summary><b>Changed files (176)</b></summary>

- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.2-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.3-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.4-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.10.5-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.11.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.11.2-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.12.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.13.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.13.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.14.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.8.3-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.2-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.3-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.9.4-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.0-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.2-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.3-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.4-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.10.5-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.11.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.11.2-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.12.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.13.0-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.13.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.14.0-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.3.6-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.4.0-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.4.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.4.2-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.5.0-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.5.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.5.2-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.6.0-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.6.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.6.2-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.6.3-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.7.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.7.2-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.7.3-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.0-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.2-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.8.3-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.0-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.1-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.2-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.3-universal.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.9.4-universal.json`
- `packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.12.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.6.3-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.6.4-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.7.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.7.2-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.8.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.8.10-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.8.7-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.8.9-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2b1/bitcoinonly/t2b1-2.9.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2b1/universal/t2b1-2.12.0-universal.json`
- `packages/connect-data/files/firmware/t2b1/universal/t2b1-2.6.3-universal.json`
- `packages/connect-data/files/firmware/t2b1/universal/t2b1-2.6.4-universal.json`
- `packages/connect-data/files/firmware/t2b1/universal/t2b1-2.7.0-universal.json`
- `packages/connect-data/files/firmware/t2b1/universal/t2b1-2.7.2-universal.json`
- `packages/connect-data/files/firmware/t2b1/universal/t2b1-2.8.0-universal.json`
- `packages/connect-data/files/firmware/t2b1/universal/t2b1-2.8.10-universal.json`
- `packages/connect-data/files/firmware/t2b1/universal/t2b1-2.8.7-universal.json`
- `packages/connect-data/files/firmware/t2b1/universal/t2b1-2.8.9-universal.json`
- `packages/connect-data/files/firmware/t2b1/universal/t2b1-2.9.1-universal.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.1.5-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.1.6-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.1.7-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.1.8-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.12.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.2-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.3-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.4-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.5-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.3.6-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.4.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.4.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.4.2-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.4.3-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.5.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.5.2-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.5.3-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.6.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.6.3-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.6.4-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.7.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.7.2-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.8.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.8.10-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.8.7-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.8.8-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.8.9-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.9.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.0.10-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.0.5-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.0.6-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.0.7-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.0.8-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.0.9-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.0-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.1-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.4-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.5-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.6-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.7-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.1.8-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.12.0-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.0-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.1-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.2-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.3-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.4-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.5-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.3.6-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.4.0-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.4.1-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.4.2-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.4.3-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.5.1-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.5.2-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.5.3-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.6.0-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.6.3-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.6.4-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.7.0-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.7.2-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.8.1-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.8.10-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.8.7-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.8.8-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.8.9-universal.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.9.1-universal.json`
- `packages/connect-data/files/firmware/t3b1/bitcoinonly/t3b1-2.12.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t3b1/bitcoinonly/t3b1-2.8.10-bitcoinonly.json`
- `packages/connect-data/files/firmware/t3b1/bitcoinonly/t3b1-2.8.3-bitcoinonly.json`
- `packages/connect-data/files/firmware/t3b1/bitcoinonly/t3b1-2.8.7-bitcoinonly.json`
- `packages/connect-data/files/firmware/t3b1/bitcoinonly/t3b1-2.8.9-bitcoinonly.json`
- `packages/connect-data/files/firmware/t3b1/bitcoinonly/t3b1-2.9.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t3b1/universal/t3b1-2.12.0-universal.json`
- `packages/connect-data/files/firmware/t3b1/universal/t3b1-2.8.10-universal.json`
- `packages/connect-data/files/firmware/t3b1/universal/t3b1-2.8.3-universal.json`
- `packages/connect-data/files/firmware/t3b1/universal/t3b1-2.8.7-universal.json`
- `packages/connect-data/files/firmware/t3b1/universal/t3b1-2.8.9-universal.json`
- `packages/connect-data/files/firmware/t3b1/universal/t3b1-2.9.1-universal.json`
- `packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.12.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.7.2-bitcoinonly.json`
- `packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.8.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.8.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.8.10-bitcoinonly.json`
- `packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.8.3-bitcoinonly.json`
- `packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.8.7-bitcoinonly.json`
- `packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.8.9-bitcoinonly.json`
- `packages/connect-data/files/firmware/t3t1/bitcoinonly/t3t1-2.9.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t3t1/universal/t3t1-2.12.0-universal.json`
- `packages/connect-data/files/firmware/t3t1/universal/t3t1-2.7.2-universal.json`
- `packages/connect-data/files/firmware/t3t1/universal/t3t1-2.8.0-universal.json`
- `packages/connect-data/files/firmware/t3t1/universal/t3t1-2.8.1-universal.json`
- `packages/connect-data/files/firmware/t3t1/universal/t3t1-2.8.10-universal.json`
- `packages/connect-data/files/firmware/t3t1/universal/t3t1-2.8.3-universal.json`
- `packages/connect-data/files/firmware/t3t1/universal/t3t1-2.8.7-universal.json`
- `packages/connect-data/files/firmware/t3t1/universal/t3t1-2.8.9-universal.json`
- `packages/connect-data/files/firmware/t3t1/universal/t3t1-2.9.1-universal.json`
- `packages/connect-data/files/firmware/t3w1/bitcoinonly/t3w1-2.12.0-bitcoinonly.json`
- `packages/connect-data/files/firmware/t3w1/bitcoinonly/t3w1-2.9.3-bitcoinonly.json`
- `packages/connect-data/files/firmware/t3w1/universal/t3w1-2.12.0-universal.json`
- `packages/connect-data/files/firmware/t3w1/universal/t3w1-2.9.3-universal.json`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test directly validates firmware readiness detection during onboarding. Changes to firmware JSON metadata files across all device models (t1b1, t2t1, t2b1, t3t1, t3b1, t3w1) could affect how firmware versions are recognized and validated as ready.
- `suite/e2e/tests/firmware/custom-firmware.test.ts` — This test exercises firmware installation on a device. Changes to firmware metadata JSON files could affect how firmware versions are validated, listed, or compared during the custom firmware installation flow.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — This test opens the firmware update modal on a T2T1 device. Changes to T2T1 firmware metadata could affect whether a firmware update is offered, what version is displayed, or how the update modal behaves.
- `suite/e2e/tests/settings/t3b1-device-settings.test.ts` — This test opens and closes the firmware update modal on a T3B1 device. Changes to T3B1 firmware metadata could affect firmware update detection and modal behavior.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — The DeviceConnect analytics event captures firmware version information. Changes to firmware metadata could alter how firmware versions are reported in the DeviceConnect event, potentially causing assertion mismatches.

</details>

_Updated: 2026-06-29T13:00:17.978Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/sync-fw-release-files/web/](https://dev.suite.sldev.cz/suite-web/chore/sync-fw-release-files/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/sync-fw-release-files&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/sync-fw-release-files&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T13:03:38.947Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T13:03:04.678Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->