### PR TITLE
refactor(e2e): improve USDT top-up logic and SOL swap handling in aft…

### DIFF
--- a/suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts
+++ b/suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts
@@ -12,6 +12,10 @@ const receiveCoinSymbol = 'SOL';
 const formattedSendAmount = `${localizeNumber(sendAmount)} ${sendTokenSymbol}`;
 const accountLabel = 'Solana #2';
 
+// afterEach constants
+const usdtTopUpThreshold = parseFloat(sendAmount) * 3;
+const solFeeReserve = 0.05;
+
 // limiting number of runs due to fees onchain and nonce issues during teardown - by using specific model and FW tags
 test.describe(
     'Trading - Swap SPL token to coin via CEX',
@@ -32,14 +36,27 @@ test.describe(
         });
 
         test.afterEach(async ({ tradingPage, devicePrompt, walletPage }) => {
-            await walletPage.openAccount({ symbol: 'sol', atIndex: 1 });
-            const balanceText = await walletPage.topPanelBalance.innerText();
-            const solBalance = parseFloat(balanceText);
-            if (solBalance < 0.1) {
+            // Only top up when USDT on Solana #2 has run low; otherwise leave the account as is.
+            const usdtBalance = await walletPage.getTokenBalance({
+                symbol: 'sol',
+                atIndex: 1,
+                tokenName: sendAssetName,
+            });
+            if (usdtBalance >= usdtTopUpThreshold) {
                 return;
             }
 
-            const swapBackAmount = (solBalance - 0.05).toFixed(6);
+            await walletPage.openAccount({ symbol: 'sol', atIndex: 1 });
+            const balanceText = await walletPage.topPanelBalance.innerText();
+            const solBalance = parseFloat(balanceText);
+
+            // Swap all SOL except the fee reserve back to USDT.
+            const sellableSol = solBalance - solFeeReserve;
+            if (sellableSol <= 0) {
+                return;
+            }
+
+            const swapBackAmount = sellableSol.toFixed(6);
 
             await walletPage.openSwapTrading({ symbol: 'sol', atIndex: 1 });
 


### PR DESCRIPTION
## Description
Improves the `afterEach` teardown in the SPL token → coin swap e2e test. Adds a USDT balance check so top-up is skipped when funds are still sufficient.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-live-swap-teardown/web/](https://dev.suite.sldev.cz/suite-web/fix-live-swap-teardown/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-live-swap-teardown&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-live-swap-teardown&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T13:36:08.018Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T13:34:59.289Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->