### PR TITLE
ci(e2e): skip e2e for documentation-only PRs

### DIFF
--- a/.github/actions/determine-test-strategy/action.yml
+++ b/.github/actions/determine-test-strategy/action.yml
@@ -1,12 +1,13 @@
 name: "Determine E2E Test Strategy"
 description: >
-  Classifies PR changes into one of three strategies:
+  Classifies PR changes into one of four strategies:
+  skip-e2e (only documentation / repo-metadata files with no runtime impact changed),
   run-everything (e2e framework changed, mixed framework+production, or CI-only changes),
   analyze (production code changed → LLM analysis needed),
   or specific-tests (only e2e test files changed).
 outputs:
   strategy:
-    description: "specific-tests | run-everything | analyze"
+    description: "skip-e2e | specific-tests | run-everything | analyze"
     value: ${{ steps.classify.outputs.strategy }}
   spec-list:
     description: "Comma-separated list of test file paths (only set when strategy=specific-tests)"
@@ -35,6 +36,28 @@ runs:
         if [[ -z "$CHANGED" ]]; then
           echo "No changed files detected. Running everything."
           echo "strategy=run-everything" >> "$GITHUB_OUTPUT"
+          echo "spec-list=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # No-runtime-impact short-circuit.
+        # If EVERY changed file is documentation or repo metadata that cannot
+        # affect the built app or the e2e tests themselves, skip e2e entirely.
+        # The set is deliberately narrow — only files whose changes provably
+        # have no runtime effect. Anything ambiguous (source, styles, configs,
+        # fixtures, assets, lockfiles) is intentionally excluded so it falls
+        # through to normal classification and is still tested.
+        #
+        # Note: a PR touching ONLY top-level markdown never reaches this
+        # workflow at all (see `paths-ignore: "**.md"` on the workflow). This
+        # check additionally covers doc-only change sets that the path filter
+        # does not catch on its own — e.g. *.mdx, LICENSE, or a mix such as
+        # `README.md` + `LICENSE` (which triggers the workflow because LICENSE
+        # is not in paths-ignore). To extend the set, add patterns below.
+        RUNTIME_RELEVANT=$(echo "$CHANGED" | grep -vE '(\.mdx?$)|(^|/)(LICENSE|CODEOWNERS|AUTHORS)$' || true)
+        if [[ -z "$RUNTIME_RELEVANT" ]]; then
+          echo "Only documentation / non-runtime files changed — skipping e2e."
+          echo "strategy=skip-e2e" >> "$GITHUB_OUTPUT"
           echo "spec-list=" >> "$GITHUB_OUTPUT"
           exit 0
         fi

--- a/.github/workflows/test-suite-web-desktop-e2e-pr.yml
+++ b/.github/workflows/test-suite-web-desktop-e2e-pr.yml
@@ -54,7 +54,7 @@ jobs:
   build-app:
     needs:
       - determine-strategy
-    if: github.repository == 'trezor/trezor-suite'
+    if: github.repository == 'trezor/trezor-suite' && needs.determine-strategy.outputs.strategy != 'skip-e2e'
     uses: ./.github/workflows/build-suite-desktop-e2e.yml
 
   post-currents-pr-info-desktop:
@@ -121,7 +121,9 @@ jobs:
   # ── Web ────────────────────────────────────────────────────────────────────
 
   build-web:
-    if: github.repository == 'trezor/trezor-suite'
+    needs:
+      - determine-strategy
+    if: github.repository == 'trezor/trezor-suite' && needs.determine-strategy.outputs.strategy != 'skip-e2e'
     uses: ./.github/workflows/build-suite-web-e2e.yml
 
   extract-branch:
@@ -137,7 +139,8 @@ jobs:
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
   build-connect:
-    needs: [extract-branch]
+    needs: [extract-branch, determine-strategy]
+    if: github.repository == 'trezor/trezor-suite' && needs.determine-strategy.outputs.strategy != 'skip-e2e'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -219,7 +222,10 @@ jobs:
           DIRECT_SPEC="${{ needs.determine-strategy.outputs.spec-list }}"
           LLM_SPEC="${{ needs.run-llm-analysis.outputs.spec-list }}"
 
-          if [[ "$STRATEGY" == "specific-tests" ]]; then
+          if [[ "$STRATEGY" == "skip-e2e" ]]; then
+            echo "No runtime-impacting files changed — no e2e tests will run."
+            echo "spec-list=" >> "$GITHUB_OUTPUT"
+          elif [[ "$STRATEGY" == "specific-tests" ]]; then
             echo "Using direct spec list from strategy determination: $DIRECT_SPEC"
             echo "spec-list=$DIRECT_SPEC" >> "$GITHUB_OUTPUT"
           elif [[ "$STRATEGY" == "analyze" ]] && [[ -n "$LLM_SPEC" ]]; then


### PR DESCRIPTION
## What & why

Adds a deterministic **`skip-e2e`** strategy to the PR e2e test-selection pipeline. When every changed file is documentation or repo metadata that provably has no runtime impact, the build and e2e jobs are skipped entirely.

Today such a change (that the workflow-level `paths-ignore` does not already catch) is classified as `analyze`, handed to the LLM selector, which returns no relevant tests — and an empty selection is interpreted downstream as **"run everything"**. So e.g. a PR touching only `*.mdx`, `LICENSE`, or a `README.md` + `LICENSE` mix currently runs the full e2e suite for nothing.

The inert set is intentionally narrow: `*.md`, `*.mdx`, `LICENSE`, `CODEOWNERS`, `AUTHORS`. Anything ambiguous (source, styles, configs, fixtures, assets, lockfiles) falls through to normal classification and is still tested. `skip-e2e` fires **only when every changed file is inert** — a single code file present makes it fall through.

## How it works

- `determine-test-strategy` action: new short-circuit emits `strategy=skip-e2e` when no runtime-relevant file changed.
- Build jobs (`build-app`, `build-web`, `build-connect`) are gated with `strategy != 'skip-e2e'`. Skipping the builds cascades cleanly: the `run-e2e-*` matrix jobs already require `needs.build-*.result == 'success'`, so they skip too, as do the dependent `post-*` info jobs. No job is left running with nothing to do.
- `resolve-spec-list` gets an explicit `skip-e2e` branch so the log is honest instead of printing "Running all tests".

## Findings from the current pipeline (context for reviewers)

The selection is a two-layer system:

1. **Deterministic classifier** (`determine-test-strategy`) routes on changed file paths: `.github/**` or e2e framework → `run-everything`; production code → `analyze`; only `suite/e2e/tests/**` → `specific-tests`.
2. **LLM step** (`run-llm-analysis` → `packages/e2e-utils/src/llmTestSelector`) runs only for `analyze`, on the trusted `develop` ref, and picks a minimal test subset from a coverage index + a nightly-built cache of test descriptions.

Key safety property: in `resolve-spec-list`, an **empty** LLM selection means **run everything** (fail-safe). There is currently no channel to express "run nothing".

## What could be improved next (and why it isn't trivial)

The original motivation was broader: also skip e2e for **types-only / no-runtime-change** source diffs (e.g. removing `as X` assertions, like #29226). That belongs in the LLM step, not here, and is **not** a cheap change because of two concrete blockers:

1. **The LLM never sees the diff content.** `buildPromptParts` receives only the changed file *names* (`git diff --name-only`) plus coverage mappings and test descriptions. It cannot tell "types-only" from "logic change" — it doesn't know *what* changed. Judging no-runtime-effect requires feeding the actual diff hunks into the prompt.
2. **"Empty = run everything" is a deliberate fail-safe.** To let the model say "skip all", it needs an explicit affirmative signal (e.g. `no_runtime_impact: true`) that is distinct from an empty/failed response — otherwise any LLM timeout or malformed output would silently skip tests, inverting the current safe default.

There is also a subtlety worth verifying even for this PR (see QA notes): job-level skips and workflow-level `paths-ignore` skips are treated differently by required status checks.

## Notes for QA

Impact / blast radius: CI-only. No product code, no user-facing change, no runtime behaviour touched. The only risk is the CI gating logic itself.

What to verify before this is trusted:
- **Required status checks.** The existing `paths-ignore: "**.md"` skips this whole workflow for pure-markdown PRs, and GitHub auto-passes a workflow skipped by path filters as a required check. This PR instead skips **jobs inside a running workflow** (`build-*` / `run-e2e-*`). Please confirm that a `skip-e2e` run does not leave a required e2e check stuck "pending" and blocking merge. If it does, the safest alternative is to instead extend the workflow-level `paths-ignore` with the same inert patterns (`**.mdx`, `**/LICENSE`, `**/CODEOWNERS`, `**/AUTHORS`) — proven semantics, zero required-check risk — and drop the job-level `skip-e2e`.
- A docs-only PR (e.g. edit a `*.mdx` or `LICENSE`) shows `build-*` and `run-e2e-*` skipped and merges cleanly.
- A mixed PR (one `.ts` + one `.md`) still runs the normal pipeline.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/e2e-skip-no-runtime-changes&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/e2e-skip-no-runtime-changes&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T13:06:24.740Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T13:02:53.554Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/e2e-skip-no-runtime-changes/web/](https://dev.suite.sldev.cz/suite-web/mroz22/e2e-skip-no-runtime-changes/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->