### PR TITLE
refactor(metadata): remove unnecessary type assertions (@suite/metadata)

### DIFF
--- a/suite/metadata/src/fromLegacyMetadataToSearchLabels.ts
+++ b/suite/metadata/src/fromLegacyMetadataToSearchLabels.ts
@@ -1,8 +1,7 @@
-import { type AccountLabels, type AccountOutputLabels } from '@suite-common/metadata-types';
+import { type AccountLabels } from '@suite-common/metadata-types';
 import {
     type SearchAccountLabels,
     type SearchOutputLabels,
-    type TxId,
 } from '@suite-common/transaction-search';
 import { asTxTargetId } from '@suite-common/wallet-types';
 import { typedObjectEntries } from '@trezor/utils';
@@ -12,11 +11,12 @@ export const fromLegacyMetadataToSearchOutputLabels = (
 ): SearchOutputLabels =>
     new Map(
         typedObjectEntries(outputLabels).map(([txid, accountOutputLabels]) => [
-            txid as TxId,
+            txid,
             new Map(
-                typedObjectEntries(accountOutputLabels as AccountOutputLabels).map(
-                    ([targetId, label]) => [asTxTargetId(`${targetId}`), label],
-                ),
+                typedObjectEntries(accountOutputLabels).map(([targetId, label]) => [
+                    asTxTargetId(`${targetId}`),
+                    label,
+                ]),
             ),
         ]),
     );

--- a/suite/metadata/src/metadataLabelingActions.ts
+++ b/suite/metadata/src/metadataLabelingActions.ts
@@ -592,7 +592,7 @@ export const init =
             dispatch({
                 type: METADATA.SET_ERROR_FOR_DEVICE,
                 payload: {
-                    deviceState: device.state!.staticSessionId,
+                    deviceState: device.state.staticSessionId,
                     failed: false,
                 },
             });
@@ -614,7 +614,7 @@ export const init =
                 dispatch({
                     type: METADATA.SET_ERROR_FOR_DEVICE,
                     payload: {
-                        deviceState: device.state!.staticSessionId,
+                        deviceState: device.state.staticSessionId,
                         failed: true,
                     },
                 });

--- a/suite/metadata/src/providers/DropboxProvider.ts
+++ b/suite/metadata/src/providers/DropboxProvider.ts
@@ -137,7 +137,7 @@ export class DropboxProvider extends AbstractMetadataProvider {
 
                 if (match && 'metadata' in match.metadata) {
                     const { result } = await this.client.filesDownload({
-                        path: match!.metadata.metadata.path_lower!,
+                        path: match.metadata.metadata.path_lower!,
                     });
 
                     // @ts-expect-error fileBlob is missing in dropbox lib types file, but it is available


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@suite/metadata`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-metadata/web/](https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-metadata/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/no-unnec-assert-metadata&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/no-unnec-assert-metadata&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-30T07:49:33.745Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-30T07:48:29.039Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->