### PR TITLE
chore(suite-native): translation IDs debug feature

### DIFF
--- a/suite-native/intl/src/IntlProviderForTests.tsx
+++ b/suite-native/intl/src/IntlProviderForTests.tsx
@@ -1,13 +1,41 @@
+import { useContext, useMemo } from 'react';
 import { IntlProvider as ReactIntlProvider } from 'react-intl';
+import { Provider, ReactReduxContext } from 'react-redux';
 
+import { configureStore } from '@reduxjs/toolkit';
+
+import { localeReducer } from './localeSlice';
 import { messages } from './messages';
 import { flatten } from './utils';
 
 // For uni test we always expect the messages to be in english, so the language selection logic can be omitted here.
 const flatMessages = flatten(messages);
 
+// Some tests mock out `react-redux` entirely, in which case there is no context/`Provider` to use
+// (and `useSelector` is already stubbed, so no real store is needed).
+const isReduxAvailable = ReactReduxContext != null && Provider != null;
+
+// Intl components (`Translation`, `useTranslate`) read from the redux `locale` slice, so they need a
+// store in the tree. Provides a minimal fallback store only when a test hasn't supplied its own,
+// so store-based tests keep using even where there is not real redux provider implemented.
+const StoreFallback = ({ children }: { children: React.ReactNode }) => {
+    const hasStore = useContext(ReactReduxContext) !== null;
+    const store = useMemo(() => configureStore({ reducer: { locale: localeReducer } }), []);
+
+    if (hasStore) {
+        return <>{children}</>;
+    }
+
+    return <Provider store={store}>{children}</Provider>;
+};
+
+const FallbackStoreProvider = ({ children }: { children: React.ReactNode }) =>
+    isReduxAvailable ? <StoreFallback>{children}</StoreFallback> : <>{children}</>;
+
 export const IntlProviderForTests = ({ children }: { children: React.ReactNode }) => (
-    <ReactIntlProvider locale="en-US" messages={flatMessages}>
-        {children}
-    </ReactIntlProvider>
+    <FallbackStoreProvider>
+        <ReactIntlProvider locale="en-US" messages={flatMessages}>
+            {children}
+        </ReactIntlProvider>
+    </FallbackStoreProvider>
 );

--- a/suite-native/intl/src/Translate.tsx
+++ b/suite-native/intl/src/Translate.tsx
@@ -1,9 +1,19 @@
 import { FormattedMessage } from 'react-intl';
+import { useSelector } from 'react-redux';
 
+import { selectAreDebugTranslationKeysDisplayed } from './localeSlice';
 import { type TxKeyPath } from './types';
 
 type TranslationProps = Omit<React.ComponentProps<typeof FormattedMessage>, 'defaultMessage'> & {
     id: TxKeyPath;
 };
 
-export const Translation = (props: TranslationProps) => <FormattedMessage {...props} />;
+export const Translation = ({ id, ...props }: TranslationProps) => {
+    const areDebugTranslationKeysDisplayed = useSelector(selectAreDebugTranslationKeysDisplayed);
+
+    if (areDebugTranslationKeysDisplayed) {
+        return id;
+    }
+
+    return <FormattedMessage id={id} {...props} />;
+};

--- a/suite-native/intl/src/__tests__/localeSlice.test.ts
+++ b/suite-native/intl/src/__tests__/localeSlice.test.ts
@@ -14,6 +14,7 @@ describe('selectSupportedLanguageLocale', () => {
             localeState: {
                 appLocaleCode: 'system',
                 systemLocaleCode: 'cs-CZ',
+                areDebugTranslationKeysDisplayed: false,
             },
             expectedResultLocale: 'cs-CZ',
         },
@@ -23,6 +24,7 @@ describe('selectSupportedLanguageLocale', () => {
             localeState: {
                 appLocaleCode: 'system',
                 systemLocaleCode: 'it-IT',
+                areDebugTranslationKeysDisplayed: false,
             },
             expectedResultLocale: DEFAULT_LOCALE,
         },
@@ -31,6 +33,7 @@ describe('selectSupportedLanguageLocale', () => {
             localeState: {
                 appLocaleCode: 'cs-CZ',
                 systemLocaleCode: 'en-US',
+                areDebugTranslationKeysDisplayed: false,
             },
             expectedResultLocale: 'cs-CZ',
         },
@@ -40,6 +43,7 @@ describe('selectSupportedLanguageLocale', () => {
             localeState: {
                 appLocaleCode: 'system',
                 systemLocaleCode: 'de-AT',
+                areDebugTranslationKeysDisplayed: false,
             },
             expectedResultLocale: 'de-DE',
         },
@@ -65,6 +69,7 @@ describe('selectLocale', () => {
             localeState: {
                 appLocaleCode: 'system',
                 systemLocaleCode: 'cs-CZ',
+                areDebugTranslationKeysDisplayed: false,
             },
             expectedResultLocale: 'cs-CZ',
         },
@@ -73,6 +78,7 @@ describe('selectLocale', () => {
             localeState: {
                 appLocaleCode: 'ja-JP',
                 systemLocaleCode: 'cs-CZ',
+                areDebugTranslationKeysDisplayed: false,
             },
             expectedResultLocale: 'ja-JP',
         },

--- a/suite-native/intl/src/hooks/useTranslate.ts
+++ b/suite-native/intl/src/hooks/useTranslate.ts
@@ -1,6 +1,8 @@
 import { useCallback } from 'react';
 import { type PrimitiveType, useIntl } from 'react-intl';
+import { useSelector } from 'react-redux';
 
+import { selectAreDebugTranslationKeysDisplayed } from '../localeSlice';
 import { type TxKeyPath } from '../types';
 
 type FormatXMLElementFn<T, R = string | T | (string | T)[]> = (parts: Array<string | T>) => R;
@@ -9,14 +11,21 @@ export type Translate = ReturnType<typeof useTranslate>['translate'];
 
 export const useTranslate = () => {
     const { formatMessage } = useIntl();
+    const areDebugTranslationKeysDisplayed = useSelector(selectAreDebugTranslationKeysDisplayed);
 
     const translate = useCallback(
         (
             id: TxKeyPath,
             values?: Record<string, PrimitiveType | FormatXMLElementFn<string, string>>,
             options?: Parameters<typeof formatMessage>[2],
-        ) => formatMessage({ id }, values, options),
-        [formatMessage],
+        ) => {
+            if (areDebugTranslationKeysDisplayed) {
+                return id;
+            }
+
+            return formatMessage({ id }, values, options);
+        },
+        [formatMessage, areDebugTranslationKeysDisplayed],
     );
 
     return { translate };

--- a/suite-native/intl/src/localeSlice.ts
+++ b/suite-native/intl/src/localeSlice.ts
@@ -9,6 +9,7 @@ export type AppLocaleOption = SupportedLocaleCode | 'system';
 export type LocaleState = {
     appLocaleCode: AppLocaleOption;
     systemLocaleCode: LocaleCode;
+    areDebugTranslationKeysDisplayed: boolean;
 };
 
 export type LocaleSliceRootState = {
@@ -18,11 +19,13 @@ export type LocaleSliceRootState = {
 export const localeInitialState: LocaleState = {
     appLocaleCode: 'system',
     systemLocaleCode: DEFAULT_LOCALE,
+    areDebugTranslationKeysDisplayed: false,
 };
 
 export const localePersistWhitelist: Array<keyof LocaleState> = [
     'appLocaleCode',
     'systemLocaleCode',
+    'areDebugTranslationKeysDisplayed',
 ];
 
 const localeSlice = createSlice({
@@ -35,13 +38,20 @@ const localeSlice = createSlice({
         setSystemLocaleCode: (state, { payload }: PayloadAction<LocaleCode>) => {
             state.systemLocaleCode = payload;
         },
+        setAreDebugTranslationKeysDisplayed: (state, { payload }: PayloadAction<boolean>) => {
+            state.areDebugTranslationKeysDisplayed = payload;
+        },
     },
 });
 
-export const { setAppLocaleCode, setSystemLocaleCode } = localeSlice.actions;
+export const { setAppLocaleCode, setSystemLocaleCode, setAreDebugTranslationKeysDisplayed } =
+    localeSlice.actions;
 export const localeReducer = localeSlice.reducer;
 
 export const selectAppLocaleCode = (state: LocaleSliceRootState) => state.locale.appLocaleCode;
+
+export const selectAreDebugTranslationKeysDisplayed = (state: LocaleSliceRootState) =>
+    state.locale.areDebugTranslationKeysDisplayed;
 
 const selectSystemLocaleCode = (state: LocaleSliceRootState) => state.locale.systemLocaleCode;
 

--- a/suite-native/module-dev-utils/src/components/DebuggingCard.tsx
+++ b/suite-native/module-dev-utils/src/components/DebuggingCard.tsx
@@ -5,12 +5,18 @@ import { isDevelopOrDebugEnv } from '@suite-native/config';
 import { captureSentryException } from '@suite-native/sentry';
 
 import { RenderingUtils } from './RenderingUtils';
+import { TranslationUtils } from './TranslationUtils';
 
 export const DebuggingCard = () => (
     <Card>
         <VStack spacing="sp12">
             <Text variant="headline-sm">Debugging</Text>
-            {isDevelopOrDebugEnv() && <RenderingUtils />}
+            {isDevelopOrDebugEnv() && (
+                <>
+                    <RenderingUtils />
+                    <TranslationUtils />
+                </>
+            )}
             <VStack>
                 <Button
                     onPress={() => {

--- a/suite-native/module-dev-utils/src/components/TranslationUtils.tsx
+++ b/suite-native/module-dev-utils/src/components/TranslationUtils.tsx
@@ -1,0 +1,28 @@
+import { useDispatch, useSelector } from 'react-redux';
+
+import { VStack } from '@suite-native/atoms';
+import {
+    selectAreDebugTranslationKeysDisplayed,
+    setAreDebugTranslationKeysDisplayed,
+} from '@suite-native/intl';
+
+import { DevCheckBoxListItem } from './DevCheckBoxListItem';
+
+export const TranslationUtils = () => {
+    const dispatch = useDispatch();
+    const areDebugTranslationKeysDisplayed = useSelector(selectAreDebugTranslationKeysDisplayed);
+
+    const toggleDebugTranslationKeys = () => {
+        dispatch(setAreDebugTranslationKeysDisplayed(!areDebugTranslationKeysDisplayed));
+    };
+
+    return (
+        <VStack>
+            <DevCheckBoxListItem
+                title="Show translation IDs"
+                onPress={toggleDebugTranslationKeys}
+                isChecked={areDebugTranslationKeysDisplayed}
+            />
+        </VStack>
+    );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add possibility to show translation IDs instead of the Crowdin copy in the UI for debug purposes.
## Notes for QA
test that no translation IDs is displayed when is the new toggle turned off. 
## Related Issue

Closes #29297 

## Screenshots:
<img width="300" alt="Screenshot 2026-07-01 at 13 55 44" src="https://github.com/user-attachments/assets/cbd7e762-65ba-4e7f-b460-cb2fa8124864" />
<img width="300" alt="Screenshot 2026-07-01 at 13 47 55" src="https://github.com/user-attachments/assets/75fb537d-2bd5-4219-ba1e-0d2567036c08" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/translation-ids-debug-feature&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->