### PR TITLE
refactor(suite-sync-evolu): remove unnecessary type assertions (@suite-common/suite-sync-evolu)

### DIFF
--- a/suite-common/suite-sync-evolu/src/data/addressTable.ts
+++ b/suite-common/suite-sync-evolu/src/data/addressTable.ts
@@ -64,7 +64,7 @@ export class AddressEvoluTable implements AddressTable {
             address,
             label: normalizeLabel(label),
             accountDescriptor: asAccountDescriptor(accountDescriptor),
-            networkSymbol: networkSymbol as NetworkSymbol,
+            networkSymbol,
         });
 
         if (!validated.ok) {

--- a/suite-common/suite-sync-evolu/src/data/outputTable.ts
+++ b/suite-common/suite-sync-evolu/src/data/outputTable.ts
@@ -18,11 +18,7 @@ import {
     createSuiteSyncUpdateError,
 } from '@suite-common/suite-sync-storage';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
-import {
-    type AccountDescriptor,
-    asAccountDescriptor,
-    asTxTargetId,
-} from '@suite-common/wallet-types';
+import { asAccountDescriptor, asTxTargetId } from '@suite-common/wallet-types';
 import { err, ok } from '@trezor/type-utils';
 
 import { normalizeLabel } from './normalizeLabel';
@@ -70,8 +66,8 @@ export class OutputEvoluTable implements OutputTable {
             txId,
             outputIndex: `${txTargetId}`,
             label: normalizeLabel(label),
-            accountDescriptor: accountDescriptor as AccountDescriptor,
-            networkSymbol: networkSymbol as NetworkSymbol,
+            accountDescriptor,
+            networkSymbol,
         });
 
         if (!validated.ok) {


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@suite-common/suite-sync-evolu`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-suite-sync-evolu/web/](https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-suite-sync-evolu/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/no-unnec-assert-suite-sync-evolu&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/no-unnec-assert-suite-sync-evolu&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/no-unnec-assert-suite-sync-evolu&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T12:49:30.180Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T12:47:20.003Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are to `addressTable.ts` and `outputTable.ts` in the suite-sync-evolu package, which define the Evolu database table schemas for address and output labels used by Suite Sync. While these files are transitively imported by 121 tests (indicating they are part of a broadly-imported module), only the Suite Sync metadata tests directly exercise the address and output label sync functionality. The recommended strategy focuses on the 5 tests that actually create, read, remove, migrate, or sync address/output labels through the Evolu relay — all other tests merely have a transitive dependency and would not exercise these table definitions in any meaningful way.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/suite-sync-evolu/src/data/addressTable.ts`
- `suite-common/suite-sync-evolu/src/data/outputTable.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test directly creates and syncs address and output labels to the Evolu Relay backend, then verifies the 'address' and 'output' tables contain the expected records. Changes to addressTable.ts and outputTable.ts directly affect the schema/logic used to store these labels.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test removes address and output labels via Suite Sync and verifies the Evolu relay 'address' and 'output' tables contain records with label: null. It directly exercises the address and output table definitions being changed.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test seeds the Evolu relay with address and output label data and verifies they sync correctly into the Suite UI. Changes to addressTable.ts and outputTable.ts could break how synced address/output labels are read and displayed.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test exercises Suite Sync across multiple wallets, verifying label data is stored under correct owner secrets in the Evolu relay. While it focuses more on wallet/account tables, it depends on the same Suite Sync infrastructure that includes the changed address and output table definitions.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test migrates labels from legacy Dropbox to Suite Sync using Evolu relay seeding. The migration path depends on the Evolu table schemas including address and output tables, so changes could affect the migration outcome.

</details>

_Updated: 2026-07-01T12:43:55.492Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->