### PR TITLE
fix(suite): tron staking currency switcher label

### DIFF
--- a/packages/suite/src/components/earn/staking/tron/TronCurrencySwitchButton.tsx
+++ b/packages/suite/src/components/earn/staking/tron/TronCurrencySwitchButton.tsx
@@ -19,7 +19,7 @@ export const TronCurrencySwitchButton = ({
 }: TronCurrencySwitchButtonProps) => {
     if (!rate?.rate) return null;
 
-    const currencySymbol = currency === 'crypto' ? cryptoCurrencySymbol : fiatCurrencySymbol;
+    const currencySymbol = currency === 'crypto' ? fiatCurrencySymbol : cryptoCurrencySymbol;
 
     const onToggle = () => {
         const newCurrency = currency === 'crypto' ? 'fiat' : 'crypto';


### PR DESCRIPTION
## Description

Typo fix for Tron staking currency switcher label.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is `TronCurrencySwitchButton.tsx`, a Tron-specific staking UI component under the earn/staking module. No static test coverage mapping exists for this file, and reviewing all 107 candidate E2E tests reveals none that exercise Tron staking flows — the existing staking tests cover ETH (`eth/initial-stake`, `eth/stake-more`, `eth/unstake`, `staking-form`), ADA (`ada/claim`, `ada/stake`, `ada/unstake`), and SOL (`sol/initial-stake`, `sol/rewards`, `sol/stake-more`, `sol/unstake`). While the route `/earn/tron/*` appears in the link-checker test's route list, that test only validates HTTP link responses, not component rendering behavior. There are no E2E tests that directly or indirectly exercise the Tron staking currency switch button, so no tests are recommended.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/earn/staking/tron/TronCurrencySwitchButton.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/earn/staking/tron/TronCurrencySwitchButton.tsx`

_Updated: 2026-07-02T09:32:34.008Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tron-staking-fiat-input&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tron-staking-fiat-input&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tron-staking-fiat-input/web/](https://dev.suite.sldev.cz/suite-web/fix/tron-staking-fiat-input/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T09:39:05.977Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |

</details>

_Updated: 2026-07-02T09:36:08.235Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->