### PR TITLE
fix(connect-explorer): re-align component colors

### DIFF
--- a/packages/connect-explorer/src/components/Method.tsx
+++ b/packages/connect-explorer/src/components/Method.tsx
@@ -167,7 +167,7 @@ export const MethodContent = styled.div<{ $manualMode?: boolean }>(
 
 const Container = styled.div`
     position: relative;
-    background: ${({ theme }) => theme.surfaceFillSunken};
+    background: ${({ theme }) => theme.elementFillField};
     border-radius: 12px;
     width: 100%;
     overflow-x: auto;

--- a/packages/connect-explorer/src/components/Param.tsx
+++ b/packages/connect-explorer/src/components/Param.tsx
@@ -21,7 +21,7 @@ const ParamWrapper = styled.div`
     border-radius: 12px;
     background-image: linear-gradient(
         to bottom,
-        ${({ theme }) => theme.surfaceFillRaised},
+        ${({ theme }) => theme.legacyBackgroundSurfaceElevation2},
         transparent
     );
 `;


### PR DESCRIPTION
## Description

Bring back more sensible colors after #28889

Affects the params background (was invisible, now it's like before) and method tester (now same backgrounds)


## Notes for QA

Check that it looks ok visually

## Screenshots:

Before 

<img width="1185" height="1102" alt="Screenshot 2026-06-30 at 15 43 04" src="https://github.com/user-attachments/assets/1819f07d-f6fc-4cbc-ac16-d3fbb8ea7762" />

After 

<img width="1185" height="1102" alt="Screenshot 2026-06-30 at 15 43 00" src="https://github.com/user-attachments/assets/75f30f8d-299a-426a-b614-729cb79c35b6" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/connect-explorer-colors/web/](https://dev.suite.sldev.cz/suite-web/fix/connect-explorer-colors/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-explorer-colors&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-explorer-colors&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-30T13:55:14.230Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-30T13:52:53.567Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->