### PR TITLE
feat(suite): pre-select tron resource with staked balance in tron unstake flow

### DIFF
--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFlow.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFlow.ts
@@ -30,7 +30,7 @@ export const useTronStakeFlow = ({
     const dispatch = useDispatch();
     const { stats } = useTronStakingStats();
 
-    const form = useTronStakeForm({ account });
+    const form = useTronStakeForm({ account, flow });
     const actions = useTronStakeActions({ account, form, flow });
 
     useTronStakePendingTransactionTracking({ account, flow });

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeForm.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeForm.ts
@@ -3,6 +3,7 @@ import { useForm } from 'react-hook-form';
 import { useTranslation } from '@suite/intl';
 import { isAddressValid } from '@suite-common/address';
 import { getNetwork } from '@suite-common/wallet-config';
+import { type TronFlow } from '@suite-common/wallet-core';
 import { type Account, type TronResourceType } from '@suite-common/wallet-types';
 import { getStakingLimitsByNetworkSymbol } from '@suite-common/wallet-utils';
 import { type FeeLevel } from '@trezor/connect';
@@ -13,7 +14,23 @@ import {
     validateReserveOrBalance,
 } from 'src/utils/suite/validation';
 
+import { getStakedBalance } from '../unstake/unstakeUtils';
 import { CUSTOM_REPRESENTATIVE } from '../vote/constants';
+
+interface GetDefaultResourceTypeProps {
+    account: Account;
+    flow: TronFlow;
+}
+
+const getDefaultResourceType = ({ account, flow }: GetDefaultResourceTypeProps) => {
+    if (flow !== 'unstake') {
+        return 'bandwidth';
+    }
+
+    const stakedBandwidthBalance = getStakedBalance(account, 'bandwidth');
+
+    return stakedBandwidthBalance === '0' ? 'energy' : 'bandwidth';
+};
 
 export type TronStakeFormValues = {
     amount: string;
@@ -25,16 +42,17 @@ export type TronStakeFormValues = {
 
 interface UseTronStakeFormProps {
     account: Account;
+    flow: TronFlow;
 }
 
-export const useTronStakeForm = ({ account }: UseTronStakeFormProps) => {
+export const useTronStakeForm = ({ account, flow }: UseTronStakeFormProps) => {
     const { translationString } = useTranslation();
 
     const methods = useForm<TronStakeFormValues>({
         mode: 'onChange',
         defaultValues: {
             amount: '',
-            resourceType: 'bandwidth',
+            resourceType: getDefaultResourceType({ account, flow }),
             selectedFee: 'normal',
             representative: '',
             customRepresentativeAddress: '',


### PR DESCRIPTION
## Description

Pre-select Tron resource with non-zero staked balance in Tron unstake flow.

## Related Issue

Resolve #29119 

## Screenshots:

https://github.com/user-attachments/assets/7fbbbc8c-da19-4bcf-9565-0cf63657fda5

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-unstake-resource-selection/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-unstake-resource-selection/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-unstake-resource-selection&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-unstake-resource-selection&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T08:31:34.430Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T08:29:59.290Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->