### PR TITLE
feat(suite): enhance AddAccountModal with network search functionality

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { selectIsDebugModeActive } from '@suite/debug';
@@ -22,7 +22,7 @@ import {
     selectEnabledNetworks,
 } from '@suite-common/wallet-core';
 import { getAvailableAccountTypes, prepareNewAccountPayload } from '@suite-common/wallet-utils';
-import { Column, Modal } from '@trezor/components';
+import { Box, Column, Modal } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { arrayPartition } from '@trezor/utils';
 
@@ -32,6 +32,9 @@ import { useAccountSearch, useDispatch, useSelector } from 'src/hooks/suite';
 import { selectIsPublic } from 'src/reducers/wallet/coinjoinReducer';
 import { type TrezorDevice } from 'src/types/suite';
 import { type Account } from 'src/types/wallet';
+import { NetworkSettingsSearchInput } from 'src/views/settings/SettingsCoins/NetworkSettingsSearchInput';
+import { NoNetworkSearchResults } from 'src/views/settings/SettingsCoins/NoNetworkSearchResults';
+import { useNetworkSettingsSearch } from 'src/views/settings/SettingsCoins/useNetworkSettingsSearch';
 
 import { AccountTypeSelect } from './AccountTypeSelect/AccountTypeSelect';
 import { AddAccountButton } from './AddAccountButton/AddAccountButton';
@@ -162,7 +165,56 @@ export const AddAccountModal = ({
         disabledNetworks,
         network => !network?.testnet,
     );
-    const testnetNetworks = [...enabledTestnetNetworks, ...disabledTestnetNetworks];
+    const testnetNetworks = useMemo(
+        () => [...enabledTestnetNetworks, ...disabledTestnetNetworks],
+        [enabledTestnetNetworks, disabledTestnetNetworks],
+    );
+
+    const allSearchableNetworks = useMemo(() => {
+        if (symbol) {
+            return [];
+        }
+
+        return [
+            ...enabledMainnetNetworks,
+            ...disabledMainnetNetworks,
+            ...(useTestnetNetworks ? testnetNetworks : []),
+            ...(showUnsupportedCoins ? unsupportedMainnets : []),
+        ];
+    }, [
+        disabledMainnetNetworks,
+        enabledMainnetNetworks,
+        showUnsupportedCoins,
+        symbol,
+        testnetNetworks,
+        unsupportedMainnets,
+        useTestnetNetworks,
+    ]);
+
+    const {
+        searchQuery,
+        hasActiveSearch,
+        hasNoSearchResults,
+        filterNetworks,
+        handleSearchChange,
+        handleSearchClear,
+    } = useNetworkSettingsSearch(allSearchableNetworks, { origin: 'add-account' });
+
+    const filteredEnabledMainnetNetworks = filterNetworks(enabledMainnetNetworks);
+    const filteredDisabledMainnetNetworks = filterNetworks(disabledMainnetNetworks);
+    const filteredTestnetNetworks = filterNetworks(testnetNetworks);
+    const filteredUnsupportedMainnets = filterNetworks(unsupportedMainnets);
+
+    const showEnabledMainnets = !hasActiveSearch || filteredEnabledMainnetNetworks.length > 0;
+    const showDisabledMainnets = !hasActiveSearch || filteredDisabledMainnetNetworks.length > 0;
+    const showTestnetsSection =
+        useTestnetNetworks &&
+        testnetNetworks.length > 0 &&
+        (!hasActiveSearch || filteredTestnetNetworks.length > 0);
+    const showUnsupportedSection =
+        showUnsupportedCoins &&
+        unsupportedMainnets.length > 0 &&
+        (!hasActiveSearch || filteredUnsupportedMainnets.length > 0);
 
     // Collect all empty accounts related to selected device and selected accountType
     const currentType = selectedAccount?.accountType ?? 'normal';
@@ -486,17 +538,8 @@ export const AddAccountModal = ({
               }
             : {
                   heading: <Translation id="TR_ADD_ACCOUNT" />,
-                  children: (
+                  children: symbol ? (
                       <Column gap={24}>
-                          {!symbol && (
-                              <SelectNetwork
-                                  heading={<Translation id="TR_ACTIVATED_COINS" />}
-                                  networks={enabledMainnetNetworks}
-                                  handleNetworkSelection={handleNetworkSelection}
-                                  onSettings={setAdvancedSettingsSymbol}
-                                  getAddDisabledMessage={getAddDisabledMessage}
-                              />
-                          )}
                           <SelectNetwork
                               heading={
                                   isAccountActivated ? (
@@ -505,28 +548,63 @@ export const AddAccountModal = ({
                                       <Translation id="TR_INACTIVE_COINS" />
                                   )
                               }
-                              networks={symbol ? visibleNetworks : disabledMainnetNetworks}
+                              networks={visibleNetworks}
                               handleNetworkSelection={handleNetworkSelection}
                               onSettings={setAdvancedSettingsSymbol}
                               getAddDisabledMessage={getAddDisabledMessage}
                           />
-                          {!symbol && !!testnetNetworks.length && useTestnetNetworks && (
-                              <SelectNetwork
-                                  heading={<Translation id="TR_TESTNET_COINS" />}
-                                  data-testid="@modal/account/activate_more_coins"
-                                  networks={testnetNetworks}
-                                  handleNetworkSelection={handleNetworkSelection}
-                                  onSettings={setAdvancedSettingsSymbol}
-                                  getAddDisabledMessage={getAddDisabledMessage}
-                              />
-                          )}
-                          {!symbol && showUnsupportedCoins && (
-                              <SelectNetwork
-                                  heading={<Translation id="TR_UNSUPPORTED_COINS" />}
-                                  data-testid="@modal/account/activate_more_coins"
-                                  networks={unsupportedMainnets}
-                                  onSettings={setAdvancedSettingsSymbol}
-                              />
+                      </Column>
+                  ) : (
+                      <Column gap={24}>
+                          <NetworkSettingsSearchInput
+                              searchQuery={searchQuery}
+                              onSearchChange={handleSearchChange}
+                              onSearchClear={handleSearchClear}
+                              dataTestId="@modal/account/network-search-input"
+                          />
+                          {hasNoSearchResults ? (
+                              <Box padding={{ vertical: 32 }}>
+                                  <NoNetworkSearchResults dataTestId="@modal/account/no-networks-found" />
+                              </Box>
+                          ) : (
+                              <>
+                                  {showEnabledMainnets && (
+                                      <SelectNetwork
+                                          heading={<Translation id="TR_ACTIVATED_COINS" />}
+                                          networks={filteredEnabledMainnetNetworks}
+                                          handleNetworkSelection={handleNetworkSelection}
+                                          onSettings={setAdvancedSettingsSymbol}
+                                          getAddDisabledMessage={getAddDisabledMessage}
+                                      />
+                                  )}
+                                  {showDisabledMainnets && (
+                                      <SelectNetwork
+                                          heading={<Translation id="TR_INACTIVE_COINS" />}
+                                          networks={filteredDisabledMainnetNetworks}
+                                          handleNetworkSelection={handleNetworkSelection}
+                                          onSettings={setAdvancedSettingsSymbol}
+                                          getAddDisabledMessage={getAddDisabledMessage}
+                                      />
+                                  )}
+                                  {showTestnetsSection && (
+                                      <SelectNetwork
+                                          heading={<Translation id="TR_TESTNET_COINS" />}
+                                          data-testid="@modal/account/activate_more_coins"
+                                          networks={filteredTestnetNetworks}
+                                          handleNetworkSelection={handleNetworkSelection}
+                                          onSettings={setAdvancedSettingsSymbol}
+                                          getAddDisabledMessage={getAddDisabledMessage}
+                                      />
+                                  )}
+                                  {showUnsupportedSection && (
+                                      <SelectNetwork
+                                          heading={<Translation id="TR_UNSUPPORTED_COINS" />}
+                                          data-testid="@modal/account/activate_more_coins"
+                                          networks={filteredUnsupportedMainnets}
+                                          onSettings={setAdvancedSettingsSymbol}
+                                      />
+                                  )}
+                              </>
                           )}
                       </Column>
                   ),

--- a/packages/suite/src/views/settings/SettingsCoins/NetworkSettingsSearchInput.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/NetworkSettingsSearchInput.tsx
@@ -5,12 +5,14 @@ type NetworkSettingsSearchInputProps = {
     searchQuery: string;
     onSearchChange: (value: string) => void;
     onSearchClear: () => void;
+    dataTestId?: string;
 };
 
 export const NetworkSettingsSearchInput = ({
     searchQuery,
     onSearchChange,
     onSearchClear,
+    dataTestId = '@settings-coins/network-search-input',
 }: NetworkSettingsSearchInputProps) => {
     const { translationString } = useTranslation();
 
@@ -22,7 +24,7 @@ export const NetworkSettingsSearchInput = ({
             placeholder={translationString('TR_SEARCH_NETWORK')}
             showClearButton
             width="100%"
-            data-testid="@settings-coins/network-search-input"
+            data-testid={dataTestId}
             leftContent={
                 <Icon name="magnifyingGlass" intent="neutral" priority="secondary" size={16} />
             }

--- a/packages/suite/src/views/settings/SettingsCoins/NoNetworkSearchResults.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/NoNetworkSearchResults.tsx
@@ -1,14 +1,25 @@
 import { Translation } from '@suite/intl';
-import { Text } from '@trezor/components';
+import { Column, H4, Paragraph } from '@trezor/components';
 
-export const NoNetworkSearchResults = () => (
-    <Text
-        typographyStyle="body-md"
-        intent="neutral"
-        priority="secondary"
-        align="center"
-        data-testid="@settings-coins/no-networks-found"
-    >
-        <Translation id="TR_NO_NETWORKS_FOUND" />
-    </Text>
+type NoNetworkSearchResultsProps = {
+    dataTestId?: string;
+};
+
+export const NoNetworkSearchResults = ({
+    dataTestId = '@settings-coins/no-networks-found',
+}: NoNetworkSearchResultsProps) => (
+    <Column alignItems="center">
+        <H4 typographyStyle="body-md" intent="neutral" align="center" data-testid={dataTestId}>
+            <Translation id="TR_NO_NETWORKS_FOUND" />
+        </H4>
+        <Paragraph
+            align="center"
+            typographyStyle="body-sm"
+            intent="neutral"
+            priority="secondary"
+            textWrap="balance"
+        >
+            <Translation id="TR_NO_NETWORKS_FOUND_DESCRIPTION" />
+        </Paragraph>
+    </Column>
 );

--- a/packages/suite/src/views/settings/SettingsCoins/useNetworkSettingsSearch.ts
+++ b/packages/suite/src/views/settings/SettingsCoins/useNetworkSettingsSearch.ts
@@ -15,7 +15,16 @@ export const filterNetworksByName = (networks: Network[], searchQuery: string) =
     return networks.filter(({ name }) => name.toLowerCase().includes(normalizedQuery));
 };
 
-export const useNetworkSettingsSearch = (allNetworks: Network[]) => {
+type NetworkSettingsSearchOrigin = 'network-settings' | 'add-account';
+
+type UseNetworkSettingsSearchOptions = {
+    origin?: NetworkSettingsSearchOrigin;
+};
+
+export const useNetworkSettingsSearch = (
+    allNetworks: Network[],
+    { origin = 'network-settings' }: UseNetworkSettingsSearchOptions = {},
+) => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const [searchQuery, setSearchQuery] = useState('');
     const hasReportedSearchUsed = useRef(false);
@@ -45,12 +54,12 @@ export const useNetworkSettingsSearch = (allNetworks: Network[]) => {
                     type: events.settingsNetworkSearchUsedEvent.name,
                     payload: {
                         platform: 'desktop',
-                        origin: 'network-settings',
+                        origin,
                     },
                 });
             }
         },
-        [analytics],
+        [analytics, origin],
     );
 
     const handleSearchClear = useCallback(() => {

--- a/suite-common/analytics/src/events/settingsNetworkSearchUsedEvent.ts
+++ b/suite-common/analytics/src/events/settingsNetworkSearchUsedEvent.ts
@@ -1,7 +1,7 @@
 import { EventType } from '../constants';
 import type { AnalyticsPlatform, AttributeDef, EventDef } from '../eventDefinition';
 
-type NetworkSettingsSearchOrigin = 'network-settings';
+type NetworkSettingsSearchOrigin = 'network-settings' | 'add-account';
 
 type Attributes = {
     platform: AttributeDef<AnalyticsPlatform>;
@@ -14,7 +14,7 @@ export const settingsNetworkSearchUsedEvent: EventDef<
 > = {
     name: EventType.SettingsNetworkSearchUsed,
     descriptionTrigger:
-        'User enters the first character in the network search input on Settings > Coins (once per search session)',
+        'User enters the first character in the network search input on Settings > Coins or in the add account modal (once per search session)',
     changelog: [{ version: '26.7.0', notes: 'added' }],
 
     attributes: {
@@ -23,7 +23,7 @@ export const settingsNetworkSearchUsedEvent: EventDef<
             changelog: [{ version: '26.7.0', notes: 'added' }],
         },
         origin: {
-            description: 'Where the search was used (`network-settings`)',
+            description: 'Where the search was used (`network-settings` or `add-account`)',
             changelog: [{ version: '26.7.0', notes: 'added' }],
         },
     },

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1885,8 +1885,13 @@ export const messages = defineMessages({
         id: 'TR_SEARCH_NETWORK',
     },
     TR_NO_NETWORKS_FOUND: {
-        defaultMessage: 'No networks found',
+        defaultMessage: 'No results',
         id: 'TR_NO_NETWORKS_FOUND',
+    },
+    TR_NO_NETWORKS_FOUND_DESCRIPTION: {
+        defaultMessage:
+            'Make sure your search terms are spelled correctly or try different keywords.',
+        id: 'TR_NO_NETWORKS_FOUND_DESCRIPTION',
     },
     TR_HIDDEN: {
         defaultMessage: 'Hidden',


### PR DESCRIPTION
## Notes for QA

Added network search to add account modal.

## Screenshots:
<img width="712" height="643" alt="image" src="https://github.com/user-attachments/assets/2653a831-919d-4eb1-b24c-da707f6d33c5" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes center on adding a network search feature to the Settings Coins page (new search input component, no-results component, search hook, and analytics event) plus modifications to the AddAccountModal. The highest risk is in the coins settings page where new UI components and search filtering logic could break network enable/disable flows. The AddAccountModal change also warrants direct testing. The new analytics event (settingsNetworkSearchUsedEvent) has no direct E2E test coverage since no existing test appears to exercise the network search feature specifically. Testing strategy should prioritize the coins settings page and add-account flows, with secondary coverage for related features that depend on network configuration.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx`
- `packages/suite/src/views/settings/SettingsCoins/NetworkSettingsSearchInput.tsx`
- `packages/suite/src/views/settings/SettingsCoins/NoNetworkSearchResults.tsx`
- `packages/suite/src/views/settings/SettingsCoins/useNetworkSettingsSearch.ts`
- `suite-common/analytics/src/events/settingsNetworkSearchUsedEvent.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — This test directly exercises the Settings Coins page where NetworkSettingsSearchInput, NoNetworkSearchResults, and useNetworkSettingsSearch are rendered. It tests enabling/disabling networks, activating assets, and configuring custom backends — all of which interact with the coin settings UI that was changed.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test navigates to the Coins settings tab, enables networks, and configures custom backends. The search input and network listing changes in SettingsCoins could directly affect the network enable/disable flow and the advanced settings modal this test relies on.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test directly exercises the AddAccountModal component that was changed, testing adding different account types (normal, taproot, segwit, legacy) for multiple coins and verifying analytics events. Changes to AddAccountModal.tsx could break account type selection and confirmation flows.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test verifies SuiteReady events reflecting user-changed settings including enabled/disabled networks. The new settingsNetworkSearchUsedEvent analytics event and changes to the coins settings page could affect analytics event payloads related to network configuration.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test enables new assets via the 'Activate Assets' modal which shares UI with the coins settings page, and tests enabling ETH through an activation flow. Changes to network search/filtering in SettingsCoins could affect how networks are discovered and enabled.
- `suite/e2e/tests/settings/electrum.test.ts` — This test navigates to the Coins settings tab to configure an Electrum backend for RegTest. Changes to the network search and filtering logic in SettingsCoins could affect the ability to find and configure the RegTest network.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test uses the global receive flow which opens an asset picker and adds a new ETH account via a modal that may use the AddAccountModal component. Changes to AddAccountModal.tsx could affect the account creation flow within the global receive/send feature.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test crawls all pages including /settings/coins and verifies links return HTTP 200. New or changed UI components (NetworkSettingsSearchInput, NoNetworkSearchResults) could introduce broken links on the coins settings page.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/analytics/src/events/settingsNetworkSearchUsedEvent.ts`

_Updated: 2026-07-02T12:21:41.795Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/add-network-search-to-add-account-modal/web/](https://dev.suite.sldev.cz/suite-web/feat/add-network-search-to-add-account-modal/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/add-network-search-to-add-account-modal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/add-network-search-to-add-account-modal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/add-network-search-to-add-account-modal&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T12:27:08.817Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-02T12:25:09.030Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->