### PR TITLE
feat(trading): decouple sell confirm page from form context

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalSell.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalSell.tsx
@@ -2,7 +2,7 @@ import { sendFormActions } from '@suite-common/wallet-core';
 import { type FormState } from '@suite-common/wallet-types';
 
 import { useDispatch } from 'src/hooks/suite';
-import { useTradingSellForm } from 'src/hooks/wallet/trading/form/useTradingSellForm';
+import { useTradingSellConfirm } from 'src/hooks/wallet/trading/useTradingSellConfirm';
 
 import { TransactionReviewModalBody } from './TransactionReviewModalBody';
 import { type TransactionReviewModalProps } from './TransactionReviewModalProps';
@@ -23,11 +23,11 @@ export const TransactionReviewModalSell = ({
     precomposedForm,
 }: TransactionReviewModalSellProps) => {
     const dispatch = useDispatch();
-    const tradingSellForm = useTradingSellForm({ pageType: 'retry' });
+    const { sendTransaction } = useTradingSellConfirm();
 
     const handleTryAgainSignTx = async () => {
         dispatch(sendFormActions.discardTransaction());
-        await tradingSellForm.sendTransaction();
+        await sendTransaction();
     };
 
     return (

--- a/packages/suite/src/hooks/wallet/trading/__tests__/useTradingSellConfirm.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/__tests__/useTradingSellConfirm.test.tsx
@@ -1,0 +1,275 @@
+import type { BankAccount, CryptoId, FiatCurrencyCode, SellFiatTrade } from 'invity-api';
+
+import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { type Account, type AccountKey } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+
+import { useTradingSellConfirm } from '../useTradingSellConfirm';
+
+jest.mock('@suite/router', () => ({
+    ...jest.requireActual('@suite/router'),
+    goto: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
+}));
+
+jest.mock('@suite-common/dependency-injection', () => ({
+    ...jest.requireActual('@suite-common/dependency-injection'),
+    useServices: () => ({ analytics: { report: jest.fn() } }),
+}));
+
+jest.mock('@suite/device', () => ({
+    ...jest.requireActual('@suite/device'),
+    useDevice: () => ({ device: { connected: true } }),
+}));
+
+jest.mock('@suite/intl', () => ({
+    ...jest.requireActual('@suite/intl'),
+    useTranslation: () => ({ translationString: (id: string) => id }),
+}));
+
+jest.mock('src/hooks/wallet/useBitcoinAmountUnit', () => ({
+    useBitcoinAmountUnit: () => ({ isBtcSatsAmountUnit: false }),
+}));
+
+jest.mock('src/hooks/wallet/trading/form/common/useTradingAssetDecimals', () => ({
+    useTradingAssetDecimals: () => ({ getAssetDecimals: () => 8 }),
+}));
+
+jest.mock('src/hooks/wallet/trading/useServerEnviroment', () => ({
+    useServerEnvironment: jest.fn(),
+}));
+
+const mockUseTradingFormAccount = jest.fn();
+jest.mock('src/hooks/wallet/trading/form/useTradingFormAccount', () => ({
+    useTradingFormAccount: () => mockUseTradingFormAccount(),
+}));
+
+jest.mock('@suite-common/message-system', () => ({
+    ...jest.requireActual('@suite-common/message-system'),
+    selectIsFeatureEnabled: () => true,
+}));
+
+jest.mock('@suite/settings', () => ({
+    ...jest.requireActual('@suite/settings'),
+    selectHasExperimentalFeature: () => () => false,
+}));
+
+const mockHandleSellTrade = jest.fn();
+jest.mock('src/hooks/wallet/trading/form/common/useTradingSellTradeRequest', () => ({
+    useTradingSellTradeRequest: () => ({
+        getTradeRequestParams: () =>
+            Promise.resolve({
+                returnUrl: 'https://return.url',
+                processResponseData: jest.fn(),
+            }),
+        handleSellTrade: mockHandleSellTrade,
+    }),
+}));
+
+const mockConfirmTradeThunk = jest.fn((args: unknown) =>
+    Object.assign(() => Promise.resolve(), { args }),
+);
+const mockSendTransactionThunk = jest.fn((args: unknown) =>
+    Object.assign(() => ({ unwrap: () => Promise.resolve(true) }), { args }),
+);
+
+jest.mock('@suite-common/trading', () => {
+    const actual = jest.requireActual('@suite-common/trading');
+
+    return {
+        ...actual,
+        selectTradingIsSlip24Allowed: () => false,
+        sellThunks: {
+            ...actual.sellThunks,
+            confirmTradeThunk: (args: unknown) => mockConfirmTradeThunk(args),
+            sendTransactionThunk: (args: unknown) => mockSendTransactionThunk(args),
+        },
+    };
+});
+
+const ACCOUNT = mockWalletAccount({ symbol: 'btc' });
+const BITCOIN_CRYPTO_ID = 'bitcoin' as CryptoId;
+const EURO_FIAT_CURRENCY = 'EUR' as FiatCurrencyCode;
+
+const SELECTED_QUOTE: SellFiatTrade = {
+    fiatStringAmount: '47.12',
+    fiatCurrency: EURO_FIAT_CURRENCY,
+    cryptoCurrency: BITCOIN_CRYPTO_ID,
+    cryptoStringAmount: '0.004',
+    quoteId: 'd369ba9e-7370-4a6e-87dc-aefd3851c735',
+    exchange: 'cexdirect',
+    paymentMethod: 'bankTransfer',
+};
+
+const QUOTES_REQUEST = {
+    fiatCurrency: EURO_FIAT_CURRENCY,
+    cryptoCurrency: BITCOIN_CRYPTO_ID,
+    amountInCrypto: true,
+};
+
+const BANK_ACCOUNT = { bankAccount: 'iban', holder: 'holder', verified: true } as BankAccount;
+
+type StateOverrides = {
+    selectedQuote?: SellFiatTrade;
+    quotesRequest?: typeof QUOTES_REQUEST;
+    isLoading?: boolean;
+    accountKey?: AccountKey;
+    accounts?: Account[];
+};
+
+const DEFAULTS: Required<StateOverrides> = {
+    selectedQuote: SELECTED_QUOTE,
+    quotesRequest: QUOTES_REQUEST,
+    isLoading: false,
+    accountKey: ACCOUNT.key,
+    accounts: [ACCOUNT],
+};
+
+const buildState = (overrides: StateOverrides = {}) => {
+    const { selectedQuote, quotesRequest, isLoading, accountKey, accounts } = {
+        ...DEFAULTS,
+        ...overrides,
+    };
+
+    return {
+        wallet: {
+            accounts,
+            trading: {
+                trades: [],
+                sell: {
+                    selectedQuote,
+                    quotesRequest,
+                    isLoading,
+                    isFromRedirect: false,
+                    transactionId: undefined,
+                    tradingAccountKey: accountKey,
+                    sellInfo: undefined,
+                },
+                buy: { tradingAccountKey: undefined },
+                exchange: { tradingAccountKey: undefined },
+            },
+        },
+    };
+};
+
+const renderConfirm = (overrides?: StateOverrides) => {
+    const state = buildState(overrides);
+
+    mockUseTradingFormAccount.mockReturnValue({
+        tradingAccountKey: state.wallet.trading.sell.tradingAccountKey,
+        account: state.wallet.accounts[0],
+        cryptoId: BITCOIN_CRYPTO_ID,
+    });
+
+    const store = configureMockStore({ preloadedState: state });
+    const { result } = renderHookWithStoreProvider(() => useTradingSellConfirm(), { store });
+
+    return { store, result };
+};
+
+const gotoActions = (store: ReturnType<typeof renderConfirm>['store']) =>
+    store.getActions().filter(action => action.type === '@router/goto');
+
+describe('useTradingSellConfirm', () => {
+    beforeEach(() => {
+        mockConfirmTradeThunk.mockClear();
+        mockSendTransactionThunk.mockClear();
+        mockHandleSellTrade.mockClear();
+        mockUseTradingFormAccount.mockReset();
+    });
+
+    describe('isConfirmDisabled', () => {
+        it('is false when quote and account are present and not loading', () => {
+            const { result } = renderConfirm();
+
+            expect(result.current.isConfirmDisabled).toBe(false);
+        });
+
+        it('is true while loading', () => {
+            const { result } = renderConfirm({ isLoading: true });
+
+            expect(result.current.isConfirmDisabled).toBe(true);
+        });
+
+        it.each<[string, StateOverrides]>([
+            ['the selected quote', { selectedQuote: undefined }],
+            ['the active account', { accountKey: undefined, accounts: [] }],
+        ])('is true when %s is missing', (_, overrides) => {
+            const { result } = renderConfirm(overrides);
+
+            expect(result.current.isConfirmDisabled).toBe(true);
+        });
+    });
+
+    describe('readiness guard', () => {
+        it('does not redirect when the quotes request is present', () => {
+            const { store } = renderConfirm();
+
+            expect(gotoActions(store)).toHaveLength(0);
+        });
+
+        it('redirects to the sell form when the quotes request is missing', () => {
+            const { store } = renderConfirm({ quotesRequest: undefined });
+
+            expect(gotoActions(store)).toEqual([
+                { type: '@router/goto', payload: { routeName: 'wallet-trading-sell' } },
+            ]);
+        });
+    });
+
+    describe('confirmTrade', () => {
+        it('dispatches confirmTradeThunk with the resolved return url and active account', async () => {
+            const { result } = renderConfirm();
+
+            await result.current.confirmTrade(BANK_ACCOUNT);
+
+            expect(mockConfirmTradeThunk).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    account: ACCOUNT,
+                    bankAccount: BANK_ACCOUNT,
+                    returnUrl: 'https://return.url',
+                }),
+            );
+        });
+
+        it('does nothing when the account is missing', async () => {
+            const { result } = renderConfirm({ accountKey: undefined, accounts: [] });
+
+            await result.current.confirmTrade(BANK_ACCOUNT);
+
+            expect(mockConfirmTradeThunk).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('addBankAccount', () => {
+        it('delegates to handleSellTrade with the selected quote', async () => {
+            const { result } = renderConfirm();
+
+            await result.current.addBankAccount();
+
+            expect(mockHandleSellTrade).toHaveBeenCalledWith(SELECTED_QUOTE);
+        });
+    });
+
+    describe('sendTransaction', () => {
+        it('dispatches sendTransactionThunk without form values from the confirm screen', async () => {
+            const { result } = renderConfirm();
+
+            await result.current.sendTransaction();
+
+            expect(mockSendTransactionThunk).toHaveBeenCalledTimes(1);
+            const [args] = mockSendTransactionThunk.mock.calls[0] as [{ account: Account }];
+
+            expect(args.account).toBe(ACCOUNT);
+            expect(args).not.toHaveProperty('formValues');
+        });
+
+        it('returns false without dispatching when the account is missing', async () => {
+            const { result } = renderConfirm({ accountKey: undefined, accounts: [] });
+
+            const success = await result.current.sendTransaction();
+
+            expect(success).toBe(false);
+            expect(mockSendTransactionThunk).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/suite/src/hooks/wallet/trading/form/common/__tests__/useTradingSellTradeRequest.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/common/__tests__/useTradingSellTradeRequest.test.tsx
@@ -1,0 +1,191 @@
+import type { CryptoId, SellFiatTrade } from 'invity-api';
+
+import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { type Account } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+
+import { useTradingSellTradeRequest } from '../useTradingSellTradeRequest';
+
+const mockCreateQuoteLink = jest.fn((..._args: unknown[]) => Promise.resolve('https://return.url'));
+jest.mock('src/utils/wallet/trading/sellUtils', () => ({
+    ...jest.requireActual('src/utils/wallet/trading/sellUtils'),
+    createQuoteLink: (...args: unknown[]) => mockCreateQuoteLink(...args),
+}));
+
+let redirectResponse: unknown;
+const mockHandleTradeThunk = jest.fn((args: unknown) =>
+    Object.assign(
+        () => {
+            if (redirectResponse) {
+                (args as { processResponseData?: (r: unknown) => void }).processResponseData?.(
+                    redirectResponse,
+                );
+            }
+
+            return Promise.resolve();
+        },
+        { args },
+    ),
+);
+jest.mock('@suite-common/trading', () => {
+    const actual = jest.requireActual('@suite-common/trading');
+
+    return {
+        ...actual,
+        sellThunks: {
+            ...actual.sellThunks,
+            handleTradeThunk: (args: unknown) => mockHandleTradeThunk(args),
+        },
+    };
+});
+
+const ACCOUNT = mockWalletAccount({ symbol: 'btc' });
+
+const QUOTE: SellFiatTrade = {
+    exchange: 'cexdirect',
+    orderId: 'order-1',
+    paymentMethod: 'bankTransfer',
+    country: 'DE',
+    fiatCurrency: 'EUR',
+    cryptoCurrency: 'bitcoin' as CryptoId,
+    cryptoStringAmount: '0.01',
+    amountInCrypto: true,
+};
+
+type StateOverrides = {
+    providerInfos?: Record<string, { flow?: string }>;
+    quotesRequest?: Record<string, unknown>;
+};
+
+const buildState = (overrides: StateOverrides = {}) => {
+    const providerInfos = overrides.providerInfos ?? { cexdirect: { flow: 'PAYMENT_GATE' } };
+    const quotesRequest =
+        'quotesRequest' in overrides
+            ? overrides.quotesRequest
+            : {
+                  country: 'DE',
+                  fiatCurrency: 'EUR',
+                  cryptoCurrency: 'bitcoin',
+                  amountInCrypto: true,
+              };
+
+    return {
+        wallet: {
+            trading: {
+                composedTransactionInfo: { selectedFee: 'normal', composed: undefined },
+                sell: {
+                    sellInfo: { providerInfos },
+                    quotesRequest,
+                },
+            },
+        },
+    };
+};
+
+const renderHelper = (account: Account | undefined, overrides?: StateOverrides) => {
+    const store = configureMockStore({ preloadedState: buildState(overrides) });
+    const { result } = renderHookWithStoreProvider(() => useTradingSellTradeRequest(account), {
+        store,
+    });
+
+    return { store, result };
+};
+
+describe('useTradingSellTradeRequest', () => {
+    beforeEach(() => {
+        mockCreateQuoteLink.mockClear();
+        mockHandleTradeThunk.mockClear();
+        redirectResponse = undefined;
+    });
+
+    describe('getTradeRequestParams', () => {
+        it('builds the return url via createQuoteLink and returns processResponseData', async () => {
+            const { result } = renderHelper(ACCOUNT);
+
+            const common = await result.current.getTradeRequestParams(QUOTE);
+
+            expect(common?.returnUrl).toBe('https://return.url');
+            expect(typeof common?.processResponseData).toBe('function');
+            expect(mockCreateQuoteLink).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    country: 'DE',
+                    fiatCurrency: 'EUR',
+                    cryptoCurrency: 'bitcoin',
+                    paymentMethod: 'bankTransfer',
+                }),
+                ACCOUNT,
+                { selectedFee: 'normal', composed: undefined },
+                'order-1',
+            );
+        });
+
+        it('passes no orderId for a non PAYMENT_GATE provider', async () => {
+            const { result } = renderHelper(ACCOUNT, {
+                providerInfos: { cexdirect: { flow: 'DEFAULT' } },
+            });
+
+            await result.current.getTradeRequestParams(QUOTE);
+
+            expect(mockCreateQuoteLink).toHaveBeenCalledWith(
+                expect.any(Object),
+                ACCOUNT,
+                expect.any(Object),
+                undefined,
+            );
+        });
+
+        it.each<[string, StateOverrides, Account | undefined]>([
+            ['the account is missing', {}, undefined],
+            ['the quotes request is missing', { quotesRequest: undefined }, ACCOUNT],
+            ['the provider is unknown', { providerInfos: {} }, ACCOUNT],
+        ])('returns undefined when %s', async (_, overrides, account) => {
+            const { result } = renderHelper(account, overrides);
+
+            const common = await result.current.getTradeRequestParams(QUOTE);
+
+            expect(common).toBeUndefined();
+            expect(mockCreateQuoteLink).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('handleSellTrade', () => {
+        it('dispatches handleTradeThunk with the account, trade and resolved return url', async () => {
+            const { result } = renderHelper(ACCOUNT);
+
+            await result.current.handleSellTrade(QUOTE);
+
+            expect(mockHandleTradeThunk).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    account: ACCOUNT,
+                    trade: QUOTE,
+                    returnUrl: 'https://return.url',
+                }),
+            );
+        });
+
+        it('does nothing when the account is missing', async () => {
+            const { result } = renderHelper(undefined);
+
+            await result.current.handleSellTrade(QUOTE);
+
+            expect(mockHandleTradeThunk).not.toHaveBeenCalled();
+        });
+
+        it('returns true when the partner trade submits a redirect form', async () => {
+            redirectResponse = { tradeForm: { form: { formMethod: 'IFRAME' } } };
+            const { result } = renderHelper(ACCOUNT);
+
+            const { isRedirecting } = await result.current.handleSellTrade(QUOTE);
+
+            expect(isRedirecting).toBe(true);
+        });
+
+        it('returns false when the partner trade does not redirect', async () => {
+            const { result } = renderHelper(ACCOUNT);
+
+            const { isRedirecting } = await result.current.handleSellTrade(QUOTE);
+
+            expect(isRedirecting).toBe(false);
+        });
+    });
+});

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingSellTradeRequest.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingSellTradeRequest.ts
@@ -1,0 +1,83 @@
+import type { SellFiatTrade, SellFiatTradeResponse } from 'invity-api';
+
+import {
+    selectTradingComposedTransactionInfo,
+    selectTradingSellInfo,
+    selectTradingSellQuotesRequest,
+    sellThunks,
+} from '@suite-common/trading';
+import { type Account } from '@suite-common/wallet-types';
+
+import { submitRequestForm } from 'src/actions/wallet/trading/tradingCommonActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { createQuoteLink } from 'src/utils/wallet/trading/sellUtils';
+
+export const useTradingSellTradeRequest = (account: Account | undefined) => {
+    const dispatch = useDispatch();
+    const sellInfo = useSelector(selectTradingSellInfo);
+    const quotesRequest = useSelector(selectTradingSellQuotesRequest);
+    const { selectedFee, composed } = useSelector(selectTradingComposedTransactionInfo);
+
+    const getTradeRequestParams = async (quote: SellFiatTrade) => {
+        const provider =
+            sellInfo?.providerInfos && quote.exchange
+                ? sellInfo.providerInfos[quote.exchange]
+                : undefined;
+        if (!quotesRequest || !provider || !account) return;
+
+        const orderId = provider.flow === 'PAYMENT_GATE' ? quote.orderId : undefined;
+
+        const returnUrl = await createQuoteLink(
+            {
+                ...quotesRequest,
+                country: quotesRequest.country ?? quote.country,
+                fiatCurrency: quotesRequest.fiatCurrency ?? quote.fiatCurrency,
+                amountInCrypto: quotesRequest.amountInCrypto ?? quote.amountInCrypto,
+                cryptoStringAmount: quotesRequest.cryptoStringAmount ?? quote.cryptoStringAmount,
+                fiatStringAmount: quotesRequest.fiatStringAmount ?? quote.fiatStringAmount,
+                cryptoCurrency: quotesRequest.cryptoCurrency ?? quote.cryptoCurrency,
+                paymentMethod: quote.paymentMethod,
+            },
+            account,
+            { selectedFee, composed },
+            orderId,
+        );
+
+        const processResponseData = (response: SellFiatTradeResponse) => {
+            dispatch(submitRequestForm(response.tradeForm?.form));
+        };
+
+        return {
+            returnUrl,
+            processResponseData,
+        };
+    };
+
+    const handleSellTrade = async (trade: SellFiatTrade) => {
+        if (!account) return { isRedirecting: false };
+
+        const tradeRequestParams = await getTradeRequestParams(trade);
+
+        if (!tradeRequestParams) return { isRedirecting: false };
+
+        const { returnUrl, processResponseData } = tradeRequestParams;
+
+        let isRedirecting = false;
+
+        await dispatch(
+            sellThunks.handleTradeThunk({
+                account,
+                trade,
+                returnUrl,
+                processResponseData: response => {
+                    isRedirecting = true;
+                    processResponseData(response);
+                },
+            }),
+        );
+
+        return { isRedirecting };
+    };
+
+    return { getTradeRequestParams, handleSellTrade };
+};

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -1,15 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 
-import type { BankAccount, SellFiatTrade, SellFiatTradeResponse } from 'invity-api';
+import type { SellFiatTrade } from 'invity-api';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
-import { type TranslationKey, useTranslation } from '@suite/intl';
 import { goto } from '@suite/router';
-import { selectHasExperimentalFeature } from '@suite/settings';
 import { useServices } from '@suite-common/dependency-injection';
-import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
-import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     TRADING_FORM_OUTPUT_AMOUNT,
     TRADING_FORM_OUTPUT_FIAT,
@@ -17,11 +13,8 @@ import {
     TRADING_FORM_PROVIDER_SELECT,
     type TradingAmountLimitProps,
     type TradingSellFormProps,
-    type TradingSignAndPushSendFormTransactionProps,
-    type TradingTransactionSell,
-    isSendRejectedError,
     selectTradingComposedTransactionInfo,
-    selectTradingIsSlip24Allowed,
+    selectTradingSellActiveTrade,
     selectTradingSellAmountLimits,
     selectTradingSellInfo,
     selectTradingSellIsFromRedirect,
@@ -30,7 +23,6 @@ import {
     selectTradingSellQuotesRequest,
     selectTradingSellSelectedQuote,
     selectTradingSellTransactionId,
-    selectTradingTrades,
     sellThunks,
     sellUtils,
     tradingSellActions,
@@ -39,22 +31,19 @@ import {
 import { networks } from '@suite-common/wallet-config';
 import { selectAccountByKey, selectBaseCurrency } from '@suite-common/wallet-core';
 
-import { signAndPushSendFormTransactionThunk } from 'src/actions/wallet/send/sendFormThunks';
-import { submitRequestForm } from 'src/actions/wallet/trading/tradingCommonActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useSolanaSubscribeBlocks } from 'src/hooks/wallet/form/useSolanaSubscribeBlocks';
 import { useTradingComposeTransaction } from 'src/hooks/wallet/trading/form/common/useTradingComposeTransaction';
 import { useTradingCurrencySwitcher } from 'src/hooks/wallet/trading/form/common/useTradingCurrencySwitcher';
 import { useTradingFormActions } from 'src/hooks/wallet/trading/form/common/useTradingFormActions';
 import { useTradingSellHandleChange } from 'src/hooks/wallet/trading/form/common/useTradingSellHandleChange';
+import { useTradingSellTradeRequest } from 'src/hooks/wallet/trading/form/common/useTradingSellTradeRequest';
 import { useTradingSellFormDefaultValues } from 'src/hooks/wallet/trading/form/useTradingSellFormDefaultValues';
 import { useTradingSellFormRedirectValues } from 'src/hooks/wallet/trading/form/useTradingSellFormRedirectValues';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { type UseTradingFormCommonProps } from 'src/types/trading/trading';
 import { type TradingSellFormContextProps } from 'src/types/trading/tradingForm';
-import { createQuoteLink } from 'src/utils/wallet/trading/sellUtils';
 
-import { useTradingAssetDecimals } from './common/useTradingAssetDecimals';
 import { useTradingClearStaleQuotes } from './common/useTradingClearStaleQuotes';
 import { useTradingInitializer } from './common/useTradingInitializer';
 import { useTradingFormAccount } from './useTradingFormAccount';
@@ -66,7 +55,6 @@ export const useTradingSellForm = ({
     const type = 'sell';
     const isFormPage = pageType === 'form';
     const dispatch = useDispatch();
-    const { translationString } = useTranslation();
     const isLoading = useSelector(selectTradingSellIsLoading);
     const quotesRequest = useSelector(selectTradingSellQuotesRequest);
     const isFromRedirect = useSelector(selectTradingSellIsFromRedirect);
@@ -83,11 +71,7 @@ export const useTradingSellForm = ({
         cryptoId,
     } = useTradingFormAccount(type);
 
-    const trades = useSelector(selectTradingTrades);
-    const trade = trades.find(
-        (trade): trade is TradingTransactionSell =>
-            trade.tradeType === 'sell' && trade.key === transactionId,
-    );
+    const trade = useSelector(selectTradingSellActiveTrade);
 
     const tradeSendAccount = useSelector(state => selectAccountByKey(state, trade?.sendAccountKey));
     const account = tradeSendAccount ?? formAccount;
@@ -98,20 +82,6 @@ export const useTradingSellForm = ({
     });
 
     const composedTransactionInfo = useSelector(selectTradingComposedTransactionInfo);
-    const { selectedFee, composed } = composedTransactionInfo;
-
-    // we consider this feature enabled unless disabled by message system
-    const isSlip24FeatureEnabled = useSelector(state =>
-        selectIsFeatureEnabled(state, Feature.trading.slip24, true),
-    );
-    const isSlip24ExperimentalFeatureEnabled = useSelector(selectHasExperimentalFeature('slip24'));
-    const isSlip24Active = useSelector(state =>
-        selectTradingIsSlip24Allowed(
-            state,
-            account,
-            isSlip24FeatureEnabled && isSlip24ExperimentalFeatureEnabled,
-        ),
-    );
 
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const network = networks[account.symbol];
@@ -145,15 +115,6 @@ export const useTradingSellForm = ({
 
     const quotesByPaymentMethod = useSelector(state =>
         selectTradingSellQuotesByPaymentMethod(state, values?.paymentMethod?.value),
-    );
-    const { getAssetDecimals } = useTradingAssetDecimals();
-    const decimals = useMemo(
-        () =>
-            getAssetDecimals({
-                accountKey: values.sendCryptoSelect?.accountKey,
-                cryptoId: values.sendCryptoSelect?.id,
-            }),
-        [getAssetDecimals, values.sendCryptoSelect?.accountKey, values.sendCryptoSelect?.id],
     );
 
     const setAmountLimits = (limits: TradingAmountLimitProps | undefined) => {
@@ -221,62 +182,13 @@ export const useTradingSellForm = ({
         setShowReserveBanner,
     });
 
-    const getCommonFunctions = async (quote: SellFiatTrade) => {
-        const provider =
-            sellInfo?.providerInfos && quote.exchange
-                ? sellInfo.providerInfos[quote.exchange]
-                : undefined;
-        if (!quotesRequest || !provider) return;
-
-        const orderId = provider.flow === 'PAYMENT_GATE' ? quote.orderId : undefined;
-
-        const returnUrl = await createQuoteLink(
-            {
-                ...quotesRequest,
-                country: quotesRequest.country ?? quote.country,
-                fiatCurrency: quotesRequest.fiatCurrency ?? quote.fiatCurrency,
-                amountInCrypto: quotesRequest.amountInCrypto ?? quote.amountInCrypto,
-                cryptoStringAmount: quotesRequest.cryptoStringAmount ?? quote.cryptoStringAmount,
-                fiatStringAmount: quotesRequest.fiatStringAmount ?? quote.fiatStringAmount,
-                cryptoCurrency: quotesRequest.cryptoCurrency ?? quote.cryptoCurrency,
-                paymentMethod: quote.paymentMethod,
-            },
-            account,
-            { selectedFee, composed },
-            orderId,
-        );
-
-        const processResponseData = (response: SellFiatTradeResponse) => {
-            dispatch(submitRequestForm(response.tradeForm?.form));
-        };
-
-        return {
-            returnUrl,
-            processResponseData,
-        };
-    };
-
-    const doSellTrade = async (trade: SellFiatTrade) => {
-        const commonFunctions = await getCommonFunctions(trade);
-
-        if (!commonFunctions) return;
-
-        const { returnUrl, processResponseData } = commonFunctions;
-
-        await dispatch(
-            sellThunks.handleTradeThunk({
-                account,
-                trade,
-                returnUrl,
-                processResponseData,
-            }),
-        );
-    };
+    const { handleSellTrade } = useTradingSellTradeRequest(account);
 
     const selectQuote = async (quote: SellFiatTrade) => {
-        const provider = sellInfo && quote.exchange ? sellInfo.providerInfos[quote.exchange] : null;
+        const quoteProvider =
+            sellInfo && quote.exchange ? sellInfo.providerInfos[quote.exchange] : null;
 
-        if (!quotesRequest || !provider) return;
+        if (!quotesRequest || !quoteProvider) return;
 
         analytics.report({
             type: events.tradeSellEvent.name,
@@ -295,15 +207,19 @@ export const useTradingSellForm = ({
             },
         });
 
-        const nextStep = () => {
-            dispatch(goto({ routeName: 'wallet-trading-sell-confirm' }));
+        const nextStep = async () => {
+            let isRedirecting = false;
 
             // empty quoteId means the partner requests login first, requestTrade to get login screen
             if (
                 (sellInfo && sellUtils.needToRegisterOrVerifyBankAccount({ quote, sellInfo })) ||
                 !quote.quoteId
             ) {
-                doSellTrade(quote);
+                ({ isRedirecting } = await handleSellTrade(quote));
+            }
+
+            if (!isRedirecting) {
+                dispatch(goto({ routeName: 'wallet-trading-sell-confirm' }));
             }
         };
 
@@ -313,94 +229,6 @@ export const useTradingSellForm = ({
                 nextStep,
             }),
         );
-    };
-
-    const confirmTrade = async (bankAccount: BankAccount) => {
-        if (!selectedQuote) return;
-
-        const quote = { ...selectedQuote, bankAccount };
-        const commonFunctions = await getCommonFunctions(quote);
-
-        if (!commonFunctions) return;
-
-        const { returnUrl, processResponseData } = commonFunctions;
-
-        const triggerAnalyticsTradeConfirmation = () => {
-            analytics.report({
-                type: events.tradeConfirmTradeEvent.name,
-                payload: { action: type },
-            });
-        };
-
-        await dispatch(
-            sellThunks.confirmTradeThunk({
-                account,
-                bankAccount,
-                returnUrl,
-                triggerAnalyticsTradeConfirmation,
-                processResponseData,
-            }),
-        );
-    };
-
-    const addBankAccount = async () => {
-        if (!selectedQuote) return;
-
-        await doSellTrade(selectedQuote);
-    };
-
-    const sendTransaction = async () => {
-        const nextStep = () => {
-            dispatch(goto({ routeName: 'wallet-trading-sell-detail' }));
-        };
-
-        const signAndPushSendFormTransaction = async ({
-            formState,
-            precomposedTransaction,
-            selectedAccount,
-            paymentRequests,
-        }: TradingSignAndPushSendFormTransactionProps) =>
-            await dispatch(
-                signAndPushSendFormTransactionThunk({
-                    formState,
-                    precomposedTransaction,
-                    selectedAccount,
-                    paymentRequests,
-                }),
-            ).unwrap();
-
-        try {
-            await dispatch(
-                sellThunks.sendTransactionThunk({
-                    account,
-                    trade: trade?.data,
-                    shouldSendInSats,
-                    decimals,
-                    formValues: values as TradingSellFormProps,
-                    // TODO: slip24 - exclude from debug mode
-                    isSlip24Active,
-                    nextStep,
-                    signAndPushSendFormTransaction,
-                }),
-            ).unwrap();
-
-            return true;
-        } catch (e) {
-            if (!isSendRejectedError<TranslationKey>(e)) {
-                return false;
-            }
-
-            if (e.type !== 'sign-transaction-timeout') {
-                dispatch(
-                    notificationsActions.addToast({
-                        type: e.type,
-                        error: translationString(e.error.id, e.error.values),
-                    }),
-                );
-            }
-
-            return false;
-        }
     };
 
     useEffect(() => {
@@ -503,11 +331,8 @@ export const useTradingSellForm = ({
         changeFeeLevel,
         composeRequest,
         setAmountLimits,
-        addBankAccount,
-        confirmTrade,
         selectQuote,
         onQuoteSelected,
-        sendTransaction,
         showReserveBanner,
         setShowReserveBanner,
         clearQuotesAndParams: () => {

--- a/packages/suite/src/hooks/wallet/trading/useTradingSellConfirm.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingSellConfirm.ts
@@ -1,0 +1,212 @@
+import { useEffect } from 'react';
+
+import type { BankAccount } from 'invity-api';
+
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
+import { useDevice } from '@suite/device';
+import { type TranslationKey, useTranslation } from '@suite/intl';
+import { goto } from '@suite/router';
+import { selectHasExperimentalFeature } from '@suite/settings';
+import { useServices } from '@suite-common/dependency-injection';
+import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import {
+    type TradingSignAndPushSendFormTransactionProps,
+    isSendRejectedError,
+    selectTradingIsSlip24Allowed,
+    selectTradingSellActiveTrade,
+    selectTradingSellInfo,
+    selectTradingSellIsFromRedirect,
+    selectTradingSellIsLoading,
+    selectTradingSellQuotesRequest,
+    selectTradingSellSelectedQuote,
+    selectTradingSellTransactionId,
+    sellThunks,
+    tradingSellActions,
+    tradingThunks,
+} from '@suite-common/trading';
+import { selectAccountByKey } from '@suite-common/wallet-core';
+
+import { signAndPushSendFormTransactionThunk } from 'src/actions/wallet/send/sendFormThunks';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useTradingAssetDecimals } from 'src/hooks/wallet/trading/form/common/useTradingAssetDecimals';
+import { useTradingSellTradeRequest } from 'src/hooks/wallet/trading/form/common/useTradingSellTradeRequest';
+import { useTradingFormAccount } from 'src/hooks/wallet/trading/form/useTradingFormAccount';
+import { useServerEnvironment } from 'src/hooks/wallet/trading/useServerEnviroment';
+import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
+
+export const useTradingSellConfirm = () => {
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const dispatch = useDispatch();
+    const { translationString } = useTranslation();
+    const { device } = useDevice();
+
+    useServerEnvironment();
+
+    const selectedQuote = useSelector(selectTradingSellSelectedQuote);
+    const sellInfo = useSelector(selectTradingSellInfo);
+    const isLoading = useSelector(selectTradingSellIsLoading);
+    const quotesRequest = useSelector(selectTradingSellQuotesRequest);
+    const isFromRedirect = useSelector(selectTradingSellIsFromRedirect);
+    const transactionId = useSelector(selectTradingSellTransactionId);
+
+    const trade = useSelector(selectTradingSellActiveTrade);
+
+    const { account: formAccount } = useTradingFormAccount('sell');
+    const tradeSendAccount = useSelector(
+        state => selectAccountByKey(state, trade?.sendAccountKey) ?? undefined,
+    );
+    const account = tradeSendAccount ?? formAccount;
+
+    const { isBtcSatsAmountUnit: shouldSendInSats } = useBitcoinAmountUnit(account?.symbol);
+
+    const { getAssetDecimals } = useTradingAssetDecimals();
+    const sellCryptoId = (trade?.data ?? selectedQuote)?.cryptoCurrency;
+    const decimals = getAssetDecimals({ accountKey: account?.key, cryptoId: sellCryptoId });
+
+    const isSlip24FeatureEnabled = useSelector(state =>
+        selectIsFeatureEnabled(state, Feature.trading.slip24, true),
+    );
+    const isSlip24ExperimentalFeatureEnabled = useSelector(selectHasExperimentalFeature('slip24'));
+    const isSlip24Active = useSelector(state =>
+        account
+            ? selectTradingIsSlip24Allowed(
+                  state,
+                  account,
+                  isSlip24FeatureEnabled && isSlip24ExperimentalFeatureEnabled,
+              )
+            : false,
+    );
+
+    const { getTradeRequestParams, handleSellTrade } = useTradingSellTradeRequest(account);
+
+    useEffect(() => {
+        dispatch(tradingThunks.loadInitialDataThunk({ activeSection: 'sell' }));
+    }, [dispatch]);
+
+    useEffect(() => {
+        if (!quotesRequest) {
+            dispatch(goto({ routeName: 'wallet-trading-sell' }));
+        }
+    }, [quotesRequest, dispatch]);
+
+    useEffect(() => {
+        if (isFromRedirect) {
+            if (transactionId && trade) {
+                dispatch(tradingSellActions.saveSelectedQuote(trade.data));
+                dispatch(tradingSellActions.setFormStep('SEND_TRANSACTION'));
+                if (trade.sendAccountKey) {
+                    dispatch(tradingSellActions.setTradingAccountKey(trade.sendAccountKey));
+                }
+            }
+
+            dispatch(tradingSellActions.setIsFromRedirect(false));
+        }
+    }, [isFromRedirect, trade, transactionId, dispatch]);
+
+    const confirmTrade = async (bankAccount: BankAccount) => {
+        if (!selectedQuote || !account) return;
+
+        const quote = { ...selectedQuote, bankAccount };
+        const commonFunctions = await getTradeRequestParams(quote);
+
+        if (!commonFunctions) return;
+
+        const { returnUrl, processResponseData } = commonFunctions;
+
+        const triggerAnalyticsTradeConfirmation = () => {
+            analytics.report({
+                type: events.tradeConfirmTradeEvent.name,
+                payload: { action: 'sell' },
+            });
+        };
+
+        await dispatch(
+            sellThunks.confirmTradeThunk({
+                account,
+                bankAccount,
+                returnUrl,
+                triggerAnalyticsTradeConfirmation,
+                processResponseData,
+            }),
+        );
+    };
+
+    const addBankAccount = async () => {
+        if (!selectedQuote) return;
+
+        await handleSellTrade(selectedQuote);
+    };
+
+    const sendTransaction = async () => {
+        if (!account) return false;
+
+        const nextStep = () => {
+            dispatch(goto({ routeName: 'wallet-trading-sell-detail' }));
+        };
+
+        const signAndPushSendFormTransaction = async ({
+            formState,
+            precomposedTransaction,
+            selectedAccount,
+            paymentRequests,
+        }: TradingSignAndPushSendFormTransactionProps) =>
+            await dispatch(
+                signAndPushSendFormTransactionThunk({
+                    formState,
+                    precomposedTransaction,
+                    selectedAccount,
+                    paymentRequests,
+                }),
+            ).unwrap();
+
+        try {
+            await dispatch(
+                sellThunks.sendTransactionThunk({
+                    account,
+                    trade: trade?.data,
+                    shouldSendInSats,
+                    decimals,
+                    // TODO: slip24 - exclude from debug mode
+                    isSlip24Active,
+                    nextStep,
+                    signAndPushSendFormTransaction,
+                }),
+            ).unwrap();
+
+            return true;
+        } catch (e) {
+            if (!isSendRejectedError<TranslationKey>(e)) {
+                return false;
+            }
+
+            if (e.type !== 'sign-transaction-timeout') {
+                dispatch(
+                    notificationsActions.addToast({
+                        type: e.type,
+                        error: translationString(e.error.id, e.error.values),
+                    }),
+                );
+            }
+
+            return false;
+        }
+    };
+
+    const isConfirmDisabled = isLoading || !selectedQuote || !account;
+
+    return {
+        selectedQuote,
+        sellInfo,
+        account,
+        device,
+        trade,
+        isLoading,
+        isConfirmDisabled,
+        confirmTrade,
+        addBankAccount,
+        sendTransaction,
+    };
+};
+
+export type TradingSellConfirmValues = ReturnType<typeof useTradingSellConfirm>;

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -2,7 +2,6 @@ import type React from 'react';
 import type { FieldPath, UseFormReturn } from 'react-hook-form';
 
 import type {
-    BankAccount,
     BuyTrade,
     BuyTradeQuoteRequest,
     CryptoId,
@@ -175,9 +174,6 @@ export interface TradingSellFormContextProps
     composeRequest: SendContextValues<TradingSellExchangeFormProps>['composeTransaction'];
     setAmountLimits: (limits?: AmountLimitProps) => void;
 
-    addBankAccount: () => void;
-    confirmTrade: (bankAccount: BankAccount) => void;
-    sendTransaction: () => Promise<boolean>;
     selectQuote: (quote: SellFiatTrade) => void;
     onQuoteSelected: (quote: SellFiatTrade) => void;
     methods: UseFormReturn<TradingSellFormProps>;
@@ -384,10 +380,6 @@ export interface TradingOfferBuyProps {
     selectedQuote: BuyTrade;
     isConfirmDisabled: boolean;
     confirmTrade: () => Promise<BuyTrade | undefined>;
-}
-
-export interface TradingOfferSellProps extends TradingOfferCommonProps {
-    selectedQuote: SellFiatTrade;
 }
 
 export interface TradingOfferExchangeProps extends Omit<

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSell.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSell.tsx
@@ -1,13 +1,22 @@
 import { Fragment, type JSX } from 'react';
 
-import { type TradingSellType, selectTradingSellFormStep } from '@suite-common/trading';
+import styled from 'styled-components';
+
+import {
+    selectTradingComposedTransactionInfo,
+    selectTradingSellActiveTrade,
+    selectTradingSellFormStep,
+    selectTradingSellInfo,
+    selectTradingSellQuotesRequest,
+    selectTradingSellSelectedQuote,
+} from '@suite-common/trading';
 import { selectAccounts } from '@suite-common/wallet-core';
-import { Card, Divider } from '@trezor/components';
-import { spacings } from '@trezor/theme';
+import { Card, Column, Divider } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
-import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
-import { type TradingOfferSellProps } from 'src/types/trading/tradingForm';
+import { type TradingSellConfirmValues } from 'src/hooks/wallet/trading/useTradingSellConfirm';
+import { type TradingGetCryptoQuoteAmountProps } from 'src/types/trading/trading';
+import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
 import { TradingOfferSellBankAccount } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellBankAccount';
 import { TradingSelectedOfferSellTransaction } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellTransaction';
 import { TradingSelectedOfferInfo } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo';
@@ -15,13 +24,39 @@ import {
     TradingSelectedOfferStepper,
     type TradingSelectedOfferStepperItemProps,
 } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferStepper';
+import { TradingWrapper } from 'src/views/wallet/trading/common/TradingWrapper';
 
-export const TradingOfferSell = (props: TradingOfferSellProps) => {
+const Wrapper = styled.div`
+    ${TradingWrapper}
+`;
+
+interface TradingOfferSellProps {
+    confirm: TradingSellConfirmValues;
+}
+
+export const TradingOfferSell = ({ confirm }: TradingOfferSellProps) => {
     const accounts = useSelector(selectAccounts);
     const formStep = useSelector(selectTradingSellFormStep);
-    const { trade } = useTradingFormContext<TradingSellType>();
+    const selectedQuote = useSelector(selectTradingSellSelectedQuote);
+    const sellInfo = useSelector(selectTradingSellInfo);
+    const quotesRequest = useSelector(selectTradingSellQuotesRequest);
+    const { composed } = useSelector(selectTradingComposedTransactionInfo);
+    const trade = useSelector(selectTradingSellActiveTrade);
 
     const sendAccount = accounts.find(account => account.key === trade?.sendAccountKey);
+    const selectedTrade = trade?.data ?? selectedQuote;
+    const isDeviceDisconnected = !confirm.device?.connected;
+
+    if (!selectedTrade) return null;
+
+    const quoteAmounts: TradingGetCryptoQuoteAmountProps = {
+        amountInCrypto: quotesRequest?.amountInCrypto,
+        sendAmount: selectedTrade.fiatStringAmount ?? '',
+        sendCurrency: selectedTrade.fiatCurrency,
+        receiveAmount: selectedTrade.cryptoStringAmount ?? '',
+        receiveCurrency: selectedTrade.cryptoCurrency,
+        networkFee: composed?.fee,
+    };
 
     const steps: (TradingSelectedOfferStepperItemProps & {
         component: JSX.Element | null;
@@ -30,28 +65,40 @@ export const TradingOfferSell = (props: TradingOfferSellProps) => {
             step: 'BANK_ACCOUNT',
             translationId: 'TR_SELL_BANK_ACCOUNT_STEP',
             isActive: formStep === 'BANK_ACCOUNT',
-            component: <TradingOfferSellBankAccount />,
+            component: <TradingOfferSellBankAccount confirm={confirm} />,
         },
         {
             step: 'SEND_TRANSACTION',
             translationId: 'TR_SELL_CONFIRM_SEND_STEP',
             isActive: formStep === 'SEND_TRANSACTION',
-            component: <TradingSelectedOfferSellTransaction />,
+            component: <TradingSelectedOfferSellTransaction confirm={confirm} />,
         },
     ];
 
     return (
-        <>
-            <Card>
-                <TradingSelectedOfferStepper steps={steps} />
-                <Divider margin={{ top: spacings.lg, bottom: spacings.xl }} />
-                {steps.map((step, index) => (
-                    <Fragment key={index}>{step.isActive && step.component}</Fragment>
-                ))}
-            </Card>
-            <Card>
-                <TradingSelectedOfferInfo {...props} selectedAccount={sendAccount} />
-            </Card>
-        </>
+        <Column gap={16}>
+            {isDeviceDisconnected && <ConnectDeviceGenericPromo />}
+
+            <Wrapper data-testid="@trading/selected-offer">
+                <Card>
+                    <TradingSelectedOfferStepper steps={steps} />
+                    <Divider margin={{ top: 20, bottom: 24 }} />
+                    {steps.map((step, index) => (
+                        <Fragment key={index}>{step.isActive && step.component}</Fragment>
+                    ))}
+                </Card>
+                <Card>
+                    <TradingSelectedOfferInfo
+                        type="sell"
+                        selectedQuote={selectedTrade}
+                        providers={sellInfo?.providerInfos}
+                        quoteAmounts={quoteAmounts}
+                        paymentMethod={selectedTrade.paymentMethod}
+                        paymentMethodName={selectedTrade.paymentMethodName}
+                        selectedAccount={sendAccount}
+                    />
+                </Card>
+            </Wrapper>
+        </Column>
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellBankAccount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellBankAccount.tsx
@@ -4,41 +4,12 @@ import { type BankAccount } from 'invity-api';
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
-import { type TradingSellType, sellUtils } from '@suite-common/trading';
-import { Button, Icon, Row, Select } from '@trezor/components';
-import { fontWeights, spacingsPx, typography } from '@trezor/theme';
+import { sellUtils } from '@suite-common/trading';
+import { Button, Column, Divider, Icon, Row, Select, Text } from '@trezor/components';
+import { spacingsPx } from '@trezor/theme';
 
 import { QuestionTooltip } from 'src/components/suite';
-import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
-
-const Wrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    margin-top: ${spacingsPx.xs};
-`;
-
-const CardContent = styled.div`
-    display: flex;
-    flex-direction: column;
-    padding: ${spacingsPx.xl};
-`;
-
-const Label = styled.div`
-    display: flex;
-    align-items: center;
-    font-weight: ${fontWeights.medium};
-`;
-
-const StyledQuestionTooltip = styled(QuestionTooltip)`
-    padding-left: ${spacingsPx.xxxs};
-`;
-
-const CustomLabel = styled(Label)`
-    padding: ${spacingsPx.sm} 0;
-    color: ${({ theme }) => theme.contentSecondary};
-`;
-
-const LabelText = styled.div``;
+import { type TradingSellConfirmValues } from 'src/hooks/wallet/trading/useTradingSellConfirm';
 
 const SelectWrapper = styled.div`
     width: 100%;
@@ -47,83 +18,18 @@ const SelectWrapper = styled.div`
     .react-select__single-value {
         width: 100%;
     }
-`;
-
-const Option = styled.div`
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    padding: 0 0 0 ${spacingsPx.xxs};
-    width: 100%;
-`;
-
-const AccountInfo = styled.div`
-    display: flex;
-    flex-direction: column;
-    flex: 2;
-`;
-
-const AccountName = styled.div`
-    display: flex;
-    color: ${({ theme }) => theme.contentSecondary};
-`;
-
-const AccountNumber = styled.div`
-    display: flex;
-    font-weight: ${fontWeights.medium};
-`;
-
-const AccountVerified = styled.div`
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-    ${typography['body-xs']}
-    color: ${({ theme }) => theme.contentBrand};
-`;
-
-const AccountNotVerified = styled(AccountVerified)`
-    color: ${({ theme }) => theme.contentSecondary};
-`;
-
-const ButtonWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding-top: ${spacingsPx.lg};
-    border-top: 1px solid ${({ theme }) => theme.borderNeutral};
-    margin: ${spacingsPx.lg} 0;
-`;
-
-const RowWrapper = styled.div`
-    margin: ${spacingsPx.xxs} 0;
-    display: flex;
 
     .react-select__value-container {
         padding-right: ${spacingsPx.lg};
     }
 `;
 
-const Left = styled.div`
-    display: flex;
-    flex: 1;
-    justify-content: flex-start;
-    flex-wrap: wrap;
-`;
+interface TradingOfferSellBankAccountProps {
+    confirm: TradingSellConfirmValues;
+}
 
-const IconWrapper = styled.div`
-    flex: none;
-    margin-right: ${spacingsPx.xxxs};
-`;
-
-export const TradingOfferSellBankAccount = () => {
-    const {
-        form: {
-            state: { isFormLoading },
-        },
-        confirmTrade,
-        addBankAccount,
-        selectedQuote,
-    } = useTradingFormContext<TradingSellType>();
+export const TradingOfferSellBankAccount = ({ confirm }: TradingOfferSellBankAccountProps) => {
+    const { confirmTrade, addBankAccount, selectedQuote, isLoading } = confirm;
     const [bankAccount, setBankAccount] = useState<BankAccount | undefined>(
         selectedQuote?.bankAccounts ? selectedQuote?.bankAccounts[0] : undefined,
     );
@@ -133,17 +39,17 @@ export const TradingOfferSellBankAccount = () => {
     const { bankAccounts } = selectedQuote;
 
     return (
-        <Wrapper>
-            <CardContent>
-                <RowWrapper>
-                    <Left>
-                        <CustomLabel>
-                            <LabelText>
+        <Column margin={{ top: 8 }}>
+            <Column padding={24}>
+                <Row margin={{ vertical: 4 }}>
+                    <Row flex="1" flexWrap="wrap">
+                        <Row alignItems="center" gap={2} padding={{ vertical: 12 }}>
+                            <Text typographyStyle="body-md" color="contentSecondary">
                                 <Translation id="TR_SELL_BANK_ACCOUNT" />
-                            </LabelText>
-                            <StyledQuestionTooltip tooltip="TR_SELL_BANK_ACCOUNT_TOOLTIP" />
-                        </CustomLabel>
-                    </Left>
+                            </Text>
+                            <QuestionTooltip tooltip="TR_SELL_BANK_ACCOUNT_TOOLTIP" />
+                        </Row>
+                    </Row>
                     <Row alignItems="center">
                         <Button
                             intent="neutral"
@@ -155,8 +61,8 @@ export const TradingOfferSellBankAccount = () => {
                             <Translation id="TR_SELL_ADD_BANK_ACCOUNT" />
                         </Button>
                     </Row>
-                </RowWrapper>
-                <RowWrapper>
+                </Row>
+                <Row margin={{ vertical: 4 }}>
                     <SelectWrapper>
                         <Select
                             onChange={(selected: BankAccount) => {
@@ -167,44 +73,52 @@ export const TradingOfferSellBankAccount = () => {
                             options={bankAccounts}
                             minValueWidth={70}
                             formatOptionLabel={(option: BankAccount) => (
-                                <Option>
-                                    <AccountInfo>
-                                        <AccountName>{option.holder}</AccountName>
-                                        <AccountNumber>
+                                <Row alignItems="center" padding={{ left: 4 }} width="100%">
+                                    <Column flex="2">
+                                        <Text typographyStyle="body-md" color="contentSecondary">
+                                            {option.holder}
+                                        </Text>
+                                        <Text typographyStyle="body-md">
                                             {sellUtils.formatIban(option.bankAccount)}
-                                        </AccountNumber>
-                                    </AccountInfo>
+                                        </Text>
+                                    </Column>
                                     {option.verified ? (
-                                        <AccountVerified>
-                                            <IconWrapper>
-                                                <Icon intent="brand" size={15} name="check" />
-                                            </IconWrapper>
-                                            <Translation id="TR_SELL_BANK_ACCOUNT_VERIFIED" />
-                                        </AccountVerified>
+                                        <Row alignItems="center" justifyContent="flex-end" gap={2}>
+                                            <Icon intent="brand" size={15} name="check" />
+                                            <Text typographyStyle="body-xs" color="contentBrand">
+                                                <Translation id="TR_SELL_BANK_ACCOUNT_VERIFIED" />
+                                            </Text>
+                                        </Row>
                                     ) : (
-                                        <AccountNotVerified>
-                                            <Translation id="TR_SELL_BANK_ACCOUNT_NOT_VERIFIED" />
-                                        </AccountNotVerified>
+                                        <Row justifyContent="flex-end">
+                                            <Text
+                                                typographyStyle="body-xs"
+                                                color="contentSecondary"
+                                            >
+                                                <Translation id="TR_SELL_BANK_ACCOUNT_NOT_VERIFIED" />
+                                            </Text>
+                                        </Row>
                                     )}
-                                </Option>
+                                </Row>
                             )}
                             isDisabled={bankAccounts.length < 2}
                         />
                     </SelectWrapper>
-                </RowWrapper>
-            </CardContent>
-            <ButtonWrapper>
+                </Row>
+            </Column>
+            <Divider margin={{ top: 20 }} />
+            <Column alignItems="center" margin={{ vertical: 20 }}>
                 <Button
                     minWidth={200}
-                    isLoading={isFormLoading}
+                    isLoading={isLoading}
                     onClick={() => {
                         if (bankAccount) confirmTrade(bankAccount);
                     }}
-                    isDisabled={isFormLoading || !bankAccount}
+                    isDisabled={isLoading || !bankAccount}
                 >
                     <Translation id="TR_SELL_GO_TO_TRANSACTION" />
                 </Button>
-            </ButtonWrapper>
-        </Wrapper>
+            </Column>
+        </Column>
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellTransaction.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellTransaction.tsx
@@ -1,65 +1,27 @@
-import styled from 'styled-components';
-
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
-import type { TradingSellType } from '@suite-common/trading';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
-import { Button, Column, Spinner, Text } from '@trezor/components';
+import { Button, Column, Divider, Spinner, Text } from '@trezor/components';
 import { useAsyncClickHandler } from '@trezor/react-utils';
-import { spacings, spacingsPx, typography } from '@trezor/theme';
+import { spacings } from '@trezor/theme';
 
 import { AccountLabeling } from 'src/components/suite/labeling/AccountLabeling';
 import { useSelector } from 'src/hooks/suite';
-import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { type TradingSellConfirmValues } from 'src/hooks/wallet/trading/useTradingSellConfirm';
 import { useTradingWatchTrade } from 'src/hooks/wallet/trading/useTradingWatchTrade';
 
-const Wrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    margin-top: ${spacingsPx.sm};
-`;
+interface TradingSelectedOfferSellTransactionProps {
+    confirm: TradingSellConfirmValues;
+}
 
-const LabelText = styled.div`
-    ${typography['body-xs']}
-    color: ${({ theme }) => theme.contentSecondary};
-`;
-
-const Value = styled.div`
-    ${typography['body-md']}
-    color: ${({ theme }) => theme.contentPrimary};
-`;
-
-const ButtonWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding-top: ${spacingsPx.lg};
-    border-top: 1px solid ${({ theme }) => theme.borderNeutral};
-    margin: ${spacingsPx.lg} 0;
-`;
-
-const Row = styled.div`
-    margin: ${spacingsPx.xl};
-`;
-
-const Address = styled.div``;
-
-export const TradingSelectedOfferSellTransaction = () => {
+export const TradingSelectedOfferSellTransaction = ({
+    confirm,
+}: TradingSelectedOfferSellTransactionProps) => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { handleClick, disabled } = useAsyncClickHandler();
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
-    const {
-        device,
-        account,
-        form: {
-            state: { isFormLoading },
-        },
-        selectedQuote,
-        sellInfo,
-        sendTransaction,
-        trade,
-    } = useTradingFormContext<TradingSellType>();
+    const { device, account, selectedQuote, sellInfo, sendTransaction, trade, isLoading } = confirm;
 
     useTradingWatchTrade({
         account,
@@ -90,84 +52,94 @@ export const TradingSelectedOfferSellTransaction = () => {
         });
     };
 
-    return (
-        <Wrapper>
-            {status === 'SEND_CRYPTO' && destinationAddress ? (
-                <>
-                    <Row>
-                        <LabelText>
-                            <Translation id="TR_SELL_SEND_FROM" />
-                        </LabelText>
-                        <Value data-testid="@trading/form/verify/account">
-                            <AccountLabeling
-                                account={account}
-                                showAccountTypeBadge
-                                accountTypeBadgeSize="small"
-                            />
-                        </Value>
-                    </Row>
-                    <Row>
-                        <LabelText>
-                            <Translation id="TR_SELL_SEND_TO" values={{ providerName }} />
-                        </LabelText>
-                        <Value data-testid="@trading/form/verify/address">
-                            <Address>{destinationAddress}</Address>
-                        </Value>
-                    </Row>
-                    {destinationPaymentExtraId && (
-                        <Row>
-                            <LabelText>
-                                {destinationPaymentExtraIdDescription?.name ? (
-                                    <Translation
-                                        id="TR_SELL_EXTRA_FIELD"
-                                        values={{
-                                            extraFieldName:
-                                                destinationPaymentExtraIdDescription.name,
-                                        }}
-                                    />
-                                ) : (
-                                    <Translation id="DESTINATION_TAG" />
-                                )}
-                            </LabelText>
-                            <Value data-testid="@trading/form/verify/extra-id">
-                                <Address>{destinationPaymentExtraId}</Address>
-                            </Value>
-                        </Row>
-                    )}
+    const handleSendAndConfirmClick = () => handleClick(() => onConfirmAndSendClick());
 
-                    <ButtonWrapper>
-                        <Button
-                            minWidth={200}
-                            isLoading={isFormLoading || disabled}
-                            isDisabled={!device?.connected || isDiscoveryRunning || disabled}
-                            onClick={() => handleClick(() => onConfirmAndSendClick())}
-                            data-testid="@trading/offer/confirm-on-trezor-and-send"
-                        >
-                            <Translation id="TR_SELL_CONFIRM_ON_TREZOR_SEND" />
-                        </Button>
-                    </ButtonWrapper>
-                </>
-            ) : (
-                <Column
-                    alignItems="center"
-                    justifyContent="center"
-                    margin={{ horizontal: spacings.lg, vertical: spacings.xxxxl }}
+    if (status !== 'SEND_CRYPTO' || !destinationAddress) {
+        return (
+            <Column
+                alignItems="center"
+                justifyContent="center"
+                margin={{ horizontal: spacings.lg, vertical: spacings.xxxxl }}
+            >
+                <Spinner size={40} isDisabled={true} margin={{ bottom: spacings.xl }} />
+                <Text>
+                    <Translation
+                        id="TR_SELL_DETAIL_WAITING_FOR_SEND_CRYPTO"
+                        values={{ providerName }}
+                    />
+                </Text>
+                <Text intent="neutral" priority="secondary">
+                    <Translation
+                        id="TR_SELL_DETAIL_WAITING_FOR_SEND_CRYPTO_INFO"
+                        values={{ providerName }}
+                    />
+                </Text>
+            </Column>
+        );
+    }
+
+    return (
+        <Column margin={{ top: 12 }}>
+            <Column margin={24}>
+                <Text typographyStyle="body-xs" color="contentSecondary">
+                    <Translation id="TR_SELL_SEND_FROM" />
+                </Text>
+                <Column data-testid="@trading/form/verify/account">
+                    <AccountLabeling
+                        account={account}
+                        showAccountTypeBadge
+                        accountTypeBadgeSize="small"
+                    />
+                </Column>
+            </Column>
+            <Column margin={24}>
+                <Text typographyStyle="body-xs" color="contentSecondary">
+                    <Translation id="TR_SELL_SEND_TO" values={{ providerName }} />
+                </Text>
+                <Text
+                    typographyStyle="body-md"
+                    color="contentPrimary"
+                    data-testid="@trading/form/verify/address"
                 >
-                    <Spinner size={40} isDisabled={true} margin={{ bottom: spacings.xl }} />
-                    <Text>
-                        <Translation
-                            id="TR_SELL_DETAIL_WAITING_FOR_SEND_CRYPTO"
-                            values={{ providerName }}
-                        />
+                    {destinationAddress}
+                </Text>
+            </Column>
+            {destinationPaymentExtraId && (
+                <Column margin={24}>
+                    <Text typographyStyle="body-xs" color="contentSecondary">
+                        {destinationPaymentExtraIdDescription?.name ? (
+                            <Translation
+                                id="TR_SELL_EXTRA_FIELD"
+                                values={{
+                                    extraFieldName: destinationPaymentExtraIdDescription.name,
+                                }}
+                            />
+                        ) : (
+                            <Translation id="DESTINATION_TAG" />
+                        )}
                     </Text>
-                    <Text intent="neutral" priority="secondary">
-                        <Translation
-                            id="TR_SELL_DETAIL_WAITING_FOR_SEND_CRYPTO_INFO"
-                            values={{ providerName }}
-                        />
+                    <Text
+                        typographyStyle="body-md"
+                        color="contentPrimary"
+                        data-testid="@trading/form/verify/extra-id"
+                    >
+                        {destinationPaymentExtraId}
                     </Text>
                 </Column>
             )}
-        </Wrapper>
+
+            <Divider margin={{ top: 24, bottom: 24 }} />
+            <Column alignItems="center" margin={{ bottom: 24 }}>
+                <Button
+                    minWidth={200}
+                    isLoading={isLoading || disabled}
+                    isDisabled={isLoading || !device?.connected || isDiscoveryRunning || disabled}
+                    onClick={handleSendAndConfirmClick}
+                    data-testid="@trading/offer/confirm-on-trezor-and-send"
+                >
+                    <Translation id="TR_SELL_CONFIRM_ON_TREZOR_SEND" />
+                </Button>
+            </Column>
+        </Column>
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOffer.tsx
@@ -1,28 +1,13 @@
-import styled from 'styled-components';
-
 import { Card, Column } from '@trezor/components';
 
-import { useTradingDeviceDisconnected } from 'src/hooks/wallet/trading/form/common/useTradingDeviceDisconnected';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
-import {
-    type TradingOfferExchangeProps,
-    type TradingOfferSellProps,
-} from 'src/types/trading/tradingForm';
+import { type TradingOfferExchangeProps } from 'src/types/trading/tradingForm';
 import {
     getCryptoQuoteAmountProps,
-    getPaymentMethod,
     getProvidersInfoProps,
     isTradingExchangeContext,
-    isTradingSellContext,
 } from 'src/utils/wallet/trading/tradingTypingUtils';
-import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
 import { TradingOfferExchange } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange';
-import { TradingOfferSell } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSell';
-import { TradingWrapper } from 'src/views/wallet/trading/common/TradingWrapper';
-
-const Wrapper = styled.div`
-    ${TradingWrapper}
-`;
 
 export const TradingSelectedOffer = () => {
     const context = useTradingFormContext();
@@ -30,12 +15,9 @@ export const TradingSelectedOffer = () => {
     const providers = getProvidersInfoProps(context);
     const selectedTrade = trade?.data || selectedQuote;
 
-    const { tradingDeviceDisconnected } = useTradingDeviceDisconnected();
-
     if (!selectedTrade) return null;
 
     const quoteAmounts = getCryptoQuoteAmountProps(selectedTrade, context);
-    const paymentMethod = getPaymentMethod(selectedTrade, context);
 
     if (isTradingExchangeContext(context)) {
         return (
@@ -49,25 +31,6 @@ export const TradingSelectedOffer = () => {
                         quoteAmounts={quoteAmounts}
                     />
                 </Card>
-            </Column>
-        );
-    }
-
-    if (isTradingSellContext(context)) {
-        return (
-            <Column gap={16}>
-                {tradingDeviceDisconnected && <ConnectDeviceGenericPromo />}
-
-                <Wrapper data-testid="@trading/selected-offer">
-                    <TradingOfferSell
-                        account={account}
-                        selectedQuote={selectedTrade as TradingOfferSellProps['selectedQuote']}
-                        providers={providers}
-                        type={context.type}
-                        quoteAmounts={quoteAmounts}
-                        {...paymentMethod}
-                    />
-                </Wrapper>
             </Column>
         );
     }

--- a/packages/suite/src/views/wallet/trading/sell/TradingSellConfirm.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/TradingSellConfirm.tsx
@@ -1,29 +1,35 @@
-import { FormProvider } from 'react-hook-form';
+import {
+    selectTradingProviderByNameAndTradeType,
+    selectTradingSellSelectedQuote,
+} from '@suite-common/trading';
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { Column } from '@trezor/components';
 
-import { TradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
-import { useTradingSellForm } from 'src/hooks/wallet/trading/form/useTradingSellForm';
-import { getProvidersInfoProps } from 'src/utils/wallet/trading/tradingTypingUtils';
-import { getTradeProvider } from 'src/utils/wallet/trading/tradingUtils';
-import { TradingContainer } from 'src/views/wallet/trading/common/TradingContainer';
-import { TradingSelectedOffer } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOffer';
+import { useSelector } from 'src/hooks/suite';
+import { useTradingSellConfirm } from 'src/hooks/wallet/trading/useTradingSellConfirm';
+import { DiscoveryWarning } from 'src/views/wallet/staking/components/StakingDashboard/components/DiscoveryWarning';
+import { TradingFooter } from 'src/views/wallet/trading/common/TradingFooter/TradingFooter';
+import { useTradingPageHeader } from 'src/views/wallet/trading/common/TradingLayout/useTradingPageHeader';
+import { TradingOfferSell } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSell';
 
-const TradingSellConfirmLoaded = () => {
-    const tradingSellContextValues = useTradingSellForm({
-        pageType: 'confirm',
-    });
-
-    const provider = getTradeProvider({
-        trade: tradingSellContextValues.selectedQuote,
-        providerInfo: getProvidersInfoProps(tradingSellContextValues),
-    });
+export const TradingSellConfirm = () => {
+    const confirm = useTradingSellConfirm();
+    const selectedQuote = useSelector(selectTradingSellSelectedQuote);
+    const provider = useSelector(state =>
+        selectTradingProviderByNameAndTradeType(state, selectedQuote?.exchange, 'sell'),
+    );
+    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
+    useTradingPageHeader();
 
     return (
-        <TradingFormContext.Provider value={tradingSellContextValues}>
-            <FormProvider {...tradingSellContextValues.methods}>
-                <TradingContainer SectionComponent={TradingSelectedOffer} provider={provider} />
-            </FormProvider>
-        </TradingFormContext.Provider>
+        <>
+            {isDiscoveryRunning && (
+                <Column margin={{ bottom: 16 }}>
+                    <DiscoveryWarning />
+                </Column>
+            )}
+            <TradingOfferSell confirm={confirm} />
+            <TradingFooter provider={provider} />
+        </>
     );
 };
-
-export const TradingSellConfirm = () => <TradingSellConfirmLoaded />;

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -23,7 +23,7 @@ import { type BuyInfo, type TradingBuyState } from '../../reducers/buyReducer';
 import { type ExchangeInfo, exchangeInitialState } from '../../reducers/exchangeReducer';
 import { type SellInfo, sellInitialState } from '../../reducers/sellReducer';
 import { type TradingRootState, initialState } from '../../reducers/tradingCommonReducer';
-import type { TradingType } from '../../types';
+import type { TradingTransactionExchange, TradingTransactionSell, TradingType } from '../../types';
 import {
     type TradingRootStateWithDeviceAndAccounts,
     bestBuyQuotePerPaymentMethodProjection,
@@ -90,6 +90,7 @@ import {
     selectTradingQuotesPerPaymentMethodByType,
     selectTradingSelectedPaymentMethodByType,
     selectTradingSellAccountKey,
+    selectTradingSellActiveTrade,
     selectTradingSellAmountLimits,
     selectTradingSellFormStep,
     selectTradingSellInfo,
@@ -744,6 +745,44 @@ describe('tradingSelectors', () => {
 
     it('selectTradingTradeByOrderId should return undefined when orderId is not found', () => {
         expect(selectTradingTradeByOrderId(state, 'unknown_order')).toBeUndefined();
+    });
+
+    describe(selectTradingSellActiveTrade.name, () => {
+        const sellTrade: TradingTransactionSell = {
+            tradeType: 'sell',
+            key: 'sell1',
+            date: '2024-01-01T00:00:00.000Z',
+            data: { orderId: 'orderId1' },
+            sendAccountKey: undefined,
+        };
+        const exchangeTrade: TradingTransactionExchange = {
+            tradeType: 'exchange',
+            key: 'exchange1',
+            date: '2024-01-01T00:00:00.000Z',
+            data: { orderId: 'orderId2' },
+            sendAccountKey: undefined,
+        };
+        const buildState = (transactionId: string | undefined): TradingRootState => ({
+            wallet: {
+                trading: {
+                    ...initialState,
+                    sell: { ...initialState.sell, transactionId },
+                    trades: [sellTrade, exchangeTrade],
+                },
+            },
+        });
+
+        it('should return the sell trade matching the sell transactionId', () => {
+            expect(selectTradingSellActiveTrade(buildState('sell1'))).toEqual(sellTrade);
+        });
+
+        it.each([
+            ['a non-sell trade sharing the same key', 'exchange1'],
+            ['no active sell transactionId', undefined],
+            ['a transactionId matching no trade', 'unknown'],
+        ])('should return undefined for %s', (_, transactionId) => {
+            expect(selectTradingSellActiveTrade(buildState(transactionId))).toBeUndefined();
+        });
     });
 
     describe(selectTradingCoinInfoByCryptoId.name, () => {

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -52,6 +52,7 @@ import {
     type TradingPaymentMethodProps,
     type TradingSellPaymentMethodProps,
     type TradingTransaction,
+    type TradingTransactionSell,
     type TradingType,
 } from '../types';
 import {
@@ -900,6 +901,17 @@ export const selectTradingExchangeTransactionId = (state: TradingRootState) =>
 
 export const selectTradingSellTransactionId = (state: TradingRootState) =>
     state.wallet.trading.sell.transactionId;
+
+export const selectTradingSellActiveTrade = (
+    state: TradingRootState,
+): TradingTransactionSell | undefined => {
+    const transactionId = selectTradingSellTransactionId(state);
+
+    return selectTradingTrades(state).find(
+        (trade): trade is TradingTransactionSell =>
+            trade.tradeType === 'sell' && trade.key === transactionId,
+    );
+};
 
 export const selectTradingBuyTransactionId = (state: TradingRootState) =>
     state.wallet.trading.buy.transactionId;

--- a/suite-common/trading/src/thunks/sell/__tests__/sendSellTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/sendSellTransactionThunk.test.ts
@@ -12,7 +12,7 @@ import { invityAPI } from '../../../invityAPI';
 import { type TradingSellState, sellInitialState } from '../../../reducers/sellReducer';
 import { initialState } from '../../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../../reducers/tradingReducer';
-import { type TradingSellFormProps, type TradingTransactionSell } from '../../../types';
+import { type TradingTransactionSell } from '../../../types';
 import { sellUtilsFixtures } from '../../../utils/sell/__fixtures__/sellUtils';
 import { tradingThunks } from '../../common';
 import { sellThunks } from '../index';
@@ -85,11 +85,8 @@ describe('sendSellTransactionThunk', () => {
             sendAccountKey: mockAccountKey({ descriptor: 'xxx' }),
         };
         const mockNextStep = jest.fn();
-        const formValues = {
-            setMaxOutputId: undefined,
-        } as TradingSellFormProps;
 
-        return { store, account, trade, formValues, mockNextStep };
+        return { store, account, trade, mockNextStep };
     };
 
     describe('should return error', () => {
@@ -102,7 +99,7 @@ describe('sendSellTransactionThunk', () => {
                 { trade: { orderId: 'orderId', cryptoStringAmount: '1' } },
             ],
         ])('%s', async (_, tradeTest) => {
-            const { store, account, formValues, mockNextStep } = getMocks();
+            const { store, account, mockNextStep } = getMocks();
 
             jest.spyOn(invityAPI, 'doSellConfirm');
 
@@ -114,7 +111,6 @@ describe('sendSellTransactionThunk', () => {
                     },
                     decimals: getNetwork(account.symbol).decimals,
                     shouldSendInSats: false,
-                    formValues,
                     nextStep: mockNextStep,
                     signAndPushSendFormTransaction: jest.fn(),
                 }),
@@ -144,7 +140,7 @@ describe('sendSellTransactionThunk', () => {
             ['when payload contains error', { type: 'error', error: { id: 'TR_ERROR' } }],
             ['when payload is not successful', { success: false }],
         ])('%s', async (_, recomposeAndSignPayload) => {
-            const { store, account, formValues, trade, mockNextStep } = getMocks();
+            const { store, account, trade, mockNextStep } = getMocks();
 
             jest.spyOn(tradingThunks, 'recomposeAndSignTxThunk').mockImplementation(
                 createThunk(
@@ -162,7 +158,6 @@ describe('sendSellTransactionThunk', () => {
                     trade: { ...trade.data },
                     decimals: getNetwork(account.symbol).decimals,
                     shouldSendInSats: false,
-                    formValues,
                     nextStep: mockNextStep,
                     signAndPushSendFormTransaction: jest.fn(),
                 }),
@@ -208,7 +203,7 @@ describe('sendSellTransactionThunk', () => {
                 { id: 'TR_TRADING_INVALID_RESPONSE' },
             ],
         ])('%s', async (_, response, error) => {
-            const { store, account, formValues, trade, mockNextStep } = getMocks();
+            const { store, account, trade, mockNextStep } = getMocks();
 
             invityAPI.doSellConfirm = () => Promise.resolve(response as unknown as SellFiatTrade);
 
@@ -218,7 +213,6 @@ describe('sendSellTransactionThunk', () => {
                     trade: { ...trade.data },
                     decimals: getNetwork(account.symbol).decimals,
                     shouldSendInSats: false,
-                    formValues,
                     nextStep: mockNextStep,
                     signAndPushSendFormTransaction: jest.fn(),
                 }),
@@ -241,7 +235,7 @@ describe('sendSellTransactionThunk', () => {
     });
 
     it('should send transaction, save trade and call next step', async () => {
-        const { store, account, formValues, trade, mockNextStep } = getMocks();
+        const { store, account, trade, mockNextStep } = getMocks();
         const responseData = {
             ...trade.data,
             error: undefined,
@@ -257,7 +251,6 @@ describe('sendSellTransactionThunk', () => {
                 trade: { ...trade.data },
                 decimals: getNetwork(account.symbol).decimals,
                 shouldSendInSats: false,
-                formValues,
                 nextStep: mockNextStep,
                 signAndPushSendFormTransaction: jest.fn(),
             }),
@@ -283,7 +276,7 @@ describe('sendSellTransactionThunk', () => {
     });
 
     it('should send transaction, save trade and call next step with shouldSendInSats true', async () => {
-        const { store, account, formValues, trade, mockNextStep } = getMocks();
+        const { store, account, trade, mockNextStep } = getMocks();
         const responseData = {
             ...trade.data,
             error: undefined,
@@ -299,7 +292,6 @@ describe('sendSellTransactionThunk', () => {
                 trade: { ...trade.data },
                 decimals: getNetwork(account.symbol).decimals,
                 shouldSendInSats: true,
-                formValues,
                 nextStep: mockNextStep,
                 signAndPushSendFormTransaction: jest.fn(),
             }),
@@ -333,13 +325,6 @@ describe('sendSellTransactionThunk', () => {
                 ...getQuote(),
                 exchange: undefined,
             },
-            sellInfo: {
-                providerInfos: {
-                    cexdirect: {
-                        lockSendAmount: false,
-                    },
-                },
-            } as any,
         });
         const responseData = {
             ...trade.data,
@@ -356,9 +341,6 @@ describe('sendSellTransactionThunk', () => {
                 trade: undefined,
                 decimals: getNetwork(account.symbol).decimals,
                 shouldSendInSats: true,
-                formValues: {
-                    setMaxOutputId: 0,
-                } as TradingSellFormProps,
                 nextStep: mockNextStep,
                 signAndPushSendFormTransaction: jest.fn(),
             }),
@@ -370,62 +352,6 @@ describe('sendSellTransactionThunk', () => {
         expect(tradingState.modalAccountKey).toBe(account.key);
         expect(tradingThunks.recomposeAndSignTxThunk).toHaveBeenCalledTimes(1);
         expect(mockedRecomposeAndSignTxThunk.mock.calls[0][0].amount).toBe('1000000');
-        expect(mockedRecomposeAndSignTxThunk.mock.calls[0][0].setMaxOutputId).toBe(0);
-        expect(tradingState.trades).toEqual([
-            {
-                tradeType: 'sell',
-                date: dateISO,
-                data: {
-                    ...responseData,
-                },
-                key: responseData.orderId,
-                sendAccountKey: accountBtc.key,
-            },
-        ]);
-        expect(tradingState.sell.transactionId).toBe('orderId');
-        expect(mockNextStep).toHaveBeenCalledTimes(1);
-        expect(result.meta.requestStatus).toEqual('fulfilled');
-    });
-
-    it('should send transaction, save trade and call next step with fallback selectedQuote with set lockSendAmount', async () => {
-        const { store, account, trade, formValues, mockNextStep } = getMocks({
-            selectedQuote: getQuote(),
-            sellInfo: {
-                providerInfos: {
-                    cexdirect: {
-                        lockSendAmount: true,
-                    },
-                },
-            } as any,
-        });
-        const responseData = {
-            ...trade.data,
-            error: undefined,
-            status: 'SUBMITTED',
-            orderId: 'orderId',
-        } as SellFiatTrade;
-
-        invityAPI.doSellConfirm = () => Promise.resolve(responseData);
-
-        const result = await store.dispatch(
-            sellThunks.sendTransactionThunk({
-                account,
-                trade: undefined,
-                decimals: getNetwork(account.symbol).decimals,
-                shouldSendInSats: true,
-                formValues,
-                nextStep: mockNextStep,
-                signAndPushSendFormTransaction: jest.fn(),
-            }),
-        );
-        const tradingState = store.getState().wallet.trading;
-        const mockedRecomposeAndSignTxThunk =
-            tradingThunks.recomposeAndSignTxThunk as unknown as jest.Mock;
-
-        expect(tradingState.modalAccountKey).toBe(account.key);
-        expect(tradingThunks.recomposeAndSignTxThunk).toHaveBeenCalledTimes(1);
-        expect(mockedRecomposeAndSignTxThunk.mock.calls[0][0].amount).toBe('1000000');
-        expect(mockedRecomposeAndSignTxThunk.mock.calls[0][0].setMaxOutputId).toBeUndefined();
         expect(tradingState.trades).toEqual([
             {
                 tradeType: 'sell',

--- a/suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts
@@ -9,11 +9,9 @@ import { invityAPI } from '../../invityAPI';
 import { tradingSellActions } from '../../reducers/sellReducer';
 import { tradingActions } from '../../reducers/tradingCommonReducer';
 import {
-    selectTradingSellInfo,
     selectTradingSellProviders,
     selectTradingSellSelectedQuote,
 } from '../../selectors/tradingSelectors';
-import { type TradingSellFormProps } from '../../types';
 import { getTradingFormState } from '../../utils';
 import { tradingThunks } from '../common';
 import { buildRecomposeInputsFromTrade } from '../common/buildRecomposeInputsFromTrade';
@@ -24,7 +22,6 @@ export type SendSellTransactionThunkProps = {
     trade: SellFiatTrade | undefined;
     shouldSendInSats: boolean | undefined;
     decimals: number;
-    formValues: TradingSellFormProps;
     isSlip24Active?: boolean;
 
     nextStep: () => void;
@@ -39,7 +36,6 @@ export const sendSellTransactionThunk = createThunk(
             trade,
             shouldSendInSats,
             decimals,
-            formValues,
             isSlip24Active,
             nextStep,
             signAndPushSendFormTransaction,
@@ -47,13 +43,10 @@ export const sendSellTransactionThunk = createThunk(
         { dispatch, getState, rejectWithValue },
     ) => {
         const selectedQuote = selectTradingSellSelectedQuote(getState());
-        const sellInfo = selectTradingSellInfo(getState());
         const providers = selectTradingSellProviders(getState());
         const selectedTrade = trade ?? selectedQuote;
         // destinationAddress may be set by useTradingWatchTrade hook to the trade object
         const destinationAddress = selectedTrade?.destinationAddress ?? trade?.destinationAddress;
-        const lockSendAmount =
-            !!sellInfo?.providerInfos[selectedTrade?.exchange ?? '']?.lockSendAmount;
 
         dispatch(tradingActions.setModalAccountKey(account.key));
 
@@ -85,8 +78,6 @@ export const sendSellTransactionThunk = createThunk(
                 ...recomposeInputs,
                 isSlip24Active,
                 signAndPushSendFormTransaction,
-                // when lockSendAmount is true, the amount should not be recomputed based on the maximum balance.
-                setMaxOutputId: lockSendAmount ? undefined : formValues.setMaxOutputId,
                 tradingFormState,
             }),
         );

--- a/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
@@ -8,7 +8,6 @@ import { type MessageSystemRootState } from '@suite-common/message-system';
 import {
     type TradingFulfillValue,
     type TradingRootStateWithDeviceAndAccounts,
-    type TradingSellFormProps,
     type TradingSendRejectedProps,
     type TradingSignAndPushSendFormTransactionProps,
     cryptoIdToNetworkAndContractAddress,
@@ -218,7 +217,6 @@ export const useTradingTransaction = ({
                     sellThunks.sendTransactionThunk({
                         account: sendAccount,
                         trade: selectedQuote as SellFiatTrade,
-                        formValues: draft as TradingSellFormProps,
                         decimals,
                         shouldSendInSats,
                         isSlip24Active,


### PR DESCRIPTION
## Description

- Move sell confirm state and actions into `useTradingSellConfirm` instead of reusing the sell form context.
- Extract sell trade request and return URL preparation into `useTradingSellTradeRequest` for form and confirm flows.
- Read the active sell trade from selectors so redirect recovery can restore the selected quote and account on confirm.
- Update sell selected-offer components and send-transaction handling to work without confirm form values.
- Add focused tests for the sell confirm hook, sell trade request helper, active-trade selector, and send-transaction thunk.

## Notes for QA

- Sell flow has to work as before

## Related Issue

Resolve #29386

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/29386-remove-form-context-sell-confirm&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/29386-remove-form-context-sell-confirm&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/29386-remove-form-context-sell-confirm&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-06T15:22:05.202Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-06T15:20:20.472Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/29386-remove-form-context-sell-confirm/web/](https://dev.suite.sldev.cz/suite-web/feat/29386-remove-form-context-sell-confirm/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->