### PR TITLE
refactor(connect): remove unnecessary type assertions (@trezor/connect)

### DIFF
--- a/packages/connect/src/api/authenticateDevice.ts
+++ b/packages/connect/src/api/authenticateDevice.ts
@@ -116,7 +116,7 @@ export default class AuthenticateDevice extends AbstractMethod<
         for (const { name, type, certSizes, sigSize } of proofTypes) {
             for (const [i, certSize] of certSizes.entries()) {
                 const cert = await getChunk({ proof_type: type, index: i }, certSize);
-                (authenticityProof[`${name}_certificates`] as string[]).push(cert);
+                authenticityProof[`${name}_certificates`].push(cert);
             }
 
             if (sigSize) {

--- a/packages/connect/src/api/cardano/cardanoUtils.ts
+++ b/packages/connect/src/api/cardano/cardanoUtils.ts
@@ -55,14 +55,14 @@ export const prepareCertificates = (certs: CardanoCertificate[]) => {
                     convertedCerts.push({
                         type: cert.type,
                         dRep: {
-                            type: cert.dRep!.type,
+                            type: cert.dRep.type,
                         },
                     });
                 } else if (cert.dRep?.type === PROTO.CardanoDRepType.KEY_HASH) {
                     convertedCerts.push({
                         type: cert.type,
                         dRep: {
-                            type: cert.dRep!.type,
+                            type: cert.dRep.type,
                             keyHash: cert.dRep.keyHash!,
                         },
                     });
@@ -70,8 +70,8 @@ export const prepareCertificates = (certs: CardanoCertificate[]) => {
                     convertedCerts.push({
                         type: cert.type,
                         dRep: {
-                            type: cert.dRep!.type,
-                            scriptHash: cert.dRep!.scriptHash!,
+                            type: cert.dRep.type,
+                            scriptHash: cert.dRep.scriptHash!,
                         },
                     });
                 }

--- a/packages/connect/src/api/common/paramsValidator.ts
+++ b/packages/connect/src/api/common/paramsValidator.ts
@@ -169,7 +169,7 @@ const getCoinRules = (coins: CoinInfo[], currentRange: FirmwareRange): FirmwareR
     coins.map(({ support = typedObjectTransformValues(DEFAULT_FIRMWARE_RANGE, () => false) }) => ({
         ...currentRange,
         ...typedObjectTransformValues(support, value => ({
-            min: (value || '0') as FirmwareBoundary,
+            min: value || '0',
             max: '0' as const,
         })),
     }));

--- a/packages/connect/src/api/firmware/verifyEntropy.ts
+++ b/packages/connect/src/api/firmware/verifyEntropy.ts
@@ -34,7 +34,7 @@ const roundFunction = async (i: number, passphrase: Buffer, e: number, salt: Buf
     // return crypto.pbkdf2Sync(data, Buffer.concat([salt, r]), iterations, r.length, 'sha256');
 
     // Nodejs + WebCrypto equivalent
-    const { subtle } = crypto as Crypto;
+    const { subtle } = crypto;
     const key = await subtle.importKey('raw', data, 'PBKDF2', false, ['deriveBits']);
     const bits = await subtle.deriveBits(
         {

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -468,7 +468,7 @@ export const getReleaseInfo = ({
     }
     const { min_firmware_version, min_bootloader_version } = release;
 
-    const changelog = getChangelog(releasesOfDevice, features as StrictFeatures);
+    const changelog = getChangelog(releasesOfDevice, features);
 
     let isNewer = false;
     let requiresIntermediary = false;

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -859,7 +859,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
         if (unitColor) {
             const deviceUnitColor = unitColor.toString();
             if (deviceUnitColor in deviceInfo.colors) {
-                this.color = (deviceInfo.colors as Record<string, string>)[deviceUnitColor];
+                this.color = deviceInfo.colors[deviceUnitColor];
             }
         }
     }

--- a/packages/connect/src/device/workflow/changeLanguage.ts
+++ b/packages/connect/src/device/workflow/changeLanguage.ts
@@ -22,8 +22,8 @@ const uploadTranslationData = async (device: IDevice, payload: ArrayBuffer | nul
         .typedCall('ChangeLanguage', ['DataChunkRequest', 'Success'], { data_length: length });
 
     while (response.type !== 'Success') {
-        const start = response.message.data_offset!;
-        const end = response.message.data_offset! + response.message.data_length!;
+        const start = response.message.data_offset;
+        const end = response.message.data_offset + response.message.data_length;
         const chunk = payload.slice(start, end);
 
         response = await device

--- a/packages/connect/src/utils/assetUtils.ts
+++ b/packages/connect/src/utils/assetUtils.ts
@@ -19,14 +19,6 @@ export class HttpRequestError extends Error {
     }
 }
 
-type FirmwareAssetMap = {
-    [device: string]: {
-        [type: string]: {
-            [file: string]: FirmwareRelease;
-        };
-    };
-};
-
 export const getReleasesAssetByDeviceModelAndFirmwareType = (
     deviceModel: DeviceModelInternal,
     firmwareType: FirmwareType,
@@ -35,9 +27,7 @@ export const getReleasesAssetByDeviceModelAndFirmwareType = (
         firmwareType === FirmwareType.BitcoinOnly ? 'bitcoinonly' : 'universal';
 
     const availableReleasesRecord =
-        (firmwareAssets as FirmwareAssetMap)?.[deviceModel.toLowerCase()]?.[
-            firmwareTypeInFileName
-        ] ?? {};
+        firmwareAssets?.[deviceModel.toLowerCase()]?.[firmwareTypeInFileName] ?? {};
 
     return Object.values(availableReleasesRecord).sort((a, b) =>
         versionUtils.isNewer(b.version, a.version) ? 1 : -1,
@@ -54,9 +44,7 @@ export const getReleaseAsset = (
     const fileName = `${deviceModel.toLowerCase()}-${version.join('.')}-${firmwareTypeInFileName}`;
     const deviceModelLower = deviceModel.toLowerCase();
 
-    const asset = (firmwareAssets as FirmwareAssetMap)?.[deviceModelLower]?.[
-        firmwareTypeInFileName
-    ]?.[fileName];
+    const asset = firmwareAssets?.[deviceModelLower]?.[firmwareTypeInFileName]?.[fileName];
 
     return asset as FirmwareRelease;
 };

--- a/packages/connect/src/utils/assets.native.ts
+++ b/packages/connect/src/utils/assets.native.ts
@@ -21,13 +21,13 @@ export function httpRequest<T extends HttpRequestType>(
                     throw new HttpRequestError(response);
                 }
                 if (type === 'binary') {
-                    return response.arrayBuffer() as unknown as HttpRequestReturnType<T>;
+                    return response.arrayBuffer();
                 }
                 if (type === 'json') {
-                    return response.json() as unknown as HttpRequestReturnType<T>;
+                    return response.json();
                 }
 
-                return response.text() as unknown as HttpRequestReturnType<T>;
+                return response.text();
             })
             .catch(error => {
                 throw error;

--- a/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
+++ b/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
@@ -61,7 +61,7 @@ export const getOnlineFirmwareBaseUrl = (
     if (!firmwareChannel) {
         return {
             ...FIRMWARE_REMOTE_BASE_URLS['production'],
-            firmwareChannel: 'production' as FirmwareChannel,
+            firmwareChannel: 'production',
         };
     }
 


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@trezor/connect`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in the `@trezor/connect` package, spanning device communication (Device.ts), firmware utilities (firmwareInfo.ts, firmwareReleaseConfigUtils.ts, verifyEntropy.ts), Cardano-specific utilities (cardanoUtils.ts), parameter validation (paramsValidator.ts), device language workflow (changeLanguage.ts), asset utilities (assetUtils.ts), and device authentication (authenticateDevice.ts). Most of these files are broadly imported across 100+ tests, so the testing strategy focuses on tests with direct functional relevance: Cardano-specific tests for cardanoUtils changes, entropy check tests for verifyEntropy changes, firmware-related onboarding tests, and TrezorConnect API tests for paramsValidator changes. The `assets.native.ts` file is a React Native-specific module with no E2E coverage in this web/desktop test suite.

<details><summary><b>Changed files (10)</b></summary>

- `packages/connect/src/api/authenticateDevice.ts`
- `packages/connect/src/api/cardano/cardanoUtils.ts`
- `packages/connect/src/api/common/paramsValidator.ts`
- `packages/connect/src/api/firmware/verifyEntropy.ts`
- `packages/connect/src/data/firmwareInfo.ts`
- `packages/connect/src/device/Device.ts`
- `packages/connect/src/device/workflow/changeLanguage.ts`
- `packages/connect/src/utils/assetUtils.ts`
- `packages/connect/src/utils/assets.native.ts`
- `packages/connect/src/utils/firmwareReleaseConfigUtils.ts`

</details>

**Recommended tests (17)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test directly exercises entropy verification failure handling during wallet creation. The changed file `verifyEntropy.ts` is the core implementation for this flow, and this test validates both entropy-mismatch errors and transport errors during entropy checks.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test directly exercises Cardano address derivation and verification behind a passphrase wallet. Changes to `cardanoUtils.ts` could affect Cardano address formatting, derivation, or validation which this test explicitly asserts on.
- `suite/e2e/tests/staking/ada/claim.test.ts` — This test exercises Cardano staking claim transactions including device confirmation with withdrawal details, account paths, and amounts. Changes to `cardanoUtils.ts` could affect transaction construction or address formatting for Cardano staking operations.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This test exercises the full Cardano staking flow including stake key registration, delegation, and vote delegation confirmations on the device. Changes to `cardanoUtils.ts` directly impact Cardano transaction building used in staking.
- `suite/e2e/tests/wallet/cardano.test.ts` — This test verifies Cardano account details, public key display, send form, and receive address confirmation on the device. Changes to `cardanoUtils.ts` could affect address derivation, xpub display, or Cardano-specific formatting.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/firmware/custom-firmware.test.ts` — This test exercises custom firmware installation which relies on firmware info and validation. Changes to `firmwareInfo.ts` and `firmwareReleaseConfigUtils.ts` could affect firmware version detection or compatibility checks during installation.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test specifically validates firmware readiness detection during onboarding. Changes to `firmwareInfo.ts` and `firmwareReleaseConfigUtils.ts` could alter how firmware readiness is determined.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — This test exercises the full wallet creation flow including firmware steps and entropy-based seed generation. Changes to `verifyEntropy.ts` and `Device.ts` could affect the create wallet and backup flow.
- `suite/e2e/tests/settings/general.test.ts` — This test changes the application language which triggers `changeLanguage.ts` on the device. Changes to the changeLanguage workflow could break language switching in settings.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — This test exercises Cardano unstaking including stake key deregistration confirmation on the device. Changes to `cardanoUtils.ts` could affect unstaking transaction construction.
- `suite/e2e/tests/trezor-connect/error.test.ts` — This test validates TrezorConnect error handling for invalid derivation paths. Changes to `paramsValidator.ts` directly affect parameter validation which determines what error messages are shown for invalid inputs.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This test exercises TrezorConnect.getAddress with device confirmation and verification. Changes to `paramsValidator.ts` and `Device.ts` could affect address export parameter validation and device interaction flow.
- `suite/e2e/tests/wallet/public-keys.test.ts` — This test verifies public keys (XPUBs) for BTC, LTC, and ADA. Changes to `cardanoUtils.ts` could affect Cardano public key derivation, and `paramsValidator.ts` changes could affect the getPublicKey API validation.

</details>

<details><summary>🟢 <b>Low priority (4)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test captures DeviceConnect events with firmware version and device model info. Changes to `Device.ts` and `authenticateDevice.ts` could affect the device info reported in analytics events.
- `suite/e2e/tests/settings/autodetect.test.ts` — This test validates locale/theme autodetection during onboarding. Changes to `changeLanguage.ts` could affect how language autodetection interacts with the device language workflow.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This test exercises Ethereum transaction signing which uses paramsValidator for input validation and Device.ts for device communication. Changes could affect the signing confirmation flow.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — This test exercises Bitcoin transaction signing with parameter validation. Changes to `paramsValidator.ts` could affect how transaction inputs are validated before signing.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/connect/src/utils/assets.native.ts`

_Updated: 2026-06-29T14:32:57.933Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/no-unnec-assert-connect&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/no-unnec-assert-connect&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/no-unnec-assert-connect&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-connect/web/](https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-connect/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T14:37:27.576Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->