### PR TITLE
feat(suite-native): Mobile swap: Do not hide continue button on approval prefetch

### DIFF
--- a/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
@@ -17,8 +17,13 @@ export const ExchangeConfirmation = () => {
     const receiveAsset = useWatch({ name: 'receiveAsset', control: form.control });
     const quote = useWatch({ name: 'quote', control: form.control });
 
-    const { canProceed, selectQuote, selectQuoteForRevoke, isLoading } =
-        useExchangeSelectQuote(form);
+    const {
+        canProceed,
+        selectQuote,
+        selectQuoteForRevoke,
+        isLoading,
+        isDexQuoteApprovalPrefetchLoadingForCandidateQuote,
+    } = useExchangeSelectQuote(form);
 
     const receiveCryptoId = receiveAsset?.cryptoId;
     const approvalStatus = getApprovalStatus(quote);
@@ -34,7 +39,13 @@ export const ExchangeConfirmation = () => {
             buttonTestId: CONFIRMATION_TEST_ID,
         });
 
-    if (!isLoading && !canProceed && !canRevoke && !isReceivingInactiveStellarToken) {
+    if (
+        !isLoading &&
+        !isDexQuoteApprovalPrefetchLoadingForCandidateQuote &&
+        !canProceed &&
+        !canRevoke &&
+        !isReceivingInactiveStellarToken
+    ) {
         return null;
     }
 
@@ -49,9 +60,11 @@ export const ExchangeConfirmation = () => {
                             onPress={selectQuote}
                             testID={CONFIRMATION_TEST_ID}
                             isDisabled={!canProceed}
-                            isLoading={isLoading}
+                            isLoading={
+                                isLoading || isDexQuoteApprovalPrefetchLoadingForCandidateQuote
+                            }
                         >
-                            {!isLoading && (
+                            {!(isLoading || isDexQuoteApprovalPrefetchLoadingForCandidateQuote) && (
                                 <Translation id="moduleTrading.tradingScreen.buttons.continue" />
                             )}
                         </Button>

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeConfirmation.test.tsx
@@ -14,7 +14,7 @@ import {
     renderWithTradingProvider,
 } from '../../../__tests__/tradingTestUtils';
 import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
-import { ExchangeConfirmation } from '../ExchangeConfirmation';
+import { CONFIRMATION_TEST_ID, ExchangeConfirmation } from '../ExchangeConfirmation';
 
 jest.mock('../../../hooks/exchange/useExchangeSelectQuote', () => ({
     useExchangeSelectQuote: jest.fn(),
@@ -49,12 +49,17 @@ describe('ExchangeConfirmation', () => {
         });
     };
 
-    const mockSelectQuote = (canProceed = true) =>
+    const mockSelectQuote = ({
+        canProceed = true,
+        isLoading = false,
+        isDexQuoteApprovalPrefetchLoadingForCandidateQuote = false,
+    }) =>
         mockUseExchangeSelectQuote.mockReturnValue({
             canProceed,
             selectQuote: jest.fn(),
             selectQuoteForRevoke: jest.fn(),
-            isLoading: false,
+            isLoading,
+            isDexQuoteApprovalPrefetchLoadingForCandidateQuote,
             isConsentRequested: false,
             giveConsent: jest.fn(),
             cancelConsent: jest.fn(),
@@ -67,8 +72,7 @@ describe('ExchangeConfirmation', () => {
             wrapper: ({ children }) => <Form form={exchangeForm}>{children}</Form>,
         });
 
-    const queryContinueButton = () =>
-        screen.queryByText(getTranslation('moduleTrading.tradingScreen.buttons.continue'));
+    const queryContinueButton = () => screen.queryByTestId(CONFIRMATION_TEST_ID);
 
     const queryRevokeButton = () =>
         screen.queryByText(getTranslation('moduleTrading.tradingScreen.buttons.revoke'));
@@ -90,7 +94,7 @@ describe('ExchangeConfirmation', () => {
     });
 
     it('should render "Continue" button when canProceed is true', () => {
-        mockSelectQuote();
+        mockSelectQuote({});
 
         renderConfirmation();
 
@@ -98,15 +102,36 @@ describe('ExchangeConfirmation', () => {
     });
 
     it('should not render "Continue" button when canProceed is false', () => {
-        mockSelectQuote(false);
+        mockSelectQuote({ canProceed: false });
 
         renderConfirmation();
 
         expect(queryContinueButton()).not.toBeOnTheScreen();
     });
 
+    it('should render "Continue" button when canProceed is false but is isLoading', () => {
+        mockSelectQuote({ canProceed: false, isLoading: true });
+
+        renderConfirmation();
+
+        expect(queryContinueButton()).toBeOnTheScreen();
+        expect(queryContinueButton()).toBeDisabled();
+    });
+
+    it('should render "Continue" button when canProceed is false but is isDexQuoteApprovalPrefetchLoadingForCandidateQuote', () => {
+        mockSelectQuote({
+            canProceed: false,
+            isDexQuoteApprovalPrefetchLoadingForCandidateQuote: true,
+        });
+
+        renderConfirmation();
+
+        expect(queryContinueButton()).toBeOnTheScreen();
+        expect(queryContinueButton()).toBeDisabled();
+    });
+
     it('should not render "Revoke" button when approval is not needed', () => {
-        mockSelectQuote();
+        mockSelectQuote({});
 
         renderConfirmation();
 
@@ -118,7 +143,7 @@ describe('ExchangeConfirmation', () => {
             ...defaultQuote,
             isDex: true,
         });
-        mockSelectQuote();
+        mockSelectQuote({});
 
         renderConfirmation();
 
@@ -131,7 +156,7 @@ describe('ExchangeConfirmation', () => {
             isDex: true,
             preapprovedStringAmount: '100',
         });
-        mockSelectQuote();
+        mockSelectQuote({});
 
         renderConfirmation();
 
@@ -146,7 +171,7 @@ describe('ExchangeConfirmation', () => {
             status: 'APPROVAL_REQ',
         });
 
-        mockSelectQuote();
+        mockSelectQuote({});
 
         renderConfirmation();
 
@@ -155,7 +180,7 @@ describe('ExchangeConfirmation', () => {
 
     it('should not render "Revoke" button when approval status is null', () => {
         setQuote(undefined);
-        mockSelectQuote();
+        mockSelectQuote({});
 
         renderConfirmation();
 
@@ -171,7 +196,7 @@ describe('ExchangeConfirmation', () => {
             send: 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId,
         });
 
-        mockSelectQuote();
+        mockSelectQuote({});
 
         renderConfirmation();
 
@@ -179,7 +204,7 @@ describe('ExchangeConfirmation', () => {
     });
 
     it('should render activate button when trading inactive Stellar token', () => {
-        mockSelectQuote();
+        mockSelectQuote({});
 
         mockUseTradingStellarActivateToken.mockReturnValue({
             isReceivingInactiveStellarToken: true,
@@ -194,7 +219,7 @@ describe('ExchangeConfirmation', () => {
     });
 
     it('should not render activate button when not trading inactive Stellar token', () => {
-        mockSelectQuote();
+        mockSelectQuote({});
 
         mockUseTradingStellarActivateToken.mockReturnValue({
             isReceivingInactiveStellarToken: false,
@@ -217,7 +242,7 @@ describe('ExchangeConfirmation', () => {
             send: 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId,
         });
 
-        mockSelectQuote(false);
+        mockSelectQuote({ canProceed: false });
 
         renderConfirmation();
 

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -124,6 +124,8 @@ describe('useExchangeSelectQuote', () => {
         it('should canProceed be false when loading', () => {
             const { result } = renderUseExchangeSelectQuote();
             expect(result.current.canProceed).toBe(false);
+            expect(result.current.isLoading).toBe(true);
+            expect(result.current.isDexQuoteApprovalPrefetchLoadingForCandidateQuote).toBe(false);
         });
 
         it('selectQuote should not dispatch selectQuoteThunk when isLoading', () => {
@@ -172,6 +174,8 @@ describe('useExchangeSelectQuote', () => {
             await act(() => Promise.resolve());
 
             expect(result.current.canProceed).toBe(false);
+            expect(result.current.isLoading).toBe(false);
+            expect(result.current.isDexQuoteApprovalPrefetchLoadingForCandidateQuote).toBe(true);
         });
 
         it('should not dispatch selectQuoteThunk while prefetch is loading for approval-required quote', () => {

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
@@ -163,6 +163,7 @@ export const useExchangeSelectQuote = (form: ExchangeFormType) => {
         sendAccount,
         receiveAccount,
         isLoading,
+        isDexQuoteApprovalPrefetchLoadingForCandidateQuote,
         selectReceiveAccount,
         selectQuote,
         selectQuoteForRevoke,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Mobile swap:
- When approval status is prefetched (for DEX provider) "Continue" button should be displayed in loading state. (disabled with loading icon)

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #29272

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=29272-mobile-swap-do-not-hide-continue-button-when-prefetching-approval&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->