### PR TITLE
fix(suite): redirect back to account staking detail on flow complete

### DIFF
--- a/packages/suite/src/components/earn/staking/tron/TronStake.tsx
+++ b/packages/suite/src/components/earn/staking/tron/TronStake.tsx
@@ -36,6 +36,7 @@ export const TronStake = ({ account }: TronStakeProps) => {
                 <Column gap={24} width="100%" maxWidth={500}>
                     {step === 'complete' ? (
                         <TronStakeComplete
+                            account={account}
                             heading={<Translation id="TR_EARN_TRON_STAKE_COMPLETE" />}
                             description={
                                 <Translation id="TR_EARN_TRON_STAKE_COMPLETE_DESCRIPTION" />

--- a/packages/suite/src/components/earn/staking/tron/TronUnstake.tsx
+++ b/packages/suite/src/components/earn/staking/tron/TronUnstake.tsx
@@ -22,6 +22,7 @@ export const TronUnstake = ({ account }: TronUnstakeProps) => {
                 <Column gap={24} width="100%" maxWidth={500}>
                     {step === 'complete' ? (
                         <TronStakeComplete
+                            account={account}
                             heading={<Translation id="TR_EARN_TRON_UNSTAKE_COMPLETE" />}
                             description={<Translation id="TR_EARN_TRON_UNSTAKE_DESCRIPTION" />}
                         >

--- a/packages/suite/src/components/earn/staking/tron/TronVote.tsx
+++ b/packages/suite/src/components/earn/staking/tron/TronVote.tsx
@@ -22,6 +22,7 @@ export const TronVote = ({ account }: TronVoteProps) => {
                 <Column gap={24} width="100%" maxWidth={500}>
                     {step === 'complete' ? (
                         <TronStakeComplete
+                            account={account}
                             heading={<Translation id="TR_EARN_TRON_VOTE_COMPLETE" />}
                             description={
                                 <Translation id="TR_EARN_TRON_VOTE_COMPLETE_DESCRIPTION" />

--- a/packages/suite/src/components/earn/staking/tron/TronWithdraw.tsx
+++ b/packages/suite/src/components/earn/staking/tron/TronWithdraw.tsx
@@ -22,6 +22,7 @@ export const TronWithdraw = ({ account }: TronWithdrawProps) => {
                 <Column gap={24} width="100%" maxWidth={500}>
                     {step === 'complete' ? (
                         <TronStakeComplete
+                            account={account}
                             heading={<Translation id="TR_EARN_TRON_WITHDRAW_COMPLETE" />}
                             description={<Translation id="TR_EARN_TRON_WITHDRAW_DESCRIPTION" />}
                         >

--- a/packages/suite/src/components/earn/staking/tron/complete/TronStakeComplete.tsx
+++ b/packages/suite/src/components/earn/staking/tron/complete/TronStakeComplete.tsx
@@ -2,22 +2,39 @@ import { type ReactNode } from 'react';
 
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
+import { type Account } from '@suite-common/wallet-types';
 import { Button, Column, IconCircle, Text } from '@trezor/components';
 
 import { useDispatch } from 'src/hooks/suite';
 import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 
 interface TronStakeCompleteProps {
+    account: Account;
     heading: ReactNode;
     description: ReactNode;
     children: ReactNode;
 }
 
-export const TronStakeComplete = ({ heading, description, children }: TronStakeCompleteProps) => {
+export const TronStakeComplete = ({
+    account,
+    heading,
+    description,
+    children,
+}: TronStakeCompleteProps) => {
     const dispatch = useDispatch();
     const { isBelowMobile } = useLayoutSize();
 
-    const handleBackToOverview = () => dispatch(goto({ routeName: 'suite-earn' }));
+    const handleBackToOverview = () =>
+        dispatch(
+            goto({
+                routeName: 'wallet-staking',
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
 
     return (
         <Column gap={16}>


### PR DESCRIPTION
## Description

After completing `Stake`/`Unstake`/`Vote`/`Withdraw`, navigate back to account staking detail page instead of the earn page.

## Related Issue

Resolve #29122 

## Screenshots:

https://github.com/user-attachments/assets/d7fa1cab-5916-4b85-8fcd-e99a3f393930

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tron-staking-complete-redirect&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tron-staking-complete-redirect&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T08:31:19.299Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T08:28:49.317Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tron-staking-complete-redirect/web/](https://dev.suite.sldev.cz/suite-web/fix/tron-staking-complete-redirect/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->