### PR TITLE
Feat/request manager misbehaving error

### DIFF
--- a/packages/coinjoin/src/client/coordinatorRequest.ts
+++ b/packages/coinjoin/src/client/coordinatorRequest.ts
@@ -69,23 +69,7 @@ export const coordinatorRequest = async <R = void>(
             const method = options.method === 'GET' ? httpGet : httpPost;
             response = await method(requestUrl, body, { ...options, signal });
         } catch (e) {
-            // NOTE: this code probably belongs to @trezor/request-manager package since errors are tightly related to TOR
-            // catch errors from:
-            // - nodejs http module (by e.code) like "socket hang up" or "socket disconnected before secure TLS connection was established" (see ./node_modules/@types/node/*/http.d.ts)
-            // - socks module (by e.type and e.message) like "Socks5 proxy rejected connection" or "Proxy connection timed out" (see ./node_modules/socks/build/common/constants)
-            // native fetch (undici) wraps network failures as `TypeError: fetch failed` and exposes the
-            // underlying error (carrying `code`/`type`/`message`) on `e.cause`; node-fetch put them on `e`.
-            // A reset connection is `ECONNRESET` under node-fetch but `UND_ERR_SOCKET` ("other side
-            // closed") under undici; both should reset the TOR circuit and retry.
-            const err = e.cause ?? e;
-            const socksErrors = ['Socks5', 'Proxy'];
-            const shouldSwitchIdentity =
-                ('code' in err && (err.code === 'ECONNRESET' || err.code === 'UND_ERR_SOCKET')) ||
-                ('type' in err &&
-                    err.type === 'system' &&
-                    socksErrors.some(se => err.message.includes(se)));
-
-            if (shouldSwitchIdentity) {
+            if (e.message.includes('CIRCUIT_MISBEHAVING')) {
                 switchIdentity();
             } else if (options.deadline) {
                 // prevent dead cycles while using "deadline" option in scheduledAction

--- a/packages/connect/src/device/checkFirmwareRevision.ts
+++ b/packages/connect/src/device/checkFirmwareRevision.ts
@@ -22,7 +22,7 @@ const NODEJS_NETWORK_ERROR_CODES = [
     'EAI_AGAIN',
     'ENETUNREACH',
     'EHOSTUNREACH',
-    'ETIMEDOUT',
+    'ETIMEDOUT', // TODO CIRCUIT_MISBEHAVING error.message
 ];
 
 // Native `fetch` (undici) reports connectivity failures as `TypeError: fetch failed` and attaches

--- a/packages/request-manager/e2e/interceptor.test.ts
+++ b/packages/request-manager/e2e/interceptor.test.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import nodeFetch from 'node-fetch';
 import path from 'path';
 import WebSocket from 'ws';
 
@@ -33,6 +34,13 @@ describe('Interceptor', () => {
     let torIdentities: TorIdentities;
 
     const torSettings = { running: true, host: hostIp, port };
+    const fetchImplementations = [
+        ['global.fetch', (...args: Parameters<typeof fetch>) => fetch(...args)],
+        ['node-fetch', nodeFetch],
+    ] as const;
+
+    const extractIp = async (response: { text: () => Promise<string> }) =>
+        (await response.text()).match(ipRegex)?.[0];
 
     const interceptorOptions: InterceptorOptions = {
         getWhitelistedDomains: () => [
@@ -81,58 +89,61 @@ describe('Interceptor', () => {
     // guarantee that the IPs of 2 different Tor circuits are different. And this is
     // part of the Tor nature.
     conditionalTest('Check if IPs are different', () => {
-        it('HTTP GET - Each identity has different ip address', async () => {
-            const identityDefault = await fetch(testGetUrlHttp, {
-                headers: { 'proxy-authorization': 'Basic default' },
-            });
-            const identityDefault2 = await fetch(testGetUrlHttp, {
-                headers: { 'Proxy-Authorization': 'Basic user' },
-            });
-            const iPIdentitieA = ((await identityDefault.text()) as any).match(ipRegex)[0];
-
-            const iPIdentitieB = ((await identityDefault2.text()) as any).match(ipRegex)[0];
-            expect(iPIdentitieA).not.toEqual(iPIdentitieB);
-        });
-
-        it('HTTPS GET - Each identity has different ip address', async () => {
-            const identityA = await fetch(testGetUrlHttps, {
-                headers: { 'proxy-authorization': 'Basic default' },
-            });
-            const identityB = await fetch(testGetUrlHttps, {
-                headers: { 'Proxy-Authorization': 'Basic user' },
-            });
-            // Parsing IP address from html provided by check.torproject.org.
-            const iPIdentitieA = ((await identityA.text()) as any).match(ipRegex)[0];
-            const iPIdentitieB = ((await identityB.text()) as any).match(ipRegex)[0];
-            // Check if identities are different when using different identity.
-            expect(iPIdentitieA).not.toEqual(iPIdentitieB);
-
-            // reset existing circuit using identity with password
-            const identityB2 = await fetch(testGetUrlHttps, {
-                headers: { 'Proxy-Authorization': 'Basic user:password' },
-            });
-            const iPIdentitieB2 = ((await identityB2.text()) as any).match(ipRegex)[0];
-            // ip for "user" did change
-            expect(iPIdentitieB2).not.toEqual(iPIdentitieB);
-        });
-
-        it('HTTPS POST - Each identity has different ip address', async () => {
-            const identityA = await fetch(testPostUrlHttps, {
+        const testCases = [
+            {
+                name: 'HTTP GET',
+                url: testGetUrlHttp,
+                method: 'GET',
+                body: undefined,
+            },
+            {
+                name: 'HTTPS GET',
+                url: testGetUrlHttps,
+                method: 'GET',
+                body: undefined,
+            },
+            {
+                name: 'HTTPS POST',
+                url: testPostUrlHttps,
                 method: 'POST',
                 body: JSON.stringify({ test: 'test' }),
-                headers: { 'proxy-authorization': 'Basic default' },
-            });
-            const identityB = await fetch(testPostUrlHttps, {
-                method: 'POST',
-                body: JSON.stringify({ test: 'test' }),
-                headers: { 'Proxy-Authorization': 'Basic user' },
-            });
+            },
+        ];
 
-            const iPIdentitieA = ((await identityA.json()) as any).origin;
-            const iPIdentitieB = ((await identityB.json()) as any).origin;
+        describe.each(fetchImplementations)('%s', (_, fetchFn) => {
+            it.each(testCases)(
+                '$name - Each identity has different ip address',
+                async ({ url, method, body }) => {
+                    const identityA = await fetchFn(url, {
+                        method,
+                        body,
+                        headers: { 'proxy-authorization': 'Basic default' },
+                    });
+                    const identityB = await fetchFn(url, {
+                        method,
+                        body,
+                        headers: { 'Proxy-Authorization': 'Basic user' },
+                    });
 
-            // Check if identities are different when using different identity.
-            expect(iPIdentitieA).not.toEqual(iPIdentitieB);
+                    const ipA = await extractIp(identityA);
+                    const ipB = await extractIp(identityB);
+
+                    expect(ipA).not.toEqual(ipB);
+                },
+            );
+
+            it(`Reset identity by changing password`, async () => {
+                const identityA = await fetchFn(testGetUrlHttps, {
+                    headers: { 'Proxy-Authorization': 'Basic user' },
+                });
+                // Reset existing circuit by changing password
+                const identityB = await fetchFn(testGetUrlHttps, {
+                    headers: { 'Proxy-Authorization': 'Basic user:password' },
+                });
+                const ipB = await extractIp(identityA);
+                const ipB2 = await extractIp(identityB);
+                expect(ipB2).not.toEqual(ipB);
+            });
         });
     });
 
@@ -180,12 +191,12 @@ describe('Interceptor', () => {
     });
 
     conditionalTest('TorControl', () => {
-        it('closing circuits', async () => {
-            await fetch(testGetUrlHttps, {
+        it.each(fetchImplementations)('%s closing circuits', async (_label, fetchFn) => {
+            await fetchFn(testGetUrlHttps, {
                 headers: { 'Proxy-Authorization': 'Basic user-circuit-1' },
             });
 
-            await fetch(testGetUrlHttps, {
+            await fetchFn(testGetUrlHttps, {
                 headers: { 'Proxy-Authorization': 'Basic user-circuit-2' },
             });
 
@@ -250,87 +261,85 @@ describe('Interceptor', () => {
 
         afterAll(() => new Promise(resolve => serverInit.server.close(resolve)));
 
-        const fetchHeaders = (url: string, options: RequestInit) =>
-            fetch(url, options).then(r => r.json());
+        const fetchHeaders = (pr: Promise<any>) => pr.then(r => r.json());
 
-        it('POST request headers', async () => {
-            const { serverUrl, host } = serverInit;
-
-            // default headers
-            await expect(
-                fetchHeaders(serverUrl, {
-                    method: 'POST',
-                    body: JSON.stringify({ test: 'test' }),
-                    headers: { 'User-Agent': 'TrezorSuite' },
-                }),
-            ).resolves.toEqual(
-                expect.objectContaining({
-                    host,
+        const headerTestCases = [
+            {
+                method: 'POST',
+                body: JSON.stringify({ test: 'test' }),
+                defaultHeaders: { 'User-Agent': 'TrezorSuite' },
+                expectedDefault: {
                     accept: '*/*',
                     'content-length': '15',
                     'content-type': 'text/plain;charset=UTF-8',
                     'user-agent': 'TrezorSuite',
-                }),
-            );
-
-            // restricted headers
-            await expect(
-                fetchHeaders(serverUrl, {
-                    method: 'POST',
-                    body: JSON.stringify({ test: 'test' }),
-                    headers: {
-                        'User-Agent': 'TrezorSuite',
-                        'Allowed-Headers': 'AcCePt-EnCoDiNg;content-type;Content-Length;HOST', // case insensitive
-                    },
-                }),
-            ).resolves.toEqual(
-                expect.objectContaining({
-                    host,
+                },
+                allowedHeaders: 'AcCePt-EnCoDiNg;content-type;Content-Length;HOST', // case insensitive
+                expectedRestricted: {
                     'content-length': '15',
                     'content-type': 'text/plain;charset=UTF-8',
-                }),
-            );
-        });
-
-        it('GET request headers', async () => {
-            const { serverUrl, host } = serverInit;
-
-            // default headers
-            await expect(
-                fetchHeaders(serverUrl, {
-                    method: 'GET',
-                    headers: { 'User-Agent': 'TrezorSuite' },
-                }),
-            ).resolves.toEqual(
-                expect.objectContaining({
-                    host,
+                },
+            },
+            {
+                method: 'GET',
+                body: undefined,
+                defaultHeaders: { 'User-Agent': 'TrezorSuite' },
+                expectedDefault: {
                     accept: '*/*',
                     'user-agent': 'TrezorSuite',
-                }),
-            );
+                },
+                allowedHeaders: 'Accept-Encoding;Content-Type;Content-Length;Host',
+                expectedRestricted: {},
+            },
+        ];
 
-            // restricted headers
-            await expect(
-                fetchHeaders(serverUrl, {
-                    method: 'GET',
-                    headers: {
-                        'User-Agent': 'TrezorSuite',
-                        'Allowed-Headers': 'Accept-Encoding;Content-Type;Content-Length;Host',
-                    },
-                }),
-            ).resolves.toEqual(
-                expect.objectContaining({
-                    host,
-                }),
+        describe.each(fetchImplementations)('%s', (_, fetchFn) => {
+            it.each(headerTestCases)(
+                '$method request headers',
+                async ({
+                    method,
+                    body,
+                    defaultHeaders,
+                    expectedDefault,
+                    allowedHeaders,
+                    expectedRestricted,
+                }) => {
+                    const { serverUrl, host } = serverInit;
+
+                    // default headers
+                    await expect(
+                        fetchHeaders(
+                            fetchFn(serverUrl, {
+                                method,
+                                body,
+                                headers: defaultHeaders,
+                            }),
+                        ),
+                    ).resolves.toEqual(expect.objectContaining({ host, ...expectedDefault }));
+
+                    // restricted headers
+                    await expect(
+                        fetchHeaders(
+                            fetchFn(serverUrl, {
+                                method,
+                                body,
+                                headers: {
+                                    ...defaultHeaders,
+                                    'Allowed-Headers': allowedHeaders,
+                                },
+                            }),
+                        ),
+                    ).resolves.toEqual(expect.objectContaining({ host, ...expectedRestricted }));
+                },
             );
         });
     });
 
-    it('Block unauthorized requests', async () => {
+    it.each(fetchImplementations)('%s Block unauthorized requests', async (_, fetchFn) => {
         torSettings.running = false;
 
         await expect(
-            fetch(testPostUrlHttps, {
+            fetchFn(testPostUrlHttps, {
                 method: 'POST',
                 body: JSON.stringify({ test: 'test' }),
                 headers: { 'Proxy-Authorization': 'Basic default' },

--- a/packages/request-manager/e2e/interceptor.test.ts
+++ b/packages/request-manager/e2e/interceptor.test.ts
@@ -50,7 +50,12 @@ describe('Interceptor', () => {
             'localhost',
             '127.0.0.1',
         ],
-        handler: () => {},
+        handler: async event => {
+            if (event.type === 'CIRCUIT_MISBEHAVING') {
+                console.log(`Circuit "${event.identity}" is misbehaving`);
+                await torController.controlPort.closeActiveCircuits();
+            }
+        },
         getTorSettings: () => torSettings,
     };
 

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -17,12 +17,13 @@
     "dependencies": {
         "@trezor/node-utils": "workspace:^",
         "@trezor/utils": "workspace:*",
-        "node-fetch": "^3.3.2",
         "socks-proxy-agent": "8.0.5",
+        "undici": "8.5.0",
         "ws": "^8.20.0"
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
+        "node-fetch": "^3.3.2",
         "tsx": "^4.21.0"
     }
 }

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -6,9 +6,9 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "scripts": {
-        "test:all": "SKIP_FLAKY_TESTS=1 yarn g:jest",
-        "test:unit": "yarn g:jest --testPathIgnorePatterns e2e",
-        "test:e2e": "yarn g:jest --runInBand --testPathIgnorePatterns tests",
+        "test:all": "SKIP_FLAKY_TESTS=1 yarn g:jest --verbose",
+        "test:unit": "yarn g:jest --verbose --testPathIgnorePatterns e2e",
+        "test:e2e": "yarn g:jest --verbose --runInBand --testPathIgnorePatterns tests",
         "type-check": "yarn g:tsc --build tsconfig.json",
         "test:stress": "tsx ./e2e/identities-stress.ts",
         "depcheck": "yarn g:depcheck",

--- a/packages/request-manager/src/httpPool.ts
+++ b/packages/request-manager/src/httpPool.ts
@@ -1,6 +1,6 @@
 import type http from 'http';
 
-import { isCircuitMisbehaving } from './isCircuitMisbehaving';
+import { CircuitMisbehavingError, isCircuitMisbehaving } from './isCircuitMisbehaving';
 import { type InterceptorOptions } from './types';
 
 export const createRequestPool = (interceptorOptions: InterceptorOptions) => {
@@ -28,19 +28,39 @@ export const createRequestPool = (interceptorOptions: InterceptorOptions) => {
             });
         });
 
-        request.on('error', (error: Error) => {
-            if (isCircuitMisbehaving(error)) {
+        // Override `emit` so that when an 'error' event fires, all listeners
+        // (including consumer ones) receive a typed CircuitMisbehavingError
+        // instead of the raw network error.
+        const originalEmit = request.emit.bind(request);
+        request.emit = (event: string, ...args: unknown[]) => {
+            if (event === 'error' && isCircuitMisbehaving(args[0])) {
                 interceptorOptions.handler({
                     type: 'CIRCUIT_MISBEHAVING',
                     identity: identity?.split(':')[0],
                 });
-            } else {
+
+                return originalEmit(
+                    'error',
+                    new CircuitMisbehavingError(
+                        {
+                            host: host ?? 'unknown',
+                            identity: identity?.split(':')[0],
+                            method: 'http',
+                        },
+                        args[0],
+                    ),
+                );
+            }
+
+            if (event === 'error') {
                 interceptorOptions.handler({
                     type: 'ERROR',
-                    error,
+                    error: args[0] as Error,
                 });
             }
-        });
+
+            return originalEmit(event, ...args);
+        };
 
         return request;
     };

--- a/packages/request-manager/src/httpPool.ts
+++ b/packages/request-manager/src/httpPool.ts
@@ -1,5 +1,6 @@
 import type http from 'http';
 
+import { isCircuitMisbehaving } from './isCircuitMisbehaving';
 import { type InterceptorOptions } from './types';
 
 export const createRequestPool = (interceptorOptions: InterceptorOptions) => {
@@ -28,13 +29,7 @@ export const createRequestPool = (interceptorOptions: InterceptorOptions) => {
         });
 
         request.on('error', (error: Error) => {
-            // catch network errors from:
-            // - nodejs http module (using error.code field) examples: "socket hang up" or "socket disconnected before secure TLS connection was established"
-            //   see ./node_modules/@types/node/*/http.d.ts
-            // - SocksClientError (using error.options field) thrown by 'socks' package (dependency of socks-proxy-agent)
-            //   see https://github.com/JoshGlazebrook/socks/blob/76d013e4c9a2d956f07868477d8f12ec0b96edfc/src/common/util.ts
-            //   see https://github.com/JoshGlazebrook/socks/blob/76d013e4c9a2d956f07868477d8f12ec0b96edfc/src/common/constants.ts
-            if (('code' in error && error.code === 'ECONNRESET') || 'options' in error) {
+            if (isCircuitMisbehaving(error)) {
                 interceptorOptions.handler({
                     type: 'CIRCUIT_MISBEHAVING',
                     identity: identity?.split(':')[0],

--- a/packages/request-manager/src/index.ts
+++ b/packages/request-manager/src/index.ts
@@ -1,6 +1,8 @@
 export { TorController } from './controller';
 export { TorControllerExternal } from './controllerExternal';
 export { createInterceptor } from './interceptor';
+export { isCircuitMisbehaving, CircuitMisbehavingError } from './isCircuitMisbehaving';
+export type { CircuitMisbehavingDetails } from './isCircuitMisbehaving';
 export type { InterceptedEvent, BootstrapEvent, TorControllerStatus } from './types';
 export { TOR_CONTROLLER_STATUS } from './types';
 export { TorIdentities } from './torIdentities';

--- a/packages/request-manager/src/interceptor/fetchHeaders.ts
+++ b/packages/request-manager/src/interceptor/fetchHeaders.ts
@@ -1,0 +1,50 @@
+const getHeaderEntries = (headers?: HeadersInit): [string, string][] => {
+    if (!headers) {
+        return [];
+    }
+
+    return [...new Headers(headers).entries()];
+};
+
+export const getHeaderValue = (headers: HeadersInit | undefined, name: string) => {
+    if (!headers) {
+        return undefined;
+    }
+
+    return new Headers(headers).get(name) ?? undefined;
+};
+
+// Internal control headers that must never reach the destination server, regardless of the
+// allow-list: `Proxy-Authorization` carries the Tor identity credentials and `Allowed-Headers` is
+// our own routing-control header.
+const internalControlHeaders = ['proxy-authorization', 'allowed-headers'];
+
+const isInternalControlHeader = (key: string) => internalControlHeaders.includes(key.toLowerCase());
+
+const isHeaderAllowed = (key: string, allowedHeadersValue: string) => {
+    const allowedKeys = allowedHeadersValue.split(';');
+    const normalizedKey = key.toLowerCase();
+
+    // Prefix match, case-insensitive - same semantics as the original socket-level stripping. Uses
+    // `startsWith` rather than a `RegExp` so allow-list values containing regex metacharacters are
+    // matched literally.
+    return allowedKeys.some(allowed => normalizedKey.startsWith(allowed.toLowerCase()));
+};
+
+// Builds the headers sent through the Tor SOCKS5 dispatcher. Internal control headers are always
+// stripped first so they can never leak. When `Allowed-Headers` is present only the allow-listed
+// headers are then kept; otherwise all remaining headers are forwarded.
+export const buildTorHeaders = (headers?: HeadersInit): Record<string, string> => {
+    const entries = getHeaderEntries(headers);
+
+    const allowedHeadersValue = getHeaderValue(headers, 'Allowed-Headers');
+
+    const withoutControlHeaders = entries.filter(([key]) => !isInternalControlHeader(key));
+
+    const filtered =
+        allowedHeadersValue !== undefined
+            ? withoutControlHeaders.filter(([key]) => isHeaderAllowed(key, allowedHeadersValue))
+            : withoutControlHeaders;
+
+    return Object.fromEntries(filtered);
+};

--- a/packages/request-manager/src/interceptor/fetchPool.ts
+++ b/packages/request-manager/src/interceptor/fetchPool.ts
@@ -1,4 +1,4 @@
-import { isCircuitMisbehaving } from '../isCircuitMisbehaving';
+import { CircuitMisbehavingError, isCircuitMisbehaving } from '../isCircuitMisbehaving';
 import { type InterceptorContext } from './interceptorTypes';
 
 const requestTimeoutLimit = 1000 * 30;
@@ -47,6 +47,11 @@ export const monitorFetch = <T extends { status: number }>({
                     type: 'CIRCUIT_MISBEHAVING',
                     identity: username,
                 });
+
+                throw new CircuitMisbehavingError(
+                    { host, identity: username, method: 'fetch' },
+                    error,
+                );
             } else {
                 context.handler({
                     type: 'ERROR',

--- a/packages/request-manager/src/interceptor/fetchPool.ts
+++ b/packages/request-manager/src/interceptor/fetchPool.ts
@@ -1,3 +1,4 @@
+import { isCircuitMisbehaving } from '../isCircuitMisbehaving';
 import { type InterceptorContext } from './interceptorTypes';
 
 const requestTimeoutLimit = 1000 * 30;
@@ -5,7 +6,7 @@ const requestTimeoutLimit = 1000 * 30;
 type MonitorFetchParams<T extends { status: number }> = {
     context: InterceptorContext;
     host: string;
-    identity?: string;
+    identity: string;
     request: Promise<T>;
 };
 
@@ -40,24 +41,11 @@ export const monitorFetch = <T extends { status: number }>({
             return response;
         },
         (error: Error) => {
-            // undici wraps connection failures in a generic error and exposes the underlying cause
-            // on the `cause` field, so we inspect both. A SocksClientError thrown by the 'socks'
-            // package carries an `options` field, while socket resets surface as 'ECONNRESET'; both
-            // indicate a misbehaving Tor circuit.
-            const cause = 'cause' in error ? (error.cause as unknown) : undefined;
-
-            const isCircuitMisbehaving = [error, cause].some(
-                candidate =>
-                    typeof candidate === 'object' &&
-                    candidate !== null &&
-                    (('code' in candidate && candidate.code === 'ECONNRESET') ||
-                        'options' in candidate),
-            );
-
-            if (isCircuitMisbehaving) {
+            if (isCircuitMisbehaving(error)) {
+                const [username] = identity.split(':');
                 context.handler({
                     type: 'CIRCUIT_MISBEHAVING',
-                    identity: identity?.split(':')[0],
+                    identity: username,
                 });
             } else {
                 context.handler({

--- a/packages/request-manager/src/interceptor/fetchPool.ts
+++ b/packages/request-manager/src/interceptor/fetchPool.ts
@@ -1,0 +1,72 @@
+import { type InterceptorContext } from './interceptorTypes';
+
+const requestTimeoutLimit = 1000 * 30;
+
+type MonitorFetchParams<T extends { status: number }> = {
+    context: InterceptorContext;
+    host: string;
+    identity?: string;
+    request: Promise<T>;
+};
+
+// Reports timing and error events for a fetch routed through undici. This mirrors the monitoring
+// that `httpPool` attaches to `http.ClientRequest`, which undici does not go through.
+export const monitorFetch = <T extends { status: number }>({
+    context,
+    host,
+    identity,
+    request,
+}: MonitorFetchParams<T>): Promise<T> => {
+    const requestTime = Date.now();
+
+    return request.then(
+        response => {
+            const timeRequestTook = Date.now() - requestTime;
+
+            const isNetworkMisbehaving = timeRequestTook > requestTimeoutLimit;
+            if (isNetworkMisbehaving) {
+                context.handler({
+                    type: 'NETWORK_MISBEHAVING',
+                });
+            }
+
+            context.handler({
+                type: 'INTERCEPTED_RESPONSE',
+                host,
+                time: timeRequestTook,
+                statusCode: response.status,
+            });
+
+            return response;
+        },
+        (error: Error) => {
+            // undici wraps connection failures in a generic error and exposes the underlying cause
+            // on the `cause` field, so we inspect both. A SocksClientError thrown by the 'socks'
+            // package carries an `options` field, while socket resets surface as 'ECONNRESET'; both
+            // indicate a misbehaving Tor circuit.
+            const cause = 'cause' in error ? (error.cause as unknown) : undefined;
+
+            const isCircuitMisbehaving = [error, cause].some(
+                candidate =>
+                    typeof candidate === 'object' &&
+                    candidate !== null &&
+                    (('code' in candidate && candidate.code === 'ECONNRESET') ||
+                        'options' in candidate),
+            );
+
+            if (isCircuitMisbehaving) {
+                context.handler({
+                    type: 'CIRCUIT_MISBEHAVING',
+                    identity: identity?.split(':')[0],
+                });
+            } else {
+                context.handler({
+                    type: 'ERROR',
+                    error,
+                });
+            }
+
+            throw error;
+        },
+    );
+};

--- a/packages/request-manager/src/interceptor/interceptFetch.ts
+++ b/packages/request-manager/src/interceptor/interceptFetch.ts
@@ -1,44 +1,89 @@
-// TODO: Nodejs fetch APIs use undici which is based on totally different design,
-// proxy-agent package is not compatible with undici, and can only be used with
-// old API like http.request.
-// See issue: https://github.com/TooTallNate/proxy-agents/issues/239 .
-import type { RequestOptions } from 'https';
-import nodeFetch, { type RequestInit } from 'node-fetch';
+// Node's global `fetch` is backed by undici, which - unlike the legacy `http`/`https` modules - does
+// not go through this package's `http.request` interception.
+// Using native nodejs undici's `Socks5ProxyAgent` to route Tor traffic.
+// https://github.com/nodejs/undici/blob/main/docs/docs/api/Socks5ProxyAgent.md
+import { fetch as undiciFetch } from 'undici';
 
+import { isWhitelistedHost } from '@trezor/utils';
+
+import { buildTorHeaders, getHeaderValue } from './fetchHeaders';
+import { monitorFetch } from './fetchPool';
 import { type Interceptor } from './interceptorTypes';
-import { getIsTorRequired } from './overloadHttpRequest';
+import { getIdentityName } from './overloadHttpRequest';
+
+const resolveHostname = (url: RequestInfo | URL) => {
+    if (typeof url === 'object' && 'hostname' in url) {
+        // case url type of URL
+        return url.hostname;
+    }
+    if (typeof url === 'object' && 'url' in url) {
+        // case url type of globalThis.Request
+        return new URL(url.url).hostname;
+    }
+    if (typeof url === 'string') {
+        // case url type of string
+        return new URL(url).hostname;
+    }
+
+    return 'unknown';
+};
 
 export const interceptFetch: Interceptor = ({ context, validateRequest }) => {
     const originalFetch = global.fetch;
 
-    global.fetch = (url, options): Promise<Response> => {
+    global.fetch = (url, options) => {
         const isTorEnabled = context.getTorSettings().running;
-        const isTorRequired = getIsTorRequired(options as Readonly<RequestOptions>);
+        const proxyAuthorization = getHeaderValue(options?.headers, 'Proxy-Authorization');
+        const isTorRequired = proxyAuthorization !== undefined;
 
-        if (isTorEnabled) {
-            return nodeFetch(url as string, options as RequestInit) as Promise<any>;
-        }
-
-        if (isTorRequired && !context.allowTorBypass) {
+        if (isTorRequired && !isTorEnabled && !context.allowTorBypass) {
             return Promise.reject(
                 new Error('Blocked request with Proxy-Authorization. TOR not enabled.'),
             );
         }
 
-        let hostname = 'unknown';
-        if (typeof url === 'object' && 'hostname' in url) {
-            // case url type of URL
-            hostname = url.hostname;
-        } else if (typeof url === 'object' && 'url' in url) {
-            // case url type of globalThis.Request
-            hostname = url.url;
-        } else if (typeof url === 'string') {
-            // case url type of string
-            hostname = new URL(url).hostname;
+        const hostname = resolveHostname(url);
+        try {
+            validateRequest({ hostname });
+        } catch (error) {
+            return Promise.reject(error);
         }
 
-        validateRequest({ hostname });
+        // Hosts that don't require Tor (e.g. localhost, dev domains) connect directly, matching the
+        // behavior of the http(s) interceptor in `overloadHttpRequest`.
+        if (!isTorEnabled || isWhitelistedHost(hostname, context.notRequiredTorDomainsList)) {
+            return originalFetch(url, options);
+        }
 
-        return originalFetch(url, options);
+        // Use the Proxy-Authorization header to select the Tor circuit, falling back to 'default'.
+        const identity = getIdentityName(proxyAuthorization) || 'default';
+        const dispatcher = context.torIdentities.getDispatcher(identity);
+        const headers = buildTorHeaders(options?.headers);
+
+        context.handler({
+            type: 'INTERCEPTED_REQUEST',
+            method: 'fetch',
+            details: `${hostname} with identity ${identity}`,
+        });
+
+        // The type mismatch is a TypeScript artifact:
+        // the compiler sees lib.dom.Request/Response as different from undici.Request even though at runtime in Node.js they're the same class.
+        const request = undiciFetch(
+            ...([
+                url,
+                {
+                    ...options,
+                    headers,
+                    dispatcher,
+                },
+            ] as Parameters<typeof undiciFetch>),
+        );
+
+        return monitorFetch({
+            context,
+            host: hostname,
+            identity,
+            request,
+        }) as unknown as Promise<Response>;
     };
 };

--- a/packages/request-manager/src/interceptor/interceptNetSocketConnect.ts
+++ b/packages/request-manager/src/interceptor/interceptNetSocketConnect.ts
@@ -9,6 +9,8 @@ export const interceptNetSocketConnect: Interceptor = ({ context, validateReques
     //    https://github.com/nodejs/node/blob/e48763840625c037282681456ecd1e1cb034f636/lib/_http_outgoing.js#L508-L510
     // 2. node-fetch always(!) adds "User-Agent", "Accept", "Connection"...
     //    https://github.com/node-fetch/node-fetch/blob/7b86e946b02dfdd28f4f8fca3d73a022cbb5ca1e/src/request.js#L226
+    // This socket-level stripping applies to the legacy http(s) module path. Global `fetch` now goes
+    // through undici (see `interceptFetch`), which filters "Allowed-Headers" at the options level.
     const originalSocketWrite = net.Socket.prototype.write;
 
     net.Socket.prototype.write = function (data, ...args) {

--- a/packages/request-manager/src/interceptor/interceptWebSocket.ts
+++ b/packages/request-manager/src/interceptor/interceptWebSocket.ts
@@ -3,6 +3,7 @@
 // See issue: https://github.com/TooTallNate/proxy-agents/issues/239
 import WebSocketNode from 'ws';
 
+import { isCircuitMisbehaving } from '../isCircuitMisbehaving';
 import { type Interceptor } from './interceptorTypes';
 
 export const interceptWebSocket: Interceptor = ({ context, validateRequest }) => {
@@ -20,13 +21,20 @@ export const interceptWebSocket: Interceptor = ({ context, validateRequest }) =>
             validateRequest({ hostname });
 
             if (context.getTorSettings().running) {
-                const agent = context.torIdentities.getIdentity(
-                    `WebSocket/${hostname}`,
-                    undefined,
-                    'https',
-                );
+                const identity = `WebSocket/${hostname}`;
+                const agent = context.torIdentities.getIdentity(identity, undefined, 'https');
 
-                return new WebSocketNode(urlString, protocols, { agent });
+                const ws = new WebSocketNode(urlString, protocols, { agent });
+                ws.on('error', (error: Error) => {
+                    if (isCircuitMisbehaving(error)) {
+                        context.handler({
+                            type: 'CIRCUIT_MISBEHAVING',
+                            identity,
+                        });
+                    }
+                });
+
+                return ws;
             }
 
             return new OriginalWebSocket(url, protocols);

--- a/packages/request-manager/src/interceptor/overloadHttpRequest.ts
+++ b/packages/request-manager/src/interceptor/overloadHttpRequest.ts
@@ -19,7 +19,7 @@ const getHeaderValue = (headers: http.OutgoingHttpHeaders | undefined, name: str
     return { key, value };
 };
 
-const getIdentityName = (proxyAuthorization?: http.OutgoingHttpHeader) => {
+export const getIdentityName = (proxyAuthorization?: http.OutgoingHttpHeader) => {
     const identity = Array.isArray(proxyAuthorization) ? proxyAuthorization[0] : proxyAuthorization;
 
     // Only return identity name if it is explicitly defined.

--- a/packages/request-manager/src/isCircuitMisbehaving.ts
+++ b/packages/request-manager/src/isCircuitMisbehaving.ts
@@ -42,3 +42,24 @@ export const isCircuitMisbehaving = (error: unknown): boolean => {
 
     return false;
 };
+
+export type CircuitMisbehavingDetails = {
+    host: string;
+    identity?: string;
+    method: 'http' | 'fetch';
+};
+
+export class CircuitMisbehavingError extends Error {
+    readonly host: string;
+    readonly identity?: string;
+    readonly method: 'http' | 'fetch';
+
+    constructor(details: CircuitMisbehavingDetails, cause: unknown) {
+        super('CIRCUIT_MISBEHAVING', { cause });
+        this.name = 'CircuitMisbehavingError';
+        this.host = details.host;
+        this.identity = details.identity;
+        this.method = details.method;
+        this.cause = cause;
+    }
+}

--- a/packages/request-manager/src/isCircuitMisbehaving.ts
+++ b/packages/request-manager/src/isCircuitMisbehaving.ts
@@ -1,0 +1,44 @@
+// Detects whether an error indicates a misbehaving Tor circuit that should be rotated.
+// Covers errors from:
+// - Node.js http module: ECONNRESET, ETIMEDOUT
+//    see ./node_modules/@types/node/*/http.d.ts
+// - undici (native fetch): UND_ERR_SOCKET ("other side closed")
+// - socks package (SocksClientError): carries an `options` field
+//    see https://github.com/JoshGlazebrook/socks/blob/76d013e4c9a2d956f07868477d8f12ec0b96edfc/src/common/util.ts
+//    see https://github.com/JoshGlazebrook/socks/blob/76d013e4c9a2d956f07868477d8f12ec0b96edfc/src/common/constants.ts
+// - socks system errors: type === 'system' with messages containing "socks" or "proxy" (case-insensitive)
+export const isCircuitMisbehaving = (error: unknown): boolean => {
+    if (typeof error !== 'object' || error === null) {
+        return false;
+    }
+
+    if (
+        'code' in error &&
+        typeof error.code === 'string' &&
+        ['ECONNRESET', 'UND_ERR_SOCKET', 'ETIMEDOUT'].includes(error.code)
+    ) {
+        return true;
+    }
+
+    if ('options' in error) {
+        return true;
+    }
+
+    const socksErrors = /socks|proxy/i;
+    if (
+        'type' in error &&
+        error.type === 'system' &&
+        'message' in error &&
+        typeof error.message === 'string' &&
+        socksErrors.test(error.message)
+    ) {
+        return true;
+    }
+
+    // undici/native fetch wraps the underlying error in `cause`
+    if ('cause' in error) {
+        return isCircuitMisbehaving(error.cause);
+    }
+
+    return false;
+};

--- a/packages/request-manager/src/torIdentities.ts
+++ b/packages/request-manager/src/torIdentities.ts
@@ -1,16 +1,64 @@
 import { SocksProxyAgent } from 'socks-proxy-agent';
+import { Socks5ProxyAgent } from 'undici';
 
 import type { TorSettings } from './types';
+
+// undici's Socks5ProxyAgent emits a one-time `ExperimentalWarning` from its constructor. We swallow
+// only that specific warning (leaving every other warning untouched) so it doesn't pollute logs.
+const createSocks5ProxyAgent = (proxyUrl: URL) => {
+    const originalEmitWarning = process.emitWarning;
+
+    process.emitWarning = (...args) => {
+        const [warning, options] = args;
+        const type = typeof options === 'string' ? options : (options as { type?: string })?.type;
+
+        if (
+            type === 'ExperimentalWarning' &&
+            String(warning).includes('SOCKS5 proxy support is experimental')
+        ) {
+            return;
+        }
+
+        return originalEmitWarning(...(args as Parameters<typeof process.emitWarning>));
+    };
+
+    try {
+        return new Socks5ProxyAgent(proxyUrl);
+    } finally {
+        process.emitWarning = originalEmitWarning;
+    }
+};
 
 export class TorIdentities {
     private readonly getTorSettings: () => TorSettings;
     private readonly identities: { [key: string]: SocksProxyAgent };
+    private readonly dispatchers: { [key: string]: Socks5ProxyAgent };
     private readonly passwords: { [key: string]: string };
 
     constructor(getTorSettings: () => TorSettings) {
         this.getTorSettings = getTorSettings;
         this.identities = {};
+        this.dispatchers = {};
         this.passwords = {};
+    }
+
+    private buildSocksServerUrl(user: string, password: string) {
+        const { host, port } = this.getTorSettings();
+
+        const socksServerUrl = new URL(`socks://${host}:${port}`);
+        socksServerUrl.username = user;
+        socksServerUrl.password = password;
+
+        return socksServerUrl;
+    }
+
+    // When a new password is requested for an existing identity we drop the cached agents so that
+    // a fresh Tor circuit is created for the new credentials.
+    private resetIdentityIfPasswordChanged(user: string, password: string) {
+        if (password && this.passwords[user] !== password) {
+            this.removeIdentity(user);
+            this.passwords[user] = password;
+        }
     }
 
     public getIdentity(
@@ -22,21 +70,11 @@ export class TorIdentities {
         const user = identityParts[0] ?? '';
         const password = identityParts[1] ?? '';
 
-        if (password && this.passwords[user] !== password) {
-            if (this.identities[user]) {
-                this.removeIdentity(user);
-            }
-            this.passwords[user] = password;
-        }
-
-        const { host, port } = this.getTorSettings();
+        this.resetIdentityIfPasswordChanged(user, password);
 
         // TODO clean agents when host/port changes?
         if (!this.identities[user]) {
-            const socksServerUrl = new URL(`socks://${host}:${port}`);
-            socksServerUrl.username = user;
-            socksServerUrl.password = password;
-            this.identities[user] = new SocksProxyAgent(socksServerUrl, {
+            this.identities[user] = new SocksProxyAgent(this.buildSocksServerUrl(user, password), {
                 timeout,
             });
         }
@@ -50,13 +88,32 @@ export class TorIdentities {
         return agent;
     }
 
+    // Returns an undici dispatcher routing through the Tor SOCKS5 proxy for the given identity.
+    // Used by the fetch interceptor, since undici bypasses the http(s) module interception.
+    public getDispatcher(identity: string): Socks5ProxyAgent {
+        const identityParts = identity.split(':');
+        const user = identityParts[0] ?? '';
+        const password = identityParts[1] ?? user; // undici's Socks5ProxyAgent requires a password if user is set
+
+        this.resetIdentityIfPasswordChanged(user, password);
+
+        if (!this.dispatchers[user]) {
+            this.dispatchers[user] = createSocks5ProxyAgent(
+                this.buildSocksServerUrl(user, password),
+            );
+        }
+
+        return this.dispatchers[user];
+    }
+
     public removeIdentity(user: string) {
         // looks like destroy does nothing, but just in case
-        const { identities } = this;
-        // @ts-expect-error: indexing with noUncheckedIndexedAccess
-        const identity: SocksProxyAgent = identities[user];
-        identity.destroy();
+        this.identities[user]?.destroy();
         delete this.identities[user];
+
+        this.dispatchers[user]?.destroy();
+        delete this.dispatchers[user];
+
         delete this.passwords[user];
     }
 }

--- a/packages/request-manager/tests/interceptor-whitelist.test.ts
+++ b/packages/request-manager/tests/interceptor-whitelist.test.ts
@@ -86,6 +86,17 @@ describe('Interceptor', () => {
     });
 
     ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'].forEach(method => {
+        it(`Blocks all not whitelisted global.fetch requests for: ${method}`, async () => {
+            // undici wraps DNS failures as "fetch failed". the actual cause is in error.cause
+            await expect(fetch(`https://${WHITELISTED_DOMAIN}`, { method })).rejects.toThrow(
+                `fetch failed`,
+            );
+
+            await expect(fetch(`https://${NOT_WHITELISTED_DOMAIN}`, { method })).rejects.toThrow(
+                `Request blocked, not whitelisted domain: ${NOT_WHITELISTED_DOMAIN}`,
+            );
+        });
+
         it(`Blocks all not whitelisted node-fetch requests for: ${method}`, async () => {
             await expect(nodeFetch(`https://${WHITELISTED_DOMAIN}`, { method })).rejects.toThrow(
                 OK_ERROR_HTTPS,
@@ -155,22 +166,5 @@ describe('Interceptor', () => {
                 `Request blocked, not whitelisted domain: ${NOT_WHITELISTED_DOMAIN}`,
             );
         }
-    });
-
-    ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'].forEach(method => {
-        it(`Blocks all not whitelisted native fetch for: ${method}`, async () => {
-            await expect(fetch(`https://${WHITELISTED_DOMAIN}`, { method })).rejects.toThrow(
-                'fetch failed',
-            );
-
-            try {
-                await fetch(`https://${NOT_WHITELISTED_DOMAIN}/`, { method });
-                expect('').toBe('Should throw an error');
-            } catch (error) {
-                expect(error.message).toBe(
-                    `Request blocked, not whitelisted domain: ${NOT_WHITELISTED_DOMAIN}`,
-                );
-            }
-        });
     });
 });

--- a/packages/request-manager/tests/isCircuitMisbehaving.test.ts
+++ b/packages/request-manager/tests/isCircuitMisbehaving.test.ts
@@ -1,4 +1,4 @@
-import { isCircuitMisbehaving } from '../src/isCircuitMisbehaving';
+import { CircuitMisbehavingError, isCircuitMisbehaving } from '../src/isCircuitMisbehaving';
 
 describe('isCircuitMisbehaving', () => {
     it('returns true for ECONNRESET error', () => {
@@ -115,5 +115,47 @@ describe('isCircuitMisbehaving', () => {
     it('returns false when cause is null', () => {
         const error = Object.assign(new TypeError('fetch failed'), { cause: null });
         expect(isCircuitMisbehaving(error)).toBe(false);
+    });
+});
+
+describe('CircuitMisbehavingError', () => {
+    it('has correct name, message and properties', () => {
+        const cause = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+        const error = new CircuitMisbehavingError(
+            { host: 'example.onion', identity: 'coinjoin-1', method: 'fetch' },
+            cause,
+        );
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error).toBeInstanceOf(CircuitMisbehavingError);
+        expect(error.name).toBe('CircuitMisbehavingError');
+        expect(error.host).toBe('example.onion');
+        expect(error.identity).toBe('coinjoin-1');
+        expect(error.method).toBe('fetch');
+        expect(error.cause).toBe(cause);
+        expect(error.message).toBe('CIRCUIT_MISBEHAVING');
+    });
+
+    it('handles missing identity', () => {
+        const cause = new Error('timeout');
+        const error = new CircuitMisbehavingError(
+            { host: 'blockstream.info', method: 'http' },
+            cause,
+        );
+
+        expect(error.identity).toBeUndefined();
+        expect(error.message).toBe('CIRCUIT_MISBEHAVING');
+    });
+
+    it('can be caught with instanceof', () => {
+        const cause = new Error('ECONNRESET');
+        const error = new CircuitMisbehavingError(
+            { host: 'coordinator.onion', identity: 'default', method: 'fetch' },
+            cause,
+        );
+
+        expect(() => {
+            throw error;
+        }).toThrow(CircuitMisbehavingError);
     });
 });

--- a/packages/request-manager/tests/isCircuitMisbehaving.test.ts
+++ b/packages/request-manager/tests/isCircuitMisbehaving.test.ts
@@ -1,0 +1,119 @@
+import { isCircuitMisbehaving } from '../src/isCircuitMisbehaving';
+
+describe('isCircuitMisbehaving', () => {
+    it('returns true for ECONNRESET error', () => {
+        const error = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+        expect(isCircuitMisbehaving(error)).toBe(true);
+    });
+
+    it('returns true for UND_ERR_SOCKET error (undici)', () => {
+        const error = Object.assign(new Error('other side closed'), { code: 'UND_ERR_SOCKET' });
+        expect(isCircuitMisbehaving(error)).toBe(true);
+    });
+
+    it('returns true for ETIMEDOUT error', () => {
+        const error = Object.assign(new Error('connect ETIMEDOUT'), { code: 'ETIMEDOUT' });
+        expect(isCircuitMisbehaving(error)).toBe(true);
+    });
+
+    it('returns true for SocksClientError (has options field)', () => {
+        const error = Object.assign(new Error('Socks5 proxy rejected connection'), {
+            options: { proxy: { host: '127.0.0.1', port: 9050 } },
+        });
+        expect(isCircuitMisbehaving(error)).toBe(true);
+    });
+
+    it('returns true for socks system error with "Socks5" in message', () => {
+        const error = Object.assign(new Error('Socks5 proxy rejected connection'), {
+            type: 'system',
+        });
+        expect(isCircuitMisbehaving(error)).toBe(true);
+    });
+
+    it('returns true for socks system error with "Proxy" in message', () => {
+        const error = Object.assign(new Error('Proxy connection timed out'), {
+            type: 'system',
+        });
+        expect(isCircuitMisbehaving(error)).toBe(true);
+    });
+
+    it('returns true for socks system error with lowercase "socks" in message', () => {
+        const error = Object.assign(new Error('socks connection refused'), {
+            type: 'system',
+        });
+        expect(isCircuitMisbehaving(error)).toBe(true);
+    });
+
+    it('returns true for socks system error with lowercase "proxy" in message', () => {
+        const error = Object.assign(new Error('proxy connection timed out'), {
+            type: 'system',
+        });
+        expect(isCircuitMisbehaving(error)).toBe(true);
+    });
+
+    it('returns true when cause has ECONNRESET (undici wrapping)', () => {
+        const cause = Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' });
+        const error = Object.assign(new TypeError('fetch failed'), { cause });
+        expect(isCircuitMisbehaving(error)).toBe(true);
+    });
+
+    it('returns true when cause has UND_ERR_SOCKET', () => {
+        const cause = Object.assign(new Error('other side closed'), { code: 'UND_ERR_SOCKET' });
+        const error = Object.assign(new TypeError('fetch failed'), { cause });
+        expect(isCircuitMisbehaving(error)).toBe(true);
+    });
+
+    it('returns true when cause has options field (SocksClientError wrapped)', () => {
+        const cause = Object.assign(new Error('Connection failed'), {
+            options: { proxy: {} },
+        });
+        const error = Object.assign(new TypeError('fetch failed'), { cause });
+        expect(isCircuitMisbehaving(error)).toBe(true);
+    });
+
+    it('returns true when cause is a socks system error', () => {
+        const cause = Object.assign(new Error('Socks5 proxy rejected connection'), {
+            type: 'system',
+        });
+        const error = Object.assign(new TypeError('fetch failed'), { cause });
+        expect(isCircuitMisbehaving(error)).toBe(true);
+    });
+
+    it('returns false for ECONNREFUSED error', () => {
+        const error = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+        expect(isCircuitMisbehaving(error)).toBe(false);
+    });
+
+    it('returns false for generic Error without relevant fields', () => {
+        const error = new Error('something went wrong');
+        expect(isCircuitMisbehaving(error)).toBe(false);
+    });
+
+    it('returns false for null', () => {
+        expect(isCircuitMisbehaving(null)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+        expect(isCircuitMisbehaving(undefined)).toBe(false);
+    });
+
+    it('returns false for a string', () => {
+        expect(isCircuitMisbehaving('ECONNRESET')).toBe(false);
+    });
+
+    it('returns false for system error without socks keywords in message', () => {
+        const error = Object.assign(new Error('ETIMEDOUT'), { type: 'system' });
+        expect(isCircuitMisbehaving(error)).toBe(false);
+    });
+
+    it('returns false when cause is not a circuit error', () => {
+        const cause = Object.assign(new Error('ECONNREFUSED'), { code: 'ECONNREFUSED' });
+        const error = Object.assign(new TypeError('fetch failed'), { cause });
+        expect(isCircuitMisbehaving(error)).toBe(false);
+    });
+
+    it('returns false when cause is null', () => {
+        const error = Object.assign(new TypeError('fetch failed'), { cause: null });
+        expect(isCircuitMisbehaving(error)).toBe(false);
+    });
+});

--- a/scripts/list-outdated-dependencies/connect-dependencies.txt
+++ b/scripts/list-outdated-dependencies/connect-dependencies.txt
@@ -72,6 +72,7 @@ tailwindcss
 tiny-worker
 ts-mixer
 ts-node
+undici
 usb
 version-bump-prompt
 ws

--- a/yarn.lock
+++ b/yarn.lock
@@ -16595,6 +16595,7 @@ __metadata:
     node-fetch: "npm:^3.3.2"
     socks-proxy-agent: "npm:8.0.5"
     tsx: "npm:^4.21.0"
+    undici: "npm:8.5.0"
     ws: "npm:^8.20.0"
   languageName: unknown
   linkType: soft
@@ -45330,6 +45331,13 @@ __metadata:
   version: 6.20.0
   resolution: "undici-types@npm:6.20.0"
   checksum: 10/583ac7bbf4ff69931d3985f4762cde2690bb607844c16a5e2fbb92ed312fe4fa1b365e953032d469fa28ba8b224e88a595f0b10a449332f83fa77c695e567dbe
+  languageName: node
+  linkType: hard
+
+"undici@npm:8.5.0":
+  version: 8.5.0
+  resolution: "undici@npm:8.5.0"
+  checksum: 10/e95913777afd47d76babfe62547bb4e9a94b93f44b50c84b4e0b6fa41c00364e31ff4f433a955b1592c3162f43e8757e2e0feae6eea195187730594523393568
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
based on https://github.com/trezor/trezor-suite/pull/28538


## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set primarily modifies the `request-manager` package (HTTP/WebSocket interception, Tor identity management, circuit misbehavior detection) and a firmware revision check in `@trezor/connect`. Most request-manager changes are internal infrastructure with no direct E2E test coverage — they are tested by their own unit/integration tests. The `checkFirmwareRevision.ts` change maps to 121+ tests via transitive imports but is a global dependency; only firmware-specific tests warrant targeted runs. The bridge-tor tests are the most relevant E2E tests since they exercise the network/bridge communication layer that request-manager underpins. Overall risk is moderate — the request-manager changes are well-isolated infrastructure, and the firmware revision check is a narrow change with broad but shallow impact.

<details><summary><b>Changed files (16)</b></summary>

- `packages/coinjoin/src/client/coordinatorRequest.ts`
- `packages/connect/src/device/checkFirmwareRevision.ts`
- `packages/request-manager/e2e/interceptor.test.ts`
- `packages/request-manager/package.json`
- `packages/request-manager/src/httpPool.ts`
- `packages/request-manager/src/index.ts`
- `packages/request-manager/src/interceptor/fetchHeaders.ts`
- `packages/request-manager/src/interceptor/fetchPool.ts`
- `packages/request-manager/src/interceptor/interceptFetch.ts`
- `packages/request-manager/src/interceptor/interceptNetSocketConnect.ts`
- `packages/request-manager/src/interceptor/interceptWebSocket.ts`
- `packages/request-manager/src/interceptor/overloadHttpRequest.ts`
- `packages/request-manager/src/isCircuitMisbehaving.ts`
- `packages/request-manager/src/torIdentities.ts`
- `packages/request-manager/tests/interceptor-whitelist.test.ts`
- `packages/request-manager/tests/isCircuitMisbehaving.test.ts`

</details>

**Recommended tests (4)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — The request-manager package handles HTTP/WebSocket interception and Tor circuit management, which is infrastructure used by the bridge communication layer. This test validates bridge spawning, connectivity, and reconnection after bridge restart — scenarios where request interception and connection pooling changes could surface regressions.
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test validates bridge daemon lifecycle management including spawning and stopping the bridge process. Changes to request-manager's HTTP pool and interceptors could affect how the bridge process communicates, particularly the bridge status HTTP endpoint checks.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — The checkFirmwareRevision.ts file is directly changed, and this test specifically validates firmware readiness detection during onboarding. A regression in firmware revision checking would directly impact this test's 'expectFirmwareToBeReady' assertion.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/suite/initial-run.test.ts` — The initial-run test handles the full onboarding flow including firmware hash check error dismissal, which is closely related to checkFirmwareRevision.ts changes. If the firmware revision check behavior changes, the firmware hash check modal dismissal flow could be affected.

</details>

⚠️ **Changes with no test coverage (15)**
- `packages/coinjoin/src/client/coordinatorRequest.ts`
- `packages/request-manager/e2e/interceptor.test.ts`
- `packages/request-manager/package.json`
- `packages/request-manager/src/httpPool.ts`
- `packages/request-manager/src/index.ts`
- `packages/request-manager/src/interceptor/fetchHeaders.ts`
- `packages/request-manager/src/interceptor/fetchPool.ts`
- `packages/request-manager/src/interceptor/interceptFetch.ts`
- `packages/request-manager/src/interceptor/interceptNetSocketConnect.ts`
- `packages/request-manager/src/interceptor/interceptWebSocket.ts`
- `packages/request-manager/src/interceptor/overloadHttpRequest.ts`
- `packages/request-manager/src/isCircuitMisbehaving.ts`
- `packages/request-manager/src/torIdentities.ts`
- `packages/request-manager/tests/interceptor-whitelist.test.ts`
- `packages/request-manager/tests/isCircuitMisbehaving.test.ts`

_Updated: 2026-07-01T15:49:59.671Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/request-manager-misbehaving-error&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/request-manager-misbehaving-error&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/request-manager-misbehaving-error&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/request-manager-misbehaving-error/web/](https://dev.suite.sldev.cz/suite-web/feat/request-manager-misbehaving-error/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T15:55:59.370Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T15:53:18.939Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->