### PR TITLE
feat(suite): add warning to tron staking accounts without active votes

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow/AccountItemContent/AccountItemContent.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow/AccountItemContent/AccountItemContent.tsx
@@ -1,6 +1,8 @@
 import { selectIsDiscreteModeActive } from '@suite-common/discreet-mode';
 import { type Account, type BaseCurrencyAmount } from '@suite-common/wallet-types';
+import { getTronAvailableVotingPower } from '@suite-common/wallet-utils';
 import { Column, Row, Text } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
 import { type AccountItemType } from 'src/types/wallet';
@@ -28,13 +30,22 @@ export const AccountItemContent = ({
 }: AccountItemContentProps) => {
     const discreetMode = useSelector(selectIsDiscreteModeActive);
 
+    const isTronStakingRow = account.symbol === 'trx' && type === 'staking';
+    const tronAvailableVotingPower = getTronAvailableVotingPower(account);
+    const tronHasActiveVotes = new BigNumber(tronAvailableVotingPower).gt(0);
+    const isTronStakingRowWithActiveVotes = isTronStakingRow && tronHasActiveVotes;
+
     const isCardanoStakingRow = account.networkType === 'cardano' && type === 'staking';
     const isFailed = !!account.failed;
 
     const canShowBalance = account.backendType !== 'coinjoin' || account.status !== 'initial';
 
     const shouldShowCryptoBalance =
-        !isCardanoStakingRow && !isFailed && canShowBalance && type !== 'tokens';
+        !isTronStakingRowWithActiveVotes &&
+        !isCardanoStakingRow &&
+        !isFailed &&
+        canShowBalance &&
+        type !== 'tokens';
 
     const shouldShowBalancePlaceholder = !isCardanoStakingRow && !isFailed && !canShowBalance;
 
@@ -59,6 +70,7 @@ export const AccountItemContent = ({
                 <AccountItemRightSide
                     account={account}
                     isCardanoStakingRow={isCardanoStakingRow}
+                    isTronStakingRowWithActiveVotes={isTronStakingRowWithActiveVotes}
                     isFailed={isFailed}
                     formattedBalance={formattedBalance}
                     customFiatValue={customFiatValue}

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow/AccountItemContent/AccountItemRightSide.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow/AccountItemContent/AccountItemRightSide.tsx
@@ -12,6 +12,7 @@ const ICON_SIZE = 16;
 type AccountItemRightSideProps = {
     account: Account;
     isCardanoStakingRow: boolean;
+    isTronStakingRowWithActiveVotes: boolean;
     isFailed: boolean;
     formattedBalance: string;
     customFiatValue?: BaseCurrencyAmount;
@@ -21,6 +22,7 @@ type AccountItemRightSideProps = {
 export const AccountItemRightSide = ({
     account,
     isCardanoStakingRow,
+    isTronStakingRowWithActiveVotes,
     isFailed,
     formattedBalance,
     customFiatValue,
@@ -40,8 +42,12 @@ export const AccountItemRightSide = ({
         );
     }
 
+    if (isTronStakingRowWithActiveVotes) {
+        return <Icon name="warning" intent="warning" size={ICON_SIZE} />;
+    }
+
     if (isFailed) {
-        return <Icon name="warning" size={ICON_SIZE} intent="warning" />;
+        return <Icon name="warning" intent="warning" size={ICON_SIZE} />;
     }
 
     return (


### PR DESCRIPTION
## Description

Add warning icon to Tron staking accounts without active votes.

## Related Issue

Resolve #29048 

## Screenshots:

<img width="100%" alt="Screenshot 2026-06-30 at 13 56 53" src="https://github.com/user-attachments/assets/de9ba1a6-c56d-49d3-861d-61f291b0c1ff" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-account-staking-warning&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-account-staking-warning&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T08:30:53.865Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T08:29:03.897Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-account-staking-warning/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-account-staking-warning/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->