### PR TITLE
fix(connect): emit DEVICE.CHANGED only on real device state change

### DIFF
--- a/packages/connect/src/api/setBusy.ts
+++ b/packages/connect/src/api/setBusy.ts
@@ -1,7 +1,7 @@
-import { DEVICE, type PermissionRequest, createDeviceMessage } from '@trezor/connect-common';
+import { type PermissionRequest } from '@trezor/connect-common';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 
-import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class SetBusy extends AbstractMethod<'setBusy', PROTO.SetBusy> {
@@ -19,17 +19,14 @@ export default class SetBusy extends AbstractMethod<'setBusy', PROTO.SetBusy> {
         return [{ permission: 'management' }];
     }
 
-    async run({ sendCoreMessage }: MethodContext) {
+    async run() {
         const cmd = this.getDevice().getCommands();
         const { message } = await cmd.typedCall('SetBusy', 'Success', this.params);
         if (this.keepSession && !!this.params.expiry_ms) {
-            // NOTE: DEVICE.CHANGED will not be emitted because session is not released
-            // change device features and trigger event manually
-            // followup: https://github.com/trezor/trezor-suite/issues/6446
+            // session is kept, so no session change will emit DEVICE.CHANGED automatically;
+            // change the feature and emit the change ourselves
             this.getDevice().features.busy = true;
-            sendCoreMessage(
-                createDeviceMessage(DEVICE.CHANGED, this.getDevice().toMessageObject()),
-            );
+            this.getDevice().emitDeviceChanged();
         }
 
         return message;

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -394,7 +394,7 @@ const onCallDevice = async (
             method.deviceState.sessionId !== device.getState()?.sessionId
         ) {
             // if session was changed from the one that was sent, send a device changed event
-            sendCoreMessage(createDeviceMessage(DEVICE.CHANGED, device.toMessageObject()));
+            device.emitDeviceChanged();
         }
 
         // TODO: This requires a massive refactoring https://github.com/trezor/trezor-suite/issues/5323

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -35,7 +35,14 @@ import {
     type TransportDeviceEvent,
 } from '@trezor/transport-common';
 import type { Deferred, Logger } from '@trezor/utils';
-import { TypedEmitter, createDeferred, isArrayMember, versionUtils } from '@trezor/utils';
+import {
+    TypedEmitter,
+    cloneObject,
+    createDeferred,
+    deepEqual,
+    isArrayMember,
+    versionUtils,
+} from '@trezor/utils';
 import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import { DeviceCommands } from './DeviceCommands';
@@ -175,6 +182,9 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
 
     readonly lifecycle = new TypedEmitter<DeviceLifecycleEvents>();
 
+    // Last DEVICE.CHANGED payload emitted to clients; used to suppress redundant emits.
+    private lastEmittedMessage?: DeviceTyped;
+
     private sessionDfd?: Deferred<Session | null>;
 
     constructor({ id, transport, descriptor, createLogger }: DeviceParams) {
@@ -293,6 +303,8 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
         this._protocol = protocolV1;
         this.thp?.resetState();
         this.thp = undefined;
+        // drop the dedup baseline so the next change is always emitted after a reset
+        this.lastEmittedMessage = undefined;
     }
 
     setBusy(value?: DeviceBusyStatus) {
@@ -398,6 +410,22 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
             this.keepTransportSession = false;
         }
 
+        this.emitDeviceChanged();
+    }
+
+    // Emit DEVICE.CHANGED only when the client-visible device representation actually changed.
+    // The transport reports a session change on every acquire/release, which would otherwise
+    // surface as a redundant DEVICE.CHANGED (causing needless re-renders in clients such as
+    // Suite) even though no client-visible state changed.
+    // See https://github.com/trezor/trezor-suite/issues/6446.
+    emitDeviceChanged() {
+        const message = this.toMessageObject();
+        if (this.lastEmittedMessage && deepEqual(this.lastEmittedMessage, message)) {
+            return;
+        }
+        // Store an immutable snapshot: toMessageObject() embeds live references (e.g. features),
+        // which can be mutated in place (e.g. setBusy), and would otherwise corrupt the baseline.
+        this.lastEmittedMessage = cloneObject(message);
         this.lifecycle.emit(DEVICE.CHANGED);
     }
 
@@ -871,7 +899,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
                 ...this._features,
                 [key]: value,
             };
-            this.lifecycle.emit(DEVICE.CHANGED);
+            this.emitDeviceChanged();
         }
     }
 

--- a/packages/connect/src/device/workflow/trezorPushNotification.ts
+++ b/packages/connect/src/device/workflow/trezorPushNotification.ts
@@ -35,7 +35,7 @@ const setupDeviceMode = async (
         } else {
             // otherwise wait for start pairing request
             device.setBusy('thp-locked');
-            device.lifecycle.emit(DEVICE.CHANGED);
+            device.emitDeviceChanged();
         }
 
         await device.release();
@@ -66,7 +66,7 @@ export const trezorPushNotificationHandler = async ({ device, message }: TpnWork
         device.setBusy(
             mode === TrezorPushNotificationMode.BootloaderMode ? 'bootloader-locked' : 'rebooting',
         );
-        device.lifecycle.emit(DEVICE.CHANGED);
+        device.emitDeviceChanged();
     }
 
     switch (type) {
@@ -86,18 +86,18 @@ export const trezorPushNotificationHandler = async ({ device, message }: TpnWork
                     ? 'bootloader-locked'
                     : 'hard-locked',
             );
-            device.lifecycle.emit(DEVICE.CHANGED);
+            device.emitDeviceChanged();
             break;
         case TrezorPushNotificationType.UNLOCK:
             await setupDeviceMode(device, decoded.mode);
             break;
         case TrezorPushNotificationType.SOFTLOCK:
             device.setBusy('pin-locked');
-            device.lifecycle.emit(DEVICE.CHANGED);
+            device.emitDeviceChanged();
             break;
         case TrezorPushNotificationType.SOFTUNLOCK:
             device.setBusy(device.features ? undefined : 'thp-locked');
-            device.lifecycle.emit(DEVICE.CHANGED);
+            device.emitDeviceChanged();
             break;
         default:
             break;

--- a/packages/connect/src/device/workflow/validateState.ts
+++ b/packages/connect/src/device/workflow/validateState.ts
@@ -1,4 +1,4 @@
-import { DEVICE, UI_REQUEST, createDeviceMessage, createUiMessage } from '@trezor/connect-common';
+import { UI_REQUEST, createUiMessage } from '@trezor/connect-common';
 import type { StaticSessionId } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { toHardenedPathPart } from '@trezor/crypto-utils';
@@ -166,7 +166,7 @@ const validateThpDeviceState = async (context: WorkflowContext) => {
 };
 
 export const validateState = async (context: WorkflowContext) => {
-    const { device, sendCoreMessage } = context;
+    const { device } = context;
 
     // Make sure that device will display pin/passphrase
     const isDeviceUnlocked = device.features.unlocked;
@@ -191,6 +191,6 @@ export const validateState = async (context: WorkflowContext) => {
     // emit additional CHANGE event if device becomes unlocked after authorization
     // features were automatically updated after PinMatrixAck in DeviceCommands
     if (!isDeviceUnlocked && device.features.unlocked) {
-        sendCoreMessage(createDeviceMessage(DEVICE.CHANGED, device.toMessageObject()));
+        device.emitDeviceChanged();
     }
 };

--- a/packages/connect/src/types/idevice.ts
+++ b/packages/connect/src/types/idevice.ts
@@ -173,6 +173,7 @@ export interface IDevice {
 
     // ─── Event methods ──────────────────────────────────────────────────────────
     emit: TypedEmitter<DeviceEvents>['emit'];
+    emitDeviceChanged(): void;
     prompt<T extends 'pin' | 'passphrase' | 'word' | 'thp_pairing'>(
         type: T,
         args: Omit<DeviceEvents[T], 'callback'>,


### PR DESCRIPTION
## Description

`DEVICE.CHANGED` is meant to signal real device state changes, but connect emitted it on every transport session change. The transport reports a session change on every acquire/release, so a normal device call — which acquires then releases the session — produced redundant `DEVICE.CHANGED` events even when no client-visible device state changed. In Suite these reach the redux store and rebuild the device object reference unconditionally, causing needless dispatches, re-renders and persisted-device writes (this matters for suite-native performance in particular).

This centralizes emission in a single `Device.emitDeviceChanged()` method that compares the outgoing `toMessageObject()` against the last emitted one (via `deepEqual`) and only emits when the client-visible representation actually changed. All emit sources — `updateDescriptor` (the session-churn source), `updateFeature`, THP push notifications, `setBusy`, `validateState` and the `keepSession` finally block — now funnel through it, so the dedup is applied uniformly and the previous manual `setBusy`/finally workarounds are no longer special-cased.

The check is safe by construction: it compares the actual outgoing payload, so it cannot drop a real change regardless of which field changed. Own session acquire/release of an acquired device yields a byte-identical payload (the transport session is not part of the message, `status` stays `available`, features/state are unchanged) and is suppressed, while genuine changes (reloaded features, `occupied`/`used` status, unlock, busy) still emit. Because the comparison runs at the single emission point, a kept-session `setBusy` correctly primes the baseline so the later `busy=false` still propagates.

This addresses the event-spam part of #6446; the "move `DEVICE.CHANGED` to the TRANSPORT event group" and the PinAck-features items are out of scope here.

## Performance impact

Honest assessment: net improvement, with a small, bounded new cost.

Added cost: each candidate `DEVICE.CHANGED` now computes `toMessageObject()` once and runs one `deepEqual` against the previously emitted payload. The comparison is dominated by the `features` object (a few dozen mostly-primitive fields) and short-circuits on the first difference, so it is on the order of microseconds. It runs on the connect side at the emission point (~twice per device call, from acquire + release, plus the other emit sites) — not on any React render or tight loop. When an emit is suppressed, the single `toMessageObject()` is the only work; when it is not suppressed, the forwarding handler recomputes `toMessageObject()` once more (pre-existing behavior), so a real change serializes the object twice — still negligible.

What it saves: every suppressed event avoids a redux dispatch, selector invalidation, a wide React re-render, and a persisted-device (IndexedDB) write in clients. Each of those is orders of magnitude more expensive than the `deepEqual` that prevents it, and a normal device call previously produced two such redundant events. suite-native benefits the most.

Memory: one retained `toMessageObject()` per connected device (`lastEmittedMessage` on the `Device` instance), released when the device is garbage-collected on disconnect. Bounded by the number of connected devices (≈1), no map/cleanup bookkeeping in Core.

Caveat: if `features` were unusually large and `DEVICE.CHANGED` fired at very high frequency, the comparison cost would grow — but it stays proportional to emit frequency (never amplified) and well below the cost of the work it removes. No other event types or hot paths are touched.

## Notes for QA

Connect-internal change; no UI or public API surface changes. The only behavioral difference is that identical, back-to-back `DEVICE.CHANGED` (`device-changed`) events are no longer delivered to clients — the events that do fire are unchanged in shape.

Worth confirming device-state transitions still reflect promptly in Suite:
- connect / disconnect; acquiring the device from another tab or app (shows as used elsewhere / occupied) and returning to available
- PIN unlock, passphrase, and label / settings changes appear immediately
- `setBusy` flows (e.g. coinjoin "do not disturb") still show and later clear the busy state
- battery level (soc) updates on supported devices
- firmware update / bootloader-mode transitions

No regression expected in what is shown, only fewer redundant updates and re-renders. Standard connect device e2e coverage applies.

## Related Issue

Refs #6446

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in @trezor/connect internals: device session management (Device.ts), core dispatch pipeline (core/index.ts), device state validation (validateState.ts), push notification handling (trezorPushNotification.ts), busy state API (setBusy.ts), and device type definitions (idevice.ts). These are foundational to all device communication, but the highest-risk tests are those that directly exercise TrezorConnect API calls (getAddress, signTransaction, ethereumSign*, getAccountInfo) and device lifecycle events (session management, disconnect/reconnect, passphrase validation). The recommended strategy prioritizes trezor-connect integration tests as high priority, with passphrase, session management, and device disconnect/reconnect tests at medium priority since they exercise specific workflows most sensitive to these changes.

<details><summary><b>Changed files (6)</b></summary>

- `packages/connect/src/api/setBusy.ts`
- `packages/connect/src/core/index.ts`
- `packages/connect/src/device/Device.ts`
- `packages/connect/src/device/workflow/trezorPushNotification.ts`
- `packages/connect/src/device/workflow/validateState.ts`
- `packages/connect/src/types/idevice.ts`

</details>

**Recommended tests (17)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test directly exercises TrezorConnect.getAddress and TrezorConnect.cancel flows, which rely on the core/index.ts dispatch loop, Device.ts session management, and validateState.ts for state validation. Changes to device workflow and core could break popup permission granting, address confirmation, and cancellation flows.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Directly tests TrezorConnect.getAddress with device confirmation, address verification, and device rejection — all paths that go through Device.ts run/call methods, validateState, and core dispatch. Changes to setBusy or device workflow could break the verify/confirmed badge flow.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Tests TrezorConnect.signTransaction with multi-step device confirmation. This exercises the core call pipeline, Device.ts command execution, and push notification handling during transaction signing — directly impacted by changes to trezorPushNotification.ts and Device.ts.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Tests Ethereum transaction signing through TrezorConnect API with device confirmation steps. This directly exercises Device.ts command execution, core dispatch, and validateState during the signing workflow.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Tests Ethereum message signing through TrezorConnect with permissions modal and device confirmation. Exercises the full Device.ts call pipeline and core index dispatch for message signing, directly affected by device workflow changes.
- `suite/e2e/tests/trezor-connect/error.test.ts` — Tests TrezorConnect error handling for invalid derivation paths. Changes to core/index.ts dispatch and Device.ts could alter how errors propagate and are displayed in the connect popup error modal.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests TrezorConnect permission granting, remembering, and revoking. The permission flow goes through core/index.ts for call processing and Device.ts for device interaction, making it directly sensitive to changes in these files.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Tests TrezorConnect.getAccountInfo which requires device communication through core dispatch, Device.ts session handling, and state validation. Account info retrieval is a core connect workflow directly impacted by these changes.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Tests TrezorConnect in webextension context with popup lifecycle management. While similar to connectPopupWeb, the webextension context adds complexity around popup opening/closing that interacts with core/index.ts and Device.ts session management.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests TrezorConnect silent mode which controls window focus behavior during connect calls. The silent mode flag is processed in core/index.ts and affects how device calls are dispatched, making it relevant to core changes.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Passphrase confirmation involves validateState.ts for checking device state consistency after passphrase entry. Changes to validateState could break the passphrase mismatch detection or passphrase caching behavior.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Tests device disconnect/reconnect with passphrase re-confirmation. validateState.ts is central to determining when passphrase needs re-entry after reconnection, and Device.ts manages session lifecycle across disconnects.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — Tests Cardano address verification with passphrase after device reconnection. validateState.ts determines whether passphrase needs re-entry, and incorrect passphrase detection flows through Device.ts.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Tests Bridge session stealing and reclaiming between multiple tabs. setBusy.ts manages device busy state which affects session acquisition, and Device.ts handles session lifecycle. Core changes could affect how session conflicts are resolved.
- `suite/e2e/tests/backup/t2t1-fail.test.ts` — Tests device disconnect during backup, which exercises Device.ts disconnect handling and trezorPushNotification.ts for notification routing during active device operations. Changes here could affect error recovery flows.
- `suite/e2e/tests/wallet/discovery.test.ts` — Tests wallet discovery with page reload interruption during active device communication. Device.ts session management and core dispatch changes could affect discovery resilience and recovery after interruption.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Tests bridge lifecycle and device reconnection after bridge restart. Device.ts session management and core/index.ts initialization are directly involved in re-establishing device communication after transport interruption.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/connect/src/api/setBusy.ts`
- `packages/connect/src/types/idevice.ts`

_Updated: 2026-07-02T13:39:16.404Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/device-change-event-spam&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/device-change-event-spam&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/device-change-event-spam&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T13:43:42.806Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-02T13:42:30.201Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/device-change-event-spam/web/](https://dev.suite.sldev.cz/suite-web/mroz22/device-change-event-spam/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->