### PR TITLE
refactor: remove unnecessary type assertions (suite-native/* small bundle)

### DIFF
--- a/suite-native/discovery/src/discoverySelectors.ts
+++ b/suite-native/discovery/src/discoverySelectors.ts
@@ -46,7 +46,7 @@ const filterUnavailableNetworks = (
             !n.support || // support is not defined => is supported
             !internalModel || // typescript. device undefined. => supported
             (n.support[internalModel] && // support is defined for current device
-                versionUtils.isNewerOrEqual(firmwareVersion, n.support[internalModel] as string)); // device version is newer or equal to support field in networks => supported
+                versionUtils.isNewerOrEqual(firmwareVersion, n.support[internalModel])); // device version is newer or equal to support field in networks => supported
 
         return (
             enabledNetworks.includes(n.symbol) &&

--- a/suite-native/module-device-onboarding/src/navigation/DeviceOnboardingStackNavigator.tsx
+++ b/suite-native/module-device-onboarding/src/navigation/DeviceOnboardingStackNavigator.tsx
@@ -43,7 +43,7 @@ export const DeviceOnboardingStackNavigator = () => {
             initialRouteName={DeviceOnboardingStackRoutes.UninitializedDeviceLanding}
             screenOptions={stackNavigationOptionsConfig}
             screenListeners={({ route }) => ({
-                focus: () => reportStepViewed(route.name as DeviceOnboardingStackRoutes),
+                focus: () => reportStepViewed(route.name),
             })}
         >
             <DeviceOnboardingStack.Screen

--- a/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
+++ b/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
@@ -17,7 +17,6 @@ import {
     type TransactionDetailStackParamList,
     type TransactionDetailStackRoutes,
 } from '@suite-native/navigation';
-import { type TypedTokenTransfer } from '@suite-native/tokens';
 import { useTransactionDetails } from '@suite-native/transaction-management';
 import {
     InstantStakeBanner,
@@ -131,7 +130,7 @@ export const TransactionDetailScreen = ({
                 <VStack spacing="sp24">
                     <TransactionDetailHeader
                         transaction={transaction}
-                        tokenTransfer={tokenTransfer as TypedTokenTransfer}
+                        tokenTransfer={tokenTransfer}
                     />
                     {isUnstakeTransaction && (
                         <InstantStakeBanner accountKey={accountKey} transaction={transaction} />
@@ -139,7 +138,7 @@ export const TransactionDetailScreen = ({
                     <TransactionDetailData
                         transaction={transaction}
                         accountKey={accountKey}
-                        tokenTransfer={tokenTransfer as TypedTokenTransfer}
+                        tokenTransfer={tokenTransfer}
                     />
                 </VStack>
                 <Button

--- a/suite-native/navigation/src/components/Screen.tsx
+++ b/suite-native/navigation/src/components/Screen.tsx
@@ -115,7 +115,7 @@ export const Screen = ({
     // We have to extract dynamic header props from header prop. While not ideal, this allows us to only send one header prop to the screen.
     const dynamicHeaderProps = ((): DynamicScreenHeaderProps | null => {
         if (isScreenHeaderPropDynamic(header)) {
-            return header.props as DynamicScreenHeaderProps;
+            return header.props;
         }
 
         return null;

--- a/suite-native/react-native-graph/src/CreateGraphPath.ts
+++ b/suite-native/react-native-graph/src/CreateGraphPath.ts
@@ -121,7 +121,7 @@ function createGraphPathBase({
 
     const points: SkPoint[] = [];
 
-    const startX = getXInRange(drawingWidth, graphData[0]!.date, range.x) + horizontalPadding;
+    const startX = getXInRange(drawingWidth, graphData[0].date, range.x) + horizontalPadding;
     const endX =
         getXInRange(drawingWidth, graphData[graphData.length - 1]!.date, range.x) +
         horizontalPadding;

--- a/suite-native/staking/src/stakeFormEthereumNativeThunks.ts
+++ b/suite-native/staking/src/stakeFormEthereumNativeThunks.ts
@@ -21,7 +21,6 @@ import { BigNumber } from '@trezor/utils';
 
 import { STAKE_NATIVE_MODULE_PREFIX } from './constants';
 import {
-    type EthereumAccount,
     type EthereumStakingVariant,
     type Failure,
     type PreparedEthereumStakingContext,
@@ -154,7 +153,7 @@ const prepareEthereumStakingContext = (
     return {
         ok: true,
         context: {
-            account: account as EthereumAccount,
+            account,
             chainId,
             gasLimit,
             variant,

--- a/suite-native/tokens/src/tokensSelectors.ts
+++ b/suite-native/tokens/src/tokensSelectors.ts
@@ -71,7 +71,7 @@ export const selectAccountTokenSymbol = createMemoizedSelector(
             return null;
         }
 
-        return tokenInfo.symbol as TokenSymbol;
+        return tokenInfo.symbol;
     },
 );
 

--- a/suite-native/trading-atoms/src/utils/general/tradeableAssetUtils.ts
+++ b/suite-native/trading-atoms/src/utils/general/tradeableAssetUtils.ts
@@ -1,7 +1,7 @@
 import type { CoinInfo, CryptoId } from 'invity-api';
 
 import { cryptoIdToSymbol, isCryptoIdForNativeToken, parseCryptoId } from '@suite-common/trading';
-import { type NetworkSymbolExtended, getDisplaySymbol } from '@suite-common/wallet-config';
+import { getDisplaySymbol } from '@suite-common/wallet-config';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { type TradeableAsset } from '@suite-native/trading-types';
 
@@ -17,10 +17,7 @@ export const coinInfoToTradeableAsset = (
 
     return {
         cryptoId,
-        symbol: getDisplaySymbol(
-            symbol.toUpperCase(),
-            tokenContractAddress,
-        ) as NetworkSymbolExtended,
+        symbol: getDisplaySymbol(symbol.toUpperCase(), tokenContractAddress),
         contractAddress: tokenContractAddress,
         networkId,
         ...info,

--- a/suite-native/transactions/src/components/TransactionList.tsx
+++ b/suite-native/transactions/src/components/TransactionList.tsx
@@ -253,9 +253,7 @@ export const TransactionList = ({
                 // month with only month name and without token txn
                 const isEmptyMonth = typeof data.at(index + 1) === 'string' || !data.at(index + 1);
 
-                return isEmptyMonth
-                    ? null
-                    : renderSectionHeader({ section: { monthKey: item as MonthKey } });
+                return isEmptyMonth ? null : renderSectionHeader({ section: { monthKey: item } });
             }
 
             const isFirstInSection = typeof data.at(index - 1) === 'string';


### PR DESCRIPTION
## Description

Enabling the type-aware ESLint rule `@typescript-eslint/no-unnecessary-type-assertion` repo-wide. For clarity and easy review its fixes are split out per package — this PR bundles several small packages (1–3 assertions each) that would otherwise be trivially small PRs: `@suite-native/discovery`, `@suite-native/module-device-onboarding`, `@suite-native/module-transactions`, `@suite-native/navigation`, `@suite-native/react-native-graph`, `@suite-native/staking`, `@suite-native/tokens`, `@suite-native/trading-atoms`, `@suite-native/transactions`.

The rule itself (the ESLint config switch) is turned on in the final enablement PR, so this change is a safe no-op on its own. Staging branch collecting the full sweep: #28979.

## Notes for QA

No QA needed — type-level / lint-only change with no runtime effect. Each removed assertion is a compiler-proven no-op (the expression already had the asserted type).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/no-unnec-assert-suitenative-small&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->