### PR TITLE
Feat/network-settings-refresh-button

### DIFF
--- a/packages/components/src/components/typography/Text/utils.ts
+++ b/packages/components/src/components/typography/Text/utils.ts
@@ -5,17 +5,13 @@ import { type CSSColor, type Color } from '@trezor/theme';
 import { type TextIntent, type TextPriority } from './types';
 import { addAlphaToHex } from '../../../utils/utils';
 
-const colorMap: Record<Exclude<TextIntent, 'neutral'>, Color> = {
+const colorMap: Record<TextIntent, Color> = {
     brand: 'contentBrand',
+    neutral: 'contentPrimary',
     info: 'contentInfo',
     warning: 'contentWarning',
     critical: 'contentCritical',
     accentViolet: 'contentAccentViolet',
-};
-
-const neutralColorMap: Record<TextPriority, Color> = {
-    primary: 'contentPrimary',
-    secondary: 'contentPrimary',
 };
 
 export const mapIntentToCSS = (
@@ -23,8 +19,7 @@ export const mapIntentToCSS = (
     priority: TextPriority,
     theme: DefaultTheme,
 ): CSSColor => {
-    const token = intent === 'neutral' ? neutralColorMap[priority] : colorMap[intent];
-    const color = theme[token];
+    const color = theme[colorMap[intent]];
 
     return priority === 'primary' ? color : addAlphaToHex(color, 0.74);
 };

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 
 import { AnimatePresence, type MotionProps, motion } from 'framer-motion';
-import styled from 'styled-components';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
@@ -23,7 +22,7 @@ import {
 import { Box, Button, Column, Switch, Text, Tooltip, motionEasing } from '@trezor/components';
 import { hasBitcoinOnlyFirmware, isBitcoinOnlyDevice } from '@trezor/device-utils';
 import { OutlineHighlight, SectionItem, SettingsSection } from '@trezor/product-components';
-import { breakpoints, spacingsPx } from '@trezor/theme';
+import { breakpoints } from '@trezor/theme';
 
 import { SettingsLayout } from 'src/components/settings/SettingsLayout';
 import { NetworkList } from 'src/components/suite/NetworkList/NetworkList';
@@ -37,12 +36,6 @@ import { FirmwareTypeSuggestion } from './FirmwareTypeSuggestion';
 import { NetworkSettingsSearchInput } from './NetworkSettingsSearchInput';
 import { NoNetworkSearchResults } from './NoNetworkSearchResults';
 import { useNetworkSettingsSearch } from './useNetworkSettingsSearch';
-
-const DiscoveryButtonWrapper = styled.div`
-    position: fixed;
-    bottom: ${spacingsPx.lg};
-    width: fit-content;
-`;
 
 const discoveryButtonAnimationConfig: MotionProps = {
     initial: { opacity: 0, y: 16 },
@@ -311,7 +304,7 @@ export const SettingsCoins = () => {
                 </Anchor>
             </SettingsSection>
 
-            <DiscoveryButtonWrapper>
+            <Box position={{ type: 'fixed', bottom: 20 }}>
                 <AnimatePresence>
                     {isDiscoveryButtonVisible && (
                         <motion.div {...discoveryButtonAnimationConfig} key="discover-button">
@@ -330,7 +323,7 @@ export const SettingsCoins = () => {
                         </motion.div>
                     )}
                 </AnimatePresence>
-            </DiscoveryButtonWrapper>
+            </Box>
         </SettingsLayout>
     );
 };

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -3,12 +3,14 @@ import { useMemo } from 'react';
 import { AnimatePresence, type MotionProps, motion } from 'framer-motion';
 import styled from 'styled-components';
 
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { selectFlags } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { Anchor, SettingsAnchor } from '@suite/router';
 import { selectHasExperimentalFeature } from '@suite/settings';
+import { useServices } from '@suite-common/dependency-injection';
 import { Context } from '@suite-common/message-system';
 import { type Network, type NetworkSymbol } from '@suite-common/wallet-config';
 import {
@@ -27,7 +29,7 @@ import { SettingsLayout } from 'src/components/settings/SettingsLayout';
 import { NetworkList } from 'src/components/suite/NetworkList/NetworkList';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
-import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 import { isCoinjoinSupportedSymbol } from 'src/utils/wallet/coinjoinUtils';
 
@@ -37,52 +39,25 @@ import { NoNetworkSearchResults } from './NoNetworkSearchResults';
 import { useNetworkSettingsSearch } from './useNetworkSettingsSearch';
 
 const DiscoveryButtonWrapper = styled.div`
-    margin-top: ${spacingsPx.xl};
+    position: fixed;
+    bottom: ${spacingsPx.lg};
     width: fit-content;
 `;
 
-const getDiscoveryButtonAnimationConfig = (isConfirmed: boolean): MotionProps => ({
-    initial: {
-        height: 0,
-        opacity: 0,
-        translateY: 16,
-        translateX: -28,
-        scale: 0.96,
+const discoveryButtonAnimationConfig: MotionProps = {
+    initial: { opacity: 0, y: 16 },
+    animate: { opacity: 1, y: 0 },
+    exit: { opacity: 0, y: 16 },
+    transition: {
+        ease: motionEasing.transition,
+        duration: 0.2,
+        opacity: { duration: 0.35 },
     },
-    animate: {
-        height: 'auto',
-        opacity: 1,
-        translateY: 0,
-        translateX: 0,
-        scale: 1,
-        transition: {
-            ease: motionEasing.transition,
-            duration: 0.2,
-            opacity: {
-                duration: 0.35,
-                ease: motionEasing.transition,
-            },
-        },
-    },
-    exit: {
-        height: 0,
-        opacity: 0,
-        translateY: 16,
-        translateX: isConfirmed ? 0 : -24,
-        scale: 0.96,
-        transformOrigin: 'bottom left',
-        transition: {
-            ease: motionEasing.transition,
-            duration: 0.2,
-            opacity: {
-                ease: motionEasing.enter,
-            },
-        },
-    },
-});
+};
 
 export const SettingsCoins = () => {
     const hasContentBelowTabletWidth = useIsContentBelowBreakpoint(breakpoints.tablet);
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const { firmwareTypeBannerClosed } = useSelector(selectFlags);
     const enabledNetworks = useSelector(selectEnabledNetworks);
@@ -96,7 +71,6 @@ export const SettingsCoins = () => {
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
     const { device, isLocked } = useDevice();
     const isDeviceLocked = !!device && isLocked();
-    const { isDiscoveryRunning } = useDiscovery();
     const isDiscoveryButtonVisible = useSelector(state =>
         selectShowRediscoverButton(state, device),
     );
@@ -214,10 +188,15 @@ export const SettingsCoins = () => {
     );
 
     const startDiscovery = () => {
+        analytics.report({
+            type: events.settingsLoadNetworksClickedEvent.name,
+            payload: {
+                platform: 'desktop',
+                origin: 'network-settings',
+            },
+        });
         dispatch(startOrRestartDiscoveryThunk());
     };
-
-    const animation = getDiscoveryButtonAnimationConfig(!!isDiscoveryRunning);
 
     return (
         <SettingsLayout>
@@ -332,10 +311,10 @@ export const SettingsCoins = () => {
                 </Anchor>
             </SettingsSection>
 
-            <AnimatePresence>
-                {isDiscoveryButtonVisible && (
-                    <motion.div {...animation} key="discover-button">
-                        <DiscoveryButtonWrapper>
+            <DiscoveryButtonWrapper>
+                <AnimatePresence>
+                    {isDiscoveryButtonVisible && (
+                        <motion.div {...discoveryButtonAnimationConfig} key="discover-button">
                             <Tooltip
                                 isActive={isDeviceLocked}
                                 content={<Translation id="TR_CONNECT_YOUR_DEVICE" />}
@@ -348,10 +327,10 @@ export const SettingsCoins = () => {
                                     <Translation id="TR_DISCOVERY_NEW_COINS" />
                                 </Button>
                             </Tooltip>
-                        </DiscoveryButtonWrapper>
-                    </motion.div>
-                )}
-            </AnimatePresence>
+                        </motion.div>
+                    )}
+                </AnimatePresence>
+            </DiscoveryButtonWrapper>
         </SettingsLayout>
     );
 };

--- a/suite/analytics/src/constants.ts
+++ b/suite/analytics/src/constants.ts
@@ -96,6 +96,7 @@ export enum EventType {
     SettingsGeneralLabelingProvider = 'settings/general/labeling-provider',
     SettingsGeneralMevProtection = 'settings/general/mev-protection',
     SettingsGeneralNetworkReserve = 'settings/general/network-reserve',
+    SettingsLoadNetworksClicked = 'settings/load-networks-clicked',
     SettingsTor = 'settings/tor',
     SettingsTorOnionLinks = 'settings/tor/onion-links',
     StakingChangeDelegate = 'staking/change-delegate',

--- a/suite/analytics/src/events/index.ts
+++ b/suite/analytics/src/events/index.ts
@@ -76,6 +76,7 @@ export { settingsGeneralEarlyAccessEvent } from './settingsGeneralEarlyAccessEve
 export { settingsGeneralLabelingProviderEvent } from './settingsGeneralLabelingProviderEvent';
 export { settingsGeneralMevProtectionEvent } from './settingsGeneralMevProtectionEvent';
 export { settingsGeneralNetworkReserveEvent } from './settingsGeneralNetworkReserveEvent';
+export { settingsLoadNetworksClickedEvent } from './settingsLoadNetworksClickedEvent';
 export { settingsTorEvent } from './settingsTorEvent';
 export { settingsTorOnionLinksEvent } from './settingsTorOnionLinksEvent';
 export { stakingChangeDelegateEvent } from './stakingChangeDelegateEvent';

--- a/suite/analytics/src/events/settingsLoadNetworksClickedEvent.ts
+++ b/suite/analytics/src/events/settingsLoadNetworksClickedEvent.ts
@@ -1,0 +1,31 @@
+import type { AnalyticsPlatform, AttributeDef, EventDef } from '@suite-common/analytics';
+
+import { EventType } from '../constants';
+
+type LoadNetworksOrigin = 'network-settings';
+
+type Attributes = {
+    platform: AttributeDef<AnalyticsPlatform>;
+    origin: AttributeDef<LoadNetworksOrigin>;
+};
+
+export const settingsLoadNetworksClickedEvent: EventDef<
+    Attributes,
+    EventType.SettingsLoadNetworksClicked
+> = {
+    name: EventType.SettingsLoadNetworksClicked,
+    descriptionTrigger:
+        'Desktop user clicks the Load networks button in Settings > Networks to start account discovery without leaving Settings',
+    changelog: [{ version: '26.7.0', notes: 'added' }],
+
+    attributes: {
+        platform: {
+            description: 'The platform where the button was clicked (`desktop`)',
+            changelog: [{ version: '26.7.0', notes: 'added' }],
+        },
+        origin: {
+            description: 'Where the button was clicked (`network-settings`)',
+            changelog: [{ version: '26.7.0', notes: 'added' }],
+        },
+    },
+};


### PR DESCRIPTION
## Notes for QA
- load networks button in networks settings is now sticky

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/network-settings-refresh-button&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/network-settings-refresh-button&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/network-settings-refresh-button/web/](https://dev.suite.sldev.cz/suite-web/feat/network-settings-refresh-button/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T11:41:13.224Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T11:39:21.817Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies the analytics events module (constants, event index, and adds a new settingsLoadNetworksClickedEvent), the SettingsCoins component, and a shared Text typography utility. The analytics changes carry moderate risk since they affect event type definitions and event exports used across many analytics tests. The SettingsCoins change directly impacts the coins settings page UI. The Text/utils.ts change maps to 121+ tests but is a broad utility unlikely to cause targeted regressions, so it is deprioritized. Testing should focus on: (1) coins settings page functionality, (2) analytics event capture correctness, and (3) any test that specifically asserts analytics event types or payloads.

<details><summary><b>Changed files (5)</b></summary>

- `packages/components/src/components/typography/Text/utils.ts`
- `packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx`
- `suite/analytics/src/constants.ts`
- `suite/analytics/src/events/index.ts`
- `suite/analytics/src/events/settingsLoadNetworksClickedEvent.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — Directly exercises SettingsCoins.tsx which was changed. This test navigates to the coins settings page, enables/disables networks, toggles testnets, and configures custom backends — all core functionality of the changed component.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Directly exercises SettingsCoins.tsx by enabling coins, configuring custom backend URLs, and verifying discovery. Tests the coin activation and advanced settings flows within the changed component.
- `suite/e2e/tests/analytics/events.test.ts` — Directly tests analytics event constants and event definitions (suiteReadyEvent, settingsAnalyticsEvent, etc.) from suite/analytics. The changes to constants.ts, events/index.ts, and the new settingsLoadNetworksClickedEvent.ts could affect event type definitions and event payloads captured here.
- `suite/e2e/tests/analytics/toggle.test.ts` — Tests analytics event firing including settingsAnalyticsEvent, settingsGeneralChangeFiatEvent, suiteReadyEvent, and routerLocationChangeEvent — all from the analytics events module that was changed. Validates that analytics events are correctly sent/suppressed.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — Tests analytics events fired from settings changes (settingsGeneralChangeFiatEvent, settingsGeneralChangeThemeEvent, settingsGeneralChangeLanguageEvent, settingsAnalyticsEvent) which come from the changed analytics events module.
- `suite/e2e/tests/analytics/staking-events.test.ts` — Tests StakingNavigate analytics events and also navigates through settings to enable networks (touching SettingsCoins.tsx). Changes to analytics constants/events could affect event type matching.
- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — Tests PromoDashboardBanner analytics event type which relies on EventType constants from the changed analytics module. Changes to constants.ts could affect event type definitions.
- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — Tests WalletConnect analytics events (WalletConnectInit, WalletConnectPaired, etc.) using EventType constants from the changed analytics module, and enables networks via SettingsCoins.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Asserts that menuToggleDiscreetEvent analytics event fires correctly, which depends on the analytics events module that was changed.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Asserts accountsNewAccountEvent analytics event is fired with correct symbol, path, and type. This event comes from the changed analytics events module. Also interacts with coin settings.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Tests asset activation via a modal that interacts with network enabling functionality related to SettingsCoins.tsx. The activate assets modal and coin enabling flow could be affected by changes to the coins settings component.
- `suite/e2e/tests/backup/t2t1-success.test.ts` — Asserts createBackupEvent analytics event is tracked with correct status, which relies on the analytics events module that was changed.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/analytics/src/events/settingsLoadNetworksClickedEvent.ts`

_Updated: 2026-07-01T11:36:30.168Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->