### PR TITLE
test(suite): fixes llm test slector premature close issue

### DIFF
--- a/.github/actions/llm-test-selector/action.yml
+++ b/.github/actions/llm-test-selector/action.yml
@@ -26,7 +26,6 @@ runs:
       with:
         path: node_modules
         key: node_modules-${{ hashFiles('yarn.lock') }}
-        restore-keys: node_modules-
 
     - name: Install dependencies
       shell: bash

--- a/packages/e2e-utils/package.json
+++ b/packages/e2e-utils/package.json
@@ -23,7 +23,7 @@
         "gh-pr-stats": "tsx ./src/ghPrStats/index.ts"
     },
     "dependencies": {
-        "@anthropic-ai/sdk": "^0.39.0",
+        "@anthropic-ai/sdk": "0.100.0",
         "@octokit/rest": "^21.1.1",
         "@trezor/trezor-user-env-link": "workspace:*",
         "@trezor/utils": "workspace:*",

--- a/packages/e2e-utils/src/llmTestSelector/index.ts
+++ b/packages/e2e-utils/src/llmTestSelector/index.ts
@@ -462,9 +462,11 @@ const selectTestsViaApi = async (
 ): Promise<Omit<SelectionResult, 'changed_files'>> => {
     const client = new Anthropic({ apiKey });
 
+    const maxTokens = 16384;
+
     const response = await client.messages.create({
         model: 'claude-opus-4-6',
-        max_tokens: 4096,
+        max_tokens: maxTokens,
         tools: [
             {
                 name: 'recommend_tests',
@@ -539,6 +541,12 @@ const selectTestsViaApi = async (
     });
 
     accumulateApiUsage(response);
+
+    if (response.stop_reason === 'max_tokens') {
+        throw new Error(
+            `Anthropic response was truncated at max_tokens (${maxTokens}) — the recommendation set was too large to fit. Increase maxTokens or narrow the candidate tests.`,
+        );
+    }
 
     type ContentBlock = { type: string; input?: unknown };
     const toolUse = (response.content as ContentBlock[]).find(b => b.type === 'tool_use');

--- a/yarn.lock
+++ b/yarn.lock
@@ -150,18 +150,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@anthropic-ai/sdk@npm:^0.39.0":
-  version: 0.39.0
-  resolution: "@anthropic-ai/sdk@npm:0.39.0"
+"@anthropic-ai/sdk@npm:0.100.0":
+  version: 0.100.0
+  resolution: "@anthropic-ai/sdk@npm:0.100.0"
   dependencies:
-    "@types/node": "npm:^18.11.18"
-    "@types/node-fetch": "npm:^2.6.4"
-    abort-controller: "npm:^3.0.0"
-    agentkeepalive: "npm:^4.2.1"
-    form-data-encoder: "npm:1.7.2"
-    formdata-node: "npm:^4.3.2"
-    node-fetch: "npm:^2.6.7"
-  checksum: 10/8f1cb2d6a797ed095503ceec4271347ba9ee101c020fe3f5080c6853a5f3a9fc874649fcd0e3ae584c33e58548368cf3fb1da167221172859a1dff1e8c3419f6
+    json-schema-to-ts: "npm:^3.1.1"
+    standardwebhooks: "npm:^1.0.0"
+  peerDependencies:
+    zod: ^3.25.0 || ^4.0.0
+  peerDependenciesMeta:
+    zod:
+      optional: true
+  bin:
+    anthropic-ai-sdk: bin/cli
+  checksum: 10/f7cb8a2e4bafd720dfc1b2f45760797f4e109b8173acfb2763a5c2d23ef5f20c05dfc0fd8f9d1c10c1ff3f92f62e432cf07ca679db1f7fd94ba2f6b2a6cf6e31
   languageName: node
   linkType: hard
 
@@ -9991,6 +9993,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@stablelib/base64@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@stablelib/base64@npm:1.0.1"
+  checksum: 10/93f3edb05d5a828a775d23ebde49884abeb456b8946942acbe6a0815630e769c59c06c7275983031c8707bdcefc1c62917aaa99522ff1ec5f457704c83b686da
+  languageName: node
+  linkType: hard
+
 "@standard-schema/spec@npm:^1.0.0, @standard-schema/spec@npm:^1.1.0":
   version: 1.1.0
   resolution: "@standard-schema/spec@npm:1.1.0"
@@ -16405,7 +16414,7 @@ __metadata:
   resolution: "@trezor/e2e-utils@workspace:packages/e2e-utils"
   dependencies:
     "@anthropic-ai/claude-code": "npm:^2.1.179"
-    "@anthropic-ai/sdk": "npm:^0.39.0"
+    "@anthropic-ai/sdk": "npm:0.100.0"
     "@currents/mcp": "npm:^2.3.2"
     "@currents/playwright": "npm:^2.1.4"
     "@octokit/rest": "npm:^21.1.1"
@@ -27782,6 +27791,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-sha256@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "fast-sha256@npm:1.3.0"
+  checksum: 10/3bef0491f10a254348ec11dcddb26e4d951cfd3b4c0662ea5843ad1be3fe184ed74d640df68565fcc60f6437548cddf49e3ac886f88a69e05b5142e862840bf9
+  languageName: node
+  linkType: hard
+
 "fast-shallow-equal@npm:^1.0.0":
   version: 1.0.0
   resolution: "fast-shallow-equal@npm:1.0.0"
@@ -32814,6 +32830,16 @@ __metadata:
     smtp-address-parser: "npm:1.0.10"
     valid-url: "npm:^1.0.9"
   checksum: 10/c78e0fb2a925767ff900081e3ff604b070d0a214be2388f241d43737b613af64ecddf0476f0752a10c10c3b56644e5062f3dac34507c6a17b4d8ae9fbf6fa823
+  languageName: node
+  linkType: hard
+
+"json-schema-to-ts@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "json-schema-to-ts@npm:3.1.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.18.3"
+    ts-algebra: "npm:^2.0.0"
+  checksum: 10/9fd0490279d36ff8b4604cc10632df05e4e5f5ee1d0a77841c927623fc1e636c47eb4ace488018c4e9a2e7e5dde5520d0870e06dfc84b930d9c98c6eacd0f041
   languageName: node
   linkType: hard
 
@@ -43085,6 +43111,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"standardwebhooks@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "standardwebhooks@npm:1.0.0"
+  dependencies:
+    "@stablelib/base64": "npm:^1.0.0"
+    fast-sha256: "npm:^1.3.0"
+  checksum: 10/02b74a3e4cd131affe8bf18945360747a5a0bf81c1d62a7bbbea3d40976b4fef4bb37de71a35cdc0fdc4d6f0d951a3b6031052e78bd086dc9b09b629b82d3919
+  languageName: node
+  linkType: hard
+
 "stat-mode@npm:^1.0.0":
   version: 1.0.0
   resolution: "stat-mode@npm:1.0.0"
@@ -44648,6 +44684,13 @@ __metadata:
   dependencies:
     utf8-byte-length: "npm:^1.0.1"
   checksum: 10/366e47a0e22cc271d37eb4e62820453fb877784b55b37218842758b7aa1d402eedd0f8833cfb5d6f7a6cae1535d84289bd5e32c4ee962d2a86962fb7038a6983
+  languageName: node
+  linkType: hard
+
+"ts-algebra@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "ts-algebra@npm:2.0.0"
+  checksum: 10/b970eef64ca9594a77337e03b9c1732c1b7a0d2c4d316638b654e921a47b40c4cc42f41821445e9e54408d5dfdf4ecca27ffa59554373033b9c92dee8b52066d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
increase sdk version to 0.100.0
increases max token to 16384 to solve also another issue we encountered.
[RUN](https://github.com/trezor/trezor-suite/actions/runs/28494696539/job/84458547369?pr=29274) with passed LLM test selector

<!--- Provide a general summary of your changes in the Title above -->

## Description

**fix(e2e-utils): bump @anthropic-ai/sdk 0.39 → 0.100 to fix LLM test selector "Premature close" in CI**

## Problem
`select-tests-llm` fails in CI with:
```
Claude invocation failed: Invalid response body while trying to fetch
https://api.anthropic.com/v1/messages: Premature close
```
It fails **only in CI**, never when run locally — which is what made it confusing.

## Root cause
- `@anthropic-ai/sdk@0.39.0` uses **`node-fetch@2`** as its HTTP layer.
- `node-fetch@2` has a bug ([nodejs/node#63989](https://github.com/nodejs/node/issues/63989)) that throws a **false `ERR_STREAM_PREMATURE_CLOSE`** on TLS + gzip + chunked + large responses starting in **Node 24.17.0**.
- We adopted Node 24.17.0 in the recent security bump (`d91141d118`). The Anthropic Messages API response is exactly TLS + gzip + chunked + large, so it triggers the bug.
- CI runs Node 24.17.0 (affected); local dev was on ≤24.16 (unaffected) — hence "only in CI".

## Fix
Upgrade `@anthropic-ai/sdk` to **0.100.0**, which drops `node-fetch@2` in favor of native `fetch`/undici — the version family the upstream issue confirms is **not** affected.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-llm-test-select&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-llm-test-select&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T05:18:56.641Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T05:17:10.121Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-llm-test-select/web/](https://dev.suite.sldev.cz/suite-web/fix-llm-test-select/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to `packages/e2e-utils/package.json` and `packages/e2e-utils/src/llmTestSelector/index.ts`. The `llmTestSelector` module is an internal CI/CD utility for selecting which tests to run — it is not imported or exercised by any of the 59 candidate E2E tests themselves. While `@trezor/e2e-utils` is referenced by many tests (for annotations, test categories, etc.), the specific changed file (`llmTestSelector/index.ts`) is a separate sub-module with no evidence of being used in any test's runtime code path. The `package.json` change is likely a dependency or metadata update. No E2E tests need to be run for this change set.

<details><summary><b>Changed files (2)</b></summary>

- `packages/e2e-utils/package.json`
- `packages/e2e-utils/src/llmTestSelector/index.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/e2e-utils/package.json`
- `packages/e2e-utils/src/llmTestSelector/index.ts`

_Updated: 2026-07-01T05:03:21.891Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->