### PR TITLE
feat(suite-native): cardano

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,5 +15,8 @@ packages/suite-data/files/bin/coinjoin/linux-x64/WalletWasabi.WabiSabiClientLibr
 packages/suite-data/files/bin/coinjoin/osx-arm64/WalletWasabi.WabiSabiClientLibrary filter=lfs diff=lfs merge=lfs -text
 packages/suite-data/files/bin/coinjoin/osx-x64/WalletWasabi.WabiSabiClientLibrary filter=lfs diff=lfs merge=lfs -text
 packages/suite-data/files/bin/coinjoin/win-x64/WalletWasabi.WabiSabiClientLibrary.exe filter=lfs diff=lfs merge=lfs -text
+suite-native/app/native-libs/cardano/android/**/*.so filter=lfs diff=lfs merge=lfs -text
+suite-native/app/native-libs/cardano/ios/**/*.a filter=lfs diff=lfs merge=lfs -text
+suite-native/app/native-libs/cardano/include/*.h filter=lfs diff=lfs merge=lfs -text
 # Changelog to be merged via union always.
 CHANGELOG.md merge=union

--- a/.github/actions/fetch-cardano-native-binaries/action.yml
+++ b/.github/actions/fetch-cardano-native-binaries/action.yml
@@ -1,0 +1,44 @@
+name: Fetch Cardano native binaries
+description: Fetch precompiled Cardano native binaries tracked by Git LFS.
+
+inputs:
+  platform:
+    description: Cardano native platform artifacts to fetch.
+    required: false
+    default: all
+  android-abis:
+    description: Comma-separated Android ABIs to fetch when platform is android or all.
+    required: false
+    default: armeabi-v7a,arm64-v8a,x86,x86_64
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch Cardano native binaries
+      shell: bash
+      env:
+        CARDANO_NATIVE_PLATFORM: ${{ inputs.platform }}
+        CARDANO_ANDROID_ABIS: ${{ inputs.android-abis }}
+      run: |
+        set -euo pipefail
+
+        include_paths=("suite-native/app/native-libs/cardano/include/**")
+
+        if [[ "$CARDANO_NATIVE_PLATFORM" == "android" || "$CARDANO_NATIVE_PLATFORM" == "all" ]]; then
+          IFS=',' read -ra android_abis <<< "$CARDANO_ANDROID_ABIS"
+
+          for android_abi in "${android_abis[@]}"; do
+            include_paths+=("suite-native/app/native-libs/cardano/android/${android_abi}/**")
+          done
+        fi
+
+        if [[ "$CARDANO_NATIVE_PLATFORM" == "ios" || "$CARDANO_NATIVE_PLATFORM" == "all" ]]; then
+          include_paths+=("suite-native/app/native-libs/cardano/ios/**")
+        fi
+
+        if [[ "$CARDANO_NATIVE_PLATFORM" != "android" && "$CARDANO_NATIVE_PLATFORM" != "ios" && "$CARDANO_NATIVE_PLATFORM" != "all" ]]; then
+          echo "Unsupported Cardano native platform: $CARDANO_NATIVE_PLATFORM" >&2
+          exit 1
+        fi
+
+        git lfs pull --include "$(IFS=','; echo "${include_paths[*]}")"

--- a/.github/workflows/build-suite-native-adhoc.yml
+++ b/.github/workflows/build-suite-native-adhoc.yml
@@ -46,6 +46,10 @@ jobs:
       - name: Install libs
         run: |
           yarn workspaces focus @suite-native/app
+      - name: Fetch Cardano native binaries
+        uses: ./.github/actions/fetch-cardano-native-binaries
+        with:
+          platform: ${{ github.event.inputs.PLATFORM == 'android' && 'android' || github.event.inputs.PLATFORM == 'ios' && 'ios' || 'all' }}
       - name: Trigger adhoc build Android
         working-directory: suite-native/app
         if: ${{ github.event.inputs.PLATFORM == 'android' || github.event.inputs.PLATFORM == 'all' }}

--- a/.github/workflows/build-suite-native-preview.yml
+++ b/.github/workflows/build-suite-native-preview.yml
@@ -74,6 +74,10 @@ jobs:
             echo "RUNTIME_BUILD_EXISTS=true" >> $GITHUB_ENV
           fi
 
+      - name: Fetch Cardano native binaries
+        if: env.RUNTIME_BUILD_EXISTS == 'false'
+        uses: ./.github/actions/fetch-cardano-native-binaries
+
       - name: Create preview builds if fingerprint changed
         # Only create preview builds if there is no build with the same runtimeVersion on EAS already
         if: env.RUNTIME_BUILD_EXISTS == 'false'

--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Install libs
         run: |
           yarn workspaces focus @suite-native/app
+      - name: Fetch Cardano native binaries
+        uses: ./.github/actions/fetch-cardano-native-binaries
       - name: Build on EAS Android
         run: eas build
           --platform android

--- a/.github/workflows/release-suite-native-production.yml
+++ b/.github/workflows/release-suite-native-production.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Install libs
         run: |
           yarn workspaces focus @suite-native/app
+      - name: Fetch Cardano native binaries
+        uses: ./.github/actions/fetch-cardano-native-binaries
+        with:
+          platform: ios
       - name: Build on EAS iOS
         run: eas build
           --platform ios
@@ -82,6 +86,10 @@ jobs:
       - name: Install libs
         run: |
           yarn workspaces focus @suite-native/app
+      - name: Fetch Cardano native binaries
+        uses: ./.github/actions/fetch-cardano-native-binaries
+        with:
+          platform: android
       - name: Build on EAS Android
         run: eas build
           --platform android
@@ -122,6 +130,10 @@ jobs:
       - name: Install libs
         run: |
           yarn workspaces focus @suite-native/app
+      - name: Fetch Cardano native binaries
+        uses: ./.github/actions/fetch-cardano-native-binaries
+        with:
+          platform: android
 
       - name: Get Suite version
         id: get_version

--- a/.github/workflows/template-suite-native-prepare-test-app-android.yml
+++ b/.github/workflows/template-suite-native-prepare-test-app-android.yml
@@ -104,8 +104,11 @@ jobs:
       ################ CACHE HIT - REPLACE JS BUNDLE ONLY ##############
 
       - name: Setup Android SDK
-        if: steps.s3_build_cache.outputs.hit == 'true'
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
+
+      - name: Install Android NDK for cache-miss build
+        if: steps.s3_build_cache.outputs.hit == 'false'
+        run: sdkmanager "ndk;27.0.12077973"
 
       - name: Download Apktool
         if: steps.s3_build_cache.outputs.hit == 'true'

--- a/.github/workflows/template-suite-native-prepare-test-app-android.yml
+++ b/.github/workflows/template-suite-native-prepare-test-app-android.yml
@@ -21,6 +21,12 @@ jobs:
         with:
           submodules: "true"
 
+      - name: Fetch Cardano native binaries
+        uses: ./.github/actions/fetch-cardano-native-binaries
+        with:
+          platform: android
+          android-abis: x86_64
+
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:

--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -37,6 +37,11 @@ jobs:
         with:
           submodules: "true"
 
+      - name: Fetch Cardano native binaries
+        uses: ./.github/actions/fetch-cardano-native-binaries
+        with:
+          platform: ios
+
       - name: Install node and yarn
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.yarn/patches/@emurgo-csl-mobile-bridge-npm-9.0.1-4bdc115e15.patch
+++ b/.yarn/patches/@emurgo-csl-mobile-bridge-npm-9.0.1-4bdc115e15.patch
@@ -1,0 +1,162 @@
+diff --git a/android/CMakeLists.txt b/android/CMakeLists.txt
+index ef0e5d75de8a09e476e2ced11d9663c5a2be59a1..863e4e6979a9d184388d8a190573b692500730d7 100644
+--- a/android/CMakeLists.txt
++++ b/android/CMakeLists.txt
+@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.13)
+ project(csl_mobile_bridge_jsi)
+ 
+ set(CMAKE_VERBOSE_MAKEFILE ON)
+-set(CMAKE_CXX_STANDARD 17)
++set(CMAKE_CXX_STANDARD 20)
+ 
+ # Paths
+ set(BUILD_DIR ${CMAKE_CURRENT_LIST_DIR}/build)
+@@ -31,6 +31,7 @@ set_target_properties(
+         react_native_haskell_shelley
+         PROPERTIES
+         IMPORTED_LOCATION ${BUILD_DIR}/rustJniLibs/android/${ANDROID_ABI}/libreact_native_haskell_shelley.so
++        IMPORTED_SONAME libreact_native_haskell_shelley.so
+ )
+ target_include_directories(
+         react_native_haskell_shelley
+diff --git a/android/build.gradle b/android/build.gradle
+index 933cb657ecde41a3370e9b2f2ce98e7af576fcab..db50015b28eadd2f7ee429a9f03f2a7fe828ccf4 100644
+--- a/android/build.gradle
++++ b/android/build.gradle
+@@ -2,7 +2,6 @@ def DEFAULT_COMPILE_SDK_VERSION = 30
+ def DEFAULT_BUILD_TOOLS_VERSION = '30.0.3'
+ def DEFAULT_MIN_SDK_VERSION = 21
+ def DEFAULT_TARGET_SDK_VERSION = 31
+-def DEFAULT_NDK_API_LEVEL = 24
+ 
+ def safeExtGet(prop, fallback) {
+     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+@@ -10,7 +9,6 @@ def safeExtGet(prop, fallback) {
+ 
+ apply plugin: 'com.android.library'
+ apply plugin: 'maven-publish'
+-apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
+ 
+ def REACT_NATIVE_VERSION = new File(['node', '--print',"JSON.parse(require('fs').readFileSync(require.resolve('react-native/package.json'), 'utf-8')).version"].execute(null, rootDir).text.trim())
+ 
+@@ -24,7 +22,6 @@ buildscript {
+   }
+ 
+   dependencies {
+-    classpath 'org.mozilla.rust-android-gradle:plugin:0.9.6'
+     classpath "com.android.tools.build:gradle:7.2.2"
+   }
+ }
+@@ -114,59 +111,45 @@ android {
+             //"${project.buildDir}/generated/source/codegen/java"
+           ]
+       }
+-      // jniLibs.srcDirs += ["${project.buildDir}/rustJniLibs/android"]
++      jniLibs.srcDirs += ["${project.buildDir}/rustJniLibs/android"]
+     }
+   }
+ }
+ 
+-// Task to install required Rust targets for Android
+-task installRustTargets(type: Exec) {
+-    description = 'Install required Rust targets for Android builds'
+-    commandLine 'rustup', 'target', 'add',
+-        'aarch64-linux-android',
+-        'armv7-linux-androideabi',
+-        'i686-linux-android',
+-        'x86_64-linux-android'
+-}
+-
+-cargo {
+-    profile = 'release'
+-    module = '../rust'
+-    libname = 'react_native_haskell_shelley'
+-    targets = ['arm', 'arm64', 'x86', 'x86_64']
+-    apiLevel = safeExtGet('ndkApiLevel', DEFAULT_NDK_API_LEVEL)
+-    prebuiltToolchains = true
+-    exec { spec, toolchain ->
+-        // Support 16KB page sizes
+-        // https://developer.android.com/guide/practices/page-sizes#other-build-systems
+-        spec.environment("RUST_ANDROID_GRADLE_CC_LINK_ARG", "-Wl,-z,max-page-size=16384,-soname,lib${libname}.so")
+-    }
++def getReactNativeArchitectures() {
++    return rootProject.hasProperty("reactNativeArchitectures")
++        ? rootProject.getProperty("reactNativeArchitectures")
++        : "armeabi-v7a,arm64-v8a,x86,x86_64"
++}
++
++def prepareCardanoNativeBridge = tasks.register("prepareCardanoNativeBridge", Exec) {
++    workingDir rootProject.rootDir.getParentFile()
++    environment "CARDANO_ANDROID_ABIS", getReactNativeArchitectures()
++    commandLine "node", new File(rootProject.rootDir.getParentFile(), "scripts/prepareCardanoNativeBridge.js").absolutePath, "android"
+ }
+ 
+ afterEvaluate {
+-    // Ensure Rust targets are installed before cargo build
+-    tasks.matching { it.name == "cargoBuild" }.configureEach {
+-        it.dependsOn("installRustTargets")
++    tasks.matching { it.name == 'javaPreCompileDebug' || it.name == 'javaPreCompileRelease' }.configureEach {
++        it.dependsOn(prepareCardanoNativeBridge)
+     }
+ 
+-    // Ensure Rust builds before any CMake build task
+-    tasks.matching { it.name.startsWith("buildCMake") }.configureEach {
+-        it.dependsOn("cargoBuild")
++    tasks.matching { it.name.matches(/merge.*JniLibFolders/) }.configureEach {
++        it.inputs.dir(new File(buildDir, "rustJniLibs/android"))
++        it.dependsOn(prepareCardanoNativeBridge)
+     }
+ }
+ 
+-tasks.whenTaskAdded { task ->
+-    if ((task.name == 'javaPreCompileDebug' || task.name == 'javaPreCompileRelease')) {
+-        task.dependsOn 'cargoBuild'
++gradle.projectsEvaluated {
++    rootProject.subprojects.each { subproject ->
++        subproject.tasks.matching { task ->
++            task.name.startsWith("configureCMake") ||
++                task.name.startsWith("buildCMake")
++        }.configureEach { task ->
++            task.dependsOn(prepareCardanoNativeBridge)
++        }
+     }
+ }
+ 
+-//https://github.com/mozilla/rust-android-gradle/issues/118
+-tasks.matching { it.name.matches(/merge.*JniLibFolders/) }.configureEach {
+-    it.inputs.dir(new File(buildDir, "rustJniLibs/android"))
+-    it.dependsOn("cargoBuild")
+-}
+-
+ repositories {
+   mavenCentral()
+   google()
+diff --git a/emurgo-csl-mobile-bridge.podspec b/emurgo-csl-mobile-bridge.podspec
+index 2394a680954f2969327e202f564101715c6f074e..18fc00959e139fd1860e03144b913824d4f38293 100644
+--- a/emurgo-csl-mobile-bridge.podspec
++++ b/emurgo-csl-mobile-bridge.podspec
+@@ -20,18 +20,20 @@ Pod::Spec.new do |s|
+   s.module_name = 'EmurgoCslMobileBridge'
+ 
+   s.script_phase = {
+-    :name => "Build Rust Binary",
+-    :script => 'bash "${PODS_TARGET_SRCROOT}/ios/build.sh"',
++    :name => "Prepare Precompiled Cardano Binary",
++    :script => 'node "$PODS_ROOT/../../scripts/prepareCardanoNativeBridge.js" ios',
+     :execution_position => :before_compile
+   }
+ 
+-  s.compiler_flags  = folly_compiler_flags + ' -DRCT_NEW_ARCH_ENABLED=1 -Wc++17-extensions'
++  s.compiler_flags  = folly_compiler_flags + ' -DRCT_NEW_ARCH_ENABLED=1 -DFOLLY_CFG_NO_COROUTINES=1 -Wc++20-extensions'
+   s.vendored_libraries = [ "$(CONFIGURATION_BUILD_DIR)/libreact_native_haskell_shelley.a" ]
+   s.libraries = "react_native_haskell_shelley"
+ 
+   s.pod_target_xcconfig    = {
+       "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(CONFIGURATION_BUILD_DIR)\"",
+-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
++      "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
++      "GCC_PREPROCESSOR_DEFINITIONS" => "$(inherited) FOLLY_CFG_NO_COROUTINES=1",
++      "OTHER_CPLUSPLUSFLAGS" => "$(inherited) -DFOLLY_CFG_NO_COROUTINES=1",
+       "ENABLE_BITCODE" => "NO",
+   }
+ 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
         "convert-figma-palette": "yarn tsx ./scripts/convertFigmaPalette.ts",
         "update-project-references": "yarn tsx ./scripts/updateProjectReferences.ts",
         "generate-icons": "yarn workspace @suite-common/icons generate-icons",
+        "generate-cardano-native-binaries": "yarn workspace @suite-native/app cardano:generate-native-binaries",
         "generate-package": "yarn workspace @trezor/scripts generate-package",
         "deps": "rimraf **/node_modules && yarn",
         "list-outdated": "./scripts/list-outdated-dependencies/list-outdated-dependencies.sh",

--- a/scripts/list-outdated-dependencies/wallet-dependencies.txt
+++ b/scripts/list-outdated-dependencies/wallet-dependencies.txt
@@ -1,3 +1,4 @@
+@emurgo/csl-mobile-bridge
 @exodus/patch-broken-hermes-typed-arrays
 @fivebinaries/coin-selection
 @hookform/resolvers

--- a/suite-native/accounts/src/tests/selectFilteredDeviceAccountsGroupedByNetworkAccountType.test.ts
+++ b/suite-native/accounts/src/tests/selectFilteredDeviceAccountsGroupedByNetworkAccountType.test.ts
@@ -195,6 +195,7 @@ describe('selectFilteredDeviceAccountsGroupedByNetworkAccountType', () => {
         ).toEqual({
             'Bitcoin Taproot accounts': [withLabel(btcTaprootAccount, null)],
             'Ethereum default accounts': [withLabel(ethAccount, 'Long-term ETH')],
+            'Cardano default accounts': [withLabel(adaAccount, null)],
         });
     });
 

--- a/suite-native/app/.detoxrc.js
+++ b/suite-native/app/.detoxrc.js
@@ -32,7 +32,7 @@ module.exports = {
         'android.release': {
             type: 'android.apk',
             binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
-            build: 'cd android && NODE_ENV=test ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release',
+            build: 'cd android && NODE_ENV=test ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release -PreactNativeArchitectures=x86_64 -x lintVitalAnalyzeRelease',
             reversePorts: [21328, 19121],
         },
     },

--- a/suite-native/app/.detoxrc.js
+++ b/suite-native/app/.detoxrc.js
@@ -32,7 +32,7 @@ module.exports = {
         'android.release': {
             type: 'android.apk',
             binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
-            build: 'cd android && NODE_ENV=test ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release -PreactNativeArchitectures=x86_64 -x lintVitalAnalyzeRelease',
+            build: 'cd android && NODE_ENV=test ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release -PreactNativeArchitectures=x86_64 -Pandroid.enablePngCrunchInReleaseBuilds=false -x lintVitalRelease',
             reversePorts: [21328, 19121],
         },
     },

--- a/suite-native/app/.gitignore
+++ b/suite-native/app/.gitignore
@@ -17,8 +17,8 @@ web-build/
 *.mobileprovision
 
 # These are generated when running `expo prebuild`
-ios/
-android/
+/ios/
+/android/
 
 # Metro
 .metro-health-check*

--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -68,6 +68,7 @@ const projectIds = {
 } as const satisfies Record<BuildType, string>;
 
 const buildType = (process.env.EXPO_PUBLIC_ENVIRONMENT as BuildType) ?? 'debug';
+const cardanoNativeBridgeNdkVersion = '27.0.12077973';
 
 // This is used only as a fallback for the local development.
 const getLocalCommitHash = (): string => {
@@ -136,7 +137,7 @@ const getPlugins = (): ExpoPlugins => {
                     minSdkVersion: 28,
                     // this fixes expo-updates build error
                     kotlinVersion: '2.1.20',
-                    ndkVersion: '27.0.12077973',
+                    ndkVersion: cardanoNativeBridgeNdkVersion,
                     // react-native-quick-crypto (since v1) and expo-sqlite both bundle their
                     // own OpenSSL libcrypto.so, which collides during mergeDebugNativeLibs.
                     // pickFirst resolves the duplicate-.so packaging conflict.
@@ -149,6 +150,7 @@ const getPlugins = (): ExpoPlugins => {
                 },
             },
         ],
+        ['./plugins/withNdkVersion', { ndkVersion: cardanoNativeBridgeNdkVersion }],
         '@trezor/react-native-usb/plugins/withUSBDevice.js',
         [
             './plugins/withAndroidMainActivityAttributes.js',

--- a/suite-native/app/cardanoPolyfills.js
+++ b/suite-native/app/cardanoPolyfills.js
@@ -1,2 +1,0 @@
-/* eslint-disable import/no-default-export */
-export default {};

--- a/suite-native/app/metro.config.js
+++ b/suite-native/app/metro.config.js
@@ -77,6 +77,8 @@ const config = {
                 'crc/calculators/crc16xmodem': `${rootNodeModulesPath}/crc/cjs-default-unwrap/calculators/crc16xmodem.js`,
                 'bignumber.js': `${rootNodeModulesPath}/bignumber.js/dist/bignumber.cjs`,
                 uuid: `${rootNodeModulesPath}/uuid/dist/index.js`,
+                '@emurgo/cardano-serialization-lib-browser': `${rootNodeModulesPath}/@emurgo/csl-mobile-bridge/src/index.ts`,
+                '@emurgo/cardano-serialization-lib-nodejs': `${rootNodeModulesPath}/@emurgo/csl-mobile-bridge/src/index.ts`,
 
                 // web3-validator package is by default trying to use non-existing minified index file. This fixes that.
                 // Can be removed once web3-validator fixup PR is merged: https://github.com/web3/web3.js/pull/7016.
@@ -93,13 +95,6 @@ const config = {
                 const source = `${rootNodeModulesPath}/@trezor/coins-${coinsModuleMatch[1]}/src/${coinsModuleMatch[2]}/index.ts`;
 
                 return getSourceFile(source);
-            }
-
-            if (moduleName.startsWith('@emurgo/cardano')) {
-                // Cardano libs doesn't have main field in package.json which will cause error in metro
-                // Also they use WASM which doesn't work in RN so we polyfill it with empty file to build errors
-                // In future we will need JS implementation of Cardano libs or C++ implementation
-                return getSourceFile('./cardanoPolyfills.js');
             }
 
             if (process.env.EXPO_PUBLIC_IS_DETOX_BUILD && moduleName === '@trezor/connect') {

--- a/suite-native/app/native-libs/cardano/README.md
+++ b/suite-native/app/native-libs/cardano/README.md
@@ -1,0 +1,63 @@
+# Cardano Native Artifacts
+
+Suite Native uses prebuilt `@emurgo/csl-mobile-bridge` Rust artifacts from this directory. Normal app development, CI,
+and release builds fetch these files through Git LFS and must not build Rust.
+
+Use the generation command only when bumping `@emurgo/csl-mobile-bridge` or when the Rust artifact needs to be rebuilt.
+
+## Prerequisites
+
+- Rust with `cargo` and `rustup`.
+- Xcode and command line tools for iOS artifacts.
+- Android SDK with NDK `27.0.12077973` for Android artifacts.
+- `ANDROID_NDK_HOME` exported for Android builds.
+
+The generator installs the required Rust targets with `rustup target add` and strips the generated binaries before they
+are stored here.
+
+## Regenerate
+
+From the repository root:
+
+```bash
+yarn
+yarn generate-cardano-native-binaries
+```
+
+To regenerate only one platform:
+
+```bash
+yarn generate-cardano-native-binaries android
+yarn generate-cardano-native-binaries ios
+```
+
+The command builds from the installed `@emurgo/csl-mobile-bridge` package and overwrites:
+
+- `android/armeabi-v7a/libreact_native_haskell_shelley.so`
+- `android/arm64-v8a/libreact_native_haskell_shelley.so`
+- `android/x86/libreact_native_haskell_shelley.so`
+- `android/x86_64/libreact_native_haskell_shelley.so`
+- `ios/libreact_native_haskell_shelley.a`
+- `ios/libreact_native_haskell_shelley_simulator.a`
+- `include/react_native_haskell_shelley.h`
+
+## Update Checklist
+
+1. Bump `@emurgo/csl-mobile-bridge` in `suite-native/app/package.json`.
+2. Run `yarn` and resolve the existing Yarn patch if needed.
+3. Run `yarn generate-cardano-native-binaries`.
+4. Stage the changed artifacts and verify they are tracked by Git LFS:
+
+    ```bash
+    git add suite-native/app/native-libs/cardano
+    git lfs status
+    git lfs ls-files suite-native/app/native-libs/cardano
+    ```
+
+5. Commit the changes.
+6. Push the Git LFS objects and the branch:
+
+    ```bash
+    git lfs push --all origin HEAD
+    git push
+    ```

--- a/suite-native/app/native-libs/cardano/android/arm64-v8a/libreact_native_haskell_shelley.so
+++ b/suite-native/app/native-libs/cardano/android/arm64-v8a/libreact_native_haskell_shelley.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b40fc7cb82d0d5b1f932f460e226e0a665d643aef2abaff103f83bdc10477b2
+size 4985808

--- a/suite-native/app/native-libs/cardano/android/armeabi-v7a/libreact_native_haskell_shelley.so
+++ b/suite-native/app/native-libs/cardano/android/armeabi-v7a/libreact_native_haskell_shelley.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb709d5a962ebd926480e6fef8a5a0191dae5d6f7a5bf187278deb035f730a0f
+size 3254360

--- a/suite-native/app/native-libs/cardano/android/x86/libreact_native_haskell_shelley.so
+++ b/suite-native/app/native-libs/cardano/android/x86/libreact_native_haskell_shelley.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf17da9fb96e13328dad7549619730abb205a77963659475fad6e4311944ddb0
+size 6102128

--- a/suite-native/app/native-libs/cardano/android/x86_64/libreact_native_haskell_shelley.so
+++ b/suite-native/app/native-libs/cardano/android/x86_64/libreact_native_haskell_shelley.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8db00b8c767d105c8eca28a68868d93a52f125bb6c3cdf446352a02d8d7645fb
+size 5457368

--- a/suite-native/app/native-libs/cardano/include/react_native_haskell_shelley.h
+++ b/suite-native/app/native-libs/cardano/include/react_native_haskell_shelley.h
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0dc0b49877bbd06b2352bde50e79511b2732c0f677d3111be3fbf4f3588ced93
+size 392142

--- a/suite-native/app/native-libs/cardano/ios/libreact_native_haskell_shelley.a
+++ b/suite-native/app/native-libs/cardano/ios/libreact_native_haskell_shelley.a
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6fbcd7e2fccb9d898f7938d3cff6668da07909f193b7ddd29b67a4b96c0e1e4
+size 26605552

--- a/suite-native/app/native-libs/cardano/ios/libreact_native_haskell_shelley_simulator.a
+++ b/suite-native/app/native-libs/cardano/ios/libreact_native_haskell_shelley_simulator.a
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b6f359451505264717bcbc0e3e9076032f80731d3e39ffc1c242598b2fe2276
+size 52565776

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -15,6 +15,7 @@
         "eas-build-post-install": "yarn workspace @suite-common/message-system sign-config",
         "eas-build-on-success": "./eas-post-success.sh",
         "prebuild:clean": "expo prebuild --clean",
+        "cardano:generate-native-binaries": "node ./scripts/generateCardanoNativeBinaries.js",
         "build:e2e": "detox build --configuration",
         "test:e2e": "node ./scripts/cleanArtifacts.js && tsx e2e/trezorDetoxRunner/index.ts",
         "test:e2e:android": "node ./scripts/cleanArtifacts.js && tsx e2e/trezorDetoxRunner/index.ts --config=e2e/trezorDetoxRunner/config/runner-android.config.js",
@@ -25,6 +26,7 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
+        "@emurgo/csl-mobile-bridge": "patch:@emurgo/csl-mobile-bridge@npm%3A9.0.1#~/.yarn/patches/@emurgo-csl-mobile-bridge-npm-9.0.1-4bdc115e15.patch",
         "@evolu/common": "8.0.0-next.5",
         "@evolu/react-native": "15.0.0-next.2",
         "@exodus/patch-broken-hermes-typed-arrays": "^1.0.0-alpha.1",

--- a/suite-native/app/plugins/withNdkVersion.js
+++ b/suite-native/app/plugins/withNdkVersion.js
@@ -1,0 +1,24 @@
+const { withProjectBuildGradle } = require('expo/config-plugins');
+
+const generatedBlockStart = '// @generated begin suite-native-ndk-version';
+const generatedBlockEnd = '// @generated end suite-native-ndk-version';
+
+module.exports = function withNdkVersion(config, { ndkVersion }) {
+    return withProjectBuildGradle(config, config2 => {
+        const ndkVersionBlock = `${generatedBlockStart}
+allprojects { ext.ndkVersion = "${ndkVersion}" }
+${generatedBlockEnd}
+`;
+
+        if (config2.modResults.contents.includes(generatedBlockStart)) {
+            config2.modResults.contents = config2.modResults.contents.replace(
+                new RegExp(`${generatedBlockStart}[\\s\\S]*?${generatedBlockEnd}\\n?`),
+                ndkVersionBlock,
+            );
+        } else {
+            config2.modResults.contents = `${ndkVersionBlock}\n${config2.modResults.contents}`;
+        }
+
+        return config2;
+    });
+};

--- a/suite-native/app/scripts/generateCardanoNativeBinaries.js
+++ b/suite-native/app/scripts/generateCardanoNativeBinaries.js
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const appRoot = path.resolve(__dirname, '..');
+const bridgeRoot = path.dirname(
+    require.resolve('@emurgo/csl-mobile-bridge/package.json', {
+        paths: [appRoot],
+    }),
+);
+const rustRoot = path.join(bridgeRoot, 'rust');
+const cardanoLibrariesRoot = path.join(appRoot, 'native-libs', 'cardano');
+const androidAPILevel = '24';
+
+const androidLibraryName = 'libreact_native_haskell_shelley.so';
+const iosLibraryName = 'libreact_native_haskell_shelley.a';
+const iosSimulatorLibraryName = 'libreact_native_haskell_shelley_simulator.a';
+const headerName = 'react_native_haskell_shelley.h';
+
+const androidTargets = [
+    {
+        abi: 'armeabi-v7a',
+        rustTarget: 'armv7-linux-androideabi',
+        linkerPrefix: 'armv7a-linux-androideabi',
+    },
+    {
+        abi: 'arm64-v8a',
+        rustTarget: 'aarch64-linux-android',
+        linkerPrefix: 'aarch64-linux-android',
+    },
+    {
+        abi: 'x86',
+        rustTarget: 'i686-linux-android',
+        linkerPrefix: 'i686-linux-android',
+    },
+    {
+        abi: 'x86_64',
+        rustTarget: 'x86_64-linux-android',
+        linkerPrefix: 'x86_64-linux-android',
+    },
+];
+
+const iosDeviceTarget = 'aarch64-apple-ios';
+const iosSimulatorTargets = ['aarch64-apple-ios-sim', 'x86_64-apple-ios'];
+const androidHostTags = {
+    darwin: 'darwin-x86_64',
+    linux: 'linux-x86_64',
+    win32: 'windows-x86_64',
+};
+
+const usage = `Usage: generateCardanoNativeBinaries.js [android|ios|all]
+
+Required for Android:
+  ANDROID_NDK_HOME=/path/to/android/sdk/ndk/27.0.12077973`;
+
+const getRustOutputPath = (rustTarget, libraryName) =>
+    path.join(rustRoot, 'target', rustTarget, 'release', libraryName);
+
+const getCardanoLibraryPath = (...pathParts) => path.join(cardanoLibrariesRoot, ...pathParts);
+
+const run = (command, args, env = {}) => {
+    console.log(`[cardano-native] ${command} ${args.join(' ')}`);
+
+    execFileSync(command, args, {
+        cwd: rustRoot,
+        env: { ...process.env, ...env },
+        stdio: 'inherit',
+    });
+};
+
+const copyArtifact = (sourcePath, destinationPath) => {
+    fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+    fs.copyFileSync(sourcePath, destinationPath);
+    console.log(`[cardano-native] copied ${path.relative(appRoot, destinationPath)}`);
+};
+
+const buildRustTarget = (rustTarget, env = {}) => {
+    run('cargo', ['build', '--release', '--target', rustTarget], env);
+};
+
+const installRustTargets = rustTargets => run('rustup', ['target', 'add', ...rustTargets]);
+
+const copyHeader = () =>
+    copyArtifact(
+        path.join(rustRoot, 'include', headerName),
+        getCardanoLibraryPath('include', headerName),
+    );
+
+const getAndroidNDKHome = () => {
+    const androidNDKHome = process.env.ANDROID_NDK_HOME;
+
+    if (!androidNDKHome) {
+        throw new Error(`ANDROID_NDK_HOME is required.\n\n${usage}`);
+    }
+
+    return androidNDKHome;
+};
+
+const getAndroidToolchainBin = () => {
+    const androidNDKHome = getAndroidNDKHome();
+    const androidHostTag = androidHostTags[process.platform];
+
+    if (!androidHostTag) {
+        throw new Error(`Unsupported Android host platform: ${process.platform}.`);
+    }
+
+    return path.join(androidNDKHome, 'toolchains', 'llvm', 'prebuilt', androidHostTag, 'bin');
+};
+
+const runFromAppRoot = (command, args) => {
+    console.log(`[cardano-native] ${command} ${args.join(' ')}`);
+
+    execFileSync(command, args, {
+        cwd: appRoot,
+        env: process.env,
+        stdio: 'inherit',
+    });
+};
+
+const stripAndroidLibrary = libraryPath => {
+    const stripPath = path.join(getAndroidToolchainBin(), 'llvm-strip');
+
+    runFromAppRoot(stripPath, ['--strip-unneeded', libraryPath]);
+};
+
+const stripIOSLibrary = libraryPath => {
+    runFromAppRoot('xcrun', ['strip', '-S', libraryPath]);
+};
+
+const buildAndCopyLibrary = ({
+    rustTarget,
+    libraryName,
+    destinationPath,
+    env = {},
+    stripLibrary,
+}) => {
+    buildRustTarget(rustTarget, env);
+    copyArtifact(getRustOutputPath(rustTarget, libraryName), destinationPath);
+    stripLibrary(destinationPath);
+};
+
+const getAndroidBuildEnv = (rustTarget, linkerPrefix) => {
+    const toolchainBin = getAndroidToolchainBin();
+    const linkerPath = path.join(toolchainBin, `${linkerPrefix}${androidAPILevel}-clang`);
+    const arPath = path.join(toolchainBin, 'llvm-ar');
+    const cargoTargetName = rustTarget.toUpperCase().replaceAll('-', '_');
+
+    return {
+        [`CC_${rustTarget.replaceAll('-', '_')}`]: linkerPath,
+        [`AR_${rustTarget.replaceAll('-', '_')}`]: arPath,
+        [`CARGO_TARGET_${cargoTargetName}_LINKER`]: linkerPath,
+        [`CARGO_TARGET_${cargoTargetName}_RUSTFLAGS`]:
+            '-C link-arg=-Wl,-z,max-page-size=16384 -C link-arg=-Wl,-soname,libreact_native_haskell_shelley.so',
+    };
+};
+
+const buildAndroid = () => {
+    installRustTargets(androidTargets.map(({ rustTarget }) => rustTarget));
+
+    for (const { abi, rustTarget, linkerPrefix } of androidTargets) {
+        buildAndCopyLibrary({
+            rustTarget,
+            libraryName: androidLibraryName,
+            destinationPath: getCardanoLibraryPath('android', abi, androidLibraryName),
+            env: getAndroidBuildEnv(rustTarget, linkerPrefix),
+            stripLibrary: stripAndroidLibrary,
+        });
+    }
+
+    copyHeader();
+};
+
+const buildIOS = () => {
+    if (process.platform !== 'darwin') {
+        throw new Error('iOS binaries can only be generated on macOS.');
+    }
+
+    installRustTargets([iosDeviceTarget, ...iosSimulatorTargets]);
+    buildAndCopyLibrary({
+        rustTarget: iosDeviceTarget,
+        libraryName: iosLibraryName,
+        destinationPath: getCardanoLibraryPath('ios', iosLibraryName),
+        stripLibrary: stripIOSLibrary,
+    });
+
+    const simulatorLibraryPaths = iosSimulatorTargets.map(rustTarget => {
+        buildRustTarget(rustTarget);
+
+        return getRustOutputPath(rustTarget, iosLibraryName);
+    });
+
+    fs.mkdirSync(getCardanoLibraryPath('ios'), { recursive: true });
+    run('lipo', [
+        '-create',
+        ...simulatorLibraryPaths,
+        '-output',
+        getCardanoLibraryPath('ios', iosSimulatorLibraryName),
+    ]);
+    stripIOSLibrary(getCardanoLibraryPath('ios', iosSimulatorLibraryName));
+
+    copyHeader();
+};
+
+const getPlatforms = () => {
+    const args = process.argv.slice(2);
+
+    if (args.includes('--help') || args.includes('-h')) {
+        console.log(usage);
+        process.exit(0);
+    }
+
+    if (args.length === 0 || args.includes('all')) {
+        return ['android', 'ios'];
+    }
+
+    if (args.some(arg => !['android', 'ios'].includes(arg))) {
+        throw new Error(usage);
+    }
+
+    return args;
+};
+
+try {
+    const platforms = getPlatforms();
+
+    if (platforms.includes('android')) {
+        buildAndroid();
+    }
+
+    if (platforms.includes('ios')) {
+        buildIOS();
+    }
+
+    console.log('[cardano-native] done');
+} catch (error) {
+    console.error(`[cardano-native] ${error.message}`);
+    process.exit(1);
+}

--- a/suite-native/app/scripts/prepareCardanoNativeBridge.js
+++ b/suite-native/app/scripts/prepareCardanoNativeBridge.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const defaultAndroidABIs = ['armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'];
+const androidLibraryName = 'libreact_native_haskell_shelley.so';
+const iosLibraryName = 'libreact_native_haskell_shelley.a';
+const cslHeaderName = 'react_native_haskell_shelley.h';
+
+const appRoot = path.resolve(__dirname, '..');
+const cardanoLibrariesRoot = path.join(appRoot, 'native-libs', 'cardano');
+const cslHeaderPath = path.join(cardanoLibrariesRoot, 'include', cslHeaderName);
+
+const isLFSPointer = filePath => {
+    if (!fs.existsSync(filePath)) {
+        return false;
+    }
+
+    const fileDescriptor = fs.openSync(filePath, 'r');
+    const buffer = Buffer.alloc(128);
+    const bytesRead = fs.readSync(fileDescriptor, buffer, 0, buffer.length, 0);
+    fs.closeSync(fileDescriptor);
+    const header = buffer.toString('utf8', 0, bytesRead);
+
+    return header.startsWith('version https://git-lfs.github.com/spec/v1');
+};
+
+const getRequestedAndroidABIs = () => {
+    const requestedABIs = (process.env.CARDANO_ANDROID_ABIS || defaultAndroidABIs.join(','))
+        .split(',')
+        .map(abi => abi.trim())
+        .filter(Boolean);
+
+    if (requestedABIs.length === 0) {
+        throw new Error('CARDANO_ANDROID_ABIS must contain at least one ABI.');
+    }
+
+    const unsupportedABIs = requestedABIs.filter(abi => !defaultAndroidABIs.includes(abi));
+
+    if (unsupportedABIs.length > 0) {
+        throw new Error(`Unsupported Cardano Android ABI: ${unsupportedABIs.join(', ')}`);
+    }
+
+    return requestedABIs;
+};
+
+const ensureArtifacts = filePaths => {
+    for (const filePath of filePaths) {
+        if (!fs.existsSync(filePath)) {
+            throw new Error(`Missing Cardano native artifact: ${filePath}`);
+        }
+
+        if (isLFSPointer(filePath)) {
+            throw new Error(`Cardano native artifact is still a Git LFS pointer: ${filePath}`);
+        }
+    }
+};
+
+const copyFile = (sourcePath, destinationPath) => {
+    fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+    fs.copyFileSync(sourcePath, destinationPath);
+};
+
+const copyArtifacts = copyPlan => {
+    ensureArtifacts(copyPlan.map(({ sourcePath }) => sourcePath));
+
+    for (const { sourcePath, destinationPath } of copyPlan) {
+        copyFile(sourcePath, destinationPath);
+    }
+};
+
+const getBridgeRoot = () => {
+    const packageJsonPath = require.resolve('@emurgo/csl-mobile-bridge/package.json', {
+        paths: [appRoot],
+    });
+
+    return path.dirname(packageJsonPath);
+};
+
+const prepareAndroid = () => {
+    const bridgeRoot = getBridgeRoot();
+    const requestedAndroidABIs = getRequestedAndroidABIs();
+    const androidJniLibsRoot = path.join(bridgeRoot, 'android', 'build', 'rustJniLibs', 'android');
+
+    fs.rmSync(androidJniLibsRoot, { recursive: true, force: true });
+
+    copyArtifacts([
+        {
+            sourcePath: cslHeaderPath,
+            destinationPath: path.join(bridgeRoot, 'rust', 'include', cslHeaderName),
+        },
+        ...requestedAndroidABIs.map(abi => ({
+            sourcePath: path.join(cardanoLibrariesRoot, 'android', abi, androidLibraryName),
+            destinationPath: path.join(androidJniLibsRoot, abi, androidLibraryName),
+        })),
+    ]);
+};
+
+const prepareIOS = () => {
+    const configurationBuildDir = process.env.CONFIGURATION_BUILD_DIR;
+
+    if (!configurationBuildDir) {
+        throw new Error('CONFIGURATION_BUILD_DIR is required to prepare Cardano iOS artifacts.');
+    }
+
+    const isSimulator =
+        process.env.PLATFORM_NAME === 'iphonesimulator' ||
+        process.env.EFFECTIVE_PLATFORM_NAME === '-iphonesimulator';
+    const sourceLibraryName = isSimulator
+        ? 'libreact_native_haskell_shelley_simulator.a'
+        : iosLibraryName;
+    const sourceLibraryPath = path.join(cardanoLibrariesRoot, 'ios', sourceLibraryName);
+
+    copyArtifacts([
+        {
+            sourcePath: sourceLibraryPath,
+            destinationPath: path.join(configurationBuildDir, iosLibraryName),
+        },
+        {
+            sourcePath: cslHeaderPath,
+            destinationPath: path.join(configurationBuildDir, cslHeaderName),
+        },
+    ]);
+};
+
+const platform = process.argv[2];
+
+if (platform === 'android') {
+    prepareAndroid();
+} else if (platform === 'ios') {
+    prepareIOS();
+} else {
+    throw new Error('Usage: prepareCardanoNativeBridge.js <android|ios>');
+}

--- a/suite-native/config/src/supportedNetworks.ts
+++ b/suite-native/config/src/supportedNetworks.ts
@@ -17,7 +17,7 @@ export const orderedAccountTypes: AccountType[] = [
     'ledger',
 ];
 
-export const sendDisabledNetworkTypes: NetworkType[] = ['cardano'];
+export const sendDisabledNetworkTypes: NetworkType[] = [];
 
 export const sortNetworks = (networksToSort: Network[]) =>
     A.sort(networksToSort, (a, b) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2765,6 +2765,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emurgo/csl-mobile-bridge@npm:9.0.1":
+  version: 9.0.1
+  resolution: "@emurgo/csl-mobile-bridge@npm:9.0.1"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/82c08d7fd2b6a06d2def418556b54f5e6901ba3b75a777abb6ea59853ba444afbc14b68704b96f7b2da27bdf1d4e711680904cb8f6464587c04d8113e9c6e580
+  languageName: node
+  linkType: hard
+
+"@emurgo/csl-mobile-bridge@patch:@emurgo/csl-mobile-bridge@npm%3A9.0.1#~/.yarn/patches/@emurgo-csl-mobile-bridge-npm-9.0.1-4bdc115e15.patch":
+  version: 9.0.1
+  resolution: "@emurgo/csl-mobile-bridge@patch:@emurgo/csl-mobile-bridge@npm%3A9.0.1#~/.yarn/patches/@emurgo-csl-mobile-bridge-npm-9.0.1-4bdc115e15.patch::version=9.0.1&hash=567a96"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/25f7dfc6e204457d46831fb2cd0362efa9927cf29901c40b0cb26ed4065093803e4b29e2b5db5fae4ac153f0eeb863e567d7f43e321e4793117a85a4a33b735b
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/aix-ppc64@npm:0.27.7"
@@ -11772,6 +11792,7 @@ __metadata:
     "@babel/core": "npm:7.29.7"
     "@config-plugins/detox": "npm:^11.0.0"
     "@currents/cmd": "npm:1.9.7"
+    "@emurgo/csl-mobile-bridge": "patch:@emurgo/csl-mobile-bridge@npm%3A9.0.1#~/.yarn/patches/@emurgo-csl-mobile-bridge-npm-9.0.1-4bdc115e15.patch"
     "@evolu/common": "npm:8.0.0-next.5"
     "@evolu/react-native": "npm:15.0.0-next.2"
     "@exodus/patch-broken-hermes-typed-arrays": "npm:^1.0.0-alpha.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in suite-native (mobile app) code: Cardano polyfills, a build script for Cardano native bridge, package.json updates, and supported networks configuration. The E2E test suite appears to target suite-web/suite-desktop rather than suite-native, so direct coverage is limited. The supportedNetworks.ts file is the most likely to have indirect effects on web/desktop tests if it's a shared configuration module, but it lives under suite-native/config which suggests it may be mobile-only. The Cardano-related changes warrant running ADA-focused tests as a precaution, but most of these changes are likely uncovered by the existing E2E suite.

<details><summary><b>Changed files (4)</b></summary>

- `suite-native/app/cardanoPolyfills.js`
- `suite-native/app/package.json`
- `suite-native/app/scripts/prepareCardanoNativeBridge.js`
- `suite-native/config/src/supportedNetworks.ts`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — suite-native/config/src/supportedNetworks.ts could affect which networks (including Cardano/ADA) are available. This test exercises the full ADA staking flow and would detect if Cardano network support was inadvertently changed or broken by network configuration updates.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — The ADA unstaking test exercises Cardano network functionality end-to-end. Changes to supportedNetworks.ts could affect ADA network availability, and the Cardano polyfill changes could impact Cardano-related functionality if shared code paths exist.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test specifically verifies Cardano (ADA) address generation and passphrase flows. Changes to Cardano polyfills and supportedNetworks configuration directly relate to Cardano network availability and functionality.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — Changes to supportedNetworks.ts could affect which coins appear on the coins settings page. This test verifies network activation/deactivation across mainnet and testnet, which would surface issues if the supported networks list changed.
- `suite/e2e/tests/wallet/public-keys.test.ts` — This test verifies public key display for BTC, LTC, and ADA. Changes to supportedNetworks.ts could affect ADA network availability, and Cardano polyfill changes could affect ADA key derivation if shared infrastructure is involved.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-native/app/cardanoPolyfills.js`
- `suite-native/app/package.json`
- `suite-native/app/scripts/prepareCardanoNativeBridge.js`

_Updated: 2026-07-01T19:43:33.130Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=codex/provit-cardano-na-mobilu&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=codex/provit-cardano-na-mobilu&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T14:27:19.723Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-02T14:24:34.535Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/codex/provit-cardano-na-mobilu/web/](https://dev.suite.sldev.cz/suite-web/codex/provit-cardano-na-mobilu/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->