### PR TITLE
feat(suite): report tron staking data to accounts/info analytics event

### DIFF
--- a/suite-common/wallet-config/src/stakingProviders.ts
+++ b/suite-common/wallet-config/src/stakingProviders.ts
@@ -1,7 +1,12 @@
-import { EVERSTAKE_POOLS, FIVE_BINARIES_POOLS } from '@suite-common/wallet-constants';
+import {
+    EVERSTAKE_POOLS,
+    FIVE_BINARIES_POOLS,
+    LUGANODES_TRON_SRS,
+    P2P_ORG_TRON_SRS,
+} from '@suite-common/wallet-constants';
 import { EVERSTAKE_VOTER_PUBKEYS } from '@trezor/coins-solana/constants';
 
-type StakingProviderId = 'everstake' | 'fivebinaries';
+type StakingProviderId = 'everstake' | 'fivebinaries' | 'luganodes' | 'p2p.org';
 
 export type StakingProvider = {
     id: StakingProviderId;
@@ -9,6 +14,7 @@ export type StakingProvider = {
     solanaVoterPubkeys: string[];
     cardanoPoolIds: string[];
     ethereumPoolNames: string[];
+    tronSrAddresses: string[];
 };
 
 const EVERSTAKE_PROVIDER: StakingProvider = {
@@ -17,6 +23,7 @@ const EVERSTAKE_PROVIDER: StakingProvider = {
     solanaVoterPubkeys: EVERSTAKE_VOTER_PUBKEYS,
     cardanoPoolIds: EVERSTAKE_POOLS,
     ethereumPoolNames: ['Everstake'],
+    tronSrAddresses: [],
 };
 
 const FIVEBINARIES_PROVIDER: StakingProvider = {
@@ -25,9 +32,33 @@ const FIVEBINARIES_PROVIDER: StakingProvider = {
     solanaVoterPubkeys: [],
     cardanoPoolIds: FIVE_BINARIES_POOLS,
     ethereumPoolNames: [],
+    tronSrAddresses: [],
 };
 
-const STAKING_PROVIDERS: readonly StakingProvider[] = [EVERSTAKE_PROVIDER, FIVEBINARIES_PROVIDER];
+const LUGANODES_PROVIDER: StakingProvider = {
+    id: 'luganodes',
+    name: 'Luganodes',
+    solanaVoterPubkeys: [],
+    cardanoPoolIds: [],
+    ethereumPoolNames: [],
+    tronSrAddresses: LUGANODES_TRON_SRS,
+};
+
+const P2P_ORG_PROVIDER: StakingProvider = {
+    id: 'p2p.org',
+    name: 'P2P.org',
+    solanaVoterPubkeys: [],
+    cardanoPoolIds: [],
+    ethereumPoolNames: [],
+    tronSrAddresses: P2P_ORG_TRON_SRS,
+};
+
+const STAKING_PROVIDERS: readonly StakingProvider[] = [
+    EVERSTAKE_PROVIDER,
+    FIVEBINARIES_PROVIDER,
+    LUGANODES_PROVIDER,
+    P2P_ORG_PROVIDER,
+];
 
 export const getStakingProviderBySolanaVoterPubkey = (
     voterPubkey: string,
@@ -41,3 +72,6 @@ export const getStakingProviderByEthereumPoolName = (
     poolName: string,
 ): StakingProvider | undefined =>
     STAKING_PROVIDERS.find(provider => provider.ethereumPoolNames.includes(poolName));
+
+export const getStakingProviderByTronSrAddress = (srAddress: string): StakingProvider | undefined =>
+    STAKING_PROVIDERS.find(provider => provider.tronSrAddresses.includes(srAddress));

--- a/suite-common/wallet-constants/src/tronStakingConstants.ts
+++ b/suite-common/wallet-constants/src/tronStakingConstants.ts
@@ -6,3 +6,8 @@ export const MIN_TRON_FOR_WITHDRAWALS = new BigNumber(0.01);
 export const MIN_TRON_BALANCE_FOR_FEE_BUFFER = new BigNumber(5);
 export const MIN_TRON_BALANCE_FOR_STAKING =
     MIN_TRON_AMOUNT_FOR_STAKING.plus(MIN_TRON_FOR_WITHDRAWALS);
+
+// Super Representative addresses offered for voting in Suite
+// source: https://earn.trezor.io/staking/v1/trx/stats
+export const LUGANODES_TRON_SRS = ['TGyrSc9ZmTdbYziuk1SKEmdtCdETafewJ9'];
+export const P2P_ORG_TRON_SRS = ['TH7Fe1W8CcLeqN4LGfqX1R9EpsnrJBQJij'];

--- a/suite-common/wallet-utils/src/stakingUtils.ts
+++ b/suite-common/wallet-utils/src/stakingUtils.ts
@@ -8,6 +8,7 @@ import {
     getStakingProviderByCardanoPoolId,
     getStakingProviderByEthereumPoolName,
     getStakingProviderBySolanaVoterPubkey,
+    getStakingProviderByTronSrAddress,
 } from '@suite-common/wallet-config';
 import {
     CARDANO_EPOCH_DAYS,
@@ -68,6 +69,7 @@ import {
     getTronAccountTotalStakingBalance,
     getTronStakingRewards,
     getTronUnstakingBalance,
+    getTronVotes,
     isSupportedTronStakingNetworkSymbol,
 } from './tronStakingUtils';
 
@@ -303,6 +305,10 @@ export const getStakingProvidersForAnalytics = (accounts: Account[]): string[] =
             return;
         }
 
+        if (!isStakingNetworkType(account.networkType)) {
+            return;
+        }
+
         switch (account.networkType) {
             case 'ethereum':
                 account.misc?.stakingPools?.forEach(pool => {
@@ -346,8 +352,19 @@ export const getStakingProvidersForAnalytics = (accounts: Account[]): string[] =
                 }
                 break;
             }
-            default:
+            case 'tron':
+                getTronVotes(account).forEach(vote => {
+                    const provider = getStakingProviderByTronSrAddress(vote.address);
+                    if (provider) {
+                        providers.add(provider.id);
+                    } else {
+                        // Account is staked but provider is unknown
+                        providers.add('unknown');
+                    }
+                });
                 break;
+            default:
+                exhaustive(account.networkType);
         }
     });
 


### PR DESCRIPTION
## Description

Add Tron staking data to `accounts/info` analytics event.

## Related Issue

Resolve #29096 

## Screenshots:

<img width="100%" alt="Screenshot 2026-07-02 at 13 18 36" src="https://github.com/user-attachments/assets/69fc24c0-7813-42c0-8759-24a2067ac562" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in staking infrastructure: staking provider configuration (stakingProviders.ts), staking utility functions (stakingUtils.ts), and Tron-specific staking constants (tronStakingConstants.ts). While these files are transitively imported by 121+ tests via broad dependency chains, only the staking-specific E2E tests directly exercise the affected functionality. The recommended strategy is to run all staking tests (ETH, SOL, ADA) at high/medium priority, plus the staking analytics test. The tronStakingConstants.ts file has no direct E2E test coverage since there are no Tron staking E2E tests in the suite.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/wallet-config/src/stakingProviders.ts`
- `suite-common/wallet-constants/src/tronStakingConstants.ts`
- `suite-common/wallet-utils/src/stakingUtils.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the full ETH staking flow including staking providers, staking utilities, and staking constants — all three changed files directly affect the staking infrastructure this test relies on (stakingProviders.ts configures providers, stakingUtils.ts computes staking logic, tronStakingConstants.ts shares the constants module).
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Tests staking additional ETH which directly uses staking provider configuration and staking utility calculations for amounts, progress indicators, and instant staking banners — all core staking infrastructure that was changed.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Tests the full ETH unstake and claim flow including staking dashboard amounts, unstaking calculations, and claim processing — directly exercises stakingUtils for balance/amount computation and stakingProviders for provider configuration.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Tests first-time SOL staking which relies on staking provider configuration (Everstake) and staking utilities for amount calculations, progress indicators, and epoch-based state transitions.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Tests SOL unstaking and claiming flow including staking dashboard state, unstake calculations, and claim processing — directly uses staking providers and staking utility functions.
- `suite/e2e/tests/staking/staking-form.test.ts` — Tests the staking form input validation (min amounts, max amounts, percentage calculations, withdrawal buffer) which directly depends on stakingUtils for balance calculations and stakingProviders for provider-specific constraints.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — Tests Cardano staking reward claiming. While ADA staking has a different flow from ETH/SOL, it still relies on staking provider configuration and staking utilities for reward amount display and fee calculations.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Tests Cardano staking delegation flow which uses staking providers (Everstake pool configuration) and staking utilities for balance and deposit calculations.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Tests Cardano unstaking which relies on staking provider configuration and staking utility functions for deposit return and balance update calculations.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Tests SOL staking rewards display and refresh behavior, which depends on staking utilities for computing staked/unstaking/reward amounts and staking providers for configuration.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Tests staking additional SOL which uses staking provider configuration and staking utility functions for amount calculations and epoch-based state management.
- `suite/e2e/tests/analytics/staking-events.test.ts` — Tests StakingNavigate analytics events fired when navigating to staking for ETH and ADA. Changes to staking providers or utilities could affect whether staking navigation options appear or fire correctly.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-constants/src/tronStakingConstants.ts`

_Updated: 2026-07-02T11:24:25.306Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-staking-accounts-info-analytics&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-staking-accounts-info-analytics&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-staking-accounts-info-analytics&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T11:29:51.516Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |

</details>

_Updated: 2026-07-02T11:28:04.939Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-staking-accounts-info-analytics/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-staking-accounts-info-analytics/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->