### PR TITLE
refactor(suite): remove unnecessary type assertions (@trezor/suite (components))

### DIFF
--- a/packages/suite/src/components/guide/GuideArticle.tsx
+++ b/packages/suite/src/components/guide/GuideArticle.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
-import type { GuideCategory } from '@suite-common/suite-types';
 import { spacingsPx } from '@trezor/theme';
 
 import { openNode, setView } from 'src/actions/suite/guideActions';
@@ -27,11 +26,7 @@ export const GuideArticle = () => {
     // Always go back to the level 1 ancestor so the user lands on the same screen they came from.
     const parentCategory =
         currentNode && indexNode
-            ? (
-                  findAncestorNodes(currentNode, indexNode).filter(
-                      node => node.type === 'category',
-                  ) as GuideCategory[]
-              )[0]
+            ? findAncestorNodes(currentNode, indexNode).filter(node => node.type === 'category')[0]
             : undefined;
 
     const goBack = () => {

--- a/packages/suite/src/components/suite/FindBar/highlight.ts
+++ b/packages/suite/src/components/suite/FindBar/highlight.ts
@@ -59,7 +59,7 @@ export const highlightText = (root: HTMLElement, query: string): number => {
     });
 
     validNodes.forEach(textNode => {
-        const text = textNode.textContent!;
+        const text = textNode.textContent;
         const matches = Array.from(text.matchAll(regex));
         if (matches.length === 0) return;
 

--- a/packages/suite/src/components/suite/FindBar/useFindInPage.ts
+++ b/packages/suite/src/components/suite/FindBar/useFindInPage.ts
@@ -24,8 +24,7 @@ export const useFindInPage = () => {
     const seqRef = useRef(0);
     const queryRef = useRef('');
 
-    const rootElement = (rootRef.current = (document.getElementById('root') ||
-        document.body) as HTMLElement);
+    const rootElement = (rootRef.current = document.getElementById('root') || document.body);
 
     const observeRoot = useCallback(() => {
         observerRef.current?.observe(rootElement, {
@@ -159,7 +158,7 @@ export const useFindInPage = () => {
 
             if (keepActive && activeOrdinalRef.current != null) {
                 const ord = clampOrdinal(activeOrdinalRef.current, total);
-                applyActiveOrdinal(ord as number | null, false);
+                applyActiveOrdinal(ord, false);
             } else {
                 applyActiveOrdinal(null);
             }
@@ -226,7 +225,7 @@ export const useFindInPage = () => {
             if (isMutatingRef.current) return;
 
             const relevant = muts.some(m => {
-                const node = m.target as Node;
+                const node = m.target;
 
                 const getParentElement = () =>
                     node.parentElement instanceof HTMLElement ? node.parentElement : null;

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckLayout.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckLayout.tsx
@@ -24,9 +24,7 @@ const isModelWithRotate = (model: DeviceModelInternal | undefined): model is Rot
     !!model && model !== DeviceModelInternal.UNKNOWN;
 
 const getDeviceModel = (deviceModelInternal: DeviceModelInternal | undefined): RotateModel =>
-    isModelWithRotate(deviceModelInternal)
-        ? deviceModelInternal
-        : (DeviceModelInternal.T3W1 as RotateModel);
+    isModelWithRotate(deviceModelInternal) ? deviceModelInternal : DeviceModelInternal.T3W1;
 
 export const SecurityCheckLayout = ({
     isFailed,

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAsset/AssetRowAsset.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAsset/AssetRowAsset.tsx
@@ -1,5 +1,4 @@
 import { type TradingAssetOption } from '@suite-common/trading';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Row } from '@trezor/components';
 import { AssetLogo, CoinLogo, shouldShowNetworkIcon } from '@trezor/product-components';
 
@@ -21,11 +20,7 @@ export function AssetRowAsset({ asset, dataTestId, onClick }: AssetRowAssetProps
         >
             <Row data-testid={dataTestId} gap={12} overflow="hidden" maxWidth="100%">
                 {asset.isNativeToken ? (
-                    <CoinLogo
-                        size={40}
-                        symbol={asset.symbol as NetworkSymbol}
-                        type="tokenWithNetwork"
-                    />
+                    <CoinLogo size={40} symbol={asset.symbol} type="tokenWithNetwork" />
                 ) : (
                     <AssetLogo
                         size={40}

--- a/packages/suite/src/components/suite/banners/MessageSystemButton.tsx
+++ b/packages/suite/src/components/suite/banners/MessageSystemButton.tsx
@@ -42,7 +42,7 @@ export const MessageSystemButton = ({ cta, id, ...props }: MessageSystemButtonPr
 
     return (
         <Banner.Button
-            onClick={onClick!}
+            onClick={onClick}
             priority="primary"
             {...(id ? { 'data-testid': `@message-system/${id}/cta` } : {})}
             {...props}

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipAccount.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipAccount.tsx
@@ -111,11 +111,7 @@ export const GraphTooltipAccount = ({
                 formatters,
             )}
             balance={
-                <FormattedCryptoAmount
-                    disableHiddenPlaceholder
-                    value={balance as string}
-                    symbol={symbol}
-                />
+                <FormattedCryptoAmount disableHiddenPlaceholder value={balance} symbol={symbol} />
             }
         />
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalBottomContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalBottomContent.tsx
@@ -100,7 +100,7 @@ export const TransactionReviewModalBottomContent = ({
                 selectedFee: selectedFee || 'normal',
                 isCoinControlEnabled: precomposedForm.isCoinControlEnabled,
                 hasCoinControlBeenOpened: precomposedForm.hasCoinControlBeenOpened,
-                txType: txType as 'stake' | 'trade' | undefined,
+                txType,
             },
         });
 
@@ -113,7 +113,7 @@ export const TransactionReviewModalBottomContent = ({
             decision.resolve(true);
             reportTransactionCreatedEvent(
                 isRbfTransaction(precomposedTx!)
-                    ? mapRbfTypeToReporting[precomposedTx!.rbfType]
+                    ? mapRbfTypeToReporting[precomposedTx.rbfType]
                     : 'sent',
             );
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
@@ -145,10 +145,5 @@ export const StakeChangeDelegateModal = ({
         return null;
     }
 
-    return (
-        <StakeChangeDelegateModalLoaded
-            onCancel={onCancel}
-            selectedAccount={selectedAccount as SelectedAccountLoaded}
-        />
-    );
+    return <StakeChangeDelegateModalLoaded onCancel={onCancel} selectedAccount={selectedAccount} />;
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -15,7 +15,6 @@ import {
 import { ConnectPopupTxSimulationModal } from 'src/components/tx-simulation/connect-popup';
 import { EarnYieldTxSimulationModal } from 'src/components/tx-simulation/earn-stablecoin';
 import { useDispatch } from 'src/hooks/suite';
-import type { AcquiredDevice } from 'src/types/suite';
 
 import { ConfirmAddressModal } from '../ConfirmAddressModal';
 import { ConfirmXpubModal } from '../ConfirmXpubModal';
@@ -69,7 +68,7 @@ export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL_CONTE
         case 'add-account':
             return (
                 <AddAccountModal
-                    device={payload.device as AcquiredDevice}
+                    device={payload.device}
                     symbol={payload.symbol}
                     noRedirect={payload.noRedirect}
                     isCoinjoinDisabled={payload.isCoinjoinDisabled}

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/BitcoinFeeCards.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/BitcoinFeeCards.tsx
@@ -82,7 +82,7 @@ export const BitcoinFeeCards = ({ feeOptions }: BitcoinFeeCardsProps) => {
                 ))}
             </FeeCardsWrapper>
             <DustPreventionNotice
-                chosenFeePerByte={selectedFeeLevel!.feePerUnit}
+                chosenFeePerByte={selectedFeeLevel.feePerUnit}
                 composedFeePerByte={
                     transactionInfo?.type === 'final' ? transactionInfo.feePerByte : undefined
                 }


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@trezor/suite (components)`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies several UI components across different functional areas: guide article rendering (GuideArticle.tsx), asset picker rows (AssetRowAsset.tsx), Bitcoin fee cards (BitcoinFeeCards.tsx), transaction review modal content, graph tooltip accounts, FindBar search functionality, security check layout, message system banners, and staking delegation modals. Most changed files (8 of 11) map to 121+ tests as broad shared components, so testing should focus on the specific features each component serves. The highest risk areas are the asset picker (affects all swap/trading tests), Bitcoin fee cards (affects BTC send and sell flows), and guide article rendering (affects guide search tests). The FindBar components have no static test coverage.

<details><summary><b>Changed files (11)</b></summary>

- `packages/suite/src/components/guide/GuideArticle.tsx`
- `packages/suite/src/components/suite/FindBar/highlight.ts`
- `packages/suite/src/components/suite/FindBar/useFindInPage.ts`
- `packages/suite/src/components/suite/SecurityCheck/SecurityCheckLayout.tsx`
- `packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAsset/AssetRowAsset.tsx`
- `packages/suite/src/components/suite/banners/MessageSystemButton.tsx`
- `packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipAccount.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalBottomContent.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx`
- `packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/BitcoinFeeCards.tsx`

</details>

**Recommended tests (21)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/general/suite-guide.test.ts` — GuideArticle.tsx is directly exercised when searching for a support article in the Suite Guide panel. This test searches for 'Install firmware' and verifies the article label is displayed, which would break if GuideArticle rendering is changed.
- `suite/e2e/tests/suite/guide.test.ts` — This test navigates guide content by clicking guide nodes and verifying labels, and searches within the guide for articles. Changes to GuideArticle.tsx directly affect article rendering in the guide panel that this test exercises.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — BitcoinFeeCards.tsx is the Bitcoin fee card component and this test specifically sets custom Bitcoin fee rates during a swap, verifying fee display on both the UI and device. Changes to fee card rendering directly affect this test's assertions.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test exercises the Bitcoin sell flow which includes Bitcoin fee calculation display and the transaction review modal bottom content. Both BitcoinFeeCards.tsx and TransactionReviewModalBottomContent.tsx are in the critical path of confirming a sell trade.
- `suite/e2e/tests/trading/swap-coins.test.ts` — AssetRowAsset.tsx is directly used in the asset picker when selecting sell/buy assets in the swap form. This test fills a swap form selecting specific assets and verifies quotes, making it directly affected by asset picker row rendering changes.
- `suite/e2e/tests/trading/navigation.test.ts` — This test verifies navigation to Buy/Sell/Swap forms from various entry points and checks that the correct cryptocurrency name is displayed. AssetRowAsset.tsx renders the asset name in the picker which is verified by verifyBuyFormOpened/verifySellFormOpened/verifySwapFormOpened.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test exercises Bitcoin send form features including multiple outputs and fee handling. BitcoinFeeCards.tsx changes directly affect the fee selection UI, and TransactionReviewModalBottomContent.tsx affects the review/confirmation step.

</details>

<details><summary>🟡 <b>Medium priority (13)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Uses the asset picker to select sell (SOL) and buy (USDC) assets, directly rendering AssetRowAsset.tsx in the picker UI. Also exercises the transaction review flow via TransactionReviewModalBottomContent.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swaps a Solana token (USDT) to Bitcoin via the asset picker, directly exercising AssetRowAsset.tsx when selecting assets in the swap form.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Swaps SPL tokens (USDT to USDC) using the asset picker, directly rendering AssetRowAsset.tsx for token selection.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests selecting a buy asset from a disabled network in the swap asset picker, which directly renders AssetRowAsset.tsx for the disabled-network asset display.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — While focused on Ethereum custom fees, this swap test uses the asset picker (AssetRowAsset.tsx) to select assets and exercises the swap confirmation flow.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Exercises the swap form with asset picker selection (AssetRowAsset.tsx) and validates input behavior including amount entry and fraction buttons.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation and includes custom Bitcoin fee rate switching, which exercises BitcoinFeeCards.tsx for BTC transactions.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Sends LTC which uses Bitcoin-like fee selection, exercising BitcoinFeeCards.tsx, and goes through the device confirmation flow involving TransactionReviewModalBottomContent.tsx.
- `suite/e2e/tests/wallet/send-doge.test.ts` — DOGE uses Bitcoin-like fee cards. This test sends DOGE and verifies transaction details on the device prompt, which involves BitcoinFeeCards.tsx for fee selection.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — The global send flow uses the asset picker to filter and select accounts, which renders AssetRowAsset.tsx. Changes to asset row rendering could affect account selection and labeling.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Uses the asset picker to search and select Ethereum as a buy asset, directly rendering AssetRowAsset.tsx. Also adds a new receive account via the asset picker flow.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Selects a Solana SPL token (Jupiter/JUP) from the asset picker, directly rendering AssetRowAsset.tsx for token selection in the buy form.
- `suite/e2e/tests/wallet/transactions.test.ts` — Cycles through graph time range filters which render GraphTooltipAccount.tsx in the transaction overview tooltip. Changes to tooltip account rendering could affect this test's graph interactions.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — StakeChangeDelegateModal.tsx is related to Cardano staking delegation changes. While this test covers initial ADA staking, the delegate change modal may be part of the staking flow infrastructure.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/suite/FindBar/highlight.ts`
- `packages/suite/src/components/suite/FindBar/useFindInPage.ts`

_Updated: 2026-06-29T14:31:19.213Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-suite-components/web/](https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-suite-components/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/no-unnec-assert-suite-components&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/no-unnec-assert-suite-components&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T14:35:44.295Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T14:34:15.678Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->