### PR TITLE
fix(trading): gate dex auto-confirm on receive coin

### DIFF
--- a/packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx
@@ -63,9 +63,7 @@ export const TradingFormOfferExchangeActions = () => {
     const isReceiveAddressSelected = !!tradingReceiveAddress.receiveAddress;
     const shouldShowApprovalStep = quote !== undefined && requiresTokenApproval(quote);
     const isQuoteOutdated = quote?.send !== sendCryptoSelect?.id;
-    const isQuoteForSelectedReceive =
-        quote?.receive === receiveCryptoSelect?.id &&
-        quote?.receiveAddress === tradingReceiveAddress.receiveAddress;
+    const isQuoteForSelectedReceive = quote?.receive === receiveCryptoSelect?.id;
     const amountTooHigh = isAmountTooHigh({
         amount,
         contractAddress: tokenAddress,


### PR DESCRIPTION
## Description
Follow-up fix for the previous swap receive-asset guard.
DEX auto-confirm now checks only the selected receive coin, so a stale quote receiveAddress no longer blocks the approval flow and leaves the form stuck on Refresh.

## Notes for QA
Verify an ERC-20 DEX swap no longer gets stuck on the Refresh button before approval/swap.
Switch the TO asset/network a few times before selecting the quote and confirm the flow still continues with the currently selected receive coin.

## Related Issue
Resolve #28143

## Screenshots:
N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to TradingFormOfferExchangeActions.tsx, the exchange/swap offer action component in the trading flow. This is a focused UI change affecting the swap/exchange confirmation and offer interaction layer. The highest-risk tests are the full swap flow tests (coin-to-coin, coin-to-token, token-to-coin, token-to-token) which directly exercise offer confirmation, transaction sending, and result display. Medium-priority tests cover fee customization, swap history, and form input scenarios that also touch the exchange actions component. No static coverage mapping was available, so all recommendations are inferred from LLM analysis of test behaviors.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-coins.test.ts` — TradingFormOfferExchangeActions.tsx is the exchange/swap offer action component. This test exercises the full swap coin-to-coin flow including confirming swap offers, which directly invokes the exchange actions UI. The test verifies swap offer confirmation, transaction detail status progression, and provider support links — all behaviors likely rendered by this component.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test covers swapping a native coin to a token (SOL→USDC), exercising the exchange offer confirmation flow and transaction detail summary — directly touching the TradingFormOfferExchangeActions component's rendering of exchange type, provider name, and confirmation actions.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping a token to a coin (USDT→BTC), including reviewing the best swap offer and confirming the exchange. The confirmation and transaction detail assertions directly exercise the exchange actions component.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests swapping SPL tokens (USDT→USDC), verifying the swap offer confirmation flow, exchange type display, and provider name — all rendered by the TradingFormOfferExchangeActions component.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests Bitcoin swap with custom fees. While focused on fee display, it still exercises the swap offer selection and confirmation flow that passes through the exchange actions component.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests Ethereum swap with custom gas fees. The swap confirmation modal and device prompt flow pass through the exchange actions component, making this relevant for regression coverage.
- `suite/e2e/tests/trading/swap-history.test.ts` — Tests swap trade order history display and transaction detail pages. The transaction detail view (status, provider, amounts) may be rendered by or closely related to the exchange actions component.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swapping a token to a disabled network asset and verifying provider info in swap quotes. The quote/offer display likely involves the exchange actions component.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form inputs, best offer display, and provider selection. While more focused on the form inputs, the best offer amount and provider assertions touch the exchange offer UI that this component likely renders.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation to swap forms from various entry points and verifies the swap form opens correctly. While it doesn't deeply exercise the exchange actions, a broken component could prevent the swap form from rendering.

</details>

_Updated: 2026-07-01T08:40:16.684Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/28143-dex-swap-refresh&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/28143-dex-swap-refresh&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/28143-dex-swap-refresh/web/](https://dev.suite.sldev.cz/suite-web/fix/28143-dex-swap-refresh/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T08:44:59.099Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T08:43:46.281Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->