### PR TITLE
feat(suite-native): add message system manager screen to dev utils

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemForm/MessageSystemFormExperiment.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemForm/MessageSystemFormExperiment.tsx
@@ -7,6 +7,7 @@ import {
     messageSystemActions,
     selectMessageSystemConfig,
     stripFieldFromMessage,
+    useConditionControls,
     validateExperimentForm,
 } from '@suite-common/message-system';
 import { type Experiments } from '@suite-common/suite-types';
@@ -17,7 +18,6 @@ import { spacings } from '@trezor/theme';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { MessageSystemJsonEditor } from './MessageSystemJsonEditor';
-import { useConditionControls } from './useConditionControls';
 import { MessageSystemExperimentToolbar } from '../MessageSystemExperiment/MessageSystemExperimentToolbar';
 
 export const MessageSystemFormExperiment = () => {

--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemForm/MessageSystemFormMessage.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemForm/MessageSystemFormMessage.tsx
@@ -1,105 +1,53 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { useTranslation } from '@suite/intl';
 import {
     CATEGORY_OPTIONS,
-    type ValidateError,
-    getDefaultActionByCategory,
     messageSystemActions,
-    selectMessageSystemConfig,
-    stripFieldFromMessage,
-    validateMessageForm,
+    useConditionControls,
+    useMessageSystemMessageForm,
 } from '@suite-common/message-system';
-import { type Action, type Category } from '@suite-common/suite-types';
-import { yup } from '@suite-common/validators';
 import { Column, Modal, Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 
 import { MessageSystemJsonEditor } from './MessageSystemJsonEditor';
-import { useConditionControls } from './useConditionControls';
 import { MessageSystemManagerToolbar } from '../MessageSystemManager/MessageSystemManagerToolbar';
 
 export const MessageSystemFormMessage = () => {
-    const defaultAction = JSON.stringify(getDefaultActionByCategory('banner'), null, 2);
-    const config = useSelector(selectMessageSystemConfig);
     const [showForm, setShowForm] = useState(false);
-    const [formData, setFormData] = useState<string>(defaultAction);
-    const [parsedData, setParsedData] = useState<Action | null>(null);
-    const [validationErrors, setValidationErrors] = useState<ValidateError[]>([]);
+    const { translationString } = useTranslation();
+    const dispatch = useDispatch();
+
+    const formatFieldError = useCallback(
+        (message: string) =>
+            message === 'TR_REQUIRED_FIELD' ? translationString(message) : message,
+        [translationString],
+    );
+
+    const {
+        formData,
+        setFormData,
+        parsedData,
+        validationErrors,
+        isValid,
+        canFormat,
+        formatJSON,
+        applyPreset,
+        resetForm,
+    } = useMessageSystemMessageForm({ formatFieldError });
+
     const { availableConditionOptions, canAddCondition, addCondition } = useConditionControls(
         parsedData,
         setFormData,
     );
-    const { translationString } = useTranslation();
-    const dispatch = useDispatch();
-
-    const isValid = validationErrors.length === 0;
-
-    const messageIds = useMemo(
-        () => new Set(config?.actions.map(action => action.message.id)),
-        [config],
-    );
-
-    useEffect(() => {
-        try {
-            const parsed = JSON.parse(formData);
-            setParsedData(parsed);
-
-            const validatedData = validateMessageForm(parsed);
-
-            if (messageIds.has(validatedData.message.id)) {
-                setValidationErrors([
-                    {
-                        field: 'message.id',
-                        message: `must be unique. “${validatedData.message.id}” is already in use.`,
-                    },
-                ]);
-            } else {
-                setValidationErrors([]);
-            }
-        } catch (error) {
-            if (error instanceof SyntaxError) {
-                const { message } = error;
-                setParsedData(null);
-                setValidationErrors([{ field: 'JSON', message }]);
-
-                return;
-            }
-
-            if (error instanceof yup.ValidationError) {
-                const errors = (error.inner?.length ? error.inner : [error]).map(e => ({
-                    field: e.path ?? 'value',
-                    message:
-                        e.message === 'TR_REQUIRED_FIELD'
-                            ? translationString(e.message)
-                            : e.message,
-                }));
-
-                setValidationErrors(stripFieldFromMessage(errors));
-
-                return;
-            }
-
-            setParsedData(null);
-            setValidationErrors([{ field: 'JSON', message: 'Unknown error occurred' }]);
-        }
-    }, [formData, messageIds, translationString]);
-
-    const formatJSON = useCallback(() => {
-        setFormData(JSON.stringify(parsedData, null, 2));
-    }, [parsedData]);
-
-    const handlePresetForm = useCallback((category: Category) => {
-        setFormData(JSON.stringify(getDefaultActionByCategory(category), null, 2));
-    }, []);
 
     const handleAddMessage = () => {
         if (parsedData) {
             dispatch(messageSystemActions.addMessage(parsedData));
             setShowForm(false);
-            setFormData(defaultAction);
+            resetForm();
         }
     };
 
@@ -120,14 +68,14 @@ export const MessageSystemFormMessage = () => {
                 categories={CATEGORY_OPTIONS}
                 availableConditions={availableConditionOptions}
                 canAddCondition={canAddCondition}
-                onPreset={handlePresetForm}
+                onPreset={applyPreset}
                 onAddCondition={addCondition}
             />
 
             <MessageSystemJsonEditor
                 value={formData}
                 isValid={isValid}
-                canFormat={parsedData !== null}
+                canFormat={canFormat}
                 errors={validationErrors}
                 onChange={setFormData}
                 onFormat={formatJSON}

--- a/suite-common/message-system/src/__tests__/useMessageSystemMessageForm.test.ts
+++ b/suite-common/message-system/src/__tests__/useMessageSystemMessageForm.test.ts
@@ -1,0 +1,123 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { type Action } from '@suite-common/suite-types';
+import {
+    act,
+    configureMockStore,
+    extraDependenciesCommonMock,
+    renderHookWithStoreProvider,
+} from '@suite-common/test-utils';
+
+import { messageSystemInitialState, prepareMessageSystemReducer } from '../messageSystemReducer';
+import { type MessageSystemState } from '../messageSystemTypes';
+import { getDefaultActionByCategory } from '../messageSystemUtils';
+import { useMessageSystemMessageForm } from '../useMessageSystemMessageForm';
+
+// jsdom 20 lacks crypto.randomUUID, which getDefaultActionByCategory relies on
+if (typeof globalThis.crypto.randomUUID !== 'function') {
+    let counter = 0;
+    Object.defineProperty(globalThis.crypto, 'randomUUID', {
+        value: () => `00000000-0000-4000-8000-${`${counter++}`.padStart(12, '0')}`,
+    });
+}
+
+const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
+
+const createStore = (actions: Action[] = []) =>
+    configureMockStore({
+        extra: {},
+        reducer: combineReducers({ messageSystem: messageSystemReducer }),
+        preloadedState: {
+            messageSystem: {
+                ...messageSystemInitialState,
+                config: {
+                    version: 1,
+                    timestamp: '2023-01-01',
+                    sequence: 1,
+                    actions,
+                    experiments: [],
+                },
+            } as unknown as MessageSystemState,
+        },
+    });
+
+const renderForm = (store = createStore()) =>
+    renderHookWithStoreProvider(() => useMessageSystemMessageForm(), { store });
+
+describe('useMessageSystemMessageForm', () => {
+    it('initializes with a valid banner preset', () => {
+        const { result } = renderForm();
+
+        const parsed = JSON.parse(result.current.formData);
+
+        expect(parsed.message.category).toBe('banner');
+        expect(result.current.parsedData).toEqual(parsed);
+        expect(result.current.validationErrors).toEqual([]);
+        expect(result.current.isValid).toBe(true);
+        expect(result.current.canFormat).toBe(true);
+    });
+
+    it('reports a JSON error for unparsable input', () => {
+        const { result } = renderForm();
+
+        act(() => {
+            result.current.setFormData('{ not json');
+        });
+
+        expect(result.current.parsedData).toBeNull();
+        expect(result.current.isValid).toBe(false);
+        expect(result.current.validationErrors).toHaveLength(1);
+        expect(result.current.validationErrors[0]?.field).toBe('JSON');
+        expect(result.current.canFormat).toBe(false);
+    });
+
+    it('surfaces yup errors for a schema-invalid action', () => {
+        const { result } = renderForm();
+        const { message, conditions } = getDefaultActionByCategory('banner');
+        const { id, ...messageWithoutId } = message;
+        const schemaInvalidAction = { message: messageWithoutId, conditions };
+
+        act(() => {
+            result.current.setFormData(JSON.stringify(schemaInvalidAction));
+        });
+
+        expect(result.current.parsedData).toEqual(schemaInvalidAction);
+        expect(result.current.canFormat).toBe(true);
+        expect(result.current.isValid).toBe(false);
+        expect(result.current.validationErrors.some(error => error.field === 'message.id')).toBe(
+            true,
+        );
+    });
+
+    it('rejects a duplicate message id', () => {
+        const existing = getDefaultActionByCategory('banner');
+        const { result } = renderForm(createStore([existing]));
+
+        const duplicate = getDefaultActionByCategory('banner');
+        duplicate.message.id = existing.message.id;
+
+        act(() => {
+            result.current.setFormData(JSON.stringify(duplicate, null, 2));
+        });
+
+        expect(result.current.isValid).toBe(false);
+        expect(result.current.validationErrors[0]?.field).toBe('message.id');
+        expect(result.current.validationErrors[0]?.message).toContain('must be unique');
+    });
+
+    it('applies the modal preset', () => {
+        const { result } = renderForm();
+
+        act(() => {
+            result.current.applyPreset('modal');
+        });
+
+        const parsed = JSON.parse(result.current.formData);
+
+        expect(parsed.message.category).toBe('modal');
+        expect(parsed.message.modal).toBeDefined();
+        // the modal preset ships with an empty image, which the schema requires the user to fill
+        expect(result.current.isValid).toBe(false);
+        expect(result.current.validationErrors[0]?.field).toBe('message.modal.image');
+    });
+});

--- a/suite-common/message-system/src/index.ts
+++ b/suite-common/message-system/src/index.ts
@@ -14,5 +14,7 @@ export * from './cachedEnvData';
 export * from './experimentUtils';
 export * from './ExperimentWrapper';
 export * from './featureFlagUtils';
+export * from './useConditionControls';
 export * from './useExperiment';
+export * from './useMessageSystemMessageForm';
 export * from './useMessageSystemStaking';

--- a/suite-common/message-system/src/useConditionControls.ts
+++ b/suite-common/message-system/src/useConditionControls.ts
@@ -1,7 +1,9 @@
 import { useCallback, useMemo } from 'react';
 
-import { CONDITION_OPTIONS, getDefaultConditionValue } from '@suite-common/message-system';
 import { type Condition } from '@suite-common/suite-types';
+
+import { CONDITION_OPTIONS } from './messageSystemConstants';
+import { getDefaultConditionValue } from './messageSystemUtils';
 
 type Parsed = { conditions?: unknown[] } | null;
 
@@ -20,13 +22,17 @@ export function useConditionControls(parsedData: Parsed, setFormData: (next: str
 
     const addCondition = useCallback(
         (conditionKey: keyof Condition) => {
-            if (!parsedData) return;
+            if (!parsedData) {
+                return;
+            }
 
             const defaultValue = getDefaultConditionValue(conditionKey);
             const existing = Array.isArray(parsedData.conditions) ? parsedData.conditions : [];
             const head = (existing[0] ?? {}) as Record<string, unknown>;
 
-            if (Object.prototype.hasOwnProperty.call(head, conditionKey)) return;
+            if (Object.prototype.hasOwnProperty.call(head, conditionKey)) {
+                return;
+            }
 
             const updatedHead = { ...head, [conditionKey]: defaultValue };
             const next = {

--- a/suite-common/message-system/src/useMessageSystemMessageForm.ts
+++ b/suite-common/message-system/src/useMessageSystemMessageForm.ts
@@ -1,0 +1,119 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { type Action, type Category } from '@suite-common/suite-types';
+import { yup } from '@suite-common/validators';
+
+import { selectMessageSystemConfig } from './messageSystemSelectors';
+import { getDefaultActionByCategory } from './messageSystemUtils';
+import {
+    type ValidateError,
+    stripFieldFromMessage,
+    validateMessageForm,
+} from './messageSystemValidation';
+
+type UseMessageSystemMessageFormArgs = {
+    // Maps a raw yup error message (e.g. the 'TR_REQUIRED_FIELD' key) to a display string.
+    formatFieldError?: (message: string) => string;
+};
+
+type MessageSystemMessageFormValidationResult = {
+    parsedData: Action | null;
+    validationErrors: ValidateError[];
+};
+
+type ParseAndValidateMessageFormArgs = {
+    formData: string;
+    messageIds: Set<string>;
+    formatFieldError?: (message: string) => string;
+};
+
+const parseAndValidateMessageForm = ({
+    formData,
+    messageIds,
+    formatFieldError,
+}: ParseAndValidateMessageFormArgs): MessageSystemMessageFormValidationResult => {
+    let parsedData: Action | null = null;
+
+    try {
+        parsedData = JSON.parse(formData);
+
+        const validatedData = validateMessageForm(parsedData);
+
+        if (messageIds.has(validatedData.message.id)) {
+            return {
+                parsedData,
+                validationErrors: [
+                    {
+                        field: 'message.id',
+                        message: `must be unique. “${validatedData.message.id}” is already in use.`,
+                    },
+                ],
+            };
+        }
+
+        return { parsedData, validationErrors: [] };
+    } catch (error) {
+        if (error instanceof SyntaxError) {
+            const { message } = error;
+
+            return { parsedData: null, validationErrors: [{ field: 'JSON', message }] };
+        }
+
+        if (error instanceof yup.ValidationError) {
+            const errors = (error.inner?.length ? error.inner : [error]).map(e => ({
+                field: e.path ?? 'value',
+                message: formatFieldError ? formatFieldError(e.message) : e.message,
+            }));
+
+            return { parsedData, validationErrors: stripFieldFromMessage(errors) };
+        }
+
+        return {
+            parsedData: null,
+            validationErrors: [{ field: 'JSON', message: 'Unknown error occurred' }],
+        };
+    }
+};
+
+export const useMessageSystemMessageForm = ({
+    formatFieldError,
+}: UseMessageSystemMessageFormArgs = {}) => {
+    const config = useSelector(selectMessageSystemConfig);
+    const [formData, setFormData] = useState<string>(() =>
+        JSON.stringify(getDefaultActionByCategory('banner'), null, 2),
+    );
+    const messageIds = useMemo(
+        () => new Set(config?.actions.map(action => action.message.id)),
+        [config],
+    );
+
+    const { parsedData, validationErrors } = useMemo(
+        () => parseAndValidateMessageForm({ formData, messageIds, formatFieldError }),
+        [formData, formatFieldError, messageIds],
+    );
+
+    const formatJSON = useCallback(() => {
+        setFormData(JSON.stringify(parsedData, null, 2));
+    }, [parsedData]);
+
+    const applyPreset = useCallback((category: Category) => {
+        setFormData(JSON.stringify(getDefaultActionByCategory(category), null, 2));
+    }, []);
+
+    const resetForm = useCallback(() => {
+        setFormData(JSON.stringify(getDefaultActionByCategory('banner'), null, 2));
+    }, []);
+
+    return {
+        formData,
+        setFormData,
+        parsedData,
+        validationErrors,
+        isValid: validationErrors.length === 0,
+        canFormat: parsedData !== null,
+        formatJSON,
+        applyPreset,
+        resetForm,
+    };
+};

--- a/suite-native/app/src/navigation/RootStackNavigator.tsx
+++ b/suite-native/app/src/navigation/RootStackNavigator.tsx
@@ -21,7 +21,7 @@ import {
     WalletConnectSwitchAccountScreen,
 } from '@suite-native/module-connect-popup';
 import { DemoAccountQuestionnaireStackNavigator } from '@suite-native/module-demo-account-questionnaire';
-import { DevUtilsScreen } from '@suite-native/module-dev-utils';
+import { DevUtilsScreen, MessageSystemManagerScreen } from '@suite-native/module-dev-utils';
 import {
     BackupFailedModalScreen,
     DeviceOnboardingStackNavigator,
@@ -244,6 +244,10 @@ export const RootStackNavigator = () => {
                 />
             </RootStack.Group>
             <RootStack.Screen name={RootStackRoutes.DevUtils} component={DevUtilsScreen} />
+            <RootStack.Screen
+                name={RootStackRoutes.MessageSystemManager}
+                component={MessageSystemManagerScreen}
+            />
             <RootStack.Screen name={RootStackRoutes.ConnectPopup} component={ConnectPopupScreen} />
             <RootStack.Screen
                 name={RootStackRoutes.WalletConnectSessionPopup}

--- a/suite-native/message-system/src/messageSystemMiddleware.ts
+++ b/suite-native/message-system/src/messageSystemMiddleware.ts
@@ -15,6 +15,8 @@ import { selectDeviceEnabledDiscoveryNetworkSymbols } from '@suite-native/discov
 
 const isAnyOfMessageSystemAffectingActions = isAnyOf(
     messageSystemActions.fetchSuccessUpdate,
+    messageSystemActions.addMessage,
+    messageSystemActions.removeMessage,
     deviceActions.selectDevice,
     deviceActions.connectDevice,
     changeNetworks,

--- a/suite-native/module-dev-utils/package.json
+++ b/suite-native/module-dev-utils/package.json
@@ -23,6 +23,7 @@
         "@suite-common/suite-sync": "workspace:*",
         "@suite-common/suite-sync-quota-manager": "workspace:*",
         "@suite-common/suite-sync-types": "workspace:*",
+        "@suite-common/suite-types": "workspace:*",
         "@suite-common/trading": "workspace:*",
         "@suite-common/validators": "workspace:*",
         "@suite-native/alerts": "workspace:*",

--- a/suite-native/module-dev-utils/src/components/MessageSystemAddMessageForm.tsx
+++ b/suite-native/module-dev-utils/src/components/MessageSystemAddMessageForm.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+
+import {
+    CATEGORY_OPTIONS,
+    messageSystemActions,
+    useConditionControls,
+    useMessageSystemMessageForm,
+} from '@suite-common/message-system';
+import { type Category, type Condition } from '@suite-common/suite-types';
+import { Button, Input, Select, Text, VStack } from '@suite-native/atoms';
+
+export const MessageSystemAddMessageForm = () => {
+    const dispatch = useDispatch();
+    const [presetCategory, setPresetCategory] = useState<Category>('banner');
+
+    const {
+        formData,
+        setFormData,
+        parsedData,
+        validationErrors,
+        isValid,
+        canFormat,
+        formatJSON,
+        applyPreset,
+        resetForm,
+    } = useMessageSystemMessageForm();
+
+    const { availableConditionOptions, canAddCondition, addCondition } = useConditionControls(
+        parsedData,
+        setFormData,
+    );
+
+    const handlePreset = (category: Category) => {
+        setPresetCategory(category);
+        applyPreset(category);
+    };
+
+    const handleAddCondition = (conditionKey: keyof Condition | '') => {
+        if (conditionKey === '') {
+            return;
+        }
+        addCondition(conditionKey);
+    };
+
+    const handleAddMessage = () => {
+        if (parsedData) {
+            dispatch(messageSystemActions.addMessage(parsedData));
+            setPresetCategory('banner');
+            resetForm();
+        }
+    };
+
+    return (
+        <VStack spacing="sp12">
+            <Text variant="body-md-strong">Add new message</Text>
+            <Select<Category>
+                title="Preset"
+                items={[...CATEGORY_OPTIONS]}
+                value={presetCategory}
+                onSelectItem={handlePreset}
+                isLabelShown
+            />
+            {canAddCondition && (
+                <Select<keyof Condition | ''>
+                    title="Add condition"
+                    items={[...availableConditionOptions]}
+                    value=""
+                    onSelectItem={handleAddCondition}
+                    isLabelShown
+                />
+            )}
+            <Input
+                label="Message JSON"
+                value={formData}
+                onChangeText={setFormData}
+                multiline
+                autoCapitalize="none"
+                autoCorrect={false}
+                hasError={!isValid}
+            />
+            {isValid ? (
+                <Text variant="body-sm">Config is valid</Text>
+            ) : (
+                validationErrors.map((error, index) => (
+                    <Text key={`${error.field}-${index}`} variant="body-sm" color="contentCritical">
+                        {error.field} {error.message}
+                    </Text>
+                ))
+            )}
+            <Button
+                intent="neutral"
+                priority="secondary"
+                size="medium"
+                isDisabled={!canFormat}
+                onPress={formatJSON}
+            >
+                Format JSON
+            </Button>
+            <Button size="medium" isDisabled={!isValid} onPress={handleAddMessage}>
+                Add message
+            </Button>
+        </VStack>
+    );
+};

--- a/suite-native/module-dev-utils/src/components/MessageSystemCard.tsx
+++ b/suite-native/module-dev-utils/src/components/MessageSystemCard.tsx
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { A } from '@mobily/ts-belt';
+import { useNavigation } from '@react-navigation/native';
 
 import {
     CONFIG_URL_REMOTE,
@@ -9,13 +10,21 @@ import {
 } from '@suite-common/message-system';
 import { Button, Card, Divider, Text, VStack } from '@suite-native/atoms';
 import { useCopyToClipboard } from '@suite-native/clipboard';
+import {
+    type RootStackParamList,
+    RootStackRoutes,
+    type StackNavigationProps,
+} from '@suite-native/navigation';
 import { isCodesignBuild } from '@trezor/env-utils';
 
 import { MessageSystemConfigSourceSelect } from './MessageSystemConfigSourceSelect';
 
+type NavigationProp = StackNavigationProps<RootStackParamList, RootStackRoutes.DevUtils>;
+
 export const MessageSystemCard = () => {
     const config = useSelector(selectMessageSystemConfig);
     const allValidMessages = useSelector(selectAllValidMessages);
+    const navigation = useNavigation<NavigationProp>();
     const copyToClipboard = useCopyToClipboard();
     const isCodesigned = isCodesignBuild();
     const remoteConfigUrl = isCodesigned ? CONFIG_URL_REMOTE.stable : CONFIG_URL_REMOTE.develop;
@@ -41,6 +50,14 @@ export const MessageSystemCard = () => {
                         onPress={handleCopyConfig}
                     >
                         Copy full config
+                    </Button>
+                    <Button
+                        intent="neutral"
+                        priority="secondary"
+                        size="medium"
+                        onPress={() => navigation.navigate(RootStackRoutes.MessageSystemManager)}
+                    >
+                        Message manager
                     </Button>
                 </VStack>
                 <Text variant="body-md-strong">Valid messages:</Text>

--- a/suite-native/module-dev-utils/src/components/MessageSystemManagerFilters.tsx
+++ b/suite-native/module-dev-utils/src/components/MessageSystemManagerFilters.tsx
@@ -1,0 +1,32 @@
+import { CATEGORY_FILTER_OPTIONS } from '@suite-common/message-system';
+import { Box, CheckBox, Select, Text, VStack } from '@suite-native/atoms';
+
+export type CategoryFilterOption = (typeof CATEGORY_FILTER_OPTIONS)[number]['value'];
+
+type MessageSystemManagerFiltersProps = {
+    showActive: boolean;
+    onToggleActive: () => void;
+    selectedCategory: CategoryFilterOption;
+    onCategoryChange: (value: CategoryFilterOption) => void;
+};
+
+export const MessageSystemManagerFilters = ({
+    showActive,
+    onToggleActive,
+    selectedCategory,
+    onCategoryChange,
+}: MessageSystemManagerFiltersProps) => (
+    <VStack spacing="sp12">
+        <Select<CategoryFilterOption>
+            title="Category"
+            items={[...CATEGORY_FILTER_OPTIONS]}
+            value={selectedCategory}
+            onSelectItem={onCategoryChange}
+            isLabelShown
+        />
+        <Box flexDirection="row" justifyContent="space-between" alignItems="center">
+            <Text>Show only active</Text>
+            <CheckBox isChecked={showActive} onChange={onToggleActive} />
+        </Box>
+    </VStack>
+);

--- a/suite-native/module-dev-utils/src/components/MessageSystemMessageItem.tsx
+++ b/suite-native/module-dev-utils/src/components/MessageSystemMessageItem.tsx
@@ -1,0 +1,61 @@
+import { toCommaSeparated } from '@suite-common/message-system';
+import { type Action } from '@suite-common/suite-types';
+import { Button, Card, Text, VStack } from '@suite-native/atoms';
+import { useCopyToClipboard } from '@suite-native/clipboard';
+
+type MessageSystemMessageItemProps = {
+    action: Action;
+    isActive: boolean;
+    isManuallyAdded: boolean;
+    onRemove: (id: string) => void;
+};
+
+export const MessageSystemMessageItem = ({
+    action,
+    isActive,
+    isManuallyAdded,
+    onRemove,
+}: MessageSystemMessageItemProps) => {
+    const copyToClipboard = useCopyToClipboard();
+    const { message, conditions } = action;
+
+    return (
+        <Card>
+            <VStack spacing="sp8">
+                <Text variant="body-sm-strong">{message.id}</Text>
+                <VStack spacing="sp2">
+                    <Text variant="body-xs">Active: {isActive ? 'yes' : 'no'}</Text>
+                    <Text variant="body-xs">Source: {isManuallyAdded ? 'in-app' : 'file'}</Text>
+                    <Text variant="body-xs">Category: {toCommaSeparated(message.category)}</Text>
+                    <Text variant="body-xs">Variant: {message.variant}</Text>
+                    <Text variant="body-xs">
+                        Dismissible: {message.dismissible ? 'true' : 'false'}
+                    </Text>
+                    <Text variant="body-xs">Priority: {message.priority}</Text>
+                </VStack>
+                <Text variant="body-sm">{message.content.en}</Text>
+                <Text variant="body-xs">{JSON.stringify(conditions, null, 2)}</Text>
+                <Button
+                    intent="neutral"
+                    priority="secondary"
+                    size="medium"
+                    onPress={() =>
+                        copyToClipboard(JSON.stringify({ conditions, message }, null, 2))
+                    }
+                >
+                    Copy
+                </Button>
+                {isManuallyAdded && (
+                    <Button
+                        intent="critical"
+                        priority="secondary"
+                        size="medium"
+                        onPress={() => onRemove(message.id)}
+                    >
+                        Remove
+                    </Button>
+                )}
+            </VStack>
+        </Card>
+    );
+};

--- a/suite-native/module-dev-utils/src/index.ts
+++ b/suite-native/module-dev-utils/src/index.ts
@@ -1,1 +1,2 @@
 export * from './screens/DevUtilsScreen';
+export * from './screens/MessageSystemManagerScreen';

--- a/suite-native/module-dev-utils/src/screens/MessageSystemManagerScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/MessageSystemManagerScreen.tsx
@@ -1,0 +1,87 @@
+import { useMemo, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import {
+    messageSystemActions,
+    selectAllManuallyAddedMessageIds,
+    selectAllValidMessages,
+    selectMessageSystemConfig,
+} from '@suite-common/message-system';
+import { Divider, Text, VStack } from '@suite-native/atoms';
+import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
+
+import { MessageSystemAddMessageForm } from '../components/MessageSystemAddMessageForm';
+import {
+    type CategoryFilterOption,
+    MessageSystemManagerFilters,
+} from '../components/MessageSystemManagerFilters';
+import { MessageSystemMessageItem } from '../components/MessageSystemMessageItem';
+
+export const MessageSystemManagerScreen = () => {
+    const config = useSelector(selectMessageSystemConfig);
+    const allValidMessages = useSelector(selectAllValidMessages);
+    const allManuallyAddedMessageIds = useSelector(selectAllManuallyAddedMessageIds);
+    const dispatch = useDispatch();
+
+    const [showActive, setShowActive] = useState<boolean>(true);
+    const [selectedCategory, setSelectedCategory] = useState<CategoryFilterOption>('all');
+
+    const validMessageIdSet = useMemo(
+        () => new Set(allValidMessages.map(message => message.id)),
+        [allValidMessages],
+    );
+
+    const filteredActions = useMemo(() => {
+        const isAllCategories = selectedCategory === 'all';
+
+        return (config?.actions ?? []).filter(({ message }) => {
+            const passesActiveFilter = !showActive || validMessageIdSet.has(message.id);
+
+            const categories = Array.isArray(message.category)
+                ? message.category
+                : [message.category];
+
+            const passesCategoryFilter = isAllCategories
+                ? true
+                : categories.includes(selectedCategory);
+
+            return passesActiveFilter && passesCategoryFilter;
+        });
+    }, [config, showActive, validMessageIdSet, selectedCategory]);
+
+    const handleRemove = (id: string) => {
+        dispatch(messageSystemActions.removeMessage(id));
+    };
+
+    return (
+        <Screen
+            header={
+                <DynamicScreenHeader
+                    title="Message system manager"
+                    subtitle={`${allValidMessages.length} active of ${config?.actions.length ?? 0}`}
+                />
+            }
+        >
+            <VStack spacing="sp16">
+                <MessageSystemManagerFilters
+                    showActive={showActive}
+                    onToggleActive={() => setShowActive(prev => !prev)}
+                    selectedCategory={selectedCategory}
+                    onCategoryChange={setSelectedCategory}
+                />
+                {filteredActions.length === 0 && <Text variant="body-sm">No messages.</Text>}
+                {filteredActions.map((action, index) => (
+                    <MessageSystemMessageItem
+                        key={`${action.message.id}-${index}`}
+                        action={action}
+                        isActive={validMessageIdSet.has(action.message.id)}
+                        isManuallyAdded={!!allManuallyAddedMessageIds?.[action.message.id]}
+                        onRemove={handleRemove}
+                    />
+                ))}
+                <Divider />
+                <MessageSystemAddMessageForm />
+            </VStack>
+        </Screen>
+    );
+};

--- a/suite-native/module-dev-utils/tsconfig.json
+++ b/suite-native/module-dev-utils/tsconfig.json
@@ -25,6 +25,9 @@
         {
             "path": "../../suite-common/suite-sync-types"
         },
+        {
+            "path": "../../suite-common/suite-types"
+        },
         { "path": "../../suite-common/trading" },
         {
             "path": "../../suite-common/validators"

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -442,6 +442,7 @@ export type RootStackParamList = {
     [RootStackRoutes.AccountSettings]: { accountKey: AccountKey };
     [RootStackRoutes.TransactionDetailStack]: NavigatorScreenParams<TransactionDetailStackParamList>;
     [RootStackRoutes.DevUtils]: undefined;
+    [RootStackRoutes.MessageSystemManager]: undefined;
     [RootStackRoutes.AccountAssets]: {
         accountKey: AccountKey;
         tab?: AccountAssetsTab;

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -18,6 +18,7 @@ export enum RootStackRoutes {
     ClaimReview = 'ClaimReview',
     ClaimTransactionDataReview = 'ClaimTransactionDataReview',
     DevUtils = 'DevUtils',
+    MessageSystemManager = 'MessageSystemManager',
     AccountSettings = 'AccountSettings',
     TransactionDetailStack = 'TransactionDetailStack',
     ReceiveStack = 'ReceiveStack',

--- a/yarn.lock
+++ b/yarn.lock
@@ -13084,6 +13084,7 @@ __metadata:
     "@suite-common/suite-sync": "workspace:*"
     "@suite-common/suite-sync-quota-manager": "workspace:*"
     "@suite-common/suite-sync-types": "workspace:*"
+    "@suite-common/suite-types": "workspace:*"
     "@suite-common/trading": "workspace:*"
     "@suite-common/validators": "workspace:*"
     "@suite-native/alerts": "workspace:*"


### PR DESCRIPTION
## Description

Adds a dev-only Message System Manager screen to the native app, reachable from the Message System card in Dev utils: lists all config actions with active/category filters, per-message copy to clipboard, remove for manually added messages, and adding new unsigned messages via a JSON editor with live schema validation.

To share the form logic with the desktop debug tool, `useConditionControls` and the JSON form state machine (`useMessageSystemMessageForm`) are extracted into `@suite-common/message-system`; the desktop form is refactored to consume them with identical behavior.

## Notes for QA

Dev tooling only, no production impact.

- Dev utils → Message system → Message manager: filters, Copy, Add message (JSON validation errors shown live), Remove on manually added messages.
- Desktop Settings → Debug → Message system manager: unchanged behavior after the hook refactor (add message form, presets, condition toolbar).

## Related Issue

—

## Screenshots:

https://github.com/user-attachments/assets/ab01aea4-710f-480a-a940-73db649cbe57




🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on the Message System feature — specifically debug/dev-utils UI forms for managing message system messages and experiments. The suite-side changes are limited to `SettingsDebug/MessageSystem/MessageSystemForm/` components, which are only used in the debug settings tab. The static coverage mapping links these to 6 tests, but examining the LLM analysis reveals that none of those tests actually interact with the Message System form components; the mapping is an artifact of broad directory-level imports (the tests use `settingsPage` debug tab for unrelated actions like adding promo banners or enabling Suite Sync). The bulk of the changes (16 of 18 files) are in `suite-native/` which is the React Native mobile app — entirely outside the scope of the Playwright web/desktop E2E test suite. No E2E tests exercise the message system debug forms or the native mobile navigation/dev-utils screens. This is a low-risk change set for the web/desktop E2E suite and no tests need to be run.

<details><summary><b>Changed files (18)</b></summary>

- `packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemForm/MessageSystemFormExperiment.tsx`
- `packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemForm/MessageSystemFormMessage.tsx`
- `suite-common/message-system/src/__tests__/useMessageSystemMessageForm.test.ts`
- `suite-common/message-system/src/index.ts`
- `suite-common/message-system/src/useConditionControls.ts`
- `suite-common/message-system/src/useMessageSystemMessageForm.ts`
- `suite-native/app/src/navigation/RootStackNavigator.tsx`
- `suite-native/message-system/src/messageSystemMiddleware.ts`
- `suite-native/module-dev-utils/package.json`
- `suite-native/module-dev-utils/src/components/MessageSystemAddMessageForm.tsx`
- `suite-native/module-dev-utils/src/components/MessageSystemCard.tsx`
- `suite-native/module-dev-utils/src/components/MessageSystemManagerFilters.tsx`
- `suite-native/module-dev-utils/src/components/MessageSystemMessageItem.tsx`
- `suite-native/module-dev-utils/src/index.ts`
- `suite-native/module-dev-utils/src/screens/MessageSystemManagerScreen.tsx`
- `suite-native/module-dev-utils/tsconfig.json`
- `suite-native/navigation/src/navigators.ts`
- `suite-native/navigation/src/routes.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (18)**
- `packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemForm/MessageSystemFormExperiment.tsx`
- `packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemForm/MessageSystemFormMessage.tsx`
- `suite-common/message-system/src/__tests__/useMessageSystemMessageForm.test.ts`
- `suite-common/message-system/src/index.ts`
- `suite-common/message-system/src/useConditionControls.ts`
- `suite-common/message-system/src/useMessageSystemMessageForm.ts`
- `suite-native/app/src/navigation/RootStackNavigator.tsx`
- `suite-native/message-system/src/messageSystemMiddleware.ts`
- `suite-native/module-dev-utils/package.json`
- `suite-native/module-dev-utils/src/components/MessageSystemAddMessageForm.tsx`
- `suite-native/module-dev-utils/src/components/MessageSystemCard.tsx`
- `suite-native/module-dev-utils/src/components/MessageSystemManagerFilters.tsx`
- `suite-native/module-dev-utils/src/components/MessageSystemMessageItem.tsx`
- `suite-native/module-dev-utils/src/index.ts`
- `suite-native/module-dev-utils/src/screens/MessageSystemManagerScreen.tsx`
- `suite-native/module-dev-utils/tsconfig.json`
- `suite-native/navigation/src/navigators.ts`
- `suite-native/navigation/src/routes.ts`

_Updated: 2026-07-06T16:15:56.022Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native-message-system-manager&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native-message-system-manager&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native-message-system-manager&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-06T16:22:04.826Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-06T16:19:50.269Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native-message-system-manager/web/](https://dev.suite.sldev.cz/suite-web/feat/native-message-system-manager/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->