### PR TITLE
Fix: TOR Proxy-Authorization header

### DIFF
--- a/.github/workflows/test-request-manager.yml
+++ b/.github/workflows/test-request-manager.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'trezor/trezor-suite'
     timeout-minutes: 60
+    env:
+      TEST_SCRIPT: ${{ github.event_name == 'workflow_dispatch' && 'test:e2e' || 'test:all' }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
@@ -38,4 +40,4 @@ jobs:
           job-summary: errors
           firewall-version: 1.11.0
       - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
-      - run: yarn workspace @trezor/request-manager test:all
+      - run: yarn workspace @trezor/request-manager ${{ env.TEST_SCRIPT }}

--- a/packages/request-manager/e2e/identities-stress.ts
+++ b/packages/request-manager/e2e/identities-stress.ts
@@ -18,7 +18,7 @@ const torDataDir = path.join(__dirname, 'tmp');
 const ipRegex = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/;
 
 const interceptorOptions: InterceptorOptions = {
-    getWhitelistedDomains: () => ['check.torproject.org'],
+    getWhitelistedDomains: () => ['check.torproject.org', 'localhost'],
     handler: () => {},
     getTorSettings: () => ({ running: true, host, port }),
 };

--- a/packages/request-manager/e2e/interceptor.test.ts
+++ b/packages/request-manager/e2e/interceptor.test.ts
@@ -25,6 +25,8 @@ const testGetUrlHttp = 'http://check.torproject.org/';
 const testGetUrlHttps = 'https://check.torproject.org/';
 const testPostUrlHttps = 'https://httpbingo.org/post';
 
+const conditionalTest = process.env.SKIP_FLAKY_TESTS ? describe.skip : describe;
+
 describe('Interceptor', () => {
     let torProcess: ReturnType<typeof torRunner> | null;
     let torController: TorController;
@@ -78,9 +80,7 @@ describe('Interceptor', () => {
     // The tests below are somehow useful but their nature is flaky since we can not
     // guarantee that the IPs of 2 different Tor circuits are different. And this is
     // part of the Tor nature.
-    // Ideally we could find a way to check that actually we are generating different
-    // circuits in each request, until then I would skip them.
-    describe.skip('Check if IPs are different', () => {
+    conditionalTest('Check if IPs are different', () => {
         it('HTTP GET - Each identity has different ip address', async () => {
             const identityDefault = await fetch(testGetUrlHttp, {
                 headers: { 'proxy-authorization': 'Basic default' },
@@ -179,8 +179,7 @@ describe('Interceptor', () => {
         });
     });
 
-    // TODO: Skipping this for now, since I want to get the most critical tests to run in CI.
-    describe.skip('TorControl', () => {
+    conditionalTest('TorControl', () => {
         it('closing circuits', async () => {
             await fetch(testGetUrlHttps, {
                 headers: { 'Proxy-Authorization': 'Basic user-circuit-1' },

--- a/packages/request-manager/e2e/interceptor.test.ts
+++ b/packages/request-manager/e2e/interceptor.test.ts
@@ -14,6 +14,7 @@ const processId = process.pid;
 
 // 1 minute before timeout, because Tor might be slow to start.
 jest.setTimeout(60000);
+jest.retryTimes(3, { logErrorsBeforeRetry: true });
 
 // Because tmp/control_auth_cookie is shared by other tests, this test should not run in parallel
 // using `--runInBand` option with jest.
@@ -22,7 +23,7 @@ const ipRegex = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/;
 
 const testGetUrlHttp = 'http://check.torproject.org/';
 const testGetUrlHttps = 'https://check.torproject.org/';
-const testPostUrlHttps = 'https://httpbin.org/post';
+const testPostUrlHttps = 'https://httpbingo.org/post';
 
 describe('Interceptor', () => {
     let torProcess: ReturnType<typeof torRunner> | null;
@@ -34,7 +35,7 @@ describe('Interceptor', () => {
     const interceptorOptions: InterceptorOptions = {
         getWhitelistedDomains: () => [
             'check.torproject.org',
-            'httpbin.org',
+            'httpbingo.org',
             'tbtc1.trezor.io',
             'localhost',
             '127.0.0.1',
@@ -70,6 +71,10 @@ describe('Interceptor', () => {
         }
     });
 
+    afterEach(async () => {
+        await torController.controlPort.closeActiveCircuits();
+    });
+
     // The tests below are somehow useful but their nature is flaky since we can not
     // guarantee that the IPs of 2 different Tor circuits are different. And this is
     // part of the Tor nature.
@@ -78,7 +83,7 @@ describe('Interceptor', () => {
     describe.skip('Check if IPs are different', () => {
         it('HTTP GET - Each identity has different ip address', async () => {
             const identityDefault = await fetch(testGetUrlHttp, {
-                headers: { 'Proxy-Authorization': 'Basic default' },
+                headers: { 'proxy-authorization': 'Basic default' },
             });
             const identityDefault2 = await fetch(testGetUrlHttp, {
                 headers: { 'Proxy-Authorization': 'Basic user' },
@@ -91,7 +96,7 @@ describe('Interceptor', () => {
 
         it('HTTPS GET - Each identity has different ip address', async () => {
             const identityA = await fetch(testGetUrlHttps, {
-                headers: { 'Proxy-Authorization': 'Basic default' },
+                headers: { 'proxy-authorization': 'Basic default' },
             });
             const identityB = await fetch(testGetUrlHttps, {
                 headers: { 'Proxy-Authorization': 'Basic user' },
@@ -115,7 +120,7 @@ describe('Interceptor', () => {
             const identityA = await fetch(testPostUrlHttps, {
                 method: 'POST',
                 body: JSON.stringify({ test: 'test' }),
-                headers: { 'Proxy-Authorization': 'Basic default' },
+                headers: { 'proxy-authorization': 'Basic default' },
             });
             const identityB = await fetch(testPostUrlHttps, {
                 method: 'POST',
@@ -210,7 +215,9 @@ describe('Interceptor', () => {
 
             // and validate state afterward
             const circuits3 = await torController.controlPort.getCircuits();
-            expect(circuits3.length).toEqual(0);
+            expect(circuits3.map(c => c.username)).not.toEqual(
+                expect.arrayContaining(['user-circuit-1', 'user-circuit-2']),
+            );
         });
     });
 

--- a/packages/request-manager/e2e/torControlPort.test.ts
+++ b/packages/request-manager/e2e/torControlPort.test.ts
@@ -18,8 +18,9 @@ const host = 'localhost';
 const port = 9998;
 const controlPort = 9999;
 
-// TODO: Skipping this for now, since I want to get the most critical tests to run in CI.
-describe.skip('TorControlPort', () => {
+const conditionalTest = process.env.SKIP_FLAKY_TESTS ? describe.skip : describe;
+
+conditionalTest('TorControlPort', () => {
     beforeAll(async () => {
         if (!fs.existsSync(torDataDir)) {
             // Make sure there is `torDataDir` directory.

--- a/packages/request-manager/jest.config.js
+++ b/packages/request-manager/jest.config.js
@@ -3,5 +3,4 @@ const baseConfig = require('../../jest.config.base.swc');
 module.exports = {
     ...baseConfig,
     testEnvironment: '../../JestCustomEnv.js',
-    testRetryTimes: 3,
 };

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -10,7 +10,7 @@
         "test:unit": "yarn g:jest --testPathIgnorePatterns e2e",
         "test:e2e": "yarn g:jest --runInBand --testPathIgnorePatterns tests",
         "type-check": "yarn g:tsc --build tsconfig.json",
-        "test:stress": "ts-node  -O '{\"module\": \"commonjs\"}' ./e2e/identities-stress.ts",
+        "test:stress": "tsx ./e2e/identities-stress.ts",
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
@@ -23,6 +23,6 @@
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
-        "ts-node": "^10.9.2"
+        "tsx": "^4.21.0"
     }
 }

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -6,7 +6,7 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "scripts": {
-        "test:all": "yarn g:jest",
+        "test:all": "SKIP_FLAKY_TESTS=1 yarn g:jest",
         "test:unit": "yarn g:jest --testPathIgnorePatterns e2e",
         "test:e2e": "yarn g:jest --runInBand --testPathIgnorePatterns tests",
         "type-check": "yarn g:tsc --build tsconfig.json",

--- a/packages/request-manager/src/interceptor/overloadHttpRequest.ts
+++ b/packages/request-manager/src/interceptor/overloadHttpRequest.ts
@@ -4,6 +4,21 @@ import { getWeakRandomId, isWhitelistedHost } from '@trezor/utils';
 
 import { type InterceptorContext } from './interceptorTypes';
 
+const PROXY_AUTH_KEY = 'proxy-authorization';
+
+const getHeaderValue = (headers: http.OutgoingHttpHeaders | undefined, name: string) => {
+    if (!headers) return;
+
+    const normalizedName = name.toLowerCase();
+    const key = Object.keys(headers).find(k => k.toLowerCase() === normalizedName);
+    if (!key) return;
+
+    const value = headers[key];
+    if (value === undefined) return;
+
+    return { key, value };
+};
+
 const getIdentityName = (proxyAuthorization?: http.OutgoingHttpHeader) => {
     const identity = Array.isArray(proxyAuthorization) ? proxyAuthorization[0] : proxyAuthorization;
 
@@ -13,13 +28,14 @@ const getIdentityName = (proxyAuthorization?: http.OutgoingHttpHeader) => {
 
 /** Should the request be blocked if Tor isn't enabled? */
 export const getIsTorRequired = (options?: Readonly<http.RequestOptions>) =>
-    !!options?.headers?.['Proxy-Authorization'];
+    !!getHeaderValue(options?.headers, PROXY_AUTH_KEY)?.value;
 
 const getIdentityForAgent = (options?: Readonly<http.RequestOptions>) => {
-    if (options?.headers?.['Proxy-Authorization']) {
+    const proxyAuthorization = getHeaderValue(options?.headers, PROXY_AUTH_KEY)?.value;
+    if (proxyAuthorization) {
         // Use Proxy-Authorization header to define proxy identity
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Proxy-Authorization
-        return getIdentityName(options.headers['Proxy-Authorization']);
+        return getIdentityName(proxyAuthorization);
     }
     if (options?.headers?.Upgrade === 'websocket') {
         // Create random identity for each websocket connection
@@ -179,7 +195,12 @@ export const overloadHttpRequest = ({
     const target = requestUrl ?? `${requestOptions.host ?? ''}${requestOptions.path ?? ''}`;
     reportInterceptedRequest(context, `${target} with agent ${!!requestOptions.agent}`);
 
-    delete requestOptions.headers?.['Proxy-Authorization'];
+    if (requestOptions.headers) {
+        const proxyAuthKey = getHeaderValue(requestOptions.headers, PROXY_AUTH_KEY)?.key;
+        if (proxyAuthKey) {
+            delete requestOptions.headers[proxyAuthKey];
+        }
+    }
 
     // Params for the original request, preserving the original call signature.
     const requestArgs: Array<string | URL | http.RequestOptions | RequestCallback | undefined> =

--- a/packages/request-manager/src/torControlPort.ts
+++ b/packages/request-manager/src/torControlPort.ts
@@ -206,7 +206,9 @@ export class TorControlPort {
         const circuits = await this.getCircuits();
         const circuitsToClose = identity
             ? circuits.filter(circuit => circuit.username === identity)
-            : circuits.filter(circuit => !circuit.username || circuit.username === 'Default');
+            : circuits.filter(
+                  circuit => !circuit.username || circuit.username.toLowerCase() === 'default',
+              );
 
         return promiseAllSequence(
             circuitsToClose.map(circuit => () => this.sendCommand(`closecircuit ${circuit.id}`)),

--- a/yarn.lock
+++ b/yarn.lock
@@ -16524,7 +16524,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     node-fetch: "npm:^3.3.2"
     socks-proxy-agent: "npm:8.0.5"
-    ts-node: "npm:^10.9.2"
+    tsx: "npm:^4.21.0"
     ws: "npm:^8.20.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We are matching `Proxy-Authorization` header case-sensitive but incoming headers could be a lower-case. 
This issue is reproducible in skipped cases of `e2e/interceptor.test.ts` .
Unskip `Check if IPs are different test cases and run `yarn workspace @trezor/request-manager test:e2e`

adjusting test fixtures:
- `https://httpbin.org/post` not responsive, returns html with error instead of json -> `httpbingo.org` seems to be better maintained
- `"test:stress"` is not working at all. throws error, so i've replaced it with `tsx ...`
```
TSError: ⨯ Unable to compile TypeScript:
error TS5110: Option 'module' must be set to 'Node16' when option 'moduleResolution' is set to 'Node16'.
   ```
  
  
  
- add `SKIP_FLAKY_TESTS` flag to be able to run all the e2e cases (manually) or only essential (on pull_request, nightly...)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to `packages/request-manager`, affecting its HTTP request interceptor (`overloadHttpRequest.ts`), its own e2e tests (`identities-stress.ts`, `interceptor.test.ts`), and its `package.json`. The request-manager package handles low-level HTTP request interception (likely for Tor/proxy functionality). None of the 17 candidate Playwright E2E tests in `suite/e2e/tests/` directly exercise or depend on the request-manager interceptor logic — they test Suite UI features like analytics, trading, onboarding, metadata sync, and connect popups. There is no static coverage mapping linking these changes to any candidate test, and the LLM analysis of the tests shows no meaningful connection to the request-manager package. The request-manager has its own e2e tests (`interceptor.test.ts`, `identities-stress.ts`) which are the appropriate tests to run but are not among the candidate Suite E2E tests. No Suite-level E2E tests are recommended.

<details><summary><b>Changed files (4)</b></summary>

- `packages/request-manager/e2e/identities-stress.ts`
- `packages/request-manager/e2e/interceptor.test.ts`
- `packages/request-manager/package.json`
- `packages/request-manager/src/interceptor/overloadHttpRequest.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (4)**
- `packages/request-manager/e2e/identities-stress.ts`
- `packages/request-manager/e2e/interceptor.test.ts`
- `packages/request-manager/package.json`
- `packages/request-manager/src/interceptor/overloadHttpRequest.ts`

_Updated: 2026-06-29T15:23:11.200Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tor-auth-header/web/](https://dev.suite.sldev.cz/suite-web/fix/tor-auth-header/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tor-auth-header&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tor-auth-header&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-30T14:30:03.827Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-30T14:28:42.706Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->