### PR TITLE
refactor(earn): collapse yield revoke txType to a single 'revoke'

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx
@@ -21,7 +21,7 @@ export type YieldApproveModalProps = {
     vaultId: string;
     spender: string;
     preapprovedAmount?: string;
-    txType: 'approve' | 'revoke' | 'revoke-only';
+    txType: 'approve' | 'revoke';
     onCancel: () => void;
     onSuccess: (txid: string) => void;
 };
@@ -68,7 +68,6 @@ export const YieldApproveModal = ({
 
                 break;
             case 'revoke':
-            case 'revoke-only':
                 openRevokeModal();
 
                 break;
@@ -163,7 +162,7 @@ export const YieldApproveModal = ({
         );
     }
 
-    if ((txType === 'revoke' || txType === 'revoke-only') && isRevokeModalOpen) {
+    if (txType === 'revoke' && isRevokeModalOpen) {
         return (
             <RevokeModal
                 cryptoId={cryptoId}
@@ -173,7 +172,7 @@ export const YieldApproveModal = ({
                 showSpender
                 preapprovedAmount={preapprovedAmount}
                 approveAmount={amount}
-                followedByApproval={txType === 'revoke'}
+                followedByApproval={false}
                 heading="TR_APPROVAL_REVOKE_TOKEN_SPENDING"
                 description="TR_EARN_YIELD_REVOKE_TOKEN_SPENDING_DESCRIPTION"
                 onCancel={handleOnRevokeCancel}

--- a/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
@@ -14,7 +14,6 @@ const getPendingTransactionLabel = (kind: YieldPendingTransactionState['type']):
         case 'approve':
             return 'TR_EXCHANGE_APPROVAL_FORM_CONFIRMING_APPROVAL';
         case 'revoke':
-        case 'revoke-only':
             return 'TR_EXCHANGE_APPROVAL_FORM_REVOKING_APPROVAL';
         case 'deposit':
             return 'TR_EARN_YIELD_PENDING_DEPOSIT';

--- a/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
@@ -48,7 +48,6 @@ const getResolutionEventType = (
         case 'approve':
             return { type: 'deposit', successType: 'approve-success' };
         case 'revoke':
-        case 'revoke-only':
             return { type: 'deposit', successType: 'revoke-success' };
         case 'deposit':
             return { type: 'deposit', successType: 'success' };
@@ -243,7 +242,7 @@ export const useYieldPendingTransactionTracking = ({
             pendingStartRef.current = null;
         }
 
-        if (pendingTransaction.type === 'revoke' || pendingTransaction.type === 'revoke-only') {
+        if (pendingTransaction.type === 'revoke') {
             dispatch(stablecoinYieldActions.revokeSuccess({ flowType, flowKey }));
             dispatch(stablecoinYieldActions.invalidateAllowance({ flowType, flowKey }));
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
@@ -58,7 +58,7 @@ type OpenYieldApproveModalParams = YieldSessionDataPayload & {
     amount: string;
     spender: string;
     preapprovedAmount?: string;
-    txType: 'approve' | 'revoke' | 'revoke-only';
+    txType: 'approve' | 'revoke';
 };
 
 type OpenYieldRevokeModalParams = YieldSessionDataPayload & {
@@ -173,7 +173,7 @@ export const openYieldRevokeModal = ({
         amount: getRevokeModalAmount({ flowType, amount: approveAmount, flowData }),
         spender,
         preapprovedAmount: allowanceAmount || undefined,
-        txType: 'revoke-only',
+        txType: 'revoke',
     });
 };
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
@@ -64,11 +64,11 @@ export type YieldApproveModalState = {
     contractAddress: string;
     spender: string;
     preapprovedAmount?: string;
-    txType: Extract<YieldPendingTransactionState['type'], 'approve' | 'revoke' | 'revoke-only'>;
+    txType: Extract<YieldPendingTransactionState['type'], 'approve' | 'revoke'>;
 };
 
 export type YieldPendingTransactionState = {
-    type: 'approve' | 'revoke' | 'revoke-only' | 'deposit' | 'withdraw' | 'redeem' | 'claim';
+    type: 'approve' | 'revoke' | 'deposit' | 'withdraw' | 'redeem' | 'claim';
     txid: string;
     amount: string;
     fee?: string;

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -265,9 +265,7 @@ export const splitYieldPendingTransaction = (
     actionKind: YieldFlowType,
 ) => {
     const isApprovalPending =
-        pendingTransaction?.type === 'approve' ||
-        pendingTransaction?.type === 'revoke' ||
-        pendingTransaction?.type === 'revoke-only';
+        pendingTransaction?.type === 'approve' || pendingTransaction?.type === 'revoke';
 
     return {
         approvalPendingTransaction: isApprovalPending ? pendingTransaction : undefined,

--- a/suite-native/module-earn/src/hooks/useYieldPendingTransaction.ts
+++ b/suite-native/module-earn/src/hooks/useYieldPendingTransaction.ts
@@ -5,7 +5,7 @@ import { type AccountKey } from '@suite-common/wallet-types';
 import { useBottomSheetModal } from '@suite-native/atoms';
 import { useTransactionDetails } from '@suite-native/transaction-management';
 
-type YieldPendingTransactionType = Exclude<YieldPendingTransactionState['type'], 'revoke-only'>;
+type YieldPendingTransactionType = YieldPendingTransactionState['type'];
 
 type UseYieldPendingTransactionParams = {
     accountKey: AccountKey | null | undefined;
@@ -20,12 +20,6 @@ const getPendingTransactionByType = (
 ) => {
     if (!pendingTransaction) {
         return undefined;
-    }
-
-    if (transactionType === 'revoke') {
-        return pendingTransaction.type === 'revoke' || pendingTransaction.type === 'revoke-only'
-            ? pendingTransaction
-            : undefined;
     }
 
     return pendingTransaction.type === transactionType ? pendingTransaction : undefined;

--- a/suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts
+++ b/suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts
@@ -98,7 +98,7 @@ export const useYieldPendingTransactionTracking = ({
             return;
         }
 
-        if (pendingTransaction.type === 'revoke' || pendingTransaction.type === 'revoke-only') {
+        if (pendingTransaction.type === 'revoke') {
             dispatch(stablecoinYieldActions.revokeSuccess(sessionParams));
             dispatch(stablecoinYieldActions.invalidateAllowance(sessionParams));
 

--- a/suite-native/module-earn/src/yieldApprovalThunks.ts
+++ b/suite-native/module-earn/src/yieldApprovalThunks.ts
@@ -50,7 +50,7 @@ type GetYieldAllowanceReviewAmountParams = {
     amount?: string;
     approvalLimitType?: YieldApprovalLimitType;
     flowData: YieldFlowResolvedData;
-    modalTxType: 'approve' | 'revoke' | 'revoke-only';
+    modalTxType: 'approve' | 'revoke';
     tokenContract: TokenAddress;
 };
 
@@ -75,7 +75,6 @@ const getYieldAllowanceReviewAmount = ({
                 tokenSymbol: flowData.token.symbol,
             });
         case 'revoke':
-        case 'revoke-only':
             return REVOKE_ALLOWANCE_AMOUNT;
         default:
             return exhaustive(modalTxType);
@@ -84,13 +83,13 @@ const getYieldAllowanceReviewAmount = ({
 
 const isExpectedAllowanceModalTxType = (
     transactionType: YieldAllowanceFormDraftTransactionType,
-    modalTxType: 'approve' | 'revoke' | 'revoke-only',
+    modalTxType: 'approve' | 'revoke',
 ) => {
     if (transactionType === 'approve') {
         return modalTxType === 'approve';
     }
 
-    return modalTxType === 'revoke' || modalTxType === 'revoke-only';
+    return modalTxType === 'revoke';
 };
 
 export const prepareYieldAllowanceReviewTransactionThunk = createThunk(

--- a/suite/analytics/src/events/yieldInteractionEvent.ts
+++ b/suite/analytics/src/events/yieldInteractionEvent.ts
@@ -35,7 +35,7 @@ export const yieldInteractionEvent: EventDef<Attributes, EventType.YieldInteract
         },
         value: {
             description:
-                'Optional sub-identifier — for `in-a-nutshell-process-tab`: `deposit` | `withdraw` | `claim`; for `withdraw-unit-toggle`: the unit being switched to (`asset` = underlying deposit token, `shares` = vault receipt token); for `withdraw-max`: the current unit (`asset` | `shares`); for `pending-tx-open`: the pending tx type (`approve` | `revoke` | `revoke-only` | `deposit` | `withdraw` | `claim`); omitted for `deposit-max`',
+                'Optional sub-identifier — for `in-a-nutshell-process-tab`: `deposit` | `withdraw` | `claim`; for `withdraw-unit-toggle`: the unit being switched to (`asset` = underlying deposit token, `shares` = vault receipt token); for `withdraw-max`: the current unit (`asset` | `shares`); for `pending-tx-open`: the pending tx type (`approve` | `revoke` | `deposit` | `withdraw` | `claim`); omitted for `deposit-max`',
             changelog: [{ version: '26.5.2', notes: 'added' }],
         },
         networkSymbol: {


### PR DESCRIPTION
## Description

The yield approval `txType` carried both `'revoke'` and `'revoke-only'`, but only `'revoke-only'` was ever produced — bare `'revoke'` was dead (modal txType + pending-tx type, desktop & native). Renames the live value to `'revoke'`, collapsing the union to `'approve' | 'revoke'`, and simplifies every `=== 'revoke' || === 'revoke-only'` check + duplicated case to a single branch.

`RevokeModal`'s `followedByApproval` (was `txType === 'revoke'`, always false in yield) is pinned to `false` to keep behavior identical — it only gates an in-modal warning banner that was never shown in yield anyway; whether it should is a separate question.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29275

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/yield-collapse-revoke-only/web/](https://dev.suite.sldev.cz/suite-web/refactor/yield-collapse-revoke-only/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/yield-collapse-revoke-only&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/yield-collapse-revoke-only&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/yield-collapse-revoke-only&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T13:02:34.456Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T13:00:33.737Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on stablecoin yield functionality — approval modals, pending transaction tracking, approval thunks, and a yield analytics event. No E2E tests have static coverage mapping to any of the changed files, and there are no dedicated stablecoin yield E2E tests in the test suite. The closest tests are the ETH staking tests which share the earn/staking UI infrastructure. Most of the changed code (especially suite-native modules, stablecoin-specific thunks/utils/types, and the yield analytics event) has no E2E test coverage at all. The risk is moderate — regressions in the yield approval flow or pending transaction tracking would be user-visible but are unlikely to break unrelated staking flows.

<details><summary><b>Changed files (10)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx`
- `packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts`
- `suite-native/module-earn/src/hooks/useYieldPendingTransaction.ts`
- `suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts`
- `suite-native/module-earn/src/yieldApprovalThunks.ts`
- `suite/analytics/src/events/yieldInteractionEvent.ts`

</details>

**Recommended tests (4)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test exercises the ETH staking flow including pending transaction tracking, progress indicators, and staking confirmation — all of which share infrastructure with the changed YieldPendingTransaction and YieldPendingTransactionTracking components. While the test targets native ETH staking rather than stablecoin yield specifically, the pending transaction tracking hooks and UI patterns are closely related.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test covers first-time ETH staking with pending transaction display, progress indicators through phases (pendingTransaction → addingToPool → receivingRewards), and confirmation flows. The YieldPendingTransaction component and tracking hooks share the earn/staking UI infrastructure being modified.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test covers ETH unstaking including pending transaction display, speed-up buttons, and claim flows. The earn yield components and approval thunks share the same staking/earn module infrastructure. Changes to YieldApproveModal or pending transaction tracking could affect the unstake/claim confirmation UX.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates the ETH staking form inputs and validation logic. While it doesn't directly test yield approval or pending transactions, changes to the stablecoin yield utils or types could affect shared form infrastructure in the earn module.

</details>

⚠️ **Changes with no test coverage (8)**
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts`
- `suite-native/module-earn/src/hooks/useYieldPendingTransaction.ts`
- `suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts`
- `suite-native/module-earn/src/yieldApprovalThunks.ts`
- `suite/analytics/src/events/yieldInteractionEvent.ts`
- `packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx`

_Updated: 2026-07-01T12:56:57.434Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->