### PR TITLE
refactor(suite-native): remove unnecessary type assertions (@suite-native/transaction-management)

### DIFF
--- a/suite-native/transaction-management/src/feesFormSchema.ts
+++ b/suite-native/transaction-management/src/feesFormSchema.ts
@@ -21,7 +21,7 @@ const FeeLevelLabels: Array<FeeLevelLabel> = ['economy', 'low', 'normal', 'high'
 const validateFeeDecimalLength = (value: string | undefined, context: Partial<FeesFormContext>) => {
     if (!value) return true;
 
-    const { networkFeeInfo, symbol } = context!;
+    const { networkFeeInfo, symbol } = context;
 
     if (!symbol) return false;
 

--- a/suite-native/transaction-management/src/hooks/fees/useFeeCalculation.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeeCalculation.ts
@@ -12,7 +12,6 @@ import {
     type AccountKey,
     type FeeLevelLabel,
     type GeneralPrecomposedTransactionFinal,
-    type PrecomposedTransactionFinal,
     isFinalPrecomposedTransaction,
 } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils';
@@ -40,9 +39,7 @@ export const useFeeCalculation = ({
     const feeLevels = useSelector(selectFeeLevels);
     const { symbol } = account ?? {};
 
-    const normalFee = isFinalPrecomposedTransaction(feeLevels.normal)
-        ? (feeLevels.normal as PrecomposedTransactionFinal)
-        : null;
+    const normalFee = isFinalPrecomposedTransaction(feeLevels.normal) ? feeLevels.normal : null;
 
     const form = useFeesForm({
         accountKey,

--- a/suite-native/transaction-management/src/hooks/fees/useFeesForm.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeesForm.ts
@@ -94,7 +94,7 @@ export const useFeesForm = ({
             : undefined;
 
     const normalFee = isFinalPrecomposedTransaction(feeLevels.normal)
-        ? (feeLevels.normal as PrecomposedTransactionFinal)
+        ? feeLevels.normal
         : undefined;
 
     const networkType = account?.symbol ? getNetworkType(account.symbol) : undefined;


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@suite-native/transaction-management`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/no-unnec-assert-txmgmt&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->