### PR TITLE
test(suite-e2e): fix unsupported device banner test

### DIFF
--- a/suite/e2e/tests/metadata/suite-sync/unsupported-device.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/unsupported-device.test.ts
@@ -2,7 +2,9 @@ import { expect, test } from '../../../support/fixtures';
 
 test.describe('Suite Sync - Unsupported device banner', { tag: ['@T1B1', '@T2T1'] }, () => {
     test.beforeEach(async ({ onboardingPage, metadataPage, settingsPage }) => {
-        await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+        await onboardingPage.completeOnboarding();
+        await settingsPage.navigateTo('application');
+        await settingsPage.toggleDebugModeInSettings();
         await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
         await metadataPage.setupQuotaManager();
         await metadataPage.initiateSuiteSyncSetup();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the `Suite Sync - Unsupported device banner` E2E test by removing the obsolete `{ keepDebugModeEnabled: true }` parameter from `onboardingPage.completeOnboarding()` (which was removed in a previous E2E helper refactor).

Instead, the test now explicitly navigates to the application settings page and enables debug mode using the standard settings page object:
    
```typescript
    await settingsPage.navigateTo('application');
    await settingsPage.toggleDebugModeInSettings();
```

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/fix-remove-debug/web/](https://dev.suite.sldev.cz/suite-web/test/fix-remove-debug/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/fix-remove-debug&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/fix-remove-debug&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T15:56:01.715Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T15:54:20.388Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->