### PR TITLE
feat(suite-native-22735): handle failed trade quotes in sell preview

### DIFF
--- a/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingSellPreviewScreen.tsx
@@ -82,7 +82,7 @@ const TradingSellPreviewScreenContent = () => {
         <Screen header={<SellPreviewScreenHeader />}>
             <ProviderStatusDevButtons />
             <LastErrorMessage tradingType="sell" />
-            <ProviderConfirmationStatusInfo />
+            <ProviderConfirmationStatusInfo quoteStatus={currentQuote?.status} />
             <SellPreviewView quote={currentQuote} txnErrorString={errorString} />
             {!isFinalized && (
                 <SellPreviewContinueButton

--- a/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.test.tsx
@@ -241,4 +241,32 @@ describe('TradingSellPreviewScreen', () => {
 
         expect(getByText('last error message')).toBeOnTheScreen();
     });
+
+    it('should show the error banner and hide the continue button when the quote has final ERROR status', async () => {
+        const trade = getSellTrade({ status: 'ERROR' });
+        mockUseTradingDetailData.trade = trade;
+
+        const { getByText, queryByTestId } = await renderTradingSellPreviewScreen({
+            wallet: {
+                trading: {
+                    sell: {
+                        selectedQuote: {
+                            ...banxaCreditCardSellQuote,
+                            status: 'ERROR',
+                        },
+                    },
+                },
+            },
+        });
+
+        expect(
+            getByText(
+                getTranslation(
+                    'moduleTrading.tradingSellPreviewScreen.providerStatus.cannotBeCompletedAlert.button',
+                ),
+            ),
+        ).toBeOnTheScreen();
+        expect(queryByTestId('@transactionManagement/fee-selector-row')).toBeNull();
+        expect(queryByTestId('@trading/sell-preview/continue-button')).toBeNull();
+    });
 });

--- a/suite-native/trading-browser-auth/src/components/ProviderConfirmationStatusInfo.tsx
+++ b/suite-native/trading-browser-auth/src/components/ProviderConfirmationStatusInfo.tsx
@@ -25,7 +25,11 @@ const FINAL_ANIMATION_STATUSES: ProviderConfirmationStatus[] = [
 
 const RESOLVE_ANIMATION_DURATION_MS = 2_000;
 
-export const ProviderConfirmationStatusInfo = () => {
+type Props = {
+    quoteStatus?: string;
+};
+
+export const ProviderConfirmationStatusInfo = ({ quoteStatus }: Props) => {
     const status = useProviderConfirmationStatus();
 
     const [displayStatus, setDisplayStatus] = useState(status);
@@ -50,12 +54,12 @@ export const ProviderConfirmationStatusInfo = () => {
         }
     }, [displayStatus, status]);
 
-    if (NOT_VISIBLE_STATUSES.includes(displayStatus)) {
-        return null;
+    if (displayStatus === 'confirmation_failed' || quoteStatus === 'ERROR') {
+        return <ConfirmationFailed />;
     }
 
-    if (displayStatus === 'confirmation_failed') {
-        return <ConfirmationFailed />;
+    if (NOT_VISIBLE_STATUSES.includes(displayStatus)) {
+        return null;
     }
 
     return <ConfirmationInProgress status={displayStatus} loadingState={loadingState} />;


### PR DESCRIPTION
## Description
- Treat quote `ERROR` as a failure case in the confirmation status component, matching the existing confirmation-failed UI.

## Notes for QA
- User is informed when quote status ends up in error (eg. quote expiration)

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/22735

## Screenshots:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-02 at 11 34 23" src="https://github.com/user-attachments/assets/b6f2b799-bb64-4a4b-badb-d28de479a68c" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/22735-mobile-sell-check-for-quote-status-in-preview-to-discard-failed-trade&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->