### PR TITLE
refactor(utxo-lib): remove unnecessary type assertions (@trezor/utxo-lib)

### DIFF
--- a/packages/utxo-lib/src/bip32.ts
+++ b/packages/utxo-lib/src/bip32.ts
@@ -142,7 +142,7 @@ class BIP32 implements BIP32Interface {
     get publicKey(): Buffer {
         if (this.__Q === undefined) this.__Q = ecc.pointFromScalar(this.__D!, true);
 
-        return this.__Q!;
+        return this.__Q;
     }
 
     get privateKey(): Buffer | undefined {

--- a/packages/utxo-lib/src/payments/embed.ts
+++ b/packages/utxo-lib/src/payments/embed.ts
@@ -48,15 +48,15 @@ export function p2data(a: Payment, opts?: PaymentOpts): Payment {
     lazy.prop(o, 'data', () => {
         if (!a.output) return;
 
-        return bscript.decompile(a.output)!.slice(1);
+        return bscript.decompile(a.output).slice(1);
     });
 
     // extended validation
     if (opts.validate) {
         if (a.output) {
             const chunks = bscript.decompile(a.output);
-            if (chunks![0] !== OPS.OP_RETURN) throw new TypeError('Output is invalid');
-            if (!chunks!.slice(1).every(v => isBuffer(v))) throw new TypeError('Output is invalid');
+            if (chunks[0] !== OPS.OP_RETURN) throw new TypeError('Output is invalid');
+            if (!chunks.slice(1).every(v => isBuffer(v))) throw new TypeError('Output is invalid');
 
             if (a.data && !stacksEqual(a.data, o.data as Buffer[]))
                 throw new TypeError('Data mismatch');

--- a/packages/utxo-lib/src/payments/p2ms.ts
+++ b/packages/utxo-lib/src/payments/p2ms.ts
@@ -61,13 +61,13 @@ export function p2ms(a: Payment, opts?: PaymentOpts): Payment {
     function decode(output: Buffer | Stack): void {
         if (decoded) return;
         decoded = true;
-        chunks = bscript.decompile(output) as Stack;
+        chunks = bscript.decompile(output);
         // @ts-expect-error: indexing with noUncheckedIndexedAccess
         const firstChunk: number = chunks[0];
         // @ts-expect-error: indexing with noUncheckedIndexedAccess
         const nChunk: number = chunks[chunks.length - 2];
-        o.m = (firstChunk as number) - OPS.OP_RESERVED;
-        o.n = (nChunk as number) - OPS.OP_RESERVED;
+        o.m = firstChunk - OPS.OP_RESERVED;
+        o.n = nChunk - OPS.OP_RESERVED;
         o.pubkeys = chunks.slice(1, -2) as Buffer[];
     }
 
@@ -105,7 +105,7 @@ export function p2ms(a: Payment, opts?: PaymentOpts): Payment {
     lazy.prop(o, 'signatures', () => {
         if (!a.input) return;
 
-        return bscript.decompile(a.input)!.slice(1);
+        return bscript.decompile(a.input).slice(1);
     });
     lazy.prop(o, 'input', () => {
         if (!a.signatures) return;

--- a/packages/utxo-lib/src/payments/p2pk.ts
+++ b/packages/utxo-lib/src/payments/p2pk.ts
@@ -4,7 +4,7 @@ import { bitcoin as BITCOIN_NETWORK } from '../networks';
 import * as ecc from '../noble-compatibility';
 import * as bscript from '../script';
 import * as lazy from './lazy';
-import { type Payment, type PaymentOpts, type StackFunction } from '../types';
+import { type Payment, type PaymentOpts } from '../types';
 import { BufferSchema, Point, PredicateSchema, Type, assertType } from '../types/validation';
 
 const { OPS } = bscript;
@@ -36,7 +36,7 @@ export function p2pk(a: Payment, opts?: PaymentOpts): Payment {
         a,
     );
 
-    const _chunks = lazy.value(() => bscript.decompile(a.input!)) as StackFunction;
+    const _chunks = lazy.value(() => bscript.decompile(a.input!));
 
     const network = a.network || BITCOIN_NETWORK;
     const o: Payment = { name: 'p2pk', network };
@@ -74,7 +74,7 @@ export function p2pk(a: Payment, opts?: PaymentOpts): Payment {
                 throw new TypeError('Output is invalid');
             if (!o.pubkey || !ecc.isPoint(o.pubkey))
                 throw new TypeError('Output pubkey is invalid');
-            if (a.pubkey && !a.pubkey.equals(o.pubkey!)) throw new TypeError('Pubkey mismatch');
+            if (a.pubkey && !a.pubkey.equals(o.pubkey)) throw new TypeError('Pubkey mismatch');
         }
 
         if (a.signature) {

--- a/packages/utxo-lib/src/payments/p2pkh.ts
+++ b/packages/utxo-lib/src/payments/p2pkh.ts
@@ -9,7 +9,7 @@ import { bitcoin as BITCOIN_NETWORK } from '../networks';
 import * as ecc from '../noble-compatibility';
 import * as bscript from '../script';
 import * as lazy from './lazy';
-import { type Payment, type PaymentOpts, type StackFunction } from '../types';
+import { type Payment, type PaymentOpts } from '../types';
 import { BufferNSchema, BufferSchema, Point, Type, assertType } from '../types/validation';
 
 const { OPS } = bscript;
@@ -43,7 +43,7 @@ export function p2pkh(a: Payment, opts?: PaymentOpts): Payment {
 
     const _address = lazy.value(() => bs58check.decodeAddress(a.address!, a.network));
 
-    const _chunks = lazy.value(() => bscript.decompile(a.input!)) as StackFunction;
+    const _chunks = lazy.value(() => bscript.decompile(a.input!));
 
     const network = a.network || BITCOIN_NETWORK;
     const o: Payment = { name: 'p2pkh', network };

--- a/packages/utxo-lib/src/payments/p2sh.ts
+++ b/packages/utxo-lib/src/payments/p2sh.ts
@@ -8,13 +8,7 @@ import * as bcrypto from '../crypto';
 import { bitcoin as BITCOIN_NETWORK } from '../networks';
 import * as bscript from '../script';
 import * as lazy from './lazy';
-import {
-    type Payment,
-    type PaymentFunction,
-    type PaymentOpts,
-    type Stack,
-    type StackFunction,
-} from '../types';
+import { type Payment, type PaymentOpts, type Stack } from '../types';
 import { BufferNSchema, BufferSchema, Type, assertType } from '../types/validation';
 
 const { OPS } = bscript;
@@ -74,7 +68,7 @@ export function p2sh(a: Payment, opts?: PaymentOpts): Payment {
 
     const _address = lazy.value(() => bs58check.decodeAddress(a.address!, a.network));
 
-    const _chunks = lazy.value(() => bscript.decompile(a.input!)) as StackFunction;
+    const _chunks = lazy.value(() => bscript.decompile(a.input!));
 
     const _redeem = lazy.value((): Payment => {
         const chunks = _chunks();
@@ -85,13 +79,13 @@ export function p2sh(a: Payment, opts?: PaymentOpts): Payment {
             input: bscript.compile(chunks.slice(0, -1)),
             witness: a.witness || [],
         };
-    }) as PaymentFunction;
+    });
 
     // output dependents
     lazy.prop(o, 'address', () => {
         if (!o.hash) return;
 
-        return bs58check.encodeAddress(o.hash, network!.scriptHash, network);
+        return bs58check.encodeAddress(o.hash, network.scriptHash, network);
     });
     lazy.prop(o, 'hash', () => {
         // in order of least effort
@@ -115,7 +109,7 @@ export function p2sh(a: Payment, opts?: PaymentOpts): Payment {
         if (!a.redeem?.input || !a.redeem.output) return;
 
         return bscript.compile(
-            ([] as Stack).concat(bscript.decompile(a.redeem.input) as Stack, a.redeem.output),
+            ([] as Stack).concat(bscript.decompile(a.redeem.input), a.redeem.output),
         );
     });
     lazy.prop(o, 'witness', () => {
@@ -124,7 +118,7 @@ export function p2sh(a: Payment, opts?: PaymentOpts): Payment {
     });
     lazy.prop(o, 'name', () => {
         const nameParts = ['p2sh'];
-        if (o.redeem?.name !== undefined) nameParts.push(o.redeem.name!);
+        if (o.redeem?.name !== undefined) nameParts.push(o.redeem.name);
 
         return nameParts.join('-');
     });
@@ -178,7 +172,7 @@ export function p2sh(a: Payment, opts?: PaymentOpts): Payment {
                 if (!hasInput && !hasWitness) throw new TypeError('Empty input');
                 if (hasInput && hasWitness) throw new TypeError('Input and witness provided');
                 if (hasInput) {
-                    const richunks = bscript.decompile(redeem.input) as Stack;
+                    const richunks = bscript.decompile(redeem.input);
                     if (!bscript.isPushOnly(richunks))
                         throw new TypeError('Non push-only scriptSig');
                 }

--- a/packages/utxo-lib/src/payments/p2wsh.ts
+++ b/packages/utxo-lib/src/payments/p2wsh.ts
@@ -7,7 +7,7 @@ import { bitcoin as BITCOIN_NETWORK } from '../networks';
 import * as ecc from '../noble-compatibility';
 import * as bscript from '../script';
 import * as lazy from './lazy';
-import { type Payment, type PaymentOpts, type StackElement, type StackFunction } from '../types';
+import { type Payment, type PaymentOpts, type StackElement } from '../types';
 import { BufferNSchema, BufferSchema, Nullable, Type, assertType } from '../types/validation';
 
 const { OPS } = bscript;
@@ -80,7 +80,7 @@ export function p2wsh(a: Payment, opts?: PaymentOpts): Payment {
         };
     });
 
-    const _rchunks = lazy.value(() => bscript.decompile(a.redeem!.input!)) as StackFunction;
+    const _rchunks = lazy.value(() => bscript.decompile(a.redeem!.input!));
 
     let { network } = a;
     if (!network) {
@@ -94,7 +94,7 @@ export function p2wsh(a: Payment, opts?: PaymentOpts): Payment {
         const words = bech32.toWords(o.hash);
         words.unshift(0x00);
 
-        return bech32.encode(network!.bech32, words);
+        return bech32.encode(network.bech32, words);
     });
     lazy.prop(o, 'hash', () => {
         if (a.output) return a.output.subarray(2);
@@ -145,7 +145,7 @@ export function p2wsh(a: Payment, opts?: PaymentOpts): Payment {
     });
     lazy.prop(o, 'name', () => {
         const nameParts = ['p2wsh'];
-        if (o.redeem?.name !== undefined) nameParts.push(o.redeem.name!);
+        if (o.redeem?.name !== undefined) nameParts.push(o.redeem.name);
 
         return nameParts.join('-');
     });
@@ -190,7 +190,7 @@ export function p2wsh(a: Payment, opts?: PaymentOpts): Payment {
 
             // is the redeem output non-empty?
             if (a.redeem.output) {
-                if (bscript.decompile(a.redeem.output)!.length === 0)
+                if (bscript.decompile(a.redeem.output).length === 0)
                     throw new TypeError('Redeem.output is invalid');
 
                 // match hash against other sources

--- a/packages/utxo-lib/src/script/index.ts
+++ b/packages/utxo-lib/src/script/index.ts
@@ -183,7 +183,7 @@ export function fromASM(asm: string) {
 
 export function toStack(chunks0: Buffer | Stack) {
     const chunks = decompile(chunks0);
-    if (!isPushOnly(chunks as Stack)) throw new TypeError('Expected push-only script');
+    if (!isPushOnly(chunks)) throw new TypeError('Expected push-only script');
 
     return chunks?.map(op => {
         if (isBuffer(op)) return op;


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@trezor/utxo-lib`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are in `@trezor/utxo-lib`, specifically in BIP32 key derivation, Bitcoin payment script types (p2pkh, p2sh, p2wsh, p2pk, p2ms, embed), and script utilities. These are core cryptographic building blocks for UTXO-based coin operations. Although all 121 tests statically depend on these files (via transitive imports), only tests that directly exercise BTC/LTC/DOGE transaction construction, address derivation, signing, or discovery are meaningfully at risk. The recommended strategy focuses on wallet send/receive/sign flows for UTXO coins, account discovery, and trading flows that construct BTC transactions.

<details><summary><b>Changed files (8)</b></summary>

- `packages/utxo-lib/src/bip32.ts`
- `packages/utxo-lib/src/payments/embed.ts`
- `packages/utxo-lib/src/payments/p2ms.ts`
- `packages/utxo-lib/src/payments/p2pk.ts`
- `packages/utxo-lib/src/payments/p2pkh.ts`
- `packages/utxo-lib/src/payments/p2sh.ts`
- `packages/utxo-lib/src/payments/p2wsh.ts`
- `packages/utxo-lib/src/script/index.ts`

</details>

**Recommended tests (17)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test sends BTC transactions on regtest including OP_RETURN outputs, which directly exercises the embed.ts payment type and script/index.ts for script construction. Changes to p2pkh, p2sh, and bip32 are also exercised during BTC transaction signing and address derivation.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Sends a DOGE transaction through the full signing flow, directly exercising utxo-lib payment types (p2pkh for DOGE addresses), bip32 for key derivation, and script construction. The test verifies amounts, fees, and transaction signing error handling.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Sends LTC via broadcast mode with a MimbleWimble peg-out output, exercising utxo-lib payment types (p2sh for LTC segwit-compatible addresses, p2wsh) and bip32 for key derivation during transaction composition and signing.
- `suite/e2e/tests/wallet/receive.test.ts` — Reveals and verifies receive addresses for BTC (which uses bip32 derivation and p2pkh/p2sh/p2wsh payment types for address generation). A regression in any payment script or bip32 derivation would produce wrong addresses, caught by this test's address format and value assertions.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Signs and verifies BTC messages using a BIP84 address, directly exercising bip32 key derivation and the payment script infrastructure for address selection. The test asserts exact signature values, so any change in key derivation or script handling would be caught.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/wallet/public-keys.test.ts` — Displays and verifies exact XPUB values for BTC and LTC accounts, which depend on bip32 derivation. Changes to bip32.ts could alter derived public keys, causing XPUB mismatches in this test's exact-match assertions.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Adds different BTC account types (normal/taproot/segwit/legacy), each of which uses different payment scripts (p2pkh for legacy, p2sh for segwit, p2wsh). Changes to payment type modules could affect account creation and derivation path handling.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — Sends BTC on regtest and verifies balance updates, exercising the transaction construction pipeline which uses utxo-lib payment types and bip32 for address derivation. Balance display correctness depends on proper UTXO handling.
- `suite/e2e/tests/wallet/discovery.test.ts` — Triggers full account discovery across multiple UTXO coins (BTC, LTC, BCH, DOGE, ZEC), which relies on bip32 derivation and payment script parsing to detect used addresses. A regression could cause discovery to miss accounts or fail entirely.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Tests BTC and LTC discovery with custom blockbook backends. Discovery depends on bip32 key derivation to generate addresses for gap limit scanning, making this sensitive to changes in bip32.ts and payment scripts.
- `suite/e2e/tests/wallet/pagination.test.ts` — Navigates paginated transactions on a legacy BTC account and verifies transaction addresses. Address display depends on payment script parsing (p2pkh for legacy accounts) and bip32 derivation.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — Imports BTC CSV with addresses and amounts into the send form, which validates addresses using payment script parsing. Changes to p2pkh/p2sh could affect address validation logic.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Initiates a BTC sell transaction requiring device signing, which exercises the full UTXO transaction construction pipeline including bip32 derivation, payment scripts, and fee calculation. Verifies exact crypto amounts and addresses.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests BTC swap with custom fee settings, verifying exact fee calculations and total amounts on the device prompt. Fee calculation relies on utxo-lib's transaction size estimation which depends on payment script types.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — Exports BTC/LTC transaction history which involves parsing transaction outputs using payment scripts. While the export itself is higher-level, the underlying transaction data interpretation depends on utxo-lib.
- `suite/e2e/tests/wallet/transactions.test.ts` — Searches and displays BTC transaction addresses, which are parsed/formatted using payment script modules. A regression in script parsing could affect address display in the transaction list.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Configures custom BTC blockbook backend and verifies account discovery succeeds. Discovery uses bip32 derivation, but the test primarily validates backend configuration rather than key derivation correctness.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/utxo-lib/src/payments/p2ms.ts`
- `packages/utxo-lib/src/payments/p2pk.ts`

_Updated: 2026-06-29T14:30:01.635Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/no-unnec-assert-utxo-lib&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/no-unnec-assert-utxo-lib&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T14:34:48.385Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T14:33:01.702Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-utxo-lib/web/](https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-utxo-lib/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->