### PR TITLE
test(suite): add new test for authenticity check

### DIFF
--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -176,10 +176,6 @@ export class OnboardingPage {
                     type: suiteSettingsActions.toggleFirmwareHashCheck.type,
                     payload: false,
                 },
-                {
-                    type: suiteSettingsActions.toggleDeviceAuthenticityCheck.type,
-                    payload: false,
-                },
             ],
         );
     }
@@ -190,6 +186,15 @@ export class OnboardingPage {
         await this.page.evaluate(action => window.store.dispatch(action), {
             type: debugActions.setShowDebugMenu.type,
             payload: false,
+        });
+    }
+
+    @step()
+    async enableDebugMode() {
+        await this.page.ensureStoreOnDesktop();
+        await this.page.evaluate(action => window.store.dispatch(action), {
+            type: debugActions.setShowDebugMenu.type,
+            payload: true,
         });
     }
 
@@ -230,8 +235,7 @@ export class OnboardingPage {
             await this.disableFirmwareRevisionCheck();
         }
 
-        // TODO https://github.com/trezor/trezor-suite/issues/22765
-        if (this.device.model === Model.T3W1) {
+        if (this.device.hasSecureElement) {
             await this.disableAuthenticityCheck();
         }
     }

--- a/suite/e2e/tests/onboarding/authenticity-check.test.ts
+++ b/suite/e2e/tests/onboarding/authenticity-check.test.ts
@@ -1,0 +1,34 @@
+import { TestCategory, TestPriority } from '@trezor/e2e-utils';
+
+import { test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
+
+// TODO: expand to T3W1 https://github.com/trezor/trezor-suite/issues/22765
+test.describe('Device authenticity check', { tag: ['@T3B1', '@T3T1'] }, () => {
+    test.beforeEach(async ({ onboardingPage, device }) => {
+        await onboardingPage.disableFirmwareHashCheck();
+        if (device.hasCanaryFirmware) {
+            await onboardingPage.disableFirmwareRevisionCheck();
+        }
+        await onboardingPage.enableDebugMode();
+        await onboardingPage.disableDisconnectPrompt();
+        await onboardingPage.optionallyDismissFwHashCheckError();
+    });
+
+    test(
+        'Suite completes device authenticity check',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verify Suite completes device authenticity check.',
+                category: TestCategory.Onboarding,
+                priority: TestPriority.Critical,
+            }),
+        },
+        async ({ analyticsSection, onboardingPage }) => {
+            await analyticsSection.continueButton.click();
+            await onboardingPage.completeOnboardingButton.click();
+            await onboardingPage.passThroughAuthenticityCheck();
+            await onboardingPage.page.discoveryShouldFinish();
+        },
+    );
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds new dedicated test for authenticity check as the last refactoring removed this step all our tests

plus extra cleanup in support methods

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-authenticity-check&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-authenticity-check&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T13:37:55.153Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T13:34:55.561Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-authenticity-check/web/](https://dev.suite.sldev.cz/suite-web/test-authenticity-check/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->