### PR TITLE
fix(suite-native): prevent wrong crypto icon on recycled list cells

### DIFF
--- a/packages/react-utils/src/hooks/__tests__/useKeyedAsyncValue.test.ts
+++ b/packages/react-utils/src/hooks/__tests__/useKeyedAsyncValue.test.ts
@@ -1,0 +1,78 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { createDeferred } from '@trezor/utils';
+
+import { useKeyedAsyncValue } from '../useKeyedAsyncValue';
+
+describe('useKeyedAsyncValue', () => {
+    it('returns undefined until the value resolves, then the value', async () => {
+        const { result } = renderHook(() => useKeyedAsyncValue('a', () => Promise.resolve(1)));
+
+        expect(result.current).toBeUndefined();
+
+        await waitFor(() => {
+            expect(result.current).toBe(1);
+        });
+    });
+
+    it('returns undefined immediately after the key changes', async () => {
+        const { result, rerender } = renderHook(
+            ({ key, value }) => useKeyedAsyncValue(key, () => Promise.resolve(value)),
+            { initialProps: { key: 'a', value: 1 } },
+        );
+
+        await waitFor(() => {
+            expect(result.current).toBe(1);
+        });
+
+        rerender({ key: 'b', value: 2 });
+
+        expect(result.current).toBeUndefined();
+
+        await waitFor(() => {
+            expect(result.current).toBe(2);
+        });
+    });
+
+    it('ignores a stale resolution that arrives after the key changed', async () => {
+        const deferredA = createDeferred<number>();
+        const { result, rerender } = renderHook(
+            ({ key, promise }) => useKeyedAsyncValue(key, () => promise),
+            { initialProps: { key: 'a', promise: deferredA.promise } },
+        );
+
+        rerender({ key: 'b', promise: Promise.resolve(2) });
+
+        await waitFor(() => {
+            expect(result.current).toBe(2);
+        });
+
+        deferredA.resolve(1);
+        await act(async () => {});
+
+        expect(result.current).toBe(2);
+    });
+
+    it('keeps returning undefined when getValue rejects', async () => {
+        const { result } = renderHook(() =>
+            useKeyedAsyncValue('a', () => Promise.reject(new Error('failed'))),
+        );
+
+        await act(async () => {});
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('uses the latest getValue closure when only the key changes', async () => {
+        const { result, rerender } = renderHook(
+            ({ key, value }) => useKeyedAsyncValue(key, () => Promise.resolve(value)),
+            { initialProps: { key: 'a', value: 1 } },
+        );
+
+        rerender({ key: 'b', value: 2 });
+
+        await waitFor(() => {
+            expect(result.current).toBe(2);
+        });
+    });
+});

--- a/packages/react-utils/src/hooks/useKeyedAsyncValue.ts
+++ b/packages/react-utils/src/hooks/useKeyedAsyncValue.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+import { useFreshRef } from './useFreshRef';
+
+/**
+ * Resolves `getValue` asynchronously and returns the result only while `key` matches the key
+ * it was resolved for, otherwise `undefined`. A reused component instance (e.g. recycled list
+ * cell) therefore never renders a stale resolution, even when promises settle out of order.
+ * A rejected `getValue` is swallowed and the hook keeps returning `undefined` for that key.
+ */
+export function useKeyedAsyncValue<T>(key: string, getValue: () => Promise<T>): T | undefined {
+    const [resolved, setResolved] = useState<{ key: string; value: T }>();
+    const getValueRef = useFreshRef(getValue);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        getValueRef.current().then(
+            value => {
+                if (!cancelled) {
+                    setResolved({ key, value });
+                }
+            },
+            () => {}, // reject → stay undefined, callers render their fallback
+        );
+
+        return () => {
+            cancelled = true;
+        };
+    }, [key, getValueRef]);
+
+    return resolved?.key === key ? resolved.value : undefined;
+}

--- a/packages/react-utils/src/index.ts
+++ b/packages/react-utils/src/index.ts
@@ -1,6 +1,7 @@
 export { useDebounce } from './hooks/useDebounce';
 export { useDebouncedValue } from './hooks/useDebouncedValue';
 export { useDidUpdate } from './hooks/useDidUpdate';
+export { useKeyedAsyncValue } from './hooks/useKeyedAsyncValue';
 export { useKeyPress } from './hooks/useKeyPress';
 export { useOnce } from './hooks/useOnce';
 export { useOnClickOutside } from './hooks/useOnClickOutside';

--- a/suite-native/icons/package.json
+++ b/suite-native/icons/package.json
@@ -23,6 +23,7 @@
         "@suite-native/theme": "workspace:*",
         "@trezor/asset-utils": "workspace:*",
         "@trezor/device-utils": "workspace:*",
+        "@trezor/react-utils": "workspace:*",
         "@trezor/styles-native": "workspace:*",
         "@trezor/theme": "workspace:*",
         "@trezor/utils": "workspace:*",

--- a/suite-native/icons/src/CryptoIcon.tsx
+++ b/suite-native/icons/src/CryptoIcon.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { Image } from 'expo-image';
 
@@ -12,6 +12,7 @@ import {
 import { getAssetLogoContractAddresses } from '@suite-common/wallet-utils';
 import { useTranslate } from '@suite-native/intl';
 import { getAssetLogoUrl } from '@trezor/asset-utils';
+import { useKeyedAsyncValue } from '@trezor/react-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { CryptoIconPlaceholder } from './CryptoIconPlaceholder';
@@ -44,8 +45,6 @@ export type CryptoIconSize = keyof typeof cryptoIconSizes;
 export const CryptoIcon = ({ symbol, contractAddress, size = 'small' }: CryptoIconProps) => {
     const { applyStyle } = useNativeStyles();
     const { translate } = useTranslate();
-    const [logoIndex, setLogoIndex] = useState(0);
-    const [showPlaceholder, setShowPlaceholder] = useState(false);
 
     const sizeNumber = typeof size === 'number' ? size : cryptoIconSizes[size];
     const iconContainerStyle = useMemo(
@@ -53,44 +52,43 @@ export const CryptoIcon = ({ symbol, contractAddress, size = 'small' }: CryptoIc
         [applyStyle, sizeNumber],
     );
 
-    const key = `${symbol}${contractAddress ?? ''}`;
+    // FlashList recycling reuses this instance for different assets, so the async and retry
+    // state is keyed by the asset and discarded on mismatch to never render a stale icon
+    const key = contractAddress ? `${symbol}:${contractAddress}` : symbol;
+    // size is part of the source identity because it is encoded in the CDN filename
+    const asyncKey = `${key}#${sizeNumber}`;
 
-    const [sourceUrls, setSourceUrls] = useState([
-        cryptoIcons[symbol.toLowerCase() as CryptoIconName],
-    ]);
+    const [loadState, setLoadState] = useState<{
+        sourceKey: string;
+        logoIndex: number;
+        failed: boolean;
+    } | null>(null);
 
-    useEffect(() => {
-        const getUrls = async () => {
-            if (isNetworkSymbol(symbol)) {
-                const coingeckoId = getCoingeckoId(symbol);
-                if (coingeckoId && contractAddress) {
-                    const logoAddresses = await getAssetLogoContractAddresses(
-                        symbol,
-                        contractAddress,
+    const resolvedUrls = useKeyedAsyncValue(asyncKey, async (): Promise<(string | number)[]> => {
+        if (isNetworkSymbol(symbol)) {
+            const coingeckoId = getCoingeckoId(symbol);
+            if (coingeckoId && contractAddress) {
+                const logoAddresses = await getAssetLogoContractAddresses(symbol, contractAddress);
+                if (logoAddresses?.length) {
+                    return logoAddresses.map(address =>
+                        getAssetLogoUrl({
+                            coingeckoId,
+                            contractAddress: address,
+                            density: 2,
+                            size: sizeNumber,
+                        }),
                     );
-                    if (logoAddresses?.length) {
-                        return logoAddresses.map(address =>
-                            getAssetLogoUrl({
-                                coingeckoId,
-                                contractAddress: address,
-                                density: 2,
-                                size: sizeNumber,
-                            }),
-                        );
-                    }
                 }
             }
+        }
 
-            return [cryptoIcons[symbol.toLowerCase() as CryptoIconName]];
-        };
+        return [cryptoIcons[symbol.toLowerCase() as CryptoIconName]];
+    });
 
-        getUrls().then(setSourceUrls);
-    }, [contractAddress, sizeNumber, symbol]);
-
-    useEffect(() => {
-        setLogoIndex(0);
-        setShowPlaceholder(false);
-    }, [sourceUrls]);
+    const sourceUrls = resolvedUrls ?? [cryptoIcons[symbol.toLowerCase() as CryptoIconName]];
+    const sourceKey = resolvedUrls ? `${asyncKey}#resolved` : `${asyncKey}#fallback`;
+    const logoIndex = loadState?.sourceKey === sourceKey ? loadState.logoIndex : 0;
+    const showPlaceholder = loadState?.sourceKey === sourceKey ? loadState.failed : false;
 
     /**
      * Retries loading the icon with the next available address in sourceUrls.
@@ -103,9 +101,9 @@ export const CryptoIcon = ({ symbol, contractAddress, size = 'small' }: CryptoIc
      */
     const handleLoadError = () => {
         if (logoIndex + 1 >= sourceUrls.length) {
-            setShowPlaceholder(true);
+            setLoadState({ sourceKey, logoIndex, failed: true });
         } else {
-            setLogoIndex(prevState => prevState + 1);
+            setLoadState({ sourceKey, logoIndex: logoIndex + 1, failed: false });
         }
     };
 
@@ -123,7 +121,7 @@ export const CryptoIcon = ({ symbol, contractAddress, size = 'small' }: CryptoIc
             source={sourceUrls[logoIndex]}
             accessibilityHint={translate('icons.cryptoIconHint')}
             accessibilityLabel={key}
-            recyclingKey={key}
+            recyclingKey={asyncKey}
             style={iconContainerStyle}
             placeholder={genericTokenIcon}
             onError={handleLoadError}

--- a/suite-native/icons/src/tests/CryptoIcon.test.tsx
+++ b/suite-native/icons/src/tests/CryptoIcon.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+
+import { getCoingeckoId } from '@suite-common/wallet-config';
+import { getAssetLogoContractAddresses } from '@suite-common/wallet-utils';
+import { act, fireEvent, renderWithBasicProvider, waitFor } from '@suite-native/test-utils';
+import { getAssetLogoUrl } from '@trezor/asset-utils';
+import { createDeferred } from '@trezor/utils';
+
+import { CryptoIcon } from '../CryptoIcon';
+
+jest.mock('@suite-common/wallet-utils', () => ({
+    ...jest.requireActual('@suite-common/wallet-utils'),
+    getAssetLogoContractAddresses: jest.fn(),
+}));
+
+const cryptoIconHint = 'Crypto Icon';
+
+const contractA = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const contractB = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+const getTokenLogoUrl = (contractAddress: string, size = 32) =>
+    getAssetLogoUrl({
+        coingeckoId: getCoingeckoId('eth')!,
+        contractAddress,
+        density: 2,
+        size,
+    });
+
+describe('CryptoIcon', () => {
+    it('renders the new asset icon immediately when a recycled instance receives new props', async () => {
+        const fresh = renderWithBasicProvider(<CryptoIcon symbol="eth" />);
+        const ethSource = fresh.getByHintText(cryptoIconHint).props.source;
+        await act(async () => {});
+        fresh.unmount();
+
+        const { getByHintText, rerender } = renderWithBasicProvider(<CryptoIcon symbol="btc" />);
+
+        // simulates FlashList cell recycling: same mounted instance, new asset props
+        rerender(<CryptoIcon symbol="eth" />);
+
+        expect(getByHintText(cryptoIconHint).props.source).toEqual(ethSource);
+
+        await act(async () => {});
+        expect(getByHintText(cryptoIconHint).props.source).toEqual(ethSource);
+    });
+
+    it('ignores a stale async url resolution that arrives after the instance was recycled', async () => {
+        const deferredA = createDeferred<string[]>();
+        (getAssetLogoContractAddresses as jest.Mock).mockImplementation(
+            (_symbol: string, contract: string) =>
+                contract === contractA ? deferredA.promise : Promise.resolve([contract]),
+        );
+
+        const { getByHintText, rerender } = renderWithBasicProvider(
+            <CryptoIcon symbol="eth" contractAddress={contractA} />,
+        );
+
+        rerender(<CryptoIcon symbol="eth" contractAddress={contractB} />);
+
+        await waitFor(() => {
+            expect(JSON.stringify(getByHintText(cryptoIconHint).props.source)).toContain(
+                getTokenLogoUrl(contractB),
+            );
+        });
+
+        deferredA.resolve([contractA]);
+        await act(async () => {});
+
+        expect(JSON.stringify(getByHintText(cryptoIconHint).props.source)).toContain(
+            getTokenLogoUrl(contractB),
+        );
+    });
+
+    it('keeps the bundled fallback icon when the url resolution rejects', async () => {
+        (getAssetLogoContractAddresses as jest.Mock).mockRejectedValue(new Error('failed'));
+
+        const { getByHintText } = renderWithBasicProvider(
+            <CryptoIcon symbol="eth" contractAddress={contractA} />,
+        );
+
+        await act(async () => {});
+
+        expect(JSON.stringify(getByHintText(cryptoIconHint).props.source)).not.toContain(
+            getTokenLogoUrl(contractA),
+        );
+    });
+
+    it('does not reuse retry failure state after the size changes', async () => {
+        (getAssetLogoContractAddresses as jest.Mock).mockImplementation(
+            (_symbol: string, contract: string) => Promise.resolve([contract]),
+        );
+
+        const { getByHintText, queryByHintText, rerender } = renderWithBasicProvider(
+            <CryptoIcon symbol="eth" contractAddress={contractA} size={32} />,
+        );
+        await act(async () => {});
+
+        // the only url candidate fails, so the placeholder is shown
+        fireEvent(getByHintText(cryptoIconHint), 'error', { nativeEvent: {} });
+        expect(queryByHintText(cryptoIconHint)).toBeNull();
+
+        rerender(<CryptoIcon symbol="eth" contractAddress={contractA} size={64} />);
+        await act(async () => {});
+
+        expect(JSON.stringify(getByHintText(cryptoIconHint).props.source)).toContain(
+            getTokenLogoUrl(contractA, 64),
+        );
+    });
+});

--- a/suite-native/icons/src/tests/CryptoIconWithNetwork.test.tsx
+++ b/suite-native/icons/src/tests/CryptoIconWithNetwork.test.tsx
@@ -36,7 +36,7 @@ describe('CryptoIconWithNetwork', () => {
         );
 
         expect(getByHintText(cryptoIconHint)).toBeTruthy();
-        expect(getByLabelText('op' + contract)).toBeTruthy();
+        expect(getByLabelText(`op:${contract}`)).toBeTruthy();
         expect(getByHintText(networkIconHint)).toBeTruthy();
     });
 });

--- a/suite-native/icons/tsconfig.json
+++ b/suite-native/icons/tsconfig.json
@@ -16,6 +16,7 @@
         { "path": "../theme" },
         { "path": "../../packages/asset-utils" },
         { "path": "../../packages/device-utils" },
+        { "path": "../../packages/react-utils" },
         {
             "path": "../../packages/styles-native"
         },

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitCard.test.tsx
@@ -42,7 +42,7 @@ describe('ExchangeApprovalLimitCard', () => {
             contractAddress: '0x123456789',
         });
 
-        expect(getByLabelText('eth0x123456789')).toBeTruthy();
+        expect(getByLabelText('eth:0x123456789')).toBeTruthy();
     });
 
     it('should call onChange when card is pressed', () => {

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitSheet.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitSheet.test.tsx
@@ -76,7 +76,7 @@ describe('ExchangeApprovalLimitSheet', () => {
     it('should render crypto icons for both cards', () => {
         const { getAllByLabelText } = renderSheet();
 
-        const cryptoIcons = getAllByLabelText('eth0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
+        const cryptoIcons = getAllByLabelText('eth:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
         expect(cryptoIcons).toHaveLength(2);
     });
 

--- a/suite-native/module-trading/src/components/general/__tests__/TradeableAssetButton.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradeableAssetButton.test.tsx
@@ -38,7 +38,7 @@ describe('TradeableAssetButton', () => {
         );
 
         expect(getByText('USDC')).toBeTruthy();
-        expect(getByLabelText('eth0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')).toBeTruthy();
+        expect(getByLabelText('eth:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')).toBeTruthy();
     });
 
     it('should call onPress callback', () => {

--- a/suite-native/trading-atoms/src/components/__tests__/IconByCryptoId.test.tsx
+++ b/suite-native/trading-atoms/src/components/__tests__/IconByCryptoId.test.tsx
@@ -39,7 +39,7 @@ describe('IconByCryptoId', () => {
             cryptoId: usdcAsset.cryptoId,
         });
 
-        expect(getByLabelText('eth0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')).toBeTruthy();
+        expect(getByLabelText('eth:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')).toBeTruthy();
         expect(queryByHintText(networkIconHint)).toBeNull();
     });
 
@@ -48,7 +48,7 @@ describe('IconByCryptoId', () => {
             cryptoId: rethOnBaseAsset.cryptoId,
         });
 
-        expect(getByLabelText('base0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c')).toBeTruthy();
+        expect(getByLabelText('base:0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c')).toBeTruthy();
         expect(queryByHintText(networkIconHint)).toBeNull();
     });
 
@@ -88,7 +88,7 @@ describe('IconByCryptoId', () => {
             });
 
             expect(getByHintText(cryptoIconHint)).toBeTruthy();
-            expect(getByLabelText('eth0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')).toBeTruthy();
+            expect(getByLabelText('eth:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')).toBeTruthy();
             expect(getByHintText(networkIconHint)).toBeTruthy();
         });
 
@@ -99,7 +99,7 @@ describe('IconByCryptoId', () => {
             });
 
             expect(getByHintText(cryptoIconHint)).toBeTruthy();
-            expect(getByLabelText('base0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c')).toBeTruthy();
+            expect(getByLabelText('base:0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c')).toBeTruthy();
             expect(getByHintText(networkIconHint)).toBeTruthy();
         });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -12648,6 +12648,7 @@ __metadata:
     "@suite-native/theme": "workspace:*"
     "@trezor/asset-utils": "workspace:*"
     "@trezor/device-utils": "workspace:*"
+    "@trezor/react-utils": "workspace:*"
     "@trezor/styles-native": "workspace:*"
     "@trezor/theme": "workspace:*"
     "@trezor/utils": "workspace:*"


### PR DESCRIPTION
## Description

`CryptoIcon` kept icon urls in untagged component state updated by an uncancelled async effect. When FlashList recycled a cell, the instance rendered the previous asset's source for a frame (with the new `recyclingKey`), and out-of-order async resolutions could permanently overwrite the urls with a stale asset's icon (e.g. BTC icon on an Arbitrum ETH row in the trading asset sheet).

The resolved urls and the retry state are now tagged with the asset key and discarded on mismatch, so the rendered source is always derived from the current props. Regression test added (fails on the previous implementation).

## Notes for QA

Scroll fast through long asset lists (e.g. trading "Your assets" sheet with many tokens/accounts) and verify icons always match the asset row. Icon retry fallbacks for ADA/XLM tokens should still work.

## Related Issue

Resolve #29354

## Screenshots:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/crypto-icon-recycling-race&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/crypto-icon-recycling-race&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/crypto-icon-recycling-race&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-04T00:25:10.769Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-04T00:22:23.949Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/crypto-icon-recycling-race/web/](https://dev.suite.sldev.cz/suite-web/fix/crypto-icon-recycling-race/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All 12 changed files are either unit tests, suite-native (mobile) components, or a shared React utility hook (`useKeyedAsyncValue`). None of the changes touch suite-web or suite-desktop source code, page objects, fixtures, or any code paths exercised by the Playwright E2E tests. The `packages/react-utils` export change adds a new hook but doesn't modify existing exports. The `suite-native/*` changes are entirely within the mobile app codebase and have no bearing on the web/desktop E2E test suite. No E2E tests need to be run for this change set.

<details><summary><b>Changed files (12)</b></summary>

- `packages/react-utils/src/hooks/__tests__/useKeyedAsyncValue.test.ts`
- `packages/react-utils/src/hooks/useKeyedAsyncValue.ts`
- `packages/react-utils/src/index.ts`
- `suite-native/icons/package.json`
- `suite-native/icons/src/CryptoIcon.tsx`
- `suite-native/icons/src/tests/CryptoIcon.test.tsx`
- `suite-native/icons/src/tests/CryptoIconWithNetwork.test.tsx`
- `suite-native/icons/tsconfig.json`
- `suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitCard.test.tsx`
- `suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitSheet.test.tsx`
- `suite-native/module-trading/src/components/general/__tests__/TradeableAssetButton.test.tsx`
- `suite-native/trading-atoms/src/components/__tests__/IconByCryptoId.test.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (12)**
- `packages/react-utils/src/hooks/__tests__/useKeyedAsyncValue.test.ts`
- `packages/react-utils/src/hooks/useKeyedAsyncValue.ts`
- `packages/react-utils/src/index.ts`
- `suite-native/icons/package.json`
- `suite-native/icons/src/CryptoIcon.tsx`
- `suite-native/icons/src/tests/CryptoIcon.test.tsx`
- `suite-native/icons/src/tests/CryptoIconWithNetwork.test.tsx`
- `suite-native/icons/tsconfig.json`
- `suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitCard.test.tsx`
- `suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitSheet.test.tsx`
- `suite-native/module-trading/src/components/general/__tests__/TradeableAssetButton.test.tsx`
- `suite-native/trading-atoms/src/components/__tests__/IconByCryptoId.test.tsx`

_Updated: 2026-07-04T00:18:51.533Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->