### PR TITLE
fix(suite): color token issues in onboarding

### DIFF
--- a/packages/components/src/components/Card/utils.tsx
+++ b/packages/components/src/components/Card/utils.tsx
@@ -80,6 +80,20 @@ export const mapCardTypeToCSS = ({
         contrast: css`
             background: ${theme.elementFillNeutralSofter};
             outline: 1px solid ${theme.elementBorderNeutralSofterAlt};
+
+            ${$isClickable &&
+            css`
+                ${$isSelected &&
+                css`
+                    outline: 2px solid ${theme.borderBrand};
+                `}
+
+                box-shadow: ${theme.surfaceShadowAction};
+
+                &:hover {
+                    box-shadow: ${theme.surfaceShadowActionHovered};
+                }
+            `}
         `,
     };
 

--- a/packages/suite/src/components/onboarding/OnboardingOption.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingOption.tsx
@@ -17,7 +17,7 @@ export const OnboardingOption = ({
     onClick,
     'data-testid': dataTestId,
 }: OnboardingOptionProps) => (
-    <Card onClick={onClick} data-testid={dataTestId} paddingType="none">
+    <Card onClick={onClick} data-testid={dataTestId} paddingType="none" type="contrast">
         <Row
             gap={20}
             justifyContent={iconName ? 'flex-start' : 'center'}

--- a/packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInitialStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInitialStep.tsx
@@ -316,7 +316,7 @@ export const FirmwareInitialStep = ({ onClose }: FirmwareInitialStepProps) => {
                 >
                     <Column gap={32}>
                         {deviceWillBeWiped && <FirmwareWipeWarning />}
-                        <Card>
+                        <Card type="contrast">
                             <FirmwareOffer targetFirmwareType={targetType} />
                         </Card>
                         <FirmwareWarningsList />

--- a/packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInstallationStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInstallationStep.tsx
@@ -61,7 +61,7 @@ export const FirmwareInstallationStep = ({ install, onSuccess }: FirmwareInstall
                 innerActions={getInnerActionComponent()}
             >
                 <Column gap={60}>
-                    <Card>
+                    <Card type="contrast">
                         <Column gap={8}>
                             <FirmwareOffer
                                 isCustomFirmware={false}

--- a/packages/suite/src/views/onboarding/steps/FirmwareStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/FirmwareStep/index.tsx
@@ -136,7 +136,7 @@ export const FirmwareStep = () => {
         case 'done': // This is shown only for NON-THP devices, THP device goes directly to the next step after successful THP pairing. see onboardingMiddleware
             if (isProgressCheckDisplayed) {
                 return (
-                    <Card paddingType="large">
+                    <Card paddingType="large" type="contrast">
                         <FirmwareInstallationProgressCheck
                             handleDismiss={handleDismissProgressCheck}
                         />

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/SelectBackupType.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/SelectBackupType.tsx
@@ -41,8 +41,8 @@ const Wrapper = styled.div`
 const SelectWrapper = styled.div`
     width: 700px;
     border-radius: ${borders.radii.sm};
-    border: 1px solid ${({ theme }) => theme.surfaceBorderRaised};
-    background: ${({ theme }) => theme.surfaceFillRaised};
+    border: 1px solid ${({ theme }) => theme.elementBorderNeutralSofterAlt};
+    background: ${({ theme }) => theme.elementFillNeutralSofter};
     position: relative;
 `;
 

--- a/suite/onboarding-components/src/OnboardingCard.tsx
+++ b/suite/onboarding-components/src/OnboardingCard.tsx
@@ -18,7 +18,7 @@ import {
 import TrezorConnect from '@trezor/connect';
 import { getDeviceColorVariant } from '@trezor/device-utils';
 import { ConfirmOnDevicePill } from '@trezor/product-components';
-import { zIndices } from '@trezor/theme';
+import { borders, zIndices } from '@trezor/theme';
 
 import { OnboardingCardButton } from './OnboardingCardButton';
 import { OnboardingCardSecondaryButton } from './OnboardingCardSecondaryButton';
@@ -116,6 +116,8 @@ export const OnboardingCard = ({
                     <Box
                         position={{ type: 'absolute', top: 0 }}
                         zIndex={isBackDropVisible ? zIndices.modal : undefined}
+                        backgroundColor="surfaceFillPage"
+                        borderRadius={borders.radii.full}
                     >
                         <IconCircle name={iconName} size={96} intent={intent} />
                     </Box>


### PR DESCRIPTION
## Notes for QA

Fixed color issues in onboarding caused by token migration.

## Screenshots:
<img width="1116" height="462" alt="image" src="https://github.com/user-attachments/assets/98b5336f-c017-485f-8f96-8db71e4a8dd3" />



<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes focus on onboarding UI components: the FirmwareStep (initial, installation, and index), SelectBackupType, OnboardingOption, OnboardingCard, and a shared Card utility. All changed files map to 121+ tests via static analysis, indicating they are broadly imported, so testing must be targeted. The highest risk is in the onboarding wallet creation and firmware check flows where these components are directly rendered. Recovery flows that pass through the firmware step are medium priority. Tests unrelated to onboarding (analytics, trading, staking, metadata, etc.) should be omitted despite static mapping since they only transitively import these components via the shared onboarding completeOnboarding helper.

<details><summary><b>Changed files (7)</b></summary>

- `packages/components/src/components/Card/utils.tsx`
- `packages/suite/src/components/onboarding/OnboardingOption.tsx`
- `packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInitialStep.tsx`
- `packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInstallationStep.tsx`
- `packages/suite/src/views/onboarding/steps/FirmwareStep/index.tsx`
- `packages/suite/src/views/onboarding/steps/SelectBackupType/SelectBackupType.tsx`
- `suite/onboarding-components/src/OnboardingCard.tsx`

</details>

**Recommended tests (17)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/onboarding/firmware-check.test.ts` — Directly tests the firmware readiness check during onboarding, which is the core flow affected by changes to FirmwareStep/index.tsx, FirmwareInitialStep.tsx, and FirmwareInstallationStep.tsx.
- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — Tests the full wallet creation flow including firmware step, seed type selection (SelectBackupType.tsx), and Shamir backup — directly exercising both the FirmwareStep and SelectBackupType changed components.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — Tests T3T1 wallet creation including firmware continuation, tutorial skip, Shamir advanced seed type selection, and backup — directly covering FirmwareStep, SelectBackupType, and OnboardingOption changes.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — Tests T3W1 wallet creation with firmware step, seed type selection (shamir-advanced via selectSeedType), and backup — directly exercising the changed FirmwareStep and SelectBackupType components.
- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` — Tests T1B1 wallet creation including firmware step passage — directly exercises the FirmwareStep changes. Also uses OnboardingOption for the create wallet button.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — Tests entropy check failure during wallet creation in onboarding, explicitly navigating through firmware continuation and seed backup type selection — directly affected by FirmwareStep and SelectBackupType changes.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — Tests offline wallet creation including firmware steps, seed type selection, and OnboardingCard rendering — directly exercises FirmwareStep, SelectBackupType, and likely OnboardingCard components.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts` — Tests T1B1 recovery flow which passes through the firmware step during onboarding — exercises FirmwareStep changes in the recovery path.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts` — Tests T1B1 advanced recovery which navigates through the firmware step during onboarding — exercises FirmwareStep changes.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts` — Tests T1B1 recovery failure handling which includes passing through the firmware check step during onboarding.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — Tests T2T1 recovery flow passing through the firmware step during onboarding, directly exercising FirmwareStep changes.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts` — Tests T2T1 recovery failure with firmware continuation step, directly exercising the FirmwareStep component changes.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — Tests recovery persistence across reloads including the firmware step and onboarding path recovery button — exercises FirmwareStep and OnboardingOption.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — Tests the onboarding flow including firmware check handling and THP pairing — exercises FirmwareStep and OnboardingOption indirectly through the completeOnboarding flow.
- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — Tests onboarding authenticity check flow which includes firmware hash check handling — exercises FirmwareStep components.
- `suite/e2e/tests/suite/initial-run.test.ts` — Tests the initial run/onboarding flow persistence including firmware hash check error dismissal and the complete onboarding button — exercises FirmwareStep and OnboardingOption changes.
- `suite/e2e/tests/firmware/custom-firmware.test.ts` — Tests custom firmware installation through device settings — while not the onboarding firmware step, it shares firmware-related UI components and the FirmwareInstallationStep may be reused.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/onboarding-components/src/OnboardingCard.tsx`

_Updated: 2026-07-02T08:45:33.616Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/onboarding-issues/web/](https://dev.suite.sldev.cz/suite-web/fix/onboarding-issues/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/onboarding-issues&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/onboarding-issues&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T08:51:07.976Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |

</details>

_Updated: 2026-07-02T08:48:27.870Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->