### PR TITLE
refactor(suite-native): remove unnecessary type assertions (@suite-native/trading-state)

### DIFF
--- a/suite-native/trading-state/src/selectors/buySelectors.ts
+++ b/suite-native/trading-state/src/selectors/buySelectors.ts
@@ -100,7 +100,7 @@ export const selectBuyFormDefaultValues = createMemoizedSelector(
     ],
     (buyInfo, coins, residenceCountry, residenceCountrySubdivision) => {
         if (!buyInfo || !coins) {
-            return {} as Partial<BuyFormValues>;
+            return {};
         }
 
         const { suggestedFiatCurrency } = buyInfo.buyInfo;

--- a/suite-native/trading-state/src/selectors/sellSelectors.ts
+++ b/suite-native/trading-state/src/selectors/sellSelectors.ts
@@ -2,7 +2,6 @@ import type { FiatCurrencyCode } from 'invity-api';
 
 import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import {
-    type TradingCountryCode,
     type TradingPaymentMethodProps,
     bestSellQuotePerPaymentMethodProjection,
     getCurrencyLabel,
@@ -58,10 +57,10 @@ export const selectSellFormDefaultValues = createMemoizedSelector(
     ],
     (sellInfo, coins, residenceCountry, residenceCountrySubdivision) => {
         if (!sellInfo || !coins) {
-            return {} as Partial<SellFormValues>;
+            return {};
         }
 
-        const country = residenceCountry ?? (sellInfo.country as TradingCountryCode);
+        const country = residenceCountry ?? sellInfo.country;
 
         const fiatCurrency = DEFAULT_FIAT_CURRENCY_FALLBACK;
         const countryDefaultValue =


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@suite-native/trading-state`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/no-unnec-assert-trading-state&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->