### PR TITLE
Hide earn estimated rewards card until amount is entered

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2650,7 +2650,6 @@ export const messages = {
             withdrawalFeesBanner:
                 "We've left {amount} {displaySymbol} in your account so you can pay for withdrawal fees.",
             estimatedRewardsLabel: 'Estimated yearly rewards',
-            estimatedRewardsPlaceholder: 'Enter amount to see rewards',
             validation: {
                 amountIsZero: 'Amount must be greater than 0.',
                 amountBelowMinimum: 'Amount must be at least {amount} {symbol}.',

--- a/suite-native/module-earn/src/components/EarnFormScreenFooter.tsx
+++ b/suite-native/module-earn/src/components/EarnFormScreenFooter.tsx
@@ -1,10 +1,5 @@
 import { useMemo } from 'react';
-import Animated, {
-    SlideInDown,
-    SlideOutDown,
-    useAnimatedStyle,
-    withTiming,
-} from 'react-native-reanimated';
+import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
 
 import { useFormatters } from '@suite-common/formatters';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
@@ -20,19 +15,24 @@ const screenFooterStyle = prepareNativeStyle(utils => ({
     backgroundColor: utils.colors.surfaceFillPage,
 }));
 
-const rewardsBoxStyle = prepareNativeStyle(utils => ({
-    backgroundColor: utils.colors.legacyBackgroundPrimarySubtleOnElevationNegative,
-    borderTopLeftRadius: utils.borders.radii.r16,
-    borderTopRightRadius: utils.borders.radii.r16,
-    borderBottomLeftRadius: utils.borders.radii.r24,
-    borderBottomRightRadius: utils.borders.radii.r24,
-    paddingBottom: utils.spacings.sp48,
-}));
+const rewardsBoxStyle = prepareNativeStyle<{ hasValidationError: boolean }>(
+    (utils, { hasValidationError }) => ({
+        backgroundColor: utils.colors.legacyBackgroundPrimarySubtleOnElevationNegative,
+        borderTopLeftRadius: utils.borders.radii.r16,
+        borderTopRightRadius: utils.borders.radii.r16,
+        borderBottomLeftRadius: utils.borders.radii.r24,
+        borderBottomRightRadius: utils.borders.radii.r24,
+        paddingBottom: utils.spacings.sp48,
+        opacity: hasValidationError ? 0 : 1,
+    }),
+);
 
-const continueButtonStyle = prepareNativeStyle(utils => ({
-    borderRadius: utils.borders.radii.round,
-    marginTop: -utils.spacings.sp32,
-}));
+const continueButtonStyle = prepareNativeStyle<{ isEstimatedRewardsVisible: boolean }>(
+    (utils, { isEstimatedRewardsVisible }) => ({
+        borderRadius: utils.borders.radii.round,
+        marginTop: isEstimatedRewardsVisible ? -utils.spacings.sp32 : 0,
+    }),
+);
 
 type EarnFormScreenFooterProps = {
     symbol: NetworkSymbol;
@@ -72,27 +72,24 @@ export const EarnFormScreenFooter = ({
     const buttonIntent = isDisabled ? 'neutral' : 'brand';
     const buttonPriority = isDisabled ? 'secondary' : 'primary';
     const hasValidationError = isDirty && isDisabled;
-
-    const rewardsAnimatedStyle = useAnimatedStyle(() => ({
-        opacity: withTiming(hasValidationError ? 0 : 1, { duration: 100 }),
-    }));
+    const isEstimatedRewardsVisible = estimatedRewards !== null;
 
     return (
         <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
             <ScreenFooterGradient />
             <Box style={applyStyle(screenFooterStyle)}>
-                <Animated.View style={[applyStyle(rewardsBoxStyle), rewardsAnimatedStyle]}>
-                    <VStack spacing="sp4" paddingTop="sp12" alignItems="center">
-                        <Text variant="body-sm" color="contentPrimary">
-                            <Translation id="earn.earnFormScreen.estimatedRewardsLabel" />
-                        </Text>
-                        <Text variant="headline-sm" color="contentBrand">
-                            {estimatedRewards ?? (
-                                <Translation id="earn.earnFormScreen.estimatedRewardsPlaceholder" />
-                            )}
-                        </Text>
-                    </VStack>
-                </Animated.View>
+                {isEstimatedRewardsVisible && (
+                    <Box style={applyStyle(rewardsBoxStyle, { hasValidationError })}>
+                        <VStack spacing="sp4" paddingTop="sp12" alignItems="center">
+                            <Text variant="body-sm" color="contentPrimary">
+                                <Translation id="earn.earnFormScreen.estimatedRewardsLabel" />
+                            </Text>
+                            <Text variant="headline-sm" color="contentBrand">
+                                {estimatedRewards}
+                            </Text>
+                        </VStack>
+                    </Box>
+                )}
                 <Button
                     key={`${buttonIntent}-${buttonPriority}`}
                     accessibilityRole="button"
@@ -101,7 +98,7 @@ export const EarnFormScreenFooter = ({
                     priority={buttonPriority}
                     onPress={onPress}
                     isDisabled={isDisabled}
-                    style={applyStyle(continueButtonStyle)}
+                    style={applyStyle(continueButtonStyle, { isEstimatedRewardsVisible })}
                 >
                     <Translation id="generic.buttons.continue" />
                 </Button>


### PR DESCRIPTION
## Description

On the native earn (staking) form, the estimated rewards card was always rendered - it showed a placeholder before any amount was entered, which left the empty ETH/SOL staking screen looking broken. The card is now shown only once the user enters an amount, and the continue button's overlap offset is applied only while the card is present. The now-unused placeholder string was removed as part of the cleanup.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29076

## Screenshots:
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2026-07-02 at 14 06 26" src="https://github.com/user-attachments/assets/78253d6e-2995-48f8-b39a-067f60258989" />
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2026-07-02 at 14 06 33" src="https://github.com/user-attachments/assets/9be51444-2b16-48f2-8b86-dd044255825f" />
