### PR TITLE
feat(suite-desktop): toggle keymap help and vim keys

### DIFF
--- a/packages/components/src/constants/keyboardEvents.ts
+++ b/packages/components/src/constants/keyboardEvents.ts
@@ -17,6 +17,7 @@ export enum KEYBOARD_CODE {
     KEY_G = 'KeyG',
     KEY_H = 'KeyH',
     KEY_I = 'KeyI',
+    KEY_J = 'KeyJ',
     KEY_K = 'KeyK',
     KEY_L = 'KeyL',
     KEY_N = 'KeyN',

--- a/packages/suite/src/actions/suite/guideActions.ts
+++ b/packages/suite/src/actions/suite/guideActions.ts
@@ -1,6 +1,6 @@
 import type { ActiveView, GuideCategory, GuideNode } from '@suite-common/suite-types';
 
-import { type Dispatch } from 'src/types/suite';
+import { type Dispatch, type GetState } from 'src/types/suite';
 
 import { GUIDE } from './constants';
 
@@ -36,6 +36,21 @@ export const setView = (payload: ActiveView) => (dispatch: Dispatch) => {
     }
 
     dispatch({ type: GUIDE.SET_VIEW, payload });
+};
+
+// Reads state at dispatch-time (via getState) rather than relying on a value captured by
+// a keyboard-shortcut handler's render closure, so the toggle can't act on a stale open/view.
+export const toggleView = (payload: ActiveView) => (dispatch: Dispatch, getState: GetState) => {
+    const { open: isOpen, view } = getState().guide;
+
+    if (isOpen && view === payload) {
+        dispatch(close());
+    } else {
+        dispatch(setView(payload));
+        if (!isOpen) {
+            dispatch(open());
+        }
+    }
 };
 
 export const openNode = (payload: GuideNode) => (dispatch: Dispatch) => {

--- a/packages/suite/src/components/guide/GuideShortcuts.tsx
+++ b/packages/suite/src/components/guide/GuideShortcuts.tsx
@@ -100,11 +100,11 @@ const walletsSection: ShortcutSection = {
         },
         {
             labelId: 'TR_GUIDE_KEYBOARD_SHORTCUTS_PREV_ACCOUNT',
-            keys: ['ALT', 'UP_ARROW'],
+            keys: ['ALT', 'KEY_K'],
         },
         {
             labelId: 'TR_GUIDE_KEYBOARD_SHORTCUTS_NEXT_ACCOUNT',
-            keys: ['ALT', 'DOWN_ARROW'],
+            keys: ['ALT', 'KEY_J'],
         },
     ],
 };

--- a/packages/suite/src/hooks/suite/useAppShortcuts.tsx
+++ b/packages/suite/src/hooks/suite/useAppShortcuts.tsx
@@ -242,12 +242,9 @@ export const useAppShortcuts = () => {
             }
         }
 
-        // press ALT + ↑ / ↓ (or the vim-style ALT + K / J alternative) to step to the
-        // previous / next account in the list
-        const isPrevAccountKey =
-            e.code === KEYBOARD_CODE.ARROW_UP || e.code === KEYBOARD_CODE.KEY_K;
-        const isNextAccountKey =
-            e.code === KEYBOARD_CODE.ARROW_DOWN || e.code === KEYBOARD_CODE.KEY_J;
+        // press ALT + K / J (vim-style) to step to the previous / next account in the list
+        const isPrevAccountKey = e.code === KEYBOARD_CODE.KEY_K;
+        const isNextAccountKey = e.code === KEYBOARD_CODE.KEY_J;
 
         if (altOnly && (isPrevAccountKey || isNextAccountKey) && orderedAccounts.length > 0) {
             e.preventDefault();
@@ -271,11 +268,9 @@ export const useAppShortcuts = () => {
             toggleDebugMode();
         }
 
-        // press SHIFT + / (i.e. "?") to toggle the keyboard shortcuts guide: open it (and
-        // jump to the shortcuts view) if it's not already showing, close it if it is.
-        // Matched by physical key + shiftKey rather than `e.key === '?'`, since holding
-        // Option/Alt on macOS changes what character Shift+/ produces (e.g. "¿").
-        if (e.code === KEYBOARD_CODE.SLASH && shiftKey && !cmdOrCtrl && !isTypingTarget(e.target)) {
+        // press "?" to toggle the keyboard shortcuts guide
+        // matched on `e.key` rather than `e.code` so it also works on non-US layouts
+        if (e.key === '?' && !cmdOrCtrl && !isTypingTarget(e.target)) {
             e.preventDefault();
             dispatch(toggleGuideView('KEYBOARD_SHORTCUTS'));
         }

--- a/packages/suite/src/hooks/suite/useAppShortcuts.tsx
+++ b/packages/suite/src/hooks/suite/useAppShortcuts.tsx
@@ -13,7 +13,7 @@ import { isDesktop } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { bioAuthActions } from 'src/actions/suite/bioAuthActions';
-import { open, setView } from 'src/actions/suite/guideActions';
+import { toggleView as toggleGuideView } from 'src/actions/suite/guideActions';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectIsBioAuthEnabled } from 'src/reducers/bioAuth';
@@ -242,14 +242,16 @@ export const useAppShortcuts = () => {
             }
         }
 
-        // press ALT + ↑ / ↓ to step to the previous / next account in the list
-        if (
-            altOnly &&
-            (e.code === KEYBOARD_CODE.ARROW_UP || e.code === KEYBOARD_CODE.ARROW_DOWN) &&
-            orderedAccounts.length > 0
-        ) {
+        // press ALT + ↑ / ↓ (or the vim-style ALT + K / J alternative) to step to the
+        // previous / next account in the list
+        const isPrevAccountKey =
+            e.code === KEYBOARD_CODE.ARROW_UP || e.code === KEYBOARD_CODE.KEY_K;
+        const isNextAccountKey =
+            e.code === KEYBOARD_CODE.ARROW_DOWN || e.code === KEYBOARD_CODE.KEY_J;
+
+        if (altOnly && (isPrevAccountKey || isNextAccountKey) && orderedAccounts.length > 0) {
             e.preventDefault();
-            const offset = e.code === KEYBOARD_CODE.ARROW_DOWN ? 1 : -1;
+            const offset = isNextAccountKey ? 1 : -1;
             const currentIndex = orderedAccounts.findIndex(
                 account =>
                     selectedAccount?.symbol === account.symbol &&
@@ -269,12 +271,13 @@ export const useAppShortcuts = () => {
             toggleDebugMode();
         }
 
-        // press ? to open the keyboard shortcuts guide
-        // `?` is a printable character, so ignore it while the user is typing
-        if (e.key === '?' && !cmdOrCtrl && !altKey && !isTypingTarget(e.target)) {
+        // press SHIFT + / (i.e. "?") to toggle the keyboard shortcuts guide: open it (and
+        // jump to the shortcuts view) if it's not already showing, close it if it is.
+        // Matched by physical key + shiftKey rather than `e.key === '?'`, since holding
+        // Option/Alt on macOS changes what character Shift+/ produces (e.g. "¿").
+        if (e.code === KEYBOARD_CODE.SLASH && shiftKey && !cmdOrCtrl && !isTypingTarget(e.target)) {
             e.preventDefault();
-            dispatch(setView('KEYBOARD_SHORTCUTS'));
-            dispatch(open());
+            dispatch(toggleGuideView('KEYBOARD_SHORTCUTS'));
         }
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- enables toggling of help on `?` click next to `ESC` option. 
- adds vim navigation to user accounts

## Notes for QA

Tested on MacOS


## Screenshots:
<img width="1240" height="818" alt="Screenshot 2026-07-02 at 15 53 34" src="https://github.com/user-attachments/assets/9f14c4f5-2c26-4352-83b1-a9710a5f2e96" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect the Guide panel's action dispatchers (guideActions.ts), the keyboard shortcut component for the guide (GuideShortcuts.tsx), the general app keyboard shortcuts hook (useAppShortcuts.tsx), and a keyboard event constants file. The primary risk is breaking guide panel open/close behavior and keyboard shortcut handling. The two guide-specific E2E tests are the most critical to run. guideActions.ts maps to 121+ tests via transitive imports, but only the guide-focused tests actually exercise guide functionality. The keyboard event constants and useAppShortcuts hook have no direct E2E test coverage for shortcut triggering since E2E tests interact via clicks rather than keyboard shortcuts.

<details><summary><b>Changed files (4)</b></summary>

- `packages/components/src/constants/keyboardEvents.ts`
- `packages/suite/src/actions/suite/guideActions.ts`
- `packages/suite/src/components/guide/GuideShortcuts.tsx`
- `packages/suite/src/hooks/suite/useAppShortcuts.tsx`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/general/suite-guide.test.ts` — This test directly exercises the Guide panel (opening, searching articles, sending bug reports) which is the primary UI surface affected by changes to guideActions.ts and GuideShortcuts.tsx. Any regression in guide open/close behavior or guide panel interactions would be caught here.
- `suite/e2e/tests/suite/guide.test.ts` — This test covers guide panel open/close without a device, guide navigation, feedback submission, guide search, and opening the guide during onboarding — all directly tied to guideActions.ts (open/close actions) and GuideShortcuts.tsx (keyboard shortcut triggers). It also tests opening the guide over modals, which exercises the guide's state management.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/suite/bug-report-form.test.ts` — This test opens the Guide panel and submits a bug report through it. Changes to guideActions.ts could affect the guide panel opening flow and the support/feedback navigation within the guide, making this a relevant secondary test.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/components/src/constants/keyboardEvents.ts`
- `packages/suite/src/hooks/suite/useAppShortcuts.tsx`

_Updated: 2026-07-03T08:32:15.058Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/key-nav-improve&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/key-nav-improve&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/key-nav-improve/web/](https://dev.suite.sldev.cz/suite-web/feat/key-nav-improve/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-07T11:26:05.623Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |

</details>

_Updated: 2026-07-07T11:23:43.225Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->