### PR TITLE
refactor(suite-native): remove unnecessary type assertions (@suite-native/storage)

### DIFF
--- a/suite-native/storage/src/migrations/walletSettings/v2.ts
+++ b/suite-native/storage/src/migrations/walletSettings/v2.ts
@@ -20,7 +20,7 @@ export const migrateAutoEjectToWalletSettings =
         });
 
         if (!devicesState || !('isDeviceAutoEjectEnabled' in devicesState)) {
-            return oldState as MigratedState; // no new migration, just pass the previous one
+            return oldState; // no new migration, just pass the previous one
         }
 
         return {

--- a/suite-native/storage/src/transforms/tokenDefinitionsTransforms.ts
+++ b/suite-native/storage/src/transforms/tokenDefinitionsTransforms.ts
@@ -29,6 +29,6 @@ export const tokenDefinitionsPersistTransform = createTransform<
 
         return result;
     },
-    outboundState => outboundState as TokenDefinitionsState,
+    outboundState => outboundState,
     { whitelist: ['tokenDefinitions'] },
 );


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@suite-native/storage`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/no-unnec-assert-storage-native&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->