### PR TITLE
fix(components): Card component of type contrast

### DIFF
--- a/packages/components/src/components/Card/utils.tsx
+++ b/packages/components/src/components/Card/utils.tsx
@@ -80,6 +80,7 @@ export const mapCardTypeToCSS = ({
         contrast: css`
             background: ${theme.elementFillNeutralSofter};
             outline: 1px solid ${theme.elementBorderNeutralSofterAlt};
+            outline-offset: -1px;
 
             ${$isClickable &&
             css`

--- a/packages/suite/src/components/backup/BackupSeedCards.tsx
+++ b/packages/suite/src/components/backup/BackupSeedCards.tsx
@@ -43,6 +43,7 @@ export const BackupSeedCards = () => {
                         key={item.key}
                         onClick={() => dispatch(backupActions.toggleCheckboxByKey(item.key))}
                         data-testid={`@backup/check-item/${item.key}`}
+                        type="contrast"
                     >
                         <Column height="100%" justifyContent="space-between">
                             <Row gap={16} alignItems="center" justifyContent="space-between">


### PR DESCRIPTION
## Notes for QA

Fixed contrast issues in onboarding.

## Screenshots:
<img width="1119" height="757" alt="image" src="https://github.com/user-attachments/assets/fc026d71-9bf2-46f5-b188-cb61d0310af5" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two files: a Card utility component (broad shared dependency used by 121 tests) and BackupSeedCards.tsx (a backup-specific component). The Card/utils.tsx change is too broadly shared to warrant running all 121 tests — only tests that specifically exercise backup seed card rendering are recommended. The primary risk is in the backup and onboarding wallet creation flows where BackupSeedCards is directly rendered. The recommended strategy focuses on the backup test suite (high priority) and onboarding wallet creation tests that include backup steps (medium priority).

<details><summary><b>Changed files (2)</b></summary>

- `packages/components/src/components/Card/utils.tsx`
- `packages/suite/src/components/backup/BackupSeedCards.tsx`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — BackupSeedCards.tsx is a backup-specific component that would be rendered during the backup flow. This test exercises the backup error path including the backup modal UI with checkboxes and error banners, directly exercising backup UI components.
- `suite/e2e/tests/backup/t2t1-success.test.ts` — This test covers the full backup happy path including pre-backup and post-backup checkboxes and the backup modal UI. BackupSeedCards.tsx is likely rendered during this seed backup flow, making it a direct exercise of the changed component.
- `suite/e2e/tests/backup/t2t1-misc.test.ts` — Tests backup modal behavior including checkbox state management and device disconnection during backup. The BackupSeedCards component is part of the backup modal UI exercised here.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/backup/t3t1-t2t1-create-additional-share.test.ts` — Tests multi-share/Shamir backup creation flow which involves backup seed UI components. BackupSeedCards.tsx may render seed card information during this additional share creation process.
- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — Wallet creation during onboarding includes the Shamir backup flow with seed backup steps. BackupSeedCards.tsx likely renders during the backup portion of the onboarding create-wallet flow.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — Similar to T2T1 wallet creation, this test covers the Shamir backup flow during onboarding on T3T1, which would render backup seed card UI components.
- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` — T1B1 wallet creation includes seed backup confirmation with checkboxes (wroteSeedProperly, madeNoDigitalCopy, willHideSeed) that likely use BackupSeedCards or related backup UI.

</details>

_Updated: 2026-07-02T12:29:01.963Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/card-type-contrast/web/](https://dev.suite.sldev.cz/suite-web/fix/card-type-contrast/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/card-type-contrast&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/card-type-contrast&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T12:35:06.570Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-02T12:32:06.310Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->