### PR TITLE
fix(suite-native): screen header button sizes

### DIFF
--- a/suite-native/module-connect-popup/src/screens/WalletConnectPairScreen.tsx
+++ b/suite-native/module-connect-popup/src/screens/WalletConnectPairScreen.tsx
@@ -111,6 +111,7 @@ export const WalletConnectPairScreen = () => {
                             intent="neutral"
                             priority="secondary"
                             iconName="qrCode"
+                            size="medium"
                             onPress={openModal}
                         />
                     }

--- a/suite-native/module-settings/src/screens/SettingsExperimentalScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsExperimentalScreen.tsx
@@ -22,6 +22,7 @@ export const SettingsExperimentalScreen = () => {
                             iconName="info"
                             intent="neutral"
                             priority="secondary"
+                            size="medium"
                             onPress={onInfoPress}
                             accessibilityRole="button"
                             accessibilityLabel="More info"


### PR DESCRIPTION
## Description
Fixes incorrect sizes of the custom buttons in the screen headers.
 - Account Rename button - alredy fixed in https://github.com/trezor/trezor-suite/pull/29116/changes#r3480741896
 - Experimental settings  - this PR
  - WalletConnectPairingScreen -this PR 
## Notes for QA

- check the screen header buttons across the app if it looks correct.

## Related Issue

Resolve #28978 

## Screenshots:
<img width="408" height="880" alt="Screenshot 2026-07-01 at 10 28 06" src="https://github.com/user-attachments/assets/40efcda0-3465-4b03-9bbe-2fb8376376e2" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/screen-header-button-sizes&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->