### PR TITLE
fix(suite-native): stabilize selected device fiat balance

### DIFF
--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -42,8 +42,6 @@ import {
     selectAccountsByDeviceState,
     selectBaseCurrency,
     selectCurrentFiatRates,
-    selectDeviceAccounts,
-    selectHasRunningDiscovery,
     selectIsDiscoveredDeviceAccountless,
 } from '@suite-common/wallet-core';
 import {
@@ -149,15 +147,6 @@ const getTotalFiatBalanceNative = ({
 
     return asBaseCurrencyAmount(instanceBalance);
 };
-
-export const selectSelectedDeviceTotalFiatBalance = createMemoizedSelector(
-    [selectDeviceAccounts, selectCurrentFiatRates, selectBaseCurrency, selectHasRunningDiscovery],
-    (deviceAccounts, rates, localCurrency, hasRunningDiscovery) =>
-        // do not return any value before discovery is finished to prevent unnecessary rerenders of portfolio graph.
-        hasRunningDiscovery
-            ? undefined
-            : getTotalFiatBalanceNative({ deviceAccounts, localCurrency, rates }),
-);
 
 export const selectDeviceTotalFiatBalanceByDeviceState = createMemoizedSelector(
     [selectAccountsByDeviceState, selectCurrentFiatRates, selectBaseCurrency],

--- a/suite-native/graph/package.json
+++ b/suite-native/graph/package.json
@@ -39,6 +39,7 @@
         "@suite-native/storage": "workspace:*",
         "@suite-native/theme": "workspace:*",
         "@suite-native/tokens": "workspace:*",
+        "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/styles-native": "workspace:*",
         "@trezor/theme": "workspace:*",
         "@trezor/type-utils": "workspace:*",

--- a/suite-native/graph/src/__tests__/selectors.test.ts
+++ b/suite-native/graph/src/__tests__/selectors.test.ts
@@ -4,15 +4,24 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type DiscoveryRootState,
+    type FiatRatesRootState,
+    type WalletSettingsRootState,
     selectDeviceMainnetAccounts,
     selectHasRunningDiscovery,
 } from '@suite-common/wallet-core';
-import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
+import {
+    type Account,
+    type AccountWithNetworkType,
+    asAccountDescriptor,
+    asCryptoBaseCurrencyCode,
+    asTimestamp,
+} from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import {
     selectDeviceHistoryIgnoredNetworkSymbols,
     selectPortfolioGraphAccountItemsIfDiscoveryIsNotRunning,
+    selectPortfolioGraphTotalFiatBalance,
 } from '../selectors';
 
 // Mock the dependencies
@@ -35,7 +44,76 @@ const mockSelectHasRunningDiscovery = selectHasRunningDiscovery as jest.MockedFu
 type TestState = DeviceRootState &
     AccountsRootState &
     DiscoveryRootState &
+    FiatRatesRootState &
+    WalletSettingsRootState &
     TokenDefinitionsRootState;
+
+const TEST_SESSION_ID = 'address@hash:0' as const;
+
+const buildPortfolioGraphBalanceState = (account: Account) =>
+    ({
+        device: {
+            selectedDevice: {
+                state: { staticSessionId: TEST_SESSION_ID },
+            },
+        },
+        wallet: {
+            accounts: [account],
+            settings: {
+                localCurrency: 'usd',
+            },
+            fiat: {
+                current: {
+                    [asCryptoBaseCurrencyCode(`${account.symbol}-usd`)]: {
+                        rate: 10,
+                        lastTickerTimestamp: asTimestamp(1),
+                        lastSuccessfulFetchTimestamp: asTimestamp(1),
+                        isLoading: false,
+                        error: null,
+                        ticker: { symbol: 'btc' },
+                    },
+                },
+            },
+        },
+        tokenDefinitions: {},
+    }) as unknown as TestState;
+
+const buildBalanceAccount = (formattedBalance: string) =>
+    mockWalletAccount({
+        symbol: 'btc',
+        descriptor: asAccountDescriptor('btc'),
+        deviceState: TEST_SESSION_ID,
+        formattedBalance,
+    });
+
+const buildEthereumClassicAccountWithStakingData = (): AccountWithNetworkType<'ethereum'> => ({
+    ...mockWalletAccount({
+        symbol: 'etc',
+        descriptor: asAccountDescriptor('etc'),
+        deviceState: TEST_SESSION_ID,
+        formattedBalance: '2',
+    }),
+    networkType: 'ethereum',
+    marker: undefined,
+    stellarCursor: undefined,
+    page: { index: 1, size: 25, total: 1 },
+    misc: {
+        nonce: '0',
+        stakingPools: [
+            {
+                contract: '0x0',
+                name: 'Everstake',
+                autocompoundBalance: '5',
+                pendingBalance: '0',
+                pendingDepositedBalance: '0',
+                depositedBalance: '0',
+                withdrawTotalAmount: '0',
+                claimableAmount: '0',
+                restakedReward: '0',
+            },
+        ],
+    },
+});
 
 describe('selectDeviceHistoryIgnoredNetworkSymbols', () => {
     let mockState: TestState;
@@ -164,5 +242,59 @@ describe('selectPortfolioGraphAccountItemsIfDiscoveryIsNotRunning', () => {
                 tokensFilter: [],
             },
         ]);
+    });
+});
+
+describe('selectPortfolioGraphTotalFiatBalance', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('returns the same reference when updated account objects have the same fiat balance', () => {
+        mockSelectHasRunningDiscovery.mockReturnValue(false);
+
+        const firstBalance = selectPortfolioGraphTotalFiatBalance(
+            buildPortfolioGraphBalanceState(buildBalanceAccount('2')),
+        );
+        const secondBalance = selectPortfolioGraphTotalFiatBalance(
+            buildPortfolioGraphBalanceState(buildBalanceAccount('2')),
+        );
+
+        expect(firstBalance?.toFixed()).toBe('20');
+        expect(firstBalance).toBe(secondBalance);
+    });
+
+    it('returns a new reference when the fiat balance changes', () => {
+        mockSelectHasRunningDiscovery.mockReturnValue(false);
+
+        const firstBalance = selectPortfolioGraphTotalFiatBalance(
+            buildPortfolioGraphBalanceState(buildBalanceAccount('2')),
+        );
+        const secondBalance = selectPortfolioGraphTotalFiatBalance(
+            buildPortfolioGraphBalanceState(buildBalanceAccount('3')),
+        );
+
+        expect(secondBalance?.toFixed()).toBe('30');
+        expect(secondBalance).not.toBe(firstBalance);
+    });
+
+    it('returns undefined while discovery is running', () => {
+        mockSelectHasRunningDiscovery.mockReturnValue(true);
+
+        expect(
+            selectPortfolioGraphTotalFiatBalance(
+                buildPortfolioGraphBalanceState(buildBalanceAccount('2')),
+            ),
+        ).toBeUndefined();
+    });
+
+    it('keeps native staking inclusion semantics for unsupported staking symbols', () => {
+        mockSelectHasRunningDiscovery.mockReturnValue(false);
+
+        const totalFiatBalance = selectPortfolioGraphTotalFiatBalance(
+            buildPortfolioGraphBalanceState(buildEthereumClassicAccountWithStakingData()),
+        );
+
+        expect(totalFiatBalance?.toFixed()).toBe('20');
     });
 });

--- a/suite-native/graph/src/portfolioGraphBalanceUtils.ts
+++ b/suite-native/graph/src/portfolioGraphBalanceUtils.ts
@@ -1,0 +1,35 @@
+import { type Account, type RatesByKey } from '@suite-common/wallet-types';
+import { getAccountFiatBalance, isStakingSymbol } from '@suite-common/wallet-utils';
+import { type BaseCurrencyCode } from '@trezor/blockchain-link-types';
+import { BigNumber } from '@trezor/utils';
+
+type GetPortfolioGraphTotalFiatBalanceParams = {
+    deviceAccounts: Account[];
+    fiatRates: RatesByKey | undefined;
+    baseCurrencyCode: BaseCurrencyCode;
+};
+
+export const getPortfolioGraphTotalFiatBalance = ({
+    deviceAccounts,
+    fiatRates,
+    baseCurrencyCode,
+}: GetPortfolioGraphTotalFiatBalanceParams) => {
+    let totalFiatBalance = new BigNumber(0);
+
+    // Preserve native portfolio semantics: staking is included per account only when mobile
+    // supports staking for that network symbol. The shared total helper exposes staking as
+    // a single global option, so it cannot express this condition.
+    deviceAccounts.forEach(account => {
+        const accountFiatBalance =
+            getAccountFiatBalance({
+                account,
+                baseCurrencyCode,
+                rates: fiatRates,
+                shouldIncludeStaking: isStakingSymbol(account.symbol),
+            }) ?? '0';
+
+        totalFiatBalance = totalFiatBalance.plus(accountFiatBalance);
+    });
+
+    return totalFiatBalance;
+};

--- a/suite-native/graph/src/selectors.ts
+++ b/suite-native/graph/src/selectors.ts
@@ -11,17 +11,36 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type DiscoveryRootState,
+    type FiatRatesRootState,
+    type WalletSettingsRootState,
     selectAccountByKey,
+    selectBaseCurrency,
+    selectCurrentFiatRates,
+    selectDeviceAccounts,
     selectDeviceMainnetAccounts,
     selectHasRunningDiscovery,
 } from '@suite-common/wallet-core';
-import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
+import {
+    type AccountKey,
+    type TokenAddress,
+    asBaseCurrencyAmount,
+} from '@suite-common/wallet-types';
 import { tryGetAccountIdentity } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { getPortfolioGraphTotalFiatBalance } from './portfolioGraphBalanceUtils';
 
 type GraphCommonRootState = DeviceRootState & AccountsRootState & TokenDefinitionsRootState;
 type PortfolioGraphRootState = GraphCommonRootState & DiscoveryRootState;
+type PortfolioGraphBalanceRootState = DeviceRootState &
+    AccountsRootState &
+    DiscoveryRootState &
+    FiatRatesRootState &
+    WalletSettingsRootState;
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<GraphCommonRootState>();
+const createPortfolioGraphBalanceSelector =
+    createWeakMapSelector.withTypes<PortfolioGraphBalanceRootState>();
 
 export const selectPortfolioGraphAccountItems = (state: GraphCommonRootState): AccountItem[] => {
     const accounts = selectDeviceMainnetAccounts(state);
@@ -51,6 +70,30 @@ export const selectPortfolioGraphAccountItemsIfDiscoveryIsNotRunning = (
 
     return selectPortfolioGraphAccountItems(state);
 };
+
+// Use a primitive decimal string as the memoization boundary. Recalculating an unchanged balance
+// creates a new BigNumber instance, which would trigger useSelector subscribers by reference.
+// BigNumber.toFixed() preserves the full decimal value without converting through a JS number.
+const selectPortfolioGraphTotalFiatBalanceValue = createPortfolioGraphBalanceSelector(
+    [selectDeviceAccounts, selectCurrentFiatRates, selectBaseCurrency, selectHasRunningDiscovery],
+    (deviceAccounts, fiatRates, baseCurrencyCode, hasRunningDiscovery) =>
+        // Do not return any value before discovery is finished to prevent unnecessary graph rerenders.
+        hasRunningDiscovery
+            ? undefined
+            : getPortfolioGraphTotalFiatBalance({
+                  deviceAccounts,
+                  fiatRates,
+                  baseCurrencyCode,
+              }).toFixed(),
+);
+
+export const selectPortfolioGraphTotalFiatBalance = createPortfolioGraphBalanceSelector(
+    [selectPortfolioGraphTotalFiatBalanceValue],
+    totalFiatBalanceValue =>
+        totalFiatBalanceValue === undefined
+            ? undefined
+            : asBaseCurrencyAmount(new BigNumber(totalFiatBalanceValue)),
+);
 
 export const selectHasDeviceHistoryEnabledAccounts = createMemoizedSelector(
     [selectDeviceMainnetAccounts],

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
@@ -4,12 +4,12 @@ import { useSelector } from 'react-redux';
 import { getNetwork } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Box, Text, VStack } from '@suite-native/atoms';
-import { selectSelectedDeviceTotalFiatBalance } from '@suite-native/device';
 import { useIsDiscoveryDurationTooLong } from '@suite-native/discovery';
 import {
     Graph,
     selectDeviceHistoryIgnoredNetworkSymbols,
     selectHasDeviceHistoryEnabledAccounts,
+    selectPortfolioGraphTotalFiatBalance,
     useGraphAtoms,
     useGraphForAllDeviceAccounts,
 } from '@suite-native/graph';
@@ -48,7 +48,7 @@ export const PortfolioGraph = forwardRef<PortfolioGraphRef>((_props, ref) => {
     const hasDeviceHistoryEnabledAccounts = useSelector(selectHasDeviceHistoryEnabledAccounts);
     const hasDeviceDiscovery = useSelector(selectHasRunningDiscovery);
     const loadingTakesLongerThanExpected = useIsDiscoveryDurationTooLong();
-    const totalFiatBalance = useSelector(selectSelectedDeviceTotalFiatBalance);
+    const totalFiatBalance = useSelector(selectPortfolioGraphTotalFiatBalance);
 
     const { graphPoints, error, isLoading, isAnyMainnetAccountPresent, refetch } =
         useGraphForAllDeviceAccounts({

--- a/yarn.lock
+++ b/yarn.lock
@@ -12598,6 +12598,7 @@ __metadata:
     "@suite-native/storage": "workspace:*"
     "@suite-native/theme": "workspace:*"
     "@suite-native/tokens": "workspace:*"
+    "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/styles-native": "workspace:*"
     "@trezor/theme": "workspace:*"
     "@trezor/type-utils": "workspace:*"


### PR DESCRIPTION
## Description

Stabilizes the Home portfolio graph total-balance selector.

- Moves the Home portfolio total-balance selector into `@suite-native/graph`.
- Memoizes the graph total balance through a primitive decimal value, so recalculating the same fiat total does not create a new `BigNumber` reference for `useSelector`.
- Preserves native balance semantics: staking is included per account only when mobile supports staking for that account symbol.
- Removes the now-unused selected-device total-balance selector from `@suite-native/device`.


## Related issue

Closes #29000

## Testing

- Added selector tests for portfolio total-balance reference stability.
- Added coverage for genuine balance changes returning a new reference.
- Added discovery coverage for returning `undefined` while discovery is running.
- Added staking regression coverage to ensure unsupported staking symbols do not include staking balance.



## Screenshots

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All changed files are under `suite-native/` (React Native mobile app packages), covering graph selectors, portfolio graph balance utilities, and a PortfolioGraph component for the mobile HomeScreen. None of the 141 candidate E2E tests cover the mobile/native app — they all target the desktop/web Trezor Suite application. There is no static coverage mapping and no inferred overlap between these native-only changes and the web/desktop Playwright E2E tests. No E2E tests need to be run for this change set; the changes are best validated by the unit test already present (`suite-native/graph/src/__tests__/selectors.test.ts`) and any native-specific test infrastructure.

<details><summary><b>Changed files (6)</b></summary>

- `suite-native/device/src/selectors.ts`
- `suite-native/graph/package.json`
- `suite-native/graph/src/__tests__/selectors.test.ts`
- `suite-native/graph/src/portfolioGraphBalanceUtils.ts`
- `suite-native/graph/src/selectors.ts`
- `suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (6)**
- `suite-native/device/src/selectors.ts`
- `suite-native/graph/package.json`
- `suite-native/graph/src/__tests__/selectors.test.ts`
- `suite-native/graph/src/portfolioGraphBalanceUtils.ts`
- `suite-native/graph/src/selectors.ts`
- `suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx`

_Updated: 2026-07-02T08:04:06.233Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=issue-29000-fiat-balance&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=issue-29000-fiat-balance&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=issue-29000-fiat-balance&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T08:09:19.916Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |

</details>

_Updated: 2026-07-02T08:07:11.892Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/issue-29000-fiat-balance/web/](https://dev.suite.sldev.cz/suite-web/issue-29000-fiat-balance/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

