### PR TITLE
fix(trading): apply custom exchange fees after recomposition

### DIFF
--- a/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
@@ -583,6 +583,110 @@ describe('recomposeAndSignTxThunk', () => {
         expect(mockSignAndPushSendFormTransaction).toHaveBeenCalledTimes(1);
     });
 
+    it('should keep the user custom feeLimit when it is higher than the recalculated normal feeLimit', async () => {
+        const { store, account, tradingFormState } = getMocks({
+            composedTransactionInfo: {
+                ...mockComposedTransactionInfo,
+                composed: {
+                    ...mockComposedTransactionInfo.composed,
+                    feeLimit: '5000',
+                },
+                selectedFee: 'custom',
+            },
+        });
+
+        const mockSignAndPushSendFormTransaction = jest.fn().mockResolvedValueOnce({
+            success: true,
+            payload: {
+                txid: 'txid',
+            },
+        });
+
+        (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementation(
+            createThunk(
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
+                (_, { fulfillWithValue }) =>
+                    fulfillWithValue({
+                        normal: {
+                            type: 'final',
+                            feeLimit: '1111',
+                            outputs: [{ amount: '10000000' }],
+                        },
+                        custom: {
+                            type: 'final',
+                            outputs: [{ amount: '10000000' }],
+                        },
+                    }),
+            ),
+        );
+
+        const response = await store.dispatch(
+            tradingThunks.recomposeAndSignTxThunk({
+                account,
+                address: 'address',
+                amount: '0.1',
+                recalculateCustomLimit: true,
+                tradingFormState,
+                signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
+            }),
+        );
+
+        expect(response.meta.requestStatus).toBe('fulfilled');
+        expect(mockSignAndPushSendFormTransaction.mock.calls[0][0].formState.feeLimit).toBe('5000');
+    });
+
+    it('should raise the user custom feeLimit to the recalculated normal feeLimit when it is lower', async () => {
+        const { store, account, tradingFormState } = getMocks({
+            composedTransactionInfo: {
+                ...mockComposedTransactionInfo,
+                composed: {
+                    ...mockComposedTransactionInfo.composed,
+                    feeLimit: '500',
+                },
+                selectedFee: 'custom',
+            },
+        });
+
+        const mockSignAndPushSendFormTransaction = jest.fn().mockResolvedValueOnce({
+            success: true,
+            payload: {
+                txid: 'txid',
+            },
+        });
+
+        (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementation(
+            createThunk(
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
+                (_, { fulfillWithValue }) =>
+                    fulfillWithValue({
+                        normal: {
+                            type: 'final',
+                            feeLimit: '1111',
+                            outputs: [{ amount: '10000000' }],
+                        },
+                        custom: {
+                            type: 'final',
+                            outputs: [{ amount: '10000000' }],
+                        },
+                    }),
+            ),
+        );
+
+        const response = await store.dispatch(
+            tradingThunks.recomposeAndSignTxThunk({
+                account,
+                address: 'address',
+                amount: '0.1',
+                recalculateCustomLimit: true,
+                tradingFormState,
+                signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
+            }),
+        );
+
+        expect(response.meta.requestStatus).toBe('fulfilled');
+        expect(mockSignAndPushSendFormTransaction.mock.calls[0][0].formState.feeLimit).toBe('1111');
+    });
+
     it('should derive the Tron fee limit from the recomposed tx (real recipient), not the offers estimate', async () => {
         const { store, tradingFormState } = getMocks({
             composedTransactionInfo: {

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -177,7 +177,10 @@ export const recomposeAndSignTxThunk = createThunk<
                 });
             }
 
-            formState.feeLimit = normalLevels.normal.feeLimit;
+            formState.feeLimit = BigNumber.max(
+                formState.feeLimit || '0',
+                normalLevels.normal.feeLimit,
+            ).toString();
         }
 
         // compose transaction again to recalculate fees based on real account values


### PR DESCRIPTION
## Description

- Wait for exchange transaction recomposition before the form can continue after a fee change.
- Ensure updated custom EVM fee values are used for the exchange trade instead of submitting the previous compose result.

## Notes for QA

- In Trading > Swap on an EVM asset, change custom max fee, priority fee, or gas limit and continue; verify the next step uses the updated fee values.

## Related Issue

Resolve #19186

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/19186-exchange-fee-recomposition&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/19186-exchange-fee-recomposition&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/19186-exchange-fee-recomposition&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-08T07:33:27.665Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T07:30:28.028Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/19186-exchange-fee-recomposition/web/](https://dev.suite.sldev.cz/suite-web/fix/19186-exchange-fee-recomposition/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change modifies recomposeAndSignTxThunk.ts, the core thunk responsible for composing and signing transactions in trading flows (sell, swap). The unit test file is also changed. The highest risk is in sell and swap E2E flows that directly invoke this thunk to compose, sign, and send transactions — these are prioritized as high. Swap fee tests that assert on composedTransactionInfo Redux state are also high priority since that state is directly produced by this thunk. Medium priority tests cover trading form inputs and buy flows that share infrastructure but don't directly compose outgoing transactions.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts`
- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (10)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test exercises the full sell BTC flow including initiating a send transaction from the confirmation screen, which directly uses recomposeAndSignTxThunk to compose and sign the transaction before sending to the provider.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test performs a full sell SOL flow including sending crypto to the provider, which triggers recomposeAndSignTxThunk for transaction composition and signing on Solana.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test performs a sell ETH flow with custom gas fees and initiates a send transaction, directly exercising the recomposeAndSignTxThunk for Ethereum transaction composition and signing.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Sells an ERC-20 token (USDC) and initiates send transaction showing device prompt with destination address and amount, directly exercising recomposeAndSignTxThunk for token transfers.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test swaps SOL to BTC, initiates the send transaction, and verifies composed transaction info from Redux state (wallet.trading.composedTransactionInfo), which is populated by recomposeAndSignTxThunk.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Swaps SOL to USDC and sends the transaction, directly using recomposeAndSignTxThunk to compose and sign the swap send transaction.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swaps USDT token to BTC and completes the send flow, directly exercising recomposeAndSignTxThunk for SPL token transfer composition and signing.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Swaps USDT to USDC tokens on Solana and sends the transaction, which uses recomposeAndSignTxThunk for composing and signing the token swap transaction.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test explicitly verifies that Redux state 'wallet.trading.composedTransactionInfo' is populated after selecting a swap offer, and checks custom BTC fee rate on the device prompt — both directly tied to recomposeAndSignTxThunk output.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Verifies composedTransactionInfo Redux state is populated and checks custom Ethereum gas parameters (gas limit, max fee, priority fee) on the device prompt — all directly produced by recomposeAndSignTxThunk.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation and percentage/max buttons that interact with fee calculation logic. The max button calculates max sellable amount by subtracting fees, which may involve transaction composition from recomposeAndSignTxThunk.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form inputs including fee computation (maxFee visibility), fraction buttons, and amount validation — swap fee resolution may trigger recomposeAndSignTxThunk for transaction composition.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — While buy flows don't typically compose outgoing transactions, this test verifies the full trading flow and trade request payload construction which shares infrastructure with the recomposeAndSignTx module.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swap form with a disabled network as buy asset. While it doesn't complete a transaction, it exercises swap quote/provider display logic that shares the trading thunk infrastructure.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts`

_Updated: 2026-07-08T07:27:30.104Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->