### PR TITLE
[WIP] fix(request-manager): address review of #28538 (undici SOCKS Tor recovery + coverage)

### DIFF
--- a/.github/workflows/test-request-manager.yml
+++ b/.github/workflows/test-request-manager.yml
@@ -20,7 +20,9 @@ jobs:
     if: github.repository == 'trezor/trezor-suite'
     timeout-minutes: 60
     env:
-      TEST_SCRIPT: ${{ github.event_name == 'workflow_dispatch' && 'test:e2e' || 'test:all' }}
+      # Run the (unflagged) real-Tor e2e suite on manual dispatch AND on the nightly schedule, so the
+      # flaky-gated circuit-isolation suites are exercised at least daily; PRs still run test:all.
+      TEST_SCRIPT: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && 'test:e2e' || 'test:all' }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6

--- a/packages/coinjoin/src/client/coordinatorRequest.ts
+++ b/packages/coinjoin/src/client/coordinatorRequest.ts
@@ -77,10 +77,21 @@ export const coordinatorRequest = async <R = void>(
             // underlying error (carrying `code`/`type`/`message`) on `e.cause`; node-fetch put them on `e`.
             // A reset connection is `ECONNRESET` under node-fetch but `UND_ERR_SOCKET` ("other side
             // closed") under undici; both should reset the TOR circuit and retry.
+            // undici ships its own SOCKS5 client (not the `socks` package), so SOCKS5 connect/auth
+            // failures surface as `UND_ERR_SOCKS5_*` codes and DON'T match the `type`/`message` branch
+            // below (no `type` field, message uses upper-case `SOCKS5`) — match them by code too.
+            // Keep the reset-code list (ECONNRESET/UND_ERR_SOCKET/UND_ERR_SOCKS5*) in sync with
+            // `isTorCircuitError` in @trezor/request-manager (can't be imported here); the legacy
+            // socks-package error is detected differently there (an `options` field) — by design.
             const err = e.cause ?? e;
             const socksErrors = ['Socks5', 'Proxy'];
+            const hasResetCode =
+                'code' in err &&
+                (err.code === 'ECONNRESET' ||
+                    err.code === 'UND_ERR_SOCKET' ||
+                    (typeof err.code === 'string' && err.code.startsWith('UND_ERR_SOCKS5')));
             const shouldSwitchIdentity =
-                ('code' in err && (err.code === 'ECONNRESET' || err.code === 'UND_ERR_SOCKET')) ||
+                hasResetCode ||
                 ('type' in err &&
                     err.type === 'system' &&
                     socksErrors.some(se => err.message.includes(se)));

--- a/packages/request-manager/e2e/interceptor.test.ts
+++ b/packages/request-manager/e2e/interceptor.test.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import nodeFetch from 'node-fetch';
 import path from 'path';
 import WebSocket from 'ws';
 
@@ -33,6 +34,13 @@ describe('Interceptor', () => {
     let torIdentities: TorIdentities;
 
     const torSettings = { running: true, host: hostIp, port };
+    const fetchImplementations = [
+        ['global.fetch', (...args: Parameters<typeof fetch>) => fetch(...args)],
+        ['node-fetch', nodeFetch],
+    ] as const;
+
+    const extractIp = async (response: { text: () => Promise<string> }) =>
+        (await response.text()).match(ipRegex)?.[0];
 
     const interceptorOptions: InterceptorOptions = {
         getWhitelistedDomains: () => [
@@ -81,58 +89,61 @@ describe('Interceptor', () => {
     // guarantee that the IPs of 2 different Tor circuits are different. And this is
     // part of the Tor nature.
     conditionalTest('Check if IPs are different', () => {
-        it('HTTP GET - Each identity has different ip address', async () => {
-            const identityDefault = await fetch(testGetUrlHttp, {
-                headers: { 'proxy-authorization': 'Basic default' },
-            });
-            const identityDefault2 = await fetch(testGetUrlHttp, {
-                headers: { 'Proxy-Authorization': 'Basic user' },
-            });
-            const iPIdentitieA = ((await identityDefault.text()) as any).match(ipRegex)[0];
-
-            const iPIdentitieB = ((await identityDefault2.text()) as any).match(ipRegex)[0];
-            expect(iPIdentitieA).not.toEqual(iPIdentitieB);
-        });
-
-        it('HTTPS GET - Each identity has different ip address', async () => {
-            const identityA = await fetch(testGetUrlHttps, {
-                headers: { 'proxy-authorization': 'Basic default' },
-            });
-            const identityB = await fetch(testGetUrlHttps, {
-                headers: { 'Proxy-Authorization': 'Basic user' },
-            });
-            // Parsing IP address from html provided by check.torproject.org.
-            const iPIdentitieA = ((await identityA.text()) as any).match(ipRegex)[0];
-            const iPIdentitieB = ((await identityB.text()) as any).match(ipRegex)[0];
-            // Check if identities are different when using different identity.
-            expect(iPIdentitieA).not.toEqual(iPIdentitieB);
-
-            // reset existing circuit using identity with password
-            const identityB2 = await fetch(testGetUrlHttps, {
-                headers: { 'Proxy-Authorization': 'Basic user:password' },
-            });
-            const iPIdentitieB2 = ((await identityB2.text()) as any).match(ipRegex)[0];
-            // ip for "user" did change
-            expect(iPIdentitieB2).not.toEqual(iPIdentitieB);
-        });
-
-        it('HTTPS POST - Each identity has different ip address', async () => {
-            const identityA = await fetch(testPostUrlHttps, {
+        const testCases = [
+            {
+                name: 'HTTP GET',
+                url: testGetUrlHttp,
+                method: 'GET',
+                body: undefined,
+            },
+            {
+                name: 'HTTPS GET',
+                url: testGetUrlHttps,
+                method: 'GET',
+                body: undefined,
+            },
+            {
+                name: 'HTTPS POST',
+                url: testPostUrlHttps,
                 method: 'POST',
                 body: JSON.stringify({ test: 'test' }),
-                headers: { 'proxy-authorization': 'Basic default' },
-            });
-            const identityB = await fetch(testPostUrlHttps, {
-                method: 'POST',
-                body: JSON.stringify({ test: 'test' }),
-                headers: { 'Proxy-Authorization': 'Basic user' },
-            });
+            },
+        ];
 
-            const iPIdentitieA = ((await identityA.json()) as any).origin;
-            const iPIdentitieB = ((await identityB.json()) as any).origin;
+        describe.each(fetchImplementations)('%s', (_, fetchFn) => {
+            it.each(testCases)(
+                '$name - Each identity has different ip address',
+                async ({ url, method, body }) => {
+                    const identityA = await fetchFn(url, {
+                        method,
+                        body,
+                        headers: { 'proxy-authorization': 'Basic default' },
+                    });
+                    const identityB = await fetchFn(url, {
+                        method,
+                        body,
+                        headers: { 'Proxy-Authorization': 'Basic user' },
+                    });
 
-            // Check if identities are different when using different identity.
-            expect(iPIdentitieA).not.toEqual(iPIdentitieB);
+                    const ipA = await extractIp(identityA);
+                    const ipB = await extractIp(identityB);
+
+                    expect(ipA).not.toEqual(ipB);
+                },
+            );
+
+            it(`Reset identity by changing password`, async () => {
+                const identityA = await fetchFn(testGetUrlHttps, {
+                    headers: { 'Proxy-Authorization': 'Basic user' },
+                });
+                // Reset existing circuit by changing password
+                const identityB = await fetchFn(testGetUrlHttps, {
+                    headers: { 'Proxy-Authorization': 'Basic user:password' },
+                });
+                const ipB = await extractIp(identityA);
+                const ipB2 = await extractIp(identityB);
+                expect(ipB2).not.toEqual(ipB);
+            });
         });
     });
 
@@ -180,12 +191,12 @@ describe('Interceptor', () => {
     });
 
     conditionalTest('TorControl', () => {
-        it('closing circuits', async () => {
-            await fetch(testGetUrlHttps, {
+        it.each(fetchImplementations)('%s closing circuits', async (_label, fetchFn) => {
+            await fetchFn(testGetUrlHttps, {
                 headers: { 'Proxy-Authorization': 'Basic user-circuit-1' },
             });
 
-            await fetch(testGetUrlHttps, {
+            await fetchFn(testGetUrlHttps, {
                 headers: { 'Proxy-Authorization': 'Basic user-circuit-2' },
             });
 
@@ -250,87 +261,85 @@ describe('Interceptor', () => {
 
         afterAll(() => new Promise(resolve => serverInit.server.close(resolve)));
 
-        const fetchHeaders = (url: string, options: RequestInit) =>
-            fetch(url, options).then(r => r.json());
+        const fetchHeaders = (pr: Promise<any>) => pr.then(r => r.json());
 
-        it('POST request headers', async () => {
-            const { serverUrl, host } = serverInit;
-
-            // default headers
-            await expect(
-                fetchHeaders(serverUrl, {
-                    method: 'POST',
-                    body: JSON.stringify({ test: 'test' }),
-                    headers: { 'User-Agent': 'TrezorSuite' },
-                }),
-            ).resolves.toEqual(
-                expect.objectContaining({
-                    host,
+        const headerTestCases = [
+            {
+                method: 'POST',
+                body: JSON.stringify({ test: 'test' }),
+                defaultHeaders: { 'User-Agent': 'TrezorSuite' },
+                expectedDefault: {
                     accept: '*/*',
                     'content-length': '15',
                     'content-type': 'text/plain;charset=UTF-8',
                     'user-agent': 'TrezorSuite',
-                }),
-            );
-
-            // restricted headers
-            await expect(
-                fetchHeaders(serverUrl, {
-                    method: 'POST',
-                    body: JSON.stringify({ test: 'test' }),
-                    headers: {
-                        'User-Agent': 'TrezorSuite',
-                        'Allowed-Headers': 'AcCePt-EnCoDiNg;content-type;Content-Length;HOST', // case insensitive
-                    },
-                }),
-            ).resolves.toEqual(
-                expect.objectContaining({
-                    host,
+                },
+                allowedHeaders: 'AcCePt-EnCoDiNg;content-type;Content-Length;HOST', // case insensitive
+                expectedRestricted: {
                     'content-length': '15',
                     'content-type': 'text/plain;charset=UTF-8',
-                }),
-            );
-        });
-
-        it('GET request headers', async () => {
-            const { serverUrl, host } = serverInit;
-
-            // default headers
-            await expect(
-                fetchHeaders(serverUrl, {
-                    method: 'GET',
-                    headers: { 'User-Agent': 'TrezorSuite' },
-                }),
-            ).resolves.toEqual(
-                expect.objectContaining({
-                    host,
+                },
+            },
+            {
+                method: 'GET',
+                body: undefined,
+                defaultHeaders: { 'User-Agent': 'TrezorSuite' },
+                expectedDefault: {
                     accept: '*/*',
                     'user-agent': 'TrezorSuite',
-                }),
-            );
+                },
+                allowedHeaders: 'Accept-Encoding;Content-Type;Content-Length;Host',
+                expectedRestricted: {},
+            },
+        ];
 
-            // restricted headers
-            await expect(
-                fetchHeaders(serverUrl, {
-                    method: 'GET',
-                    headers: {
-                        'User-Agent': 'TrezorSuite',
-                        'Allowed-Headers': 'Accept-Encoding;Content-Type;Content-Length;Host',
-                    },
-                }),
-            ).resolves.toEqual(
-                expect.objectContaining({
-                    host,
-                }),
+        describe.each(fetchImplementations)('%s', (_, fetchFn) => {
+            it.each(headerTestCases)(
+                '$method request headers',
+                async ({
+                    method,
+                    body,
+                    defaultHeaders,
+                    expectedDefault,
+                    allowedHeaders,
+                    expectedRestricted,
+                }) => {
+                    const { serverUrl, host } = serverInit;
+
+                    // default headers
+                    await expect(
+                        fetchHeaders(
+                            fetchFn(serverUrl, {
+                                method,
+                                body,
+                                headers: defaultHeaders,
+                            }),
+                        ),
+                    ).resolves.toEqual(expect.objectContaining({ host, ...expectedDefault }));
+
+                    // restricted headers
+                    await expect(
+                        fetchHeaders(
+                            fetchFn(serverUrl, {
+                                method,
+                                body,
+                                headers: {
+                                    ...defaultHeaders,
+                                    'Allowed-Headers': allowedHeaders,
+                                },
+                            }),
+                        ),
+                    ).resolves.toEqual(expect.objectContaining({ host, ...expectedRestricted }));
+                },
             );
         });
     });
 
-    it('Block unauthorized requests', async () => {
+    it.each(fetchImplementations)('%s Block unauthorized requests', async (_, fetchFn) => {
         torSettings.running = false;
 
         await expect(
-            fetch(testPostUrlHttps, {
+            fetchFn(testPostUrlHttps, {
                 method: 'POST',
                 body: JSON.stringify({ test: 'test' }),
                 headers: { 'Proxy-Authorization': 'Basic default' },

--- a/packages/request-manager/e2e/interceptor.test.ts
+++ b/packages/request-manager/e2e/interceptor.test.ts
@@ -140,9 +140,9 @@ describe('Interceptor', () => {
                 const identityB = await fetchFn(testGetUrlHttps, {
                     headers: { 'Proxy-Authorization': 'Basic user:password' },
                 });
-                const ipB = await extractIp(identityA);
-                const ipB2 = await extractIp(identityB);
-                expect(ipB2).not.toEqual(ipB);
+                const ipA = await extractIp(identityA);
+                const ipB = await extractIp(identityB);
+                expect(ipB).not.toEqual(ipA);
             });
         });
     });
@@ -231,6 +231,11 @@ describe('Interceptor', () => {
         });
     });
 
+    // NOTE: the server here is `localhost`, which is whitelisted, so these requests take the DIRECT
+    // branch of interceptFetch (originalFetch) and the header restriction is enforced by the
+    // socket-level stripping in `interceptNetSocketConnect`, NOT by `buildTorHeaders`. The fetch-path
+    // `buildTorHeaders` allow-list + Proxy-Authorization/Allowed-Headers stripping is covered
+    // deterministically (no Tor needed) in tests/fetchHeaders.test.ts.
     describe('Allowed-Headers', () => {
         // create simple http server and respond with received headers
         const createHttpServer = () =>

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -17,12 +17,13 @@
     "dependencies": {
         "@trezor/node-utils": "workspace:^",
         "@trezor/utils": "workspace:*",
-        "node-fetch": "^3.3.2",
         "socks-proxy-agent": "8.0.5",
+        "undici": "8.5.0",
         "ws": "^8.20.0"
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
+        "node-fetch": "^3.3.2",
         "tsx": "^4.21.0"
     }
 }

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -6,9 +6,9 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "scripts": {
-        "test:all": "SKIP_FLAKY_TESTS=1 yarn g:jest",
-        "test:unit": "yarn g:jest --testPathIgnorePatterns e2e",
-        "test:e2e": "yarn g:jest --runInBand --testPathIgnorePatterns tests",
+        "test:all": "SKIP_FLAKY_TESTS=1 yarn g:jest --verbose",
+        "test:unit": "yarn g:jest --verbose --testPathIgnorePatterns e2e",
+        "test:e2e": "yarn g:jest --verbose --runInBand --testPathIgnorePatterns tests",
         "type-check": "yarn g:tsc --build tsconfig.json",
         "test:stress": "tsx ./e2e/identities-stress.ts",
         "depcheck": "yarn g:depcheck",

--- a/packages/request-manager/src/interceptor/fetchHeaders.ts
+++ b/packages/request-manager/src/interceptor/fetchHeaders.ts
@@ -1,0 +1,50 @@
+const getHeaderEntries = (headers?: HeadersInit): [string, string][] => {
+    if (!headers) {
+        return [];
+    }
+
+    return [...new Headers(headers).entries()];
+};
+
+export const getHeaderValue = (headers: HeadersInit | undefined, name: string) => {
+    if (!headers) {
+        return undefined;
+    }
+
+    return new Headers(headers).get(name) ?? undefined;
+};
+
+// Internal control headers that must never reach the destination server, regardless of the
+// allow-list: `Proxy-Authorization` carries the Tor identity credentials and `Allowed-Headers` is
+// our own routing-control header.
+const internalControlHeaders = ['proxy-authorization', 'allowed-headers'];
+
+const isInternalControlHeader = (key: string) => internalControlHeaders.includes(key.toLowerCase());
+
+const isHeaderAllowed = (key: string, allowedHeadersValue: string) => {
+    const allowedKeys = allowedHeadersValue.split(';');
+    const normalizedKey = key.toLowerCase();
+
+    // Prefix match, case-insensitive - same semantics as the original socket-level stripping. Uses
+    // `startsWith` rather than a `RegExp` so allow-list values containing regex metacharacters are
+    // matched literally.
+    return allowedKeys.some(allowed => normalizedKey.startsWith(allowed.toLowerCase()));
+};
+
+// Builds the headers sent through the Tor SOCKS5 dispatcher. Internal control headers are always
+// stripped first so they can never leak. When `Allowed-Headers` is present only the allow-listed
+// headers are then kept; otherwise all remaining headers are forwarded.
+export const buildTorHeaders = (headers?: HeadersInit): Record<string, string> => {
+    const entries = getHeaderEntries(headers);
+
+    const allowedHeadersValue = getHeaderValue(headers, 'Allowed-Headers');
+
+    const withoutControlHeaders = entries.filter(([key]) => !isInternalControlHeader(key));
+
+    const filtered =
+        allowedHeadersValue !== undefined
+            ? withoutControlHeaders.filter(([key]) => isHeaderAllowed(key, allowedHeadersValue))
+            : withoutControlHeaders;
+
+    return Object.fromEntries(filtered);
+};

--- a/packages/request-manager/src/interceptor/fetchPool.ts
+++ b/packages/request-manager/src/interceptor/fetchPool.ts
@@ -1,4 +1,5 @@
 import { type InterceptorContext } from './interceptorTypes';
+import { isTorCircuitError } from './torError';
 
 const requestTimeoutLimit = 1000 * 30;
 
@@ -40,21 +41,11 @@ export const monitorFetch = <T extends { status: number }>({
             return response;
         },
         (error: Error) => {
-            // undici wraps connection failures in a generic error and exposes the underlying cause
-            // on the `cause` field, so we inspect both. A SocksClientError thrown by the 'socks'
-            // package carries an `options` field, while socket resets surface as 'ECONNRESET'; both
-            // indicate a misbehaving Tor circuit.
-            const cause = 'cause' in error ? (error.cause as unknown) : undefined;
-
-            const isCircuitMisbehaving = [error, cause].some(
-                candidate =>
-                    typeof candidate === 'object' &&
-                    candidate !== null &&
-                    (('code' in candidate && candidate.code === 'ECONNRESET') ||
-                        'options' in candidate),
-            );
-
-            if (isCircuitMisbehaving) {
+            // `isTorCircuitError` recognises the failure shapes of both transports (undici's
+            // UND_ERR_SOCKET / UND_ERR_SOCKS5_* as well as the legacy socks ECONNRESET / `options`),
+            // so a misbehaving circuit reached over `fetch`/undici still triggers the global
+            // circuit-reset recovery (CIRCUIT_MISBEHAVING -> reset-tor-circuits -> closeActiveCircuits).
+            if (isTorCircuitError(error)) {
                 context.handler({
                     type: 'CIRCUIT_MISBEHAVING',
                     identity: identity?.split(':')[0],

--- a/packages/request-manager/src/interceptor/fetchPool.ts
+++ b/packages/request-manager/src/interceptor/fetchPool.ts
@@ -1,0 +1,72 @@
+import { type InterceptorContext } from './interceptorTypes';
+
+const requestTimeoutLimit = 1000 * 30;
+
+type MonitorFetchParams<T extends { status: number }> = {
+    context: InterceptorContext;
+    host: string;
+    identity?: string;
+    request: Promise<T>;
+};
+
+// Reports timing and error events for a fetch routed through undici. This mirrors the monitoring
+// that `httpPool` attaches to `http.ClientRequest`, which undici does not go through.
+export const monitorFetch = <T extends { status: number }>({
+    context,
+    host,
+    identity,
+    request,
+}: MonitorFetchParams<T>): Promise<T> => {
+    const requestTime = Date.now();
+
+    return request.then(
+        response => {
+            const timeRequestTook = Date.now() - requestTime;
+
+            const isNetworkMisbehaving = timeRequestTook > requestTimeoutLimit;
+            if (isNetworkMisbehaving) {
+                context.handler({
+                    type: 'NETWORK_MISBEHAVING',
+                });
+            }
+
+            context.handler({
+                type: 'INTERCEPTED_RESPONSE',
+                host,
+                time: timeRequestTook,
+                statusCode: response.status,
+            });
+
+            return response;
+        },
+        (error: Error) => {
+            // undici wraps connection failures in a generic error and exposes the underlying cause
+            // on the `cause` field, so we inspect both. A SocksClientError thrown by the 'socks'
+            // package carries an `options` field, while socket resets surface as 'ECONNRESET'; both
+            // indicate a misbehaving Tor circuit.
+            const cause = 'cause' in error ? (error.cause as unknown) : undefined;
+
+            const isCircuitMisbehaving = [error, cause].some(
+                candidate =>
+                    typeof candidate === 'object' &&
+                    candidate !== null &&
+                    (('code' in candidate && candidate.code === 'ECONNRESET') ||
+                        'options' in candidate),
+            );
+
+            if (isCircuitMisbehaving) {
+                context.handler({
+                    type: 'CIRCUIT_MISBEHAVING',
+                    identity: identity?.split(':')[0],
+                });
+            } else {
+                context.handler({
+                    type: 'ERROR',
+                    error,
+                });
+            }
+
+            throw error;
+        },
+    );
+};

--- a/packages/request-manager/src/interceptor/interceptFetch.ts
+++ b/packages/request-manager/src/interceptor/interceptFetch.ts
@@ -1,44 +1,89 @@
-// TODO: Nodejs fetch APIs use undici which is based on totally different design,
-// proxy-agent package is not compatible with undici, and can only be used with
-// old API like http.request.
-// See issue: https://github.com/TooTallNate/proxy-agents/issues/239 .
-import type { RequestOptions } from 'https';
-import nodeFetch, { type RequestInit } from 'node-fetch';
+// Node's global `fetch` is backed by undici, which - unlike the legacy `http`/`https` modules - does
+// not go through this package's `http.request` interception.
+// Using native nodejs undici's `Socks5ProxyAgent` to route Tor traffic.
+// https://github.com/nodejs/undici/blob/main/docs/docs/api/Socks5ProxyAgent.md
+import { fetch as undiciFetch } from 'undici';
 
+import { isWhitelistedHost } from '@trezor/utils';
+
+import { buildTorHeaders, getHeaderValue } from './fetchHeaders';
+import { monitorFetch } from './fetchPool';
 import { type Interceptor } from './interceptorTypes';
-import { getIsTorRequired } from './overloadHttpRequest';
+import { getIdentityName } from './overloadHttpRequest';
+
+const resolveHostname = (url: RequestInfo | URL) => {
+    if (typeof url === 'object' && 'hostname' in url) {
+        // case url type of URL
+        return url.hostname;
+    }
+    if (typeof url === 'object' && 'url' in url) {
+        // case url type of globalThis.Request
+        return new URL(url.url).hostname;
+    }
+    if (typeof url === 'string') {
+        // case url type of string
+        return new URL(url).hostname;
+    }
+
+    return 'unknown';
+};
 
 export const interceptFetch: Interceptor = ({ context, validateRequest }) => {
     const originalFetch = global.fetch;
 
-    global.fetch = (url, options): Promise<Response> => {
+    global.fetch = (url, options) => {
         const isTorEnabled = context.getTorSettings().running;
-        const isTorRequired = getIsTorRequired(options as Readonly<RequestOptions>);
+        const proxyAuthorization = getHeaderValue(options?.headers, 'Proxy-Authorization');
+        const isTorRequired = proxyAuthorization !== undefined;
 
-        if (isTorEnabled) {
-            return nodeFetch(url as string, options as RequestInit) as Promise<any>;
-        }
-
-        if (isTorRequired && !context.allowTorBypass) {
+        if (isTorRequired && !isTorEnabled && !context.allowTorBypass) {
             return Promise.reject(
                 new Error('Blocked request with Proxy-Authorization. TOR not enabled.'),
             );
         }
 
-        let hostname = 'unknown';
-        if (typeof url === 'object' && 'hostname' in url) {
-            // case url type of URL
-            hostname = url.hostname;
-        } else if (typeof url === 'object' && 'url' in url) {
-            // case url type of globalThis.Request
-            hostname = url.url;
-        } else if (typeof url === 'string') {
-            // case url type of string
-            hostname = new URL(url).hostname;
+        const hostname = resolveHostname(url);
+        try {
+            validateRequest({ hostname });
+        } catch (error) {
+            return Promise.reject(error);
         }
 
-        validateRequest({ hostname });
+        // Hosts that don't require Tor (e.g. localhost, dev domains) connect directly, matching the
+        // behavior of the http(s) interceptor in `overloadHttpRequest`.
+        if (!isTorEnabled || isWhitelistedHost(hostname, context.notRequiredTorDomainsList)) {
+            return originalFetch(url, options);
+        }
 
-        return originalFetch(url, options);
+        // Use the Proxy-Authorization header to select the Tor circuit, falling back to 'default'.
+        const identity = getIdentityName(proxyAuthorization) || 'default';
+        const dispatcher = context.torIdentities.getDispatcher(identity);
+        const headers = buildTorHeaders(options?.headers);
+
+        context.handler({
+            type: 'INTERCEPTED_REQUEST',
+            method: 'fetch',
+            details: `${hostname} with identity ${identity}`,
+        });
+
+        // The type mismatch is a TypeScript artifact:
+        // the compiler sees lib.dom.Request/Response as different from undici.Request even though at runtime in Node.js they're the same class.
+        const request = undiciFetch(
+            ...([
+                url,
+                {
+                    ...options,
+                    headers,
+                    dispatcher,
+                },
+            ] as Parameters<typeof undiciFetch>),
+        );
+
+        return monitorFetch({
+            context,
+            host: hostname,
+            identity,
+            request,
+        }) as unknown as Promise<Response>;
     };
 };

--- a/packages/request-manager/src/interceptor/interceptFetch.ts
+++ b/packages/request-manager/src/interceptor/interceptFetch.ts
@@ -32,58 +32,68 @@ export const interceptFetch: Interceptor = ({ context, validateRequest }) => {
     const originalFetch = global.fetch;
 
     global.fetch = (url, options) => {
-        const isTorEnabled = context.getTorSettings().running;
-        const proxyAuthorization = getHeaderValue(options?.headers, 'Proxy-Authorization');
-        const isTorRequired = proxyAuthorization !== undefined;
-
-        if (isTorRequired && !isTorEnabled && !context.allowTorBypass) {
-            return Promise.reject(
-                new Error('Blocked request with Proxy-Authorization. TOR not enabled.'),
-            );
-        }
-
-        const hostname = resolveHostname(url);
+        // Native `fetch` never throws synchronously — it always returns a (possibly rejected)
+        // promise. `resolveHostname`/`getHeaderValue` and `validateRequest` can throw on a malformed
+        // url/headers or a blocked host, so the whole body is guarded to preserve that contract.
         try {
+            const isTorEnabled = context.getTorSettings().running;
+            const proxyAuthorization = getHeaderValue(options?.headers, 'Proxy-Authorization');
+            const isTorRequired = proxyAuthorization !== undefined;
+
+            const hostname = resolveHostname(url);
             validateRequest({ hostname });
+
+            // Hosts that don't require Tor (e.g. localhost, dev domains) connect directly. The
+            // whitelist is checked BEFORE the Tor-required block so its ordering matches the http(s)
+            // interceptor in `overloadHttpRequest` (there a whitelisted host returns untouched
+            // before `enforceTorRequirement`): a whitelisted host is allowed even when it carries a
+            // Proxy-Authorization header while Tor is off.
+            if (isWhitelistedHost(hostname, context.notRequiredTorDomainsList)) {
+                return originalFetch(url, options);
+            }
+
+            if (!isTorEnabled) {
+                if (isTorRequired && !context.allowTorBypass) {
+                    return Promise.reject(
+                        new Error('Blocked request with Proxy-Authorization. TOR not enabled.'),
+                    );
+                }
+
+                return originalFetch(url, options);
+            }
+
+            // Use the Proxy-Authorization header to select the Tor circuit, falling back to 'default'.
+            const identity = getIdentityName(proxyAuthorization) || 'default';
+            const dispatcher = context.torIdentities.getDispatcher(identity);
+            const headers = buildTorHeaders(options?.headers);
+
+            context.handler({
+                type: 'INTERCEPTED_REQUEST',
+                method: 'fetch',
+                details: `${hostname} with identity ${identity}`,
+            });
+
+            // The type mismatch is a TypeScript artifact:
+            // the compiler sees lib.dom.Request/Response as different from undici.Request even though at runtime in Node.js they're the same class.
+            const request = undiciFetch(
+                ...([
+                    url,
+                    {
+                        ...options,
+                        headers,
+                        dispatcher,
+                    },
+                ] as Parameters<typeof undiciFetch>),
+            );
+
+            return monitorFetch({
+                context,
+                host: hostname,
+                identity,
+                request,
+            }) as unknown as Promise<Response>;
         } catch (error) {
             return Promise.reject(error);
         }
-
-        // Hosts that don't require Tor (e.g. localhost, dev domains) connect directly, matching the
-        // behavior of the http(s) interceptor in `overloadHttpRequest`.
-        if (!isTorEnabled || isWhitelistedHost(hostname, context.notRequiredTorDomainsList)) {
-            return originalFetch(url, options);
-        }
-
-        // Use the Proxy-Authorization header to select the Tor circuit, falling back to 'default'.
-        const identity = getIdentityName(proxyAuthorization) || 'default';
-        const dispatcher = context.torIdentities.getDispatcher(identity);
-        const headers = buildTorHeaders(options?.headers);
-
-        context.handler({
-            type: 'INTERCEPTED_REQUEST',
-            method: 'fetch',
-            details: `${hostname} with identity ${identity}`,
-        });
-
-        // The type mismatch is a TypeScript artifact:
-        // the compiler sees lib.dom.Request/Response as different from undici.Request even though at runtime in Node.js they're the same class.
-        const request = undiciFetch(
-            ...([
-                url,
-                {
-                    ...options,
-                    headers,
-                    dispatcher,
-                },
-            ] as Parameters<typeof undiciFetch>),
-        );
-
-        return monitorFetch({
-            context,
-            host: hostname,
-            identity,
-            request,
-        }) as unknown as Promise<Response>;
     };
 };

--- a/packages/request-manager/src/interceptor/interceptNetSocketConnect.ts
+++ b/packages/request-manager/src/interceptor/interceptNetSocketConnect.ts
@@ -9,6 +9,8 @@ export const interceptNetSocketConnect: Interceptor = ({ context, validateReques
     //    https://github.com/nodejs/node/blob/e48763840625c037282681456ecd1e1cb034f636/lib/_http_outgoing.js#L508-L510
     // 2. node-fetch always(!) adds "User-Agent", "Accept", "Connection"...
     //    https://github.com/node-fetch/node-fetch/blob/7b86e946b02dfdd28f4f8fca3d73a022cbb5ca1e/src/request.js#L226
+    // This socket-level stripping applies to the legacy http(s) module path. Global `fetch` now goes
+    // through undici (see `interceptFetch`), which filters "Allowed-Headers" at the options level.
     const originalSocketWrite = net.Socket.prototype.write;
 
     net.Socket.prototype.write = function (data, ...args) {

--- a/packages/request-manager/src/interceptor/overloadHttpRequest.ts
+++ b/packages/request-manager/src/interceptor/overloadHttpRequest.ts
@@ -19,7 +19,7 @@ const getHeaderValue = (headers: http.OutgoingHttpHeaders | undefined, name: str
     return { key, value };
 };
 
-const getIdentityName = (proxyAuthorization?: http.OutgoingHttpHeader) => {
+export const getIdentityName = (proxyAuthorization?: http.OutgoingHttpHeader) => {
     const identity = Array.isArray(proxyAuthorization) ? proxyAuthorization[0] : proxyAuthorization;
 
     // Only return identity name if it is explicitly defined.

--- a/packages/request-manager/src/interceptor/torError.ts
+++ b/packages/request-manager/src/interceptor/torError.ts
@@ -1,0 +1,48 @@
+// A Tor request can fail because the underlying SOCKS circuit misbehaves — the proxy refused the
+// connection, the exit closed the socket, auth was rejected, and so on. Those failures should reset
+// the circuit and retry, but they surface with different shapes depending on the transport:
+//
+// - legacy `http`/`https` module + `socks-proxy-agent`: a `SocksClientError` from the `socks`
+//   package, which carries an `options` field; a reset socket has `code: 'ECONNRESET'`.
+// - native `fetch` (undici): a generic `TypeError: fetch failed` whose underlying error is on
+//   `cause`. undici ships its OWN SOCKS5 client (it does not use the `socks` package), so a closed
+//   socket is `code: 'UND_ERR_SOCKET'` ("other side closed") and SOCKS5 connect/auth failures are
+//   `code: 'UND_ERR_SOCKS5_*'` — none of them carry an `options` field or `ECONNRESET`.
+//
+// Recognising all of these keeps circuit recovery working regardless of which transport ran the
+// request. This is the single source of truth for "is this a misbehaving Tor circuit?"; keep it in
+// sync with the equivalent check in @trezor/coinjoin `coordinatorRequest` (which cannot import from
+// this package).
+
+const CIRCUIT_ERROR_CODES = ['ECONNRESET', 'UND_ERR_SOCKET'];
+
+const isCircuitErrorCandidate = (candidate: unknown): boolean => {
+    if (typeof candidate !== 'object' || candidate === null) {
+        return false;
+    }
+
+    // `socks` package SocksClientError (legacy http path / node-fetch)
+    if ('options' in candidate) {
+        return true;
+    }
+
+    if ('code' in candidate) {
+        const { code } = candidate as { code?: unknown };
+        if (typeof code === 'string') {
+            return CIRCUIT_ERROR_CODES.includes(code) || code.startsWith('UND_ERR_SOCKS5');
+        }
+    }
+
+    return false;
+};
+
+// undici wraps connection failures in a generic error and exposes the underlying error on `cause`,
+// so both the error itself and its cause are inspected.
+export const isTorCircuitError = (error: unknown): boolean => {
+    const cause =
+        typeof error === 'object' && error !== null && 'cause' in error
+            ? (error as { cause: unknown }).cause
+            : undefined;
+
+    return [error, cause].some(isCircuitErrorCandidate);
+};

--- a/packages/request-manager/src/torIdentities.ts
+++ b/packages/request-manager/src/torIdentities.ts
@@ -97,6 +97,8 @@ export class TorIdentities {
 
         this.resetIdentityIfPasswordChanged(user, password);
 
+        // TODO clean agents when host/port changes? (same caveat as getIdentity above — the socks
+        // host/port is captured at construction time and cached until the password changes)
         if (!this.dispatchers[user]) {
             this.dispatchers[user] = createSocks5ProxyAgent(
                 this.buildSocksServerUrl(user, password),

--- a/packages/request-manager/src/torIdentities.ts
+++ b/packages/request-manager/src/torIdentities.ts
@@ -1,16 +1,64 @@
 import { SocksProxyAgent } from 'socks-proxy-agent';
+import { Socks5ProxyAgent } from 'undici';
 
 import type { TorSettings } from './types';
+
+// undici's Socks5ProxyAgent emits a one-time `ExperimentalWarning` from its constructor. We swallow
+// only that specific warning (leaving every other warning untouched) so it doesn't pollute logs.
+const createSocks5ProxyAgent = (proxyUrl: URL) => {
+    const originalEmitWarning = process.emitWarning;
+
+    process.emitWarning = (...args) => {
+        const [warning, options] = args;
+        const type = typeof options === 'string' ? options : (options as { type?: string })?.type;
+
+        if (
+            type === 'ExperimentalWarning' &&
+            String(warning).includes('SOCKS5 proxy support is experimental')
+        ) {
+            return;
+        }
+
+        return originalEmitWarning(...(args as Parameters<typeof process.emitWarning>));
+    };
+
+    try {
+        return new Socks5ProxyAgent(proxyUrl);
+    } finally {
+        process.emitWarning = originalEmitWarning;
+    }
+};
 
 export class TorIdentities {
     private readonly getTorSettings: () => TorSettings;
     private readonly identities: { [key: string]: SocksProxyAgent };
+    private readonly dispatchers: { [key: string]: Socks5ProxyAgent };
     private readonly passwords: { [key: string]: string };
 
     constructor(getTorSettings: () => TorSettings) {
         this.getTorSettings = getTorSettings;
         this.identities = {};
+        this.dispatchers = {};
         this.passwords = {};
+    }
+
+    private buildSocksServerUrl(user: string, password: string) {
+        const { host, port } = this.getTorSettings();
+
+        const socksServerUrl = new URL(`socks://${host}:${port}`);
+        socksServerUrl.username = user;
+        socksServerUrl.password = password;
+
+        return socksServerUrl;
+    }
+
+    // When a new password is requested for an existing identity we drop the cached agents so that
+    // a fresh Tor circuit is created for the new credentials.
+    private resetIdentityIfPasswordChanged(user: string, password: string) {
+        if (password && this.passwords[user] !== password) {
+            this.removeIdentity(user);
+            this.passwords[user] = password;
+        }
     }
 
     public getIdentity(
@@ -22,21 +70,11 @@ export class TorIdentities {
         const user = identityParts[0] ?? '';
         const password = identityParts[1] ?? '';
 
-        if (password && this.passwords[user] !== password) {
-            if (this.identities[user]) {
-                this.removeIdentity(user);
-            }
-            this.passwords[user] = password;
-        }
-
-        const { host, port } = this.getTorSettings();
+        this.resetIdentityIfPasswordChanged(user, password);
 
         // TODO clean agents when host/port changes?
         if (!this.identities[user]) {
-            const socksServerUrl = new URL(`socks://${host}:${port}`);
-            socksServerUrl.username = user;
-            socksServerUrl.password = password;
-            this.identities[user] = new SocksProxyAgent(socksServerUrl, {
+            this.identities[user] = new SocksProxyAgent(this.buildSocksServerUrl(user, password), {
                 timeout,
             });
         }
@@ -50,13 +88,32 @@ export class TorIdentities {
         return agent;
     }
 
+    // Returns an undici dispatcher routing through the Tor SOCKS5 proxy for the given identity.
+    // Used by the fetch interceptor, since undici bypasses the http(s) module interception.
+    public getDispatcher(identity: string): Socks5ProxyAgent {
+        const identityParts = identity.split(':');
+        const user = identityParts[0] ?? '';
+        const password = identityParts[1] ?? user; // undici's Socks5ProxyAgent requires a password if user is set
+
+        this.resetIdentityIfPasswordChanged(user, password);
+
+        if (!this.dispatchers[user]) {
+            this.dispatchers[user] = createSocks5ProxyAgent(
+                this.buildSocksServerUrl(user, password),
+            );
+        }
+
+        return this.dispatchers[user];
+    }
+
     public removeIdentity(user: string) {
         // looks like destroy does nothing, but just in case
-        const { identities } = this;
-        // @ts-expect-error: indexing with noUncheckedIndexedAccess
-        const identity: SocksProxyAgent = identities[user];
-        identity.destroy();
+        this.identities[user]?.destroy();
         delete this.identities[user];
+
+        this.dispatchers[user]?.destroy();
+        delete this.dispatchers[user];
+
         delete this.passwords[user];
     }
 }

--- a/packages/request-manager/tests/fetchHeaders.test.ts
+++ b/packages/request-manager/tests/fetchHeaders.test.ts
@@ -1,0 +1,88 @@
+import { buildTorHeaders, getHeaderValue } from '../src/interceptor/fetchHeaders';
+
+// `buildTorHeaders` is the fetch-path guard that must never let the Tor identity
+// (`Proxy-Authorization`) or the internal `Allowed-Headers` routing header reach the destination
+// server. It is a pure function, so it is tested deterministically here (no Tor / no network),
+// unlike the e2e `Allowed-Headers` suite which — because it targets a whitelisted localhost — runs
+// the DIRECT path and only exercises the legacy socket-level stripping.
+describe('fetchHeaders', () => {
+    describe('buildTorHeaders', () => {
+        it('always strips the internal control headers (Proxy-Authorization, Allowed-Headers)', () => {
+            // The control headers are even added to the allow-list, so ONLY the dedicated strip step
+            // (not the allow-list filter) can remove them — this isolates that the strip actually runs.
+            const result = buildTorHeaders({
+                'Proxy-Authorization': 'Basic secret-identity',
+                'Allowed-Headers': 'Proxy-Authorization;Allowed-Headers;Content-Type',
+                'Content-Type': 'application/json',
+            });
+
+            expect(result).not.toHaveProperty('proxy-authorization');
+            expect(result).not.toHaveProperty('allowed-headers');
+            expect(result).toEqual({ 'content-type': 'application/json' });
+        });
+
+        it('strips the identity header even when no allow-list is present', () => {
+            const result = buildTorHeaders({
+                'proxy-authorization': 'Basic secret-identity',
+                'user-agent': 'Trezor Suite',
+            });
+
+            expect(result).not.toHaveProperty('proxy-authorization');
+            expect(result).toEqual({ 'user-agent': 'Trezor Suite' });
+        });
+
+        it('keeps only allow-listed headers when Allowed-Headers is present (case-insensitive prefix)', () => {
+            const result = buildTorHeaders({
+                'Proxy-Authorization': 'Basic id',
+                'Allowed-Headers': 'AcCePt-EnCoDiNg;content-type;Content-Length;HOST', // case insensitive
+                'Accept-Encoding': 'gzip',
+                'Content-Type': 'application/json',
+                'Content-Length': '15',
+                Host: 'example.com',
+                'User-Agent': 'Trezor Suite', // not allow-listed -> dropped (anti-fingerprinting)
+            });
+
+            expect(result).toEqual({
+                'accept-encoding': 'gzip',
+                'content-type': 'application/json',
+                'content-length': '15',
+                host: 'example.com',
+            });
+            expect(result).not.toHaveProperty('user-agent');
+            expect(result).not.toHaveProperty('proxy-authorization');
+        });
+
+        it('forwards all non-control headers when no Allowed-Headers is present', () => {
+            const result = buildTorHeaders({
+                'Content-Type': 'application/json',
+                'User-Agent': 'Trezor Suite',
+            });
+
+            expect(result).toEqual({
+                'content-type': 'application/json',
+                'user-agent': 'Trezor Suite',
+            });
+        });
+
+        it('returns an empty object when there are no headers', () => {
+            expect(buildTorHeaders()).toEqual({});
+            expect(buildTorHeaders(undefined)).toEqual({});
+        });
+    });
+
+    describe('getHeaderValue', () => {
+        it('reads a header case-insensitively', () => {
+            expect(
+                getHeaderValue({ 'Proxy-Authorization': 'Basic x' }, 'proxy-authorization'),
+            ).toBe('Basic x');
+            expect(
+                getHeaderValue({ 'proxy-authorization': 'Basic x' }, 'Proxy-Authorization'),
+            ).toBe('Basic x');
+        });
+
+        it('returns undefined for a missing header or no headers', () => {
+            expect(getHeaderValue({ 'Content-Type': 'x' }, 'Proxy-Authorization')).toBeUndefined();
+            expect(getHeaderValue(undefined, 'Proxy-Authorization')).toBeUndefined();
+        });
+    });
+});

--- a/packages/request-manager/tests/fetchPool.test.ts
+++ b/packages/request-manager/tests/fetchPool.test.ts
@@ -1,0 +1,123 @@
+import { monitorFetch } from '../src/interceptor/fetchPool';
+import { type InterceptorContext } from '../src/interceptor/interceptorTypes';
+import { type InterceptedEvent } from '../src/types';
+
+const createContext = () => {
+    const events: InterceptedEvent[] = [];
+    const context = {
+        handler: (event: InterceptedEvent) => events.push(event),
+    } as unknown as InterceptorContext;
+
+    return { context, events };
+};
+
+const rejectedWith = (error: unknown): Promise<{ status: number }> => Promise.reject(error);
+
+// undici wraps the underlying failure on `error.cause`
+const undiciError = (code: string) =>
+    Object.assign(new TypeError('fetch failed'), { cause: { code } });
+
+const undiciSocketReset = undiciError('UND_ERR_SOCKET');
+const undiciSocks5Failure = undiciError('UND_ERR_SOCKS5_REPLY_5');
+// node-fetch / the socks package put the discriminating field on the error itself
+const nodeFetchReset = Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' });
+const socksClientError = Object.assign(new Error('Socks5 proxy rejected connection'), {
+    options: {},
+});
+
+describe('fetchPool / monitorFetch', () => {
+    // The circuit-failure shapes that must trigger the desktop-wide Tor recovery
+    // (CIRCUIT_MISBEHAVING -> reset-tor-circuits -> closeActiveCircuits). These cover BOTH slots
+    // `isTorCircuitError` inspects: the field on `error.cause` (undici) and on the error itself
+    // (node-fetch / the socks package).
+    it.each([
+        ['undici socket reset (cause.code UND_ERR_SOCKET)', undiciSocketReset],
+        ['undici SOCKS5 connect failure (cause.code UND_ERR_SOCKS5_*)', undiciSocks5Failure],
+        ['node-fetch socket reset (top-level code ECONNRESET)', nodeFetchReset],
+        ['socks SocksClientError (top-level `options`)', socksClientError],
+    ])('classifies %s as CIRCUIT_MISBEHAVING', async (_label, error) => {
+        const { context, events } = createContext();
+
+        await expect(
+            monitorFetch({
+                context,
+                host: 'coordinator',
+                identity: 'alice',
+                request: rejectedWith(error),
+            }),
+        ).rejects.toBeDefined();
+
+        expect(events).toEqual([{ type: 'CIRCUIT_MISBEHAVING', identity: 'alice' }]);
+    });
+
+    it('reports the identity without its password portion', async () => {
+        const { context, events } = createContext();
+
+        await expect(
+            monitorFetch({
+                context,
+                host: 'coordinator',
+                identity: 'alice:some-password',
+                request: rejectedWith(undiciSocketReset),
+            }),
+        ).rejects.toBeDefined();
+
+        expect(events).toEqual([{ type: 'CIRCUIT_MISBEHAVING', identity: 'alice' }]);
+    });
+
+    it('classifies an unrelated error as a plain ERROR (not a circuit failure)', async () => {
+        const { context, events } = createContext();
+        const error = new Error('boom');
+
+        await expect(
+            monitorFetch({
+                context,
+                host: 'coordinator',
+                identity: 'alice',
+                request: rejectedWith(error),
+            }),
+        ).rejects.toBe(error);
+
+        expect(events).toEqual([{ type: 'ERROR', error }]);
+    });
+
+    it('re-throws the original error so downstream consumers can still handle it', async () => {
+        const { context } = createContext();
+
+        await expect(
+            monitorFetch({
+                context,
+                host: 'coordinator',
+                request: rejectedWith(undiciSocketReset),
+            }),
+        ).rejects.toBe(undiciSocketReset);
+    });
+
+    it('emits INTERCEPTED_RESPONSE with the status code on success', async () => {
+        const { context, events } = createContext();
+
+        const response = await monitorFetch({
+            context,
+            host: 'example.com',
+            identity: 'alice',
+            request: Promise.resolve({ status: 200 }),
+        });
+
+        expect(response).toEqual({ status: 200 });
+        expect(events).toContainEqual({
+            type: 'INTERCEPTED_RESPONSE',
+            host: 'example.com',
+            time: expect.any(Number),
+            statusCode: 200,
+        });
+    });
+
+    // Guard against a silent breakage of the experimental undici SOCKS5 API that per-identity Tor
+    // circuit isolation depends on: if a future undici bump drops/renames the export, fail loudly here.
+    // undici is imported lazily (not at module top) so this one guard cannot prevent the rest of the
+    // suite — which needs no undici runtime — from running on a Node that differs from the pinned one.
+    it('undici still exports the experimental Socks5ProxyAgent used for Tor isolation', async () => {
+        const { Socks5ProxyAgent } = await import('undici');
+        expect(typeof Socks5ProxyAgent).toBe('function');
+    });
+});

--- a/packages/request-manager/tests/interceptor-whitelist.test.ts
+++ b/packages/request-manager/tests/interceptor-whitelist.test.ts
@@ -86,6 +86,17 @@ describe('Interceptor', () => {
     });
 
     ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'].forEach(method => {
+        it(`Blocks all not whitelisted global.fetch requests for: ${method}`, async () => {
+            // undici wraps DNS failures as "fetch failed". the actual cause is in error.cause
+            await expect(fetch(`https://${WHITELISTED_DOMAIN}`, { method })).rejects.toThrow(
+                `fetch failed`,
+            );
+
+            await expect(fetch(`https://${NOT_WHITELISTED_DOMAIN}`, { method })).rejects.toThrow(
+                `Request blocked, not whitelisted domain: ${NOT_WHITELISTED_DOMAIN}`,
+            );
+        });
+
         it(`Blocks all not whitelisted node-fetch requests for: ${method}`, async () => {
             await expect(nodeFetch(`https://${WHITELISTED_DOMAIN}`, { method })).rejects.toThrow(
                 OK_ERROR_HTTPS,
@@ -155,22 +166,5 @@ describe('Interceptor', () => {
                 `Request blocked, not whitelisted domain: ${NOT_WHITELISTED_DOMAIN}`,
             );
         }
-    });
-
-    ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'].forEach(method => {
-        it(`Blocks all not whitelisted native fetch for: ${method}`, async () => {
-            await expect(fetch(`https://${WHITELISTED_DOMAIN}`, { method })).rejects.toThrow(
-                'fetch failed',
-            );
-
-            try {
-                await fetch(`https://${NOT_WHITELISTED_DOMAIN}/`, { method });
-                expect('').toBe('Should throw an error');
-            } catch (error) {
-                expect(error.message).toBe(
-                    `Request blocked, not whitelisted domain: ${NOT_WHITELISTED_DOMAIN}`,
-                );
-            }
-        });
     });
 });

--- a/packages/request-manager/tests/torIdentities.test.ts
+++ b/packages/request-manager/tests/torIdentities.test.ts
@@ -1,0 +1,62 @@
+import { Socks5ProxyAgent } from 'undici';
+
+import { TorIdentities } from '../src/torIdentities';
+
+// The undici Socks5ProxyAgent is stubbed so this runs as a pure unit test (no Tor, no network): each
+// constructed "dispatcher" just records the SOCKS proxy URL it was built from, which is where the Tor
+// identity is encoded (username/password -> Tor IsolateSOCKSAuth -> one circuit per identity).
+jest.mock('undici', () => ({
+    Socks5ProxyAgent: jest.fn((proxyUrl: URL) => ({ proxyUrl, destroy: jest.fn() })),
+}));
+
+const Socks5Mock = Socks5ProxyAgent as unknown as jest.Mock;
+
+const getTorSettings = () => ({ running: true, host: '127.0.0.1', port: 9050 });
+
+// the URL passed to the Nth Socks5ProxyAgent construction
+const proxyUrlOf = (call: number): URL => Socks5Mock.mock.calls[call][0];
+
+describe('TorIdentities.getDispatcher', () => {
+    beforeEach(() => Socks5Mock.mockClear());
+
+    it('encodes distinct identities as distinct SOCKS credentials (distinct circuits)', () => {
+        const tor = new TorIdentities(getTorSettings);
+        const alice = tor.getDispatcher('alice');
+        const bob = tor.getDispatcher('bob');
+
+        expect(alice).not.toBe(bob);
+        expect(Socks5Mock).toHaveBeenCalledTimes(2);
+        expect(proxyUrlOf(0).username).toBe('alice');
+        expect(proxyUrlOf(1).username).toBe('bob');
+        expect(proxyUrlOf(0).username).not.toBe(proxyUrlOf(1).username);
+    });
+
+    it('caches the dispatcher for a stable identity (same circuit reused)', () => {
+        const tor = new TorIdentities(getTorSettings);
+        const first = tor.getDispatcher('alice');
+        const second = tor.getDispatcher('alice');
+
+        expect(first).toBe(second);
+        expect(Socks5Mock).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to the user as password for a bare identity (undici requires a password)', () => {
+        const tor = new TorIdentities(getTorSettings);
+        tor.getDispatcher('alice');
+
+        expect(proxyUrlOf(0).username).toBe('alice');
+        expect(proxyUrlOf(0).password).toBe('alice');
+    });
+
+    it('resets the circuit on a password change: tears down and recreates the dispatcher', () => {
+        const tor = new TorIdentities(getTorSettings);
+        const before = tor.getDispatcher('alice') as unknown as { destroy: jest.Mock };
+        const after = tor.getDispatcher('alice:fresh-password');
+
+        expect(after).not.toBe(before);
+        expect(before.destroy).toHaveBeenCalledTimes(1); // old circuit torn down
+        expect(Socks5Mock).toHaveBeenCalledTimes(2);
+        expect(proxyUrlOf(1).username).toBe('alice');
+        expect(proxyUrlOf(1).password).toBe('fresh-password');
+    });
+});

--- a/scripts/list-outdated-dependencies/connect-dependencies.txt
+++ b/scripts/list-outdated-dependencies/connect-dependencies.txt
@@ -72,6 +72,7 @@ tailwindcss
 tiny-worker
 ts-mixer
 ts-node
+undici
 usb
 version-bump-prompt
 ws

--- a/yarn.lock
+++ b/yarn.lock
@@ -16595,6 +16595,7 @@ __metadata:
     node-fetch: "npm:^3.3.2"
     socks-proxy-agent: "npm:8.0.5"
     tsx: "npm:^4.21.0"
+    undici: "npm:8.5.0"
     ws: "npm:^8.20.0"
   languageName: unknown
   linkType: soft
@@ -45330,6 +45331,13 @@ __metadata:
   version: 6.20.0
   resolution: "undici-types@npm:6.20.0"
   checksum: 10/583ac7bbf4ff69931d3985f4762cde2690bb607844c16a5e2fbb92ed312fe4fa1b365e953032d469fa28ba8b224e88a595f0b10a449332f83fa77c695e567dbe
+  languageName: node
+  linkType: hard
+
+"undici@npm:8.5.0":
+  version: 8.5.0
+  resolution: "undici@npm:8.5.0"
+  checksum: 10/e95913777afd47d76babfe62547bb4e9a94b93f44b50c84b4e0b6fa41c00364e31ff4f433a955b1592c3162f43e8757e2e0feae6eea195187730594523393568
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**WIP — do not merge.** This is a proposal stacked directly on top of #28538 (`undici-socks`): its base is that branch, not `develop`, so the diff here is only the review fixes. I deliberately did not push to `undici-socks` — once we agree, these can be folded into #28538 or landed right after it.

Addresses findings from a deep review of #28538. The core per-identity Tor circuit isolation is structurally correct; the real issues were in the failure/recovery path and in verification.

## Applied

### Circuit recovery (HIGH)
undici does not use the `socks` package — its failures surface as `UND_ERR_SOCKET` (socket reset) and `UND_ERR_SOCKS5_*` (connect/auth), with no `options`/`type`/`ECONNRESET`. Both recovery classifiers under-matched, so undici SOCKS failures degraded recovery:
- `monitorFetch` now uses a shared `isTorCircuitError` (new `torError.ts`) that recognises the undici and legacy socks shapes, so a misbehaving circuit over `fetch` still triggers the desktop-wide reset (`CIRCUIT_MISBEHAVING` → `module/reset-tor-circuits` → `closeActiveCircuits()`). The stale comment claiming resets surface as `ECONNRESET` is fixed.
- `coordinatorRequest` (coinjoin) now switches identity on `UND_ERR_SOCKS5_*` connect failures. Its `type === 'system'` + message-includes-`Socks5` branch was dead under undici (no `type` field; undici's message is upper-case `SOCKS5`), so SOCKS5 connect-refused/unreachable/auth failures previously retried against the same stuck circuit until the deadline.

### Verification (HIGH)
The real-Tor isolation e2e (`Check if IPs are different`, `TorControl`) is `describe.skip` on every PR and nightly run (`SKIP_FLAKY_TESTS`), so the experimental `Socks5ProxyAgent`'s isolation guarantee was verified only on a manual, flaky `workflow_dispatch`. Added deterministic unit coverage that runs per-PR without Tor:
- `tests/torIdentities.test.ts` — distinct identity → distinct SOCKS credentials/dispatcher, identity caching, and circuit reset (drop + recreate) on password change.
- `tests/fetchPool.test.ts` — `CIRCUIT_MISBEHAVING` vs `ERROR` classification across undici (`UND_ERR_SOCKET`/`UND_ERR_SOCKS5_*`), node-fetch (`ECONNRESET`) and socks (`options`) shapes; plus a smoke assert that undici still exports `Socks5ProxyAgent` so a breaking undici bump fails loudly.
- `tests/fetchHeaders.test.ts` — `buildTorHeaders` always strips `Proxy-Authorization`/`Allowed-Headers` and applies the allow-list case-insensitively. This is the privacy-critical strip that the e2e `Allowed-Headers` suite does not actually cover (it targets a whitelisted localhost, so it runs the direct/socket-level path, not `buildTorHeaders` — clarified with a comment).
- The nightly `schedule` now runs `test:e2e` (unflagged) so the real-Tor isolation suites run at least daily. Tor is already provisioned by the e2e (PRs already start it via `test:all`), so this needs no new infra.

### Interceptor correctness (MEDIUM/LOW)
- `interceptFetch` checks the `notRequiredTor` whitelist BEFORE the "Proxy-Authorization while Tor is off" block, matching `overloadHttpRequest`. Previously a request to a whitelisted host (127.0.0.1/localhost/.sldev.cz) carrying `Proxy-Authorization` while Tor was off was rejected on the fetch path but allowed on the http path (only diverged in production-mode builds where `allowTorBypass` is false).
- `interceptFetch` no longer throws synchronously on a malformed url/headers — native fetch is contractually never-throw.
- Fixed swapped `ipA`/`ipB` variable names in the "Reset identity" e2e; added the host/port-change cleanup TODO to `getDispatcher` for parity with `getIdentity`.

## Deferred / declined (open for discussion)
- **Unbounded `dispatchers` map growth** — pre-existing pattern (mirrors the legacy `identities` map), object-graph only (idle sockets drop after undici's keepAlive). A clean fix needs cross-package wiring to round-ended; left as-is.
- **Dispatcher-level timeout** — coinjoin already bounds each request via `scheduleAction` + AbortSignal, and a too-tight layer-level timeout risks breaking slow-but-legitimate Tor requests. Not adding a speculative timeout.
- **Experimental-undici drift guard** — covered lightly by the export smoke test + comment; a resolutions pin / CI note can follow if wanted.
- **Stripping `Proxy-Authorization` on the direct/whitelisted branch** — pre-existing parity with the http path; no production leak (no coordinator host is whitelisted). Declined as speculative hardening.

## Notes for QA
No user-facing behaviour change intended — this hardens Tor circuit failure-recovery and adds test coverage. Blast radius = coinjoin-over-Tor on desktop. Recommended: a manual coinjoin-over-Tor smoke that **forces a circuit failure** (e.g. an unreachable/failing coordinator or killed exit) and confirms the identity switches / circuit resets under undici — the one scenario no automated gate covers. Otherwise no QA needed.
