### PR TITLE
Suite native - communicate available claim in unstake flow

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2657,6 +2657,8 @@ export const messages = {
             },
         },
         unstakeFlowScreen: {
+            canClaimWarning:
+                'You can already claim {amount}. Claim now or wait until your new unstake is processed.',
             instantlyAvailable: {
                 label: 'Instantly available (est.)',
                 infoTitle: 'Instantly available (estimate)',

--- a/suite-native/module-earn/src/components/UnstakeCanClaimAlert.tsx
+++ b/suite-native/module-earn/src/components/UnstakeCanClaimAlert.tsx
@@ -1,0 +1,32 @@
+import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS, useFormatters } from '@suite-common/formatters';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { InlineAlertBox } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+type UnstakeCanClaimAlertProps = {
+    claimableAmount: string;
+    symbol: NetworkSymbol;
+};
+
+export const UnstakeCanClaimAlert = ({ claimableAmount, symbol }: UnstakeCanClaimAlertProps) => {
+    const { CryptoAmountFormatter: amountFormatter } = useFormatters();
+
+    return (
+        <InlineAlertBox
+            variant="info"
+            title={
+                <Translation
+                    id="earn.unstakeFlowScreen.canClaimWarning"
+                    values={{
+                        amount: amountFormatter.format(claimableAmount, {
+                            isBalance: true,
+                            maxDisplayedDecimals: BASE_CRYPTO_MAX_DISPLAYED_DECIMALS,
+                            symbol,
+                            isEllipsisAppended: false,
+                        }),
+                    }}
+                />
+            }
+        />
+    );
+};

--- a/suite-native/module-earn/src/hooks/useUnstakeForm.ts
+++ b/suite-native/module-earn/src/hooks/useUnstakeForm.ts
@@ -15,6 +15,8 @@ import { useForm, useWatch } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import {
     type NativeStakingRootState,
+    selectCanClaimByAccountKey,
+    selectClaimableAmountByAccountKey,
     selectStakedBalanceByAccountKey,
 } from '@suite-native/staking';
 import { BigNumber } from '@trezor/utils';
@@ -34,6 +36,13 @@ export const useUnstakeForm = (accountKey: AccountKey) => {
     const stakedBalance = useSelector((state: NativeStakingRootState) =>
         selectStakedBalanceByAccountKey(state, accountKey),
     );
+    const canClaim = useSelector((state: NativeStakingRootState) =>
+        selectCanClaimByAccountKey(state, accountKey),
+    );
+    const claimableAmount =
+        useSelector((state: NativeStakingRootState) =>
+            selectClaimableAmountByAccountKey(state, accountKey),
+        ) ?? '0';
 
     const network = account ? getNetwork(account.symbol) : null;
 
@@ -100,6 +109,8 @@ export const useUnstakeForm = (accountKey: AccountKey) => {
         form,
         amountValue,
         stakedBalance,
+        canClaim,
+        claimableAmount,
         showNetworkFeeWarning,
         formDraft,
         formDraftKey,

--- a/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
@@ -25,6 +25,7 @@ import {
 import { FeeSelector } from '@suite-native/transaction-management';
 
 import { EarnOutputFields } from '../components/EarnOutputFields';
+import { UnstakeCanClaimAlert } from '../components/UnstakeCanClaimAlert';
 import { UnstakeFlowScreenHeader } from '../components/UnstakeFlowScreenHeader';
 import { UnstakingTimelineCard } from '../components/UnstakingTimelineCard';
 import { useNavigateBackAnalytics } from '../hooks/useNavigateBackAnalytics';
@@ -61,6 +62,8 @@ export const UnstakeFlowScreen = () => {
         form,
         amountValue,
         stakedBalance,
+        canClaim,
+        claimableAmount,
         showNetworkFeeWarning,
         formDraft,
         formDraftKey,
@@ -135,6 +138,14 @@ export const UnstakeFlowScreen = () => {
                     <InlineAlertBox
                         variant="warning"
                         title={<Translation id="earn.earnFormScreen.networkFeeWarning" />}
+                    />
+                </Box>
+            )}
+            {canClaim && networkSymbol && (
+                <Box marginTop="sp16">
+                    <UnstakeCanClaimAlert
+                        claimableAmount={claimableAmount}
+                        symbol={networkSymbol}
                     />
                 </Box>
             )}


### PR DESCRIPTION
## Description

On desktop, the unstake flow already tells users when they have an available claim so they can claim now instead of waiting out another unstaking cooldown. This adds the same information to the native (mobile) unstake flow: when a claim is available, an info banner at the top of the unstake form shows the claimable amount (ETH and SOL).

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29310

## Screenshots:
<img width="1290" height="2524" alt="Simulator Screenshot - iPhone 16 Plus - 2026-07-01 at 17 55 05" src="https://github.com/user-attachments/assets/f8c7ad4a-7813-4d51-8c0c-b46b650760a7" />
