### PR TITLE
fix(device): cardano endless passphrase prompting

### DIFF
--- a/suite-common/device/src/deviceReducer.ts
+++ b/suite-common/device/src/deviceReducer.ts
@@ -74,14 +74,22 @@ const mergeDeviceState = (
 ): DeviceState | undefined => {
     const currentState = device.state;
 
-    return currentState &&
-        upcoming.state &&
-        currentState.staticSessionId === upcoming.state.staticSessionId &&
-        currentState.sessionId !== upcoming.state.sessionId
-        ? // update sessionId for the same staticSessionId
-          { ...currentState, sessionId: upcoming.state.sessionId }
-        : // ignore device state updates. we set device state explicitly using addAuthorizedDevice or setDeviceState
-          currentState;
+    // Device state is set explicitly via addAuthorizedDevice/setDeviceState. For the same session we only
+    // sync the volatile sessionId and deriveCardano from connect, so the cardano-derived session is not
+    // recreated (re-prompting the passphrase) on every cardano call.
+    if (
+        !currentState ||
+        !upcoming.state ||
+        currentState.staticSessionId !== upcoming.state.staticSessionId
+    ) {
+        return currentState;
+    }
+
+    return {
+        ...currentState,
+        sessionId: upcoming.state.sessionId,
+        deriveCardano: upcoming.state.deriveCardano ?? currentState.deriveCardano,
+    };
 };
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- passphrase on Cardano should no longer be asked many times

## Notes for QA

- try to play with different Cardano scenarios and check that passphrase prompt is no longer appearing on every cardano sign tx but also check that it is possible to really sign the transactions

## Related Issue

Resolve #28513

## Screenshots:

https://github.com/user-attachments/assets/4dd1f3c8-58a9-4dc4-88f8-801759b720d8


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to deviceReducer.ts, a core Redux reducer that manages all device state including connection status, device features, wallet instances, passphrase handling, discovery state, and device session management. Since this file is imported by all 121 tests, a targeted approach is needed. The highest-risk tests are those that directly exercise device state transitions (connect/disconnect/reconnect), multi-device/multi-wallet session management, and passphrase wallet lifecycle. Medium-priority tests cover device-derived analytics events, discovery state reads, and device settings changes. Low-priority tests are included only where there is a concrete device state transition path being tested.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/device/src/deviceReducer.ts`

</details>

**Recommended tests (18)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test directly exercises device session management, device status transitions (connected/disconnected/use-here), and device switching — all core behaviors managed by the deviceReducer. Changes to device state handling could break session acquisition, status display, and multi-tab device management.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test exercises wallet discovery, device switching (eject/add standard wallet), and device state management. The deviceReducer manages device instances and wallet state that directly impacts discovery and device switcher functionality.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Tests device disconnect/reconnect with passphrase caching preserved across reconnection. The deviceReducer manages device state, passphrase caching, and remembered device instances — all critical paths exercised by this test.
- `suite/e2e/tests/backup/t2t1-fail.test.ts` — Tests device disconnect during backup and proper error handling on reconnect. The deviceReducer handles device connect/disconnect state transitions, device status indicators, and backup-failed device state — all directly tested here.
- `suite/e2e/tests/suite/initial-run.test.ts` — Tests the initial run persistence and device connection state across reloads. The deviceReducer manages the connected device status (@deviceStatus-connected) that is the final assertion, and THP pairing state which is part of device initialization.

</details>

<details><summary>🟡 <b>Medium priority (11)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — DeviceConnect and DeviceDisconnect analytics events are derived from device state managed by the deviceReducer. Changes to device state shape (firmware version, model, pin/passphrase protection, backup type) would directly affect the DeviceConnect event payload.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Tests adding multiple hidden wallets, switching between them, passphrase mismatch detection, and wallet labeling in device switcher — all of which depend on device/wallet instance state managed by the deviceReducer.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — Tests sequential numbering of passphrase wallets across add/eject operations. The deviceReducer manages the wallet instance list and numbering logic that determines TR_PASSPHRASE_WALLET ids.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — Tests duplicate passphrase detection when adding a hidden wallet. The deviceReducer tracks device instances and their passphrase state, which is the mechanism for detecting duplicates.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — Tests dispatching setSimulatedEntropyCheckFail via deviceActions into the Redux store. The deviceReducer handles this action and the resulting device-compromised modal state, which is directly asserted.
- `suite/e2e/tests/wallet/discovery.test.ts` — Directly reads wallet.discovery status from the Redux store managed by the deviceReducer, and tests discovery resilience across page reloads. Changes to device state could affect discovery status tracking.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — Tests device state persistence across page reloads and device reconnections during recovery mode. The deviceReducer manages recovery mode state and device reconnection handling.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — Tests device disconnect/reconnect status indicators and passphrase re-entry after reconnection. The deviceReducer manages device connected/disconnected status and passphrase state.
- `suite/e2e/tests/settings/passphrase.test.ts` — Tests enabling passphrase protection on a device via settings. The deviceReducer stores device features including passphrase_protection state that changes when this setting is applied.
- `suite/e2e/tests/wallet/without-device.test.ts` — Tests device disconnected status display and connection modal behavior when device is not present. The deviceReducer manages the disconnected device state and remembered device instances.
- `suite/e2e/tests/backup/t2t1-misc.test.ts` — Tests backup behavior when device is disconnected but remembered, showing @backup/no-device state. The deviceReducer manages remembered device state and device availability checks.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/recovery/dry-run.test.ts` — Tests recovery dry run with device disconnect/reconnect scenarios. The deviceReducer handles device connection state that affects whether the recovery flow can reinitialize after bridge restart.
- `suite/e2e/tests/passphrase/passphrase-cancel.test.ts` — Tests canceling passphrase entry during hidden wallet addition. The deviceReducer manages the device prompt state and wallet addition flow that could be affected by state changes.

</details>

_Updated: 2026-06-30T06:20:03.583Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/cardano-endless-passphrase-prompt&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/cardano-endless-passphrase-prompt&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/cardano-endless-passphrase-prompt&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-30T06:24:15.426Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-30T06:23:48.980Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/cardano-endless-passphrase-prompt/web/](https://dev.suite.sldev.cz/suite-web/fix/cardano-endless-passphrase-prompt/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->