### PR TITLE
feat(trading): gate SLIP-24 on firmware 2.12.1+

### DIFF
--- a/suite-common/trading/src/constants.ts
+++ b/suite-common/trading/src/constants.ts
@@ -24,6 +24,8 @@ export const TRADING_SLIP24_SUPPORTED_NETWORK_TYPES: NetworkType[] = [
     'ripple',
 ];
 
+export const TRADING_SLIP24_MIN_FIRMWARE_VERSION = '2.12.1';
+
 export const TRADING_EXCHANGE_RATE = 'rateType';
 export const TRADING_EXCHANGE_RATE_FIXED = 'fixed';
 export const TRADING_EXCHANGE_RATE_FLOATING = 'floating';

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -345,6 +345,11 @@ describe('tradingSelectors', () => {
                         staticSessionId:
                             'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@448CCE89D32A733A1632F345:0' as StaticSessionId,
                     },
+                    features: {
+                        major_version: 2,
+                        minor_version: 12,
+                        patch_version: 1,
+                    },
                 },
             },
         }) as unknown as TradingRootStateWithDeviceAndAccounts;
@@ -2111,6 +2116,21 @@ describe('tradingSelectors', () => {
         it('should return false when firmware has slip24 in unavailableCapabilities', () => {
             if (state.device.selectedDevice) {
                 state.device.selectedDevice.unavailableCapabilities = { slip24: 'no-support' };
+            }
+            expect(selectTradingIsSlip24Allowed(state, accountBtc as any, true)).toBe(false);
+        });
+
+        it('should return false when firmware version is older than the minimum', () => {
+            if (state.device.selectedDevice?.features) {
+                state.device.selectedDevice.features.minor_version = 12;
+                state.device.selectedDevice.features.patch_version = 0;
+            }
+            expect(selectTradingIsSlip24Allowed(state, accountBtc as any, true)).toBe(false);
+        });
+
+        it('should return false when firmware version is unknown', () => {
+            if (state.device.selectedDevice) {
+                state.device.selectedDevice.features = undefined;
             }
             expect(selectTradingIsSlip24Allowed(state, accountBtc as any, true)).toBe(false);
         });

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -10,7 +10,11 @@ import {
     type SellFiatTrade,
 } from 'invity-api';
 
-import { type DeviceRootState, selectDeviceUnavailableCapabilities } from '@suite-common/device';
+import {
+    type DeviceRootState,
+    selectDeviceFirmwareVersion,
+    selectDeviceUnavailableCapabilities,
+} from '@suite-common/device';
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { type NetworkSymbolExtended, isNetworkSymbol } from '@suite-common/wallet-config';
 import {
@@ -21,9 +25,12 @@ import {
 import { type Account, type SelectedAccountStatus } from '@suite-common/wallet-types';
 import { getSupportedCoins } from '@trezor/address-validator';
 import { exhaustive } from '@trezor/type-utils';
-import { unique } from '@trezor/utils';
+import { unique, versionUtils } from '@trezor/utils';
 
-import { TRADING_SLIP24_SUPPORTED_NETWORK_TYPES } from '../constants';
+import {
+    TRADING_SLIP24_MIN_FIRMWARE_VERSION,
+    TRADING_SLIP24_SUPPORTED_NETWORK_TYPES,
+} from '../constants';
 import {
     EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES,
     type GroupedTradingExchangeQuotes,
@@ -878,13 +885,17 @@ export const selectTradingVerifiedAddress = (state: TradingRootState) =>
 export const selectTradingIsSlip24Allowed = createMemoizedSelectorWithDeviceAndAccounts(
     [
         state => selectDeviceUnavailableCapabilities(state),
+        state => selectDeviceFirmwareVersion(state),
         (_: TradingRootState, account: Account | undefined) => account,
         (_: TradingRootState, __: Account | undefined, isSlip24Active: boolean) => isSlip24Active,
     ],
-    (unavailableCapabilities, account, isSlip24Active) => {
+    (unavailableCapabilities, firmwareVersion, account, isSlip24Active) => {
         if (!account) return false;
 
-        const isFirmwareVersionSlip24Compatible = !unavailableCapabilities?.['slip24'];
+        const isFirmwareVersionSlip24Compatible =
+            !unavailableCapabilities?.['slip24'] &&
+            !!firmwareVersion &&
+            versionUtils.isNewerOrEqual(firmwareVersion, TRADING_SLIP24_MIN_FIRMWARE_VERSION);
         const isNetworkSupported = TRADING_SLIP24_SUPPORTED_NETWORK_TYPES.includes(
             account.networkType,
         );

--- a/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
@@ -92,7 +92,10 @@ describe('recomposeAndSignTxThunk', () => {
         selectedFee: 'normal' as const,
     };
 
-    const getMocks = (initialTradingState?: Partial<TradingState>) => {
+    const getMocks = (
+        initialTradingState?: Partial<TradingState>,
+        deviceFeatures?: Partial<NonNullable<TrezorDevice['features']>>,
+    ) => {
         const account = accountBtc as Account;
         const device = mockSuiteDevice();
 
@@ -102,6 +105,7 @@ describe('recomposeAndSignTxThunk', () => {
                     major_version: 2,
                     minor_version: 8,
                     patch_version: 11,
+                    ...deviceFeatures,
                 },
             } as TrezorDevice,
         };
@@ -573,11 +577,17 @@ describe('recomposeAndSignTxThunk', () => {
     });
 
     it('should create payment requests when SLIP24 is active and conditions are met', async () => {
-        const { store, account, tradingFormState } = getMocks({
-            composedTransactionInfo: {
-                ...mockComposedTransactionInfo,
+        const { store, account, tradingFormState } = getMocks(
+            {
+                composedTransactionInfo: {
+                    ...mockComposedTransactionInfo,
+                },
             },
-        });
+            {
+                minor_version: 12,
+                patch_version: 1,
+            },
+        );
 
         const mockSignAndPushSendFormTransaction = jest.fn().mockResolvedValueOnce({
             success: true,


### PR DESCRIPTION
Hides the SLIP-24 payment request flow on devices running firmware older than 2.12.1.

The connect `slip24` capability only gates protocol support (2.9.1), so `selectTradingIsSlip24Allowed` now additionally requires the selected device firmware to be `>= 2.12.1`, treating an unknown version as unsupported.

Built as a follow-up on top of `feat/suite-slip24-payment-request-validation`.

## Notes for QA

- On a device with firmware **>= 2.12.1**: start a trade (exchange/sell) on a SLIP-24 supported network (BTC, ETH, SOL, XRP, XLM) and confirm the SLIP-24 payment request review screen appears.
- On a device with firmware **< 2.12.1**: the SLIP-24 flow must NOT appear; the trade falls back to the standard review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/slip24-min-firmware-gate&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/slip24-min-firmware-gate&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/slip24-min-firmware-gate&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are in `suite-common/trading/src/constants.ts` and `suite-common/trading/src/selectors/tradingSelectors.ts`, which are core trading infrastructure files. While these map to 121 tests via static analysis (indicating they are broadly imported), only the trading-specific E2E tests directly exercise the buy/sell/swap flows that consume these selectors and constants. The recommended strategy focuses on comprehensive coverage of all trading flows (buy, sell, swap across multiple networks and assets) while excluding unrelated tests (analytics, backup, onboarding, metadata, etc.) that only transitively depend on these files. The unit test file for tradingSelectors has no E2E coverage mapping but provides direct unit-level validation of the selector changes.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/trading/src/constants.ts`
- `suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts`
- `suite-common/trading/src/selectors/tradingSelectors.ts`

</details>

**Recommended tests (20)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test directly exercises the trading/buy flow including quotes, trade confirmation, and watch polling — all of which rely on trading selectors and constants for state management, quote processing, and trade payload construction.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests the buy flow for Ethereum including asset selection, quote display, and trade confirmation — directly consuming trading selectors for quote/trade state and constants for API endpoint configuration.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Full sell BTC flow including quote display, best offer selection, confirmation details, and device prompt — directly uses trading selectors for composed transaction info and trade state.
- `suite/e2e/tests/trading/swap-coins.test.ts` — End-to-end swap flow (SOL→BTC) with quote selection, trade confirmation, status polling through multiple states, and provider support link — heavily depends on trading selectors for composedTransactionInfo and swap state management.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form input behavior including asset selection, amount validation, fraction buttons, and quote syncing — directly exercises trading selectors for swap quotes, provider selection, and fee computation.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation to buy/sell/swap forms from multiple entry points and verifies the correct crypto is preselected — relies on trading selectors to determine the active trading context and form state.

</details>

<details><summary>🟡 <b>Medium priority (13)</b></summary>

- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests buy form validation (min/max limits, no offers) which depends on trading constants for limit definitions and selectors for quote processing state.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Tests buying a Solana SPL token (JUP) through the trading flow with crypto amount input mode — exercises trading selectors for token-specific quote handling and trade payload construction.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests selling ETH with custom gas fees — uses trading selectors for composed transaction info and fee calculation, plus constants for API endpoints.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token (USDC) through the sell flow — exercises trading selectors for token-specific quote/trade state management.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation (decimals, insufficient funds, percentage buttons, max) which depends on trading selectors for balance retrieval and amount computation.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests the full sell SOL flow including quote display, confirmation, device prompt, and status transitions — uses trading selectors for fee calculation and trade state.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests swapping SOL to USDC token with receive account selection — exercises trading selectors for cross-network swap state and quote processing.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping USDT token to BTC — exercises trading selectors for token-to-coin swap quote handling and trade confirmation state.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests swapping SPL tokens (USDT→USDC) — exercises trading selectors for token-to-token swap state management on Solana network.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests custom Bitcoin fee settings during swap — directly checks Redux state wallet.trading.composedTransactionInfo which is managed by trading selectors.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests custom Ethereum fee settings during swap — directly checks Redux state wallet.trading.composedTransactionInfo managed by trading selectors.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swapping to an asset on a disabled network — exercises trading selectors for handling quotes when buy asset network is not enabled.
- `suite/e2e/tests/trading/swap-history.test.ts` — Tests viewing swap trade history and detail sidebar — uses trading selectors for retrieving and displaying historical trade data and status translations.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — The buy button on the assets section navigates to the trading page — a regression in trading constants or selectors could break this navigation path.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts`

_Updated: 2026-06-29T17:03:44.994Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/slip24-min-firmware-gate/web/](https://dev.suite.sldev.cz/suite-web/feat/slip24-min-firmware-gate/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-30T14:54:08.337Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-30T14:56:20.539Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->