### PR TITLE
test(e2e): add Suite Sync unsupported device banner tests

### DIFF
--- a/suite/e2e/support/pageObjects/metadata/metadataPage.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataPage.ts
@@ -30,6 +30,8 @@ export class MetadataPage {
     readonly closeSuiteSyncNotificationButton: Locator;
     readonly migrateLabelsButton: Locator;
     readonly migrateFromLocalFileButton: Locator;
+    readonly unsupportedBanner: Locator;
+    readonly suiteSyncBannerDismissButton: Locator;
 
     constructor(
         private readonly page: Page,
@@ -57,6 +59,10 @@ export class MetadataPage {
         this.migrateLabelsButton = page.getByTestId('@settings/metadata/migrate-button');
         this.migrateFromLocalFileButton = page.getByTestId(
             '@modal/legacy-labeling-migration/file-system-button',
+        );
+        this.unsupportedBanner = page.getByTestId('@notification/suite-sync-unsupported-device');
+        this.suiteSyncBannerDismissButton = page.getByTestId(
+            '@notification/suite-sync-unsupported-device/dismiss',
         );
     }
 

--- a/suite/e2e/tests/metadata/suite-sync/unsupported-device.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/unsupported-device.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '../../../support/fixtures';
+
+test.describe('Suite Sync - Unsupported device banner', { tag: ['@T1B1', '@T2T1'] }, () => {
+    test.beforeEach(async ({ onboardingPage, metadataPage, settingsPage }) => {
+        await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+        await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
+        await metadataPage.setupQuotaManager();
+        await metadataPage.initiateSuiteSyncSetup();
+    });
+
+    test('Banner appears once and does not reappear after dismissal', async ({
+        dashboardPage,
+        walletPage,
+        metadataPage,
+    }) => {
+        await test.step('Banner is visible after enabling Suite Sync', async () => {
+            await expect(metadataPage.unsupportedBanner).toHaveTranslation(
+                'TR_SUITE_SYNC_UNSUPPORTED_DEVICE_BANNER',
+            );
+        });
+
+        await test.step('Banner stays visible when selecting a wallet', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await dashboardPage.walletAtIndex(0).click();
+            await expect(metadataPage.unsupportedBanner).toHaveTranslation(
+                'TR_SUITE_SYNC_UNSUPPORTED_DEVICE_BANNER',
+            );
+        });
+
+        await test.step('Banner stays visible when navigating to Send', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await walletPage.openSendFormButton.click();
+            await expect(metadataPage.unsupportedBanner).toHaveTranslation(
+                'TR_SUITE_SYNC_UNSUPPORTED_DEVICE_BANNER',
+            );
+        });
+
+        await test.step('Banner stays visible when navigating to Receive', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await walletPage.receiveButton.click();
+            await expect(metadataPage.unsupportedBanner).toHaveTranslation(
+                'TR_SUITE_SYNC_UNSUPPORTED_DEVICE_BANNER',
+            );
+        });
+
+        await test.step('Dismiss the banner', async () => {
+            await metadataPage.suiteSyncBannerDismissButton.click();
+            await expect(metadataPage.unsupportedBanner).toBeHidden();
+        });
+
+        await test.step('Banner does not reappear when selecting a wallet', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await dashboardPage.walletAtIndex(0).click();
+            await expect(metadataPage.unsupportedBanner).toBeHidden();
+        });
+
+        await test.step('Banner does not reappear when navigating to Send', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await walletPage.openSendFormButton.click();
+            await expect(metadataPage.unsupportedBanner).toBeHidden();
+        });
+
+        await test.step('Banner does not reappear when navigating to Receive', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await walletPage.receiveButton.click();
+            await expect(metadataPage.unsupportedBanner).toBeHidden();
+        });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

New test for checking banner on unsupported Suite Sync devices

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/e2e/suite-sync-unsupported-device/web/](https://dev.suite.sldev.cz/suite-web/e2e/suite-sync-unsupported-device/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=e2e/suite-sync-unsupported-device&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=e2e/suite-sync-unsupported-device&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T14:07:34.593Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T14:05:01.882Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->