### PR TITLE
fix(trading): wire approval error details to exchange UI

### DIFF
--- a/suite-common/trading/src/thunks/exchange/__tests__/confirmApprovalThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/confirmApprovalThunk.test.ts
@@ -220,38 +220,51 @@ describe('confirmApprovalThunk', () => {
 
     describe('when API returns error response', () => {
         it.each([
-            ['response.error is defined', { error: 'Server error' }, 'Server error'],
             [
-                'response.status is undefined',
-                { status: undefined },
-                'Error response from the server',
+                'response.error is defined',
+                { error: 'Server error' },
+                { code: 'unknown', message: 'Server error' },
             ],
+            ['response.status is undefined', { status: undefined }, { code: 'unknown' }],
+            ['response.orderId is undefined', { orderId: undefined }, { code: 'unknown' }],
+            ['response.status is ERROR', { status: 'ERROR' }, { code: 'unknown' }],
             [
-                'response.orderId is undefined',
-                { orderId: undefined },
-                'Error response from the server',
+                'response has errorDetails but no error string',
+                {
+                    status: 'ERROR',
+                    errorDetails: {
+                        origin: 'partner',
+                        externalCode: '-100',
+                        code: 'invalid_amount',
+                        amount: { key: 'BTC', value: '0.00001', min: '0.001', max: '5' },
+                    },
+                },
+                { code: 'invalid_amount', message: '-100', values: { min: '0.001', max: '5' } },
             ],
-            ['response.status is ERROR', { status: 'ERROR' }, 'Error response from the server'],
-        ])('should log error and save quote when %s', async (_, mockResponse, expectedMessage) => {
-            const { store, receiveAddress, account, trade, mockProcessResponseData } = getMocks();
-            const tradeResponse = { ...trade, ...mockResponse } as ExchangeTrade;
+        ])(
+            'should log error and save quote when %s',
+            async (_, mockResponse, expectedErrorMessage) => {
+                const { store, receiveAddress, account, trade, mockProcessResponseData } =
+                    getMocks();
+                const tradeResponse = { ...trade, ...mockResponse } as ExchangeTrade;
 
-            invityAPI.doExchangeTrade = () => Promise.resolve(tradeResponse);
+                invityAPI.doExchangeTrade = () => Promise.resolve(tradeResponse);
 
-            const response = await dispatchThunk(store, {
-                receiveAddress,
-                account,
-                trade,
-                processResponseData: mockProcessResponseData,
-            });
+                const response = await dispatchThunk(store, {
+                    receiveAddress,
+                    account,
+                    trade,
+                    processResponseData: mockProcessResponseData,
+                });
 
-            expect(findLogErrorAction(store)?.payload).toEqual({
-                tradingType: 'exchange',
-                errorMessage: expectedMessage,
-            });
-            expect(getExchangeState(store).selectedQuote).toEqual(tradeResponse);
-            expect(response).toEqual(tradeResponse);
-        });
+                expect(findLogErrorAction(store)?.payload).toEqual({
+                    tradingType: 'exchange',
+                    errorMessage: expectedErrorMessage,
+                });
+                expect(getExchangeState(store).selectedQuote).toEqual(tradeResponse);
+                expect(response).toEqual(tradeResponse);
+            },
+        );
     });
 
     describe('when API returns approval status', () => {

--- a/suite-common/trading/src/thunks/exchange/confirmApprovalThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/confirmApprovalThunk.ts
@@ -1,4 +1,4 @@
-import { type ExchangeTrade } from 'invity-api';
+import { type CryptoId, type ExchangeTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
 import { type Account } from '@suite-common/wallet-types';
@@ -8,11 +8,13 @@ import { invityAPI } from '../../invityAPI';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
 import { tradingActions } from '../../reducers/tradingCommonReducer';
 import {
+    selectTradingCoinSymbolByCryptoId,
     selectTradingExchangeAccountKey,
     selectTradingExchangeReceiveAccountKey,
     selectTradingExchangeSelectedQuote,
 } from '../../selectors/tradingSelectors';
 import { getUnusedAddressFromAccount } from '../../utils';
+import { resolveExchangeTradeError } from '../../utils/exchange/resolveExchangeTradeError';
 import { logErrorThunk } from '../common/logErrorThunk';
 
 export type ConfirmApprovalThunkProps = {
@@ -36,6 +38,9 @@ export const confirmApprovalThunk = createThunk(
         }: ConfirmApprovalThunkProps,
         { dispatch, getState },
     ) => {
+        const getCoinSymbol = (cryptoId: CryptoId) =>
+            selectTradingCoinSymbolByCryptoId(getState(), cryptoId);
+
         const selectedQuote = selectTradingExchangeSelectedQuote(getState());
         const sendAccountKey = selectTradingExchangeAccountKey(getState());
         const receiveAccountKey = selectTradingExchangeReceiveAccountKey(getState());
@@ -90,7 +95,7 @@ export const confirmApprovalThunk = createThunk(
         ) {
             dispatch(
                 logErrorThunk({
-                    errorMessage: response.error || 'Error response from the server',
+                    errorMessage: resolveExchangeTradeError(response, { getCoinSymbol }),
                     tradingType: 'exchange',
                 }),
             );

--- a/suite-common/trading/src/utils/exchange/__tests__/resolveExchangeTradeError.test.ts
+++ b/suite-common/trading/src/utils/exchange/__tests__/resolveExchangeTradeError.test.ts
@@ -56,7 +56,7 @@ describe('resolveExchangeTradeError', () => {
         });
     });
 
-    it('falls back to the backend error as the message when errorDetails carries neither message nor externalCode', () => {
+    it('returns no message when errorDetails carries neither message nor externalCode', () => {
         const source: Partial<TradeError> = {
             error: 'Backend went boom',
             errorDetails: { origin: 'partner', code: 'unknown' },
@@ -64,7 +64,7 @@ describe('resolveExchangeTradeError', () => {
 
         expect(resolveExchangeTradeError(source)).toEqual({
             code: 'unknown',
-            message: 'Backend went boom',
+            message: undefined,
         });
     });
 

--- a/suite-common/trading/src/utils/exchange/resolveExchangeTradeError.ts
+++ b/suite-common/trading/src/utils/exchange/resolveExchangeTradeError.ts
@@ -65,7 +65,7 @@ export const resolveExchangeTradeError = (
     const resolveSymbol = (cryptoId: string): string =>
         getCoinSymbol?.(cryptoId as CryptoId) ?? cryptoId;
 
-    const base = { message: details.message ?? details.externalCode ?? source.error };
+    const base = { message: details.message ?? details.externalCode };
     const asUnknown = (): ResolvedTradeError => ({ ...base, code: 'unknown' });
 
     switch (details.code) {


### PR DESCRIPTION
## Description

- Use `resolveExchangeTradeError` in the exchange approval thunk so API `errorDetails` are passed to the UI in the same structured format as the main confirm flow.
- Preserve partner-provided approval error payloads such as `invalid_amount` values instead of falling back to a generic server error.
- Cover approval failures with and without plain `error` strings in the approval thunk unit test.

## Notes for QA

- In Swap approval flow, trigger a confirm response with `status: ERROR` and structured `errorDetails`, and verify the UI shows the mapped human-readable error instead of a generic server error.
- In Swap approval flow, trigger an approval error with only a plain `error` string, and verify the same message is still shown.

## Related Issue

Resolve #26471

## Screenshots:

N/A

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/26471-approval-error-details/web/](https://dev.suite.sldev.cz/suite-web/fix/26471-approval-error-details/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/26471-approval-error-details&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/26471-approval-error-details&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/26471-approval-error-details&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-30T10:07:37.014Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-30T10:08:31.847Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->