### PR TITLE
Tron claim flow

### DIFF
--- a/packages/connect-common/src/types/api/tron/common.ts
+++ b/packages/connect-common/src/types/api/tron/common.ts
@@ -39,6 +39,13 @@ const TronWithdrawExpireUnfreezeContract = Type.Object({
     }),
 });
 
+const TronWithdrawBalanceContract = Type.Object({
+    type: Type.Literal('WithdrawBalanceContract'),
+    parameter: Type.Object({
+        value: PROTO.TronWithdrawBalance,
+    }),
+});
+
 const TronVoteWitnessContract = Type.Object({
     type: Type.Literal('VoteWitnessContract'),
     parameter: Type.Object({
@@ -53,6 +60,7 @@ export const TronContracts = Type.Union([
     TronFreezeBalanceV2Contract,
     TronUnfreezeBalanceV2Contract,
     TronWithdrawExpireUnfreezeContract,
+    TronWithdrawBalanceContract,
     TronVoteWitnessContract,
 ]);
 
@@ -113,6 +121,7 @@ export const TronContractInput = Type.Union([
     TronFreezeBalanceV2ContractInput,
     TronUnfreezeBalanceV2ContractInput,
     TronWithdrawExpireUnfreezeContract,
+    TronWithdrawBalanceContract,
     TronVoteWitnessContractInput,
 ]);
 

--- a/packages/connect/src/api/tron/__tests__/tronEncode.test.ts
+++ b/packages/connect/src/api/tron/__tests__/tronEncode.test.ts
@@ -95,6 +95,26 @@ const WITHDRAW = {
     },
 } as const;
 
+const CLAIM_CONTRACT: TronContracts = {
+    type: 'WithdrawBalanceContract',
+    parameter: {
+        value: {
+            owner_address: OWNER_ADDRESS,
+        },
+    },
+};
+
+const CLAIM = {
+    signature:
+        'a7f8602b02413e9dded0170daa5b4ada9a2679198af276be456f4faea1bc326f5070789bec5e6471de3f726f4fe0c9daced8df183e4a62804db26d5650c59a521c',
+    blockParams: {
+        ref_block_bytes: 'e942',
+        ref_block_hash: '6394747da9fee421',
+        expiration: 1752562632000,
+        timestamp: 1752562572000,
+    },
+} as const;
+
 const VOTE_CONTRACT: TronContracts = {
     type: 'VoteWitnessContract',
     parameter: {
@@ -179,6 +199,19 @@ describe('tron/encodeBroadcastTransaction', () => {
         // @ts-expect-error: indexing with noUncheckedIndexedAccess
         const firstSignature: (typeof signature)[number] = signature[0];
         expect(bytesToHex(firstSignature)).toBe(WITHDRAW.signature);
+    });
+
+    it('embeds rawData and signature for a claim', () => {
+        const rawDataHex = bytesToHex(encodeTronContractRawData(CLAIM_CONTRACT, CLAIM.blockParams));
+        const result = encodeBroadcastTransaction(rawDataHex, CLAIM.signature);
+
+        const decoded = decodeBroadcastTransaction(result);
+        expect(bytesToHex(decoded.rawData)).toBe(rawDataHex);
+        expect(decoded.signature).toHaveLength(1);
+        const { signature } = decoded;
+        // @ts-expect-error: indexing with noUncheckedIndexedAccess
+        const firstSignature: (typeof signature)[number] = signature[0];
+        expect(bytesToHex(firstSignature)).toBe(CLAIM.signature);
     });
 
     it('embeds rawData and signature for a vote', () => {

--- a/packages/connect/src/api/tron/api/tronSignTransaction.ts
+++ b/packages/connect/src/api/tron/api/tronSignTransaction.ts
@@ -69,6 +69,7 @@ const transformContract = (input: TronContractInput): TronContracts => {
         case 'TransferContract':
         case 'TriggerSmartContract':
         case 'WithdrawExpireUnfreezeContract':
+        case 'WithdrawBalanceContract':
             return input;
     }
 };
@@ -79,6 +80,7 @@ const contractMapping = {
     FreezeBalanceV2Contract: 'TronFreezeBalanceV2Contract',
     UnfreezeBalanceV2Contract: 'TronUnfreezeBalanceV2Contract',
     WithdrawExpireUnfreezeContract: 'TronWithdrawUnfreeze',
+    WithdrawBalanceContract: 'TronWithdrawBalance',
     VoteWitnessContract: 'TronVoteWitnessContract',
 } as const satisfies Record<TronContractsTypes, PROTO.MessageKey>;
 

--- a/packages/connect/src/api/tron/tronEncode.ts
+++ b/packages/connect/src/api/tron/tronEncode.ts
@@ -105,6 +105,20 @@ const encodeInnerContract = (contract: TronContracts): InnerContract => {
                 ),
             };
         }
+        case 'WithdrawBalanceContract': {
+            const { owner_address } = contract.parameter.value;
+            const schema = getSchema('TronWithdrawBalance');
+
+            return {
+                type: TronRawContractType.WithdrawBalanceContract,
+                bytes: toBinary(
+                    schema,
+                    create(schema, {
+                        ownerAddress: hexToBytes(owner_address ?? ''),
+                    }),
+                ),
+            };
+        }
         case 'VoteWitnessContract': {
             const { owner_address, votes } = contract.parameter.value;
             const schema = getSchema('TronVoteWitnessContract');

--- a/packages/suite-desktop-ui/src/support/desktopComponents.ts
+++ b/packages/suite-desktop-ui/src/support/desktopComponents.ts
@@ -6,6 +6,7 @@ import { ConnectPopup } from 'src/views/connect-popup';
 import { Dashboard } from 'src/views/dashboard';
 import { Earn } from 'src/views/earn';
 import {
+    EarnTronClaim,
     EarnTronRedirect,
     EarnTronStake,
     EarnTronUnstake,
@@ -55,6 +56,7 @@ export const desktopComponents: Record<PageName, ComponentType> = {
     'earn-tron-vote': EarnTronVote,
     'earn-tron-unstake': EarnTronUnstake,
     'earn-tron-withdraw': EarnTronWithdraw,
+    'earn-tron-claim': EarnTronClaim,
     'suite-connect-popup': ConnectPopup,
     'notifications-index': Notification,
 

--- a/packages/suite-web/src/support/webComponents.ts
+++ b/packages/suite-web/src/support/webComponents.ts
@@ -69,6 +69,13 @@ export const webComponents: Record<PageName, LazyExoticComponent<ComponentType>>
             }),
         ),
     ),
+    'earn-tron-claim': lazy(() =>
+        import(/* webpackChunkName: "earn" */ 'src/views/earn/tron/index').then(
+            ({ EarnTronClaim }) => ({
+                default: EarnTronClaim,
+            }),
+        ),
+    ),
     'suite-connect-popup': lazy(() =>
         import(/* webpackChunkName: "connect-popup" */ 'src/views/connect-popup/index').then(
             ({ ConnectPopup }) => ({ default: ConnectPopup }),

--- a/packages/suite/src/components/earn/index.ts
+++ b/packages/suite/src/components/earn/index.ts
@@ -22,6 +22,7 @@ export { TronStake } from './staking/tron/TronStake';
 export { TronUnstake } from './staking/tron/TronUnstake';
 export { TronVote } from './staking/tron/TronVote';
 export { TronWithdraw } from './staking/tron/TronWithdraw';
+export { TronClaim } from './staking/tron/TronClaim';
 export { YieldDeposit } from './yield/deposit/YieldDeposit';
 export { YieldWithdraw } from './yield/withdraw/YieldWithdraw';
 export { EarnStakingInfo } from './modals/EarnInANutshell/components/EarnStakingInfo';

--- a/packages/suite/src/components/earn/staking/tron/TronClaim.tsx
+++ b/packages/suite/src/components/earn/staking/tron/TronClaim.tsx
@@ -1,8 +1,11 @@
+import { Translation } from '@suite/intl';
 import { type Account } from '@suite-common/wallet-types';
 import { Column } from '@trezor/components';
 
 import { TronStakeContext } from './TronStakeContext';
 import { TronClaimForm } from './claim/TronClaimForm';
+import { TronClaimSummaryCard } from './complete/TronClaimSummaryCard';
+import { TronStakeComplete } from './complete/TronStakeComplete';
 import { useTronStakeFlow } from './hooks/useTronStakeFlow';
 
 interface TronClaimProps {
@@ -11,12 +14,23 @@ interface TronClaimProps {
 
 export const TronClaim = ({ account }: TronClaimProps) => {
     const context = useTronStakeFlow({ account, flow: 'claim' });
+    const { step } = context.actions;
 
     return (
         <TronStakeContext.Provider value={context}>
             <Column alignItems="center">
                 <Column gap={24} width="100%" maxWidth={500}>
-                    <TronClaimForm />
+                    {step === 'complete' ? (
+                        <TronStakeComplete
+                            account={account}
+                            heading={<Translation id="TR_EARN_TRON_CLAIM_COMPLETE" />}
+                            description={<Translation id="TR_EARN_TRON_CLAIM_DESCRIPTION" />}
+                        >
+                            <TronClaimSummaryCard />
+                        </TronStakeComplete>
+                    ) : (
+                        <TronClaimForm />
+                    )}
                 </Column>
             </Column>
         </TronStakeContext.Provider>

--- a/packages/suite/src/components/earn/staking/tron/TronClaim.tsx
+++ b/packages/suite/src/components/earn/staking/tron/TronClaim.tsx
@@ -1,0 +1,24 @@
+import { type Account } from '@suite-common/wallet-types';
+import { Column } from '@trezor/components';
+
+import { TronStakeContext } from './TronStakeContext';
+import { TronClaimForm } from './claim/TronClaimForm';
+import { useTronStakeFlow } from './hooks/useTronStakeFlow';
+
+interface TronClaimProps {
+    account: Account;
+}
+
+export const TronClaim = ({ account }: TronClaimProps) => {
+    const context = useTronStakeFlow({ account, flow: 'claim' });
+
+    return (
+        <TronStakeContext.Provider value={context}>
+            <Column alignItems="center">
+                <Column gap={24} width="100%" maxWidth={500}>
+                    <TronClaimForm />
+                </Column>
+            </Column>
+        </TronStakeContext.Provider>
+    );
+};

--- a/packages/suite/src/components/earn/staking/tron/claim/TronClaimAmount.tsx
+++ b/packages/suite/src/components/earn/staking/tron/claim/TronClaimAmount.tsx
@@ -1,0 +1,37 @@
+import { Translation } from '@suite/intl';
+import { getTronStakingRewards } from '@suite-common/wallet-utils';
+import { Card, Column, Row, Text } from '@trezor/components';
+import { CoinLogo } from '@trezor/product-components';
+
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+
+import { useTronStakeContext } from '../TronStakeContext';
+import { TronStakeInfoRow } from '../TronStakeInfoRow';
+
+export const TronClaimAmount = () => {
+    const { account } = useTronStakeContext();
+    const reward = getTronStakingRewards(account);
+
+    return (
+        <Card paddingType="none">
+            <TronStakeInfoRow label={<Translation id="AMOUNT" />}>
+                <Row alignItems="center" gap={8}>
+                    <CoinLogo symbol={account.symbol} size={24} />
+                    <Column gap={2} alignItems="flex-end">
+                        <Text typographyStyle="body-md-strong">
+                            <FormattedCryptoAmount value={reward} symbol={account.symbol} />
+                        </Text>
+                        <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                            <BaseCurrencyValue
+                                amount={reward}
+                                symbol={account.symbol}
+                                showApproximationIndicator
+                            />
+                        </Text>
+                    </Column>
+                </Row>
+            </TronStakeInfoRow>
+        </Card>
+    );
+};

--- a/packages/suite/src/components/earn/staking/tron/claim/TronClaimForm.tsx
+++ b/packages/suite/src/components/earn/staking/tron/claim/TronClaimForm.tsx
@@ -1,0 +1,42 @@
+import { FormProvider } from 'react-hook-form';
+
+import { Translation } from '@suite/intl';
+import { Banner, Column, Text } from '@trezor/components';
+
+import { useTronStakeContext } from '../TronStakeContext';
+import { TronStakeFees } from '../TronStakeFees';
+import { TronStakePendingTransaction } from '../TronStakePendingTransaction';
+import { TronClaimAmount } from './TronClaimAmount';
+import { TronClaimSubmitButton } from './TronClaimSubmitButton';
+
+export const TronClaimForm = () => {
+    const { form, actions } = useTronStakeContext();
+    const { error } = actions;
+
+    return (
+        <FormProvider {...form.methods}>
+            <Column gap={16}>
+                <Text typographyStyle="headline-md">
+                    <Translation id="TR_EARN_TRON_CLAIM_TITLE" />
+                </Text>
+
+                <TronClaimAmount />
+
+                <TronStakeFees />
+
+                {error && (
+                    <Banner
+                        intent="warning"
+                        description={<Translation id="TR_EARN_TRON_SUBMIT_ERROR" />}
+                    />
+                )}
+
+                <TronClaimSubmitButton />
+
+                <TronStakePendingTransaction
+                    title={<Translation id="TR_EARN_TRON_PENDING_CLAIM" />}
+                />
+            </Column>
+        </FormProvider>
+    );
+};

--- a/packages/suite/src/components/earn/staking/tron/claim/TronClaimSubmitButton.tsx
+++ b/packages/suite/src/components/earn/staking/tron/claim/TronClaimSubmitButton.tsx
@@ -1,0 +1,35 @@
+import { useDevice } from '@suite/device';
+import { Translation } from '@suite/intl';
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { getTronStakingRewards } from '@suite-common/wallet-utils';
+import { Button } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { useSelector } from 'src/hooks/suite';
+
+import { useTronStakeContext } from '../TronStakeContext';
+
+export const TronClaimSubmitButton = () => {
+    const { device, isLocked } = useDevice();
+    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
+    const { account, actions } = useTronStakeContext();
+    const { isSubmitting, pendingTxid, submitAction } = actions;
+
+    const hasReward = new BigNumber(getTronStakingRewards(account)).gt(0);
+    const isDeviceLocked = !!device?.connected && !!device?.available && isLocked();
+
+    const isDisabled = !hasReward || isSubmitting || isDeviceLocked || !!pendingTxid;
+    const isLoading = isSubmitting || isDiscoveryRunning;
+
+    return (
+        <Button
+            size="large"
+            width="100%"
+            onClick={submitAction}
+            isDisabled={isDisabled}
+            isLoading={isLoading}
+        >
+            <Translation id="TR_CONTINUE" />
+        </Button>
+    );
+};

--- a/packages/suite/src/components/earn/staking/tron/complete/TronClaimSummaryCard.tsx
+++ b/packages/suite/src/components/earn/staking/tron/complete/TronClaimSummaryCard.tsx
@@ -1,0 +1,49 @@
+import { Translation } from '@suite/intl';
+import { Card, Column, Divider, Icon, Row, Text } from '@trezor/components';
+import { CoinLogo } from '@trezor/product-components';
+
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+
+import { useTronStakeContext } from '../TronStakeContext';
+import { TronStakeInfoRow } from '../TronStakeInfoRow';
+
+export const TronClaimSummaryCard = () => {
+    const { account, form } = useTronStakeContext();
+    const { amount } = form.methods.getValues();
+
+    return (
+        <Card type="contrast" paddingType="none">
+            <Column gap={0}>
+                <TronStakeInfoRow label={<Translation id="TR_EARN_YIELD_STATUS" />}>
+                    <Row alignItems="center" gap={8}>
+                        <Icon name="checkCircleFilled" intent="brand" />
+                        <Text typographyStyle="body-md" intent="brand">
+                            <Translation id="TR_EARN_YIELD_COMPLETED" />
+                        </Text>
+                    </Row>
+                </TronStakeInfoRow>
+
+                <Divider color="borderNeutral" margin={0} />
+
+                <TronStakeInfoRow label={<Translation id="TR_EARN_TRON_CLAIMED" />}>
+                    <Row alignItems="center" gap={8}>
+                        <CoinLogo symbol={account.symbol} size={24} />
+                        <Column gap={2} alignItems="flex-end">
+                            <Text typographyStyle="body-md-strong">
+                                <FormattedCryptoAmount value={amount} symbol={account.symbol} />
+                            </Text>
+                            <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                                <BaseCurrencyValue
+                                    amount={amount}
+                                    symbol={account.symbol}
+                                    showApproximationIndicator
+                                />
+                            </Text>
+                        </Column>
+                    </Row>
+                </TronStakeInfoRow>
+            </Column>
+        </Card>
+    );
+};

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
@@ -6,6 +6,7 @@ import {
     type TronStakeStepId,
     composeTronFreezeFeeLevelsThunk,
     selectTronStakeSession,
+    submitTronClaimThunk,
     submitTronFreezeThunk,
     submitTronUnstakeThunk,
     submitTronVoteThunk,
@@ -15,6 +16,7 @@ import {
 import { type Account } from '@suite-common/wallet-types';
 import {
     asAmountSubunit,
+    getTronStakingRewards,
     getTronWithdrawableBalance,
     subunitsToUnits,
 } from '@suite-common/wallet-utils';
@@ -171,6 +173,20 @@ export const useTronStakeActions = ({
                 );
                 break;
             case 'claim':
+                form.methods.setValue('amount', getTronStakingRewards(account));
+                dispatch(
+                    submitTronClaimThunk({
+                        account,
+                        device,
+                        requestPushApproval: async () =>
+                            Boolean(
+                                await dispatch(openDeferredModal({ type: 'review-transaction' })),
+                            ),
+                        onSigningStart: () => dispatch(preserveModal()),
+                        onSettled: () => dispatch(closeModal()),
+                    }),
+                );
+                break;
             case 'complete':
                 break;
             default:

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
@@ -170,6 +170,7 @@ export const useTronStakeActions = ({
                     }),
                 );
                 break;
+            case 'claim':
             case 'complete':
                 break;
             default:

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFees.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFees.ts
@@ -66,6 +66,7 @@ export const useTronStakeFees = (): TronStakeFees => {
                     dispatch(composeTronWithdrawFeeLevelsThunk({ account }))
                         .unwrap()
                         .catch(() => undefined);
+            case 'claim':
             case 'complete':
                 return undefined;
             default:

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFees.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFees.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import {
+    composeTronClaimFeeLevelsThunk,
     composeTronFreezeFeeLevelsThunk,
     composeTronUnstakeFeeLevelsThunk,
     composeTronVoteFeeLevelsThunk,
@@ -67,6 +68,10 @@ export const useTronStakeFees = (): TronStakeFees => {
                         .unwrap()
                         .catch(() => undefined);
             case 'claim':
+                return () =>
+                    dispatch(composeTronClaimFeeLevelsThunk({ account }))
+                        .unwrap()
+                        .catch(() => undefined);
             case 'complete':
                 return undefined;
             default:

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
@@ -80,6 +80,7 @@ export const Navigation = ({ children }: NavigationProps) => {
                                   'earn-tron-vote',
                                   'earn-tron-unstake',
                                   'earn-tron-withdraw',
+                                  'earn-tron-claim',
                               ],
                           } as NavigationItemProps,
                       ]

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -266,6 +266,8 @@ const getOutputTitle = (
             return <Translation id="TR_SUMMARY" />;
         case 'tron-withdraw':
             return <Translation id="TR_SUMMARY" />;
+        case 'tron-claim':
+            return <Translation id="TR_STAKE_CLAIM" />;
         default:
             return exhaustive(type);
     }
@@ -588,6 +590,14 @@ const getOutputLines = ({
                     type: 'safe-address',
                     label: <Translation id="TR_EARN_TRON_CLAIM_ADDRESS" />,
                     value,
+                },
+            ];
+        case 'tron-claim':
+            return [
+                {
+                    id: 'tron-claim',
+                    type: 'data',
+                    value: translationString('TR_EARN_TRON_CLAIM_CONFIRM'),
                 },
             ];
         default:

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -21,6 +21,7 @@ const SIGN_TX_ROUTES = [
     'earn-tron-vote',
     'earn-tron-unstake',
     'earn-tron-withdraw',
+    'earn-tron-claim',
 ] as const;
 
 const SIGN_TX_CONNECT_METHODS = [

--- a/packages/suite/src/utils/suite/transactionReview.ts
+++ b/packages/suite/src/utils/suite/transactionReview.ts
@@ -114,6 +114,10 @@ export const getTransactionReviewModalActionTranslation = ({
         return { id: 'TR_EARN_TRON_WITHDRAW_TITLE' };
     }
 
+    if (routeName === 'earn-tron-claim') {
+        return { id: 'TR_EARN_TRON_CLAIM_TITLE' };
+    }
+
     if (
         precomposedForm.tronStaking?.kind === 'freeze' ||
         precomposedForm.tronStaking?.kind === 'unstake'

--- a/packages/suite/src/views/earn/tron/EarnTronClaim.tsx
+++ b/packages/suite/src/views/earn/tron/EarnTronClaim.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+
+import { goto } from '@suite/router';
+import { selectIsDebugModeActive } from '@suite/settings';
+
+import { TronStakePageHeader } from 'src/components/earn';
+import { useEarnRouteAccount } from 'src/components/earn/utils/useEarnRouteAccount';
+import { AccountNotExists } from 'src/components/wallet/WalletLayout/AccountException/AccountNotExists';
+import { useDispatch, useLayout, useSelector } from 'src/hooks/suite';
+
+export const EarnTronClaim = () => {
+    const dispatch = useDispatch();
+    const isDebugModeActive = useSelector(selectIsDebugModeActive);
+    const { account } = useEarnRouteAccount();
+
+    useLayout('Earn', <TronStakePageHeader account={account} />);
+
+    useEffect(() => {
+        if (!isDebugModeActive) {
+            dispatch(goto({ routeName: 'suite-earn' }));
+        }
+    }, [isDebugModeActive, dispatch]);
+
+    if (!isDebugModeActive) {
+        return null;
+    }
+
+    if (!account) {
+        return <AccountNotExists />;
+    }
+
+    return null;
+};

--- a/packages/suite/src/views/earn/tron/EarnTronClaim.tsx
+++ b/packages/suite/src/views/earn/tron/EarnTronClaim.tsx
@@ -1,33 +1,16 @@
-import { useEffect } from 'react';
-
-import { goto } from '@suite/router';
-import { selectIsDebugModeActive } from '@suite/settings';
-
-import { TronStakePageHeader } from 'src/components/earn';
+import { TronClaim, TronStakePageHeader } from 'src/components/earn';
 import { useEarnRouteAccount } from 'src/components/earn/utils/useEarnRouteAccount';
 import { AccountNotExists } from 'src/components/wallet/WalletLayout/AccountException/AccountNotExists';
-import { useDispatch, useLayout, useSelector } from 'src/hooks/suite';
+import { useLayout } from 'src/hooks/suite';
 
 export const EarnTronClaim = () => {
-    const dispatch = useDispatch();
-    const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const { account } = useEarnRouteAccount();
 
     useLayout('Earn', <TronStakePageHeader account={account} />);
-
-    useEffect(() => {
-        if (!isDebugModeActive) {
-            dispatch(goto({ routeName: 'suite-earn' }));
-        }
-    }, [isDebugModeActive, dispatch]);
-
-    if (!isDebugModeActive) {
-        return null;
-    }
 
     if (!account) {
         return <AccountNotExists />;
     }
 
-    return null;
+    return <TronClaim account={account} />;
 };

--- a/packages/suite/src/views/earn/tron/index.ts
+++ b/packages/suite/src/views/earn/tron/index.ts
@@ -2,4 +2,5 @@ export { EarnTronStake } from './EarnTronStake';
 export { EarnTronVote } from './EarnTronVote';
 export { EarnTronUnstake } from './EarnTronUnstake';
 export { EarnTronWithdraw } from './EarnTronWithdraw';
+export { EarnTronClaim } from './EarnTronClaim';
 export { EarnTronRedirect } from './EarnTronRedirect';

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx
@@ -1,21 +1,36 @@
 import { Translation } from '@suite/intl';
+import { goto } from '@suite/router';
 import { type Account } from '@suite-common/wallet-types';
 import { getTronStakingRewards } from '@suite-common/wallet-utils';
 import { Box, Button, Card, Column, Row, Text } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
 import { BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
+import { useDispatch } from 'src/hooks/suite';
 
 interface TronVotingRewardsCardProps {
     account: Account;
 }
 
 export const TronVotingRewardsCard = ({ account }: TronVotingRewardsCardProps) => {
+    const dispatch = useDispatch();
     const rewards = getTronStakingRewards(account);
 
     if (new BigNumber(rewards).lte(0)) {
         return null;
     }
+
+    const goToClaim = () =>
+        dispatch(
+            goto({
+                routeName: 'earn-tron-claim',
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
 
     return (
         <Card paddingType="none">
@@ -37,7 +52,7 @@ export const TronVotingRewardsCard = ({ account }: TronVotingRewardsCardProps) =
                                 />
                             </Text>
                         </Column>
-                        <Button intent="brand" priority="primary" isDisabled>
+                        <Button intent="neutral" priority="secondary" onClick={goToClaim}>
                             <Translation id="TR_STAKE_CLAIM" />
                         </Button>
                     </Row>

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -81,6 +81,8 @@ export { composeTronUnstakeFeeLevelsThunk } from './stake/tron/actions/unstake/c
 export { submitTronUnstakeThunk } from './stake/tron/actions/unstake/submitUnstake';
 export { composeTronWithdrawFeeLevelsThunk } from './stake/tron/actions/withdraw/composeWithdraw';
 export { submitTronWithdrawThunk } from './stake/tron/actions/withdraw/submitWithdraw';
+export { composeTronClaimFeeLevelsThunk } from './stake/tron/actions/claim/composeClaim';
+export { submitTronClaimThunk } from './stake/tron/actions/claim/submitClaim';
 export * from './stake/tron/tronStakeTypes';
 export * from './token/stellarTokenThunks';
 export * from './tokens/tokenSelectors';

--- a/suite-common/wallet-core/src/stake/tron/actions/claim/claimContract.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/claim/claimContract.ts
@@ -1,0 +1,35 @@
+import { type Account, type FormState } from '@suite-common/wallet-types';
+import { tronUtils } from '@trezor/blockchain-link-utils';
+
+export const buildWithdrawBalanceContract = ({ ownerHex }: { ownerHex: string }) =>
+    ({
+        type: 'WithdrawBalanceContract' as const,
+        parameter: {
+            value: {
+                owner_address: ownerHex,
+            },
+        },
+    }) as const;
+
+export type TronClaimContract = ReturnType<typeof buildWithdrawBalanceContract>;
+
+export const buildClaimContract = (account: Account) => {
+    const ownerHex = tronUtils.tronAddressToHex(account.descriptor);
+
+    if (!ownerHex) {
+        return null;
+    }
+
+    return buildWithdrawBalanceContract({ ownerHex });
+};
+
+export const buildClaimReviewForm = (): FormState => ({
+    outputs: [],
+    feePerUnit: '0',
+    feeLimit: '',
+    options: ['broadcast'],
+    tronStaking: { kind: 'claim' },
+    isCoinControlEnabled: false,
+    hasCoinControlBeenOpened: false,
+    selectedUtxos: [],
+});

--- a/suite-common/wallet-core/src/stake/tron/actions/claim/composeClaim.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/claim/composeClaim.ts
@@ -1,0 +1,72 @@
+import { createThunk } from '@suite-common/redux-utils';
+import {
+    type Account,
+    type PrecomposedLevels,
+    type PrecomposedTransactionFinal,
+} from '@suite-common/wallet-types';
+import { computeBandwidthFeeLevel } from '@suite-common/wallet-utils';
+import TrezorConnect from '@trezor/connect';
+
+import { buildClaimContract } from './claimContract';
+import {
+    TRON_DUMMY_BLOCK_HASH,
+    TRON_DUMMY_BLOCK_HEIGHT,
+    TRON_STAKE_MODULE,
+} from '../../shared/constants';
+import { type TronStakeError } from '../../tronStakeTypes';
+
+export interface ClaimThunkArguments {
+    account: Account;
+}
+
+export const composeTronClaimFeeLevelsThunk = createThunk<
+    PrecomposedLevels,
+    ClaimThunkArguments,
+    { rejectValue: TronStakeError }
+>(
+    `${TRON_STAKE_MODULE}/composeTronClaimFeeLevelsThunk`,
+    async ({ account }, { rejectWithValue }) => {
+        if (account.networkType !== 'tron') {
+            return rejectWithValue({ kind: 'compose-failed', message: 'Invalid network type.' });
+        }
+
+        const contract = buildClaimContract(account);
+
+        if (!contract) {
+            return rejectWithValue({ kind: 'compose-failed', message: 'Invalid owner address.' });
+        }
+
+        const estimate = await TrezorConnect.tronComposeTransaction({
+            contract,
+            blockHash: TRON_DUMMY_BLOCK_HASH,
+            blockHeight: TRON_DUMMY_BLOCK_HEIGHT,
+        });
+
+        if (!estimate.success) {
+            return rejectWithValue({ kind: 'compose-failed', message: estimate.error.message });
+        }
+
+        const bytes = estimate.payload.bandwidth;
+
+        const feeLevel = computeBandwidthFeeLevel({
+            availableStakedBandwidth: account.misc.tronResources?.availableStakedBandwidth ?? 0,
+            availableFreeBandwidth: account.misc.tronResources?.availableFreeBandwidth ?? 0,
+            bytes,
+        });
+
+        const feeInSun = feeLevel.feePerTx || '0';
+
+        const tx: PrecomposedTransactionFinal = {
+            type: 'final',
+            totalSpent: feeInSun,
+            fee: feeInSun,
+            feePerByte: feeLevel.feePerUnit ?? '0',
+            bytes,
+            inputs: [],
+            outputs: [{ address: account.descriptor, amount: '0' }],
+            outputsPermutation: [0],
+        };
+
+        return { normal: tx };
+    },
+);

--- a/suite-common/wallet-core/src/stake/tron/actions/claim/submitClaim.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/claim/submitClaim.ts
@@ -1,0 +1,169 @@
+import { createThunk } from '@suite-common/redux-utils';
+import { type TrezorDevice } from '@suite-common/suite-types';
+import {
+    asAmountUnit,
+    getAccountIdentity,
+    getTronStakingRewards,
+    unitsToSubunits,
+} from '@suite-common/wallet-utils';
+import TrezorConnect from '@trezor/connect';
+import { BigNumber } from '@trezor/utils';
+
+import { buildClaimContract, buildClaimReviewForm } from './claimContract';
+import { type ClaimThunkArguments, composeTronClaimFeeLevelsThunk } from './composeClaim';
+import { addFakePendingTronTxThunk } from '../../../../transactions/transactionsThunks';
+import { TRON_STAKE_MODULE } from '../../shared/constants';
+import { signTronContract } from '../../shared/signTronContract';
+import { tronStakeActions } from '../../tronStakeReducer';
+import { type TronFlow } from '../../tronStakeTypes';
+
+interface SubmitClaimThunkArguments extends ClaimThunkArguments {
+    device: TrezorDevice;
+    requestPushApproval: () => Promise<boolean>;
+    onSigningStart?: () => void;
+    onSettled?: () => void;
+}
+
+export const submitTronClaimThunk = createThunk<void, SubmitClaimThunkArguments>(
+    `${TRON_STAKE_MODULE}/submitTronClaimThunk`,
+    async ({ account, device, requestPushApproval, onSigningStart, onSettled }, { dispatch }) => {
+        const { key: accountKey } = account;
+        const flow: TronFlow = 'claim';
+
+        if (account.networkType !== 'tron') {
+            dispatch(
+                tronStakeActions.submitFinished({
+                    accountKey,
+                    flow,
+                    error: { kind: 'compose-failed', message: 'Invalid network type.' },
+                }),
+            );
+
+            return;
+        }
+
+        const contract = buildClaimContract(account);
+
+        if (!contract) {
+            dispatch(
+                tronStakeActions.submitFinished({
+                    accountKey,
+                    flow,
+                    error: { kind: 'compose-failed', message: 'Invalid owner address.' },
+                }),
+            );
+
+            return;
+        }
+
+        dispatch(tronStakeActions.submitStarted({ accountKey, flow }));
+
+        try {
+            const composed = await dispatch(composeTronClaimFeeLevelsThunk({ account }))
+                .unwrap()
+                .catch(() => undefined);
+            const precomposedTx = composed?.normal?.type === 'final' ? composed.normal : undefined;
+
+            if (!precomposedTx) {
+                dispatch(
+                    tronStakeActions.submitFinished({
+                        accountKey,
+                        flow,
+                        error: { kind: 'compose-failed' },
+                    }),
+                );
+
+                return;
+            }
+
+            dispatch(
+                tronStakeActions.storePrecomposedTransaction({
+                    precomposedTx,
+                    precomposedForm: buildClaimReviewForm(),
+                    accountKey,
+                }),
+            );
+
+            onSigningStart?.();
+
+            const signResult = await signTronContract({ account, device, contract });
+
+            if ('error' in signResult) {
+                dispatch(
+                    tronStakeActions.submitFinished({ accountKey, flow, error: signResult.error }),
+                );
+
+                return;
+            }
+
+            dispatch(
+                tronStakeActions.storeSignedTransaction({
+                    serializedTx: { tx: signResult.serializedTx, symbol: account.symbol },
+                }),
+            );
+
+            const isPushApproved = await requestPushApproval();
+
+            if (!isPushApproved) {
+                dispatch(
+                    tronStakeActions.submitFinished({
+                        accountKey,
+                        flow,
+                        error: { kind: 'cancelled' },
+                    }),
+                );
+
+                return;
+            }
+
+            const pushResult = await TrezorConnect.pushTransaction({
+                tx: signResult.serializedTx,
+                coin: account.symbol,
+                identity: getAccountIdentity(account),
+            });
+
+            if (!pushResult.success) {
+                dispatch(
+                    tronStakeActions.submitFinished({
+                        accountKey,
+                        flow,
+                        error: { kind: 'broadcast-failed', message: pushResult.error.message },
+                    }),
+                );
+
+                return;
+            }
+
+            const { txid } = pushResult.payload;
+
+            dispatch(
+                addFakePendingTronTxThunk({
+                    account,
+                    txid,
+                    amount: '0',
+                    fee: precomposedTx.fee ?? '0',
+                    type: 'self',
+                    target: {
+                        addresses: [account.descriptor],
+                        amount: unitsToSubunits({
+                            value: asAmountUnit(new BigNumber(getTronStakingRewards(account))),
+                            symbol: account.symbol,
+                        }).toString(),
+                    },
+                    tronSpecific: {
+                        contractType: 'WithdrawBalanceContract',
+                        operation: 'claim',
+                        bandwidthUsage: new BigNumber(precomposedTx.fee).isZero()
+                            ? String(precomposedTx.bytes)
+                            : undefined,
+                    },
+                }),
+            );
+
+            dispatch(tronStakeActions.submitFinished({ accountKey, flow, txid }));
+        } finally {
+            onSettled?.();
+            dispatch(tronStakeActions.discardTransaction());
+        }
+    },
+);

--- a/suite-common/wallet-core/src/stake/tron/shared/signTronContract.ts
+++ b/suite-common/wallet-core/src/stake/tron/shared/signTronContract.ts
@@ -3,6 +3,7 @@ import { type Account } from '@suite-common/wallet-types';
 import { getAccountIdentity } from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
 
+import { type TronClaimContract } from '../actions/claim/claimContract';
 import { type TronFreezeContract } from '../actions/freeze/freezeContract';
 import { type TronUnstakeContract } from '../actions/unstake/unstakeContract';
 import { type TronVoteContract } from '../actions/vote/voteContract';
@@ -13,7 +14,8 @@ type TronStakeContract =
     | TronFreezeContract
     | TronUnstakeContract
     | TronVoteContract
-    | TronWithdrawContract;
+    | TronWithdrawContract
+    | TronClaimContract;
 
 type SignTronContractResult = { serializedTx: string } | { error: TronStakeError };
 

--- a/suite-common/wallet-core/src/stake/tron/tronStakeTypes.ts
+++ b/suite-common/wallet-core/src/stake/tron/tronStakeTypes.ts
@@ -1,4 +1,4 @@
-export const TRON_FLOWS = ['stake', 'vote', 'unstake', 'withdraw'] as const;
+export const TRON_FLOWS = ['stake', 'vote', 'unstake', 'withdraw', 'claim'] as const;
 export type TronFlow = (typeof TRON_FLOWS)[number];
 
 export const TRON_FLOW_STEPS = {
@@ -6,6 +6,7 @@ export const TRON_FLOW_STEPS = {
     vote: ['vote', 'complete'],
     unstake: ['unstake', 'complete'],
     withdraw: ['withdraw', 'complete'],
+    claim: ['claim', 'complete'],
 } as const satisfies Record<TronFlow, readonly string[]>;
 
 export type TronStakeStepId = (typeof TRON_FLOW_STEPS)[TronFlow][number];

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -19,7 +19,8 @@ export type UtxoSorting = 'newestFirst' | 'oldestFirst' | 'smallestFirst' | 'lar
 export type TronStakingFormState =
     | { kind: 'freeze' | 'unstake'; resource: 'bandwidth' | 'energy' }
     | { kind: 'vote'; votes: string }
-    | { kind: 'withdraw' };
+    | { kind: 'withdraw' }
+    | { kind: 'claim' };
 
 export type FormStateTradingCryptoCurrency = {
     cryptoId: CryptoId | undefined;

--- a/suite-common/wallet-types/src/transactionReviewOutput.ts
+++ b/suite-common/wallet-types/src/transactionReviewOutput.ts
@@ -26,6 +26,7 @@ export type ReviewOutput =
               | 'swap_intent'
               | 'tron-vote'
               | 'tron-withdraw'
+              | 'tron-claim'
               | 'fee-limit';
           label?: string;
           value: string;

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -411,6 +411,12 @@ const constructNewFlow = ({
         return outputs;
     }
 
+    if (tronStaking?.kind === 'claim') {
+        outputs.push({ type: 'tron-claim', value: '' });
+
+        return outputs;
+    }
+
     if (networkType === 'stellar') {
         if (!isUpdatedStellarSendFlow) {
             outputs.push({

--- a/suite/e2e/tests/general/check-links.test.ts
+++ b/suite/e2e/tests/general/check-links.test.ts
@@ -176,6 +176,7 @@ const SECTIONS = {
         '/earn/tron/vote',
         '/earn/tron/unstake',
         '/earn/tron/withdraw',
+        '/earn/tron/claim',
     ],
 } as const satisfies Record<string, string[]>;
 

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10672,6 +10672,14 @@ export const messages = defineMessages({
         id: 'TR_EARN_TRON_WITHDRAWN',
         defaultMessage: 'Withdrawn',
     },
+    TR_EARN_TRON_PENDING_CLAIM: {
+        id: 'TR_EARN_TRON_PENDING_CLAIM',
+        defaultMessage: 'Confirming claim…',
+    },
+    TR_EARN_TRON_CLAIM_TITLE: {
+        id: 'TR_EARN_TRON_CLAIM_TITLE',
+        defaultMessage: 'Claim rewards',
+    },
     TR_EARN_TRON_UNSTAKE_TITLE: {
         id: 'TR_EARN_TRON_UNSTAKE_TITLE',
         defaultMessage: 'Unstake',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10684,6 +10684,18 @@ export const messages = defineMessages({
         id: 'TR_EARN_TRON_CLAIM_CONFIRM',
         defaultMessage: 'Claim voting rewards?',
     },
+    TR_EARN_TRON_CLAIM_COMPLETE: {
+        id: 'TR_EARN_TRON_CLAIM_COMPLETE',
+        defaultMessage: 'Rewards claimed',
+    },
+    TR_EARN_TRON_CLAIM_DESCRIPTION: {
+        id: 'TR_EARN_TRON_CLAIM_DESCRIPTION',
+        defaultMessage: 'The claimed amount was added to your balance.',
+    },
+    TR_EARN_TRON_CLAIMED: {
+        id: 'TR_EARN_TRON_CLAIMED',
+        defaultMessage: 'Claimed',
+    },
     TR_EARN_TRON_UNSTAKE_TITLE: {
         id: 'TR_EARN_TRON_UNSTAKE_TITLE',
         defaultMessage: 'Unstake',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10680,6 +10680,10 @@ export const messages = defineMessages({
         id: 'TR_EARN_TRON_CLAIM_TITLE',
         defaultMessage: 'Claim rewards',
     },
+    TR_EARN_TRON_CLAIM_CONFIRM: {
+        id: 'TR_EARN_TRON_CLAIM_CONFIRM',
+        defaultMessage: 'Claim voting rewards?',
+    },
     TR_EARN_TRON_UNSTAKE_TITLE: {
         id: 'TR_EARN_TRON_UNSTAKE_TITLE',
         defaultMessage: 'Unstake',

--- a/suite/router-config/src/routeConfig.ts
+++ b/suite/router-config/src/routeConfig.ts
@@ -83,6 +83,12 @@ export const routes = [
         params: earnParams,
     },
     {
+        name: 'earn-tron-claim',
+        pattern: '/earn/tron/claim',
+        app: 'earn-staking',
+        params: earnParams,
+    },
+    {
         name: 'suite-version',
         pattern: '/version',
         app: 'version',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds the **Tron claim rewards flow**

Key changes:
  - **connect** — encode `WithdrawBalanceContract`
  - **suite-common** — claim compose / sign / submit thunks + fake pending tx
  - **suite** — claim route scaffold, form UI, submit wiring, review modal,  success screen

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28671

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This PR primarily adds Tron claim staking functionality (new views, components, hooks, contract actions) and modifies shared transaction review infrastructure (TransactionReviewOutput, reviewTransactionUtils, transactionReviewOutput types, buttonRequestMiddleware, sendForm types). The Tron-specific code has no E2E test coverage yet. The highest risk is in the shared transaction review pipeline changes which could affect any send/staking confirmation flow. The check-links test is directly modified and must run. The recommended strategy focuses on the check-links test (directly changed + validates new routes) and transaction review flows across ETH/ADA/SOL staking and wallet send tests where the modified review components are exercised.

<details><summary><b>Changed files (33)</b></summary>

- `packages/connect-common/src/types/api/tron/common.ts`
- `packages/connect/src/api/tron/__tests__/tronEncode.test.ts`
- `packages/connect/src/api/tron/api/tronSignTransaction.ts`
- `packages/connect/src/api/tron/tronEncode.ts`
- `packages/suite-desktop-ui/src/support/desktopComponents.ts`
- `packages/suite-web/src/support/webComponents.ts`
- `packages/suite/src/components/earn/index.ts`
- `packages/suite/src/components/earn/staking/tron/TronClaim.tsx`
- `packages/suite/src/components/earn/staking/tron/claim/TronClaimAmount.tsx`
- `packages/suite/src/components/earn/staking/tron/claim/TronClaimForm.tsx`
- `packages/suite/src/components/earn/staking/tron/claim/TronClaimSubmitButton.tsx`
- `packages/suite/src/components/earn/staking/tron/complete/TronClaimSummaryCard.tsx`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFees.ts`
- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx`
- `packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts`
- `packages/suite/src/utils/suite/transactionReview.ts`
- `packages/suite/src/views/earn/tron/EarnTronClaim.tsx`
- `packages/suite/src/views/earn/tron/index.ts`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx`
- `suite-common/wallet-core/src/index.ts`
- `suite-common/wallet-core/src/stake/tron/actions/claim/claimContract.ts`
- `suite-common/wallet-core/src/stake/tron/actions/claim/composeClaim.ts`
- `suite-common/wallet-core/src/stake/tron/actions/claim/submitClaim.ts`
- `suite-common/wallet-core/src/stake/tron/shared/signTronContract.ts`
- `suite-common/wallet-core/src/stake/tron/tronStakeTypes.ts`
- `suite-common/wallet-types/src/sendForm.ts`
- `suite-common/wallet-types/src/transactionReviewOutput.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.ts`
- `suite/e2e/tests/general/check-links.test.ts`
- `suite/intl/src/messages.ts`
- `suite/router-config/src/routeConfig.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test file is itself directly changed in this PR. It also validates all application routes against the router config, which was changed (routeConfig.ts). New Tron earn routes (e.g., /earn/tron/claim) added in routeConfig.ts must be covered by the SECTIONS mapping in this test or it will fail.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — The TransactionReviewOutput.tsx and transactionReview.ts changes affect the transaction review modal used during staking claim confirmation flows. This ADA claim test exercises device confirmation of withdrawal details (amount, fee, address), which goes through the modified transaction review output rendering pipeline.
- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking involves device confirmation screens for stake delegation that flow through the modified TransactionReviewOutput and buttonRequestMiddleware. Changes to transaction review rendering or button request handling could affect the staking confirmation flow.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — ADA unstaking exercises the device confirmation flow for stake key deregistration, which passes through the modified TransactionReviewOutput and buttonRequestMiddleware. Similar risk profile to the ADA stake test.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking uses the transaction review modal to show staking amount and fee confirmation on the device. Changes to TransactionReviewOutput.tsx and reviewTransactionUtils.ts could affect how staking transaction details are rendered during the confirmation step.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstaking and claiming flows exercise the transaction review modal for device confirmation. Changes to buttonRequestMiddleware and TransactionReviewOutput could affect how the unstake/claim confirmation prompts are handled.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test verifies ETH send form confirmation details on the device prompt, which flows through TransactionReviewOutput.tsx and transactionReview.ts. Changes to transaction review rendering and the sendForm types (sendForm.ts) directly affect how send confirmation outputs are displayed.
- `suite/e2e/tests/wallet/send-sol.test.ts` — SOL send flow exercises the transaction review modal for device confirmation of address, amount, and fee. Changes to TransactionReviewOutput.tsx and reviewTransactionUtils.ts could affect how SOL send confirmation outputs render.
- `suite/e2e/tests/wallet/send-base.test.ts` — Base network send test verifies transaction review details on device prompt including gas parameters. Changes to TransactionReviewOutput.tsx and the transaction review utilities affect this confirmation flow.
- `suite/e2e/tests/wallet/send-doge.test.ts` — DOGE send test exercises transaction review outputs (amount, total, fee, address) on the device prompt modal. Changes to TransactionReviewOutput.tsx and reviewTransactionUtils.ts could affect the rendering of these confirmation details.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — The Sidebar Navigation.tsx was changed, which renders the staking navigation entry points. This test validates StakingNavigate analytics events when clicking staking from the account menu, which could be affected by navigation component changes.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstake and claim flows use the transaction review modal for device confirmation. While the changes primarily target Tron staking, the modified transaction review types (transactionReviewOutput.ts) and utilities (reviewTransactionUtils.ts) are shared across all staking flows.

</details>

⚠️ **Changes with no test coverage (23)**
- `packages/connect-common/src/types/api/tron/common.ts`
- `packages/connect/src/api/tron/__tests__/tronEncode.test.ts`
- `packages/connect/src/api/tron/api/tronSignTransaction.ts`
- `packages/connect/src/api/tron/tronEncode.ts`
- `packages/suite-desktop-ui/src/support/desktopComponents.ts`
- `packages/suite/src/components/earn/index.ts`
- `packages/suite/src/components/earn/staking/tron/TronClaim.tsx`
- `packages/suite/src/components/earn/staking/tron/claim/TronClaimAmount.tsx`
- `packages/suite/src/components/earn/staking/tron/claim/TronClaimForm.tsx`
- `packages/suite/src/components/earn/staking/tron/claim/TronClaimSubmitButton.tsx`
- `packages/suite/src/components/earn/staking/tron/complete/TronClaimSummaryCard.tsx`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFees.ts`
- `packages/suite/src/views/earn/tron/EarnTronClaim.tsx`
- `packages/suite/src/views/earn/tron/index.ts`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx`
- `suite-common/wallet-core/src/index.ts`
- `suite-common/wallet-core/src/stake/tron/actions/claim/claimContract.ts`
- `suite-common/wallet-core/src/stake/tron/actions/claim/composeClaim.ts`
- `suite-common/wallet-core/src/stake/tron/actions/claim/submitClaim.ts`
- `suite-common/wallet-core/src/stake/tron/shared/signTronContract.ts`
- `suite-common/wallet-core/src/stake/tron/tronStakeTypes.ts`
- `suite/intl/src/messages.ts`

_Updated: 2026-07-03T10:32:39.977Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-claim-flow/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-claim-flow/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-claim-flow&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-claim-flow&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-claim-flow&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-03T10:37:37.806Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-03T10:35:46.432Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->