### PR TITLE
refactor(suite-sync): remove unnecessary type assertions (@suite-common/suite-sync)

### DIFF
--- a/suite-common/suite-sync/src/data/labeling/fromSuiteSyncToSearchAccountLabels.ts
+++ b/suite-common/suite-sync/src/data/labeling/fromSuiteSyncToSearchAccountLabels.ts
@@ -2,7 +2,6 @@ import { type SuiteSyncAddress, type SuiteSyncOutput } from '@suite-common/suite
 import {
     type SearchAccountLabels,
     type SearchOutputLabels,
-    type TxId,
 } from '@suite-common/transaction-search';
 import { asTxTargetId } from '@suite-common/wallet-types';
 
@@ -14,10 +13,10 @@ export const fromSuiteSyncToSearchOutputLabels = (
     outputLabels.reduce<SearchOutputLabels>((acc, { txId, txTargetId, label }) => {
         if (label === null) return acc;
 
-        if (!acc.has(txId as TxId)) {
-            acc.set(txId as TxId, new Map([[asTxTargetId(`${txTargetId}`), label]]));
+        if (!acc.has(txId)) {
+            acc.set(txId, new Map([[asTxTargetId(`${txTargetId}`), label]]));
         } else {
-            acc.get(txId as TxId)?.set(asTxTargetId(`${txTargetId}`), label);
+            acc.get(txId)?.set(asTxTargetId(`${txTargetId}`), label);
         }
 
         return acc;

--- a/suite-common/suite-sync/src/data/suiteSyncDataReducer.ts
+++ b/suite-common/suite-sync/src/data/suiteSyncDataReducer.ts
@@ -39,7 +39,7 @@ const ensureWallet = (
         };
     }
 
-    return state.wallets[walletDescriptor]!;
+    return state.wallets[walletDescriptor];
 };
 
 export const suiteSyncDataSlice = createSlice({

--- a/suite-common/suite-sync/src/suiteSyncMiddleware.ts
+++ b/suite-common/suite-sync/src/suiteSyncMiddleware.ts
@@ -26,7 +26,7 @@ export const prepareSuiteSyncMiddleware = createMiddlewareWithExtraDeps(
         }
 
         if (selectIsSuiteSyncEnabled(getState()) && isAnyOf(selectDeviceThunk.fulfilled)(action)) {
-            const { payload } = action as ReturnType<typeof selectDeviceThunk.fulfilled>;
+            const { payload } = action;
 
             if (isTrezorDeviceWithState(payload.device) && payload.device.discovered) {
                 const suiteSyncErrors = selectHasDeviceSuiteSyncError(


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@suite-common/suite-sync`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-suite-sync-common/web/](https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-suite-sync-common/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/no-unnec-assert-suite-sync-common&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/no-unnec-assert-suite-sync-common&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-30T07:51:09.841Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->