### PR TITLE
fix(trading): disable actions when network fee is missing

### DIFF
--- a/packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx
@@ -5,7 +5,7 @@ import type { CryptoId } from 'invity-api';
 import { Translation } from '@suite/intl';
 import {
     requiresTokenApproval,
-    selectTradingComposedTransactionInfo,
+    selectIsTradingNetworkFeeMissing,
     tradingExchangeActions,
 } from '@suite-common/trading';
 import { isAmountTooHigh } from '@suite-common/wallet-utils';
@@ -38,10 +38,6 @@ export const TradingFormOfferExchangeActions = () => {
 
     const modalControls = useReceiveAddressModalControls();
 
-    const composedTransactionInfo = useSelector(selectTradingComposedTransactionInfo);
-    const fee = composedTransactionInfo?.composed?.fee;
-    const isFeeRequiredButMissingValue = fee === undefined || fee === '';
-
     const { outputs, sendCryptoSelect, receiveCryptoSelect } = watch();
     const { amount, tokenAddress } = getTradingFirstOutput(outputs);
     const areSatsUsed = !!shouldSendInSats;
@@ -54,6 +50,10 @@ export const TradingFormOfferExchangeActions = () => {
         selectedAssetCryptoId,
         isBaseButtonDisabled,
     } = useTradingFormOfferCommon<'exchange'>();
+
+    const isNetworkFeeMissing = useSelector(reduxState =>
+        selectIsTradingNetworkFeeMissing(reduxState, quote),
+    );
 
     const { stellarActivateButton, stellarActivateModal } = useTradingStellarActivation({
         account: tradingReceiveAddress.selectedAccount ?? undefined,
@@ -76,7 +76,7 @@ export const TradingFormOfferExchangeActions = () => {
         : state.isFormLoading || isLoadingQuote;
 
     const isButtonDisabled =
-        isBaseButtonDisabled || amountTooHigh || isFeeRequiredButMissingValue || isLoading;
+        isBaseButtonDisabled || amountTooHigh || isNetworkFeeMissing || isLoading;
 
     useEffect(() => {
         const initConfirmTrade = async () => {

--- a/packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.tsx
@@ -1,4 +1,4 @@
-import { selectTradingComposedTransactionInfo, tradingSellActions } from '@suite-common/trading';
+import { selectIsTradingNetworkFeeMissing, tradingSellActions } from '@suite-common/trading';
 import { isAmountTooHigh } from '@suite-common/wallet-utils';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -21,14 +21,11 @@ export const TradingFormOfferSellActions = () => {
         form: { state },
     } = context;
 
-    const composedTransactionInfo = useSelector(selectTradingComposedTransactionInfo);
+    const isNetworkFeeMissing = useSelector(selectIsTradingNetworkFeeMissing);
 
     const { outputs } = watch();
     const { amount, tokenAddress } = getTradingFirstOutput(outputs);
     const areSatsUsed = !!shouldSendInSats;
-
-    const fee = composedTransactionInfo?.composed?.fee;
-    const isFeeRequiredButMissingValue = fee === undefined || fee === '';
 
     const amountTooHigh = isAmountTooHigh({
         amount,
@@ -40,10 +37,7 @@ export const TradingFormOfferSellActions = () => {
     const { quote, confirmButtonData, isBaseButtonDisabled } = useTradingFormOfferCommon<'sell'>();
 
     const isButtonDisabled =
-        isBaseButtonDisabled ||
-        amountTooHigh ||
-        isFeeRequiredButMissingValue ||
-        state.isFormLoading;
+        isBaseButtonDisabled || amountTooHigh || isNetworkFeeMissing || state.isFormLoading;
 
     const onSelectQuote = () => {
         if (!quote) return;

--- a/packages/suite/src/views/wallet/trading/sell/__tests__/TradingFormOfferSellActions.test.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/__tests__/TradingFormOfferSellActions.test.tsx
@@ -1,0 +1,99 @@
+import '@suite-common/test-utils/src/globalOverrides';
+
+import { screen } from '@testing-library/react';
+
+import { configureMockStore } from '@suite-common/test-utils';
+import { type Account } from '@suite-common/wallet-types';
+
+import { type AppState } from 'src/reducers/store';
+import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
+import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
+import { renderWithProviders } from 'src/support/tests/hooksHelper';
+
+import { TradingFormOfferSellActions } from '../TradingFormOfferSellActions';
+
+const mockUseTradingFormContext = jest.fn();
+const mockUseTradingFormOfferCommon = jest.fn();
+
+jest.mock('src/hooks/wallet/trading/form/useTradingCommonForm', () => ({
+    useTradingFormContext: () => mockUseTradingFormContext(),
+}));
+
+jest.mock(
+    'src/views/wallet/trading/common/TradingForm/TradingFormOffer/hooks/useTradingFormOfferCommon',
+    () => ({ useTradingFormOfferCommon: () => mockUseTradingFormOfferCommon() }),
+);
+
+jest.mock(
+    'src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferConfirmButton',
+    () => ({
+        TradingFormOfferConfirmButton: ({
+            isDisabled,
+            testId,
+        }: {
+            isDisabled: boolean;
+            testId: string;
+        }) => <button data-testid={testId} disabled={isDisabled} />,
+    }),
+);
+
+jest.mock('src/views/wallet/trading/common/TradingKYCWarning', () => ({
+    TradingKYCWarning: () => null,
+}));
+
+jest.mock(
+    'src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC',
+    () => ({ TradingFormOfferOTC: () => null }),
+);
+
+const account = { symbol: 'btc', availableBalance: '0', tokens: [] } as unknown as Account;
+
+const renderWithNetworkFee = (composed: { fee: string } | undefined) => {
+    const store = configureMockStore({
+        preloadedState: {
+            ...initialAppState,
+            wallet: {
+                ...initialAppState.wallet,
+                trading: { composedTransactionInfo: { composed } },
+            },
+        } as unknown as AppState,
+    });
+
+    renderWithProviders(
+        store,
+        extraDependenciesDesktopMock.services,
+        <TradingFormOfferSellActions />,
+    );
+};
+
+describe('TradingFormOfferSellActions', () => {
+    beforeEach(() => {
+        mockUseTradingFormContext.mockReturnValue({
+            account,
+            watch: () => ({ outputs: [] }),
+            shouldSendInSats: false,
+            form: { state: { isFormLoading: false } },
+        });
+        mockUseTradingFormOfferCommon.mockReturnValue({
+            quote: { orderId: 'test-order' },
+            confirmButtonData: {},
+            isBaseButtonDisabled: false,
+        });
+    });
+
+    it.each([
+        ['is enabled when the network fee is present', { fee: '12345' }, false],
+        ['is disabled when the network fee is missing', undefined, true],
+        ['is disabled when the network fee is an empty string', { fee: '' }, true],
+    ] as [string, { fee: string } | undefined, boolean][])(
+        'confirm button %s',
+        (_title, composed, expectedDisabled) => {
+            renderWithNetworkFee(composed);
+
+            expect(screen.getByTestId('@trading/form/sell-button')).toHaveProperty(
+                'disabled',
+                expectedDisabled,
+            );
+        },
+    );
+});

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -2,6 +2,7 @@ import {
     type BuyTrade,
     type Coins,
     type CryptoId,
+    type ExchangeTrade,
     type FiatCurrenciesProps,
     type FiatCurrencyCode,
     type Platforms,
@@ -30,6 +31,7 @@ import {
     selectDeviceHasTradingTrades,
     selectDeviceTradingTradesOrderedByDate,
     selectGroupedTradingExchangeQuotes,
+    selectIsTradingNetworkFeeMissing,
     selectTradedAccountKeys,
     selectTrading,
     selectTradingAccountAccordingActiveSection,
@@ -54,6 +56,7 @@ import {
     selectTradingCoinInfoByCryptoId,
     selectTradingCoinSymbolByCryptoId,
     selectTradingComposedTransactionInfo,
+    selectTradingDisplayComposedFee,
     selectTradingExchange,
     selectTradingExchangeAmountLimits,
     selectTradingExchangeBuyCryptoIds,
@@ -1262,6 +1265,54 @@ describe('tradingSelectors', () => {
             },
             selectedFee: 'normal',
         });
+    });
+
+    const gaslessQuote = {
+        orderId: 'test-order',
+        exchange: '1inchfusion',
+        isDex: true,
+        signData: {
+            type: 'eip712-typed-data' as const,
+            data: { primaryType: 'Order' },
+        },
+    } as unknown as ExchangeTrade;
+
+    describe(selectTradingDisplayComposedFee.name, () => {
+        it.each([
+            ['return the composed fee for a regular quote', { fee: '12345' }, undefined, '12345'],
+            ['return undefined when there is no composed fee', undefined, undefined, undefined],
+            ['return "0" for an EIP-712-signed (gasless) quote', undefined, gaslessQuote, '0'],
+        ] as [
+            string,
+            { fee: string } | undefined,
+            ExchangeTrade | undefined,
+            string | undefined,
+        ][])('should %s', (_title, composed, quote, expected) => {
+            state.wallet.trading.composedTransactionInfo.composed = composed as any;
+
+            expect(selectTradingDisplayComposedFee(state, quote)).toBe(expected);
+        });
+    });
+
+    describe(selectIsTradingNetworkFeeMissing.name, () => {
+        it.each([
+            ['false when the composed fee is present', { fee: '12345' }, undefined, false],
+            ['true when the composed fee is undefined', undefined, undefined, true],
+            ['true when the composed fee is an empty string', { fee: '' }, undefined, true],
+            [
+                'false for an EIP-712-signed (gasless) quote even without a composed fee',
+                undefined,
+                gaslessQuote,
+                false,
+            ],
+        ] as [string, { fee: string } | undefined, ExchangeTrade | undefined, boolean][])(
+            'should be %s',
+            (_title, composed, quote, expected) => {
+                state.wallet.trading.composedTransactionInfo.composed = composed as any;
+
+                expect(selectIsTradingNetworkFeeMissing(state, quote)).toBe(expected);
+            },
+        );
     });
 
     describe(selectTradingAccountAccordingActiveSection.name, () => {

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -683,6 +683,15 @@ export const selectTradingDisplayComposedFee = (
 ): string | undefined =>
     getDisplayNetworkFee(quote, state.wallet.trading.composedTransactionInfo.composed?.fee);
 
+export const selectIsTradingNetworkFeeMissing = (
+    state: TradingRootState,
+    quote?: ExchangeTrade,
+): boolean => {
+    const fee = selectTradingDisplayComposedFee(state, quote);
+
+    return fee === undefined || fee === '';
+};
+
 export const selectTradingAccountAccordingActiveSection =
     createMemoizedSelectorWithDeviceAndAccounts(
         [


### PR DESCRIPTION
## Description

- Add a shared trading selector for the missing network fee state.
- Disable the swap offer action when the network fee is unavailable.
- Disable sell offer actions when the network fee is unavailable.
- Disable approval and confirm-on-Trezor actions when the fee disappears during confirmation.

## Notes for QA

- In Trading > Swap, select a quote and verify the action button stays disabled whenever the network fee is missing.
- In Trading > Swap review, reproduce a missing-fee state and verify Approve and Confirm on Trezor stay disabled until the fee is shown again.
- In Trading > Sell, select a quote and verify the action button stays disabled whenever the network fee is missing.

## Related Issue

Resolve #27425

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on trading/coinmarket functionality: sell offer actions (TradingFormOfferSellActions), exchange/swap offer actions (TradingFormOfferExchangeActions), and trading selectors (tradingSelectors.ts). The highest risk is in the sell and swap E2E flows that directly exercise offer selection, confirmation, and trade submission. tradingSelectors.ts maps to 121 tests but is a broad dependency — only trading-specific tests that use quote/offer data from these selectors are relevant. The unit test files (TradingFormOfferSellActions.test.tsx and tradingSelectors.test.ts) provide additional coverage but are not E2E tests. Focus testing on sell flows across different coins and swap/exchange flows to catch regressions in offer actions and selector logic.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx`
- `packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.tsx`
- `packages/suite/src/views/wallet/trading/sell/__tests__/TradingFormOfferSellActions.test.tsx`
- `suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts`
- `suite-common/trading/src/selectors/tradingSelectors.ts`

</details>

**Recommended tests (17)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Directly exercises the sell trading flow including offer confirmation and trade request submission. TradingFormOfferSellActions.tsx is the component that renders sell offer action buttons, and tradingSelectors.ts provides data to the sell flow. Changes here could break offer selection, confirmation, or trade payload generation.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests the full ETH sell flow including best offer confirmation and device prompt, directly exercising the TradingFormOfferSellActions component for Ethereum sells with custom gas fees.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests sell flow for Solana including best offer selection, confirmation, device prompt, and offer comparison modal. Directly exercises the TradingFormOfferSellActions component and uses trading selectors for quote/offer data.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token (USDC) through the sell flow, which directly uses TradingFormOfferSellActions for offer confirmation and tradingSelectors for quote data retrieval.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Tests the full swap/exchange flow (SOL→BTC) including best offer confirmation and transaction status progression. TradingFormOfferExchangeActions.tsx handles the exchange offer actions, and tradingSelectors provides swap quote data.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests swapping SOL to USDC token, exercising TradingFormOfferExchangeActions for offer confirmation and tradingSelectors for quote/provider data. Verifies exchange type, provider name, and confirmation details.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping USDT token to BTC, directly exercising the exchange offer actions component and trading selectors for quote data, provider matching, and confirmation flow.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests swapping SPL tokens (USDT→USDC) which exercises exchange offer actions and relies on trading selectors for swap quote and provider data.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests swap from BTC to ETH with custom fee settings, exercising the exchange offer actions and swap confirmation flow. Fee calculation relies on trading selectors for composed transaction info.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests swap from ETH to BTC with custom Ethereum gas fees, exercising exchange offer actions and trading selectors for composed transaction info and fee display.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation and percentage buttons. While focused on form inputs rather than offer actions, changes to tradingSelectors could affect how balance and validation data is provided to the sell form.
- `suite/e2e/tests/trading/swap-history.test.ts` — Tests swap trade order history display which uses tradingSelectors for trade data retrieval and status mapping. Changes to selectors could affect how historical trade data is read and displayed.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form inputs, offer selection, and provider display. Uses tradingSelectors for quote syncing and best offer amount computation. Changes to selectors could affect offer display and validation.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swap with a disabled network buy asset, verifying provider info from quotes. The tradingSelectors changes could affect how quotes and provider data are selected for display.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation to buy/sell/swap forms from various entry points and verifies correct form rendering. Changes to sell and exchange action components could affect form initialization.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Buy flow doesn't use TradingFormOfferSellActions or ExchangeActions directly, but tradingSelectors is a shared dependency that could affect quote/offer data retrieval in buy flows.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Buy ETH flow shares tradingSelectors for quote and offer data. While not directly testing sell/exchange actions, selector changes could affect shared buy flow data paths.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/views/wallet/trading/sell/__tests__/TradingFormOfferSellActions.test.tsx`
- `suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts`

_Updated: 2026-07-02T06:03:29.681Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/27425-disable-trading-actions-without-fee/web/](https://dev.suite.sldev.cz/suite-web/fix/27425-disable-trading-actions-without-fee/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/27425-disable-trading-actions-without-fee&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/27425-disable-trading-actions-without-fee&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/27425-disable-trading-actions-without-fee&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T06:08:18.696Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |

</details>

_Updated: 2026-07-02T06:06:37.508Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->