### PR TITLE
fix(trading): restore selected account after redirect

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/__tests__/useTradingFormAccount.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/__tests__/useTradingFormAccount.test.tsx
@@ -1,0 +1,82 @@
+import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import type { StaticSessionId } from '@trezor/connect';
+
+import { useTradingFormAccount } from '../useTradingFormAccount';
+
+const DEVICE_STATE: StaticSessionId = '1stTestnetAddress@device_id:0';
+
+const FIRST_ELIGIBLE_ACCOUNT: Account = mockWalletAccount({
+    symbol: 'eth',
+    descriptor: asAccountDescriptor('0xFirstEligible'),
+    balance: '1000000000000000000',
+});
+const TRADE_ACCOUNT: Account = mockWalletAccount({
+    symbol: 'eth',
+    descriptor: asAccountDescriptor('0xTradeAccount'),
+    balance: '2000000000000000000',
+});
+const INELIGIBLE_TRADE_ACCOUNT: Account = mockWalletAccount({
+    symbol: 'eth',
+    descriptor: asAccountDescriptor('0xIneligibleTradeAccount'),
+    balance: '0',
+    tokens: [],
+});
+
+const buildState = (accounts: Account[], sellTradingAccountKey?: string) => ({
+    device: { selectedDevice: { state: { staticSessionId: DEVICE_STATE } } },
+    tokenDefinitions: {},
+    wallet: {
+        accounts,
+        trading: {
+            sell: { tradingAccountKey: sellTradingAccountKey },
+            buy: { tradingAccountKey: undefined },
+            exchange: { tradingAccountKey: undefined },
+            prefilledFromAccount: { key: undefined, cryptoId: undefined },
+        },
+    },
+});
+
+const renderForSell = (
+    sellTradingAccountKey?: string,
+    accounts: Account[] = [FIRST_ELIGIBLE_ACCOUNT, TRADE_ACCOUNT],
+) => {
+    const store = configureMockStore({
+        preloadedState: buildState(accounts, sellTradingAccountKey),
+    });
+    const { result } = renderHookWithStoreProvider(() => useTradingFormAccount('sell'), { store });
+
+    return result;
+};
+
+describe('useTradingFormAccount – sell account across redirect', () => {
+    it('resolves a fallback account (not the trade account) when tradingAccountKey is lost', () => {
+        const result = renderForSell(undefined);
+
+        expect(result.current.account.key).toBe(FIRST_ELIGIBLE_ACCOUNT.key);
+        expect(result.current.account.key).not.toBe(TRADE_ACCOUNT.key);
+    });
+
+    it('resolves the trade account when tradingAccountKey is rehydrated from the trade', () => {
+        const result = renderForSell(TRADE_ACCOUNT.key);
+
+        expect(result.current.account.key).toBe(TRADE_ACCOUNT.key);
+    });
+
+    it('discards the rehydrated tradingAccountKey when the trade account is not eligible', () => {
+        // Restoring tradingAccountKey from trade.sendAccountKey is not enough on its own:
+        // useTradingFormAccount runs the key through the eligibility resolver and drops it
+        // when the account has no balance/tokens, falling back to a different eligible
+        // account. This is why post-trade steps derive the account directly from
+        // trade.sendAccountKey (see useTradingSellForm / useTradingExchangeForm) instead of
+        // relying on this resolver.
+        const result = renderForSell(INELIGIBLE_TRADE_ACCOUNT.key, [
+            FIRST_ELIGIBLE_ACCOUNT,
+            INELIGIBLE_TRADE_ACCOUNT,
+        ]);
+
+        expect(result.current.account.key).not.toBe(INELIGIBLE_TRADE_ACCOUNT.key);
+        expect(result.current.account.key).toBe(FIRST_ELIGIBLE_ACCOUNT.key);
+    });
+});

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -48,6 +48,7 @@ import { getNetwork, isAccountBasedNetwork } from '@suite-common/wallet-config';
 import {
     ETHEREUM_ADJUST_GAS_LIMIT,
     fetchAndUpdateAccountThunk,
+    selectAccountByKey,
     updateFeeInfoThunk,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
@@ -98,7 +99,26 @@ export const useTradingExchangeForm = ({
     const exchangeInfo = useSelector(selectTradingExchangeInfo);
     const composedTransactionInfo = useSelector(selectTradingComposedTransactionInfo);
     const { selectedFee, composed } = composedTransactionInfo;
-    const { account, tradingAccountKey: accountKey, cryptoId } = useTradingFormAccount(type);
+    const {
+        account: formAccount,
+        tradingAccountKey: accountKey,
+        cryptoId,
+    } = useTradingFormAccount(type);
+
+    const trades = useSelector(selectTradingTrades);
+    const trade = useMemo(
+        () =>
+            trades.find(
+                (trade): trade is TradingTransactionExchange =>
+                    trade.tradeType === 'exchange' &&
+                    !!transactionId &&
+                    trade.data.orderId === transactionId,
+            ),
+        [trades, transactionId],
+    );
+
+    const tradeSendAccount = useSelector(state => selectAccountByKey(state, trade?.sendAccountKey));
+    const account = tradeSendAccount ?? formAccount;
 
     // used for disabling approve/revoke controls when
     // quotes are scheduled to refresh after changing swap form inputs
@@ -130,17 +150,6 @@ export const useTradingExchangeForm = ({
     const { symbol } = account;
     const { isBtcSatsAmountUnit: shouldSendInSats } = useBitcoinAmountUnit(symbol);
     const network = getNetwork(account.symbol);
-    const trades = useSelector(selectTradingTrades);
-    const trade = useMemo(
-        () =>
-            trades.find(
-                (trade): trade is TradingTransactionExchange =>
-                    trade.tradeType === 'exchange' &&
-                    !!transactionId &&
-                    trade.data.orderId === transactionId,
-            ),
-        [trades, transactionId],
-    );
 
     const { defaultCurrency, defaultValues } = useTradingExchangeFormDefaultValues(
         accountKey,
@@ -683,6 +692,9 @@ export const useTradingExchangeForm = ({
             if (transactionId && trade) {
                 dispatch(tradingExchangeActions.saveSelectedQuote(trade.data));
                 dispatch(tradingExchangeActions.setFormStep('SEND_TRANSACTION'));
+                if (trade.sendAccountKey) {
+                    dispatch(tradingExchangeActions.setTradingAccountKey(trade.sendAccountKey));
+                }
             }
 
             dispatch(tradingExchangeActions.setIsFromRedirect(false));

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -37,7 +37,7 @@ import {
     tradingThunks,
 } from '@suite-common/trading';
 import { networks } from '@suite-common/wallet-config';
-import { selectBaseCurrency } from '@suite-common/wallet-core';
+import { selectAccountByKey, selectBaseCurrency } from '@suite-common/wallet-core';
 
 import { signAndPushSendFormTransactionThunk } from 'src/actions/wallet/send/sendFormThunks';
 import { submitRequestForm } from 'src/actions/wallet/trading/tradingCommonActions';
@@ -77,7 +77,20 @@ export const useTradingSellForm = ({
 
     const [showReserveBanner, setShowReserveBanner] = useState<boolean>(false);
 
-    const { account, tradingAccountKey: accountKey, cryptoId } = useTradingFormAccount(type);
+    const {
+        account: formAccount,
+        tradingAccountKey: accountKey,
+        cryptoId,
+    } = useTradingFormAccount(type);
+
+    const trades = useSelector(selectTradingTrades);
+    const trade = trades.find(
+        (trade): trade is TradingTransactionSell =>
+            trade.tradeType === 'sell' && trade.key === transactionId,
+    );
+
+    const tradeSendAccount = useSelector(state => selectAccountByKey(state, trade?.sendAccountKey));
+    const account = tradeSendAccount ?? formAccount;
 
     const { device } = useTradingInitializer({
         pageType,
@@ -104,11 +117,6 @@ export const useTradingSellForm = ({
     const network = networks[account.symbol];
     const { isBtcSatsAmountUnit: shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
     const localCurrencyOption = { value: baseCurrencyCode, label: baseCurrencyCode.toUpperCase() };
-    const trades = useSelector(selectTradingTrades);
-    const trade = trades.find(
-        (trade): trade is TradingTransactionSell =>
-            trade.tradeType === 'sell' && trade.key === transactionId,
-    );
 
     const { defaultValues, defaultCountry, defaultSubdivision, defaultCurrency } =
         useTradingSellFormDefaultValues(
@@ -446,6 +454,9 @@ export const useTradingSellForm = ({
             if (transactionId && trade && pageType !== 'retry') {
                 dispatch(tradingSellActions.saveSelectedQuote(trade.data));
                 dispatch(tradingSellActions.setFormStep('SEND_TRANSACTION'));
+                if (trade.sendAccountKey) {
+                    dispatch(tradingSellActions.setTradingAccountKey(trade.sendAccountKey));
+                }
             }
 
             dispatch(tradingSellActions.setIsFromRedirect(false));


### PR DESCRIPTION
## Description

- resume the sell send-transaction step with the account stored on the trade instead of falling back to the current eligible form account
- resume the exchange send-transaction step with the account stored on the trade instead of falling back to the current eligible form account
- add a regression test showing generic trading account rehydration can still fall back when the saved account is not eligible

## Notes for QA

- In Trading > Sell for ETH, choose account 2, continue to a partner and return, verify the Send transaction step still shows account 2.
- In Trading > Exchange, choose a non-default source account, continue through a partner redirect and return, verify the original source account stays selected.

## Related Issue

Resolve #29292

## Screenshots:

N/A

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/29292-trading-redirect-account/web/](https://dev.suite.sldev.cz/suite-web/fix/29292-trading-redirect-account/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/29292-trading-redirect-account&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/29292-trading-redirect-account&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T12:57:41.053Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T12:55:42.409Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes target two trading form hooks (useTradingExchangeForm.ts for swap/exchange and useTradingSellForm.ts for sell) plus a unit test for a shared trading form account hook. Both hooks map to 121 tests via static analysis, but this is due to broad transitive imports — only the trading-specific E2E tests actually exercise these code paths. The recommended strategy focuses on sell and swap E2E tests at high priority, with fee and input validation tests at medium priority. The unit test file has no E2E coverage but is self-contained.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/__tests__/useTradingFormAccount.test.tsx`
- `packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts`
- `packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts`

</details>

**Recommended tests (16)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Directly exercises the sell trading flow which uses useTradingSellForm.ts. The test fills a sell form, confirms quotes, verifies confirmation details, and initiates send — all behaviors governed by the sell form hook.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests the Ethereum sell flow with custom gas fees, which directly exercises useTradingSellForm.ts for ETH-specific sell form logic including fee configuration and transaction confirmation.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests the Solana sell flow end-to-end including form filling, quote display, device confirmation, and transaction status polling — all directly powered by useTradingSellForm.ts.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Tests the swap/exchange flow (SOL to BTC) including form filling, quote selection, device confirmation, and transaction status tracking — directly exercising useTradingExchangeForm.ts.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests swapping SOL to USDC token via the exchange form, covering quote display, receive account selection, and transaction confirmation — directly exercising useTradingExchangeForm.ts.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token (USDC) through the sell flow, directly exercising useTradingSellForm.ts for token-specific sell logic.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation (decimal limits, insufficient funds, percentage buttons, max amount, fiat/crypto switching) — all logic managed by useTradingSellForm.ts.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping USDT token to BTC through the exchange form, covering token confirmation and transaction flow directly powered by useTradingExchangeForm.ts.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests swapping SPL tokens (USDT to USDC) through the exchange/swap form, directly exercising useTradingExchangeForm.ts for token-to-token swap logic.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests custom Bitcoin fee settings during a swap, exercising the fee calculation path within useTradingExchangeForm.ts.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests custom Ethereum fee settings (gas limit, max fee per gas, priority fee) during swap, exercising fee-related logic in useTradingExchangeForm.ts.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form inputs including asset selection, amount validation, fraction buttons, and provider selection — behaviors that rely on useTradingExchangeForm.ts for form state management.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swap form behavior when the buy asset belongs to a disabled network, which exercises edge case handling in useTradingExchangeForm.ts.
- `suite/e2e/tests/trading/swap-history.test.ts` — Tests swap trade history display and detail views which rely on data produced by the exchange form flow. Changes to useTradingExchangeForm.ts could affect how trade data is structured.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation to sell and swap forms from various entry points, verifying the correct form opens for the right coin. Changes to form hooks could affect form initialization logic.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/buy-negative.test.ts` — While this tests the buy form (not sell/exchange), the trading form hooks share common infrastructure (useTradingFormAccount). Changes to account handling in the shared test file could surface here.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/hooks/wallet/trading/form/__tests__/useTradingFormAccount.test.tsx`

_Updated: 2026-07-01T12:52:29.182Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->