### PR TITLE
refactor(suite-native): remove unnecessary type assertions (@suite-native/module-earn)

### DIFF
--- a/suite-native/module-earn/src/components/YieldTransactionReviewOutputList.tsx
+++ b/suite-native/module-earn/src/components/YieldTransactionReviewOutputList.tsx
@@ -7,7 +7,6 @@ import { VStack } from '@suite-native/atoms';
 import {
     LIST_VERTICAL_SPACING,
     SlidingFooterOverlay,
-    type StatefulReviewOutput,
     useActiveStepOffset,
 } from '@suite-native/transaction-management';
 
@@ -73,17 +72,14 @@ const getSummaryState = ({
 };
 
 const getStatefulOutputs = ({ activeStep, isSigned, outputs }: GetStatefulOutputsParams) =>
-    outputs.map(
-        (output: ReviewOutput, index) =>
-            ({
-                ...output,
-                state: getOutputState({
-                    activeStep,
-                    index,
-                    isSigned: isSigned ?? false,
-                }),
-            }) as StatefulReviewOutput,
-    );
+    outputs.map((output: ReviewOutput, index) => ({
+        ...output,
+        state: getOutputState({
+            activeStep,
+            index,
+            isSigned: isSigned ?? false,
+        }),
+    }));
 
 export const YieldTransactionReviewOutputList = ({
     accountKey,

--- a/suite-native/module-earn/src/hooks/useInstantUnstakeBanner.ts
+++ b/suite-native/module-earn/src/hooks/useInstantUnstakeBanner.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { getChangedInternalTx, getInstantStakeType } from '@suite-common/staking';
-import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type TransactionsRootState,
@@ -69,7 +69,7 @@ export const useInstantUnstakeBanner = (
 
     return {
         amount,
-        displaySymbol: getNetworkDisplaySymbol(symbol as NetworkSymbol),
+        displaySymbol: getNetworkDisplaySymbol(symbol),
         unstakingPeriodInDays,
         dismiss,
     };


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@suite-native/module-earn`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/no-unnec-assert-module-earn&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->