### PR TITLE
Fix(suite): updateAll migrations losing data

### DIFF
--- a/packages/suite/src/storage/definitions.ts
+++ b/packages/suite/src/storage/definitions.ts
@@ -49,6 +49,15 @@ export interface DBWalletAccountTransaction {
     order: number;
 }
 
+/**
+ * IDB Schema definition used in Suite Web & Desktop.
+ *
+ * Note that some stores are singletons – only one specific `key` is expected to hold the entire serialized payload,
+ * those must have `key` typed as a constant string, to ensure consistency in `preloadStore`, migrations, etc.
+ * Meanwhile, some stores contain a collection of keys, those have `key` as a broader type.
+ *
+ * Note that this is the latest schema, but actual app IDB may carry outdated values not removed in migrations.
+ */
 export interface SuiteDBSchema extends DBSchema {
     bioAuth: {
         key: 'bioAuth';
@@ -59,7 +68,7 @@ export interface SuiteDBSchema extends DBSchema {
         value: string[];
     };
     phishingMetadata: {
-        key: string;
+        key: 'phishingMetadata';
         value: PhishingState;
     };
     txs: {
@@ -86,7 +95,7 @@ export interface SuiteDBSchema extends DBSchema {
         value: ReceiveAccountState;
     };
     suiteSettings: {
-        key: string;
+        key: 'suite';
         value: {
             settings: SuiteSettingsState;
             flags: FlagsState;
@@ -99,7 +108,7 @@ export interface SuiteDBSchema extends DBSchema {
         value: RatesByTimestamps;
     };
     walletSettings: {
-        key: string;
+        key: 'wallet';
         value: WalletSettings;
     };
     backendSettings: {
@@ -111,13 +120,13 @@ export interface SuiteDBSchema extends DBSchema {
         value: DeviceWithEmptyPath;
     };
     thp: {
-        key: string;
+        key: 'value';
         value: {
             credentials: ThpSuiteCredentials[];
         };
     };
     bluetooth: {
-        key: string;
+        key: 'value';
         value: {
             knownDevices: DesktopBluetoothDevice[];
         };
@@ -142,7 +151,7 @@ export interface SuiteDBSchema extends DBSchema {
         value: CoinjoinDebugSettings;
     };
     analytics: {
-        key: string;
+        key: 'suite';
         value: AnalyticsState;
     };
     graph: {
@@ -175,7 +184,7 @@ export interface SuiteDBSchema extends DBSchema {
         value: SuiteSyncQuotaManagerState;
     };
     messageSystem: {
-        key: string;
+        key: 'suite';
         value: {
             currentSequence: number;
             config: MessageSystem | null;

--- a/packages/suite/src/storage/migrations/versions/26.5.0.1.ts
+++ b/packages/suite/src/storage/migrations/versions/26.5.0.1.ts
@@ -1,4 +1,5 @@
 import { createMigration } from '@suite/idb-migration-utils';
+import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
 
 import { type SuiteDBSchema } from 'src/storage/definitions';
@@ -18,6 +19,17 @@ export default createMigration<SuiteDBSchema>('26.5.0.1', async (db, tx) => {
     };
 
     const addressDisplayType = await getSuiteSettingsAddressDisplayType();
+    const walletSettingsStore = tx.objectStore('walletSettings');
+    const hasAnyWalletSettings = (await walletSettingsStore.count()) > 0;
+
+    if (!hasAnyWalletSettings) {
+        await walletSettingsStore.put(
+            { ...initialWalletSettingsState, addressDisplayType },
+            'wallet',
+        );
+
+        return;
+    }
 
     await updateAll(tx, 'walletSettings', walletSettings => ({
         ...walletSettings,

--- a/packages/suite/src/storage/migrations/versions/__tests__/26.5.0.1.test.ts
+++ b/packages/suite/src/storage/migrations/versions/__tests__/26.5.0.1.test.ts
@@ -1,6 +1,7 @@
 import '@suite-common/test-utils/src/globalOverrides';
 import { type IDBPDatabase, deleteDB, openDB } from 'idb';
 
+import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
 
 import { type SuiteDBSchema } from 'src/storage/definitions';
@@ -77,6 +78,31 @@ describe('migration 26.5.0.1', () => {
 
         const wallet = await migratedDb.get('walletSettings', 'wallet');
         expect(wallet?.addressDisplayType).toBe(AddressDisplayOptions.CHUNKED);
+
+        migratedDb.close();
+    });
+
+    test('creates walletSettings entry if the store is empty', async () => {
+        const db = await openDB(DB_NAME, INITIAL_VERSION, {
+            upgrade(db) {
+                db.createObjectStore('suiteSettings');
+                db.createObjectStore('walletSettings');
+            },
+        });
+        await db.put(
+            'suiteSettings',
+            { settings: { addressDisplayType: AddressDisplayOptions.ORIGINAL } },
+            'suite',
+        );
+        db.close();
+
+        const migratedDb = await runMigration();
+
+        const wallet = await migratedDb.get('walletSettings', 'wallet');
+        expect(wallet).toEqual({
+            ...initialWalletSettingsState,
+            addressDisplayType: AddressDisplayOptions.ORIGINAL,
+        });
 
         migratedDb.close();
     });


### PR DESCRIPTION
Fix a migration that can lose data in specific circumstances.  

## Description

In Suite we often use IDB in a way where a store (table) has only one key (row), and under that key the entire data payload as a singleton.

But migrations are still done with `updateAll`, which assumes it will act on exactly one key of the store.

This has a potential for a very specific error: if we are moving data from _somewhere else_ to the singleton, the migration will fail if the singleton has not yet been created.
It will fail **silently**, just lose the data, because `updateAll` "successfully" acts on 0 keys.

Such error was found randomly in https://github.com/trezor/trezor-suite/pull/29089 → investigate all similar occurrences.

- ac1e9c3b Cleanup in `SuiteDBSchema` to make it clear by typescript which store is which
- 49830e92 Fix one such occurrence that was found

Note: Cases where you for example take something of `walletSettings` and put it into `walletSettings` are OK. If the singleton key doesn't exist, it means there is no data to be migrated, so it's no problem that there is nowhere to migrate it _to_. Only somewhere else → `walletSettings` is a problem

## Notes for QA

This PR surfaced a new tiny bug:

1. in anonymous window, open https://dev.suite.sldev.cz/suite-web/release/26.4/web/
2. go to Settings > Application > Application, change Address display → Continuous
3. do not change anything else
4. reload to see it's still there
5. go to https://dev.suite.sldev.cz/suite-web/release/26.5/web/
6. setting is Spaced :x:  (changed UI makes it not clear, but Continuos should mean toggle is **off**)

In step 5. go instead to https://dev.suite.sldev.cz/suite-web/fix/updateAll-migrations/web/ 
and Spaced is off as it should be :heavy_check_mark: 

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/updateAll-migrations/web/](https://dev.suite.sldev.cz/suite-web/fix/updateAll-migrations/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/updateAll-migrations&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/updateAll-migrations&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T12:20:52.293Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T12:19:02.198Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->