### PR TITLE
Chore: TS7 compatibility preparation

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     },
     "resolutions": {
         "typescript": "6.0.3",
+        "@types/jest": "30.0.0",
         "prettier": "^3.8.3",
         "react-native": "0.85.3",
         "type-fest": "5.5.0",
@@ -144,7 +145,7 @@
         "@swc/core": "^1.15.40",
         "@swc/jest": "^0.2.39",
         "@trezor/eslint": "workspace:*",
-        "@types/jest": "29.5.12",
+        "@types/jest": "30.0.0",
         "@types/node": "22.13.10",
         "babel-jest": "30.0.0",
         "depcheck": "^1.4.7",

--- a/packages/analytics-docs/package.json
+++ b/packages/analytics-docs/package.json
@@ -29,7 +29,7 @@
         "vite-plugin-node-polyfills": "^0.26.0"
     },
     "devDependencies": {
-        "@types/jest": "29.5.12",
+        "@types/jest": "30.0.0",
         "@types/react-dom": "19.2.3",
         "tsx": "^4.21.0"
     }

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -68,7 +68,7 @@
         "@trezor/e2e-utils": "workspace:*",
         "@trezor/eslint": "workspace:*",
         "@trezor/type-utils": "workspace:*",
-        "@types/jest": "29.5.12",
+        "@types/jest": "30.0.0",
         "@types/node": "22.13.10",
         "html-webpack-plugin": "5.6.7",
         "tiny-worker": "^2.3.0",

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -76,7 +76,7 @@
         "@trezor/transport-common": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
         "@types/chrome": "^0.1.40",
-        "@types/jest": "29.5.12",
+        "@types/jest": "30.0.0",
         "@types/node": "22.13.10"
     }
 }

--- a/packages/connect-data/package.json
+++ b/packages/connect-data/package.json
@@ -49,7 +49,7 @@
     },
     "devDependencies": {
         "@types/chrome": "^0.1.40",
-        "@types/jest": "29.5.12",
+        "@types/jest": "30.0.0",
         "@types/node": "22.13.10"
     }
 }

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -54,7 +54,7 @@
         "@trezor/eslint": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@types/chrome": "^0.1.40",
-        "@types/jest": "29.5.12",
+        "@types/jest": "30.0.0",
         "@types/w3c-web-usb": "^1.0.14",
         "@types/web": "^0.0.345",
         "xvfb-maybe": "^0.2.1"

--- a/packages/schema-utils/package.json
+++ b/packages/schema-utils/package.json
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@sinclair/typebox": "^0.34.49",
-        "@trezor/type-utils": "workspace:*",
+        "@trezor/utils": "workspace:*",
         "ts-mixer": "^6.0.4"
     },
     "peerDependencies": {

--- a/packages/schema-utils/src/custom-types/keyof-enum.ts
+++ b/packages/schema-utils/src/custom-types/keyof-enum.ts
@@ -5,49 +5,34 @@ import {
     type TEnum,
     type TEnumKey,
     type TEnumValue,
-    type TLiteral,
-    type TUnion,
+    type TKeyOf,
+    type TNull,
+    type TObject,
 } from '@sinclair/typebox';
 
-import { type UnionToIntersection } from '@trezor/type-utils';
+import { typedObjectFromEntries, typedObjectKeys } from '@trezor/utils';
 
-// LastInUnion<A | B> = B
-type LastInUnion<U> =
-    UnionToIntersection<U extends unknown ? (x: U) => 0 : never> extends (x: infer L) => 0
-        ? L
-        : never;
+type TKeyOfEnumObject<T extends Record<string, string | number>> = TObject<{
+    [Key in Extract<keyof T, string>]: TNull;
+}>;
 
-// TLiteral<"a" | "b"> => TLiteral<"a"> | TLiteral<"b">
-type DistributeLiterals<T extends string | number | symbol> = T extends T
-    ? T extends string | number
-        ? TLiteral<T>
-        : never
-    : never;
-
-// TLiteral<"A"> | TLiteral<"B"> => [TLiteral<"A">, TLiteral<"B".]
-type UnionToTuple<U extends TLiteral, Last = LastInUnion<U>> = [U] extends [never]
-    ? []
-    : [...UnionToTuple<Exclude<U, Last>>, Last];
-
-// Explicitly make sure every element is a TLiteral
-type TLiteralGuard<T extends unknown[]> = {
-    [K in keyof T]: T[K] extends TLiteral<string | number> ? T[K] : never;
-};
-
-export interface TKeyOfEnum<T extends Record<string, string | number>> extends TUnion<
-    TLiteralGuard<UnionToTuple<DistributeLiterals<keyof T>>>
-> {
+export type TKeyOfEnum<T extends Record<string, string | number>> = TKeyOf<TKeyOfEnumObject<T>> & {
     [Hint]: 'KeyOfEnum';
-}
+};
 
 export class KeyofEnumBuilder extends JavaScriptTypeBuilder {
     KeyOfEnum<T extends Record<string, string | number>>(
         schema: T,
         options?: SchemaOptions,
     ): TKeyOfEnum<T> {
-        const keys = Object.keys(schema).map(key => this.Literal(key));
+        const properties = typedObjectFromEntries(
+            typedObjectKeys(schema).map(key => [key, this.Null()]),
+        );
 
-        return this.Union(keys, { ...options, [Hint]: 'KeyOfEnum' }) as TKeyOfEnum<T>;
+        return this.KeyOf(this.Object(properties), {
+            ...options,
+            [Hint]: 'KeyOfEnum',
+        }) as TKeyOfEnum<T>;
     }
 
     Enum<V extends TEnumValue, T extends Record<TEnumKey, V>>(

--- a/packages/schema-utils/tsconfig.json
+++ b/packages/schema-utils/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
-        { "path": "../type-utils" },
+        { "path": "../utils" },
         { "path": "../eslint" }
     ]
 }

--- a/packages/schema-utils/tsconfig.lib.json
+++ b/packages/schema-utils/tsconfig.lib.json
@@ -6,7 +6,7 @@
         "rootDir": "./src"
     },
     "references": [
-        { "path": "../type-utils" },
+        { "path": "../utils" },
         { "path": "../eslint" }
     ]
 }

--- a/packages/transport-bluetooth/package.json
+++ b/packages/transport-bluetooth/package.json
@@ -33,7 +33,7 @@
         "@trezor/websocket-client": "workspace:*"
     },
     "devDependencies": {
-        "@types/jest": "29.5.12",
+        "@types/jest": "30.0.0",
         "@types/node": "22.13.10",
         "html-webpack-plugin": "5.6.7",
         "react": "19.2.3",

--- a/packages/utils/src/typedObject.ts
+++ b/packages/utils/src/typedObject.ts
@@ -3,15 +3,23 @@
    that nobody else has to write them. */
 import { type KeysOfUnion, type NarrowObjectWithKey } from '@trezor/type-utils';
 
+/** Typed wrapper around `Object.entries()` that preserves key and value types. */
 export const typedObjectEntries = <T extends Record<string, unknown>>(
     obj: T,
 ): [keyof T, T[keyof T]][] => Object.entries(obj) as [keyof T, T[keyof T]][];
 
-export const typedObjectFromEntries = <T extends readonly (readonly [string, unknown])[]>(
-    entries: T,
-): { [K in T[number] as K[0]]: K[1] } =>
-    Object.fromEntries(entries) as { [K in T[number] as K[0]]: K[1] };
+type TypedObjectFromEntries<T extends readonly (readonly [PropertyKey, unknown])[]> = {
+    [Entry in T[number] as Entry[0]]: Entry[1];
+};
 
+/** Typed wrapper around `Object.fromEntries()` that keeps key literals (if the input entries keep them too). */
+export const typedObjectFromEntries = <
+    const T extends readonly (readonly [PropertyKey, unknown])[],
+>(
+    entries: T,
+): TypedObjectFromEntries<T> => Object.fromEntries(entries) as TypedObjectFromEntries<T>;
+
+/** Maps object values while preserving the original object keys in the result type. */
 export const typedObjectTransformValues = <T extends Record<string, unknown>, U>(
     obj: T,
     transform: (value: T[keyof T], key: keyof T) => U,
@@ -20,13 +28,17 @@ export const typedObjectTransformValues = <T extends Record<string, unknown>, U>
         Object.entries(obj).map(([key, value]) => [key, transform(value as T[keyof T], key)]),
     ) as { [K in keyof T]: U };
 
+/** Typed wrapper around `Object.keys()` that preserves `keyof T`. */
 export const typedObjectKeys = <T extends Record<string, unknown>>(obj: T): Array<keyof T> =>
     Object.keys(obj) as Array<keyof T>;
 
+/** Typed wrapper around `Object.values()` that preserves the union of object value types. */
 export const typedObjectValues = <T extends Record<string, unknown>>(obj: T): Array<T[keyof T]> =>
     Object.values(obj) as Array<T[keyof T]>;
 
 /**
+ * Type guard for checking whether an object owns a property from a union of possible keys.
+ *
  * @example
  * ```ts
  * type Props = { a: number; b: string } & ({ foo: number } | { bar: string });
@@ -43,6 +55,7 @@ export function hasOwn<T extends object, K extends KeysOfUnion<T>>(
     return Object.hasOwn(obj, key);
 }
 
+/** Type guard for checking whether an unknown value contains the given property. */
 export function hasProp<K extends PropertyKey>(obj: unknown, prop: K): obj is Record<K, unknown> {
     return typeof obj === 'object' && obj !== null && prop in obj;
 }

--- a/packages/utils/tests/typedObjectFromEntries.type-test.ts
+++ b/packages/utils/tests/typedObjectFromEntries.type-test.ts
@@ -1,4 +1,4 @@
-import { typedObjectFromEntries, typedObjectKeys } from '../src/typedObject';
+import { typedObjectEntries, typedObjectFromEntries, typedObjectKeys } from '../src/typedObject';
 
 const map = {
     a: 1,
@@ -14,7 +14,12 @@ export const _test2: { [K in keyof typeof map]: number } = typedObjectFromEntrie
     typedObjectKeys(map).map(k => [k, map[k] * 2]),
 );
 
+const multiplyValues = <T extends Record<string, number>>(input: T) =>
+    typedObjectFromEntries(typedObjectEntries(input).map(([key, value]) => [key, value * 2]));
+
+export const _test3: { [K in keyof typeof map]: number } = multiplyValues(map);
+
 // @ts-expect-error String cannot be assigned to number as map-value
-export const _test3: { [K in keyof typeof map]: number } = typedObjectFromEntries(
+export const _test4: { [K in keyof typeof map]: number } = typedObjectFromEntries(
     typedObjectKeys(map).map(k => [k, '']),
 );

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -58,7 +58,7 @@
         "tslib": "^2.6.2"
     },
     "devDependencies": {
-        "@types/jest": "29.5.12",
+        "@types/jest": "30.0.0",
         "@types/node": "22.13.10",
         "@types/web": "^0.0.345",
         "@types/ws": "^8.5.13"

--- a/suite-native/app/metro.config.js
+++ b/suite-native/app/metro.config.js
@@ -121,15 +121,17 @@ const configWithStorybook = mergeConfig(
     }),
 );
 
+let exportedConfig = configWithStorybook;
+
 if (
     process.env.EXPO_PUBLIC_IS_DETOX_BUILD !== 'true' &&
     process.env.EXPO_PUBLIC_ENVIRONMENT === 'debug'
 ) {
     // enable Rozenite plugins only in debug build
-    module.exports = withRozenite(configWithStorybook, {
+    exportedConfig = withRozenite(configWithStorybook, {
         enhanceMetroConfig: originalConfig => withRozeniteReduxDevTools(originalConfig),
         enabled: true,
     });
-} else {
-    module.exports = configWithStorybook;
 }
+
+module.exports = exportedConfig;

--- a/suite-native/atoms/src/types.ts
+++ b/suite-native/atoms/src/types.ts
@@ -1,7 +1,6 @@
 export type TestProps = {
     ['data-testid']?: never;
     ['data-test']?: never;
-    ['data-testid']?: never;
     ['data-testId']?: never;
     ['data-testID']?: never;
     ['testID']?: string;

--- a/suite-native/forms/package.json
+++ b/suite-native/forms/package.json
@@ -20,7 +20,6 @@
         "react-hook-form": "^7.77.0",
         "react-native": "0.85.3",
         "react-native-reanimated": "4.3.1",
-        "type-fest": "5.5.0",
-        "yup": "1.7.1"
+        "type-fest": "5.5.0"
     }
 }

--- a/suite-native/forms/src/hooks/useForm.ts
+++ b/suite-native/forms/src/hooks/useForm.ts
@@ -1,12 +1,14 @@
 import {
     type FieldValues,
+    type Resolver,
     type UseFormProps,
     type UseFormReturn,
     useForm as hookFormUseForm,
 } from 'react-hook-form';
 
 import { yupResolver } from '@hookform/resolvers/yup';
-import { type AnyObjectSchema } from 'yup';
+
+type ValidationSchema = Parameters<typeof yupResolver>[0];
 
 export { useFormState, useWatch, useController } from 'react-hook-form';
 
@@ -14,15 +16,20 @@ interface UseFormArgs<
     TFieldValues extends FieldValues = FieldValues,
     TContext extends object = object,
 > extends Omit<UseFormProps<TFieldValues, TContext>, 'resolver'> {
-    validation: AnyObjectSchema;
+    validation: ValidationSchema;
 }
 
 export const useForm = <TFieldValues extends FieldValues, TContext extends object = object>({
     validation,
     ...otherArgs
 }: UseFormArgs<TFieldValues, TContext>): UseFormReturn<TFieldValues> => {
+    // TS7 infers Yup object schemas as transformed optionalized shapes
+    // (`MakeKeysOptional<T>`) which does not match the form contract used
+    // across suite-native. Keep that mismatch contained in this wrapper.
+    const resolver = yupResolver(validation) as Resolver<TFieldValues, TContext, TFieldValues>;
+
     const form = hookFormUseForm<TFieldValues, TContext>({
-        resolver: yupResolver(validation),
+        resolver,
         reValidateMode: 'onChange',
         mode: 'onTouched',
         ...otherArgs,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12555,7 +12555,6 @@ __metadata:
     react-native: "npm:0.85.3"
     react-native-reanimated: "npm:4.3.1"
     type-fest: "npm:5.5.0"
-    yup: "npm:1.7.1"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16610,7 +16610,7 @@ __metadata:
     "@sinclair/typebox": "npm:^0.34.49"
     "@sinclair/typebox-codegen": "npm:^0.11.1"
     "@trezor/eslint": "workspace:*"
-    "@trezor/type-utils": "workspace:*"
+    "@trezor/utils": "workspace:*"
     ts-mixer: "npm:^6.0.4"
     tsx: "npm:^4.21.0"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4693,6 +4693,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/expect-utils@npm:30.4.1":
+  version: 30.4.1
+  resolution: "@jest/expect-utils@npm:30.4.1"
+  dependencies:
+    "@jest/get-type": "npm:30.1.0"
+  checksum: 10/3f0337ec791d669cacd07594521f2da71b956712dfd0c0007253dd5e886ef640df510af1357878a80ac56f09d3db9fd68e3db66959f0fdb3add5f551dd7e0f35
+  languageName: node
+  linkType: hard
+
 "@jest/expect-utils@npm:^29.7.0":
   version: 29.7.0
   resolution: "@jest/expect-utils@npm:29.7.0"
@@ -15868,7 +15877,7 @@ __metadata:
     "@trezor/react-utils": "workspace:*"
     "@trezor/theme": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:30.0.0"
     "@types/react-dom": "npm:19.2.3"
     "@vitejs/plugin-react": "npm:^6.0.1"
     date-fns: "npm:^4.1.0"
@@ -15966,7 +15975,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
     "@trezor/websocket-client": "workspace:*"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:30.0.0"
     "@types/node": "npm:22.13.10"
     "@types/web": "npm:^0.0.345"
     html-webpack-plugin: "npm:5.6.7"
@@ -16127,7 +16136,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
     "@types/chrome": "npm:^0.1.40"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:30.0.0"
     "@types/node": "npm:22.13.10"
   peerDependencies:
     tslib: ^2.6.2
@@ -16139,7 +16148,7 @@ __metadata:
   resolution: "@trezor/connect-data@workspace:packages/connect-data"
   dependencies:
     "@types/chrome": "npm:^0.1.40"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:30.0.0"
     "@types/node": "npm:22.13.10"
   peerDependencies:
     "@trezor/device-utils": "workspace:*"
@@ -16283,7 +16292,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     "@trezor/websocket-client": "workspace:*"
     "@types/chrome": "npm:^0.1.40"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:30.0.0"
     "@types/w3c-web-usb": "npm:^1.0.14"
     "@types/web": "npm:^0.0.345"
     xvfb-maybe: "npm:^0.2.1"
@@ -17150,7 +17159,7 @@ __metadata:
     "@trezor/transport-common": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@trezor/websocket-client": "workspace:*"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:30.0.0"
     "@types/node": "npm:22.13.10"
     html-webpack-plugin: "npm:5.6.7"
     react: "npm:19.2.3"
@@ -17348,7 +17357,7 @@ __metadata:
   resolution: "@trezor/websocket-client@workspace:packages/websocket-client"
   dependencies:
     "@trezor/utils": "workspace:*"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:30.0.0"
     "@types/node": "npm:22.13.10"
     "@types/web": "npm:^0.0.345"
     "@types/ws": "npm:^8.5.13"
@@ -17920,13 +17929,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jest@npm:29.5.12":
-  version: 29.5.12
-  resolution: "@types/jest@npm:29.5.12"
+"@types/jest@npm:30.0.0":
+  version: 30.0.0
+  resolution: "@types/jest@npm:30.0.0"
   dependencies:
-    expect: "npm:^29.0.0"
-    pretty-format: "npm:^29.0.0"
-  checksum: 10/312e8dcf92cdd5a5847d6426f0940829bca6fe6b5a917248f3d7f7ef5d85c9ce78ef05e47d2bbabc40d41a930e0e36db2d443d2610a9e3db9062da2d5c904211
+    expect: "npm:^30.0.0"
+    pretty-format: "npm:^30.0.0"
+  checksum: 10/cdeaa924c68b5233d9ff92861a89e7042df2b0f197633729bcf3a31e65bd4e9426e751c5665b5ac2de0b222b33f100a5502da22aefce3d2c62931c715e88f209
   languageName: node
   linkType: hard
 
@@ -26863,7 +26872,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:^29.0.0, expect@npm:^29.7.0":
+"expect@npm:^29.7.0":
   version: 29.7.0
   resolution: "expect@npm:29.7.0"
   dependencies:
@@ -26873,6 +26882,20 @@ __metadata:
     jest-message-util: "npm:^29.7.0"
     jest-util: "npm:^29.7.0"
   checksum: 10/63f97bc51f56a491950fb525f9ad94f1916e8a014947f8d8445d3847a665b5471b768522d659f5e865db20b6c2033d2ac10f35fcbd881a4d26407a4f6f18451a
+  languageName: node
+  linkType: hard
+
+"expect@npm:^30.0.0":
+  version: 30.4.1
+  resolution: "expect@npm:30.4.1"
+  dependencies:
+    "@jest/expect-utils": "npm:30.4.1"
+    "@jest/get-type": "npm:30.1.0"
+    jest-matcher-utils: "npm:30.4.1"
+    jest-message-util: "npm:30.4.1"
+    jest-mock: "npm:30.4.1"
+    jest-util: "npm:30.4.1"
+  checksum: 10/f25051e5073c55369199ec3108ac01c60074bd09dad0b5a6c9fe40596438051cb52607e0e97505126422535b8d0dacab13aa29bb14e9fac71630bc710201a3f1
   languageName: node
   linkType: hard
 
@@ -31960,6 +31983,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-matcher-utils@npm:30.4.1, jest-matcher-utils@npm:^30.0.5":
+  version: 30.4.1
+  resolution: "jest-matcher-utils@npm:30.4.1"
+  dependencies:
+    "@jest/get-type": "npm:30.1.0"
+    chalk: "npm:^4.1.2"
+    jest-diff: "npm:30.4.1"
+    pretty-format: "npm:30.4.1"
+  checksum: 10/4da6e5c7fe5903fae7394233ea4b892567fb027065670c03096d01be0b389f858055c5ade20d59e82fedec6f3287e6f1720de526cd9a9ad3495432320adb9194
+  languageName: node
+  linkType: hard
+
 "jest-matcher-utils@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-matcher-utils@npm:29.7.0"
@@ -31969,18 +32004,6 @@ __metadata:
     jest-get-type: "npm:^29.6.3"
     pretty-format: "npm:^29.7.0"
   checksum: 10/981904a494299cf1e3baed352f8a3bd8b50a8c13a662c509b6a53c31461f94ea3bfeffa9d5efcfeb248e384e318c87de7e3baa6af0f79674e987482aa189af40
-  languageName: node
-  linkType: hard
-
-"jest-matcher-utils@npm:^30.0.5":
-  version: 30.4.1
-  resolution: "jest-matcher-utils@npm:30.4.1"
-  dependencies:
-    "@jest/get-type": "npm:30.1.0"
-    chalk: "npm:^4.1.2"
-    jest-diff: "npm:30.4.1"
-    pretty-format: "npm:30.4.1"
-  checksum: 10/4da6e5c7fe5903fae7394233ea4b892567fb027065670c03096d01be0b389f858055c5ade20d59e82fedec6f3287e6f1720de526cd9a9ad3495432320adb9194
   languageName: node
   linkType: hard
 
@@ -32044,6 +32067,17 @@ __metadata:
     "@types/node": "npm:*"
     jest-util: "npm:30.3.0"
   checksum: 10/9d2a9e52c2aebc486e9accaf641efa5c6589666e883b5ac1987261d0e2c105a06b885c22aeeb1cd7582e421970c95e34fe0b41bc4a8c06d7e3e4c27651e76ad1
+  languageName: node
+  linkType: hard
+
+"jest-mock@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest-mock@npm:30.4.1"
+  dependencies:
+    "@jest/types": "npm:30.4.1"
+    "@types/node": "npm:*"
+    jest-util: "npm:30.4.1"
+  checksum: 10/8d0c2794130217b9030b888ce380fe57d82388eec19351bd666440ba46f1e24a7e2bdf42cbe9bcfda2b881d4c0ea09db3c80131b9ab788fb5224af2a1339b422
   languageName: node
   linkType: hard
 
@@ -39211,7 +39245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:30.4.1, pretty-format@npm:^30.0.5":
+"pretty-format@npm:30.4.1, pretty-format@npm:^30.0.0, pretty-format@npm:^30.0.5":
   version: 30.4.1
   resolution: "pretty-format@npm:30.4.1"
   dependencies:
@@ -39246,7 +39280,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^29.0.0, pretty-format@npm:^29.7.0":
+"pretty-format@npm:^29.7.0":
   version: 29.7.0
   resolution: "pretty-format@npm:29.7.0"
   dependencies:
@@ -44560,7 +44594,7 @@ __metadata:
     "@swc/core": "npm:^1.15.40"
     "@swc/jest": "npm:^0.2.39"
     "@trezor/eslint": "workspace:*"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:30.0.0"
     "@types/node": "npm:22.13.10"
     babel-jest: "npm:30.0.0"
     depcheck: "npm:^1.4.7"


### PR DESCRIPTION
## Description

Changes to fix Typescript 7, while we still stay on Typescript 6.

Those changes are compatible for both versions :heavy_check_mark:  

## Notes for QA

Mobile app works (but sufficiently covered by E2E tests) 

## Related Issue

Prerequisite for https://github.com/trezor/trezor-suite/issues/29231

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/TS7-compatibility-preparation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/TS7-compatibility-preparation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/TS7-compatibility-preparation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T08:16:48.375Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T08:14:34.314Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/TS7-compatibility-preparation/web/](https://dev.suite.sldev.cz/suite-web/chore/TS7-compatibility-preparation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->