### PR TITLE
refactor(trading): remove unnecessary type assertions (@suite-common/trading)

### DIFF
--- a/suite-common/trading/src/hooks/useTradingAssets.ts
+++ b/suite-common/trading/src/hooks/useTradingAssets.ts
@@ -100,7 +100,7 @@ export function createAssetOption({
             isNativeToken: true,
             id: networkConfig.tradeCryptoId as CryptoId,
             name: networkConfig.name,
-            coingeckoId: networkConfig.coingeckoId!,
+            coingeckoId: networkConfig.coingeckoId,
             symbol: networkConfig.symbol,
             displaySymbol: networkConfig.displaySymbol,
             contractAddress: contractAddress as TradingAssetOptionNativeToken['contractAddress'],
@@ -116,7 +116,7 @@ export function createAssetOption({
         return null;
     }
 
-    const networkConfig = getNetwork(networkSymbol)! as NetworkConfigWithoutTestnets;
+    const networkConfig = getNetwork(networkSymbol) as NetworkConfigWithoutTestnets;
 
     const coinInfoSymbol = coinInfo.symbol;
 
@@ -125,7 +125,7 @@ export function createAssetOption({
         id: cryptoId,
         name: coinInfo.name,
         symbol: coinInfoSymbol,
-        coingeckoId: networkConfig.coingeckoId!,
+        coingeckoId: networkConfig.coingeckoId,
         displaySymbol: getDisplaySymbol(coinInfoSymbol.toUpperCase(), contractAddress),
         contractAddress: contractAddress!,
         networkName: networkConfig.name,
@@ -205,7 +205,7 @@ export function createAssetTokenOption<
 
     return {
         id: getCryptoId(networkSymbol, token.contract),
-        coingeckoId: network.coingeckoId!,
+        coingeckoId: network.coingeckoId,
 
         isNativeToken: false,
 
@@ -295,7 +295,7 @@ export function useTradingAssets() {
             token: Pick<TokenInfo, 'contract' | 'symbol' | 'name'>,
         ): TradingAssetOptionWithContractAddress => {
             const { coins, platforms } = getCoinsAndPlatforms();
-            const cryptoId = getCryptoId(networkSymbol, token.contract) as CryptoId;
+            const cryptoId = getCryptoId(networkSymbol, token.contract);
 
             if (coins?.[cryptoId]) {
                 const result = createAssetOption({

--- a/suite-common/trading/src/regional.ts
+++ b/suite-common/trading/src/regional.ts
@@ -53,7 +53,7 @@ class Regional {
     }
 
     isSanctioned(country: string): boolean {
-        return SANCTIONED_COUNTRIES.has(country as TradingCountryCode);
+        return SANCTIONED_COUNTRIES.has(country);
     }
 
     getCountryOptionWithWorldwideFallback(country: string): TradingCountryOption {

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -184,7 +184,7 @@ export const selectTradingBuyInfo = createMemoizedSelector(
                 defaultAmountsOfFiatCurrencies,
             },
             supportedCryptoCurrencies: new Set(buyInfo.supportedCryptoCurrencies),
-            supportedFiatCurrencies: new Set(buyInfo.supportedFiatCurrencies as FiatCurrencyCode[]),
+            supportedFiatCurrencies: new Set(buyInfo.supportedFiatCurrencies),
         };
     },
 );


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@suite-common/trading`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-trading-common/web/](https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-trading-common/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/no-unnec-assert-trading-common&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/no-unnec-assert-trading-common&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/no-unnec-assert-trading-common&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-30T07:51:41.210Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-30T07:50:14.430Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->