### PR TITLE
refactor(components): remove unnecessary type assertions (@trezor/components)

### DIFF
--- a/packages/components/src/components/Box/Box.tsx
+++ b/packages/components/src/components/Box/Box.tsx
@@ -160,7 +160,7 @@ export const Box = ({
             onMouseLeave={onMouseLeave}
             $shadow={shadow}
             tabIndex={tabIndex}
-            ref={ref as React.Ref<HTMLDivElement>}
+            ref={ref}
             {...frameProps}
         >
             {children}

--- a/packages/components/src/components/Flex/Flex.stories.tsx
+++ b/packages/components/src/components/Flex/Flex.stories.tsx
@@ -97,7 +97,7 @@ const argTypes: Partial<ArgTypes<FlexProps>> = {
 
 const meta: Meta = {
     title: 'Layout',
-} as Meta;
+};
 export default meta;
 
 export const Row: StoryObj<FlexProps> = {

--- a/packages/components/src/components/Icon/Icon.tsx
+++ b/packages/components/src/components/Icon/Icon.tsx
@@ -155,7 +155,7 @@ export const Icon = ({
             <SVG
                 tabIndex={onClick && !isDisabled ? 0 : undefined}
                 onKeyDown={handleOnKeyDown}
-                src={icons[name as IconName]}
+                src={icons[name]}
                 beforeInjection={handleInjection}
             />
         </Container>

--- a/packages/components/src/components/IconCircle/IconCircle.stories.tsx
+++ b/packages/components/src/components/IconCircle/IconCircle.stories.tsx
@@ -7,11 +7,7 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import { icons } from '@suite-common/icons/src/icons';
 import { typedObjectKeys } from '@trezor/utils';
 
-import {
-    IconCircle as IconCircleComponent,
-    type IconCircleProps,
-    allowedIconCircleFrameProps,
-} from './IconCircle';
+import { IconCircle as IconCircleComponent, allowedIconCircleFrameProps } from './IconCircle';
 import { iconCircleIntents, iconCircleSizes } from './types';
 import { getFramePropsStory } from '../../utils/frameProps';
 
@@ -21,7 +17,7 @@ const meta: Meta<typeof IconCircleComponent> = {
 export default meta;
 
 export const IconCircle: StoryObj<typeof meta> = {
-    render: props => <IconCircleComponent {...(props as IconCircleProps)} />,
+    render: props => <IconCircleComponent {...props} />,
     args: {
         intent: 'brand',
         name: 'butterfly',

--- a/packages/components/src/components/Popover/utils.tsx
+++ b/packages/components/src/components/Popover/utils.tsx
@@ -24,8 +24,8 @@ export const convertPopoverPlacement = ({
     }
 
     if (alignment === 'center') {
-        return position as Placement;
+        return position;
     }
 
-    return `${position}-${alignment}` as Placement;
+    return `${position}-${alignment}`;
 };

--- a/packages/components/src/components/colors.stories.tsx
+++ b/packages/components/src/components/colors.stories.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { type Meta } from '@storybook/react';
 import styled, { useTheme } from 'styled-components';
 
-import { type CSSColor, colorVariants, colorsV2, typography } from '@trezor/theme';
+import { colorVariants, colorsV2, typography } from '@trezor/theme';
 import { hexToRgba, throwError } from '@trezor/utils';
 
 import { Box } from './Box/Box';
@@ -164,14 +164,14 @@ export const Colors = () => {
                                     $value={
                                         colorVariants[theme][
                                             tokenName as keyof (typeof colorVariants)[ThemeKey]
-                                        ] as CSSColor
+                                        ]
                                     }
                                     $isColorCodeVisible={isColorCodeVisible}
                                 >
                                     {isColorCodeVisible &&
-                                        (colorVariants[theme][
+                                        colorVariants[theme][
                                             tokenName as keyof (typeof colorVariants)[ThemeKey]
-                                        ] as CSSColor)}
+                                        ]}
                                 </Color>
                             ))}
                         </Column>

--- a/packages/components/src/components/loaders/ProgressPie/ProgressPie.stories.tsx
+++ b/packages/components/src/components/loaders/ProgressPie/ProgressPie.stories.tsx
@@ -10,7 +10,7 @@ import { getFramePropsStory } from '../../../utils/frameProps';
 const meta: Meta = {
     title: 'ProgressPie',
     component: ProgressPieComponent,
-} as Meta;
+};
 export default meta;
 
 export const ProgressPie: StoryObj<ProgressPieProps> = {


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@trezor/components`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files consist of low-level shared UI components (Box, Icon, Popover utils) and Storybook story files. The three source files (Box.tsx, Icon.tsx, Popover/utils.tsx) are extremely broad dependencies used by virtually every page in the application — they each map to 121 tests. However, none of the changes appear to alter component behavior in ways that would specifically affect any particular E2E test flow. The four remaining changed files are Storybook stories (Flex, IconCircle, colors, ProgressPie) which have no E2E test coverage and are documentation/development-only artifacts. Given that these are foundational UI primitives with no targeted behavioral changes evident, no E2E tests are specifically warranted — any rendering regressions would be caught by visual regression or unit/component tests rather than E2E flows.

<details><summary><b>Changed files (7)</b></summary>

- `packages/components/src/components/Box/Box.tsx`
- `packages/components/src/components/Flex/Flex.stories.tsx`
- `packages/components/src/components/Icon/Icon.tsx`
- `packages/components/src/components/IconCircle/IconCircle.stories.tsx`
- `packages/components/src/components/Popover/utils.tsx`
- `packages/components/src/components/colors.stories.tsx`
- `packages/components/src/components/loaders/ProgressPie/ProgressPie.stories.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (4)**
- `packages/components/src/components/Flex/Flex.stories.tsx`
- `packages/components/src/components/IconCircle/IconCircle.stories.tsx`
- `packages/components/src/components/colors.stories.tsx`
- `packages/components/src/components/loaders/ProgressPie/ProgressPie.stories.tsx`

_Updated: 2026-06-29T14:34:21.913Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-components/web/](https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-components/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/no-unnec-assert-components&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/no-unnec-assert-components&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T14:37:57.554Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T14:37:56.338Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->