### PR TITLE
refactor(suite): remove unnecessary type assertions (@trezor/suite (actions, utils, support, services, storage))

### DIFF
--- a/packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts
+++ b/packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts
@@ -60,7 +60,7 @@ export const bluetoothSlice = createSliceWithExtraDeps({
 
         builder
             .addCase(deviceActions.deviceDisconnect, (state, action) => {
-                commonReducer(state, action as AnyAction);
+                commonReducer(state, action);
 
                 state.knownDevices = state.knownDevices.map(device => {
                     if (device.deviceId === action.payload.id) {

--- a/packages/suite/src/actions/device/deviceSlice.ts
+++ b/packages/suite/src/actions/device/deviceSlice.ts
@@ -47,7 +47,7 @@ export const deviceSlice = createSliceWithExtraDeps({
                 isAnyOf(deviceActions.connectDevice, deviceActions.connectUnacquiredDevice),
                 (state, action) => {
                     state.isConnectionModalOpen = false;
-                    commonReducer(state, action as AnyAction);
+                    commonReducer(state, action);
                 },
             )
             .addDefaultCase((state, action) => {

--- a/packages/suite/src/actions/suite/protocolActions.ts
+++ b/packages/suite/src/actions/suite/protocolActions.ts
@@ -23,7 +23,7 @@ import type { SendFormState } from 'src/reducers/suite/protocolReducer';
 import { asSuiteServices } from 'src/support/extraDependencies';
 import { type Dispatch, type GetState } from 'src/types/suite';
 import { parseUri } from 'src/utils/suite/parseUri';
-import { type CoinProtocolInfo, getProtocolInfo } from 'src/utils/suite/protocol';
+import { getProtocolInfo } from 'src/utils/suite/protocol';
 
 import { PROTOCOL } from './constants';
 
@@ -71,7 +71,7 @@ export const handleProtocolRequest =
         }
 
         if (protocol && !('error' in protocol) && getNetworkSymbolForProtocol(protocol.scheme)) {
-            const { scheme, amount, address, token, tokenAmount } = protocol as CoinProtocolInfo;
+            const { scheme, amount, address, token, tokenAmount } = protocol;
 
             dispatch(saveCoinProtocol(scheme, address, amount, token, tokenAmount));
             dispatch(

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -1,7 +1,6 @@
 import { createAction } from '@reduxjs/toolkit';
 
 import { asTypedDesktopAnalytics, events } from '@suite/analytics';
-import type { TranslationKey } from '@suite/intl';
 import { openDeferredModal } from '@suite/modal';
 import { selectRouterUrl } from '@suite/router';
 import { suiteSettingsActions } from '@suite/settings';
@@ -133,7 +132,7 @@ export const toggleTor =
             dispatch(
                 notificationsActions.addToast({
                     type: 'tor-toggle-error',
-                    error: ipcResponse.error as TranslationKey,
+                    error: ipcResponse.error,
                 }),
             );
 

--- a/packages/suite/src/actions/wallet/trading/tradingCommonActions.ts
+++ b/packages/suite/src/actions/wallet/trading/tradingCommonActions.ts
@@ -56,7 +56,7 @@ export const convertDrafts = () => (dispatch: Dispatch, getState: GetState) => {
             const conversion = areSatsSelected
                 ? convertAmountUnitsToSubunits
                 : convertAmountSubunitsToUnits;
-            const decimals = getAccountDecimals(relatedAccount.symbol)!;
+            const decimals = getAccountDecimals(relatedAccount.symbol);
 
             if (draft.cryptoInput) {
                 draft.cryptoInput = conversion(draft.cryptoInput, decimals);

--- a/packages/suite/src/services/coinjoin/coinjoinService.ts
+++ b/packages/suite/src/services/coinjoin/coinjoinService.ts
@@ -36,7 +36,7 @@ export class CoinjoinService {
     private static instances: PartialRecord<CoinjoinSymbol, CoinjoinServiceInstance> = {};
 
     static async createInstance({ symbol, prison, settings }: CoinjoinCreateInstance) {
-        if (this.instances[symbol]) return this.instances[symbol] as CoinjoinServiceInstance;
+        if (this.instances[symbol]) return this.instances[symbol];
         const config = settings ?? getCoinjoinConfig(symbol);
         const [backend, client] = await loadInstance({ ...config, prison });
         const instance = { backend, client };

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -98,7 +98,7 @@ export const runLegacyMigrations: OnUpgradeFunc<SuiteDBSchema> = async (
 
         await updateAll(transaction, 'accounts', account => {
             account.metadata = {
-                key: '' as AccountKey,
+                key: '',
                 // @ts-expect-error
                 fileName: '',
                 aesKey: '',

--- a/packages/suite/src/support/suite/useConnectPopup.tsx
+++ b/packages/suite/src/support/suite/useConnectPopup.tsx
@@ -104,7 +104,7 @@ export const useConnectPopup = (
                 dispatch(
                     connectPopupCallThunk({
                         method: method as CallMethodKeys,
-                        payload: params as Parameters<typeof connectPopupCallThunk>[0]['payload'],
+                        payload: params,
                         source: {
                             type: CALL_SOURCE_WEB,
                             origin: popupLink.origin,

--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -314,7 +314,7 @@ const prepareContent = (
 
             return [...targets, ...tokens, ...internalTransfers, ...cardanoStaking];
         })
-        .filter(isNotNull) as Fields[];
+        .filter(isNotNull);
 };
 
 export const sanitizeCsvValue = (value: string): string => {

--- a/packages/suite/src/utils/wallet/trading/tradingTypingUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/tradingTypingUtils.ts
@@ -200,14 +200,14 @@ export const getSelectedQuote = (
 
     if (isTradingBuyContext(context)) {
         return getQuotesFilteredByProviderAndPaymentMethod<BuyTrade>(
-            context.quotes as BuyTrade[],
+            context.quotes,
             provider,
             paymentMethod?.value,
         )?.[0];
     }
 
     return getQuotesFilteredByProviderAndPaymentMethod<SellFiatTrade>(
-        context.quotes as SellFiatTrade[],
+        context.quotes,
         provider,
         paymentMethod?.value,
     )?.[0];


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@trezor/suite (actions, utils, support, services, storage)`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set touches two distinct areas: (1) transaction export utilities (exportTransactionsUtils.ts) and (2) trading/coinmarket infrastructure (tradingCommonActions.ts, tradingTypingUtils.ts). The remaining changed files (deviceSlice, suiteActions, protocolActions, desktopBluetoothReducer, coinjoinService, useConnectPopup, storage migrations) all map to 121 tests each, indicating they are broad global dependencies — changes there are unlikely to cause test-specific regressions without more targeted evidence. The recommended strategy focuses on the two high-impact areas: export transaction tests and trading flow tests, with a storage migration test included at low priority as a safety check.

<details><summary><b>Changed files (10)</b></summary>

- `packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts`
- `packages/suite/src/actions/device/deviceSlice.ts`
- `packages/suite/src/actions/suite/protocolActions.ts`
- `packages/suite/src/actions/suite/suiteActions.ts`
- `packages/suite/src/actions/wallet/trading/tradingCommonActions.ts`
- `packages/suite/src/services/coinjoin/coinjoinService.ts`
- `packages/suite/src/storage/migrations/index.ts`
- `packages/suite/src/support/suite/useConnectPopup.tsx`
- `packages/suite/src/utils/wallet/exportTransactionsUtils.ts`
- `packages/suite/src/utils/wallet/trading/tradingTypingUtils.ts`

</details>

**Recommended tests (21)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — Directly exercises exportTransactionsUtils.ts which was changed. This test exports transactions in PDF, CSV, and JSON formats across multiple coin networks, making it the primary validation for changes to the export utility.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test explicitly exports a CSV file and verifies its content contains labeled output data, directly exercising exportTransactionsUtils.ts. A regression in the export utility would cause the CSV content assertion to fail.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Exercises the full buy trading flow including trade request payloads and confirmation. Changes to tradingCommonActions.ts and tradingTypingUtils.ts directly affect trading action dispatching and type handling used in the buy flow.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Full sell flow test that validates trade request payloads, confirmation details, and device prompts. Both tradingCommonActions.ts (action dispatching) and tradingTypingUtils.ts (type utilities) are directly involved in the sell trading pipeline.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Comprehensive swap flow test (SOL→BTC) with status polling, confirmation, and toast verification. tradingCommonActions.ts governs swap trade dispatching and tradingTypingUtils.ts handles type transformations used throughout the swap flow.

</details>

<details><summary>🟡 <b>Medium priority (14)</b></summary>

- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests the ETH buy flow including asset selection, quote display, and trade confirmation. Changes to trading common actions and typing utils could affect the buy flow's data handling for Ethereum specifically.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Tests buying a Solana SPL token (JUP) with specific trade payload verification. tradingTypingUtils.ts changes could affect how token-level crypto IDs and types are resolved in the buy flow.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests ETH sell flow with custom gas fees and trade confirmation. Changes to tradingCommonActions affect how sell trades are dispatched, and tradingTypingUtils affects type handling for ETH sell quotes.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Full Solana sell flow with trade payload verification, watch polling, and status transitions. Both changed trading files are in the critical path for sell trade dispatch and type handling.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests SOL→USDC swap with receive account selection and confirmation. tradingTypingUtils.ts changes could affect how token crypto IDs are resolved in cross-asset swaps.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests USDT→BTC swap across networks. tradingTypingUtils handles type transformations for token-to-coin swaps which is the exact scenario this test covers.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests buy form validation edge cases (max/min limits, empty quotes). tradingTypingUtils changes could affect how quote data types are parsed and validated in error scenarios.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation (decimals, insufficient funds, percentage buttons). tradingTypingUtils changes could affect how amount types are handled in the sell form validation logic.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation to buy/sell/swap forms from various entry points. tradingCommonActions and tradingTypingUtils affect how trading state is initialized when navigating to trading views.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests BTC swap with custom fee settings. tradingCommonActions handles the composed transaction info state that this test verifies via Redux store inspection.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests ETH swap with custom gas parameters. tradingCommonActions manages the composedTransactionInfo Redux state that this test directly reads and asserts on.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token (USDC). tradingTypingUtils changes could affect how token types are resolved in the sell flow for ERC-20 tokens specifically.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests SPL token-to-token swap (USDT→USDC). tradingTypingUtils handles the type resolution for token crypto IDs which is critical for same-network token swaps.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — Tests CSV import into the send form. While this tests importing rather than exporting, changes to exportTransactionsUtils.ts may share CSV parsing/formatting logic that could affect import behavior.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swapping to a disabled network asset. tradingTypingUtils changes could affect how crypto IDs for disabled networks are resolved, though this is a narrow edge case.
- `suite/e2e/tests/suite/initial-run.test.ts` — Tests initial run persistence across reloads. Changes to storage/migrations/index.ts could affect how the initial run state is migrated, potentially breaking the persistence behavior this test validates.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts`
- `packages/suite/src/actions/suite/protocolActions.ts`
- `packages/suite/src/services/coinjoin/coinjoinService.ts`
- `packages/suite/src/support/suite/useConnectPopup.tsx`

_Updated: 2026-06-29T14:32:22.306Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-suite-actions/web/](https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-suite-actions/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/no-unnec-assert-suite-actions&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/no-unnec-assert-suite-actions&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T14:37:11.306Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T14:35:28.780Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->