### PR TITLE
fix(suite): rename apy to apr for tron how stake works modal

### DIFF
--- a/packages/suite/src/components/earn/modals/EarnInANutshell/TronStakeInANutshellModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/TronStakeInANutshellModal.tsx
@@ -48,8 +48,8 @@ export const TronStakeInANutshellModal = ({
                         content={{
                             text: (
                                 <Translation
-                                    id="TR_EARN_APY_APPROX"
-                                    values={{ apyPercent: formatApyValue(maxApr) }}
+                                    id="TR_EARN_APR_APPROX"
+                                    values={{ aprPercent: formatApyValue(maxApr) }}
                                 />
                             ),
                         }}

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10303,6 +10303,10 @@ export const messages = defineMessages({
         id: 'TR_EARN_APY_APPROX',
         defaultMessage: '~{apyPercent}% APY',
     },
+    TR_EARN_APR_APPROX: {
+        id: 'TR_EARN_APR_APPROX',
+        defaultMessage: '~{aprPercent}% APR',
+    },
     TR_EARN_NOT_AVAILABLE: {
         id: 'TR_EARN_NOT_AVAILABLE',
         defaultMessage: 'Not available',


### PR DESCRIPTION
## Description

Rename `APY` to `APR` for Tron `How Staking Works` modal.

## Related Issue

Resolve #29132 

## Screenshots:

<img width="100%" alt="Screenshot 2026-06-30 at 12 54 32" src="https://github.com/user-attachments/assets/0c3140ea-311d-490d-890c-801cec2e0e5e" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tron-how-staking-works-modal-apr&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tron-how-staking-works-modal-apr&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T08:31:22.733Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T08:28:45.416Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tron-how-staking-works-modal-apr/web/](https://dev.suite.sldev.cz/suite-web/fix/tron-how-staking-works-modal-apr/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->