### PR TITLE
fix(connect-examples): add crypto polyfill to expo mobile example

### DIFF
--- a/packages/connect-examples/mobile-expo/README.md
+++ b/packages/connect-examples/mobile-expo/README.md
@@ -9,3 +9,20 @@
 Will start the Expo app in Android emulator/device.
 
 You will also need to have the Trezor Suite app installed. Follow the instructions in [@suite-native/app](https://github.com/trezor/trezor-suite/blob/develop/suite-native/app/README.md) to run a dev version of the app.
+
+### Crypto polyfill
+
+React Native/Expo does not provide the Web Crypto API that `@trezor/connect-mobile` depends on (it uses `crypto.randomUUID`). The example polyfills it in [`index.js`](./index.js) before the app starts:
+
+- [`expo-standard-web-crypto`](https://www.npmjs.com/package/expo-standard-web-crypto) installs `crypto.getRandomValues`.
+- [`expo-crypto`](https://docs.expo.dev/versions/latest/sdk/crypto/) backs `crypto.randomUUID`, which the polyfill above does not cover.
+
+```js
+import { randomUUID } from 'expo-crypto';
+import { polyfillWebCrypto } from 'expo-standard-web-crypto';
+
+polyfillWebCrypto();
+if (typeof crypto !== 'undefined' && !crypto.randomUUID) {
+    crypto.randomUUID = randomUUID;
+}
+```

--- a/packages/connect-examples/mobile-expo/index.js
+++ b/packages/connect-examples/mobile-expo/index.js
@@ -1,5 +1,4 @@
 import { registerRootComponent } from 'expo';
-
 import { randomUUID } from 'expo-crypto';
 import { polyfillWebCrypto } from 'expo-standard-web-crypto';
 

--- a/packages/connect-examples/mobile-expo/index.js
+++ b/packages/connect-examples/mobile-expo/index.js
@@ -1,6 +1,17 @@
 import { registerRootComponent } from 'expo';
 
+import { randomUUID } from 'expo-crypto';
+import { polyfillWebCrypto } from 'expo-standard-web-crypto';
+
 import { App } from './App';
+
+// React Native/Expo does not ship the Web Crypto API that @trezor/connect-mobile
+// relies on. `polyfillWebCrypto` installs `crypto.getRandomValues`; `crypto.randomUUID`
+// (used by connect-mobile) is not covered, so we back it with expo-crypto.
+polyfillWebCrypto();
+if (typeof crypto !== 'undefined' && !crypto.randomUUID) {
+    crypto.randomUUID = randomUUID;
+}
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,

--- a/packages/connect-examples/mobile-expo/package.json
+++ b/packages/connect-examples/mobile-expo/package.json
@@ -12,7 +12,9 @@
     "dependencies": {
         "@trezor/connect-mobile": "workspace:*",
         "expo": "~56.0.6",
+        "expo-crypto": "~56.0.4",
         "expo-linking": "~56.0.12",
+        "expo-standard-web-crypto": "~56.0.3",
         "expo-status-bar": "~56.0.4",
         "react": "19.2.3",
         "react-native": "0.85.3"

--- a/packages/connect-explorer/src/pages/index.mdx
+++ b/packages/connect-explorer/src/pages/index.mdx
@@ -477,6 +477,26 @@ import IconWeb from '../components/icons/IconWeb';
                 yarn add @trezor/connect-mobile
                 ```
 
+                {<h3>Crypto polyfill</h3>}
+
+                React Native/Expo does not ship the Web Crypto API that `@trezor/connect-mobile` relies on (it uses `crypto.randomUUID`). Install the polyfill packages:
+
+                ```bash
+                npx expo install expo-crypto expo-standard-web-crypto
+                ```
+
+                Then apply the polyfill before your app starts (for example at the top of `index.js`). `expo-standard-web-crypto` installs `crypto.getRandomValues`, while `crypto.randomUUID` is backed by `expo-crypto`:
+
+                ```javascript
+                import { randomUUID } from 'expo-crypto';
+                import { polyfillWebCrypto } from 'expo-standard-web-crypto';
+
+                polyfillWebCrypto();
+                if (typeof crypto !== 'undefined' && !crypto.randomUUID) {
+                    crypto.randomUUID = randomUUID;
+                }
+                ```
+
                 {<h3>Initialization of the API</h3>}
 
                 ```javascript

--- a/scripts/list-outdated-dependencies/trade-dependencies.txt
+++ b/scripts/list-outdated-dependencies/trade-dependencies.txt
@@ -44,6 +44,7 @@ expo-mcp
 expo-secure-store
 expo-sharing
 expo-splash-screen
+expo-standard-web-crypto
 expo-status-bar
 expo-system-ui
 expo-store-review

--- a/yarn.lock
+++ b/yarn.lock
@@ -22962,7 +22962,9 @@ __metadata:
     "@trezor/connect-mobile": "workspace:*"
     "@types/react": "npm:19.2.14"
     expo: "npm:~56.0.6"
+    expo-crypto: "npm:~56.0.4"
     expo-linking: "npm:~56.0.12"
+    expo-standard-web-crypto: "npm:~56.0.3"
     expo-status-bar: "npm:~56.0.4"
     react: "npm:19.2.3"
     react-native: "npm:0.85.3"
@@ -27352,6 +27354,15 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10/9e3beef346093d47afb86f58c5343aa84183f0148fe88cb4bf595ca2c720034d66fee32320abbea125c4344e22abc57d7a2f745dcec88b346f321ecfa3b67527
+  languageName: node
+  linkType: hard
+
+"expo-standard-web-crypto@npm:~56.0.3":
+  version: 56.0.3
+  resolution: "expo-standard-web-crypto@npm:56.0.3"
+  peerDependencies:
+    expo-crypto: ^56.0.4
+  checksum: 10/7cee6d80754b08fcae1c169e53cc58604ebeacbee1c226dacc57b6fc0d14f05f228654dc0a17e20068c7f50d88919a296241031bf8f60575aac77b11ff4ba744
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

The Expo mobile example for `@trezor/connect-mobile` was missing a Web Crypto polyfill, which React Native/Expo does not provide but `@trezor/connect-mobile` requires (it uses `crypto.randomUUID`). This adds `expo-standard-web-crypto` (for `crypto.getRandomValues`) and `expo-crypto` (to back `crypto.randomUUID`, which the former does not cover) and wires the polyfill up in the example's `index.js` entry point before the app starts. The setup is now documented both in the example's README and in the Connect Explorer mobile tutorial (`connect-explorer/src/pages/index.mdx`).

## Notes for QA

Run the `mobile-expo` example (`cd packages/connect-examples/mobile-expo && yarn ios`) and confirm `TrezorConnect` operations (e.g. Get Address, Sign Message) work without a `crypto.randomUUID is not a function` error. 
Also verify the new "Crypto polyfill" step is explained in the Connect Explorer mobile Quick start manual.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are exclusively within `packages/connect-examples/mobile-expo/`, which is a standalone mobile Expo example app (index.js and package.json). These files are not part of the Trezor Suite application, its E2E test infrastructure, or any shared library consumed by the Suite. None of the 52 candidate E2E tests exercise mobile Expo example code, and there is no static or inferred connection between these changes and any test. The risk of regression to Suite functionality is effectively zero, and no E2E tests need to be run.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect-examples/mobile-expo/index.js`
- `packages/connect-examples/mobile-expo/package.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/connect-examples/mobile-expo/index.js`
- `packages/connect-examples/mobile-expo/package.json`

_Updated: 2026-07-01T16:02:11.167Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=expo-crypto-polyfill&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=expo-crypto-polyfill&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T16:07:25.008Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T16:05:09.847Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/expo-crypto-polyfill/web/](https://dev.suite.sldev.cz/suite-web/expo-crypto-polyfill/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->