### PR TITLE
fix(suite-native): sync account rename label form

### DIFF
--- a/suite-native/labeling/src/LabelEditForm.tsx
+++ b/suite-native/labeling/src/LabelEditForm.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 
 import { yup } from '@suite-common/validators';
 import { Button, type InputType, VStack } from '@suite-native/atoms';
 import { Form, TextInputField, useForm } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
+
+import { useSyncLabelForm } from './useSyncLabelForm';
 
 const labelValidationSchema = yup.object({
     label: yup.string().required(),
@@ -25,16 +27,15 @@ export const LabelEditForm = ({ label, onSubmit }: LabelEditFormParam) => {
     });
     const {
         handleSubmit,
-        reset,
-        formState: { isValid, isDirty },
+        formState: { isValid },
     } = form;
 
-    // Sync form when labels load asynchronously (e.g. after turning on Suite Sync).
-    useEffect(() => {
-        if (!isDirty) {
-            reset({ label: label ?? '' });
-        }
-    }, [isDirty, label, reset]);
+    const getResetValues = useCallback(
+        (newLabel: string | null): FormValues => ({ label: newLabel ?? '' }),
+        [],
+    );
+
+    useSyncLabelForm({ form, label, getResetValues });
 
     const onConfirm = handleSubmit((formValues: FormValues) => {
         onSubmit(formValues.label);

--- a/suite-native/labeling/src/index.ts
+++ b/suite-native/labeling/src/index.ts
@@ -1,4 +1,5 @@
 export { EditableLabelLayout } from './EditableLabelLayout';
 export { LabelEditForm } from './LabelEditForm';
+export { useSyncLabelForm } from './useSyncLabelForm';
 export type { CombinedLabelingState } from './selectors';
 export { selectIsLabellingAllowed } from './selectors';

--- a/suite-native/labeling/src/useSyncLabelForm.ts
+++ b/suite-native/labeling/src/useSyncLabelForm.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+import { type FieldValues, type UseFormReturn } from '@suite-native/forms';
+
+type UseSyncLabelFormParams<TFormValues extends FieldValues> = {
+    form: Pick<UseFormReturn<TFormValues>, 'formState' | 'reset'>;
+    label: string | null;
+    getResetValues: (label: string | null) => TFormValues;
+};
+
+export const useSyncLabelForm = <TFormValues extends FieldValues>({
+    form,
+    label,
+    getResetValues,
+}: UseSyncLabelFormParams<TFormValues>) => {
+    const {
+        reset,
+        formState: { isDirty },
+    } = form;
+
+    useEffect(() => {
+        if (!isDirty) {
+            reset(getResetValues(label));
+        }
+    }, [getResetValues, isDirty, label, reset]);
+};

--- a/suite-native/module-accounts-management/src/components/AccountRenameForm.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountRenameForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useWatch } from 'react-hook-form';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -20,7 +20,11 @@ import { Box, Button, type InputType, VStack } from '@suite-native/atoms';
 import { featureUsed } from '@suite-native/feature-feedback';
 import { Form, TextInputField } from '@suite-native/forms';
 import { Translation, useTranslate } from '@suite-native/intl';
-import { type CombinedLabelingState, selectIsLabellingAllowed } from '@suite-native/labeling';
+import {
+    type CombinedLabelingState,
+    selectIsLabellingAllowed,
+    useSyncLabelForm,
+} from '@suite-native/labeling';
 import { useSuiteSyncErrorHandler } from '@suite-native/suite-sync';
 
 type AccountRenameFormProps = {
@@ -57,6 +61,13 @@ export const AccountRenameForm = ({ accountKey, onSubmit }: AccountRenameFormPro
     const hasErrors = Object.keys(errors).length > 0;
 
     const accountLabelLength = useWatch({ control, name: 'accountLabel' })?.length ?? 0;
+
+    const getResetValues = useCallback(
+        (newLabel: string | null): AccountFormValues => ({ accountLabel: newLabel ?? '' }),
+        [],
+    );
+
+    useSyncLabelForm({ form, label: accountLabel, getResetValues });
 
     useEffect(() => {
         // Focus account label input field and open keyboard on the first render.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes account rename form initialization when Suite Sync labels are fetched asynchronously, especially after enabling Suite Sync for the first time.

What changed:
- Added a shared `useSyncLabelForm` hook in `@suite-native/labeling`.
- Updated `LabelEditForm` to use the shared hook instead of owning the sync effect inline.
- Updated `AccountRenameForm` to use the same pristine-form synchronization behavior.
- Kept account rename submit behavior unchanged: Suite Sync/Evolu is used when labeling is enabled, and the legacy native account label path is still used when labeling is not enabled.

The shared hook resets form values from the latest label only while the form is not dirty, so asynchronously fetched labels populate the form without overwriting user edits.

## Notes for QA
Please retest same flow with address labels too.


## Related Issue

Resolve #29260


https://github.com/user-attachments/assets/31f945c1-cb63-4722-8cb4-4769ace5d908



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/account-rename-label-sync&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->