### PR TITLE
fix(alerts): return button action results

### DIFF
--- a/suite-native/alerts/package.json
+++ b/suite-native/alerts/package.json
@@ -16,7 +16,6 @@
         "@trezor/env-utils": "workspace:*",
         "@trezor/styles-native": "workspace:*",
         "@trezor/theme": "workspace:*",
-        "@trezor/type-utils": "workspace:*",
         "jotai": "2.17.1",
         "react": "19.2.3",
         "react-native": "0.85.3",

--- a/suite-native/alerts/src/useShowAlertResult.ts
+++ b/suite-native/alerts/src/useShowAlertResult.ts
@@ -1,14 +1,7 @@
-import { type Result, err, ok } from '@trezor/type-utils';
-
 import { type Alert } from './alertsAtoms';
 import { useAlert } from './useAlert';
 
-type AlertResult = Result<void, { type: 'cancelled' }>;
-
-type ShowAlertResultParams = Omit<Alert, 'onPressPrimaryButton' | 'onPressSecondaryButton'> & {
-    onPressPrimaryButton?: () => AlertResult | Promise<AlertResult> | void;
-    onPressSecondaryButton?: () => AlertResult | Promise<AlertResult> | void;
-};
+type AlertResult = { action: 'primaryButton' | 'secondaryButton' };
 
 export const useShowAlertResult = () => {
     const { showAlert } = useAlert();
@@ -17,18 +10,18 @@ export const useShowAlertResult = () => {
         onPressPrimaryButton,
         onPressSecondaryButton,
         ...alert
-    }: ShowAlertResultParams): Promise<AlertResult> =>
+    }: Alert): Promise<AlertResult> =>
         new Promise(resolve =>
             showAlert({
                 ...alert,
                 onPressPrimaryButton: () => {
-                    void Promise.resolve(onPressPrimaryButton?.()).then(result =>
-                        resolve(result ?? ok()),
+                    void Promise.resolve(onPressPrimaryButton?.()).then(_ =>
+                        resolve({ action: 'primaryButton' }),
                     );
                 },
                 onPressSecondaryButton: () => {
-                    void Promise.resolve(onPressSecondaryButton?.()).then(result =>
-                        resolve(result ?? err({ type: 'cancelled' })),
+                    void Promise.resolve(onPressSecondaryButton?.()).then(_ =>
+                        resolve({ action: 'secondaryButton' }),
                     );
                 },
             }),

--- a/suite-native/alerts/tsconfig.json
+++ b/suite-native/alerts/tsconfig.json
@@ -8,7 +8,6 @@
         {
             "path": "../../packages/styles-native"
         },
-        { "path": "../../packages/theme" },
-        { "path": "../../packages/type-utils" }
+        { "path": "../../packages/theme" }
     ]
 }

--- a/suite-native/suite-sync/src/useTurnOnSuiteSyncGuard.tsx
+++ b/suite-native/suite-sync/src/useTurnOnSuiteSyncGuard.tsx
@@ -97,7 +97,7 @@ export const useTurnOnSuiteSyncGuard = () => {
         return ok();
     };
 
-    const confirmSuiteSyncEnable = (): Promise<AddLabelSuiteSyncGuardResult> => {
+    const confirmSuiteSyncEnable = async (): Promise<AddLabelSuiteSyncGuardResult> => {
         if (!isDeviceConnected) {
             navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
                 screen: AuthorizeDeviceStackRoutes.DeviceConnectionGuard,
@@ -106,13 +106,15 @@ export const useTurnOnSuiteSyncGuard = () => {
             return Promise.resolve(err({ type: 'cancelled' }));
         }
 
-        return showAlertResult({
+        await showAlertResult({
             title: <Translation id="suiteSync.enableAlert.title" />,
             description: <Translation id="suiteSync.enableAlert.description" />,
             primaryButtonTitle: <Translation id="suiteSync.enableAlert.cta" />,
             onPressPrimaryButton: handleTurnOnSuiteSync,
             secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
         });
+
+        return ok();
     };
 
     const ensureSuiteSyncReadyForAddLabel = async (): Promise<AddLabelSuiteSyncGuardResult> => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11741,7 +11741,6 @@ __metadata:
     "@trezor/env-utils": "workspace:*"
     "@trezor/styles-native": "workspace:*"
     "@trezor/theme": "workspace:*"
-    "@trezor/type-utils": "workspace:*"
     jotai: "npm:2.17.1"
     react: "npm:19.2.3"
     react-native: "npm:0.85.3"


### PR DESCRIPTION
Simplifies a code for `showAlertResult` to handle results more elegantly 

## Notes for QA

Only code improvement, no test needed

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=make-results-better-for-alert&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=make-results-better-for-alert&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=make-results-better-for-alert&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in suite-native packages: `suite-native/alerts` (package.json, a hook, and tsconfig) and `suite-native/suite-sync` (a guard hook). These are native-specific modules, and the E2E test suite primarily targets web/desktop Suite. The `useTurnOnSuiteSyncGuard` change has the highest potential impact on E2E tests since Suite Sync functionality is tested extensively in the metadata/suite-sync test group. However, since these are suite-native files, the web/desktop E2E tests may not exercise the exact same code paths — the guard logic may only apply to the mobile/native app. The alerts package changes (package.json, tsconfig, and a hook) appear to be native-only with no corresponding web E2E coverage. Risk is low-to-medium overall.

<details><summary><b>Changed files (4)</b></summary>

- `suite-native/alerts/package.json`
- `suite-native/alerts/src/useShowAlertResult.ts`
- `suite-native/alerts/tsconfig.json`
- `suite-native/suite-sync/src/useTurnOnSuiteSyncGuard.tsx`

</details>

**Recommended tests (8)**

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — The changed file `useTurnOnSuiteSyncGuard.tsx` is part of the suite-sync module. This test exercises Suite Sync enablement flows across multiple wallets, including device confirmation prompts and banner interactions that could be gated by the sync guard logic.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test covers enabling Suite Sync with device confirmation prompts (confirmSuiteSyncSetup), which is likely gated by the `useTurnOnSuiteSyncGuard` hook. Changes to the guard could affect whether Suite Sync can be initiated.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test enables Suite Sync and creates labels that sync to the Evolu relay. The `useTurnOnSuiteSyncGuard` hook may control the guard/confirmation flow before Suite Sync can be turned on, directly affecting this test's setup path.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test enables Suite Sync and then removes labels, verifying relay sync. The guard hook change could affect the Suite Sync enablement step required before label operations.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — This test enables Suite Sync, updates labels, and removes them. The `useTurnOnSuiteSyncGuard` change could affect the initial Suite Sync enablement flow that this test depends on.
- `suite/e2e/tests/metadata/suite-sync/unsupported-device.test.ts` — This test validates the unsupported device banner behavior after enabling Suite Sync. The guard hook may be involved in determining device support and showing appropriate UI when Suite Sync is turned on.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test migrates from legacy Dropbox labeling to Suite Sync. The guard hook change could affect the Suite Sync enablement step during migration, though the migration path may use a different code path.
- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — This test covers legacy-to-Suite Sync migration including device prompt confirmation for sync keys. The guard hook could influence the migration enablement flow.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-native/alerts/package.json`
- `suite-native/alerts/src/useShowAlertResult.ts`
- `suite-native/alerts/tsconfig.json`

_Updated: 2026-07-13T14:29:45.131Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/make-results-better-for-alert/web/](https://dev.suite.sldev.cz/suite-web/make-results-better-for-alert/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-13T14:33:18.512Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-13T14:32:47.295Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->