### PR TITLE
refactor(utils): remove unnecessary type assertions (@trezor/utils)

### DIFF
--- a/packages/utils/src/cloneObject.ts
+++ b/packages/utils/src/cloneObject.ts
@@ -15,7 +15,7 @@ export const cloneObject = <T>(obj: T, seen = new WeakMap<object, any>()): T => 
     if (ArrayBuffer.isView(obj)) {
         const TypedArrayConstructor = obj.constructor as new (...args: any[]) => typeof obj;
 
-        return new TypedArrayConstructor(obj) as any;
+        return new TypedArrayConstructor(obj);
     }
 
     const clone: any = Array.isArray(obj) ? [] : {};

--- a/packages/utils/src/typedObject.ts
+++ b/packages/utils/src/typedObject.ts
@@ -21,7 +21,7 @@ export const typedObjectTransformValues = <T extends Record<string, unknown>, U>
     ) as { [K in keyof T]: U };
 
 export const typedObjectKeys = <T extends Record<string, unknown>>(obj: T): Array<keyof T> =>
-    Object.keys(obj) as Array<keyof T>;
+    Object.keys(obj);
 
 export const typedObjectValues = <T extends Record<string, unknown>>(obj: T): Array<T[keyof T]> =>
     Object.values(obj) as Array<T[keyof T]>;


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@trezor/utils`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-utils/web/](https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-utils/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/no-unnec-assert-utils&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/no-unnec-assert-utils&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-30T07:53:15.542Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-30T07:51:40.290Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->