### PR TITLE
refactor(earn): make yield approval deposit-only and tidy YieldApproveStep

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
@@ -4,65 +4,31 @@ import { Translation } from '@suite/intl';
 import type {
     YieldFlowDisplayToken,
     YieldPendingTransactionState,
-    YieldPositionFlowType,
 } from '@suite-common/wallet-core';
 import { Banner, Button, Column } from '@trezor/components';
+import { exhaustive } from '@trezor/type-utils';
 
 import { YieldAmountCard } from './YieldAmountCard';
 import { YieldApprovedAmountCard } from './YieldApprovedAmountCard';
 import { YieldPendingTransaction } from './YieldPendingTransaction';
 import type { YieldApprovalAction } from '../yieldFlowUtils';
 
-const approveStepTranslationMap = {
-    deposit: {
-        amountLabelTranslationId: 'AMOUNT',
-        balanceLabelTranslationId: 'TR_BALANCE',
-    },
-    withdraw: {
-        amountLabelTranslationId: 'TR_EARN_YIELD_AMOUNT_TO_WITHDRAW',
-        balanceLabelTranslationId: 'TR_EARN_YIELD_DEPOSITED',
-    },
-    redeem: {
-        amountLabelTranslationId: 'TR_EARN_YIELD_AMOUNT_TO_WITHDRAW',
-        balanceLabelTranslationId: 'TR_EARN_YIELD_DEPOSITED',
-    },
-} as const;
-
-type ApproveButtonTranslationId =
-    | 'TR_EARN_YIELD_APPROVE_TOKEN_BUTTON'
-    | 'TR_EARN_YIELD_REVOKE_APPROVAL'
-    | 'TR_EARN_YIELD_INCREASE_APPROVAL'
-    | 'TR_APPROVE_DATA_TITLE'
-    | 'TR_CONTINUE';
-
-type GetApproveButtonTranslationIdParams = {
-    approvalAction: YieldApprovalAction;
-};
-
-const getApproveButtonTranslationId = ({
-    approvalAction,
-}: GetApproveButtonTranslationIdParams): ApproveButtonTranslationId => {
-    if (approvalAction === 'approve') {
-        return 'TR_EARN_YIELD_APPROVE_TOKEN_BUTTON';
+const getApproveButtonTranslationId = (approvalAction: YieldApprovalAction) => {
+    switch (approvalAction) {
+        case 'approve':
+            return 'TR_EARN_YIELD_APPROVE_TOKEN_BUTTON';
+        case 'revoke':
+            return 'TR_EARN_YIELD_REVOKE_APPROVAL';
+        case 'increase':
+            return 'TR_EARN_YIELD_INCREASE_APPROVAL';
+        case 'continue':
+            return 'TR_CONTINUE';
+        default:
+            return exhaustive(approvalAction);
     }
-
-    if (approvalAction === 'revoke') {
-        return 'TR_EARN_YIELD_REVOKE_APPROVAL';
-    }
-
-    if (approvalAction === 'increase') {
-        return 'TR_EARN_YIELD_INCREASE_APPROVAL';
-    }
-
-    if (approvalAction === 'continue') {
-        return 'TR_CONTINUE';
-    }
-
-    return 'TR_APPROVE_DATA_TITLE';
 };
 
 export type YieldApproveStepProps = {
-    flowType: YieldPositionFlowType;
     token: YieldFlowDisplayToken;
     variant: 'active' | 'done';
     summaryValue: ReactNode;
@@ -83,7 +49,6 @@ export type YieldApproveStepProps = {
 };
 
 export const YieldApproveStep = ({
-    flowType,
     token,
     variant,
     summaryValue,
@@ -101,11 +66,7 @@ export const YieldApproveStep = ({
     onRevoke,
     onPendingTxClick,
 }: YieldApproveStepProps) => {
-    const { amountLabelTranslationId, balanceLabelTranslationId } =
-        approveStepTranslationMap[flowType];
-    const approveButtonId = getApproveButtonTranslationId({
-        approvalAction,
-    });
+    const approveButtonId = getApproveButtonTranslationId(approvalAction);
     const approvedAmountValue = approvedAmount ?? '0';
     const shouldEnableRevoke =
         canRevokeAllowance && !isApprovedAmountLoading && !hasApprovedAmountError && !isLoading;
@@ -127,12 +88,12 @@ export const YieldApproveStep = ({
                         tokenSymbol={token.symbol}
                         decimals={token.decimals}
                         summary={{
-                            labelTranslationId: balanceLabelTranslationId,
+                            labelTranslationId: 'TR_BALANCE',
                             value: summaryValue,
                             onMaxClick: pendingApproveTransaction ? undefined : onMaxClick,
                         }}
                         heading={{
-                            amountLabelTranslationId,
+                            amountLabelTranslationId: 'AMOUNT',
                         }}
                         warning={warning}
                         isDisabled={!!pendingApproveTransaction}

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -234,7 +234,6 @@ export const YieldDepositForm = () => {
                                     }
                                 >
                                     <YieldApproveStep
-                                        flowType="deposit"
                                         token={token}
                                         variant={approveStepState === 'done' ? 'done' : 'active'}
                                         summaryValue={

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -351,6 +351,10 @@ export const useYieldFlow = ({
     const isDeviceConnected = !!device?.connected && !!device?.available;
 
     const submitApprove = useCallback(() => {
+        if (flowType !== 'deposit') {
+            return;
+        }
+
         if (!isDeviceConnected) {
             openDeviceConnectionModal();
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
@@ -31,6 +31,10 @@ export type YieldSessionDataAmountPayload = YieldSessionDataPayload & {
     amount: string;
 };
 
+type SubmitYieldApprovePayload = YieldSessionDataAmountPayload & {
+    flowType: 'deposit';
+};
+
 type InitYieldAllowancePayload = YieldSessionDataPayload & {
     flowType: 'deposit';
     shouldSkipApprovalStep?: boolean;
@@ -292,10 +296,7 @@ export const submitYieldRevokeThunk = createThunk(
 
 export const submitYieldApproveThunk = createThunk(
     `${YIELD_THUNK_PREFIX}/submitApprove`,
-    async (
-        { flowKey, flowType, flowData, amount }: YieldSessionDataAmountPayload,
-        { dispatch },
-    ) => {
+    async ({ flowKey, flowType, flowData, amount }: SubmitYieldApprovePayload, { dispatch }) => {
         const requestAmount = getApprovalRequestAmount({
             flowType,
             amount,
@@ -311,12 +312,6 @@ export const submitYieldApproveThunk = createThunk(
         dispatch(stablecoinYieldActions.startSubmittingApproval({ flowType, flowKey }));
 
         try {
-            if (flowType === 'withdraw') {
-                dispatch(stablecoinYieldActions.cancelModification({ flowType, flowKey }));
-
-                return;
-            }
-
             const spender = getAllowanceSpender(flowData);
             const tokenContractAddress = flowData.token.contractAddress;
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -333,13 +333,6 @@ export const stablecoinYieldSlice = createSlice({
                 session.step = 'action';
             });
         },
-        cancelModification(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
-            withSession(state, action.payload, session => {
-                session.approval.isModifyMode = false;
-                session.approval.isRevokeRequired = false;
-                session.step = 'approve';
-            });
-        },
         revokeSuccess(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
             withSession(state, action.payload, session => {
                 session.approval.isModifyMode = false;


### PR DESCRIPTION
## Description

The approval step only runs for deposit (withdraw/redeem skip it, claim has none). Narrows `submitYieldApproveThunk` + `YieldApproveStep` to `flowType: 'deposit'`, drops the unreachable withdraw branch and the orphaned `cancelModification` action, and tidies `YieldApproveStep` (single-entry map, redundant `flowType` prop, dead `default`, needless type).

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29257

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/yield-approve-deposit-only&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/yield-approve-deposit-only&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/yield-approve-deposit-only&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T12:28:18.249Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T12:28:07.214Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on the earn/yield staking feature: the deposit form component, an approval step component, a shared yield flow hook, and stablecoin-specific yield approval thunks and reducer. The highest risk is to ETH staking flows (initial stake, stake more, unstake) which directly exercise these components. SOL and ADA staking tests share the yield flow infrastructure and should be run at medium priority. The YieldApproveStep.tsx file maps to 121 tests via static analysis, but this is a false positive from broad bundling — only staking/earn tests actually exercise this component. The stablecoin yield approval thunks and reducer have no direct test coverage but are exercised indirectly through the staking E2E flows.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx`
- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the full ETH staking deposit flow including form submission, device confirmation, and transaction lifecycle. The changed files include YieldDepositForm, YieldApproveStep, useYieldFlow hook, and stablecoin yield thunks/reducer — all of which are part of the earn/yield deposit pipeline that this staking flow exercises.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test covers staking additional ETH on an already-staked account, exercising the staking form, confirmation, and transaction flow. Changes to YieldDepositForm and the yield flow hooks directly affect how the deposit/stake-more form operates and submits.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — The unstake flow shares the yield flow infrastructure (useYieldFlow hook) and interacts with the same reducer/thunk layer for managing yield state. Changes to stablecoinYieldReducer and approval thunks could affect unstaking and claiming flows.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates the ETH staking form's input validation, percentage/max buttons, crypto/fiat switching, and balance calculations. The YieldDepositForm component directly renders these form elements, and changes to it could break validation logic or amount calculations.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL staking uses shared yield flow infrastructure. While the stablecoin yield changes are more ETH/ERC-20 focused, the useYieldFlow hook and YieldDepositForm are shared across staking flows, so SOL staking could be affected.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — SOL stake-more flow exercises the deposit form and yield flow hook, which are among the changed files. Changes to how the deposit form handles amounts or approval steps could impact this flow.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstake shares the yield flow hook infrastructure. Changes to useYieldFlow or the stablecoin yield reducer could affect the unstaking/claiming state management.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — SOL rewards display depends on staking state managed in part by the yield reducer. While less directly impacted, changes to stablecoinYieldReducer could affect how staking amounts are tracked and displayed.
- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking uses the shared yield flow and deposit form components. Though ADA staking has its own specific flow, the shared useYieldFlow hook and YieldDepositForm could introduce regressions.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — ADA claim rewards flow could be affected by changes to the yield flow hook or reducer state management, though ADA uses its own Blockfrost-based claiming flow that is somewhat independent from the stablecoin yield approval changes.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — ADA unstaking is mostly independent but shares the yield flow hook. Changes to useYieldFlow could theoretically affect the flow state transitions during unstaking.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`

_Updated: 2026-07-01T12:24:52.322Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/yield-approve-deposit-only/web/](https://dev.suite.sldev.cz/suite-web/refactor/yield-approve-deposit-only/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->