### PR TITLE
chore(urls): update links to kb

### DIFF
--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -47,11 +47,11 @@ export const HOW_TO_CHOOSE_RIGHT_NETWORK_URL = withPlatformUtm(
 );
 
 export const RECOVERY_ISSUES_LINK = withPlatformUtm(
-    'https://trezor.io/support/troubleshooting/trezor-suite-issues/trezor-recovery-issues#lost-wallet-backup',
+    'https://trezor.io/support/troubleshooting/trezor-suite-issues/troubleshoot-wallet-backup-and-recovery-problems#lost-wallet-backup',
 );
 
 export const PIN_HELP_URL = withPlatformUtm(
-    'https://trezor.io/support/troubleshooting/device-issues/how-to-enter-pin-on-model-one',
+    'https://trezor.io/support/troubleshooting/device-issues/how-to-enter-your-pin-on-trezor-model-one',
 );
 
 export const TREZOR_SUPPORT_URL: Url = withPlatformUtm('https://trezor.io/support');
@@ -63,7 +63,7 @@ export const TREZOR_SUPPORT_DEVICE_URL: Url = withPlatformUtm(
     'https://trezor.io/support/troubleshooting/device-issues/trezor-suite-doesn-t-see-my-device',
 );
 export const TREZOR_SUPPORT_RECOVERY_ISSUES_URL: Url = withPlatformUtm(
-    'https://trezor.io/support/troubleshooting/trezor-suite-issues/trezor-recovery-issues',
+    'https://trezor.io/support/troubleshooting/trezor-suite-issues/troubleshoot-wallet-backup-and-recovery-problems',
 );
 export const TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL: Url = withPlatformUtm(
     'https://trezor.io/support/troubleshooting/device-issues/trezor-safe-device-authentication-check-failed',
@@ -87,7 +87,7 @@ export const TREZOR_SUPPORT_DIFFERENT_PACKAGING: Url = withPlatformUtm(
     'https://trezor.io/support/logistics/order-shipping-faq/why-is-my-box-different-from-what-is-shown-on-the-website',
 );
 export const TREZOR_SUPPORT_RESET_PIN: Url = withPlatformUtm(
-    'https://trezor.io/support/troubleshooting/device-issues/how-to-reset-your-pin',
+    'https://trezor.io/support/troubleshooting/device-issues/how-to-reset-your-trezor-pin-using-factory-reset',
 );
 
 export const TREZOR_SUPPORT_MULTIPLE_ACCOUNTS: Url = withPlatformUtm(
@@ -202,7 +202,7 @@ export const HELP_CENTER_FW_DOWNGRADE_T3W1_URL: Url = withPlatformUtm(
     'https://trezor.io/support/troubleshooting/device-issues/install-custom-firmware-on-trezor-safe-7',
 );
 export const HELP_CENTER_RECOVERY_ISSUES_URL: Url = withPlatformUtm(
-    'https://trezor.io/support/troubleshooting/trezor-suite-issues/trezor-recovery-issues',
+    'https://trezor.io/support/troubleshooting/trezor-suite-issues/troubleshoot-wallet-backup-and-recovery-problems',
 );
 export const HELP_CENTER_ADVANCED_RECOVERY_URL: Url = withPlatformUtm(
     'https://trezor.io/guides/backups-recovery/general-standards/advanced-recovery-on-model-one',
@@ -211,7 +211,7 @@ export const HELP_CENTER_XPUB_URL: Url = withPlatformUtm(
     'https://trezor.io/learn/supported-assets/bitcoin/what-is-a-public-key-xpub',
 );
 export const HELP_CENTER_BIP329_URL: Url = withPlatformUtm(
-    'https://trezor.io/learn/advanced/standards-proposals/what-is-bip-329',
+    'https://trezor.io/learn/advanced/standards-proposals/what-is-bip-329-portable-labels-for-bitcoin-transactions',
 );
 export const HELP_CENTER_BIP32_URL: Url = withPlatformUtm(
     'https://trezor.io/learn/advanced/standards-proposals/what-is-bip32',
@@ -244,7 +244,7 @@ export const HELP_CENTER_ADA_STAKING: Url = withPlatformUtm(
     'https://trezor.io/guides/sending-receiving-staking-funds/staking-assets-in-trezor-suite/staking-cardano-ada-in-trezor-suite',
 );
 export const HELP_CENTER_SEED_CARD_URL: Url = withPlatformUtm(
-    'https://trezor.io/learn/security-privacy/personal-security-standards/wallet-backup-card',
+    'https://trezor.io/learn/security-privacy/personal-security-standards/wallet-backup-cards-download-and-print-for-your-trezor',
 );
 export const HELP_CENTER_MULTI_SHARE_BACKUP_URL: Url = withPlatformUtm(
     'https://trezor.io/guides/backups-recovery/advanced-wallets/multi-share-backup-on-trezor',
@@ -262,7 +262,7 @@ export const HELP_CENTER_EVM_ADDRESS_CHECKSUM: Url = withPlatformUtm(
     'https://trezor.io/learn/advanced/blockchain-architecture-technologies/evm-address-checksum-in-trezor-suite',
 );
 export const HELP_CENTER_EVM_SEND_TO_CONTRACT_URL = withPlatformUtm(
-    'https://trezor.io/support/troubleshooting/coins-tokens/where-is-my-ethereum',
+    'https://trezor.io/support/troubleshooting/coins-tokens/ethereum-or-tokens-not-showing-in-trezor-suite',
 );
 export const HELP_CENTER_FIRMWARE_REVISION_CHECK: Url = withPlatformUtm(
     'https://trezor.io/learn/security-privacy/how-trezor-keeps-you-safe/trezor-firmware-revision-check',
@@ -285,11 +285,11 @@ export const HELP_CENTER_CANCEL_TRANSACTION: Url = withPlatformUtm(
 );
 // TODO: update this link when the article is ready
 export const HELP_CENTER_SOL_SEND: Url = withPlatformUtm(
-    'https://trezor.io/learn/supported-assets/solana/solana',
+    'https://trezor.io/learn/supported-assets/solana/solana-what-it-is-and-how-it-works-with-trezor',
 );
 
 export const HELP_CENTER_SOLANA_HELP_URL: Url = withPlatformUtm(
-    'https://trezor.io/support/troubleshooting/coins-tokens/where-is-my-solana',
+    'https://trezor.io/support/troubleshooting/coins-tokens/why-your-sol-isn-t-showing-up-in-trezor-suite',
 );
 
 export const UNINSTALL_BRIDGE_URL: Url = withPlatformUtm(


### PR DESCRIPTION
## Description

Update of KB links in `packages/urls/src/urls.ts`

- old: https://trezor.io/support/troubleshooting/trezor-suite-issues/trezor-recovery-issues#lost-wallet-backup
  - new: https://trezor.io/support/troubleshooting/trezor-suite-issues/troubleshoot-wallet-backup-and-recovery-problems#lost-wallet-backup
- old: https://trezor.io/support/troubleshooting/device-issues/how-to-enter-pin-on-model-one
  - new: https://trezor.io/support/troubleshooting/device-issues/how-to-enter-your-pin-on-trezor-model-one
- old: https://trezor.io/support/troubleshooting/trezor-suite-issues/trezor-recovery-issues
  - new: https://trezor.io/support/troubleshooting/trezor-suite-issues/troubleshoot-wallet-backup-and-recovery-problems
- old: https://trezor.io/support/troubleshooting/device-issues/how-to-reset-your-pin
  - new: https://trezor.io/support/troubleshooting/device-issues/how-to-reset-your-trezor-pin-using-factory-reset
- old: https://trezor.io/learn/advanced/standards-proposals/what-is-bip-329
  - new: https://trezor.io/learn/advanced/standards-proposals/what-is-bip-329-portable-labels-for-bitcoin-transactions
- old: https://trezor.io/learn/security-privacy/personal-security-standards/wallet-backup-card
  - new: https://trezor.io/learn/security-privacy/personal-security-standards/wallet-backup-cards-download-and-print-for-your-trezor
- old: https://trezor.io/support/troubleshooting/coins-tokens/where-is-my-ethereum
  - new: https://trezor.io/support/troubleshooting/coins-tokens/ethereum-or-tokens-not-showing-in-trezor-suite
- old: https://trezor.io/learn/supported-assets/solana/solana
  - new: https://trezor.io/learn/supported-assets/solana/solana-what-it-is-and-how-it-works-with-trezor
- old: https://trezor.io/support/troubleshooting/coins-tokens/where-is-my-solana
  - new: https://trezor.io/support/troubleshooting/coins-tokens/why-your-sol-isn-t-showing-up-in-trezor-suite

## Notes for QA

Check that the new links used in Suite opens KB without redirection to a different URL or 404 page.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to packages/urls/src/urls.ts, which is a global URL constants file imported by 121 tests. Since this is a broad utility, most tests only transitively depend on it. The key risk is that any modified, added, or removed URL constants could break tests that explicitly assert on URL values (check-links, backup fail link, browser warning links, version page commit link). The recommended strategy is to run the small set of tests that directly assert on URL values or crawl links, rather than the full 121-test suite.

<details><summary><b>Changed files (1)</b></summary>

- `packages/urls/src/urls.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test explicitly validates that all hyperlinks across the application return HTTP 200 responses. Changes to packages/urls/src/urls.ts (which defines URL constants like HELP_CENTER_RECOVERY_ISSUES_URL and others) directly affect the link targets this test crawls and checks. A broken or changed URL would be caught here.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test explicitly asserts that the backup failed setting link href matches the HELP_CENTER_RECOVERY_ISSUES_URL base from @trezor/urls. A change to that URL constant would directly break this assertion.
- `suite/e2e/tests/browser/safari.test.ts` — The unsupported browser page displays links to download the Desktop App and Chrome as alternatives. These download URLs likely come from packages/urls/src/urls.ts, and the test validates page content via ARIA snapshots that include these links.
- `suite/e2e/tests/suite/version-page.test.ts` — This test asserts the commit hash link href contains 'https://github.com/trezor/trezor-suite/commits/', which is likely defined in or derived from packages/urls/src/urls.ts. A change to GitHub URL patterns would break this assertion.

</details>

_Updated: 2026-07-02T20:36:44.710Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/update-kb-urls&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/update-kb-urls&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-02T20:42:48.425Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-02T20:40:17.317Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/update-kb-urls/web/](https://dev.suite.sldev.cz/suite-web/chore/update-kb-urls/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->