### PR TITLE
refactor(suite-native): remove unnecessary type assertions (@suite-native/atoms)

### DIFF
--- a/suite-native/atoms/src/CompoundRoundedIcon.tsx
+++ b/suite-native/atoms/src/CompoundRoundedIcon.tsx
@@ -73,7 +73,7 @@ export const CompoundRoundedIcon = ({
             {compoundIcons.map(({ name, color, size }) =>
                 name && name in icons ? (
                     <Icon
-                        name={name as IconName}
+                        name={name}
                         color={color}
                         size={size}
                         key={`${name}-${color ?? 'default'}-${size ?? 'default'}`}

--- a/suite-native/atoms/src/Input/SearchInputWithCancel.tsx
+++ b/suite-native/atoms/src/Input/SearchInputWithCancel.tsx
@@ -80,7 +80,7 @@ export function SearchInputWithCancel<R extends ClearAndBlur | null>({
         <HStack alignItems="center" spacing={0}>
             <Animated.View layout={LinearTransition} style={applyStyle(inputWrapperStyle)}>
                 <SearchComponent
-                    {...(searchRef ? { ref: searchRef as React.Ref<any> } : {})}
+                    {...(searchRef ? { ref: searchRef } : {})}
                     placeholder={placeholder ?? translate('moduleTrading.defaultSearchLabel')}
                     onFocus={() => {
                         setIsInputActive(true);

--- a/suite-native/atoms/src/RoundedIcon.tsx
+++ b/suite-native/atoms/src/RoundedIcon.tsx
@@ -88,7 +88,7 @@ export const RoundedIcon = ({
         >
             {children ??
                 (name && name in icons ? (
-                    <Icon name={name as IconName} color={iconColor} size={iconSize} />
+                    <Icon name={name} color={iconColor} size={iconSize} />
                 ) : (
                     symbol && <CryptoIcon symbol={symbol} contractAddress={contractAddress} />
                 ))}


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@suite-native/atoms`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/no-unnec-assert-atoms&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->