### PR TITLE
refactor(suite-native): remove unnecessary type assertions (@suite-native/module-stellar-token-management)

### DIFF
--- a/suite-native/module-stellar-token-management/src/hooks/useStellarFeeScreen.ts
+++ b/suite-native/module-stellar-token-management/src/hooks/useStellarFeeScreen.ts
@@ -18,9 +18,7 @@ import {
 } from '@suite-common/wallet-core';
 import {
     type AccountKey,
-    type FeeLevelLabel,
     type FormState,
-    type PrecomposedTransactionFinal,
     type TokenAddress,
     isFinalPrecomposedTransaction,
 } from '@suite-common/wallet-types';
@@ -122,7 +120,7 @@ export const useStellarFeeScreen = ({
         selectFeeLevels(state),
     );
     const normalFeePerUnit = isFinalPrecomposedTransaction(precomposedFeeLevels.normal)
-        ? (precomposedFeeLevels.normal as PrecomposedTransactionFinal).feePerByte
+        ? precomposedFeeLevels.normal.feePerByte
         : undefined;
 
     const {
@@ -136,7 +134,7 @@ export const useStellarFeeScreen = ({
         handleCustomFeeSet,
     } = useFeesManagement({
         accountKey,
-        selectedFee: (formDraft?.selectedFee as FeeLevelLabel) ?? 'normal',
+        selectedFee: formDraft?.selectedFee ?? 'normal',
         selectedFeePerUnit: formDraft?.feePerUnit ?? normalFeePerUnit,
         updateThunk: updateStellarTokenSelectedFeeLevelThunk,
         formDraftKey,

--- a/suite-native/module-stellar-token-management/src/thunks.ts
+++ b/suite-native/module-stellar-token-management/src/thunks.ts
@@ -13,7 +13,6 @@ import {
 import {
     type AccountKey,
     type FormState,
-    type PrecomposedTransactionFinal,
     type TokenAddress,
     isFinalPrecomposedTransaction,
 } from '@suite-common/wallet-types';
@@ -147,7 +146,7 @@ export const composeStellarTrustlineFeesThunk = createThunk(
 
             // Get the actual composed normal fee to use as default for custom fee
             const composedNormalFee = isFinalPrecomposedTransaction(result.payload.normal)
-                ? (result.payload.normal as PrecomposedTransactionFinal).feePerByte
+                ? result.payload.normal.feePerByte
                 : normalFeePerUnit;
 
             // Store form draft for fee selection with the composed fee


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@suite-native/module-stellar-token-management`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/no-unnec-assert-stellar-token&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->