### PR TITLE
Tron - Fiat input for Unstake/Freeze

### DIFF
--- a/packages/suite/src/components/earn/staking/tron/TronCurrencySwitchButton.tsx
+++ b/packages/suite/src/components/earn/staking/tron/TronCurrencySwitchButton.tsx
@@ -1,0 +1,34 @@
+import { Translation } from '@suite/intl';
+import { type Rate } from '@suite-common/wallet-types';
+import { TextButton } from '@trezor/components';
+
+interface TronCurrencySwitchButtonProps {
+    rate?: Rate;
+    currency: 'crypto' | 'fiat';
+    setCurrency: (currency: 'crypto' | 'fiat') => void;
+    fiatCurrencySymbol: string;
+    cryptoCurrencySymbol: string;
+}
+
+export const TronCurrencySwitchButton = ({
+    rate,
+    currency,
+    setCurrency,
+    fiatCurrencySymbol,
+    cryptoCurrencySymbol,
+}: TronCurrencySwitchButtonProps) => {
+    if (!rate?.rate) return null;
+
+    const currencySymbol = currency === 'crypto' ? cryptoCurrencySymbol : fiatCurrencySymbol;
+
+    const onToggle = () => {
+        const newCurrency = currency === 'crypto' ? 'fiat' : 'crypto';
+        setCurrency(newCurrency);
+    };
+
+    return (
+        <TextButton type="button" size="small" onClick={onToggle}>
+            <Translation id="TR_EARN_ENTER_AMOUNT_IN" values={{ currency: currencySymbol }} />
+        </TextButton>
+    );
+};

--- a/packages/suite/src/components/earn/staking/tron/freeze/TronFreezeAmount.tsx
+++ b/packages/suite/src/components/earn/staking/tron/freeze/TronFreezeAmount.tsx
@@ -1,10 +1,15 @@
 import { useFormState } from 'react-hook-form';
 
-import { Translation } from '@suite/intl';
+import { Translation, useTranslation } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
 import { formInputsMaxLength } from '@suite-common/validators';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
-import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
+import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import {
+    asAmountSubunit,
+    getStakingLimitsByNetworkSymbol,
+    subunitsToUnits,
+    toFiatCurrency,
+} from '@suite-common/wallet-utils';
 import { Banner, Button, Column, Row, Text } from '@trezor/components';
 import { NumberInput } from '@trezor/product-components';
 import { BigNumber } from '@trezor/utils';
@@ -12,40 +17,155 @@ import { BigNumber } from '@trezor/utils';
 import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 import { useSelector } from 'src/hooks/suite';
+import {
+    validateDecimals,
+    validateMin,
+    validateReserveOrBalance,
+} from 'src/utils/suite/validation';
 
+import { TronCurrencySwitchButton } from '../TronCurrencySwitchButton';
 import { useTronStakeContext } from '../TronStakeContext';
 
 export const TronFreezeAmount = () => {
     const locale = useSelector(selectLanguage);
-    const { account, form, actions } = useTronStakeContext();
-    const { control } = form.methods;
+    const { translationString } = useTranslation();
+    const { account, form, actions, amountInput } = useTronStakeContext();
+    const { control, getValues, setValue } = form.methods;
     const { errors } = useFormState({ control });
     const isDisabled = !!actions.pendingTxid;
+
+    const {
+        currency,
+        setCurrency,
+        onCryptoAmountChange,
+        onFiatAmountChange,
+        currentRate,
+        baseCurrencyCode,
+    } = amountInput;
 
     const availableBalance = subunitsToUnits({
         value: asAmountSubunit(new BigNumber(account.availableBalance)),
         symbol: account.symbol,
     }).toString();
 
+    const stakingLimits = getStakingLimitsByNetworkSymbol(account.symbol);
+    const minStakingAmount = stakingLimits?.MIN_AMOUNT_FOR_STAKING;
+
+    const networkDisplaySymbol = getNetworkDisplaySymbol(account.symbol);
+
+    const cryptoInputRules = {
+        required: translationString('AMOUNT_IS_NOT_SET'),
+        validate: {
+            min: validateMin(translationString),
+            minStakingAmount: (value: string) => {
+                if (value && minStakingAmount?.isGreaterThan(value)) {
+                    return translationString('TR_EARN_STAKING_DASHBOARD_MINIMUM_STAKE', {
+                        amount: minStakingAmount.toString(),
+                        displaySymbol: networkDisplaySymbol,
+                    });
+                }
+            },
+            decimals: validateDecimals(translationString, {
+                decimals: getNetwork(account.symbol).decimals,
+            }),
+            reserveOrBalance: validateReserveOrBalance(translationString, { account }),
+        },
+    };
+
+    const fiatInputRules = {
+        required: translationString('AMOUNT_IS_NOT_SET'),
+        validate: {
+            min: validateMin(translationString),
+            minStakingAmount: (value: string) => {
+                if (!currentRate?.rate) return true;
+                if (!minStakingAmount) return true;
+
+                const minStakingAmountFiat = toFiatCurrency({
+                    amount: minStakingAmount.toString(),
+                    rate: currentRate.rate,
+                })?.toFixed(2, BigNumber.ROUND_FLOOR);
+
+                if (!minStakingAmountFiat) return true;
+
+                if (value && new BigNumber(minStakingAmountFiat).isGreaterThan(value)) {
+                    return translationString('TR_EARN_STAKING_DASHBOARD_MINIMUM_STAKE', {
+                        amount: minStakingAmountFiat,
+                        displaySymbol: baseCurrencyCode.toUpperCase(),
+                    });
+                }
+            },
+            decimals: validateDecimals(translationString, { decimals: 2 }),
+            balance: (value: string) => {
+                if (!currentRate?.rate) return true;
+
+                const availableFiat = toFiatCurrency({
+                    amount: availableBalance,
+                    rate: currentRate.rate,
+                })?.toFixed(2, BigNumber.ROUND_FLOOR);
+
+                return (
+                    !availableFiat ||
+                    new BigNumber(value || 0).lte(availableFiat) ||
+                    translationString('AMOUNT_IS_NOT_ENOUGH')
+                );
+            },
+        },
+    };
+
+    const handleSetMax = async () => {
+        form.methods.clearErrors(['amount', 'fiatAmount']);
+
+        await actions.setMax();
+
+        if (currentRate?.rate) {
+            const maxAmount = getValues('amount');
+
+            const fiatValue = toFiatCurrency({
+                amount: maxAmount,
+                rate: currentRate.rate,
+            })?.toFixed(2, BigNumber.ROUND_FLOOR);
+
+            setValue('fiatAmount', fiatValue ?? '', { shouldDirty: true });
+        }
+    };
+
+    const hasError = !!errors.amount || !!errors.fiatAmount;
+    const errorMessage = errors.amount?.message ?? errors.fiatAmount?.message;
+
+    const numberInputProps = {
+        name: currency === 'crypto' ? 'amount' : 'fiatAmount',
+        locale,
+        control,
+        rules: currency === 'crypto' ? cryptoInputRules : fiatInputRules,
+        maxLength: currency === 'crypto' ? formInputsMaxLength.amount : formInputsMaxLength.fiat,
+        isDisabled,
+        hasError,
+        onChange: currency === 'crypto' ? onCryptoAmountChange : onFiatAmountChange,
+        rightContent: (
+            <Text typographyStyle="body-md" intent="neutral" priority="secondary">
+                {currency === 'crypto' ? networkDisplaySymbol : baseCurrencyCode.toUpperCase()}
+            </Text>
+        ),
+    } as const;
+
     return (
         <Column gap={8}>
-            <Text typographyStyle="body-md">
-                <Translation id="AMOUNT" />
-            </Text>
-            <NumberInput
-                name="amount"
-                locale={locale}
-                control={control}
-                rules={form.amountRules}
-                maxLength={formInputsMaxLength.amount}
-                isDisabled={isDisabled}
-                hasError={!!errors.amount}
-                rightContent={
-                    <Text typographyStyle="body-md" intent="neutral" priority="secondary">
-                        {getNetworkDisplaySymbol(account.symbol)}
-                    </Text>
-                }
-            />
+            <Row justifyContent="space-between" alignItems="center" gap={8}>
+                <Text typographyStyle="body-md">
+                    <Translation id="AMOUNT" />
+                </Text>
+
+                <TronCurrencySwitchButton
+                    rate={currentRate}
+                    currency={currency}
+                    setCurrency={setCurrency}
+                    fiatCurrencySymbol={baseCurrencyCode.toUpperCase()}
+                    cryptoCurrencySymbol={networkDisplaySymbol}
+                />
+            </Row>
+
+            <NumberInput {...numberInputProps} />
+
             <Row justifyContent="space-between" alignItems="center" gap={8}>
                 <Row alignItems="center" gap={8}>
                     <Text typographyStyle="body-md" intent="neutral" priority="secondary">
@@ -58,7 +178,7 @@ export const TronFreezeAmount = () => {
                         size="small"
                         intent="neutral"
                         priority="secondary"
-                        onClick={actions.setMax}
+                        onClick={handleSetMax}
                         isDisabled={isDisabled}
                     >
                         <Translation id="TR_FRACTION_BUTTONS_MAX" />
@@ -72,8 +192,9 @@ export const TronFreezeAmount = () => {
                     />
                 </Text>
             </Row>
-            {errors.amount?.message && (
-                <Banner intent="warning" description={<Text>{errors.amount.message}</Text>} />
+
+            {!!errorMessage && (
+                <Banner intent="warning" description={<Text>{errorMessage}</Text>} />
             )}
         </Column>
     );

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronAmountInput.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronAmountInput.ts
@@ -1,0 +1,81 @@
+import { useCallback, useState } from 'react';
+import { type UseFormReturn } from 'react-hook-form';
+
+import { getNetwork } from '@suite-common/wallet-config';
+import { selectBaseCurrency, selectFiatRatesByFiatRateKey } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import {
+    fromBaseCurrencyToCryptoUnit,
+    getFiatRateKey,
+    toFiatCurrency,
+} from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { useSelector } from 'src/hooks/suite';
+
+import { type TronStakeFormValues } from './useTronStakeForm';
+
+type UseTronAmountInputProps = {
+    account: Account;
+    methods: UseFormReturn<TronStakeFormValues>;
+};
+
+export const useTronAmountInput = ({ account, methods }: UseTronAmountInputProps) => {
+    const [currency, setCurrency] = useState<'crypto' | 'fiat'>('crypto');
+
+    const { setValue, clearErrors } = methods;
+
+    const baseCurrencyCode = useSelector(selectBaseCurrency);
+
+    const fiatRateKey = getFiatRateKey(account.symbol, baseCurrencyCode);
+    const { decimals } = getNetwork(account.symbol);
+
+    const currentRate = useSelector(state =>
+        selectFiatRatesByFiatRateKey(state, fiatRateKey, 'current'),
+    );
+
+    const onCryptoAmountChange = useCallback(
+        (cryptoAmount: string) => {
+            clearErrors(['amount', 'fiatAmount']);
+
+            setValue('amount', cryptoAmount, { shouldDirty: true, shouldValidate: true });
+
+            if (currentRate?.rate) {
+                const fiatValue = toFiatCurrency({
+                    amount: cryptoAmount,
+                    rate: currentRate.rate,
+                })?.toFixed(2, BigNumber.ROUND_FLOOR);
+
+                setValue('fiatAmount', fiatValue ?? '', { shouldDirty: true });
+            }
+        },
+        [currentRate, setValue, clearErrors],
+    );
+
+    const onFiatAmountChange = useCallback(
+        (fiatAmount: string) => {
+            clearErrors(['amount', 'fiatAmount']);
+
+            setValue('fiatAmount', fiatAmount, { shouldDirty: true, shouldValidate: true });
+
+            if (currentRate?.rate) {
+                const cryptoValue = fromBaseCurrencyToCryptoUnit({
+                    fiatAmount,
+                    rate: currentRate.rate,
+                })?.toFixed(decimals);
+
+                setValue('amount', cryptoValue ?? '', { shouldDirty: true, shouldValidate: true });
+            }
+        },
+        [currentRate, decimals, setValue, clearErrors],
+    );
+
+    return {
+        currency,
+        setCurrency,
+        onCryptoAmountChange,
+        onFiatAmountChange,
+        currentRate,
+        baseCurrencyCode,
+    };
+};

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFlow.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFlow.ts
@@ -7,6 +7,7 @@ import { type Account } from '@suite-common/wallet-types';
 
 import { useDispatch } from 'src/hooks/suite';
 
+import { useTronAmountInput } from './useTronAmountInput';
 import { type TronStakeActions, useTronStakeActions } from './useTronStakeActions';
 import { useTronStakeForm } from './useTronStakeForm';
 import { useTronStakePendingTransactionTracking } from './useTronStakePendingTransactionTracking';
@@ -16,6 +17,7 @@ export interface TronStakeContextValues {
     representatives: UseQueryResult<TrxStats>;
     form: ReturnType<typeof useTronStakeForm>;
     actions: TronStakeActions;
+    amountInput: ReturnType<typeof useTronAmountInput>;
 }
 
 interface UseTronStakeFlowProps {
@@ -33,6 +35,10 @@ export const useTronStakeFlow = ({
     const form = useTronStakeForm({ account, flow });
     const actions = useTronStakeActions({ account, form, flow });
 
+    const { methods } = form;
+
+    const amountInput = useTronAmountInput({ account, methods });
+
     useTronStakePendingTransactionTracking({ account, flow });
 
     useEffect(
@@ -49,5 +55,6 @@ export const useTronStakeFlow = ({
         representatives: stats,
         form,
         actions,
+        amountInput,
     };
 };

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeForm.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeForm.ts
@@ -34,6 +34,7 @@ const getDefaultResourceType = ({ account, flow }: GetDefaultResourceTypeProps) 
 
 export type TronStakeFormValues = {
     amount: string;
+    fiatAmount: string;
     resourceType: TronResourceType;
     selectedFee: FeeLevel['label'];
     representative: string;
@@ -52,6 +53,7 @@ export const useTronStakeForm = ({ account, flow }: UseTronStakeFormProps) => {
         mode: 'onChange',
         defaultValues: {
             amount: '',
+            fiatAmount: '',
             resourceType: getDefaultResourceType({ account, flow }),
             selectedFee: 'normal',
             representative: '',

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeForm.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeForm.ts
@@ -2,17 +2,9 @@ import { useForm } from 'react-hook-form';
 
 import { useTranslation } from '@suite/intl';
 import { isAddressValid } from '@suite-common/address';
-import { getNetwork } from '@suite-common/wallet-config';
 import { type TronFlow } from '@suite-common/wallet-core';
 import { type Account, type TronResourceType } from '@suite-common/wallet-types';
-import { getStakingLimitsByNetworkSymbol } from '@suite-common/wallet-utils';
 import { type FeeLevel } from '@trezor/connect';
-
-import {
-    validateDecimals,
-    validateMin,
-    validateReserveOrBalance,
-} from 'src/utils/suite/validation';
 
 import { getStakedBalance } from '../unstake/unstakeUtils';
 import { CUSTOM_REPRESENTATIVE } from '../vote/constants';
@@ -61,30 +53,6 @@ export const useTronStakeForm = ({ account, flow }: UseTronStakeFormProps) => {
         },
     });
 
-    const stakingLimits = getStakingLimitsByNetworkSymbol(account.symbol);
-    const minStakingAmount = stakingLimits?.MIN_AMOUNT_FOR_STAKING;
-
-    const { displaySymbol } = getNetwork(account.symbol);
-
-    const amountRules = {
-        required: translationString('AMOUNT_IS_NOT_SET'),
-        validate: {
-            min: validateMin(translationString),
-            minStakingAmount: (value: string) => {
-                if (value && minStakingAmount?.isGreaterThan(value)) {
-                    return translationString('TR_EARN_STAKING_DASHBOARD_MINIMUM_STAKE', {
-                        amount: minStakingAmount.toString(),
-                        displaySymbol,
-                    });
-                }
-            },
-            decimals: validateDecimals(translationString, {
-                decimals: getNetwork(account.symbol).decimals,
-            }),
-            reserveOrBalance: validateReserveOrBalance(translationString, { account }),
-        },
-    };
-
     const customRepresentativeRules = {
         validate: {
             validAddress: (value: string, { representative }: TronStakeFormValues) => {
@@ -102,7 +70,6 @@ export const useTronStakeForm = ({ account, flow }: UseTronStakeFormProps) => {
 
     return {
         methods,
-        amountRules,
         customRepresentativeRules,
     };
 };

--- a/packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeAmount.tsx
+++ b/packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeAmount.tsx
@@ -4,6 +4,7 @@ import { Translation, useTranslation } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
 import { formInputsMaxLength } from '@suite-common/validators';
 import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { toFiatCurrency } from '@suite-common/wallet-utils';
 import { Banner, Button, Column, Row, Text } from '@trezor/components';
 import { NumberInput } from '@trezor/product-components';
 import { BigNumber } from '@trezor/utils';
@@ -13,21 +14,33 @@ import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmoun
 import { useSelector } from 'src/hooks/suite';
 import { validateDecimals, validateMin } from 'src/utils/suite/validation';
 
+import { TronCurrencySwitchButton } from '../TronCurrencySwitchButton';
 import { useTronStakeContext } from '../TronStakeContext';
 import { getStakedBalance } from './unstakeUtils';
 
 export const TronUnstakeAmount = () => {
     const locale = useSelector(selectLanguage);
     const { translationString } = useTranslation();
-    const { account, form, actions } = useTronStakeContext();
-    const { control, setValue } = form.methods;
+    const { account, form, actions, amountInput } = useTronStakeContext();
+    const { control } = form.methods;
     const { errors } = useFormState({ control });
     const isDisabled = !!actions.pendingTxid;
+
+    const {
+        currency,
+        setCurrency,
+        onCryptoAmountChange,
+        onFiatAmountChange,
+        currentRate,
+        baseCurrencyCode,
+    } = amountInput;
 
     const resourceType = useWatch({ control, name: 'resourceType' });
     const stakedBalance = getStakedBalance(account, resourceType);
 
-    const amountRules = {
+    const networkDisplaySymbol = getNetworkDisplaySymbol(account.symbol);
+
+    const cryptoInputRules = {
         required: translationString('AMOUNT_IS_NOT_SET'),
         validate: {
             min: validateMin(translationString),
@@ -40,25 +53,65 @@ export const TronUnstakeAmount = () => {
         },
     };
 
+    const fiatInputRules = {
+        required: translationString('AMOUNT_IS_NOT_SET'),
+        validate: {
+            min: validateMin(translationString),
+            decimals: validateDecimals(translationString, { decimals: 2 }),
+            staked: (value: string) => {
+                if (!currentRate?.rate) return true;
+
+                const stakedFiat = toFiatCurrency({
+                    amount: stakedBalance,
+                    rate: currentRate.rate,
+                })?.toFixed(2, BigNumber.ROUND_FLOOR);
+
+                return (
+                    !stakedFiat ||
+                    new BigNumber(value || 0).lte(stakedFiat) ||
+                    translationString('TR_EARN_TRON_UNSTAKE_AMOUNT_EXCEEDS_STAKED')
+                );
+            },
+        },
+    };
+
+    const hasError = !!errors.amount || !!errors.fiatAmount;
+    const errorMessage = errors.amount?.message ?? errors.fiatAmount?.message;
+
+    const numberInputProps = {
+        name: currency === 'crypto' ? 'amount' : 'fiatAmount',
+        locale,
+        control,
+        rules: currency === 'crypto' ? cryptoInputRules : fiatInputRules,
+        maxLength: currency === 'crypto' ? formInputsMaxLength.amount : formInputsMaxLength.fiat,
+        isDisabled,
+        hasError,
+        onChange: currency === 'crypto' ? onCryptoAmountChange : onFiatAmountChange,
+        rightContent: (
+            <Text typographyStyle="body-md" intent="neutral" priority="secondary">
+                {currency === 'crypto' ? networkDisplaySymbol : baseCurrencyCode.toUpperCase()}
+            </Text>
+        ),
+    } as const;
+
     return (
         <Column gap={8}>
-            <Text typographyStyle="body-md">
-                <Translation id="AMOUNT" />
-            </Text>
-            <NumberInput
-                name="amount"
-                locale={locale}
-                control={control}
-                rules={amountRules}
-                maxLength={formInputsMaxLength.amount}
-                isDisabled={isDisabled}
-                hasError={!!errors.amount}
-                rightContent={
-                    <Text typographyStyle="body-md" intent="neutral" priority="secondary">
-                        {getNetworkDisplaySymbol(account.symbol)}
-                    </Text>
-                }
-            />
+            <Row justifyContent="space-between" alignItems="center" gap={8}>
+                <Text typographyStyle="body-md">
+                    <Translation id="AMOUNT" />
+                </Text>
+
+                <TronCurrencySwitchButton
+                    rate={currentRate}
+                    currency={currency}
+                    setCurrency={setCurrency}
+                    fiatCurrencySymbol={baseCurrencyCode.toUpperCase()}
+                    cryptoCurrencySymbol={networkDisplaySymbol}
+                />
+            </Row>
+
+            <NumberInput {...numberInputProps} />
+
             <Row justifyContent="space-between" alignItems="center" gap={8}>
                 <Row alignItems="center" gap={8}>
                     <Text typographyStyle="body-md" intent="neutral" priority="secondary">
@@ -70,7 +123,7 @@ export const TronUnstakeAmount = () => {
                         size="small"
                         intent="neutral"
                         priority="secondary"
-                        onClick={() => setValue('amount', stakedBalance, { shouldValidate: true })}
+                        onClick={() => onCryptoAmountChange(stakedBalance)}
                         isDisabled={isDisabled}
                     >
                         <Translation id="TR_FRACTION_BUTTONS_MAX" />
@@ -84,8 +137,9 @@ export const TronUnstakeAmount = () => {
                     />
                 </Text>
             </Row>
-            {errors.amount?.message && (
-                <Banner intent="warning" description={<Text>{errors.amount.message}</Text>} />
+
+            {!!errorMessage && (
+                <Banner intent="warning" description={<Text>{errorMessage}</Text>} />
             )}
         </Column>
     );

--- a/packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeResourceSelect.tsx
+++ b/packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeResourceSelect.tsx
@@ -25,6 +25,7 @@ export const TronUnstakeResourceSelect = () => {
     const handleChange = (value: TronResourceType) => {
         setValue('resourceType', value);
         resetField('amount');
+        resetField('fiatAmount');
     };
 
     return (

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -8519,6 +8519,10 @@ export const messages = defineMessages({
         id: 'TR_EARN_CLAIM_REWARDS_BUTTON',
         defaultMessage: 'Claim',
     },
+    TR_EARN_ENTER_AMOUNT_IN: {
+        id: 'TR_EARN_ENTER_AMOUNT_IN',
+        defaultMessage: 'Enter amount in {currency}',
+    },
     TR_RECEIVING_SYMBOL: {
         id: 'TR_RECEIVING_SYMBOL',
         defaultMessage:


### PR DESCRIPTION
## Description

Add option to switch between crypto/fiat input in Tron unstake/freeze flow.

## Related Issue

Resolve #28701 
Resolve #28498 

## Screenshots

https://github.com/user-attachments/assets/663a9fcb-02d5-4a5a-9bac-bc90cd4cbb01

https://github.com/user-attachments/assets/2de65ada-7369-4e7e-bfa2-7f40d9762e12


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-staking-amount-in-fiat/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-staking-amount-in-fiat/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-staking-amount-in-fiat&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-staking-amount-in-fiat&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T11:13:25.231Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T11:11:04.855Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in Tron staking UI components (freeze/unstake amounts, currency switching, stake form/flow hooks) and the shared intl messages file. There are no E2E tests in the candidate suite that directly test Tron staking flows — the /earn/tron routes exist in the app but have no dedicated E2E test coverage. The messages.ts change is a broad shared file, but without static mapping data showing which tests reference it, and given the Tron-specific nature of the other changes, the risk to existing tests is low. The recommended strategy is to run the staking form test (closest analog to the changed staking input logic) and the link checker (which validates Tron earn pages load without errors).

<details><summary><b>Changed files (8)</b></summary>

- `packages/suite/src/components/earn/staking/tron/TronCurrencySwitchButton.tsx`
- `packages/suite/src/components/earn/staking/tron/freeze/TronFreezeAmount.tsx`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronAmountInput.ts`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFlow.ts`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeForm.ts`
- `packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeAmount.tsx`
- `packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeResourceSelect.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — This test exercises the ETH staking form including amount input validation, fraction buttons, max button, and crypto/fiat switching. The changed files include useTronAmountInput.ts and TronCurrencySwitchButton.tsx which handle similar amount input and currency switching patterns in the Tron staking flow. While this test targets ETH, shared staking form infrastructure from the earn/staking module could be affected, and messages.ts changes could affect translation keys used in staking validation errors.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test crawls all application routes including /earn/tron, /earn/tron/stake, /earn/tron/unstake, and /earn/tron/withdraw. Changes to TronFreezeAmount, TronUnstakeAmount, TronUnstakeResourceSelect, and related hooks could cause rendering errors on these Tron earn pages, which would be caught by this test's page-load verification.

</details>

⚠️ **Changes with no test coverage (7)**
- `packages/suite/src/components/earn/staking/tron/TronCurrencySwitchButton.tsx`
- `packages/suite/src/components/earn/staking/tron/freeze/TronFreezeAmount.tsx`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronAmountInput.ts`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFlow.ts`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeForm.ts`
- `packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeAmount.tsx`
- `packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeResourceSelect.tsx`

_Updated: 2026-07-01T11:07:59.587Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->