### PR TITLE
refactor: remove unnecessary type assertions (suite-common/* small bundle)

### DIFF
--- a/suite-common/bluetooth/src/bluetoothReducer.ts
+++ b/suite-common/bluetooth/src/bluetoothReducer.ts
@@ -63,7 +63,7 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
                                     nearbyDevice.connectionStatus?.type !== 'pairing-error' &&
                                     !state.ignoredDeviceIds.includes(nearbyDevice.id),
                             ) as Draft<T>[],
-                    ) as Draft<T>[];
+                    );
                 },
             )
             .addCase(
@@ -72,12 +72,12 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
                     if (state.nearbyDevices !== null) {
                         state.nearbyDevices = state.nearbyDevices.map(it =>
                             it.id === deviceId ? { ...it, connectionStatus } : it,
-                        ) as Draft<T>[];
+                        );
                     }
 
                     state.knownDevices = state.knownDevices.map(it =>
                         it.id === deviceId ? { ...it, connectionStatus } : it,
-                    ) as Draft<T>[];
+                    );
                 },
             )
             .addCase(bluetoothActions.deviceUpdateAction, (state, { payload: { device } }) => {

--- a/suite-common/connect-popup/src/permissionsGrouping.ts
+++ b/suite-common/connect-popup/src/permissionsGrouping.ts
@@ -28,7 +28,7 @@ export const groupPermissionsByCoin = (permissions: PermissionRequest[]): Groupe
         byCoin.get(coin)!.push(permission);
     }
 
-    const coinFirst = order.filter(c => c !== undefined) as string[];
+    const coinFirst = order.filter(c => c !== undefined);
     const groups: GroupedPermissions[] = coinFirst.map(coin => ({
         coin,
         permissions: unique(byCoin.get(coin)!),

--- a/suite-common/earn-stablecoin/src/signing/stablecoinYieldSigningUtils.ts
+++ b/suite-common/earn-stablecoin/src/signing/stablecoinYieldSigningUtils.ts
@@ -124,7 +124,7 @@ export const buildStablecoinYieldReviewState = ({
     token,
     symbol,
 }: BuildStablecoinYieldReviewStateParams): BuildStablecoinYieldReviewStateResult => {
-    const gasPriceHex = tx.maxFeePerGas ?? tx.gasPrice ?? ('0x0' as `0x${string}`);
+    const gasPriceHex = tx.maxFeePerGas ?? tx.gasPrice ?? '0x0';
     const gasLimit = fromHex(tx.gasLimit);
     const gasPrice = fromHex(gasPriceHex);
     const feePerUnit = fromHex(gasPriceHex).asWei().toGwei();

--- a/suite-common/graph/src/graphBalanceEvents.ts
+++ b/suite-common/graph/src/graphBalanceEvents.ts
@@ -38,7 +38,7 @@ export const formatBalanceMovementEventsAmounts = (
                 sent: Math.abs(sentTotal - sentToSelf),
                 received: Math.abs(receivedTotal - sentToSelf),
             },
-        } as BalanceMovementEvent;
+        };
     });
 
 /**
@@ -117,7 +117,7 @@ export const mergeGroups = ({
                     accountKey,
                 },
             ),
-        } as GroupedBalanceMovementEvent;
+        };
     });
 
 /**  Relative number that ensure that there is no more than 30 points in each graph.  */

--- a/suite-common/redux-utils/src/createReducerWithExtraDeps.ts
+++ b/suite-common/redux-utils/src/createReducerWithExtraDeps.ts
@@ -40,10 +40,5 @@ export const castExtraStore = <E, S extends EnhancedStore<any, any>>(
     return {
         store,
         extra,
-    } as {
-        store: S & {
-            dispatch: ThunkDispatch<S, E, any>;
-        };
-        extra: NonNullable<E>;
     };
 };

--- a/suite-common/walletconnect/src/adapters/stellar.ts
+++ b/suite-common/walletconnect/src/adapters/stellar.ts
@@ -110,10 +110,7 @@ const stellarSignXDR = createThunk<
             }),
         );
 
-        const response = (await trezorConnectPopupActions.getPopupCallDeferred(true)
-            .promise) as Awaited<
-            ReturnType<typeof trezorConnectPopupActions.getPopupCallDeferred>['promise']
-        >;
+        const response = await trezorConnectPopupActions.getPopupCallDeferred(true).promise;
         if (!response.success) {
             console.error('stellar_signXDR error', response);
             throw new Error('Stellar signing error');

--- a/suite/suite-sync/src/suiteSyncSlice.ts
+++ b/suite/suite-sync/src/suiteSyncSlice.ts
@@ -78,7 +78,7 @@ export const suiteSyncSlice = createSliceWithExtraDeps({
                 }
             })
             .addDefaultCase((state, action) => {
-                suiteSyncReducer(state, action as AnyAction);
+                suiteSyncReducer(state, action);
             });
     },
 });


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR bundles several small packages (1–3 assertions each) that would otherwise be trivially small PRs: `@suite-common/bluetooth`, `@suite-common/connect-popup`, `@suite-common/earn-stablecoin`, `@suite-common/graph`, `@suite-common/redux-utils`, `@suite-common/walletconnect`, `@suite/suite-sync`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/no-unnec-assert-suitecommon-small&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/no-unnec-assert-suitecommon-small&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/no-unnec-assert-suitecommon-small&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-30T11:31:15.742Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-30T11:29:08.602Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-suitecommon-small/web/](https://dev.suite.sldev.cz/suite-web/mroz22/no-unnec-assert-suitecommon-small/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->