### PR TITLE
feat(suite): add numbered steps to tron stake flow

### DIFF
--- a/packages/suite/src/components/earn/staking/tron/TronStake.tsx
+++ b/packages/suite/src/components/earn/staking/tron/TronStake.tsx
@@ -49,16 +49,56 @@ export const TronStake = ({ account }: TronStakeProps) => {
                             <Text typographyStyle="headline-md">
                                 <Translation id="TR_EARN_TRON_STAKE_TITLE" />
                             </Text>
-                            <StepList bulletSize="small" bulletGap={12} gap={24} titleGap={16}>
+
+                            <StepList
+                                isOrdered
+                                bulletSize="large"
+                                bulletGap={12}
+                                gap={24}
+                                titleGap={16}
+                            >
                                 <StepList.Item
                                     state={getStepState('freeze')}
-                                    title={<Translation id="TR_EARN_TRON_FREEZE_STEP_TITLE" />}
+                                    title={
+                                        <Column gap={2} width="100%">
+                                            <Text
+                                                typographyStyle="body-xs"
+                                                intent="neutral"
+                                                priority="secondary"
+                                                case="uppercase"
+                                            >
+                                                <Translation
+                                                    id="TR_STEP_OF_TOTAL"
+                                                    values={{ index: 1, total: 2 }}
+                                                />
+                                            </Text>
+
+                                            <Translation id="TR_EARN_TRON_FREEZE_STEP_TITLE" />
+                                        </Column>
+                                    }
                                 >
                                     {step === 'freeze' && <TronFreezeStep />}
                                 </StepList.Item>
+
                                 <StepList.Item
                                     state={getStepState('vote')}
-                                    title={<Translation id="TR_EARN_TRON_VOTE_STEP_TITLE" />}
+                                    title={
+                                        <Column gap={2} width="100%">
+                                            <Text
+                                                typographyStyle="body-xs"
+                                                intent="neutral"
+                                                priority="secondary"
+                                                case="uppercase"
+                                            >
+                                                <Translation
+                                                    id="TR_STEP_OF_TOTAL"
+                                                    values={{ index: 2, total: 2 }}
+                                                />
+                                            </Text>
+
+                                            <Translation id="TR_EARN_TRON_VOTE_STEP_TITLE" />
+                                        </Column>
+                                    }
                                 >
                                     {step === 'vote' && <TronVoteStep />}
                                 </StepList.Item>


### PR DESCRIPTION
## Description

Add numbered progress steps to Tron stake flow, same as in Stablecoin Yield.

## Related Issue

Resolve #29121 

## Screenshots:

https://github.com/user-attachments/assets/79f8535f-1ff3-4eb1-820f-3ba5f9d294ec

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-stake-numbered-steps&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-stake-numbered-steps&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T09:23:55.350Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T09:22:06.517Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-stake-numbered-steps/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-stake-numbered-steps/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to the TronStake component (packages/suite/src/components/earn/staking/tron/TronStake.tsx). There are no E2E tests in the test suite that specifically cover Tron staking flows — the existing staking tests cover ETH, ADA, and SOL but not TRX/Tron staking. The only tangentially related test is the link checker which crawls /earn/tron/stake. This represents a significant gap in E2E test coverage for Tron staking functionality.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/earn/staking/tron/TronStake.tsx`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test crawls all application routes including /earn/tron/stake and validates that pages load correctly and all links return HTTP 200. Since TronStake.tsx is a component rendered on the Tron staking route, changes could break page rendering or introduce broken links.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/earn/staking/tron/TronStake.tsx`

_Updated: 2026-07-01T09:18:40.413Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->