### PR TITLE
refactor(address-validator): remove unnecessary type assertions (@trezor/address-validator)

### DIFF
--- a/packages/address-validator/src/validators/ada_validator.ts
+++ b/packages/address-validator/src/validators/ada_validator.ts
@@ -24,7 +24,7 @@ function getDecoded(address: string): any {
     try {
         const decoded = base58.decode(address);
 
-        return cbor.decode(new Uint8Array(decoded).buffer as ArrayBuffer);
+        return cbor.decode(new Uint8Array(decoded).buffer);
     } catch {
         return null;
     }

--- a/packages/address-validator/src/validators/bitcoin_validator.ts
+++ b/packages/address-validator/src/validators/bitcoin_validator.ts
@@ -348,10 +348,7 @@ export const isAddressValid = (address: string, symbol: NetworkSymbol): boolean 
     return addrType !== undefined && addrType !== addressType.WITNESS_UNKNOWN;
 };
 
-const getSupportedCoins = (): NetworkSymbol[] => [
-    ...(typedObjectKeys(BITCOIN_CURRENCIES) as NetworkSymbol[]),
-    'bch',
-];
+const getSupportedCoins = (): NetworkSymbol[] => [...typedObjectKeys(BITCOIN_CURRENCIES), 'bch'];
 
 export const bitcoinValidator: AddressValidator = {
     isAddressValid,


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR removes the assertions the rule flags as unnecessary in `@trezor/address-validator`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/no-unnec-assert-address-validator&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/no-unnec-assert-address-validator&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-address-validator/web/](https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-address-validator/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-30T07:53:46.151Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->