### PR TITLE
feat(blockchain-link): evm specific data for gas

### DIFF
--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -121,7 +121,7 @@ export interface EthereumSpecific {
     /** Transaction nonce (sequential number from the sender). */
     nonce: number;
     /** Maximum gas allowed by the sender for this transaction. */
-    gasLimit: number;
+    gasLimit?: number;
     /** Actual gas consumed by the transaction execution. */
     gasUsed?: number;
     /** Price (in Wei or base units) per gas unit. */
@@ -897,8 +897,8 @@ export interface WsEstimateFeeReq {
     };
 }
 export interface Eip1559Fee {
-    maxFeePerGas: string;
-    maxPriorityFeePerGas: string;
+    maxFeePerGas?: string;
+    maxPriorityFeePerGas?: string;
     minWaitTimeEstimate?: number;
     maxWaitTimeEstimate?: number;
 }
@@ -991,4 +991,14 @@ export interface MempoolTxidFilterEntries {
     entries?: { [key: string]: string };
     /** Indicates if a zeroed key was used in filter calculation. */
     usedZeroedKey?: boolean;
+}
+export interface EthereumGasData {
+    baseFeePerGas?: string;
+    blockGasUsed?: string;
+    blockGasLimit?: string;
+}
+export interface WsNewBlock {
+    height: number;
+    hash: string;
+    evmData: EthereumGasData | null;
 }

--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -10,6 +10,7 @@ import type {
     Tx as BlockbookTx,
     Utxo as BlockbookUtxo,
     ContractInfoResult,
+    EthereumGasData,
     FiatTicker,
     MempoolTxidFilterEntries,
     WsAccountUtxoReq,
@@ -20,6 +21,7 @@ import type {
     WsEstimateFeeRes,
     WsInfoRes,
     WsMempoolFiltersReq,
+    WsNewBlock,
 } from './blockbook-api';
 import type { AccountBalanceHistory, FiatRatesBySymbol, TokenStandard } from './common';
 import type {
@@ -142,7 +144,8 @@ export interface Push {
 
 export type Fee = Omit<RequiredKey<WsEstimateFeeRes, 'feePerUnit'>, 'eip1559'>[];
 
-export type BlockNotification = Pick<BlockbookBlock, 'hash' | 'height'>;
+export type BlockNotification = WsNewBlock;
+export type { EthereumGasData };
 
 export type MempoolTransactionNotification = RequiredKey<
     Transaction,

--- a/packages/blockchain-link-types/src/index.ts
+++ b/packages/blockchain-link-types/src/index.ts
@@ -35,6 +35,7 @@ export type {
     TronUnstakingBatch,
     TronVote,
     Eip1559Fees,
+    EthereumGasData,
 } from './blockbook-api';
 
 export type {

--- a/packages/blockchain-link-types/src/responses.ts
+++ b/packages/blockchain-link-types/src/responses.ts
@@ -1,5 +1,5 @@
 import type { Block, ContractInfoResponse, MempoolTransactionNotification } from './blockbook';
-import { type Eip1559Fees } from './blockbook-api';
+import { type Eip1559Fees, type EthereumGasData } from './blockbook-api';
 import type {
     AccountBalanceHistory,
     AccountInfo,
@@ -126,6 +126,7 @@ export interface BlockEvent {
     payload: {
         blockHeight: number;
         blockHash: string;
+        evmData?: EthereumGasData | null;
     };
 }
 

--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -172,7 +172,7 @@ const getTransactionFee = (tx: BlockbookTransaction): string => {
     if (tx.chainExtraData?.payloadType === 'tron') {
         return tx.chainExtraData.payload?.totalFee || tx.fees;
     }
-    if (tx.ethereumSpecific && !tx.ethereumSpecific.gasUsed) {
+    if (tx.ethereumSpecific && !tx.ethereumSpecific.gasUsed && tx.ethereumSpecific.gasLimit) {
         return new BigNumber(
             tx.ethereumSpecific.maxFeePerGas ?? tx.ethereumSpecific.gasPrice ?? '0',
         )
@@ -339,6 +339,7 @@ export const transformTransaction = (
         ethereumSpecific: tx.ethereumSpecific && {
             ...tx.ethereumSpecific,
             gasPrice: tx.ethereumSpecific.gasPrice ?? '0', // even if it shouldn't, `null` sometimes came from Erigon
+            gasLimit: tx.ethereumSpecific.gasLimit ?? 0,
         },
         tronSpecific:
             tx.chainExtraData?.payloadType === 'tron' ? tx.chainExtraData.payload : undefined,

--- a/packages/blockchain-link/src/workers/blockbook/index.ts
+++ b/packages/blockchain-link/src/workers/blockbook/index.ts
@@ -196,6 +196,7 @@ const onNewBlock = ({ post }: Context, event: BlockNotification) => {
             payload: {
                 blockHeight: event.height,
                 blockHash: event.hash,
+                evmData: event.evmData ?? null,
             },
         },
     });

--- a/packages/blockchain-link/src/workers/evm-rpc/handlers/getBlock.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/handlers/getBlock.ts
@@ -11,11 +11,16 @@ export const getBlock = async (
     const client = await request.connect();
     const blockId = request.payload;
 
-    const block = await client.getBlock(
-        isHex(blockId)
-            ? { blockHash: blockId, includeTransactions: true }
-            : { blockNumber: BigInt(blockId), includeTransactions: true },
-    );
+    let blockParams: Parameters<typeof client.getBlock>[0];
+    if (blockId === 'latest') {
+        blockParams = { blockTag: 'latest', includeTransactions: true };
+    } else if (isHex(blockId)) {
+        blockParams = { blockHash: blockId, includeTransactions: true };
+    } else {
+        blockParams = { blockNumber: BigInt(blockId), includeTransactions: true };
+    }
+
+    const block = await client.getBlock(blockParams);
 
     if (!block) {
         throw new CustomError('worker_runtime', `Block ${blockId} not found`);

--- a/packages/blockchain-link/src/workers/evm-rpc/mappers/block.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/mappers/block.ts
@@ -34,6 +34,20 @@ const mapBlockTransaction = (
     value: tx.value.toString(10),
     fees: tx.gas && tx.gasPrice ? (tx.gas * tx.gasPrice).toString(10) : '0',
     confirmations,
+    ethereumSpecific: {
+        status: 1,
+        nonce: tx.nonce,
+        gasLimit: Number(tx.gas),
+        type: tx.typeHex ? parseInt(tx.typeHex, 16) : undefined,
+        maxPriorityFeePerGas:
+            'maxPriorityFeePerGas' in tx && tx.maxPriorityFeePerGas != null
+                ? tx.maxPriorityFeePerGas.toString()
+                : undefined,
+        maxFeePerGas:
+            'maxFeePerGas' in tx && tx.maxFeePerGas != null
+                ? tx.maxFeePerGas.toString()
+                : undefined,
+    },
 });
 
 interface MapGetBlockResponseParams {

--- a/packages/blockchain-link/tests/unit/fixtures/notifications-blockbook.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/notifications-blockbook.ts
@@ -31,6 +31,7 @@ const notifyBlocks = [
         result: {
             blockHash: 'abcd',
             blockHeight: 1,
+            evmData: null,
         },
     },
     {
@@ -51,6 +52,7 @@ const notifyBlocks = [
         result: {
             blockHash: 'efgh',
             blockHeight: 2,
+            evmData: null,
         },
     },
     {
@@ -86,6 +88,7 @@ const notifyBlocks = [
         result: {
             blockHash: 'efgh05',
             blockHeight: 5,
+            evmData: null,
         },
     },
     {
@@ -118,6 +121,7 @@ const notifyBlocks = [
         result: {
             blockHash: 'abcd',
             blockHeight: 1,
+            evmData: null,
         },
     },
 ] as const;

--- a/packages/connect/src/backend/fees/EthereumFeeLevels.ts
+++ b/packages/connect/src/backend/fees/EthereumFeeLevels.ts
@@ -20,8 +20,6 @@ export class EthereumFeeLevels extends MiscFeeLevels {
             // @ts-expect-error: indexing with noUncheckedIndexedAccess
             const response: (typeof estimateResult)[number] = estimateResult[0];
 
-            const { eip1559 } = response;
-
             // gas price in wei
             const maxFeeInWei = new BigNumber(this.coinInfo.maxFee).multipliedBy('1e+9').toNumber();
             const minFeeInWei = new BigNumber(this.coinInfo.minFee).multipliedBy('1e+9').toNumber();
@@ -30,10 +28,16 @@ export class EthereumFeeLevels extends MiscFeeLevels {
             // validate gas price from backend; clamp and round to integer wei (backend may return decimal)
             const feePerUnit = new BigNumber(clamp(feeInWei, minFeeInWei, maxFeeInWei)).toFixed(0);
 
+            const { eip1559 } = response;
+
             if (eip1559?.baseFeePerGas) {
                 const minMaxPriorityFeePerGas = new BigNumber(this.coinInfo.minPriorityFee)
                     .multipliedBy('1e+9')
                     .toNumber();
+
+                // Fallback block estimates used when the provider (e.g. 1inch) doesn't supply
+                // per-tier wait times. Values match typical EIP-1559 confirmation expectations.
+                const defaultBlocks = { low: 4, medium: 2, high: 1 } as const;
 
                 const levels = (['low', 'medium', 'high'] as const).map(levelKey => {
                     const level = eip1559[levelKey];
@@ -55,16 +59,15 @@ export class EthereumFeeLevels extends MiscFeeLevels {
                         BigNumber.min(maxFeePerGas, level.maxPriorityFeePerGas),
                     ).toFixed(0);
 
+                    const blocksFromWaitTime = level.maxWaitTimeEstimate
+                        ? Math.ceil(level.maxWaitTimeEstimate / 1000 / this.coinInfo.blockTime)
+                        : 0;
+
                     return {
                         label,
                         feePerUnit,
                         feeLimit: response.feeLimit,
-                        blocks: Math.ceil(
-                            Math.max(
-                                1,
-                                (level?.maxWaitTimeEstimate || 0) / 1000 / this.coinInfo.blockTime,
-                            ),
-                        ),
+                        blocks: blocksFromWaitTime || defaultBlocks[levelKey],
                         baseFeePerGas: eip1559.baseFeePerGas,
                         maxFeePerGas,
                         maxPriorityFeePerGas,

--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -74,11 +74,11 @@ async function getEstimatedFee({
     const gasLimit = feeLevel.feeLimit ?? ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT;
     const eip1559MediumFee = feeLevel.eip1559?.medium;
 
-    if (eip1559MediumFee && feeLevel.eip1559) {
+    if (eip1559MediumFee?.maxFeePerGas && eip1559MediumFee?.maxPriorityFeePerGas) {
         return {
             maxFeePerGas: eip1559MediumFee.maxFeePerGas,
             maxPriorityFeePerGas: eip1559MediumFee.maxPriorityFeePerGas,
-            baseFeePerGas: feeLevel.eip1559.baseFeePerGas,
+            baseFeePerGas: feeLevel.eip1559?.baseFeePerGas,
             gasLimit,
         };
     }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -184,7 +184,7 @@ export const BasicTxDetails = ({
                             iconName="gasPump"
                         >
                             {tx.ethereumSpecific.gasLimit}
-                            {tx.ethereumSpecific.gasUsed && (
+                            {tx.ethereumSpecific.gasUsed && tx.ethereumSpecific.gasLimit && (
                                 <>
                                     {' / '}
                                     {tx.ethereumSpecific.gasUsed} (

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/EthereumFeeCards.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/EthereumFeeCards.tsx
@@ -61,6 +61,8 @@ export const EthereumFeeCards = ({ feeOptions }: EthereumFeeCardsProps) => {
         return null;
     }
 
+    const units = getFeeUnits(networkType);
+
     return (
         <>
             <FeeCardsWrapper data-testid="@wallet/fee-details">
@@ -107,15 +109,15 @@ export const EthereumFeeCards = ({ feeOptions }: EthereumFeeCardsProps) => {
                                     >
                                         <Translation id="TR_MAX_FEE_PER_GAS" />
                                         <Text isMonospaced>
-                                            {fee.maxFeePerGas} {getFeeUnits(networkType)}
+                                            {fee.maxFeePerGas} {units}
                                         </Text>
                                         <Translation id="TR_MAX_PRIORITY_FEE_PER_GAS" />
                                         <Text isMonospaced>
-                                            {fee.maxPriorityFeePerGas} {getFeeUnits(networkType)}
+                                            {fee.maxPriorityFeePerGas} {units}
                                         </Text>
                                         <Translation id="TR_BASE_FEE" />
                                         <Text isMonospaced>
-                                            {fee.baseFeePerGas} {getFeeUnits(networkType)}
+                                            {fee.baseFeePerGas} {units}
                                         </Text>
                                     </Grid>
                                 </>
@@ -124,6 +126,7 @@ export const EthereumFeeCards = ({ feeOptions }: EthereumFeeCardsProps) => {
                     />
                 ))}
             </FeeCardsWrapper>
+
             {isDebug && cachedGasLimit && (
                 <Row alignItems="baseline" justifyContent="space-between">
                     <Row gap={spacings.xxs}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Introduces subscription to get last block values needed for gas computations and improves compatibility with other RPC providers 

## Notes for QA

Make sure to test Mainnet gas tiers as well as Base + gas tiers for swaps

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/evm-fee/web/](https://dev.suite.sldev.cz/suite-web/fix/evm-fee/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/evm-fee&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/evm-fee&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/evm-fee&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T09:08:11.944Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T09:06:26.453Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set touches three main areas: (1) blockchain-link types/utils/workers for blockbook and EVM-RPC block handling, (2) Ethereum fee level calculation in @trezor/connect, (3) UI components for Ethereum fee cards and transaction detail modals, plus a stablecoin yield claim thunk. The highest risk is in Ethereum fee display and calculation — tests exercising custom ETH gas fees in send/swap/sell flows should be prioritized. Blockbook and EVM-RPC changes affect discovery and backend communication but are mostly type-level changes with lower regression risk at the E2E level. The stablecoin yield claim thunk and several blockchain-link internal files have no direct E2E test coverage.

<details><summary><b>Changed files (13)</b></summary>

- `packages/blockchain-link-types/src/blockbook-api.ts`
- `packages/blockchain-link-types/src/blockbook.ts`
- `packages/blockchain-link-types/src/index.ts`
- `packages/blockchain-link-types/src/responses.ts`
- `packages/blockchain-link-utils/src/blockbook.ts`
- `packages/blockchain-link/src/workers/blockbook/index.ts`
- `packages/blockchain-link/src/workers/evm-rpc/handlers/getBlock.ts`
- `packages/blockchain-link/src/workers/evm-rpc/mappers/block.ts`
- `packages/blockchain-link/tests/unit/fixtures/notifications-blockbook.ts`
- `packages/connect/src/backend/fees/EthereumFeeLevels.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx`
- `packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/EthereumFeeCards.tsx`

</details>

**Recommended tests (15)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — This test directly exercises Ethereum send with custom gas fees (gas limit, max fee per gas, max priority fee per gas). Changes to EthereumFeeCards.tsx and EthereumFeeLevels.ts directly affect how Ethereum fees are displayed and calculated in the send form, which is the core of this test.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test specifically validates custom Ethereum fee settings (gas limit, max fee per gas, max priority fee per gas) during a swap transaction. Changes to EthereumFeeCards.tsx and EthereumFeeLevels.ts directly impact the fee display and calculation logic exercised by this test.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test exercises the Ethereum sell flow with custom gas fee settings (gas limit, max fee per gas, max priority fee per gas). The EthereumFeeCards.tsx component renders the fee UI that this test interacts with, and EthereumFeeLevels.ts provides the fee level data.
- `suite/e2e/tests/wallet/send-base.test.ts` — This test validates custom Ethereum fees on the Base (EVM L2) network during a send transaction, directly exercising gas limit, max fee per gas, and max priority fee per gas display. Changes to EthereumFeeCards.tsx and EthereumFeeLevels.ts affect Base network fee handling since Base is an EVM chain.

</details>

<details><summary>🟡 <b>Medium priority (11)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking involves sending an Ethereum transaction where fee levels from EthereumFeeLevels.ts are used. The test verifies fee display on the device prompt, which could be affected by changes to fee calculation logic.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstaking and claiming both involve Ethereum transactions with fee calculations. Changes to EthereumFeeLevels.ts could affect the fee amounts displayed during unstake/claim confirmation on the device.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Staking more ETH involves an Ethereum transaction where fee levels are calculated using EthereumFeeLevels.ts. The test verifies fee display on the device prompt during the staking confirmation.
- `suite/e2e/tests/staking/staking-form.test.ts` — The staking form test validates ETH staking amount input and fee display. Changes to EthereumFeeLevels.ts could affect the fee estimation that determines the withdrawal buffer and max staking amount calculations.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Selling an ERC-20 token involves Ethereum transaction fee calculation. The test verifies fee display during the sell confirmation, which could be affected by changes to EthereumFeeLevels.ts.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — While this test focuses on Bitcoin fee settings, the trading fees component (EthereumFeeCards.tsx) is part of the same CollapsibleFees module. Changes to fee card rendering could inadvertently affect the fee switcher UI used across networks.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test opens transaction detail modals that render BasicTxDetails.tsx. Changes to the transaction detail modal component could affect how transaction details (txid, amounts) are displayed in this test.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test interacts with the transaction overview and searches for transactions. BasicTxDetails.tsx is rendered in the transaction detail modal which could be opened during transaction inspection flows.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test configures custom blockbook backends for BTC and ETH. Changes to blockchain-link blockbook worker and blockbook-utils could affect how custom backend connections are established and how discovery results are processed.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends and verifies discovery completes. Changes to blockchain-link blockbook worker and utils directly affect blockbook communication and response parsing used during discovery.
- `suite/e2e/tests/wallet/discovery.test.ts` — Discovery across multiple coins (BTC, ETH, LTC, etc.) relies on blockchain-link workers for account data. Changes to blockbook worker, EVM RPC handlers, and EthereumFeeLevels could affect whether discovery completes successfully.

</details>

⚠️ **Changes with no test coverage (9)**
- `packages/blockchain-link-types/src/blockbook-api.ts`
- `packages/blockchain-link-types/src/blockbook.ts`
- `packages/blockchain-link-types/src/index.ts`
- `packages/blockchain-link-types/src/responses.ts`
- `packages/blockchain-link/src/workers/blockbook/index.ts`
- `packages/blockchain-link/src/workers/evm-rpc/handlers/getBlock.ts`
- `packages/blockchain-link/src/workers/evm-rpc/mappers/block.ts`
- `packages/blockchain-link/tests/unit/fixtures/notifications-blockbook.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`

_Updated: 2026-07-01T09:03:35.913Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->