### PR TITLE
chore(suite): move Tron custom representative under debug mode

### DIFF
--- a/packages/suite/src/components/earn/staking/tron/vote/TronVoteRepresentativeSelect.tsx
+++ b/packages/suite/src/components/earn/staking/tron/vote/TronVoteRepresentativeSelect.tsx
@@ -1,7 +1,11 @@
+import { useMemo } from 'react';
 import { useFormState, useWatch } from 'react-hook-form';
 
+import { DebugOnlyBadge, selectIsDebugModeActive } from '@suite/debug';
 import { Translation, useTranslation } from '@suite/intl';
 import { Column, Input, Row, Select, Text } from '@trezor/components';
+
+import { useSelector } from 'src/hooks/suite';
 
 import { formatApyValue } from '../../../utils/earnApyUtils';
 import { useTronStakeContext } from '../TronStakeContext';
@@ -18,6 +22,7 @@ type FormatContext = { context: 'menu' | 'value' };
 
 export const TronVoteRepresentativeSelect = () => {
     const { translationString } = useTranslation();
+    const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const { representatives, form, actions } = useTronStakeContext();
     const { control, setValue, register } = form.methods;
 
@@ -30,19 +35,30 @@ export const TronVoteRepresentativeSelect = () => {
         form.customRepresentativeRules,
     );
 
-    const options: RepresentativeOption[] = [
-        ...(representatives.data ?? []).map(({ address, name, apr }) => ({
-            value: address,
-            name,
-            address,
-            apr,
-        })),
-        { value: CUSTOM_REPRESENTATIVE, name: '' },
-    ];
+    const options: RepresentativeOption[] = useMemo(() => {
+        const baseOptions: RepresentativeOption[] =
+            representatives.data?.map(({ address, name, apr }) => ({
+                value: address,
+                name,
+                address,
+                apr,
+            })) ?? [];
+
+        if (isDebugModeActive) {
+            baseOptions.push({ value: CUSTOM_REPRESENTATIVE, name: '' });
+        }
+
+        return baseOptions;
+    }, [representatives.data, isDebugModeActive]);
 
     const formatOptionLabel = (option: RepresentativeOption, { context }: FormatContext) => {
         if (option.value === CUSTOM_REPRESENTATIVE) {
-            return <Translation id="TR_EARN_TRON_ENTER_DIFFERENT_REPRESENTATIVE" />;
+            return (
+                <Row justifyContent="space-between" alignItems="center" gap={12}>
+                    <Translation id="TR_EARN_TRON_ENTER_DIFFERENT_REPRESENTATIVE" />
+                    <DebugOnlyBadge />
+                </Row>
+            );
         }
 
         if (context === 'value') {


### PR DESCRIPTION
## Description

Move Tron custom representative option under debug mode.

## Related Issue

Resolve #29161 

## Screenshots:

<img width="100%" alt="Screenshot 2026-06-30 at 14 57 26" src="https://github.com/user-attachments/assets/335c3705-e649-4324-a4a4-de6c8e4ed0a2" />

<img width="100%" alt="Screenshot 2026-06-30 at 14 57 34" src="https://github.com/user-attachments/assets/0a422e04-d5e3-48f2-b8c2-b723ac571bbf" />

<img width="100%" alt="Screenshot 2026-06-30 at 14 57 38" src="https://github.com/user-attachments/assets/2f34da64-0673-4f63-af5f-273a9756e8fe" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/tron-custom-representative-debug-mode/web/](https://dev.suite.sldev.cz/suite-web/chore/tron-custom-representative-debug-mode/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/tron-custom-representative-debug-mode&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/tron-custom-representative-debug-mode&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T08:31:31.159Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T08:30:00.877Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->