### PR TITLE
feat(suite-native): reorganize Features section in settings

### DIFF
--- a/suite-native/experimental-features/src/experimentalFeatures.ts
+++ b/suite-native/experimental-features/src/experimentalFeatures.ts
@@ -16,7 +16,4 @@ export const FEEDBACK_FEATURE_CONFIGS: Record<ExperimentalFeature, { titleKey: T
     'suite-sync': {
         titleKey: 'moduleSettings.advanced.experimentalFeatures.suiteSync.title',
     },
-    'testnet-networks': {
-        titleKey: 'moduleSettings.experimental.testnets.title',
-    },
 };

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1082,6 +1082,10 @@ export const messages = {
                         saved: 'Server settings saved.',
                     },
                 },
+                security: {
+                    title: 'Security',
+                    subtitle: 'Protect your transactions',
+                },
                 advanced: {
                     title: 'Advanced',
                     subtitle: 'Enable expert features for power users',
@@ -1374,6 +1378,30 @@ export const messages = {
                 },
             },
         },
+        security: {
+            title: 'Security',
+            mevProtection: {
+                title: 'MEV protection',
+                subtitle:
+                    'Stay safe and secure fair prices by preventing others from interfering with your transactions. Available on {supportedNetworks}.',
+            },
+            dustPhishing: {
+                title: 'Dust phishing protection',
+                subtitle:
+                    'Hide suspicious micro transactions used in scams from your transaction history.',
+                enableProtection: 'Enable protection',
+                dustThresholdTitle: 'Dust phishing threshold',
+                dustThresholdDescription:
+                    'Transactions below this amount are marked as suspicious and hidden.',
+                save: 'Save',
+                placeholder: 'Enter dust threshold in USD',
+                errors: {
+                    empty: 'Dust threshold is required',
+                    number: 'Enter a valid number',
+                    positive: 'Dust threshold must be a positive number',
+                },
+            },
+        },
         advanced: {
             title: 'Advanced',
             authenticityChecks: {
@@ -1410,31 +1438,10 @@ export const messages = {
                 subtitle:
                     'Reserve a small amount of the native token on {supportedNetworks} to cover any extra network fees when you send, swap, or sell your assets.',
             },
-            mevProtection: {
-                title: 'MEV protection',
-                subtitle:
-                    'Stay safe and secure fair prices by preventing others from interfering with your transactions. Available on {supportedNetworks}.',
-            },
             addressDisplay: {
                 title: 'Spaced address formatting',
                 subtitle:
                     'Add spaces to addresses for easier reading. When off, addresses are shown as a continuous string.',
-            },
-            dustPhishing: {
-                title: 'Dust phishing protection',
-                subtitle:
-                    'Hide suspicious micro transactions used in scams from your transaction history.',
-                enableProtection: 'Enable protection',
-                dustThresholdTitle: 'Dust phishing threshold',
-                dustThresholdDescription:
-                    'Transactions below this amount are marked as suspicious and hidden.',
-                save: 'Save',
-                placeholder: 'Enter dust threshold in USD',
-                errors: {
-                    empty: 'Dust threshold is required',
-                    number: 'Enter a valid number',
-                    positive: 'Dust threshold must be a positive number',
-                },
             },
             bitcoinBackends: {
                 title: 'Bitcoin backend',
@@ -1479,6 +1486,11 @@ export const messages = {
                     title: 'Suite Sync',
                 },
             },
+            testnets: {
+                title: 'Testnet networks',
+                description:
+                    'Send and receive transactions on testnet networks. These assets are for testing purposes only and have no real value.',
+            },
             featureFeedback: {
                 title: 'Rate your {featureName} experience',
                 description:
@@ -1493,10 +1505,9 @@ export const messages = {
         experimental: {
             title: 'Experimental',
             subtitle: 'For experienced users only. Use at your own risk.',
-            testnets: {
-                title: 'Testnet networks',
-                description:
-                    'Send and receive transactions on testnet networks. These assets are for testing purposes only and have no real value.',
+            noneAvailable: {
+                title: 'None available',
+                subtitle: 'No experimental features currently available.',
             },
         },
         appLog: {

--- a/suite-native/module-settings/src/components/DustPhishingThresholdCard.tsx
+++ b/suite-native/module-settings/src/components/DustPhishingThresholdCard.tsx
@@ -10,8 +10,8 @@ export const DustPhishingThresholdCard = () => {
     return (
         <PressableCardWithIconLayout
             icon="detective"
-            title={<Translation id="moduleSettings.advanced.dustPhishing.title" />}
-            description={<Translation id="moduleSettings.advanced.dustPhishing.subtitle" />}
+            title={<Translation id="moduleSettings.security.dustPhishing.title" />}
+            description={<Translation id="moduleSettings.security.dustPhishing.subtitle" />}
             onPress={() => navigateTo(SettingsStackRoutes.SettingsDustPhishing)}
         />
     );

--- a/suite-native/module-settings/src/components/FeaturesSettings.tsx
+++ b/suite-native/module-settings/src/components/FeaturesSettings.tsx
@@ -62,6 +62,13 @@ export const FeaturesSettings = () => {
                 />
             )}
             <AppSettingsCardWithIconLayout
+                icon="shield"
+                title={<Translation id="moduleSettings.items.features.security.title" />}
+                subtitle={<Translation id="moduleSettings.items.features.security.subtitle" />}
+                onPress={() => navigateTo(SettingsStackRoutes.SettingsSecurity)}
+                testID="@settings/security"
+            />
+            <AppSettingsCardWithIconLayout
                 icon="shieldWarning"
                 title={<Translation id="moduleSettings.items.features.advanced.title" />}
                 subtitle={<Translation id="moduleSettings.items.features.advanced.subtitle" />}

--- a/suite-native/module-settings/src/components/ToggleMevProtectionCard.tsx
+++ b/suite-native/module-settings/src/components/ToggleMevProtectionCard.tsx
@@ -28,10 +28,10 @@ export const ToggleMevProtectionCard = () => {
             isChecked={isMevProtectionEnabled}
             onChange={handleToggle}
             accessibilityLabel="MEV protection"
-            text={<Translation id="moduleSettings.advanced.mevProtection.title" />}
+            text={<Translation id="moduleSettings.security.mevProtection.title" />}
             description={
                 <Translation
-                    id="moduleSettings.advanced.mevProtection.subtitle"
+                    id="moduleSettings.security.mevProtection.subtitle"
                     values={{ supportedNetworks }}
                 />
             }

--- a/suite-native/module-settings/src/components/ToggleTestnetsCard.tsx
+++ b/suite-native/module-settings/src/components/ToggleTestnetsCard.tsx
@@ -1,23 +1,15 @@
 import { useDispatch, useSelector } from 'react-redux';
 
-import { useServices } from '@suite-common/dependency-injection';
-import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { TouchableSwitchRow } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { selectAreTestnetsEnabled, toggleAreTestnetsEnabled } from '@suite-native/settings';
 
 export const ToggleTestnetsCard = () => {
     const dispatch = useDispatch();
-    const { analytics } = useServices(selectNativeAnalyticsDep);
     const areTestnetsEnabled = useSelector(selectAreTestnetsEnabled);
 
-    const handleToggleTestnets = (value: boolean) => {
+    const handleToggleTestnets = () => {
         dispatch(toggleAreTestnetsEnabled());
-
-        analytics.report({
-            type: events.settingsToggleExperimentalFeatureEvent.name,
-            payload: { feature: 'testnet-networks', value },
-        });
     };
 
     return (
@@ -25,8 +17,8 @@ export const ToggleTestnetsCard = () => {
             icon="coinSlash"
             isChecked={areTestnetsEnabled}
             onChange={handleToggleTestnets}
-            text={<Translation id="moduleSettings.experimental.testnets.title" />}
-            description={<Translation id="moduleSettings.experimental.testnets.description" />}
+            text={<Translation id="moduleSettings.advanced.testnets.title" />}
+            description={<Translation id="moduleSettings.advanced.testnets.description" />}
             accessibilityLabel="Testnets toggle"
             testID="settings/testnets-touchable-row"
         />

--- a/suite-native/module-settings/src/hooks/useDustPhishingForm.ts
+++ b/suite-native/module-settings/src/hooks/useDustPhishingForm.ts
@@ -30,17 +30,17 @@ const getDustThresholdValidation = (translate: Translate) =>
         .string()
         .test({
             name: 'is-empty',
-            message: translate('moduleSettings.advanced.dustPhishing.errors.empty'),
+            message: translate('moduleSettings.security.dustPhishing.errors.empty'),
             test: validateIsEmpty,
         })
         .test({
             name: 'is-valid-number',
-            message: translate('moduleSettings.advanced.dustPhishing.errors.number'),
+            message: translate('moduleSettings.security.dustPhishing.errors.number'),
             test: validateIsNumber,
         })
         .test({
             name: 'is-positive-number',
-            message: translate('moduleSettings.advanced.dustPhishing.errors.positive'),
+            message: translate('moduleSettings.security.dustPhishing.errors.positive'),
             test: validateIsPositiveNumber,
         });
 

--- a/suite-native/module-settings/src/navigation/SettingsStackNavigator.tsx
+++ b/suite-native/module-settings/src/navigation/SettingsStackNavigator.tsx
@@ -16,6 +16,7 @@ import { SettingsExperimentalScreen } from '../screens/SettingsExperimentalScree
 import { SettingsNetworksScreen } from '../screens/SettingsNetworksScreen';
 import { SettingsPreferencesScreen } from '../screens/SettingsPreferencesScreen';
 import { SettingsPrivacyScreen } from '../screens/SettingsPrivacyScreen';
+import { SettingsSecurityScreen } from '../screens/SettingsSecurityScreen';
 import { SettingsSuiteSyncScreen } from '../screens/SettingsSuiteSyncScreen';
 import { SettingsSupportScreen } from '../screens/SettingsSupportScreen';
 import { TurnOffDeviceAuthenticityCheckScreen } from '../screens/TurnOffDeviceAuthenticityCheckScreen';
@@ -63,6 +64,10 @@ export const SettingsStackNavigator = () => (
             options={{ title: SettingsStackRoutes.SettingsSuiteSync }}
             name={SettingsStackRoutes.SettingsSuiteSync}
             component={SettingsSuiteSyncScreen}
+        />
+        <SettingsStack.Screen
+            name={SettingsStackRoutes.SettingsSecurity}
+            component={SettingsSecurityScreen}
         />
         <SettingsStack.Screen
             name={SettingsStackRoutes.SettingsAdvanced}

--- a/suite-native/module-settings/src/screens/SettingsAdvancedScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsAdvancedScreen.tsx
@@ -1,20 +1,17 @@
 import { useSelector } from 'react-redux';
 
-import { selectIsMevProtectionSettingsVisible } from '@suite-common/mev';
 import { selectIsNetworkReserveSettingsVisible } from '@suite-common/wallet-core';
 import { VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
 
-import { DustPhishingThresholdCard } from '../components/DustPhishingThresholdCard';
 import { ToggleAddressDisplayCard } from '../components/ToggleAddressDisplayCard';
 import { ToggleDeviceAuthenticityCheckCard } from '../components/ToggleDeviceAuthenticityCheckCard';
 import { ToggleFirmwareAuthenticityCheckCard } from '../components/ToggleFirmwareAuthenticityCheckCard';
-import { ToggleMevProtectionCard } from '../components/ToggleMevProtectionCard';
 import { ToggleNetworkReserveCheckCard } from '../components/ToggleNetworkReserveCheckCard';
+import { ToggleTestnetsCard } from '../components/ToggleTestnetsCard';
 
 export const SettingsAdvancedScreen = () => {
-    const isMevProtectionSettingsVisible = useSelector(selectIsMevProtectionSettingsVisible);
     const isNetworkReserveSettingsVisible = useSelector(selectIsNetworkReserveSettingsVisible);
 
     return (
@@ -24,11 +21,10 @@ export const SettingsAdvancedScreen = () => {
             }
         >
             <VStack spacing="sp16">
-                <ToggleAddressDisplayCard />
-                {isMevProtectionSettingsVisible && <ToggleMevProtectionCard />}
-                <DustPhishingThresholdCard />
                 <ToggleFirmwareAuthenticityCheckCard />
                 <ToggleDeviceAuthenticityCheckCard />
+                <ToggleAddressDisplayCard />
+                <ToggleTestnetsCard />
                 {isNetworkReserveSettingsVisible && <ToggleNetworkReserveCheckCard />}
             </VStack>
         </Screen>

--- a/suite-native/module-settings/src/screens/SettingsDustPhishingScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsDustPhishingScreen.tsx
@@ -51,8 +51,8 @@ export const SettingsDustPhishingScreen = () => {
         <Screen
             header={
                 <DynamicScreenHeader
-                    title={<Translation id="moduleSettings.advanced.dustPhishing.title" />}
-                    subtitle={<Translation id="moduleSettings.advanced.dustPhishing.subtitle" />}
+                    title={<Translation id="moduleSettings.security.dustPhishing.title" />}
+                    subtitle={<Translation id="moduleSettings.security.dustPhishing.subtitle" />}
                 />
             }
         >
@@ -68,7 +68,7 @@ export const SettingsDustPhishingScreen = () => {
                             <VStack flex={1}>
                                 <HStack justifyContent="space-between" flex={1}>
                                     <Text variant="body-md-strong">
-                                        <Translation id="moduleSettings.advanced.dustPhishing.enableProtection" />
+                                        <Translation id="moduleSettings.security.dustPhishing.enableProtection" />
                                     </Text>
                                     <Switch
                                         isChecked={dustPhishingIsEnabled}
@@ -86,11 +86,11 @@ export const SettingsDustPhishingScreen = () => {
                             <HStack justifyContent="space-between" flex={1}>
                                 <VStack flex={1} spacing="sp2">
                                     <Text variant="body-md-strong">
-                                        <Translation id="moduleSettings.advanced.dustPhishing.dustThresholdTitle" />
+                                        <Translation id="moduleSettings.security.dustPhishing.dustThresholdTitle" />
                                     </Text>
 
                                     <Text variant="body-sm" color="contentSecondary">
-                                        <Translation id="moduleSettings.advanced.dustPhishing.dustThresholdDescription" />
+                                        <Translation id="moduleSettings.security.dustPhishing.dustThresholdDescription" />
                                     </Text>
                                 </VStack>
                             </HStack>
@@ -100,13 +100,13 @@ export const SettingsDustPhishingScreen = () => {
                                     <TextInputField
                                         name="dustThreshold"
                                         label={translate(
-                                            'moduleSettings.advanced.dustPhishing.placeholder',
+                                            'moduleSettings.security.dustPhishing.placeholder',
                                         )}
                                     />
 
                                     {!isDisabled && (
                                         <Button size="medium" onPress={onSubmit}>
-                                            <Translation id="moduleSettings.advanced.dustPhishing.save" />
+                                            <Translation id="moduleSettings.security.dustPhishing.save" />
                                         </Button>
                                     )}
                                 </VStack>

--- a/suite-native/module-settings/src/screens/SettingsExperimentalScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsExperimentalScreen.tsx
@@ -1,10 +1,8 @@
-import { IconButton, VStack } from '@suite-native/atoms';
+import { IconButton, PictogramTitleHeader, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
 import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
 import { EXPERIMENTAL_FEATURES_KB_URL } from '@trezor/urls';
-
-import { ToggleTestnetsCard } from '../components/ToggleTestnetsCard';
 
 export const SettingsExperimentalScreen = () => {
     const openLink = useOpenLink();
@@ -32,8 +30,15 @@ export const SettingsExperimentalScreen = () => {
                 />
             }
         >
-            <VStack spacing="sp16">
-                <ToggleTestnetsCard />
+            <VStack marginTop="sp32" spacing="sp16">
+                <PictogramTitleHeader
+                    variant="info"
+                    title={<Translation id="moduleSettings.experimental.noneAvailable.title" />}
+                    titleVariant="headline-md"
+                    subtitle={
+                        <Translation id="moduleSettings.experimental.noneAvailable.subtitle" />
+                    }
+                />
             </VStack>
         </Screen>
     );

--- a/suite-native/module-settings/src/screens/SettingsSecurityScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsSecurityScreen.tsx
@@ -1,0 +1,26 @@
+import { useSelector } from 'react-redux';
+
+import { selectIsMevProtectionSettingsVisible } from '@suite-common/mev';
+import { VStack } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
+
+import { DustPhishingThresholdCard } from '../components/DustPhishingThresholdCard';
+import { ToggleMevProtectionCard } from '../components/ToggleMevProtectionCard';
+
+export const SettingsSecurityScreen = () => {
+    const isMevProtectionSettingsVisible = useSelector(selectIsMevProtectionSettingsVisible);
+
+    return (
+        <Screen
+            header={
+                <DynamicScreenHeader title={<Translation id="moduleSettings.security.title" />} />
+            }
+        >
+            <VStack spacing="sp16">
+                {isMevProtectionSettingsVisible && <ToggleMevProtectionCard />}
+                <DustPhishingThresholdCard />
+            </VStack>
+        </Screen>
+    );
+};

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -160,6 +160,7 @@ export type SettingsStackParamList = {
         networkSymbol: NetworkSymbol;
     };
     [SettingsStackRoutes.SettingsSuiteSync]: undefined;
+    [SettingsStackRoutes.SettingsSecurity]: undefined;
     [SettingsStackRoutes.SettingsAdvanced]: undefined;
     [SettingsStackRoutes.SettingsDustPhishing]: undefined;
     [SettingsStackRoutes.SettingsExperimental]: undefined;

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -287,6 +287,7 @@ export enum SettingsStackRoutes {
     SettingsNetworks = 'SettingsNetworks',
     SettingsNetworkBackends = 'SettingsNetworkBackends',
     SettingsSuiteSync = 'SettingsSuiteSync',
+    SettingsSecurity = 'SettingsSecurity',
     SettingsAdvanced = 'SettingsAdvanced',
     SettingsDustPhishing = 'SettingsDustPhishing',
     SettingsExperimental = 'SettingsExperimental',

--- a/suite-native/settings/src/settingsSlice.ts
+++ b/suite-native/settings/src/settingsSlice.ts
@@ -4,7 +4,7 @@ import { type EarnYieldWorkerBaseUrl } from '@suite-common/earn-stablecoin-defs'
 import { isDetoxTestBuild } from '@suite-native/config';
 import { DEVICE } from '@trezor/connect';
 
-export type ExperimentalFeature = 'suite-sync' | 'testnet-networks';
+export type ExperimentalFeature = 'suite-sync';
 
 export interface AppSettingsState {
     isOnboardingFinished: boolean;


### PR DESCRIPTION
Reorganization only. Text and icon tweaks to be done in a separate PR.

## Related Issue

Resolve #29146

## Tasks

- [x] Move translations in Crowdin

## Screenshots

| Settings | Security | Advance |
| --- | --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/9ca414e2-d04d-42fd-b8d0-dc9430ffee03" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/1b0d1ccb-7057-42d5-8740-be1113a44d9a" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/d8d86ebc-d1ef-400e-aa94-02b49fa4913a" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/settings-reorganization&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->