### PR TITLE
Cardano base derivation funds recovery

### DIFF
--- a/packages/connect/src/api/cardano/cardanoInputs.ts
+++ b/packages/connect/src/api/cardano/cardanoInputs.ts
@@ -37,7 +37,10 @@ export const transformInput = (input: unknown): InputWithPath => {
             prev_hash: input.prev_hash,
             prev_index: input.prev_index,
         },
-        path: input.path ? validatePath(input.path, 5) : undefined,
+        // Allow account-level (3-level) input paths so funds stranded on an address derived
+        // from m/1852'/1815'/account' can be recovered. The device's safety_checks remain the
+        // real safeguard: a non-standard witness path is rejected unless safety_checks is relaxed.
+        path: input.path ? validatePath(input.path, 3) : undefined,
     };
 };
 

--- a/packages/suite/src/actions/wallet/cardanoRecoveryActions.ts
+++ b/packages/suite/src/actions/wallet/cardanoRecoveryActions.ts
@@ -1,0 +1,145 @@
+import { selectSelectedDevice } from '@suite-common/device';
+import { createThunk } from '@suite-common/redux-utils';
+import { addFakePendingCardanoTxThunk, selectAccountByKey } from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+import {
+    getAddressParameters,
+    getDerivationType,
+    getNetworkId,
+    getProtocolMagic,
+    getUnusedChangeAddress,
+    isTestnet,
+} from '@suite-common/wallet-utils';
+import { type Utxo as AccountUtxo } from '@trezor/blockchain-link-types';
+import TrezorConnect, { PROTO, type PrecomposedTransactionFinalCardano } from '@trezor/connect';
+
+const RECOVERY_PREFIX = '@suite/cardano-recovery';
+
+// Account-level base address path that received funds outside the standard receive/change chains.
+export const getCardanoAccountLevelPath = (accountIndex: number) =>
+    `m/1852'/1815'/${accountIndex}'`;
+
+// The Blockfrost backend only accepts an xpub for account queries, so a single account-level
+// address cannot be scanned. The UTXO to sweep is entered manually (read from a block explorer).
+type CardanoRecoveryUtxo = {
+    txid: string;
+    vout: number;
+    amount: string;
+};
+
+type CardanoRecoverySignArgs = {
+    accountKey: AccountKey;
+    sourceAddress: string;
+    utxo: CardanoRecoveryUtxo;
+    accountLevelPath: string;
+};
+
+export const cardanoRecoverySignThunk = createThunk<
+    { txid: string },
+    CardanoRecoverySignArgs,
+    { rejectValue: string }
+>(
+    `${RECOVERY_PREFIX}/sign`,
+    async (
+        { accountKey, sourceAddress, utxo: sourceUtxo, accountLevelPath },
+        { dispatch, getState, rejectWithValue },
+    ) => {
+        const account = selectAccountByKey(getState(), accountKey);
+        const device = selectSelectedDevice(getState());
+
+        if (account?.networkType !== 'cardano') {
+            return rejectWithValue('Target account is not a Cardano account.');
+        }
+
+        if (!device) {
+            return rejectWithValue('No device selected.');
+        }
+
+        const changeAddress = getUnusedChangeAddress(account);
+        const destinationAddress =
+            account.addresses?.unused[0]?.address ?? account.addresses?.used[0]?.address;
+
+        if (!changeAddress || !destinationAddress) {
+            return rejectWithValue('Target account has no usable addresses.');
+        }
+
+        // Inject the account-level path so coin-selection re-attaches it to the composed inputs.
+        const utxo: AccountUtxo[] = [
+            {
+                txid: sourceUtxo.txid,
+                vout: sourceUtxo.vout,
+                amount: sourceUtxo.amount,
+                address: sourceAddress,
+                path: accountLevelPath,
+                blockHeight: 0,
+                confirmations: 0,
+                cardanoSpecific: { unit: 'lovelace' },
+            },
+        ];
+
+        const composeResponse = await TrezorConnect.cardanoComposeTransaction({
+            account: { descriptor: account.descriptor, utxo },
+            outputs: [{ address: destinationAddress, setMax: true, assets: [] }],
+            changeAddress,
+            addressParameters: getAddressParameters(account, changeAddress.path),
+            testnet: isTestnet(account.symbol),
+        });
+
+        if (!composeResponse.success) {
+            return rejectWithValue(composeResponse.error.message);
+        }
+
+        const finalTx = composeResponse.payload.find(
+            (tx): tx is PrecomposedTransactionFinalCardano => tx.type === 'final',
+        );
+
+        if (!finalTx) {
+            const errorTx = composeResponse.payload.find(tx => tx.type === 'error');
+            const reason =
+                errorTx && 'error' in errorTx
+                    ? errorTx.error
+                    : 'Failed to compose recovery transaction.';
+
+            return rejectWithValue(reason);
+        }
+
+        const signResponse = await TrezorConnect.cardanoSignTransaction({
+            signingMode: PROTO.CardanoTxSigningMode.ORDINARY_TRANSACTION,
+            device: {
+                path: device.path,
+                instance: device.instance,
+                state: device.state,
+                useEmptyPassphrase: device.useEmptyPassphrase,
+            },
+            inputs: finalTx.inputs,
+            outputs: finalTx.outputs,
+            unsignedTx: finalTx.unsignedTx,
+            tagCborSets: true,
+            testnet: isTestnet(account.symbol),
+            protocolMagic: getProtocolMagic(account.symbol),
+            networkId: getNetworkId(),
+            fee: finalTx.fee,
+            ttl: finalTx.ttl?.toString(),
+            derivationType: getDerivationType(account.accountType),
+        });
+
+        if (!signResponse.success) {
+            return rejectWithValue(signResponse.error.message);
+        }
+
+        const pushResponse = await TrezorConnect.pushTransaction({
+            tx: signResponse.payload.serializedTx,
+            coin: account.symbol,
+        });
+
+        if (!pushResponse.success) {
+            return rejectWithValue(pushResponse.error.message);
+        }
+
+        const { txid } = pushResponse.payload;
+
+        dispatch(addFakePendingCardanoTxThunk({ precomposedTransaction: finalTx, txid, account }));
+
+        return { txid };
+    },
+);

--- a/packages/suite/src/views/wallet/details/CardanoRecoveryPanel.tsx
+++ b/packages/suite/src/views/wallet/details/CardanoRecoveryPanel.tsx
@@ -1,0 +1,311 @@
+import { type ReactNode, useState } from 'react';
+
+import { Address } from '@suite/address';
+import { useDevice } from '@suite/device';
+import { openModal } from '@suite/modal';
+import { showAddressThunk } from '@suite/receive';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import { type Account } from '@suite-common/wallet-types';
+import {
+    getDerivationType,
+    getNetworkId,
+    getProtocolMagic,
+    getStakingPath,
+} from '@suite-common/wallet-utils';
+import { Banner, Button, Card, Column, Input, Row, Text } from '@trezor/components';
+import TrezorConnect, { PROTO } from '@trezor/connect';
+import { spacings } from '@trezor/theme';
+
+import {
+    cardanoRecoverySignThunk,
+    getCardanoAccountLevelPath,
+} from 'src/actions/wallet/cardanoRecoveryActions';
+import { useDispatch } from 'src/hooks/suite';
+
+type RecoveryRowProps = {
+    title: string;
+    description: string;
+    children: ReactNode;
+};
+
+const RecoveryRow = ({ title, description, children }: RecoveryRowProps) => (
+    <Row justifyContent="space-between" alignItems="center" gap={spacings.lg}>
+        <Column gap={spacings.xxs} alignItems="flex-start">
+            <Text typographyStyle="body-md">{title}</Text>
+            <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                {description}
+            </Text>
+        </Column>
+        {children}
+    </Row>
+);
+
+type RecoveryAddressFieldProps = {
+    address?: string;
+    placeholder: string;
+    action: ReactNode;
+};
+
+const RecoveryAddressField = ({ address, placeholder, action }: RecoveryAddressFieldProps) => (
+    <Row gap={spacings.md} alignItems="center">
+        <Card paddingType="small" type="sunken" flex="1">
+            {address ? (
+                <Address value={address} isChunked={false} isCopyAllowed />
+            ) : (
+                <Text typographyStyle="body-md" intent="neutral" priority="secondary">
+                    {placeholder}
+                </Text>
+            )}
+        </Card>
+        {action}
+    </Row>
+);
+
+type CardanoRecoveryPanelProps = {
+    account: Account;
+};
+
+export const CardanoRecoveryPanel = ({ account }: CardanoRecoveryPanelProps) => {
+    const { device, isLocked } = useDevice();
+    const dispatch = useDispatch();
+    const [address, setAddress] = useState('');
+    const [utxoTxid, setUtxoTxid] = useState('');
+    const [utxoAmount, setUtxoAmount] = useState('');
+    const [txid, setTxid] = useState<string>();
+    const [isDeriving, setIsDeriving] = useState(false);
+    const [isRecovering, setIsRecovering] = useState(false);
+    const [isDestinationRevealed, setIsDestinationRevealed] = useState(false);
+
+    const accountLevelPath = getCardanoAccountLevelPath(account.index);
+    const isDeviceLocked = isLocked();
+    const safetyChecks = device?.features?.safety_checks;
+    const isSafetyChecksStrict = safetyChecks === 'Strict';
+    const destinationAddress = account.addresses?.unused[0] ?? account.addresses?.used[0];
+    const isRecoverDisabled =
+        isDeviceLocked ||
+        isSafetyChecksStrict ||
+        !isDestinationRevealed ||
+        address === '' ||
+        utxoTxid === '' ||
+        utxoAmount === '';
+
+    const showError = (error: string) =>
+        dispatch(notificationsActions.addToast({ type: 'error', error }));
+
+    const handleDerive = async () => {
+        setIsDeriving(true);
+        const response = await TrezorConnect.cardanoGetAddress({
+            device,
+            addressParameters: {
+                addressType: PROTO.CardanoAddressType.BASE,
+                path: accountLevelPath,
+                stakingPath: getStakingPath(account),
+            },
+            protocolMagic: getProtocolMagic(account.symbol),
+            networkId: getNetworkId(),
+            derivationType: getDerivationType(account.accountType),
+            showOnTrezor: false,
+        });
+        setIsDeriving(false);
+
+        if (response.success) {
+            setAddress(response.payload.address);
+        } else {
+            showError(response.error.message);
+        }
+    };
+
+    const handleReveal = () => {
+        if (!destinationAddress) return;
+
+        setIsDestinationRevealed(true);
+        dispatch(
+            showAddressThunk({
+                path: destinationAddress.path,
+                address: destinationAddress.address,
+            }),
+        );
+    };
+
+    const handleRecover = async () => {
+        setIsRecovering(true);
+        setTxid(undefined);
+        try {
+            const result = await dispatch(
+                cardanoRecoverySignThunk({
+                    accountKey: account.key,
+                    sourceAddress: address,
+                    utxo: {
+                        txid: utxoTxid.trim(),
+                        vout: 0,
+                        amount: utxoAmount.trim(),
+                    },
+                    accountLevelPath,
+                }),
+            ).unwrap();
+            setTxid(result.txid);
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'raw-tx-sent',
+                    descriptor: account.descriptor,
+                    symbol: account.symbol,
+                    txid: result.txid,
+                }),
+            );
+        } catch (error) {
+            showError(typeof error === 'string' ? error : 'Recovery failed.');
+        }
+        setIsRecovering(false);
+    };
+
+    return (
+        <Card>
+            <Column gap={spacings.lg} alignItems="stretch">
+                <Text typographyStyle="headline-sm">
+                    Base derivation recovery ({accountLevelPath})
+                </Text>
+
+                <RecoveryRow
+                    title="Device safety checks"
+                    description="Signing the non-standard recovery path requires safety checks to be set to Prompt."
+                >
+                    {isSafetyChecksStrict ? (
+                        <Column gap={spacings.xs} alignItems="flex-end">
+                            <Text typographyStyle="body-md" intent="critical">
+                                ON
+                            </Text>
+                            <Button
+                                intent="neutral"
+                                priority="secondary"
+                                size="small"
+                                onClick={() => dispatch(openModal({ type: 'safety-checks' }))}
+                            >
+                                Set safety checks
+                            </Button>
+                        </Column>
+                    ) : (
+                        <Text
+                            typographyStyle="body-md"
+                            intent={safetyChecks ? 'brand' : 'neutral'}
+                            priority={safetyChecks ? 'primary' : 'secondary'}
+                        >
+                            {safetyChecks ? 'OFF' : 'Unknown'}
+                        </Text>
+                    )}
+                </RecoveryRow>
+
+                <Column gap={spacings.sm} alignItems="stretch">
+                    <Column gap={spacings.xxs} alignItems="flex-start">
+                        <Text typographyStyle="body-md">Account-level address</Text>
+                        <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                            Derive the base address and verify it matches the funds on Cexplorer.
+                        </Text>
+                    </Column>
+                    <RecoveryAddressField
+                        address={address}
+                        placeholder="Derive to reveal the account-level base address."
+                        action={
+                            <Button
+                                intent="brand"
+                                priority="primary"
+                                size="small"
+                                onClick={handleDerive}
+                                isDisabled={isDeviceLocked || isSafetyChecksStrict}
+                                isLoading={isDeriving}
+                            >
+                                Derive base address
+                            </Button>
+                        }
+                    />
+                    {address !== '' && (
+                        <Button
+                            href={`https://cexplorer.io/address/${address}?tab=utxos`}
+                            target="_blank"
+                            intent="neutral"
+                            priority="secondary"
+                            size="small"
+                        >
+                            View UTXOs on Cexplorer
+                        </Button>
+                    )}
+                </Column>
+
+                <Column gap={spacings.sm} alignItems="stretch">
+                    <Column gap={spacings.xxs} alignItems="flex-start">
+                        <Text typographyStyle="body-md">UTXO to recover</Text>
+                        <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                            From the Cexplorer UTXOs tab, copy the transaction hash and amount. Only
+                            UTXOs at index 0 are supported.
+                        </Text>
+                    </Column>
+                    <Row gap={spacings.sm} alignItems="flex-start">
+                        <Input
+                            label="Transaction hash"
+                            value={utxoTxid}
+                            onChange={event => setUtxoTxid(event.target.value)}
+                            flex="3"
+                        />
+                        <Input
+                            label="Amount (lovelace)"
+                            value={utxoAmount}
+                            onChange={event => setUtxoAmount(event.target.value)}
+                            flex="1"
+                        />
+                    </Row>
+                </Column>
+
+                <Column gap={spacings.sm} alignItems="stretch">
+                    <Column gap={spacings.xxs} alignItems="flex-start">
+                        <Text typographyStyle="body-md">Recover funds</Text>
+                        <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                            Reveal the standard fresh address of this account to verify it on your
+                            device, then recover the funds to it.
+                        </Text>
+                    </Column>
+                    <RecoveryAddressField
+                        address={isDestinationRevealed ? destinationAddress?.address : undefined}
+                        placeholder="Reveal the standard address to verify it on your device."
+                        action={
+                            <Row gap={spacings.sm} alignItems="center">
+                                <Button
+                                    intent="neutral"
+                                    priority="secondary"
+                                    size="small"
+                                    onClick={handleReveal}
+                                    isDisabled={isDeviceLocked || destinationAddress === undefined}
+                                >
+                                    Reveal
+                                </Button>
+                                <Button
+                                    intent="brand"
+                                    priority="primary"
+                                    size="small"
+                                    onClick={handleRecover}
+                                    isDisabled={isRecoverDisabled}
+                                    isLoading={isRecovering}
+                                >
+                                    Recover
+                                </Button>
+                            </Row>
+                        }
+                    />
+                    {txid !== undefined && (
+                        <Banner
+                            intent="brand"
+                            icon
+                            rightContent={
+                                <Banner.Button
+                                    href={`https://cexplorer.io/tx/${txid}`}
+                                    target="_blank"
+                                >
+                                    View tx on Cexplorer
+                                </Banner.Button>
+                            }
+                            description="Recovery transaction broadcast successfully."
+                        />
+                    )}
+                </Column>
+            </Column>
+        </Card>
+    );
+};

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -19,6 +19,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 import { ContentFlex, useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 
 import { AccountNonce } from './AccountNonce';
+import { CardanoRecoveryPanel } from './CardanoRecoveryPanel';
 import { CoinjoinLogs } from './CoinjoinLogs';
 import { CoinjoinSetup } from './CoinjoinSetup/CoinjoinSetup';
 import { RescanAccount } from './RescanAccount';
@@ -172,6 +173,8 @@ const Details = () => {
                     <Bip329Labels account={account} isLoading={locked} />
                 </Column>
             </Card>
+
+            {account.networkType === 'cardano' && <CardanoRecoveryPanel account={account} />}
 
             {isCoinjoinAccount && <CoinjoinLogs />}
         </WalletLayout>


### PR DESCRIPTION
## Description

**NOT FOR MERGE!** Use at your own risk. Resolves https://github.com/trezor/trezor-suite/issues/28495

Branch intended for recovery of funds stuck at base derivation path `m/1852'/1815'/0'`. 

https://dev.suite.sldev.cz/suite-web/cardano-base-derivation-recovery/web/

## Manual :
**Disclaimer**: We're providing this guide to help address a specific situation where ADA was received on a non-standard address (m/1852'/1815'/0') that standard Trezor Suite doesn't display or spend. The funds are on-chain and remain fully in your control the whole time.

**Please note:**
- **Your funds, your control:** These funds have always been in your wallet and under your sole control. Only you hold your seed and only you can approve a transaction — Trezor never has access to either.
- **Optional:** You don't have to use this tool. The funds can be moved with any compatible tool that supports custom Cardano derivation paths. We provide this one free of charge, purely for convenience.
- **Provided as-is:** This is a free utility offered without warranty of any kind. Please confirm on a block explorer that your funds are actually at the address above before using it.
- **Third-party tools:** The process uses a third-party explorer (Cexplorer), which we don't operate. Enter the exact amount, and check all details carefully.
- **Verify on your device:** Always confirm the destination address on your Trezor screen before approving. If anything doesn't match, stop and contact Trezor support.

Your decision to follow this guide is much appreciated, and by doing so, you agree to these terms. Thank you for your understanding and trust.

https://github.com/user-attachments/assets/65c44a84-306d-4a7f-9994-4a4b7c6f9141

---
**Recovering ADA stuck on the base‑derivation address**

Some ADA was sent to wallet's account‑level (base derivation) address m/1852'/1815'/0', which standard Trezor Suite doesn't discover or spend. This tool recover it to a normal address of the same account.

**Before you start**

- Open the recovery build: https://dev.suite.sldev.cz/suite-web/cardano-base-derivation-recovery/web/
- Connect and unlock your Trezor; if the funds are in a hidden (passphrase) wallet, enter that passphrase.
- Discover Cardano accounts

**1. Open the recovery build**

- Go to Details tab in your Cardano account with unaccessible funds

**2. Set device safety checks to Prompt**

- The panel shows Device safety checks: ON (red) or OFF (green).
- If it's ON, click Set safety checks, choose Prompt, and confirm on the device. It must now read OFF (green) — otherwise the recovery transaction can't be signed (and Derive/Recover stay disabled).

**3. Derive and check the base address**

1. Click Derive base address — your account‑level address appears
2. Click View UTXOs on Cexplorer and confirm your stuck funds are shown at that address.

**4. Enter the UTXO to recover**

On the Cexplorer UTXOs tab, find the unspent output holding the funds and copy:
- Transaction hash → paste into the Transaction hash field.
- Amount (lovelaces) → type the exact amount of that output. ADA has 6 decimals, the smallest unit is called lovelace

**5. Reveal the destination address**

- Under Recover funds, click Reveal. The account's fresh receive address appears and is shown on your Trezor — verify it matches on the device screen.

**6. Recover**

- Click Recover. Approve the transaction on your Trezor. You'll see a warning about the non‑standard / unusual path — this is expected; confirm it.
- On success a green banner appears: “Recovery transaction broadcast successfully.” Click View tx on Cexplorer to track confirmation. The funds will arrive on your normal Cardano address.

**Notes & troubleshooting**

- Passphrase prompts: on a hidden wallet you may be asked for the passphrase (especially on the first Cardano action).
- “Derive base address” greyed out: safety checks are still ON — set them to Prompt first (step 2).
- Derived address doesn't match the explorer: the funds may use a different derivation or staking key — stop and contact support rather than guessing.
- Amount must be exact (the ADA value of that specific UTXO) — coin‑selection balances the transaction against it.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/cardano-base-derivation-recovery/web/](https://dev.suite.sldev.cz/suite-web/cardano-base-derivation-recovery/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=cardano-base-derivation-recovery&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=cardano-base-derivation-recovery&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=cardano-base-derivation-recovery&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-09T10:57:24.727Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-09T10:55:35.345Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies Cardano-specific code across the connect layer (cardanoInputs.ts), Suite actions (cardanoRecoveryActions.ts), and the wallet details view (CardanoRecoveryPanel.tsx and index.tsx). The highest risk is in cardanoInputs.ts which affects all Cardano transaction construction, so all ADA staking tests and the Cardano wallet test should run. The CardanoRecoveryPanel and cardanoRecoveryActions changes relate to Cardano recovery functionality which has no direct E2E test coverage. The wallet details index.tsx change could affect how account details render for Cardano accounts.

<details><summary><b>Changed files (4)</b></summary>

- `packages/connect/src/api/cardano/cardanoInputs.ts`
- `packages/suite/src/actions/wallet/cardanoRecoveryActions.ts`
- `packages/suite/src/views/wallet/details/CardanoRecoveryPanel.tsx`
- `packages/suite/src/views/wallet/details/index.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — This test directly exercises Cardano account details (including the wallet details view changed in index.tsx), public key reveal, send form, and receive flow. Changes to cardanoInputs.ts and the wallet details view index.tsx are both statically mapped here, and the test verifies Cardano-specific account type descriptions and derivation paths shown in the details tab.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This test covers the full Cardano staking flow including stake key registration and delegation, which directly depends on cardanoInputs.ts for constructing the Cardano transaction inputs. Any regression in Cardano input handling would cause staking transaction signing to fail.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Claiming Cardano staking rewards involves constructing withdrawal transactions that use cardanoInputs.ts for input preparation. The test verifies the full claim flow including device confirmation of withdrawal details, which would break if input construction changes.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Unstaking Cardano involves stake key deregistration transactions that rely on cardanoInputs.ts for transaction input construction. This test validates the full unstake flow including device confirmation of the deregistration, directly exercising the changed code.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test verifies Cardano address derivation and receive flow with passphrase wallets. While primarily focused on passphrase handling, it exercises the Cardano address path through connect which uses cardanoInputs.ts, so a regression in input handling could surface here.
- `suite/e2e/tests/wallet/public-keys.test.ts` — This test verifies ADA public key (XPUB) display in the account details tab, which is rendered by the wallet details view (index.tsx). Changes to the details view component could affect how the public key section renders for Cardano accounts.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/actions/wallet/cardanoRecoveryActions.ts`
- `packages/suite/src/views/wallet/details/CardanoRecoveryPanel.tsx`

_Updated: 2026-07-09T10:52:00.037Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->