### PR TITLE
refactor(wallet-core): remove redundant and dead state from yield approval session

### DIFF
--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -572,7 +572,7 @@ export const useYieldFlow = ({
         isApprovalInsufficient,
         isSubmittingApprove:
             session.approval.isSubmitting ||
-            session.approval.isInitializingAllowance ||
+            session.approval.allowanceStatus === 'loading' ||
             session.approval.modalState !== null,
         isSubmittingAction: session.action.isSubmitting,
         setAmountInput,

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
@@ -260,8 +260,6 @@ export const initYieldAllowanceThunk = createThunk<void, InitYieldAllowancePaylo
         } catch (error) {
             dispatch(stablecoinYieldActions.setAllowanceError({ flowType, flowKey }));
             throw error;
-        } finally {
-            dispatch(stablecoinYieldActions.finishInitializingAllowance({ flowType, flowKey }));
         }
     },
 );

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -72,9 +72,7 @@ export type StablecoinYieldSessionState = {
         allowanceAmount: string | null;
         modalState: YieldApproveModalState | null;
         isSubmitting: boolean;
-        isPending: boolean;
         allowanceStatus: YieldAllowanceStatus;
-        isInitializingAllowance: boolean;
         isModifyMode: boolean;
         isRevokeRequired: boolean;
     };
@@ -114,9 +112,7 @@ export const initialStablecoinYieldSessionState: StablecoinYieldSessionState = {
         allowanceAmount: null,
         modalState: null,
         isSubmitting: false,
-        isPending: false,
         allowanceStatus: 'idle',
-        isInitializingAllowance: false,
         isModifyMode: false,
         isRevokeRequired: false,
     },
@@ -278,15 +274,6 @@ export const stablecoinYieldSlice = createSlice({
         ) {
             withSession(state, action.payload, session => {
                 session.approval.allowanceStatus = 'loading';
-                session.approval.isInitializingAllowance = true;
-            });
-        },
-        finishInitializingAllowance(
-            state,
-            action: PayloadAction<StablecoinYieldSessionActionPayload>,
-        ) {
-            withSession(state, action.payload, session => {
-                session.approval.isInitializingAllowance = false;
             });
         },
         setInitializedAllowance(
@@ -307,7 +294,6 @@ export const stablecoinYieldSlice = createSlice({
         invalidateAllowance(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
             withSession(state, action.payload, session => {
                 session.approval.allowanceStatus = 'idle';
-                session.approval.isInitializingAllowance = false;
             });
         },
         enterModifyMode(
@@ -337,7 +323,6 @@ export const stablecoinYieldSlice = createSlice({
                 session.approval.modalState = null;
                 session.approval.isRevokeRequired = false;
                 session.action.amount = action.payload.amount;
-                session.approval.isPending = false;
                 session.action.pendingTransaction = null;
                 session.action.review = null;
                 session.step = 'action';
@@ -361,7 +346,6 @@ export const stablecoinYieldSlice = createSlice({
                 session.approval.allowanceAmount = '0';
                 session.approval.allowanceStatus = 'loaded';
                 session.approval.isRevokeRequired = false;
-                session.approval.isPending = false;
                 session.action.pendingTransaction = null;
             });
         },
@@ -422,10 +406,6 @@ export const stablecoinYieldSlice = createSlice({
                 session.action.pendingTransaction = action.payload.tx;
                 session.action.pendingReceiptAmount =
                     action.payload.receiptAmount ?? session.action.pendingReceiptAmount;
-                session.approval.isPending =
-                    action.payload.tx.type === 'approve' ||
-                    action.payload.tx.type === 'revoke' ||
-                    action.payload.tx.type === 'revoke-only';
             });
         },
         completeAction(
@@ -452,7 +432,6 @@ export const stablecoinYieldSlice = createSlice({
         transactionFailed(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
             withSession(state, action.payload, session => {
                 session.action.pendingTransaction = null;
-                session.approval.isPending = false;
                 session.error = 'TR_EARN_YIELD_ERROR_TRANSACTION_FAILED';
             });
         },

--- a/suite-native/module-earn/src/hooks/useYieldSession.ts
+++ b/suite-native/module-earn/src/hooks/useYieldSession.ts
@@ -27,8 +27,7 @@ export const useYieldSession = ({
         selectStablecoinYieldSessionByFlowKey(state, flowType, flowKey),
     );
     const hasSession = !!session;
-    const hasPendingTransaction =
-        session?.approval.isPending || !!session?.action.pendingTransaction;
+    const hasPendingTransaction = !!session?.action.pendingTransaction;
 
     useEffect(() => {
         if (flowKey && !hasSession) {


### PR DESCRIPTION
## Description

Removes two redundant fields from the stablecoin-yield `session.approval` state:

- **`isInitializingAllowance`** - duplicated `allowanceStatus === 'loading'`, now reads the status directly (and drops the empty `finishInitializingAllowance` action)
- **`isPending`** - dead/derived state; its single suite-native reader now uses `pendingTransaction != null` directly

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29248

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-approval-redundant-state&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-approval-redundant-state&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/yield-approval-redundant-state&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-30T11:58:39.322Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-30T11:56:40.215Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-approval-redundant-state/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-approval-redundant-state/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect stablecoin yield flow hooks, approval thunks, and reducer in the earn/yield module. There are no E2E tests that directly test stablecoin yield functionality, indicating a significant coverage gap for the core changed functionality. However, the earn/staking E2E tests share the same component hierarchy and wallet-core infrastructure, so they serve as the best available proxy for detecting regressions. ETH staking tests are prioritized highest since they are closest to the EVM yield flow, followed by ADA and SOL staking as medium-priority tests that exercise the broader earn module.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`
- `suite-native/module-earn/src/hooks/useYieldSession.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — The changed files include useYieldFlow.ts (earn/yield hook) and stablecoin yield reducer/thunks. ETH initial staking exercises the earn/staking flow end-to-end, including the staking form, confirmation, and transaction lifecycle — which likely shares infrastructure with yield flows and the earn component tree where useYieldFlow is used.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — The stake-more flow exercises the earn staking form and transaction confirmation for ETH, which shares the earn component hierarchy with yield flows. Changes to useYieldFlow and the stablecoin yield reducer could affect shared state management or form behavior in the earn module.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstake and claim flow exercises the full earn/staking lifecycle including pending transactions, claiming, and balance updates. The yield flow hook and stablecoin yield thunks could affect shared earn infrastructure used in unstaking.
- `suite/e2e/tests/staking/staking-form.test.ts` — The staking form test validates input validation, percentage buttons, max amount calculations, and crypto/fiat switching in the ETH staking form. useYieldFlow.ts is in the earn/yield component tree, and the staking form shares the same earn UI infrastructure — changes here could break form behavior.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — ADA claim exercises earn/staking reward claiming flow which may share earn module infrastructure with the yield flow. While ADA staking is distinct from stablecoin yield, the earn component tree is shared.
- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking tests the earn staking nutshell modal and staking form flow, which share the earn component hierarchy with yield flows. A regression in shared earn state management could surface here.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — ADA unstake exercises the earn unstaking flow which shares UI infrastructure and potentially state management patterns with the yield flow hooks and stablecoin yield reducer.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL initial staking exercises the earn staking form including Everstake acknowledgement and progress indicators. These share the earn module component tree where useYieldFlow resides.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — SOL stake-more exercises the earn staking form and transaction lifecycle which shares infrastructure with the yield flow components modified in this changeset.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstake and claim flow exercises the full earn lifecycle. Changes to the stablecoin yield approval thunks and reducer could affect shared wallet-core earn infrastructure.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — SOL rewards display exercises the staking dashboard and reward list, which may be affected by changes to the earn/yield state management in the stablecoin yield reducer.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`
- `suite-native/module-earn/src/hooks/useYieldSession.ts`

_Updated: 2026-07-01T11:02:46.390Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->