### PR TITLE
refactor(wallet-core): remove unnecessary type assertions (@suite-common/wallet-core)

### DIFF
--- a/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
@@ -2,7 +2,6 @@ import { type PayloadAction } from '@reduxjs/toolkit';
 
 import { createReducerWithExtraDeps, createWeakMapSelector } from '@suite-common/redux-utils';
 import {
-    type BackendType,
     type NetworkSymbol,
     getNetworkOptional,
     networksCollection,
@@ -153,12 +152,12 @@ export const prepareBlockchainReducer = createReducerWithExtraDeps(
                     delete state[symbol].backends.selected;
                 } else if (!action.payload.urls.length) {
                     delete state[symbol].backends.selected;
-                    delete state[symbol].backends.urls?.[type as BackendType];
+                    delete state[symbol].backends.urls?.[type];
                 } else {
-                    state[symbol].backends.selected = type as BackendType;
+                    state[symbol].backends.selected = type;
                     state[symbol].backends.urls = {
                         ...state[symbol].backends.urls,
-                        [type as BackendType]: action.payload.urls,
+                        [type]: action.payload.urls,
                     };
                 }
             })

--- a/suite-common/wallet-core/src/discovery/discoveryReducer.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryReducer.ts
@@ -1,5 +1,5 @@
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
-import { type Discovery, type DiscoveryStatus, type Timestamp } from '@suite-common/wallet-types';
+import { type Discovery, type DiscoveryStatus } from '@suite-common/wallet-types';
 import { type DeviceUniquePath } from '@trezor/connect';
 
 import { discoveryActions } from './discoveryActions';
@@ -47,7 +47,7 @@ export const prepareDiscoveryReducer = createReducerWithExtraDeps(
                 isAddingHiddenWallet: payload.isAddingHiddenWallet,
                 isAddingExistingWallet: payload.isAddingExistingWallet,
                 useScopedCallIds: payload.useScopedCallIds,
-                startTimestamp: Date.now() as Timestamp,
+                startTimestamp: Date.now(),
             };
         });
         builder.addCase(discoveryActions.updateDiscovery, (state, { payload }) => {

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts
@@ -95,10 +95,10 @@ export const selectTickerFromAccounts = (
 
     return pipe(
         accounts,
-        A.map(account => [
+        A.map((account): TickerId[] => [
             {
                 symbol: account.symbol,
-            } as TickerId,
+            },
             ...(account.tokens || [])
                 .filter(token => new BigNumber(token.balance ?? '0').gt(0))
                 .map(

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -383,7 +383,7 @@ export const periodicFetchFiatRatesThunk = createThunk(
         const isWindowVisible = selectIsWindowVisible(getState());
 
         if (ratesTimeouts[rateType]) {
-            clearTimeout(ratesTimeouts[rateType]!);
+            clearTimeout(ratesTimeouts[rateType]);
         }
 
         if (isWindowVisible) {

--- a/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
@@ -158,7 +158,7 @@ export const composeBitcoinTransactionFeeLevelsThunk = createThunk<
         response.payload.forEach((tx, index) => {
             // @ts-expect-error: indexing with noUncheckedIndexedAccess
             const predefinedLevel: (typeof predefinedLevels)[number] = predefinedLevels[index];
-            const feeLabel = predefinedLevel.label as FeeLevel['label'];
+            const feeLabel = predefinedLevel.label;
             resultLevels[feeLabel] = tx as PrecomposedTransaction;
         });
 

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -327,7 +327,7 @@ export const composeEthereumTransactionFeeLevelsThunk = createThunk<
         response.forEach((tx, index) => {
             // @ts-expect-error: indexing with noUncheckedIndexedAccess
             const predefinedLevel: (typeof predefinedLevels)[number] = predefinedLevels[index];
-            const feeLabel = predefinedLevel.label as FeeLevel['label'];
+            const feeLabel = predefinedLevel.label;
             resultLevels[feeLabel] = tx;
         });
 

--- a/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
@@ -163,7 +163,7 @@ export const composeRippleStellarTransactionFeeLevelsThunk = createThunk<
         response.forEach((tx, index) => {
             // @ts-expect-error: indexing with noUncheckedIndexedAccess
             const predefinedLevel: (typeof predefinedLevels)[number] = predefinedLevels[index];
-            const feeLabel = predefinedLevel.label as FeeLevel['label'];
+            const feeLabel = predefinedLevel.label;
             resultLevels[feeLabel] = tx;
         });
 

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -297,7 +297,7 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
         response.forEach((tx, index) => {
             // @ts-expect-error: indexing with noUncheckedIndexedAccess
             const predefinedLevel: (typeof predefinedLevels)[number] = predefinedLevels[index];
-            const feeLabel = predefinedLevel.label as FeeLevel['label'];
+            const feeLabel = predefinedLevel.label;
             resultLevels[feeLabel] = tx;
         });
 

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -132,7 +132,7 @@ export const convertSendFormDraftsBtcAmountUnitsThunk = createThunk(
                     : convertAmountSubunitsToUnits;
 
             const updatedDraft = cloneObject(draft);
-            const amountDecimals = getAccountDecimals(relatedAccount.symbol)!;
+            const amountDecimals = getAccountDecimals(relatedAccount.symbol);
 
             updatedDraft.outputs.forEach(output => {
                 if (output.amount && areSatsSupported) {

--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
@@ -363,7 +363,7 @@ export const selectTransactionsWithMissingRates = (
         D.mapWithKey((key, txs) => ({
             account: selectAccountByKey(state, key as AccountKey),
             txs: txs.filter(tx => {
-                const fiatRateKey = getFiatRateKey(tx.symbol, localCurrency as BaseCurrencyCode);
+                const fiatRateKey = getFiatRateKey(tx.symbol, localCurrency);
                 const roundedTimestamp = roundTimestampToNearestPastHour(tx.blockTime as Timestamp);
                 const historicRate = historicFiatRates?.[fiatRateKey]?.[roundedTimestamp];
 

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -26,7 +26,7 @@ import {
     replaceEthereumSpecific,
     tryGetAccountIdentity,
 } from '@suite-common/wallet-utils';
-import { type TokenInfo, type TokenStandard } from '@trezor/blockchain-link-types';
+import { type TokenInfo } from '@trezor/blockchain-link-types';
 import { blockbookUtils } from '@trezor/blockchain-link-utils';
 import TrezorConnect, {
     type AccountInfo,
@@ -311,7 +311,7 @@ const buildFakePendingEvmTx = ({
     if (token) {
         const tokenTransfer: TokenTransfer = {
             type: 'sent',
-            standard: token.standard as TokenStandard,
+            standard: token.standard,
             amount,
             from: fromAddress,
             to: toAddress,


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@suite-common/wallet-core`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-wallet-core/web/](https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-wallet-core/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/no-unnec-assert-wallet-core&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/no-unnec-assert-wallet-core&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/no-unnec-assert-wallet-core&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T14:37:57.637Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T14:36:01.000Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->