### PR TITLE
refactor(suite-native): remove unnecessary type assertions (@suite-native/module-trading)

### DIFF
--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -90,7 +90,7 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: 
                                     parameter: 'cryptoTo',
                                 },
                             });
-                            prevCryptoId.current = asset?.cryptoId as CryptoId | undefined;
+                            prevCryptoId.current = asset?.cryptoId;
                             setValue('cryptoValue', undefined, { shouldValidate: true });
                             dispatch(
                                 prevSymbol === symbol

--- a/suite-native/module-trading/src/hooks/buy/useBuyQuotes.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyQuotes.ts
@@ -2,7 +2,6 @@ import { type RefObject, useCallback, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { isFulfilled } from '@reduxjs/toolkit';
-import type { BuyTrade } from 'invity-api';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { invariant } from '@suite-common/suite-utils';
@@ -162,7 +161,7 @@ const useBuyQuotesThunk = (
         const requestPromise = dispatch(buyThunks.handleRequestThunk(payload));
         quotesPromiseRef.current = requestPromise;
         const action = await requestPromise;
-        if (isFulfilled(action) && (action.payload as BuyTrade[]).length > 0) {
+        if (isFulfilled(action) && action.payload.length > 0) {
             analytics.report({
                 type: events.tradingQuoteReceivedEvent.name,
                 payload: {

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
@@ -132,7 +132,7 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, watch }: ExchangeFor
                             },
                         });
 
-                        prevSendCryptoId.current = sendAsset?.cryptoId as CryptoId | undefined;
+                        prevSendCryptoId.current = sendAsset?.cryptoId;
                         setValue('sendCryptoAmount', undefined, { shouldValidate: true });
                         if (sendAsset?.cryptoId === receiveAsset?.cryptoId) {
                             setValue('receiveAsset', undefined);
@@ -154,9 +154,7 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, watch }: ExchangeFor
                             },
                         });
 
-                        prevReceiveCryptoId.current = receiveAsset?.cryptoId as
-                            | CryptoId
-                            | undefined;
+                        prevReceiveCryptoId.current = receiveAsset?.cryptoId;
                         dispatch(
                             prevReceiveSymbol === receiveSymbol
                                 ? exchangeActions.receiveTokenChanged()

--- a/suite-native/module-trading/src/hooks/general/form/useCountryChangeEffect.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useCountryChangeEffect.ts
@@ -2,7 +2,6 @@ import { useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 
 import {
-    type TradingCountryCode,
     type TradingCountryOption,
     type TradingCountrySubdivisionOption,
 } from '@suite-common/trading';
@@ -16,7 +15,7 @@ export const useCountryChangeEffect = (watch: CountrySubdivisionFormWatch) => {
     const dispatch = useDispatch();
 
     const [countryOption, countrySubdivisionOption] = watch(['country', 'countrySubdivision']);
-    const country = countryOption?.value as TradingCountryCode | undefined;
+    const country = countryOption?.value;
     const countrySubdivision = countrySubdivisionOption?.value;
 
     const prevCountryCode = useRef(country);

--- a/suite-native/module-trading/src/hooks/general/useMyAssetsFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/general/useMyAssetsFilteredData.ts
@@ -13,7 +13,7 @@ const filterCallback = (item: MyAssetRow, filterValue: string): boolean => {
     }
 
     const normalized = normalizeForSearch(filterValue);
-    const asset = item as MyAssetTradeable;
+    const asset = item;
 
     return (
         normalizeForSearch(asset.name).includes(normalized) ||
@@ -72,9 +72,7 @@ export const useMyAssetsFilteredData = (sections: SectionListData<MyAssetRow, Ac
             Array.from(
                 new Set(
                     sections.flatMap(section =>
-                        section.data
-                            .filter(item => item.isEnabled)
-                            .map(item => (item as MyAssetTradeable).symbol),
+                        section.data.filter(item => item.isEnabled).map(item => item.symbol),
                     ),
                 ),
             ),

--- a/suite-native/module-trading/src/hooks/general/useProviderFilters.ts
+++ b/suite-native/module-trading/src/hooks/general/useProviderFilters.ts
@@ -2,11 +2,7 @@ import { useMemo, useState } from 'react';
 
 import { type TradingTradeType } from '@suite-common/trading';
 import { useTranslate } from '@suite-native/intl';
-import type {
-    FilterItem,
-    SectionListData,
-    SectionListDataArray,
-} from '@suite-native/trading-atoms';
+import type { FilterItem, SectionListData } from '@suite-native/trading-atoms';
 import { type QuotesByCategories, type QuotesCategory } from '@suite-native/trading-types';
 import { exhaustive } from '@trezor/type-utils';
 
@@ -34,7 +30,7 @@ export const useProviderFilters = <T extends TradingTradeType>(
 
             return {
                 key: category,
-                data: items as SectionListDataArray<T>,
+                data: items,
                 label: '',
                 sectionData: typedCategory,
             };

--- a/suite-native/module-trading/src/hooks/sell/useSellForm.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellForm.ts
@@ -70,7 +70,7 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: 
                                     parameter: 'cryptoFrom',
                                 },
                             });
-                            prevCryptoId.current = sendAsset?.cryptoId as CryptoId | undefined;
+                            prevCryptoId.current = sendAsset?.cryptoId;
                             setValue('cryptoStringAmount', undefined, { shouldValidate: true });
                             dispatch(sellActions.sendAssetChanged());
                         }

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -205,7 +205,7 @@ export const composeTradingTransactionThunk = createThunk(
                     const composed = (await dispatch(
                         enhancePrecomposedTransactionThunk({
                             transactionFormValues: formState,
-                            precomposedTransaction: selectedLevel as PrecomposedTransactionFinal,
+                            precomposedTransaction: selectedLevel,
                             selectedAccount: account,
                         }),
                     ).unwrap()) as PrecomposedTransactionFinal;
@@ -309,8 +309,7 @@ export const composeEvmApprovalFeeLevelsThunk = createThunk(
                 return rejectWithValue('Token not found in account');
             }
 
-            const approvalType =
-                approvalTypeOverride ?? ((quoteApprovalType ?? 'INFINITE') as DexApprovalType);
+            const approvalType = approvalTypeOverride ?? quoteApprovalType ?? 'INFINITE';
             const { allowanceAmount } = getAllowanceAmount({
                 rawAmount: sendStringAmount,
                 approvalType,
@@ -343,7 +342,7 @@ export const composeEvmApprovalFeeLevelsThunk = createThunk(
 
                 const selectedLevel = feeLevels[selectedFeeLevel];
                 if (selectedLevel && isFinalPrecomposedTransaction(selectedLevel)) {
-                    const composed = selectedLevel as PrecomposedTransactionFinal;
+                    const composed = selectedLevel;
 
                     dispatch(
                         tradingCommonActions.saveComposedTransactionInfo({

--- a/suite-native/module-trading/src/utils/buy/quotesUtils.ts
+++ b/suite-native/module-trading/src/utils/buy/quotesUtils.ts
@@ -3,7 +3,6 @@ import type { BuyTrade, CoinInfo, PlatformsInfo } from 'invity-api';
 import { invariant } from '@suite-common/suite-utils';
 import {
     type TradingBuyFormProps,
-    type TradingCountryOption,
     type TradingPaymentMethodListProps,
     createAssetOption,
     cryptoIdToNetwork,
@@ -74,7 +73,7 @@ export const tradingBuyFormToTradingBuyFormProps = (
             label: currencyName,
         },
         cryptoSelect: createAssetOption({ cryptoId: asset.cryptoId, coinInfo, platformInfo })!,
-        countrySelect: country as TradingCountryOption,
+        countrySelect: country,
         countrySubdivisionSelect: countrySubdivision,
         paymentMethod: getPaymentMethodFromBuyForm(form),
         amountInCrypto,

--- a/suite-native/module-trading/src/utils/tradingFormUtils.ts
+++ b/suite-native/module-trading/src/utils/tradingFormUtils.ts
@@ -61,7 +61,7 @@ export const createFormStateForSendForm = ({
 
     if (isExchangeTrade(quote)) {
         // Exchange quote (swap)
-        const exchangeQuote = quote as ExchangeTrade;
+        const exchangeQuote = quote;
         const exchangeProviders = providers as Record<string, ExchangeProviderInfo>;
         outputAddress = exchangeQuote.sendAddress || '';
         outputAmount = exchangeQuote.sendStringAmount || '';
@@ -90,7 +90,7 @@ export const createFormStateForSendForm = ({
         });
     } else {
         // Sell quote (crypto to fiat)
-        const sellQuote = quote as SellFiatTrade;
+        const sellQuote = quote;
         const sellProviders = providers as Record<string, SellProviderInfo>;
         outputAddress = sellQuote.destinationAddress || '';
         outputAmount = sellQuote.cryptoStringAmount || '';


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@suite-native/module-trading`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/no-unnec-assert-module-trading&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->