### PR TITLE
refactor(coinjoin): remove unnecessary type assertions (@trezor/coinjoin)

### DIFF
--- a/packages/coinjoin/src/backend/filters.ts
+++ b/packages/coinjoin/src/backend/filters.ts
@@ -29,7 +29,7 @@ const createFilter = (data: Buffer, { P = P_DEFAULT, M = M_DEFAULT }) => {
 };
 
 export const getAddressScript = (address: string, network: Network) =>
-    addressBjs.toOutputScript(address, network) as Buffer;
+    addressBjs.toOutputScript(address, network);
 
 export const getMultiFilter = (filterHex: string, { P, M, key }: FilterParams = {}) => {
     if (!filterHex) return () => false;

--- a/packages/coinjoin/src/client/Status.ts
+++ b/packages/coinjoin/src/client/Status.ts
@@ -5,12 +5,7 @@ import * as coordinator from './coordinator';
 import { coordinatorRequest } from './coordinatorRequest';
 import { STATUS_TIMEOUT } from '../constants';
 import { RoundPhase } from '../enums';
-import {
-    type CoinjoinClientSettings,
-    type CoinjoinClientVersion,
-    type CoinjoinStatusEvent,
-    type LogEvent,
-} from '../types';
+import { type CoinjoinClientSettings, type CoinjoinStatusEvent, type LogEvent } from '../types';
 import { type Round } from '../types/coordinator';
 import { patchResponse } from '../utils/http';
 import { transformStatus } from '../utils/roundUtils';
@@ -249,7 +244,7 @@ export class Status extends TypedEmitter<StatusEvents> {
             majorVersion: version?.BackenMajordVersion ?? '0',
             commitHash: version?.CommitHash ?? 'deadbeef',
             legalDocumentsVersion: version?.Ww2LegalDocumentsVersion ?? '1.0',
-        } as CoinjoinClientVersion;
+        };
     }
 
     async start() {

--- a/packages/coinjoin/src/client/analyzeTransactions.ts
+++ b/packages/coinjoin/src/client/analyzeTransactions.ts
@@ -26,14 +26,14 @@ const transformVinVout = (vinvout: EnhancedVinVout, network: Network) => {
     const Address: string = addresses[0];
     const Value = Number(vinvout.value);
 
-    if (vinvout.isAccountOwned) return { Address, Value } as AnalyzeInternalVinVout;
+    if (vinvout.isAccountOwned) return { Address, Value };
 
     const ScriptPubKey = addressBjs.toOutputScript(Address, network).toString('hex');
 
     return {
         ScriptPubKey,
         Value,
-    } as AnalyzeExternalVinVout;
+    };
 };
 
 const isInternal = (


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@trezor/coinjoin`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-coinjoin/web/](https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-coinjoin/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/no-unnec-assert-coinjoin&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/no-unnec-assert-coinjoin&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-30T07:52:53.226Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-30T07:51:32.149Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->