### PR TITLE
feat(suite-native): enable slip24 payment requests for trading behind a feature flag

### DIFF
--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -902,11 +902,14 @@ export const selectTradingIsSlip24Allowed = createMemoizedSelectorWithDeviceAndA
     [
         state => selectDeviceUnavailableCapabilities(state),
         state => selectDeviceFirmwareVersion(state),
-        (_: TradingRootState, account: Account | undefined) => account,
-        (_: TradingRootState, __: Account | undefined, isSlip24Active: boolean) => isSlip24Active,
+        (_: TradingRootState, account: Account | undefined | null) => account,
+        (_: TradingRootState, __: Account | undefined | null, isSlip24Active: boolean) =>
+            isSlip24Active,
     ],
     (unavailableCapabilities, firmwareVersion, account, isSlip24Active) => {
-        if (!account) return false;
+        if (!account) {
+            return false;
+        }
 
         const isFirmwareVersionSlip24Compatible =
             !unavailableCapabilities?.['slip24'] &&

--- a/suite-native/config/src/types.ts
+++ b/suite-native/config/src/types.ts
@@ -13,6 +13,7 @@ export type LaunchArguments = {
     isFirmwareUpdateEnabled?: boolean;
     isTradingResidenceCheckEnabled?: boolean;
     isTradingDebugEnabled?: boolean;
+    isTradingSlip24Enabled?: boolean;
     isN4w1BackupEnabled?: boolean;
     isN4W1BackupEnabled?: boolean;
 };

--- a/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
+++ b/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
@@ -21,6 +21,7 @@ describe('featureFlagsSlice', () => {
                 isDebugKeysAllowed: false,
                 isTradingResidenceCheckEnabled: true,
                 isTradingDebugEnabled: false,
+                isTradingSlip24Enabled: false,
                 isN4w1BackupEnabled: false,
             });
         });
@@ -38,6 +39,7 @@ describe('featureFlagsSlice', () => {
                 isDebugKeysAllowed: false,
                 isTradingResidenceCheckEnabled: false,
                 isTradingDebugEnabled: false,
+                isTradingSlip24Enabled: false,
                 isN4w1BackupEnabled: false,
             });
         });

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -9,6 +9,7 @@ export const FeatureFlag = {
     IsDebugKeysAllowed: 'isDebugKeysAllowed',
     IsTradingResidenceCheckEnabled: 'isTradingResidenceCheckEnabled',
     IsTradingDebugEnabled: 'isTradingDebugEnabled',
+    IsTradingSlip24Enabled: 'isTradingSlip24Enabled',
     IsN4w1BackupEnabled: 'isN4w1BackupEnabled',
 } as const;
 
@@ -33,6 +34,8 @@ export const featureFlagsInitialState: FeatureFlagsState = {
         (isIOs() && process.env.EXPO_PUBLIC_FF_IS_TRADING_RESIDENCE_CHECK_ENABLED !== 'false'),
     [FeatureFlag.IsTradingDebugEnabled]:
         process.env.EXPO_PUBLIC_FF_IS_TRADING_DEBUG_ENABLED === 'true',
+    [FeatureFlag.IsTradingSlip24Enabled]:
+        process.env.EXPO_PUBLIC_FF_IS_TRADING_SLIP24_ENABLED === 'true',
     [FeatureFlag.IsN4w1BackupEnabled]: process.env.EXPO_PUBLIC_FF_IS_N4W1_BACKUP_ENABLED === 'true',
 };
 
@@ -42,6 +45,7 @@ export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsCardanoSendEnabled,
     FeatureFlag.IsTradingResidenceCheckEnabled,
     FeatureFlag.IsTradingDebugEnabled,
+    FeatureFlag.IsTradingSlip24Enabled,
     FeatureFlag.IsN4w1BackupEnabled,
 ];
 

--- a/suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx
@@ -13,6 +13,7 @@ const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsDebugKeysAllowed]: 'Device Auth Check Debug Keys',
     [FeatureFlagEnum.IsTradingResidenceCheckEnabled]: '💰 Trading Residence Check',
     [FeatureFlagEnum.IsTradingDebugEnabled]: '💰 Trading Debug Mode',
+    [FeatureFlagEnum.IsTradingSlip24Enabled]: '💰 Trading SLIP-24',
     [FeatureFlagEnum.IsN4w1BackupEnabled]: 'N4W1 Backup',
 } as const satisfies Record<FeatureFlagEnum, string>;
 

--- a/suite-native/module-trading/src/hooks/general/__tests__/useComposeTradingTransaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useComposeTradingTransaction.test.ts
@@ -1,5 +1,6 @@
 import { formDraftActions } from '@suite-common/wallet-core';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { FeatureFlag } from '@suite-native/feature-flags';
 import { type TestStore, act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import {
     getBtcAccount,
@@ -43,6 +44,7 @@ describe('useComposeTradingTransaction', () => {
         return createTradingLightStore({
             tradeType: 'exchange',
             overrides: {
+                featureFlags: { [FeatureFlag.IsTradingSlip24Enabled]: true },
                 wallet: {
                     accounts: [btcAccount],
                     fees: {
@@ -65,9 +67,12 @@ describe('useComposeTradingTransaction', () => {
     };
 
     const renderUseComposeTradingTransaction = (store: TestStore) =>
-        renderHookWithStoreProvider(() => useComposeTradingTransaction({ tradeType: 'exchange' }), {
-            store,
-        });
+        renderHookWithStoreProvider(
+            () => useComposeTradingTransaction({ tradeType: 'exchange' }),
+            {
+                store,
+            },
+        );
 
     beforeEach(() => {
         mockComposeTradingTransactionThunk.mockClear();
@@ -114,6 +119,7 @@ describe('useComposeTradingTransaction', () => {
                 feeLimit: '21000',
                 maxPriorityFeePerGas: '2',
                 maxFeePerGas: '100',
+                isSlip24Active: true,
             }),
         );
     });

--- a/suite-native/module-trading/src/hooks/general/__tests__/useComposeTradingTransaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useComposeTradingTransaction.test.ts
@@ -45,6 +45,11 @@ describe('useComposeTradingTransaction', () => {
             tradeType: 'exchange',
             overrides: {
                 featureFlags: { [FeatureFlag.IsTradingSlip24Enabled]: true },
+                device: {
+                    selectedDevice: {
+                        features: { major_version: 2, minor_version: 12, patch_version: 1 },
+                    },
+                },
                 wallet: {
                     accounts: [btcAccount],
                     fees: {
@@ -67,12 +72,9 @@ describe('useComposeTradingTransaction', () => {
     };
 
     const renderUseComposeTradingTransaction = (store: TestStore) =>
-        renderHookWithStoreProvider(
-            () => useComposeTradingTransaction({ tradeType: 'exchange' }),
-            {
-                store,
-            },
-        );
+        renderHookWithStoreProvider(() => useComposeTradingTransaction({ tradeType: 'exchange' }), {
+            store,
+        });
 
     beforeEach(() => {
         mockComposeTradingTransactionThunk.mockClear();

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTradingTransaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTradingTransaction.test.ts
@@ -80,7 +80,20 @@ describe('useTradingTransaction', () => {
                     trading: tradingState,
                     accounts: getMockAccounts(),
                 },
-                ...(featureFlags ? { featureFlags } : {}),
+                ...(featureFlags
+                    ? {
+                          featureFlags,
+                          device: {
+                              selectedDevice: {
+                                  features: {
+                                      major_version: 2,
+                                      minor_version: 12,
+                                      patch_version: 1,
+                                  },
+                              },
+                          },
+                      }
+                    : {}),
             },
         });
     };

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTradingTransaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTradingTransaction.test.ts
@@ -1,4 +1,5 @@
 import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { FeatureFlag } from '@suite-native/feature-flags';
 import { type TestStore, act } from '@suite-native/test-utils-store';
 import {
     getBtcAccount,
@@ -63,7 +64,7 @@ const btc2Account = getBtcAccount({ descriptor: asAccountDescriptor('btc2') });
 describe('useTradingTransaction', () => {
     const getMockAccounts = () => [btc1Account, btc2Account];
 
-    const getInitializedStore = () => {
+    const getInitializedStore = (featureFlags?: Partial<Record<FeatureFlag, boolean>>) => {
         const tradingState = getInitializedTradingStateWithQuotes();
 
         // Add the required account keys to the exchange state
@@ -79,6 +80,7 @@ describe('useTradingTransaction', () => {
                     trading: tradingState,
                     accounts: getMockAccounts(),
                 },
+                ...(featureFlags ? { featureFlags } : {}),
             },
         });
     };
@@ -166,6 +168,28 @@ describe('useTradingTransaction', () => {
                 },
                 unwrap: expect.any(Function),
             });
+        });
+
+        it('should pass isSlip24Active: true to sendTransactionThunk when the feature flag is on', async () => {
+            const store = getInitializedStore({ [FeatureFlag.IsTradingSlip24Enabled]: true });
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const mockNextStep = jest.fn();
+
+            const { result } = renderUseTradingTransaction({ store });
+
+            await act(async () => {
+                await result.current.signAndSendTransaction({
+                    nextStep: mockNextStep,
+                    onError: jest.fn(),
+                });
+            });
+
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'sendTransactionThunkMock',
+                    payload: expect.objectContaining({ isSlip24Active: true }),
+                }),
+            );
         });
     });
 

--- a/suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.ts
+++ b/suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.ts
@@ -17,7 +17,10 @@ import {
 } from '@suite-common/wallet-core';
 import { type FeeLevelLabel } from '@suite-common/wallet-types';
 import { type FeatureFlagsRootState } from '@suite-native/feature-flags';
-import { getFormDraftKeyByTradeType, selectIsTradingSlip24Enabled } from '@suite-native/trading-state';
+import {
+    getFormDraftKeyByTradeType,
+    selectIsTradingSlip24Enabled,
+} from '@suite-native/trading-state';
 
 import { composeTradingTransactionThunk } from '../../thunks';
 

--- a/suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.ts
+++ b/suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.ts
@@ -1,10 +1,13 @@
 import { useCallback } from 'react';
 import { useDispatch, useStore } from 'react-redux';
 
-import { selectTradingAccountKeyByTradeType } from '@suite-common/trading';
+import { type MessageSystemRootState } from '@suite-common/message-system';
+import {
+    type TradingRootStateWithDeviceAndAccounts,
+    selectTradingAccountKeyByTradeType,
+} from '@suite-common/trading';
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import {
-    type AccountsRootState,
     type FeesRootState,
     type FormDraftRootState,
     selectAccountByKey,
@@ -13,14 +16,16 @@ import {
     updateFeeInfoThunk,
 } from '@suite-common/wallet-core';
 import { type FeeLevelLabel } from '@suite-common/wallet-types';
-import { type TradingRootState, getFormDraftKeyByTradeType } from '@suite-native/trading-state';
+import { type FeatureFlagsRootState } from '@suite-native/feature-flags';
+import { getFormDraftKeyByTradeType, selectIsTradingSlip24Enabled } from '@suite-native/trading-state';
 
 import { composeTradingTransactionThunk } from '../../thunks';
 
-type TradingTransactionRootState = TradingRootState &
-    AccountsRootState &
+type TradingTransactionRootState = TradingRootStateWithDeviceAndAccounts &
     FeesRootState &
-    FormDraftRootState;
+    FormDraftRootState &
+    MessageSystemRootState &
+    FeatureFlagsRootState;
 
 type UseComposeTradingTransactionProps = {
     tradeType: 'exchange' | 'sell';
@@ -62,6 +67,8 @@ export const useComposeTradingTransaction = ({ tradeType }: UseComposeTradingTra
             return;
         }
 
+        const isSlip24Active = selectIsTradingSlip24Enabled(state, sendAccount);
+
         try {
             await dispatch(
                 composeTradingTransactionThunk({
@@ -74,6 +81,7 @@ export const useComposeTradingTransaction = ({ tradeType }: UseComposeTradingTra
                     feeLimit: draft?.feeLimit,
                     maxPriorityFeePerGas: draft?.maxPriorityFeePerGas,
                     maxFeePerGas: draft?.maxFeePerGas,
+                    isSlip24Active,
                 }),
             ).unwrap();
         } catch (error) {

--- a/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
@@ -4,8 +4,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import { isFulfilled } from '@reduxjs/toolkit';
 import type { ExchangeTrade, SellFiatTrade } from 'invity-api';
 
+import { type MessageSystemRootState } from '@suite-common/message-system';
 import {
     type TradingFulfillValue,
+    type TradingRootStateWithDeviceAndAccounts,
     type TradingSellFormProps,
     type TradingSendRejectedProps,
     type TradingSignAndPushSendFormTransactionProps,
@@ -28,9 +30,14 @@ import {
     selectSendSerializedTx,
 } from '@suite-common/wallet-core';
 import { type FeeLevelLabel, type TokenAddress } from '@suite-common/wallet-types';
+import { type FeatureFlagsRootState } from '@suite-native/feature-flags';
 import { type TxKeyPath } from '@suite-native/intl';
 import { type TokensRootState, selectAccountTokenDecimals } from '@suite-native/tokens';
-import { type TradingRootState, getFormDraftKeyByTradeType } from '@suite-native/trading-state';
+import {
+    type TradingRootState,
+    getFormDraftKeyByTradeType,
+    selectIsTradingSlip24Enabled,
+} from '@suite-native/trading-state';
 import {
     selectFeeLevels,
     usePrecomposedTransactionError,
@@ -130,8 +137,14 @@ export const useTradingTransaction = ({
         resolveConsent: resolveTransactionSendConsent,
     } = useConsent();
 
-    // TODO: slip24 - not implemented in mobile
-    const isSlip24Active = false;
+    const isSlip24Active = useSelector(
+        (
+            state: MessageSystemRootState &
+                FeatureFlagsRootState &
+                TradingRootStateWithDeviceAndAccounts,
+        ) => selectIsTradingSlip24Enabled(state, sendAccount ?? undefined),
+    );
+
     const { composeTradingTransaction } = useComposeTradingTransaction({ tradeType });
 
     // cancel txn signing on unmount

--- a/suite-native/trading-state/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/commonSelectors.test.ts
@@ -82,6 +82,7 @@ const getPreloadedState = ({
     exchange,
     concierge,
     blacklist,
+    slip24,
     residence,
     countryCode,
 }: {
@@ -90,6 +91,7 @@ const getPreloadedState = ({
     exchange?: boolean;
     concierge?: boolean;
     blacklist?: boolean;
+    slip24?: boolean;
     residence?: boolean;
     countryCode?: TradingCountryCode | undefined;
 }) => {
@@ -122,6 +124,12 @@ const getPreloadedState = ({
         features.push({
             domain: 'trading.restrictions.blacklist',
             flag: blacklist,
+        });
+    }
+    if (slip24 !== undefined) {
+        features.push({
+            domain: 'trading.slip24',
+            flag: slip24,
         });
     }
 
@@ -262,25 +270,51 @@ describe('commonSelectors', () => {
     });
 
     describe('selectIsTradingSlip24Enabled', () => {
-        const getSlip24State = (isFeatureFlagEnabled: boolean) =>
+        const getSlip24State = (
+            isFeatureFlagEnabled: boolean,
+            features: object | undefined = {
+                major_version: 2,
+                minor_version: 12,
+                patch_version: 1,
+            },
+        ) =>
             ({
                 messageSystem: messageSystemState,
                 featureFlags: {
                     ...featureFlagsInitialState,
                     [FeatureFlag.IsTradingSlip24Enabled]: isFeatureFlagEnabled,
                 },
-                device: deviceInitialState,
+                device: { selectedDevice: { features } },
                 wallet: { trading: tradingInitialState },
             }) as any;
 
-        it('should be enabled when the feature flag is on for a supported network', () => {
+        it('should be enabled when the feature flag is on for a supported network and firmware', () => {
             expect(selectIsTradingSlip24Enabled(getSlip24State(true), getBtcAccount())).toBe(true);
+        });
+
+        it('should be disabled when the device firmware is too old', () => {
+            const state = getSlip24State(true, {
+                major_version: 2,
+                minor_version: 12,
+                patch_version: 0,
+            });
+
+            expect(selectIsTradingSlip24Enabled(state, getBtcAccount())).toBe(false);
         });
 
         it('should be disabled when the feature flag is off', () => {
             expect(selectIsTradingSlip24Enabled(getSlip24State(false), getBtcAccount())).toBe(
                 false,
             );
+        });
+
+        it('should be disabled when the message-system feature is disabled', () => {
+            const state = {
+                ...getSlip24State(true),
+                messageSystem: getPreloadedState({ slip24: false }).messageSystem,
+            };
+
+            expect(selectIsTradingSlip24Enabled(state, getBtcAccount())).toBe(false);
         });
 
         it('should be disabled for an unsupported network type', () => {

--- a/suite-native/trading-state/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/commonSelectors.test.ts
@@ -48,6 +48,7 @@ import {
     selectIsTradingEnabled,
     selectIsTradingExchangeEnabled,
     selectIsTradingSellEnabled,
+    selectIsTradingSlip24Enabled,
     selectTradeToBeOpened,
     selectTradesToWatchByAccount,
     selectTradingEnvironment,
@@ -257,6 +258,39 @@ describe('commonSelectors', () => {
 
         it('should correctly select that concierge is enabled if remote feature is not set', () => {
             expect(selectIsTradingConciergeEnabled(getPreloadedState({}))).toBe(true);
+        });
+    });
+
+    describe('selectIsTradingSlip24Enabled', () => {
+        const getSlip24State = (isFeatureFlagEnabled: boolean) =>
+            ({
+                messageSystem: messageSystemState,
+                featureFlags: {
+                    ...featureFlagsInitialState,
+                    [FeatureFlag.IsTradingSlip24Enabled]: isFeatureFlagEnabled,
+                },
+                device: deviceInitialState,
+                wallet: { trading: tradingInitialState },
+            }) as any;
+
+        it('should be enabled when the feature flag is on for a supported network', () => {
+            expect(selectIsTradingSlip24Enabled(getSlip24State(true), getBtcAccount())).toBe(true);
+        });
+
+        it('should be disabled when the feature flag is off', () => {
+            expect(selectIsTradingSlip24Enabled(getSlip24State(false), getBtcAccount())).toBe(
+                false,
+            );
+        });
+
+        it('should be disabled for an unsupported network type', () => {
+            expect(selectIsTradingSlip24Enabled(getSlip24State(true), getCardanoAccount())).toBe(
+                false,
+            );
+        });
+
+        it('should be disabled when there is no account', () => {
+            expect(selectIsTradingSlip24Enabled(getSlip24State(true), undefined)).toBe(false);
         });
     });
 

--- a/suite-native/trading-state/src/selectors/commonSelectors.ts
+++ b/suite-native/trading-state/src/selectors/commonSelectors.ts
@@ -134,7 +134,7 @@ export const selectIsTradingConciergeEnabled = (
 
 export const selectIsTradingSlip24Enabled = (
     state: MessageSystemRootState & FeatureFlagsRootState & TradingRootStateWithDeviceAndAccounts,
-    account: Account | undefined,
+    account: Account | undefined | null,
 ) =>
     selectTradingIsSlip24Allowed(
         state,

--- a/suite-native/trading-state/src/selectors/commonSelectors.ts
+++ b/suite-native/trading-state/src/selectors/commonSelectors.ts
@@ -20,6 +20,7 @@ import {
     cryptoIdToSymbol,
     isFinalStatus,
     selectDeviceTradingTrades,
+    selectTradingIsSlip24Allowed,
     selectTradingSupportedSymbols,
     toTokenCryptoId,
 } from '@suite-common/trading';
@@ -130,6 +131,17 @@ export const selectIsTradingSellEnabled = (state: MessageSystemRootState & Featu
 export const selectIsTradingConciergeEnabled = (
     state: MessageSystemRootState & FeatureFlagsRootState,
 ) => selectIsFeatureEnabled(state, Feature.trading.concierge, true);
+
+export const selectIsTradingSlip24Enabled = (
+    state: MessageSystemRootState & FeatureFlagsRootState & TradingRootStateWithDeviceAndAccounts,
+    account: Account | undefined,
+) =>
+    selectTradingIsSlip24Allowed(
+        state,
+        account,
+        selectIsFeatureEnabled(state, Feature.trading.slip24, true) &&
+            selectIsFeatureFlagEnabled(state, FeatureFlag.IsTradingSlip24Enabled),
+    );
 
 export const selectIsTradingEnabled = (
     state: MessageSystemRootState & FeatureFlagsRootState & TradingRootState,


### PR DESCRIPTION
## Description

Enables SLIP-24 payment requests (clear-signing) for trading swaps/sells in suite-native, previously hard-disabled by `const isSlip24Active = false`.

Gated behind two flags fed into `selectTradingIsSlip24Allowed` (firmware + supported-network checks):
- message-system `Feature.trading.slip24` (default on, remotely killable)
- new local `IsTradingSlip24Enabled` feature flag (**default off**, toggle in dev-utils Feature Flags)

Also threads `isSlip24Active` into the compose call so compose and sign agree on the flag.

## Notes for QA

Off by default — no behavior change unless enabled. To test: dev-utils → Feature Flags → enable "💰 Trading SLIP-24", then run a swap/sell on a SLIP-24-capable device on a supported network (BTC/ETH/SOL/XLM/XRP). The device should show the payment-request memo screen.

## Related Issue

Resolve

## Screenshots:

N/A — clear-signing is rendered on the Trezor device, not in-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=advisor/001-enable-slip24-native&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=advisor/001-enable-slip24-native&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=advisor/001-enable-slip24-native&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are almost entirely in the `suite-native/` directory, which is the React Native mobile app codebase. These files (feature flags, trading hooks, trading state selectors, dev utils components) have no corresponding Playwright E2E tests because the E2E test suite targets the desktop/web Trezor Suite application, not the mobile app. The one shared file (`suite-common/trading/src/selectors/tradingSelectors.ts`) maps to 121 tests, indicating it is a broadly imported utility. However, without knowing the specific nature of the change to `tradingSelectors.ts`, and given that it maps to nearly every test in the suite, there is no concrete evidence from the test analyses that any specific E2E test's behavior would be affected — trading selectors are consumed by many components but changes to selector logic in `suite-common` would most directly impact the trading flows. If the change is purely additive (e.g., adding a new selector used only by native), no web E2E tests are affected. If existing selectors were modified, the trading tests would be most relevant, but this is speculative without diff content. No E2E tests are recommended as high priority; the risk to the web/desktop Suite is very low.

<details><summary><b>Changed files (11)</b></summary>

- `suite-common/trading/src/selectors/tradingSelectors.ts`
- `suite-native/config/src/types.ts`
- `suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts`
- `suite-native/feature-flags/src/featureFlagsSlice.ts`
- `suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx`
- `suite-native/module-trading/src/hooks/general/__tests__/useComposeTradingTransaction.test.ts`
- `suite-native/module-trading/src/hooks/general/__tests__/useTradingTransaction.test.ts`
- `suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.ts`
- `suite-native/module-trading/src/hooks/general/useTradingTransaction.ts`
- `suite-native/trading-state/src/selectors/__tests__/commonSelectors.test.ts`
- `suite-native/trading-state/src/selectors/commonSelectors.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (10)**
- `suite-native/config/src/types.ts`
- `suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts`
- `suite-native/feature-flags/src/featureFlagsSlice.ts`
- `suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx`
- `suite-native/module-trading/src/hooks/general/__tests__/useComposeTradingTransaction.test.ts`
- `suite-native/module-trading/src/hooks/general/__tests__/useTradingTransaction.test.ts`
- `suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.ts`
- `suite-native/module-trading/src/hooks/general/useTradingTransaction.ts`
- `suite-native/trading-state/src/selectors/__tests__/commonSelectors.test.ts`
- `suite-native/trading-state/src/selectors/commonSelectors.ts`

_Updated: 2026-07-02T15:35:41.771Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T15:41:38.246Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-02T15:39:11.229Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/advisor/001-enable-slip24-native/web/](https://dev.suite.sldev.cz/suite-web/advisor/001-enable-slip24-native/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->