### PR TITLE
fix(suite-native): center tron staking votes bottom sheet modal text

### DIFF
--- a/suite-native/module-earn/src/components/TronStakingVotesBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/TronStakingVotesBottomSheet.tsx
@@ -15,15 +15,11 @@ export const TronStakingVotesBottomSheet = ({ ref, onClose }: TronStakingVotesBo
     const { applyStyle } = useNativeStyles();
 
     return (
-        <BottomSheetModal
-            ref={ref}
-            title={
-                <Text variant="headline-sm" textAlign="center">
-                    <Translation id="earn.tron.votesBottomSheet.title" />
-                </Text>
-            }
-            paddingHorizontal="sp24"
-        >
+        <BottomSheetModal ref={ref} paddingHorizontal="sp4">
+            <Text variant="headline-sm" textAlign="center">
+                <Translation id="earn.tron.votesBottomSheet.title" />
+            </Text>
+
             <Text
                 color="contentSecondary"
                 textAlign="center"


### PR DESCRIPTION
## Description

Center Tron staking votes bottom sheet modal text.

## Related Issue

Resolve #29167 

## Screenshots:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-02 at 15 32 29" src="https://github.com/user-attachments/assets/8de303c2-f71a-40bf-8a0c-dfab622179a7" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/tron-votes-bottom-sheet-modal-centered&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->