### PR TITLE
refactor(suite): remove unnecessary type assertions (@trezor/suite (hooks))

### DIFF
--- a/packages/suite/src/hooks/earn/useClaimForm.ts
+++ b/packages/suite/src/hooks/earn/useClaimForm.ts
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 import { getStakeFormsDefaultValues, getStakingContractAddress } from '@suite-common/staking';
 import { getNetwork } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
-import { type Account, type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import { type Account } from '@suite-common/wallet-types';
 import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 import { throwError } from '@trezor/utils';
 
@@ -124,9 +124,7 @@ export const useClaimForm = ({ account }: UseClaimFormsProps): ClaimContextValue
         const values = getValues();
         const composedTx = composedLevels ? composedLevels[selectedFee] : undefined;
         if (composedTx?.type === 'final') {
-            const result = await dispatch(
-                signTransaction(values, composedTx as PrecomposedTransactionFinal),
-            );
+            const result = await dispatch(signTransaction(values, composedTx));
 
             if (result?.success) {
                 clearForm();

--- a/packages/suite/src/hooks/earn/useStakeForm.ts
+++ b/packages/suite/src/hooks/earn/useStakeForm.ts
@@ -11,11 +11,7 @@ import {
     selectRawNetworkFeeInfo,
     useFormDraft,
 } from '@suite-common/wallet-core';
-import {
-    type Account,
-    type PrecomposedTransactionFinal,
-    type StakeFormState,
-} from '@suite-common/wallet-types';
+import { type Account, type StakeFormState } from '@suite-common/wallet-types';
 import {
     fromBaseCurrencyToCryptoUnit,
     fromWei,
@@ -357,9 +353,7 @@ export const useStakeForm = ({ account }: UseStakeFormProps): StakeContextValues
         const composedTx = composedLevels ? composedLevels[selectedFee] : undefined;
         if (composedTx?.type === 'final') {
             setIsLoading(true);
-            const result = await dispatch(
-                signTransaction(values, composedTx as PrecomposedTransactionFinal),
-            );
+            const result = await dispatch(signTransaction(values, composedTx));
 
             setIsLoading(false);
             if (result?.success) {

--- a/packages/suite/src/hooks/earn/useWithdrawalForm.ts
+++ b/packages/suite/src/hooks/earn/useWithdrawalForm.ts
@@ -15,7 +15,7 @@ import {
     selectRawNetworkFeeInfo,
     useFormDraft,
 } from '@suite-common/wallet-core';
-import { type Account, type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import { type Account } from '@suite-common/wallet-types';
 import {
     fromBaseCurrencyToCryptoUnit,
     getConvertedOrDefaultFeeInfo,
@@ -273,9 +273,7 @@ export const useWithdrawalForm = ({ account }: UseWithdrawalFormProps): Withdraw
         const values = getValues();
         const composedTx = composedLevels ? composedLevels[selectedFee] : undefined;
         if (composedTx?.type === 'final') {
-            const result = await dispatch(
-                signTransaction(values, composedTx as PrecomposedTransactionFinal),
-            );
+            const result = await dispatch(signTransaction(values, composedTx));
 
             if (result?.success) {
                 clearForm();

--- a/packages/suite/src/hooks/suite/useLocalNetworkAccessPermission.ts
+++ b/packages/suite/src/hooks/suite/useLocalNetworkAccessPermission.ts
@@ -19,7 +19,7 @@ export const useLocalNetworkAccessPermission = () => {
                     permission.onchange = ev => {
                         if (ev?.target && 'state' in ev.target) {
                             // @ts-expect-error outdated type definitions
-                            setLocalNetworkAccessPermission(ev!.target!.state);
+                            setLocalNetworkAccessPermission(ev.target.state);
                         }
                     };
                 })

--- a/packages/suite/src/hooks/wallet/allowance/useAllowanceCompose.ts
+++ b/packages/suite/src/hooks/wallet/allowance/useAllowanceCompose.ts
@@ -108,7 +108,7 @@ export const useAllowanceCompose = ({
                 return null;
             }
 
-            return result ? { levels: result as PrecomposedLevels, feeLevel } : null;
+            return result ? { levels: result, feeLevel } : null;
         },
         onMutate: () => {
             setComposedLevels(undefined);

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 
-import type { BankAccount, CryptoId, SellFiatTrade, SellFiatTradeResponse } from 'invity-api';
+import type { BankAccount, SellFiatTrade, SellFiatTradeResponse } from 'invity-api';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { type TranslationKey, useTranslation } from '@suite/intl';
@@ -38,7 +38,6 @@ import {
 } from '@suite-common/trading';
 import { networks } from '@suite-common/wallet-config';
 import { selectBaseCurrency } from '@suite-common/wallet-core';
-import { type AccountKey } from '@suite-common/wallet-types';
 
 import { signAndPushSendFormTransactionThunk } from 'src/actions/wallet/send/sendFormThunks';
 import { submitRequestForm } from 'src/actions/wallet/trading/tradingCommonActions';
@@ -143,8 +142,8 @@ export const useTradingSellForm = ({
     const decimals = useMemo(
         () =>
             getAssetDecimals({
-                accountKey: values.sendCryptoSelect?.accountKey as AccountKey,
-                cryptoId: values.sendCryptoSelect?.id as CryptoId,
+                accountKey: values.sendCryptoSelect?.accountKey,
+                cryptoId: values.sendCryptoSelect?.id,
             }),
         [getAssetDecimals, values.sendCryptoSelect?.accountKey, values.sendCryptoSelect?.id],
     );

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellFormRedirectValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellFormRedirectValues.ts
@@ -43,7 +43,7 @@ export const useTradingSellFormRedirectValues = (
                             getContractAddressForNetworkSymbol(account.symbol, token.contract) ===
                             getContractAddressForNetworkSymbol(
                                 assetOption.networkSymbol,
-                                assetOption.contractAddress!,
+                                assetOption.contractAddress,
                             ),
                     )
                 );

--- a/packages/suite/src/hooks/wallet/useChangeDelegateForm.ts
+++ b/packages/suite/src/hooks/wallet/useChangeDelegateForm.ts
@@ -9,7 +9,6 @@ import {
 } from '@suite-common/wallet-core';
 import {
     type ChangeDelegateFormState,
-    type PrecomposedTransactionFinal,
     type SelectedAccountLoaded,
 } from '@suite-common/wallet-types';
 import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
@@ -111,9 +110,7 @@ export const useChangeDelegateForm = ({
         const values = getValues();
         const composedTx = composedLevels ? composedLevels[selectedFee] : undefined;
         if (composedTx?.type === 'final') {
-            const result = await dispatch(
-                signTransaction(values, composedTx as PrecomposedTransactionFinal),
-            );
+            const result = await dispatch(signTransaction(values, composedTx));
 
             if (result?.success) {
                 clearForm();


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@trezor/suite (hooks)`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies hooks related to three functional areas: (1) earn/staking forms (useStakeForm, useClaimForm, useWithdrawalForm), (2) trading sell forms (useTradingSellForm, useTradingSellFormRedirectValues), and (3) swap/allowance composition (useAllowanceCompose). Additionally, useLocalNetworkAccessPermission and useChangeDelegateForm are changed but map to 121+ tests each as broad global dependencies — these are likely utility-level changes that don't warrant broad test coverage. The recommended strategy focuses on directly exercising staking flows (ETH stake/unstake/claim), sell trading flows (BTC/ETH/SOL/token sell), and swap transaction composition, with medium priority for cross-chain staking tests (ADA, SOL) that may share form patterns.

<details><summary><b>Changed files (8)</b></summary>

- `packages/suite/src/hooks/earn/useClaimForm.ts`
- `packages/suite/src/hooks/earn/useStakeForm.ts`
- `packages/suite/src/hooks/earn/useWithdrawalForm.ts`
- `packages/suite/src/hooks/suite/useLocalNetworkAccessPermission.ts`
- `packages/suite/src/hooks/wallet/allowance/useAllowanceCompose.ts`
- `packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts`
- `packages/suite/src/hooks/wallet/trading/form/useTradingSellFormRedirectValues.ts`
- `packages/suite/src/hooks/wallet/useChangeDelegateForm.ts`

</details>

**Recommended tests (22)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test directly exercises the ETH unstaking and claiming flow, which uses useWithdrawalForm (unstake) and useClaimForm (claim). Changes to these hooks could break the unstake/claim transaction confirmation, amount calculation, or form submission.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the first-time ETH staking flow end-to-end, directly using useStakeForm for the staking form, amount entry, and transaction confirmation. Changes to useStakeForm could break staking initiation, amount validation, or device confirmation.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test covers staking additional ETH on an already-staked account, directly exercising useStakeForm for the stake-more form including amount input, Everstake acknowledgment, and transaction confirmation.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates the ETH staking form's input validation (min amount, max decimals, insufficient funds, percentage buttons, max button, crypto/fiat switching), which is directly powered by useStakeForm.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test exercises the full BTC sell flow including form fill, best offer confirmation, trade request payload, and send initiation. It directly exercises useTradingSellForm and useTradingSellFormRedirectValues for the sell form logic and redirect handling.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test covers selling ETH with custom gas fees through the sell form, directly using useTradingSellForm for form logic and fee handling, and useTradingSellFormRedirectValues for redirect after trade confirmation.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — This test covers selling an ERC-20 token (USDC) through the sell flow, directly exercising useTradingSellForm for token sell form logic and useTradingSellFormRedirectValues for post-trade redirect handling.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test covers the full SOL sell flow including form fill, best offer, confirmation, send, and toast verification. It directly uses useTradingSellForm for the sell form and useTradingSellFormRedirectValues for redirect logic.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test validates sell form input validation (decimal limits, insufficient funds, percentage buttons, max amount, currency switching) which is directly powered by useTradingSellForm.

</details>

<details><summary>🟡 <b>Medium priority (12)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — This test covers Cardano staking reward claiming. While useClaimForm is primarily for ETH, changes to the claim form hook pattern could indirectly affect the Cardano claim flow if shared utilities or patterns were refactored.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This test covers Cardano staking initiation. Changes to useStakeForm could affect shared staking patterns used by Cardano staking if the hook is a shared dependency.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — This test covers Cardano unstaking. Changes to useWithdrawalForm could affect shared unstaking patterns if they share infrastructure with Cardano's unstake flow.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test covers SOL initial staking. Changes to useStakeForm could affect the Solana staking flow if the form hook is shared across networks.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — This test covers staking more SOL on an already-staked account. Changes to useStakeForm could affect stake-more functionality if the hook is shared.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — This test covers SOL unstaking and claiming. Changes to useWithdrawalForm and useClaimForm could affect the Solana unstake/claim flow.
- `suite/e2e/tests/trading/navigation.test.ts` — This test verifies that sell form navigation from various entry points (dashboard, account, global header, token) correctly opens the sell form. Changes to useTradingSellForm could affect form initialization when navigating to the sell tab.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Swap flows use useAllowanceCompose for composing swap transactions. Changes to this hook could affect swap transaction composition and fee calculation.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This swap test uses useAllowanceCompose for composing the swap transaction. Changes to allowance composition could affect the swap send flow.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Token-to-coin swaps rely on useAllowanceCompose for transaction composition. Changes could affect how allowances are computed for token swaps.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Token-to-token swaps (USDT to USDC) use useAllowanceCompose. Changes to the allowance compose hook could break token swap transaction preparation.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test validates custom Ethereum fee settings during swap, which involves useAllowanceCompose for transaction composition with custom gas parameters.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test covers Bitcoin custom fees during swap. useAllowanceCompose is primarily relevant for token allowances, but changes could indirectly affect swap transaction composition infrastructure.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/hooks/suite/useLocalNetworkAccessPermission.ts`
- `packages/suite/src/hooks/wallet/useChangeDelegateForm.ts`

_Updated: 2026-06-29T14:31:49.165Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-suite-hooks/web/](https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-suite-hooks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/no-unnec-assert-suite-hooks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/no-unnec-assert-suite-hooks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T14:36:12.541Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T14:35:11.782Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->