### PR TITLE
[nit] fix(wallet-core): correct boolean operator in visible non-empty account filter

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsSelectors.ts
+++ b/suite-common/wallet-core/src/accounts/accountsSelectors.ts
@@ -172,7 +172,7 @@ export const selectVisibleNonEmptyDeviceAccountsByNetworkSymbol = createMemoized
     accounts =>
         pipe(
             accounts,
-            A.filter(account => !account.empty || account.visible),
+            A.filter(account => !account.empty && account.visible),
             returnStableArrayIfEmpty,
         ),
 );

--- a/suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts
+++ b/suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts
@@ -9,6 +9,7 @@ import { type AccountsRootState } from '../accountsReducer';
 import {
     selectAddressByNetworkAndPath,
     selectVisibleDeviceAccountsMap,
+    selectVisibleNonEmptyDeviceAccountsByNetworkSymbol,
 } from '../accountsSelectors';
 
 const BTC_DEVICE_SSID: `${string}@${string}:${number}` =
@@ -229,6 +230,27 @@ describe('accountsSelectors', () => {
             expect(result.get(btcAccount.key)).toEqual(
                 expect.objectContaining({ key: btcAccount.key }),
             );
+        });
+    });
+
+    describe(selectVisibleNonEmptyDeviceAccountsByNetworkSymbol.name, () => {
+        it('returns a visible non-empty account', () => {
+            const result = selectVisibleNonEmptyDeviceAccountsByNetworkSymbol(
+                getStateWithSelectedDevice(mockState, BTC_DEVICE),
+                'btc',
+            );
+
+            expect(result).toHaveLength(1);
+            expect(result[0]?.symbol).toBe('btc');
+        });
+
+        it('excludes a visible but empty account', () => {
+            const result = selectVisibleNonEmptyDeviceAccountsByNetworkSymbol(
+                getStateWithSelectedDevice(mockState, ETH_DEVICE),
+                'eth',
+            );
+
+            expect(result).toHaveLength(0);
         });
     });
 });


### PR DESCRIPTION
## Description

Split out from the bug-fix sweep umbrella #28977.

`selectVisibleNonEmptyDeviceAccountsByNetworkSymbol` filtered accounts with `!account.empty || account.visible`. That `||` negated both conditions the selector's name promises: it also returned **visible-but-empty** accounts and **non-empty-but-hidden** accounts. The fix uses `!account.empty && account.visible` so only visible non-empty accounts pass.

The selector's only consumer is `AssetCoinName` on the dashboard, where it drives the per-coin account count shown under each asset — so the count was inflated for anyone with hidden or empty accounts.

Adds two focused unit tests (included vs. excluded) covering the operator.

## Related PRs

Part of the #28977 sweep, alongside:
- #28995 — `fix(connect)`: size bare uint/int EIP-712 fields as 256-bit
- #29082 — `fix(wallet-core)`: guard removeAccount from deleting the wrong account

## Notes for QA

Low blast radius, single selector used only on the dashboard AssetsView. To verify: with a device that has at least one hidden or empty account, the account count shown under a coin name on the dashboard should now exclude those (previously they were counted). No signing, no persistence, no migration touched.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change modifies accountsSelectors.ts, a widely-imported utility (121 tests mapped) that provides account filtering, grouping, and selection logic used across most wallet-related views. Since it's a broad dependency, the testing strategy focuses on tests that most directly exercise account selection, filtering, discovery, and grouping — the core behaviors of these selectors. The unit test file (accountsSelectors.test.ts) has no E2E coverage but provides its own unit-level validation. The highest risk is in account discovery, account type grouping, and search/filter flows where selector logic is most exercised.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-core/src/accounts/accountsSelectors.ts`
- `suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coins, triggers account discovery, reloads mid-discovery, and verifies all account balances are visible. accountsSelectors are directly used to resolve and display discovered accounts, making this the most direct E2E exerciser of account selector logic.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds different account types (normal, taproot, segwit, legacy) and asserts account counts per type group via getAccountsInTypeGroupCount/getAccountsForCoinInTypeGroupCount, which rely on accountsSelectors to filter and group accounts.
- `suite/e2e/tests/wallet/account-search.test.ts` — Account search filtering directly depends on accountsSelectors to filter which accounts are visible/hidden based on search queries. The test asserts specific accounts are shown or hidden after typing in the search field.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Tests wallet discovery by ejecting a wallet and adding a standard wallet, then verifying account balance visibility. Account selection and display after discovery depends on accountsSelectors.
- `suite/e2e/tests/dashboard/assets.test.ts` — Verifies that newly enabled assets appear correctly in grid and table views after activation. The assets section relies on accountsSelectors to determine which accounts/assets to display on the dashboard.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Tests account discovery with custom blockbook backends and verifies the dashboard graph is displayed. Discovery completion and account visibility depend on accountsSelectors resolving discovered accounts.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — Tests that account balances update correctly after receiving funds on regtest. Balance display relies on accountsSelectors to select the correct account and its balance data.
- `suite/e2e/tests/wallet/public-keys.test.ts` — Opens specific coin accounts and navigates to account details to view public keys. Account selection by coin type uses accountsSelectors to locate the correct account.
- `suite/e2e/tests/settings/coins.test.ts` — Tests enabling/disabling networks and verifying account visibility on the dashboard, including empty state when all coins are disabled. Account presence detection uses accountsSelectors.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — Opens a Cardano account and verifies account details. While it exercises account selection, it's a straightforward single-account scenario less likely to be affected by selector changes.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts`

_Updated: 2026-07-02T14:10:56.661Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-visible-nonempty-account-filter&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-visible-nonempty-account-filter&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fix-visible-nonempty-account-filter&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T14:16:54.641Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-02T14:14:30.574Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-visible-nonempty-account-filter/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-visible-nonempty-account-filter/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->