### PR TITLE
refactor(suite): remove unnecessary type assertions (@trezor/suite (views))

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemForm/useConditionControls.ts
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemForm/useConditionControls.ts
@@ -7,10 +7,10 @@ type Parsed = { conditions?: unknown[] } | null;
 
 export function useConditionControls(parsedData: Parsed, setFormData: (next: string) => void) {
     const availableConditionOptions = useMemo(() => {
-        if (!Array.isArray(parsedData?.conditions) || !parsedData!.conditions![0]) {
+        if (!Array.isArray(parsedData?.conditions) || !parsedData.conditions[0]) {
             return CONDITION_OPTIONS;
         }
-        const head = parsedData!.conditions![0] as Record<keyof Condition, unknown>;
+        const head = parsedData.conditions[0] as Record<keyof Condition, unknown>;
         const used = new Set(Object.keys(head));
 
         return CONDITION_OPTIONS.filter(o => !used.has(o.value));

--- a/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
@@ -189,7 +189,7 @@ export const Experimental = () => {
                             {experimentalFeatures.map(feature => (
                                 <FeatureLine
                                     key={feature}
-                                    feature={feature as ExperimentalFeature}
+                                    feature={feature}
                                     enabledFeatures={enabledFeatures}
                                 />
                             ))}

--- a/packages/suite/src/views/settings/SettingsGeneral/TorExternal.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/TorExternal.tsx
@@ -51,7 +51,7 @@ export const TorExternal = () => {
         if (!torSettings) return;
         const { externalPort } = torSettings;
         const selectedOption = options.find(o => o.value === externalPort);
-        setSelectedOption(selectedOption!);
+        setSelectedOption(selectedOption);
     }, [torSettings]);
 
     const onChange = async ({ value }: { value: number }) => {

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
@@ -69,7 +69,7 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
 
     useEffect(() => {
         if (hasNetworkFeatures(account, 'tokens') && !isSetMaxActive) {
-            const amountValue = getValues(`outputs.${outputId}.amount`) as string;
+            const amountValue = getValues(`outputs.${outputId}.amount`);
             if (amountValue) setAmount(outputId, amountValue);
         }
     }, [account, outputId, tokenWatch, setAmount, getValues, isSetMaxActive]);

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/EthStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/EthStakingDashboard.tsx
@@ -51,7 +51,7 @@ export const EthStakingDashboard = ({ selectedAccount }: EthStakingDashboardProp
     const dispatch = useDispatch();
 
     const lastTxBlockTime = stakeTxs[0]?.blockTime;
-    const timestamp = hasStakeInPendingDepositedState(account!) ? lastTxBlockTime : undefined;
+    const timestamp = hasStakeInPendingDepositedState(account) ? lastTxBlockTime : undefined;
 
     const { data: validatorQueueData, isLoading: isValidatorQueueLoading } =
         useEthereumValidatorsQueue({ account, timestamp });

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputContent.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputContent.tsx
@@ -5,7 +5,7 @@ import {
     type TradingAssetOption,
     type TradingAssetSellOption,
 } from '@suite-common/trading';
-import { type NetworkSymbol, getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { Column, Row, Text } from '@trezor/components';
 import { AssetLogo, CoinLogo } from '@trezor/product-components';
 
@@ -38,7 +38,7 @@ export function AssetPickerInputContent({ value }: AssetPickerInputContentProps)
     return (
         <Row gap={12}>
             {isNativeToken ? (
-                <CoinLogo size={32} symbol={symbol as NetworkSymbol} type="tokenWithNetwork" />
+                <CoinLogo size={32} symbol={symbol} type="tokenWithNetwork" />
             ) : (
                 <AssetLogo
                     size={32}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
@@ -120,7 +120,7 @@ export const TradingSellFormInputs = () => {
                                     balance={outputAmount}
                                     displaySymbol={sendCryptoSelect?.id}
                                     symbol={account.symbol}
-                                    tokenAddress={tokenAddress as TokenAddress}
+                                    tokenAddress={tokenAddress}
                                     showOnlyAmount
                                     amountInCrypto={amountInCrypto}
                                     decimals={sendAssetDecimals}

--- a/packages/suite/src/views/wallet/trading/common/TradingOffers/useTradingOfferRate.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingOffers/useTradingOfferRate.ts
@@ -64,7 +64,7 @@ export const useTradingOfferRate = (trade: TradingTradeType | undefined): string
     const rate = fromBigNumber.div(toBigNumber);
 
     const fromSymbol = isFromCrypto
-        ? (cryptoIdToCoinSymbol(fromCurrency as CryptoId) ?? fromCurrency).toUpperCase()
+        ? (cryptoIdToCoinSymbol(fromCurrency) ?? fromCurrency).toUpperCase()
         : fromCurrency;
     const rateFormatted = `${formatExchangeRate(rate)} ${fromSymbol}`;
 

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
@@ -4,7 +4,7 @@ import { AccountLabel } from '@suite/account';
 import { Address } from '@suite/address';
 import { Translation, useTranslation } from '@suite/intl';
 import { cryptoIdToNetworkSymbolAndContractAddress, useTradingAssets } from '@suite-common/trading';
-import { type NetworkSymbol, getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { type Account, type TokenAddress } from '@suite-common/wallet-types';
 import { Card, Column, Row, Skeleton, Text } from '@trezor/components';
 import { AssetLogo, CoinLogo } from '@trezor/product-components';
@@ -99,11 +99,7 @@ export const TradingInfoItem = ({
                     <Row padding={16} gap={8} justifyContent="space-between">
                         <Row gap={8} alignItems="center">
                             {isNativeToken ? (
-                                <CoinLogo
-                                    size={40}
-                                    symbol={symbol as NetworkSymbol}
-                                    type="tokenWithNetwork"
-                                />
+                                <CoinLogo size={40} symbol={symbol} type="tokenWithNetwork" />
                             ) : (
                                 <AssetLogo
                                     size={40}

--- a/packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx
@@ -130,7 +130,7 @@ export const SummaryCards = ({
                     shallDisplayBaseCurrency && totalReceivedFiatMap[localCurrency] ? (
                         <BaseCurrencyAmountFormatter
                             currency={localCurrency}
-                            value={totalReceivedFiatMap[localCurrency]!}
+                            value={totalReceivedFiatMap[localCurrency]}
                         />
                     ) : undefined
                 }
@@ -145,7 +145,7 @@ export const SummaryCards = ({
                     shallDisplayBaseCurrency && totalSentFiatMap[localCurrency] ? (
                         <BaseCurrencyAmountFormatter
                             currency={localCurrency}
-                            value={totalSentFiatMap[localCurrency]!}
+                            value={totalSentFiatMap[localCurrency]}
                         />
                     ) : undefined
                 }


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@trezor/suite (views)`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-suite-views/web/](https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-suite-views/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/no-unnec-assert-suite-views&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/no-unnec-assert-suite-views&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T14:35:02.530Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T14:34:44.240Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set touches multiple UI components across trading (sell form, asset picker, offer info items, offer rates), wallet send (token select), staking (ETH staking dashboard), transactions (summary cards), and settings (experimental, Tor, debug). The highest risk areas are the trading sell form inputs, ETH staking dashboard, and token select in the send form, as these are core interactive components. The settings changes (Experimental.tsx, TorExternal.tsx) map to 91+ tests but are likely cosmetic/layout changes that don't affect the behavior of those tests. The useTradingOfferRate.ts hook has no static test mapping but is inferred to be used in swap/trading offer display flows. Testing strategy should focus on trading sell/swap flows, ETH staking dashboard, and send form functionality.

<details><summary><b>Changed files (10)</b></summary>

- `packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemForm/useConditionControls.ts`
- `packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx`
- `packages/suite/src/views/settings/SettingsGeneral/TorExternal.tsx`
- `packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx`
- `packages/suite/src/views/wallet/staking/components/EthStakingDashboard/EthStakingDashboard.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputContent.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingOffers/useTradingOfferRate.ts`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx`
- `packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx`

</details>

**Recommended tests (25)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/trading/sell-inputs.test.ts` — Directly exercises TradingSellFormInputs.tsx (sell form validation, fraction buttons, currency switching) and AssetPickerInputContent.tsx (asset picker in sell form). Both components were changed and this test validates their core interactive behaviors.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests the full sell flow end-to-end including the sell form inputs (TradingSellFormInputs.tsx), asset picker (AssetPickerInputContent.tsx), and offer confirmation details (TradingInfoItem.tsx). All three changed trading components are exercised in this flow.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Directly tests EthStakingDashboard.tsx, verifying staking dashboard empty state, staking form, pending transaction display, and progress indicators. The changed component is the core of this test's UI.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Tests the EthStakingDashboard with existing staked amounts, the stake-more flow, and instant staking banner — all rendered by the changed EthStakingDashboard.tsx component.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Tests unstaking and claiming flows within the ETH staking dashboard, directly exercising EthStakingDashboard.tsx for displaying staked/unstaking/claimable amounts and button states.
- `suite/e2e/tests/staking/staking-form.test.ts` — Tests ETH staking form validation, fraction buttons, max button, and crypto/fiat switching — all within the EthStakingDashboard.tsx component that was changed.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Tests the Ethereum send form including token selection via TokenSelect.tsx. Changes to the token select component could affect how the send form renders and behaves for ETH transactions.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Tests the full sell BTC flow including confirmation details rendered by TradingInfoItem.tsx (fiat amount, crypto amount, provider, payment method, destination address display).

</details>

<details><summary>🟡 <b>Medium priority (13)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Tests the buy flow including offer preview/confirmation screen which renders TradingInfoItem.tsx for displaying fiat amount, crypto amount, and provider details.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests buy form validation and asset picker interactions. Changes to AssetPickerInputContent.tsx could affect how the buy form loads and displays asset selection.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation to buy/sell/swap forms from various entry points. Changes to TradingSellFormInputs.tsx and AssetPickerInputContent.tsx could affect whether forms render correctly after navigation.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests ETH sell flow with confirmation details rendered by TradingInfoItem.tsx. Changes to the info item component could affect display of fiat/crypto amounts and provider info.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token with confirmation details rendered by TradingInfoItem.tsx, verifying correct display of token amounts and provider information.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Tests the swap flow with confirmation details (exchange type, provider, amounts) rendered by TradingInfoItem.tsx, and the swap form uses AssetPickerInputContent.tsx. Also useTradingOfferRate.ts may affect offer rate display.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests cross-chain swap with confirmation details (TradingInfoItem.tsx) and asset picker (AssetPickerInputContent.tsx). The useTradingOfferRate.ts hook may affect displayed exchange rates.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Tests the Solana send form which uses TokenSelect.tsx for token selection. Changes could affect send form rendering for SOL transactions.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Tests sending DOGE which renders the send form using TokenSelect.tsx. Changes to token selection could affect the DOGE send form behavior.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Tests multiple send form features (add/remove outputs, OP_RETURN, locktime, unit switching) that render through the send form containing TokenSelect.tsx.
- `suite/e2e/tests/wallet/transactions.test.ts` — Tests the account transactions overview including graph time range filters and transaction search. SummaryCards.tsx is a component in the transactions view that was changed.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping a token to a coin using the asset picker and confirmation details, both of which involve changed components (AssetPickerInputContent.tsx, TradingInfoItem.tsx).
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form input interactions including asset picker selection (AssetPickerInputContent.tsx) and offer rate display that may use useTradingOfferRate.ts.

</details>

<details><summary>🟢 <b>Low priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests BTC swap with custom fees. The swap confirmation uses TradingInfoItem.tsx but the test primarily focuses on fee calculations rather than info item rendering.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests ETH swap with custom gas fees. Uses TradingInfoItem.tsx in confirmation but focuses on fee display rather than info item content.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests ETH buy flow with confirmation details. Uses AssetPickerInputContent.tsx for asset selection and TradingInfoItem.tsx in confirmation, but less directly impacted than sell/swap flows.
- `suite/e2e/tests/wallet/send-base.test.ts` — Tests Base network send form which includes TokenSelect.tsx. The test focuses on fee display and device confirmation rather than token selection directly.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemForm/useConditionControls.ts`

_Updated: 2026-06-29T15:16:40.941Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->