### PR TITLE
feat(suite-native): report settings/testnet-networks-toggle analytics event

### DIFF
--- a/suite-common/analytics/src/constants.ts
+++ b/suite-common/analytics/src/constants.ts
@@ -18,6 +18,7 @@ export enum EventType {
     SettingsDeviceWipe = 'settings/device/wipe',
     SettingsGeneralLabeling = 'settings/general/labeling',
     SettingsNetworkSearchUsed = 'settings/network-search-used',
+    SettingsTestnetNetworksToggle = 'settings/testnet-networks-toggle',
     // eslint-disable-next-line local-rules/analytics-event-name
     SuiteSyncLabelCreated = 'suite-sync/label',
     WalletConnectInit = 'wallet-connect/init',

--- a/suite-common/analytics/src/events/index.ts
+++ b/suite-common/analytics/src/events/index.ts
@@ -10,6 +10,7 @@ export { settingsDeviceChangeLabelEvent } from './settingsDeviceChangeLabelEvent
 export { settingsDeviceWipeEvent } from './settingsDeviceWipeEvent';
 export { settingsGeneralLabelingEvent } from './settingsGeneralLabelingEvent';
 export { settingsNetworkSearchUsedEvent } from './settingsNetworkSearchUsedEvent';
+export { settingsTestnetNetworksToggleEvent } from './settingsTestnetNetworksToggleEvent';
 export { walletConnectInitEvent } from './walletConnectInitEvent';
 export { walletConnectPairedEvent } from './walletConnectPairedEvent';
 export { walletConnectProposalApprovedEvent } from './walletConnectProposalApprovedEvent';

--- a/suite-common/analytics/src/events/settingsTestnetNetworksToggleEvent.ts
+++ b/suite-common/analytics/src/events/settingsTestnetNetworksToggleEvent.ts
@@ -1,0 +1,22 @@
+import { EventType } from '../constants';
+import type { AttributeDef, EventDef } from '../eventDefinition';
+
+type Attributes = {
+    enabled: AttributeDef<boolean>;
+};
+
+export const settingsTestnetNetworksToggleEvent: EventDef<
+    Attributes,
+    EventType.SettingsTestnetNetworksToggle
+> = {
+    name: EventType.SettingsTestnetNetworksToggle,
+    descriptionTrigger: 'User enables or disables Testnet networks in application settings',
+    changelog: [{ version: '26.7.1', notes: 'added' }],
+
+    attributes: {
+        enabled: {
+            changelog: [{ version: '26.7.1', notes: 'added' }],
+            description: '`true` if Testnet networks are enabled, `false` if disabled',
+        },
+    },
+};

--- a/suite-native/module-settings/src/components/ToggleTestnetsCard.tsx
+++ b/suite-native/module-settings/src/components/ToggleTestnetsCard.tsx
@@ -1,15 +1,25 @@
 import { useDispatch, useSelector } from 'react-redux';
 
+import { events } from '@suite-common/analytics';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { TouchableSwitchRow } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { selectAreTestnetsEnabled, toggleAreTestnetsEnabled } from '@suite-native/settings';
 
 export const ToggleTestnetsCard = () => {
     const dispatch = useDispatch();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
+
     const areTestnetsEnabled = useSelector(selectAreTestnetsEnabled);
 
-    const handleToggleTestnets = () => {
+    const handleToggleTestnets = (value: boolean) => {
         dispatch(toggleAreTestnetsEnabled());
+
+        analytics.report({
+            type: events.settingsTestnetNetworksToggleEvent.name,
+            payload: { enabled: value },
+        });
     };
 
     return (


### PR DESCRIPTION
## Description

Analytics event `settings/testnet-networks-toggle` reported on mobile.

## Related Issue

Follow-up for #29233

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes introduce a new analytics event (settingsTestnetNetworksToggleEvent) and modify the analytics constants and events index module. The primary risk is breaking existing analytics event type resolution or event firing. The highest priority tests are those that directly validate analytics event payloads and lifecycle (events.test.ts, toggle.test.ts). Medium priority tests exercise the testnet toggle flow where the new event would fire. The native component change (ToggleTestnetsCard.tsx) is in suite-native and has no E2E coverage in the suite web/desktop test suite.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/analytics/src/constants.ts`
- `suite-common/analytics/src/events/index.ts`
- `suite-common/analytics/src/events/settingsTestnetNetworksToggleEvent.ts`
- `suite-native/module-settings/src/components/ToggleTestnetsCard.tsx`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test directly validates analytics events including SuiteReady which reports enabledNetworks, experimentalFeatures (testnet-networks), and other suite settings. The changed files add a new settingsTestnetNetworksToggleEvent and modify the analytics events index/constants. This test imports from @suite/analytics events and validates the full event payload structure after toggling testnet networks.
- `suite/e2e/tests/analytics/toggle.test.ts` — This test exercises analytics event firing for settings changes and validates the analytics enable/disable lifecycle. It imports from @suite/analytics events module which is directly modified. Changes to constants.ts and the events index could affect event type matching used in this test's assertions.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — This test validates that settings changes fire correct analytics events (fiat, theme, language, analytics toggle). It uses @suite/analytics events module which is modified. While the new testnet toggle event is not directly tested here, changes to the events index or constants could break existing event type resolution.
- `suite/e2e/tests/settings/coins.test.ts` — This test covers enabling testnet networks via the coins settings page, including toggling testnet visibility. The new settingsTestnetNetworksToggleEvent would be fired during testnet toggle actions exercised by this test, making it relevant for validating the new event fires correctly in context.
- `suite/e2e/tests/settings/electrum.test.ts` — This test toggles testnet networks in settings (toggleTestnetNetworks) which is the exact user action that would trigger the new settingsTestnetNetworksToggleEvent. It validates the end-to-end flow of enabling testnets and using them.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test imports from @suite/analytics EventType constants to validate staking analytics events. Changes to the constants or events index could theoretically break EventType resolution, though the specific staking events are unlikely to be affected.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test validates that a menuToggleDiscreetEvent analytics event fires correctly, importing from @suite/analytics events module. Changes to the events index re-export structure could affect this test's event type imports.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-native/module-settings/src/components/ToggleTestnetsCard.tsx`

_Updated: 2026-07-03T07:29:29.748Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native/testnet-networks-analytics-event/web/](https://dev.suite.sldev.cz/suite-web/feat/native/testnet-networks-analytics-event/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/testnet-networks-analytics-event&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/testnet-networks-analytics-event&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/testnet-networks-analytics-event&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-03T07:35:43.560Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-03T07:32:30.214Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->