### PR TITLE
feat(suite): add tron vote allocation modal

### DIFF
--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { getTronVotedApr, useTronStakingStats } from '@suite-common/earn-staking-api';
@@ -24,12 +26,15 @@ import { formatApr } from 'src/components/earn/staking/tron/voteUtils';
 import { BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
 
+import { TronVoteAllocationModal } from './TronVoteAllocationModal/TronVoteAllocationModal';
+
 interface TronStakedCardProps {
     account: Account;
 }
 
 export const TronStakedCard = ({ account }: TronStakedCardProps) => {
     const dispatch = useDispatch();
+    const [isVoteAllocationOpen, setIsVoteAllocationOpen] = useState(false);
     const { stats, maxApr } = useTronStakingStats();
 
     const stakedBalance = getTronAccountTotalStakingBalance(account) ?? '0';
@@ -122,7 +127,7 @@ export const TronStakedCard = ({ account }: TronStakedCardProps) => {
                                 intent="neutral"
                                 priority="secondary"
                                 isUnderlined
-                                onClick={() => goToFlow('earn-tron-vote')}
+                                onClick={() => setIsVoteAllocationOpen(true)}
                             >
                                 <Translation
                                     id="TR_EARN_TRON_VOTES_TO_ALLOCATE"
@@ -134,16 +139,29 @@ export const TronStakedCard = ({ account }: TronStakedCardProps) => {
                 ) : (
                     <>
                         {shouldShowRemainingVotes && (
-                            <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                            <TextButton
+                                size="small"
+                                intent="neutral"
+                                priority="secondary"
+                                isUnderlined
+                                onClick={() => setIsVoteAllocationOpen(true)}
+                            >
                                 <Translation
                                     id="TR_EARN_TRON_REMAINING_VOTES"
                                     values={{ remaining: remainingVotes, total: totalVotes }}
                                 />
-                            </Text>
+                            </TextButton>
                         )}
                     </>
                 )}
             </Row>
+
+            {isVoteAllocationOpen && (
+                <TronVoteAllocationModal
+                    account={account}
+                    onClose={() => setIsVoteAllocationOpen(false)}
+                />
+            )}
         </Card>
     );
 };

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVoteAllocationModal/TronVoteAllocationModal.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVoteAllocationModal/TronVoteAllocationModal.tsx
@@ -1,0 +1,138 @@
+import { Translation } from '@suite/intl';
+import { goto } from '@suite/router';
+import { useTronStakingStats } from '@suite-common/earn-staking-api';
+import { type Account } from '@suite-common/wallet-types';
+import {
+    getTronAvailableVotingPower,
+    getTronTotalVotingPower,
+    getTronVotes,
+} from '@suite-common/wallet-utils';
+import {
+    Banner,
+    Button,
+    Card,
+    Column,
+    Modal,
+    Paragraph,
+    Row,
+    Table,
+    Text,
+} from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { TronStakeInfoRow } from 'src/components/earn/staking/tron/TronStakeInfoRow';
+import { useDispatch } from 'src/hooks/suite';
+
+import { TronVoteAllocationRow } from './TronVoteAllocationRow';
+
+interface TronVoteAllocationModalProps {
+    account: Account;
+    onClose: () => void;
+}
+
+export const TronVoteAllocationModal = ({ account, onClose }: TronVoteAllocationModalProps) => {
+    const dispatch = useDispatch();
+    const { stats } = useTronStakingStats();
+
+    const remainingVotes = getTronAvailableVotingPower(account);
+    const totalVotes = getTronTotalVotingPower(account);
+    const hasRemainingVotes = new BigNumber(remainingVotes).gt(0);
+    const votes = getTronVotes(account);
+    const hasVotes = votes.length > 0;
+
+    const goToVote = () => {
+        dispatch(
+            goto({
+                routeName: 'earn-tron-vote',
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
+        onClose();
+    };
+
+    return (
+        <Modal
+            width={600}
+            heading={<Translation id="TR_EARN_TRON_VOTE_ALLOCATION" />}
+            onCancel={onClose}
+        >
+            <Column gap={16} alignItems="stretch">
+                <Card type="contrast" paddingType="none">
+                    <TronStakeInfoRow
+                        label={<Translation id="TR_EARN_TRON_REMAINING_VOTES_LABEL" />}
+                    >
+                        <Text typographyStyle="body-md-strong">
+                            {remainingVotes}/{totalVotes}
+                        </Text>
+                    </TronStakeInfoRow>
+                </Card>
+
+                {hasRemainingVotes && (
+                    <Banner
+                        intent="info"
+                        icon
+                        description={<Translation id="TR_EARN_TRON_ASSIGN_VOTES_BANNER" />}
+                        rightContent={
+                            <Banner.Button onClick={goToVote}>
+                                <Translation id="TR_EARN_TRON_VOTE" />
+                            </Banner.Button>
+                        }
+                    />
+                )}
+
+                <Card paddingType="none">
+                    <Table>
+                        <Table.Header>
+                            <Table.Row>
+                                <Table.Cell>
+                                    <Translation id="TR_EARN_TRON_REPRESENTATIVE" />
+                                </Table.Cell>
+                                <Table.Cell>
+                                    <Translation id="TR_TRON_VOTES" />
+                                </Table.Cell>
+                                <Table.Cell>
+                                    <Translation id="TR_EARN_TRON_APR_LABEL" />
+                                </Table.Cell>
+                            </Table.Row>
+                        </Table.Header>
+                        <Table.Body>
+                            {hasVotes ? (
+                                votes.map(vote => (
+                                    <TronVoteAllocationRow
+                                        key={vote.address}
+                                        vote={vote}
+                                        representatives={stats.data}
+                                    />
+                                ))
+                            ) : (
+                                <Table.Row>
+                                    <Table.Cell colSpan={3} align="center">
+                                        <Paragraph
+                                            typographyStyle="body-sm"
+                                            intent="neutral"
+                                            priority="secondary"
+                                        >
+                                            <Translation id="TR_EARN_TRON_NO_VOTES" />
+                                        </Paragraph>
+                                    </Table.Cell>
+                                </Table.Row>
+                            )}
+                        </Table.Body>
+                    </Table>
+                </Card>
+
+                {hasVotes && (
+                    <Row>
+                        <Button intent="neutral" priority="secondary" onClick={goToVote}>
+                            <Translation id="TR_EARN_TRON_CHANGE_VOTES" />
+                        </Button>
+                    </Row>
+                )}
+            </Column>
+        </Modal>
+    );
+};

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVoteAllocationModal/TronVoteAllocationRow.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVoteAllocationModal/TronVoteAllocationRow.tsx
@@ -1,0 +1,22 @@
+import { type TrxStats } from '@suite-common/earn-staking-api';
+import { type TronVote } from '@trezor/blockchain-link-types';
+import { Table } from '@trezor/components';
+
+import { formatApr } from 'src/components/earn/staking/tron/voteUtils';
+
+interface TronVoteAllocationRowProps {
+    vote: TronVote;
+    representatives: TrxStats | undefined;
+}
+
+export const TronVoteAllocationRow = ({ vote, representatives }: TronVoteAllocationRowProps) => {
+    const representative = representatives?.find(({ address }) => address === vote.address);
+
+    return (
+        <Table.Row>
+            <Table.Cell>{representative?.name ?? vote.address}</Table.Cell>
+            <Table.Cell>{vote.voteCount}</Table.Cell>
+            <Table.Cell>{formatApr(representative?.apr)}</Table.Cell>
+        </Table.Row>
+    );
+};

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10503,6 +10503,30 @@ export const messages = defineMessages({
         id: 'TR_EARN_TRON_ASSIGN_VOTES_TOOLTIP',
         defaultMessage: 'Assign all votes to earn more rewards.',
     },
+    TR_EARN_TRON_VOTE_ALLOCATION: {
+        id: 'TR_EARN_TRON_VOTE_ALLOCATION',
+        defaultMessage: 'Vote allocation',
+    },
+    TR_EARN_TRON_CHANGE_VOTES: {
+        id: 'TR_EARN_TRON_CHANGE_VOTES',
+        defaultMessage: 'Change votes',
+    },
+    TR_EARN_TRON_REPRESENTATIVE: {
+        id: 'TR_EARN_TRON_REPRESENTATIVE',
+        defaultMessage: 'Representative',
+    },
+    TR_EARN_TRON_REMAINING_VOTES_LABEL: {
+        id: 'TR_EARN_TRON_REMAINING_VOTES_LABEL',
+        defaultMessage: 'Remaining votes',
+    },
+    TR_EARN_TRON_ASSIGN_VOTES_BANNER: {
+        id: 'TR_EARN_TRON_ASSIGN_VOTES_BANNER',
+        defaultMessage: 'Assign all of your votes to earn more rewards.',
+    },
+    TR_EARN_TRON_NO_VOTES: {
+        id: 'TR_EARN_TRON_NO_VOTES',
+        defaultMessage: 'You haven’t voted for any representatives yet.',
+    },
     TR_EARN_TRON_UNSTAKING: {
         id: 'TR_EARN_TRON_UNSTAKING',
         defaultMessage: 'Unstaking (~{days} days)',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Implements vote allocation modal shown by clicking on remaining votes on the staking dashboard


## Notes for QA



## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29051

## Screenshots:

<img width="610" height="315" alt="Screenshot 2026-07-01 at 15 26 20" src="https://github.com/user-attachments/assets/10e14514-9757-4f10-84ee-5ac8da81c86f" />
<img width="615" height="331" alt="Screenshot 2026-07-01 at 15 38 11" src="https://github.com/user-attachments/assets/e1d55c14-3a4c-4689-85bc-c2130d274eb1" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on Tron staking UI components (TronStakedCard, TronVoteAllocationModal, TronVoteAllocationRow) and the shared intl messages file. There are no E2E tests in the candidate suite that specifically cover Tron staking dashboard functionality — the existing staking tests cover ETH, ADA, and SOL but not TRX/Tron. The messages.ts file is a broad shared dependency used by virtually all tests, but without knowing the specific message keys changed, only tests that render Tron-related pages are concretely at risk. The check-links test is the only candidate that explicitly navigates to Tron staking routes. The Tron staking components represent a significant gap in E2E test coverage.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVoteAllocationModal/TronVoteAllocationModal.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVoteAllocationModal/TronVoteAllocationRow.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test crawls all application routes including /earn/tron, /earn/tron/stake, /earn/tron/vote, /earn/tron/unstake, /earn/tron/withdraw and validates that links return HTTP 200. Changes to TronStakedCard and TronVoteAllocationModal could affect the rendered links on Tron staking pages. The messages.ts change could also introduce broken or missing translation keys that affect link rendering.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVoteAllocationModal/TronVoteAllocationModal.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVoteAllocationModal/TronVoteAllocationRow.tsx`

_Updated: 2026-07-01T13:42:26.615Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-votes-allocation-modal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-votes-allocation-modal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T13:48:22.666Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T13:46:05.108Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-votes-allocation-modal/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-votes-allocation-modal/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->