### PR TITLE
refactor(connect): de-duplicate shared constructions into connect-common helpers

### DIFF
--- a/packages/connect-common/src/factory.ts
+++ b/packages/connect-common/src/factory.ts
@@ -17,6 +17,23 @@ export interface ConnectFactoryDependencies<SettingsType extends Record<string, 
     dispose: TrezorConnect['dispose'];
 }
 
+/**
+ * Bind a class instance implementing `ConnectFactoryDependencies` to a plain deps object
+ * suitable for `factory`. Every host package (connect, connect-web, connect-webextension,
+ * connect-mobile) previously repeated the same `impl.method.bind(impl)` block.
+ */
+export const bindConnectFactoryDependencies = <SettingsType extends Record<string, any>>(
+    impl: ConnectFactoryDependencies<SettingsType>,
+): ConnectFactoryDependencies<SettingsType> => ({
+    eventEmitter: impl.eventEmitter,
+    init: impl.init.bind(impl),
+    call: impl.call.bind(impl),
+    updateConnectSettings: impl.updateConnectSettings.bind(impl),
+    uiResponse: impl.uiResponse.bind(impl),
+    cancel: impl.cancel.bind(impl),
+    dispose: impl.dispose.bind(impl),
+});
+
 export const factory = <
     SettingsType extends Record<string, any>,
     ExtraMethodsType extends Record<string, any>,

--- a/packages/connect-common/src/impl/dynamic.ts
+++ b/packages/connect-common/src/impl/dynamic.ts
@@ -8,6 +8,7 @@ import type { ConnectDynamicSettings, ConnectImplSettings } from '../types';
 import type { UpdateConnectSettings } from '../types/api/core/updateConnectSettings';
 import { ConnectEmitter } from '../types/emitter';
 import { type CancelParams } from '../utils/cancelParams';
+import { createUpdateConnectSettingsUnsupportedMessage } from '../utils/updateConnectSettings';
 
 type ImplType = 'core-in-suite-desktop' | 'core-in-suite-web';
 
@@ -106,14 +107,7 @@ export class TrezorConnectDynamic implements ConnectFactoryDependencies<Record<n
     }
 
     public updateConnectSettings(_params: UpdateConnectSettings) {
-        return Promise.resolve(
-            createErrorMessage(
-                ERRORS.TypedError(
-                    'Method_InvalidPackage',
-                    'updateConnectSettings is not supported in this implementation',
-                ),
-            ),
-        );
+        return createUpdateConnectSettingsUnsupportedMessage();
     }
 
     public async call(params: CallMethodPayload) {

--- a/packages/connect-common/src/messageChannel/abstract.ts
+++ b/packages/connect-common/src/messageChannel/abstract.ts
@@ -3,15 +3,10 @@
  * this file is bundled into content script so be careful what you are importing not to bloat the bundle
  */
 
-import {
-    type Deferred,
-    TypedEmitter,
-    createDeferred,
-    createDeferredManager,
-    scheduleAction,
-} from '@trezor/utils';
+import { type Deferred, TypedEmitter, createDeferred, scheduleAction } from '@trezor/utils';
 
 import type { Log } from '../utils/debug';
+import { createUUIDDeferredManager } from '../utils/deferred';
 
 export interface AbstractMessageChannelConstructorParams {
     sendFn: (message: any) => void;
@@ -40,7 +35,7 @@ export abstract class AbstractMessageChannel<
 > extends TypedEmitter<{
     message: Message<IncomingMessages>;
 }> {
-    protected messages = createDeferredManager({ generateId: (): string => crypto.randomUUID() });
+    protected messages = createUUIDDeferredManager();
     /** queue of messages that were scheduled before handshake */
     protected messagesQueue: any[] = [];
 

--- a/packages/connect-common/src/messageChannel/serviceworker-window-ext-connectable.ts
+++ b/packages/connect-common/src/messageChannel/serviceworker-window-ext-connectable.ts
@@ -1,3 +1,5 @@
+import { resolveAfter } from '@trezor/utils';
+
 import { AbstractMessageChannel, type AbstractMessageChannelConstructorParams } from './abstract';
 
 /**
@@ -70,14 +72,8 @@ export class ServiceWorkerWindowExtConnectableChannel<
                 this.sendChain = this.sendChain
                     .catch(() => {})
                     .then(() => this.doSend(message))
-                    .then(
-                        () =>
-                            new Promise(resolve =>
-                                setTimeout(
-                                    resolve,
-                                    ServiceWorkerWindowExtConnectableChannel.SEND_SETTLE_MS,
-                                ),
-                            ),
+                    .then(() =>
+                        resolveAfter(ServiceWorkerWindowExtConnectableChannel.SEND_SETTLE_MS),
                     );
             },
             logger,

--- a/packages/connect-common/src/utils/cancelParams.ts
+++ b/packages/connect-common/src/utils/cancelParams.ts
@@ -1,3 +1,6 @@
+import type { CoreCallCancelMessage } from '../events/call';
+import { CORE_CALL_CANCEL } from '../events/core-call';
+
 // The string form is supported for backward compatibility with older API
 // versions where `cancel(reason)` accepted a single reason string.
 export type CancelParams = string | { reason?: string; callId?: string };
@@ -10,4 +13,13 @@ export const normalizeCancelParams = (
     }
 
     return params ?? {};
+};
+
+export const createCoreCallCancelMessage = (params?: CancelParams): CoreCallCancelMessage => {
+    const { reason, callId } = normalizeCancelParams(params);
+
+    return {
+        type: CORE_CALL_CANCEL,
+        payload: reason || callId ? { reason, callId } : null,
+    };
 };

--- a/packages/connect-common/src/utils/deferred.ts
+++ b/packages/connect-common/src/utils/deferred.ts
@@ -1,0 +1,9 @@
+import { type DeferredManager, createDeferredManager } from '@trezor/utils';
+
+/**
+ * Message-promise managers across connect share the same id scheme: a random
+ * UUID string. Centralizing the generator keeps that scheme in one place instead
+ * of repeating the `generateId` lambda in every message channel.
+ */
+export const createUUIDDeferredManager = <T = any>(): DeferredManager<T, string> =>
+    createDeferredManager<T, string>({ generateId: () => crypto.randomUUID() });

--- a/packages/connect-common/src/utils/updateConnectSettings.ts
+++ b/packages/connect-common/src/utils/updateConnectSettings.ts
@@ -1,0 +1,15 @@
+import { ERRORS } from '../constants';
+import { createErrorMessage } from '../events/core';
+
+// Shared response for implementations (proxy/deeplink/dynamic-fallback) that do
+// not support runtime settings updates. Kept here so all host packages return
+// an identical error message instead of re-declaring it.
+export const createUpdateConnectSettingsUnsupportedMessage = () =>
+    Promise.resolve(
+        createErrorMessage(
+            ERRORS.TypedError(
+                'Method_InvalidPackage',
+                'updateConnectSettings is not supported in this implementation',
+            ),
+        ),
+    );

--- a/packages/connect-explorer-theme/src/utils/patch-normalize-pages.ts
+++ b/packages/connect-explorer-theme/src/utils/patch-normalize-pages.ts
@@ -1,7 +1,7 @@
 import { normalizePages } from 'nextra/normalize-pages';
 import { type Folder, type MdxFile, type PageMapItem } from 'nextra/types';
 
-const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
+import { capitalizeFirstLetter } from '@trezor/utils';
 
 const FOLDER_TITLE_OVERRIDES: Record<string, string> = {
     common: 'Common Methods',
@@ -44,7 +44,7 @@ export const patchedNormalizePages = (
         // Methods folders should have capitalized names
         replaceMeta(methodsFolder, page => [
             page.name,
-            FOLDER_TITLE_OVERRIDES[page.name] ?? capitalize(page.name),
+            FOLDER_TITLE_OVERRIDES[page.name] ?? capitalizeFirstLetter(page.name),
         ]);
         // Methods sub items should have original names
         methodsFolder?.children.forEach(folder => {

--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -5,7 +5,6 @@ import {
     DEFAULT_DOMAIN_MAJOR_VER,
 } from '@trezor/connect-common/src/data/version';
 import { type CallMethodPayload } from '@trezor/connect-common/src/events';
-import { createErrorMessage } from '@trezor/connect-common/src/events';
 import {
     type ConnectFactoryDependencies,
     bindConnectFactoryDependencies,
@@ -21,6 +20,7 @@ import {
     type CancelParams,
     normalizeCancelParams,
 } from '@trezor/connect-common/src/utils/cancelParams';
+import { createUpdateConnectSettingsUnsupportedMessage } from '@trezor/connect-common/src/utils/updateConnectSettings';
 import { createDeferredManager, removeTrailingSlashes } from '@trezor/utils';
 
 type BuildUrlParams = {
@@ -54,7 +54,7 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies<Connect
     private manifest?: Manifest;
 
     public updateConnectSettings(_params: UpdateConnectSettings) {
-        return Promise.resolve(createErrorMessage(ERRORS.TypedError('Method_InvalidPackage')));
+        return createUpdateConnectSettingsUnsupportedMessage();
     }
 
     private openDeeplink: (method: string, id: string, params: any) => void = () => {

--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -20,8 +20,9 @@ import {
     type CancelParams,
     normalizeCancelParams,
 } from '@trezor/connect-common/src/utils/cancelParams';
+import { createUUIDDeferredManager } from '@trezor/connect-common/src/utils/deferred';
 import { createUpdateConnectSettingsUnsupportedMessage } from '@trezor/connect-common/src/utils/updateConnectSettings';
-import { createDeferredManager, removeTrailingSlashes } from '@trezor/utils';
+import { removeTrailingSlashes } from '@trezor/utils';
 
 type BuildUrlParams = {
     method: string;
@@ -49,7 +50,7 @@ const buildUrl = ({ method, id, params, connectSrc, callbackUrl, manifest }: Bui
 
 export class TrezorConnectDeeplink implements ConnectFactoryDependencies<ConnectMobileSettings> {
     public eventEmitter = new ConnectEmitter();
-    private messages = createDeferredManager({ generateId: (): string => crypto.randomUUID() });
+    private messages = createUUIDDeferredManager();
 
     private manifest?: Manifest;
 

--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -6,7 +6,11 @@ import {
 } from '@trezor/connect-common/src/data/version';
 import { type CallMethodPayload } from '@trezor/connect-common/src/events';
 import { createErrorMessage } from '@trezor/connect-common/src/events';
-import { type ConnectFactoryDependencies, factory } from '@trezor/connect-common/src/factory';
+import {
+    type ConnectFactoryDependencies,
+    bindConnectFactoryDependencies,
+    factory,
+} from '@trezor/connect-common/src/factory';
 import type {
     ConnectMobileSettings,
     Manifest,
@@ -176,15 +180,7 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies<Connect
 
 const impl = new TrezorConnectDeeplink();
 const TrezorConnect = factory<ConnectMobileSettings, { handleDeeplink: (url: string) => void }>(
-    {
-        eventEmitter: impl.eventEmitter,
-        init: impl.init.bind(impl),
-        call: impl.call.bind(impl),
-        uiResponse: impl.uiResponse.bind(impl),
-        updateConnectSettings: impl.updateConnectSettings.bind(impl),
-        cancel: impl.cancel.bind(impl),
-        dispose: impl.dispose.bind(impl),
-    },
+    bindConnectFactoryDependencies(impl),
     { handleDeeplink: impl.handleDeeplink.bind(impl) },
 );
 

--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -1,7 +1,6 @@
 import * as ERRORS from '@trezor/connect-common/src/constants/errors';
 import {
     CORE_CALL,
-    CORE_CALL_CANCEL,
     type CallMethodAnyResponse,
     type CallMethodPayload,
     POPUP,
@@ -10,7 +9,7 @@ import type { ConnectImpl } from '@trezor/connect-common/src/impl/dynamic';
 import type { ConnectImplSettings, Manifest } from '@trezor/connect-common/src/types/settings';
 import {
     type CancelParams,
-    normalizeCancelParams,
+    createCoreCallCancelMessage,
 } from '@trezor/connect-common/src/utils/cancelParams';
 import { WebsocketClient, WebsocketError } from '@trezor/websocket-client';
 
@@ -36,11 +35,7 @@ export class CoreInSuiteDesktop implements ConnectImpl {
     }
 
     public cancel(params?: CancelParams) {
-        const { reason, callId } = normalizeCancelParams(params);
-        this.ws.sendMessage({
-            type: CORE_CALL_CANCEL,
-            payload: reason || callId ? { reason, callId } : null,
-        });
+        this.ws.sendMessage(createCoreCallCancelMessage(params));
     }
 
     private async handshake() {

--- a/packages/connect-web/src/impl/core-in-suite-web.ts
+++ b/packages/connect-web/src/impl/core-in-suite-web.ts
@@ -1,7 +1,6 @@
 import * as ERRORS from '@trezor/connect-common/src/constants/errors';
 import {
     CORE_CALL,
-    CORE_CALL_CANCEL,
     type CallMethodAnyResponse,
     type CallMethodPayload,
     createErrorMessage,
@@ -10,6 +9,7 @@ import type { ConnectImpl } from '@trezor/connect-common/src/impl/dynamic';
 import type { ConnectImplSettings } from '@trezor/connect-common/src/types/settings';
 import {
     type CancelParams,
+    createCoreCallCancelMessage,
     normalizeCancelParams,
 } from '@trezor/connect-common/src/utils/cancelParams';
 import { type Log, initLog } from '@trezor/connect-common/src/utils/debug';
@@ -45,13 +45,9 @@ export class CoreInSuiteWeb implements ConnectImpl {
         // delayed behind queued sends (relevant for the webextension
         // channel whose sendChain serialises chrome.tabs.update calls).
         this._popupManager?.channel?.clearPendingSends();
-        this._popupManager?.channel?.postMessage(
-            {
-                type: CORE_CALL_CANCEL,
-                payload: reason || callId ? { reason, callId } : null,
-            },
-            { usePromise: false },
-        );
+        this._popupManager?.channel?.postMessage(createCoreCallCancelMessage(params), {
+            usePromise: false,
+        });
     }
 
     public init({ env, manifest, version, debug }: ConnectImplSettings): Promise<void> {

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -1,4 +1,4 @@
-import { factory } from '@trezor/connect-common/src/factory';
+import { bindConnectFactoryDependencies, factory } from '@trezor/connect-common/src/factory';
 import { TrezorConnectDynamic } from '@trezor/connect-common/src/impl/dynamic';
 
 import { CoreInSuiteDesktop } from './impl/core-in-suite-desktop';
@@ -11,15 +11,7 @@ const impl = new TrezorConnectDynamic({
     },
 });
 
-const TrezorConnect = factory({
-    eventEmitter: impl.eventEmitter,
-    init: impl.init.bind(impl),
-    call: impl.call.bind(impl),
-    uiResponse: impl.uiResponse.bind(impl),
-    updateConnectSettings: impl.updateConnectSettings.bind(impl),
-    cancel: impl.cancel.bind(impl),
-    dispose: impl.dispose.bind(impl),
-});
+const TrezorConnect = factory(bindConnectFactoryDependencies(impl));
 
 export default TrezorConnect;
 export * from '@trezor/connect-common/src/constants';

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -1,7 +1,7 @@
 // note: at the moment, there is something in the root of @trezor/connect-common that pulls entire PROTO runtime, thus
 // these targeted imports
 import { CORE_CALL_CANCEL, POPUP } from '@trezor/connect-common/src/events';
-import { factory } from '@trezor/connect-common/src/factory';
+import { bindConnectFactoryDependencies, factory } from '@trezor/connect-common/src/factory';
 import { TrezorConnectDynamic } from '@trezor/connect-common/src/impl/dynamic';
 // Import as src not lib due to webpack issues with inlining content script later
 import { ServiceWorkerWindowChannel } from '@trezor/connect-common/src/messageChannel/serviceworker-window';
@@ -18,16 +18,7 @@ const impl = new TrezorConnectDynamic({
     },
 });
 
-// Bind all methods due to shadowing `this`
-const TrezorConnect = factory({
-    eventEmitter: impl.eventEmitter,
-    init: impl.init.bind(impl),
-    call: impl.call.bind(impl),
-    uiResponse: impl.uiResponse.bind(impl),
-    updateConnectSettings: impl.updateConnectSettings.bind(impl),
-    cancel: impl.cancel.bind(impl),
-    dispose: impl.dispose.bind(impl),
-});
+const TrezorConnect = factory(bindConnectFactoryDependencies(impl));
 
 const initProxyChannel = () => {
     const channel = new ServiceWorkerWindowChannel<{

--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -1,10 +1,5 @@
 import { ERRORS, WEBEXTENSION } from '@trezor/connect-common/src/constants';
-import {
-    CORE_CALL,
-    CORE_CALL_CANCEL,
-    type CallMethod,
-    POPUP,
-} from '@trezor/connect-common/src/events';
+import { CORE_CALL, type CallMethod, POPUP } from '@trezor/connect-common/src/events';
 import { createErrorMessage } from '@trezor/connect-common/src/events';
 import { factory } from '@trezor/connect-common/src/factory';
 import { WindowServiceWorkerChannel } from '@trezor/connect-common/src/messageChannel/window-serviceworker';
@@ -15,7 +10,7 @@ import type {
 import { ConnectEmitter } from '@trezor/connect-common/src/types/emitter';
 import {
     type CancelParams,
-    normalizeCancelParams,
+    createCoreCallCancelMessage,
 } from '@trezor/connect-common/src/utils/cancelParams';
 
 const eventEmitter = new ConnectEmitter();
@@ -29,14 +24,7 @@ const dispose = () => {
 
 const cancel = (params?: CancelParams) => {
     if (_channel) {
-        const { reason, callId } = normalizeCancelParams(params);
-        _channel.postMessage(
-            {
-                type: CORE_CALL_CANCEL,
-                payload: reason || callId ? { reason, callId } : null,
-            },
-            { usePromise: false },
-        );
+        _channel.postMessage(createCoreCallCancelMessage(params), { usePromise: false });
 
         return Promise.resolve(_channel.clear());
     }

--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -12,6 +12,7 @@ import {
     type CancelParams,
     createCoreCallCancelMessage,
 } from '@trezor/connect-common/src/utils/cancelParams';
+import { createUpdateConnectSettingsUnsupportedMessage } from '@trezor/connect-common/src/utils/updateConnectSettings';
 
 const eventEmitter = new ConnectEmitter();
 let _channel: any;
@@ -70,14 +71,7 @@ const init = (settings: ConnectDynamicSettings): Promise<void> => {
 };
 
 const updateConnectSettings = (_params: UpdateConnectSettings) =>
-    Promise.resolve(
-        createErrorMessage(
-            ERRORS.TypedError(
-                'Method_InvalidPackage',
-                'updateConnectSettings is not supported in this implementation',
-            ),
-        ),
-    );
+    createUpdateConnectSettingsUnsupportedMessage();
 const call: CallMethod = async (params: any) => {
     try {
         const response = await _channel.postMessage({

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -1,7 +1,6 @@
 import {
     BLOCKCHAIN_EVENT,
     CORE_CALL,
-    CORE_CALL_CANCEL,
     DEVICE_EVENT,
     RESPONSE_EVENT,
     SET_ENABLED_NETWORKS,
@@ -25,7 +24,7 @@ import { parseConnectSettings } from '@trezor/connect-common/src/data/connectSet
 import { ConnectEmitter } from '@trezor/connect-common/src/types/emitter';
 import {
     type CancelParams,
-    normalizeCancelParams,
+    createCoreCallCancelMessage,
 } from '@trezor/connect-common/src/utils/cancelParams';
 import { noopLogger } from '@trezor/connect-common/src/utils/debug';
 import { TRANSPORT } from '@trezor/transport-common';
@@ -203,11 +202,7 @@ export abstract class CoreInModule implements ConnectFactoryDependencies<Connect
     }
 
     public cancel(params?: CancelParams) {
-        const { reason, callId } = normalizeCancelParams(params);
-        this.handleCoreMessage({
-            type: CORE_CALL_CANCEL,
-            payload: reason || callId ? { reason, callId } : null,
-        });
+        this.handleCoreMessage(createCoreCallCancelMessage(params));
     }
 
     public dispose() {

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -27,8 +27,9 @@ import {
     createCoreCallCancelMessage,
 } from '@trezor/connect-common/src/utils/cancelParams';
 import { noopLogger } from '@trezor/connect-common/src/utils/debug';
+import { createUUIDDeferredManager } from '@trezor/connect-common/src/utils/deferred';
 import { TRANSPORT } from '@trezor/transport-common';
-import { type Logger, cloneObject, createDeferredManager } from '@trezor/utils';
+import { type Logger, cloneObject } from '@trezor/utils';
 
 import { initCoreState } from '../core';
 
@@ -49,10 +50,8 @@ export abstract class CoreInModule implements ConnectFactoryDependencies<Connect
         // No-op until init() resolves the host logger settings.
         this.log = noopLogger;
         this.coreManager = initCoreState();
-        this.messagePromises = createDeferredManager<
-            Omit<MethodResponseMessage, 'event' | 'type'>,
-            string
-        >({ generateId: (): string => crypto.randomUUID() });
+        this.messagePromises =
+            createUUIDDeferredManager<Omit<MethodResponseMessage, 'event' | 'type'>>();
     }
 
     // handle messages to core

--- a/packages/connect/src/index.browser.ts
+++ b/packages/connect/src/index.browser.ts
@@ -1,4 +1,9 @@
-import { ERRORS, type UpdateConnectSettings, factory } from '@trezor/connect-common';
+import {
+    ERRORS,
+    type UpdateConnectSettings,
+    bindConnectFactoryDependencies,
+    factory,
+} from '@trezor/connect-common';
 import { TRANSPORT } from '@trezor/transport-common';
 
 import { config } from './data/config';
@@ -33,20 +38,9 @@ class CoreInModuleWeb extends CoreInModule {
 const impl = new CoreInModuleWeb();
 
 // Exported to enable using directly
-const TrezorConnect = factory(
-    {
-        eventEmitter: impl.eventEmitter,
-        init: impl.init.bind(impl),
-        call: impl.call.bind(impl),
-        updateConnectSettings: impl.updateConnectSettings.bind(impl),
-        uiResponse: impl.uiResponse.bind(impl),
-        cancel: impl.cancel.bind(impl),
-        dispose: impl.dispose.bind(impl),
-    },
-    {
-        requestWebUSBDevice: impl.requestWebUSBDevice.bind(impl),
-    },
-);
+const TrezorConnect = factory(bindConnectFactoryDependencies(impl), {
+    requestWebUSBDevice: impl.requestWebUSBDevice.bind(impl),
+});
 
 export default TrezorConnect;
 

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,5 +1,5 @@
 import type { UpdateConnectSettings } from '@trezor/connect-common';
-import { factory } from '@trezor/connect-common';
+import { bindConnectFactoryDependencies, factory } from '@trezor/connect-common';
 
 import { updateProxy } from './backend/BlockchainLink';
 import { CoreInModule } from './impl/core-in-module';
@@ -16,18 +16,7 @@ class CoreInModuleNode extends CoreInModule {
 
 const impl = new CoreInModuleNode();
 
-const TrezorConnect = factory(
-    {
-        eventEmitter: impl.eventEmitter,
-        init: impl.init.bind(impl),
-        call: impl.call.bind(impl),
-        updateConnectSettings: impl.updateConnectSettings.bind(impl),
-        uiResponse: impl.uiResponse.bind(impl),
-        cancel: impl.cancel.bind(impl),
-        dispose: impl.dispose.bind(impl),
-    },
-    {},
-);
+const TrezorConnect = factory(bindConnectFactoryDependencies(impl), {});
 
 export default TrezorConnect;
 


### PR DESCRIPTION
## Description

Duplicate-consolidation sweep across the `@trezor/connect*` packages. Each commit extracts one repeated construction into a shared helper in `@trezor/connect-common`, with no change to public API or runtime behaviour:

- `bindConnectFactoryDependencies(impl)` — replaces the hand-written `impl.method.bind(impl)` block passed into `factory()` in 5 host packages.
- `createCoreCallCancelMessage(params)` — replaces the inline `{ type: CORE_CALL_CANCEL, payload: … }` construction at 4 call-sites across 3 packages.
- `createUpdateConnectSettingsUnsupportedMessage()` — replaces the duplicated "updateConnectSettings not supported" error-message construction in 3 host packages.
- `createUUIDDeferredManager<T>()` — replaces the repeated `createDeferredManager({ generateId: () => crypto.randomUUID() })` in 3 packages.
- Two remaining util-like snippets now reuse existing `@trezor/utils` helpers (`capitalizeFirstLetter`, `resolveAfter`).

Net −32 lines. The helpers are imported directly by path (`@trezor/connect-common/src/...`); `bindConnectFactoryDependencies` rides the existing `export * from './factory'` barrel, so no barrel or public-surface change.

One intentional behaviour alignment worth noting: `connect-mobile`'s `updateConnectSettings` previously returned `Method_InvalidPackage` with no message; it now returns the same code with the shared descriptive message, matching the other packages.

## Related Issue

N/A — mechanical de-duplication sweep.

## Screenshots

N/A — no UI.

## Notes for QA

No QA needed. Pure refactor with byte-identical trees to the pre-rewrite branch: no functional change, no public API change, no dependency change. The only observable difference is a more descriptive error message on `connect-mobile.updateConnectSettings()` (a code path that returns an "unsupported" error either way). Blast radius is limited to `@trezor/connect*` wiring; CI type-check + unit tests cover it.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies core TrezorConnect infrastructure: the factory pattern, message channel abstractions, deferred/cancel utilities, connect settings, and all platform-specific implementations (suite-desktop, suite-web, webextension, mobile, core-in-module). The highest risk is in the trezor-connect E2E tests which directly test TrezorConnect API calls through these exact code paths. Medium risk exists for wallet operations (send, receive, sign) that internally use TrezorConnect through core-in-module.ts. The 121 tests mapped via core-in-module.ts are mostly Suite UI tests that use connect as a transitive dependency — only those with explicit device communication flows (signing, address verification) warrant testing.

<details><summary><b>Changed files (17)</b></summary>

- `packages/connect-common/src/factory.ts`
- `packages/connect-common/src/impl/dynamic.ts`
- `packages/connect-common/src/messageChannel/abstract.ts`
- `packages/connect-common/src/messageChannel/serviceworker-window-ext-connectable.ts`
- `packages/connect-common/src/utils/cancelParams.ts`
- `packages/connect-common/src/utils/deferred.ts`
- `packages/connect-common/src/utils/updateConnectSettings.ts`
- `packages/connect-explorer-theme/src/utils/patch-normalize-pages.ts`
- `packages/connect-mobile/src/index.ts`
- `packages/connect-web/src/impl/core-in-suite-desktop.ts`
- `packages/connect-web/src/impl/core-in-suite-web.ts`
- `packages/connect-web/src/index.ts`
- `packages/connect-webextension/src/index.ts`
- `packages/connect-webextension/src/proxy/index.ts`
- `packages/connect/src/impl/core-in-module.ts`
- `packages/connect/src/index.browser.ts`
- `packages/connect/src/index.ts`

</details>

**Recommended tests (16)**

<details><summary>🔴 <b>High priority (10)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises TrezorConnect.getAddress through the suite-web popup flow, directly using connect-web/src/impl/core-in-suite-web.ts and connect-web/src/index.ts. Changes to popup lifecycle management, message channels, and cancel handling in connect-common are core to this test's happy path and cancellation scenarios.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test exercises TrezorConnect from a webextension context, directly using connect-webextension/src/index.ts, connect-webextension/src/proxy/index.ts, and the service-worker message channel. Changes to serviceworker-window-ext-connectable.ts and the webextension proxy are core to this flow.
- `suite/e2e/tests/trezor-connect/error.test.ts` — This test initializes TrezorConnect with coreMode 'suite-desktop' and validates error display for invalid paths. It directly exercises connect-web/src/impl/core-in-suite-desktop.ts and the connect initialization/factory code paths.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Uses TrezorConnect.init with coreMode 'suite-desktop' and ethereumSignMessage, directly exercising the core-in-suite-desktop implementation and connect-web index. Changes to deferred promises and message channels could break the signing flow.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Uses TrezorConnect.init with coreMode 'suite-desktop' and ethereumSignTransaction with multi-step device confirmation. Directly exercises core-in-suite-desktop.ts and the connect factory/deferred utilities.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Calls TrezorConnect.getAccountInfo with coreMode 'suite-desktop', testing permissions modal and account selection. Directly uses core-in-suite-desktop.ts and connect-web index entry point.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Tests single and bundle getAddress calls with device verification and rejection handling via TrezorConnect with coreMode 'suite-desktop'. Directly exercises connect-web/core-in-suite-desktop.ts and cancel/deferred utilities.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests TrezorConnect permissions grant/revoke/remember flow with coreMode 'suite-desktop'. Directly exercises core-in-suite-desktop.ts, connect settings update logic, and the connect factory.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Tests Bitcoin signTransaction via TrezorConnect with coreMode 'suite-desktop', including multi-step device prompts. Directly uses core-in-suite-desktop.ts and the connect entry point.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests TrezorConnect silent mode with coreMode 'suite-desktop', involving permissions persistence and IPC focus control. Directly exercises core-in-suite-desktop.ts, connect settings, and the factory pattern.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — Signs and verifies Ethereum messages through the Suite app which internally uses TrezorConnect. Changes to core-in-module.ts (the in-suite connect implementation) and deferred utilities could affect the device communication flow.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Signs and verifies Bitcoin messages through the Suite app using TrezorConnect internally. Changes to core-in-module.ts and message channel abstractions could affect the signing flow.
- `suite/e2e/tests/wallet/receive.test.ts` — Receive address flow calls TrezorConnect.getAddress internally through core-in-module.ts for on-device address verification. Changes to deferred and cancel utilities could affect address reveal flows.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Sends an Ethereum transaction requiring device signing through TrezorConnect internally. Changes to core-in-module.ts and the deferred/message channel abstractions are exercised during the signing confirmation flow.
- `suite/e2e/tests/wallet/cardano.test.ts` — Exercises TrezorConnect for Cardano public key reveal and address confirmation on device. Changes to core-in-module.ts deferred handling could affect the device communication during key/address reveal.
- `suite/e2e/tests/wallet/public-keys.test.ts` — Shows public keys (XPUBs) for BTC/LTC/ADA via device prompt using TrezorConnect internally. Changes to core-in-module.ts and deferred utilities affect the device interaction flow for key export.

</details>

⚠️ **Changes with no test coverage (5)**
- `packages/connect-common/src/impl/dynamic.ts`
- `packages/connect-explorer-theme/src/utils/patch-normalize-pages.ts`
- `packages/connect-mobile/src/index.ts`
- `packages/connect/src/index.browser.ts`
- `packages/connect/src/index.ts`

_Updated: 2026-07-02T06:16:22.996Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/rewrite-commits-english/web/](https://dev.suite.sldev.cz/suite-web/mroz22/rewrite-commits-english/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/rewrite-commits-english&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/rewrite-commits-english&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/rewrite-commits-english&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T06:22:02.185Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |

</details>

_Updated: 2026-07-02T06:19:03.313Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->