### PR TITLE
test(suite): refactor solana mock

### DIFF
--- a/packages/e2e-utils/src/index.ts
+++ b/packages/e2e-utils/src/index.ts
@@ -1,5 +1,7 @@
 export * from './currentsApi';
 export { BackendWebsocketServerMock } from './mocks/backendServer';
+export { SolanaRpcServerMock, PASSTHROUGH } from './mocks/solanaRpcServerMock';
+export type { SolanaRpcHandler } from './mocks/solanaRpcServerMock';
 export { DropboxMock } from './mocks/dropbox';
 export { GoogleMock } from './mocks/google';
 export { GitHubReporterBase, InitializationState } from './githubReporter/gitHubReporterBase';

--- a/packages/e2e-utils/src/mocks/solanaRpcServerMock.ts
+++ b/packages/e2e-utils/src/mocks/solanaRpcServerMock.ts
@@ -1,0 +1,176 @@
+import http from 'http';
+import { type WebSocket, WebSocketServer } from 'ws';
+
+import { getFreePort } from '@trezor/node-utils';
+
+/**
+ * Returned by a handler that wants the request forwarded to the upstream backend,
+ * mirroring an unmocked Solana JSON-RPC method.
+ */
+export const PASSTHROUGH = Symbol('passthrough');
+
+export type SolanaRpcHandler = (params: unknown[]) => unknown | typeof PASSTHROUGH;
+
+type JsonRpcRequest = { id?: number | string; method?: string; params?: unknown[] };
+
+/**
+ * Local Solana JSON-RPC backend used in e2e tests. Unlike Playwright's `page.route`, it intercepts
+ * at the network destination, so it also serves the blockchain-link worker running outside Chromium
+ * (desktop). Set it as a custom Solana backend via its `url`.
+ *
+ * - HTTP: mocked methods are answered from their handler, the rest are proxied to `upstreamUrl`.
+ * - WebSocket (same port): acknowledges `@solana/kit` subscriptions so `accountNotifications` resolve.
+ */
+export class SolanaRpcServerMock {
+    private readonly handlers = new Map<string, SolanaRpcHandler>();
+    private httpServer?: http.Server;
+    private subscriptionServer?: WebSocketServer;
+    private port?: number;
+    private nextSubscriptionId = 1;
+
+    constructor(private readonly upstreamUrl: string) {}
+
+    get url(): string {
+        if (this.port === undefined) {
+            throw new Error('SolanaRpcServerMock is not running');
+        }
+
+        return `http://localhost:${this.port}`;
+    }
+
+    setHandler(method: string, handler: SolanaRpcHandler): void {
+        this.handlers.set(method, handler);
+    }
+
+    async start(): Promise<void> {
+        [this.port] = await getFreePort();
+        this.httpServer = http.createServer((request, response) =>
+            this.handleHttpRequest(request, response),
+        );
+        this.subscriptionServer = new WebSocketServer({ server: this.httpServer });
+        this.subscriptionServer.on('connection', socket =>
+            socket.on('message', data => this.acknowledgeSubscription(socket, data)),
+        );
+
+        await new Promise<void>(resolve => this.httpServer!.listen(this.port, resolve));
+    }
+
+    dropConnections(): void {
+        this.subscriptionServer?.clients.forEach(client => client.terminate());
+    }
+
+    async stop(): Promise<void> {
+        this.subscriptionServer?.clients.forEach(client => client.terminate());
+        this.subscriptionServer?.close();
+        if (!this.httpServer) {
+            return;
+        }
+        // close() alone would hang on the worker's keep-alive sockets, so drop them explicitly
+        await new Promise<void>(resolve => {
+            this.httpServer!.close(() => resolve());
+            this.httpServer!.closeAllConnections();
+        });
+    }
+
+    private acknowledgeSubscription(socket: WebSocket, data: unknown) {
+        let message: JsonRpcRequest;
+        try {
+            message = JSON.parse(String(data));
+        } catch {
+            return;
+        }
+
+        const method = message.method ?? '';
+        if (method.endsWith('Unsubscribe')) {
+            socket.send(JSON.stringify({ jsonrpc: '2.0', id: message.id, result: true }));
+        } else if (method.endsWith('Subscribe')) {
+            socket.send(
+                JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: message.id,
+                    result: this.nextSubscriptionId++,
+                }),
+            );
+        }
+    }
+
+    private handleHttpRequest(request: http.IncomingMessage, response: http.ServerResponse) {
+        response.setHeader('access-control-allow-origin', '*');
+        response.setHeader('access-control-allow-headers', 'content-type');
+        response.setHeader('access-control-allow-methods', 'POST, OPTIONS');
+        if (request.method === 'OPTIONS') {
+            response.writeHead(204).end();
+
+            return;
+        }
+
+        const chunks: Buffer[] = [];
+        request.on('data', chunk => chunks.push(chunk));
+        request.on('end', () => this.respondToRpcCall(Buffer.concat(chunks), response));
+    }
+
+    private async respondToRpcCall(rawBody: Buffer, response: http.ServerResponse) {
+        let request: JsonRpcRequest;
+        try {
+            request = JSON.parse(rawBody.toString());
+        } catch {
+            response.writeHead(400).end();
+
+            return;
+        }
+
+        try {
+            const handler = request.method ? this.handlers.get(request.method) : undefined;
+            if (!handler) {
+                await this.proxyToUpstream(rawBody, response);
+
+                return;
+            }
+
+            const result = await handler(request.params ?? []);
+            if (result === PASSTHROUGH) {
+                await this.proxyToUpstream(rawBody, response);
+
+                return;
+            }
+            if (result === undefined) {
+                throw new Error(
+                    `Handler for "${request.method}" returned undefined; return PASSTHROUGH to proxy to upstream`,
+                );
+            }
+
+            this.sendJson(response, 200, { jsonrpc: '2.0', id: request.id, result });
+        } catch (error) {
+            if (response.headersSent) {
+                response.end();
+
+                return;
+            }
+            this.sendJson(response, 500, {
+                jsonrpc: '2.0',
+                id: request.id,
+                error: { code: -32603, message: String(error) },
+            });
+        }
+    }
+
+    private async proxyToUpstream(rawBody: Buffer, response: http.ServerResponse) {
+        try {
+            const upstreamResponse = await fetch(this.upstreamUrl, {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: rawBody.toString(),
+            });
+            response.writeHead(upstreamResponse.status, { 'content-type': 'application/json' });
+            response.end(await upstreamResponse.text());
+        } catch {
+            response.writeHead(502).end();
+        }
+    }
+
+    private sendJson(response: http.ServerResponse, status: number, body: unknown) {
+        const payload = JSON.stringify(body);
+        response.writeHead(status, { 'content-type': 'application/json' });
+        response.end(payload);
+    }
+}

--- a/suite/e2e/support/common.ts
+++ b/suite/e2e/support/common.ts
@@ -34,10 +34,19 @@ export function step(stepName?: string) {
     /* eslint-disable @typescript-eslint/no-unsafe-function-type */
     return function decorator(target: Function, context: ClassMethodDecoratorContext) {
         return function replacementMethod(this: any, ...args: any) {
-            const name = stepName || `${this.constructor.name + '.' + (context.name as string)}`;
-            const params = args.map((arg: any) => JSON.stringify(arg)).join(', '); // Serialize arguments
+            const result = target.call(this, ...args);
 
-            return test.step(`${name}(${params})`, async () => await target.call(this, ...args));
+            // Only wrap async results in test.step. Wrapping synchronous methods could introduce
+            // race conditions, so we return their result untouched.
+            if (result instanceof Promise) {
+                const name =
+                    stepName || `${this.constructor.name + '.' + (context.name as string)}`;
+                const params = args.map((arg: any) => JSON.stringify(arg)).join(', '); // Serialize arguments
+
+                return test.step(`${name}(${params})`, async () => await result);
+            }
+
+            return result;
         };
     };
     /* eslint-enable @typescript-eslint/no-unsafe-function-type */

--- a/suite/e2e/support/fixtures.ts
+++ b/suite/e2e/support/fixtures.ts
@@ -117,8 +117,11 @@ const test = suiteBaseTest.extend<Fixtures>({
         await use(blockbookMock);
         blockbookMock.stop();
     },
-    solanaStakingMock: async ({ page }, use) => {
-        await use(new SolanaStakingMock(page));
+    solanaStakingMock: async ({ target }, use) => {
+        const solanaStakingMock = new SolanaStakingMock(target);
+        await solanaStakingMock.start();
+        await use(solanaStakingMock);
+        await solanaStakingMock.stop();
     },
     tradingMock: async ({ page }, use) => {
         await use(new TradingMock(page));

--- a/suite/e2e/support/mocks/solanaStakingMock.ts
+++ b/suite/e2e/support/mocks/solanaStakingMock.ts
@@ -1,304 +1,166 @@
-import type { Page, Route } from '@playwright/test';
+import { PASSTHROUGH, SolanaRpcServerMock } from '@trezor/e2e-utils';
 
-import { solanaUrlPattern } from './tradingMock';
-import solSimulateTransactionResponse from '../../fixtures/staking/sol-simulate-stake-transaction.json';
-import transactionResponse from '../../fixtures/staking/sol-stake-transactionResponse.json';
+import solSimulateStakeTransaction from '../../fixtures/staking/sol-simulate-stake-transaction.json';
+import solStakeTransaction from '../../fixtures/staking/sol-stake-transactionResponse.json';
 import {
     SolanaStakingAccount,
     solStakingAccountDeactivating,
     solStakingAccountFirst,
 } from '../../fixtures/staking/sol-staking-accounts';
-import { step } from '../common';
+import { isDesktopProject, step } from '../common';
+import { PlaywrightTarget } from '../testExtends/suiteTestOptions';
 
-type JsonRequestBody = {
-    id?: number | string;
-    method?: string;
-    params?: unknown[];
-};
+const UPSTREAM_URL = 'https://sol.trezor.io/';
+const ACCOUNT_ADDRESS = '8NapsSamBA2jd8VR8SZw4aXSvSAHiskUZXaiYW1HxTGe';
+const STAKE_PROGRAM_ADDRESS = 'Stake11111111111111111111111111111111111111';
+const TRANSACTION_SIGNATURE =
+    '41ZJr1SqnXVXym6EKrvfELQWh4pPdPeUSrj1GvcPNq9eL7Dh7QyCQXS65yahU6QtoBBNnfEJNGQ7poWRe4Gbk2Zd';
 
-type SolanaRouteHandler = {
-    enabled: boolean;
-    predicate?: (params?: unknown[]) => boolean;
-    respond: (route: Route, body: JsonRequestBody) => Promise<void>;
-};
+// Frozen so stake warmup/withdraw/claim amounts stay deterministic; they depend on the relation
+// between a stake account's activation/deactivation epoch and the current epoch.
+const INITIAL_EPOCH = 864;
+const ACCOUNT_BALANCE_LAMPORTS = 1_000_000_000_000;
+const SLOTS_IN_EPOCH = 432000;
+const SLOT_INDEX = 376284;
 
-export type SolanaRouteHandlers = Record<SolanaRouteMethod, SolanaRouteHandler>;
-
-export type SolanaRouteMethod =
-    | 'getEpochInfo'
-    | 'getBalance'
-    | 'sendTransaction'
-    | 'simulateTransaction'
-    | 'getSignatureStatuses'
-    | 'getSignaturesForAddress'
-    | 'getTransaction'
-    | 'getProgramAccounts'
-    | 'getRecentPrioritizationFees'
-    | 'getFeeForMessage'
-    | 'getMinimumBalanceForRentExemption';
-
-const BASE_EPOCH = 864; // chosen based of our mocked program accounts activation/deactivation epochs
-
-export const fulfillWithResult = async (route: Route, body: JsonRequestBody, result: unknown) => {
-    await route.fulfill({
-        json: {
-            jsonrpc: '2.0',
-            id: body.id,
-            result,
-        },
-    });
-};
-
-const createDefaultHandlers = (): SolanaRouteHandlers => ({
-    // handler to freeze epoch info so stake warmup/withdraw/claim amount dont change over time
-    // their state is defined by relation between activationEpoch, deactivationEpoch and current epoch
-    getEpochInfo: {
-        enabled: true,
-        respond: async (route, body) => {
-            const slotIndex = 376284;
-            const slotsInEpoch = 432000;
-            await fulfillWithResult(route, body, {
-                absoluteSlot: BASE_EPOCH * slotsInEpoch + slotIndex,
-                blockHeight: 359120112,
-                epoch: BASE_EPOCH,
-                slotIndex,
-                slotsInEpoch,
-                transactionCount: 464794163561,
-            });
-        },
-    },
-    // handler to mock initial SOL balance for staking
-    getBalance: {
-        enabled: true,
-        predicate: params => params?.[0] === '8NapsSamBA2jd8VR8SZw4aXSvSAHiskUZXaiYW1HxTGe',
-        respond: async (route, body) => {
-            await fulfillWithResult(route, body, {
-                context: { slot: 0 },
-                value: 1_000_000_000_000,
-            });
-        },
-    },
-    //handlers for staking transaction flow
-    sendTransaction: {
-        enabled: true,
-        respond: async (route, body) => {
-            await fulfillWithResult(
-                route,
-                body,
-                '41ZJr1SqnXVXym6EKrvfELQWh4pPdPeUSrj1GvcPNq9eL7Dh7QyCQXS65yahU6QtoBBNnfEJNGQ7poWRe4Gbk2Zd',
-            );
-        },
-    },
-    simulateTransaction: {
-        enabled: true,
-        respond: async (route, body) => {
-            await fulfillWithResult(route, body, {
-                value: solSimulateTransactionResponse,
-            });
-        },
-    },
-    getSignatureStatuses: {
-        enabled: true,
-        respond: async (route, body) => {
-            await fulfillWithResult(route, body, {
-                value: [
-                    {
-                        slot: 48,
-                        confirmations: null,
-                        err: null,
-                        status: { Ok: null },
-                        confirmationStatus: 'finalized',
-                    },
-                ],
-            });
-        },
-    },
-    //handlers for finalizing staking transaction flow
-    getSignaturesForAddress: {
-        enabled: false,
-        predicate: params => params?.[0] === '8NapsSamBA2jd8VR8SZw4aXSvSAHiskUZXaiYW1HxTGe',
-        respond: async (route, body) => {
-            await fulfillWithResult(route, body, [
-                {
-                    blockTime: 1758796808,
-                    confirmationStatus: 'finalized',
-                    err: null,
-                    memo: null,
-                    signature:
-                        '41ZJr1SqnXVXym6EKrvfELQWh4pPdPeUSrj1GvcPNq9eL7Dh7QyCQXS65yahU6QtoBBNnfEJNGQ7poWRe4Gbk2Zd',
-                    slot: 369150991,
-                },
-            ]);
-        },
-    },
-    getTransaction: {
-        enabled: false,
-        predicate: params =>
-            params?.[0] ===
-            '41ZJr1SqnXVXym6EKrvfELQWh4pPdPeUSrj1GvcPNq9eL7Dh7QyCQXS65yahU6QtoBBNnfEJNGQ7poWRe4Gbk2Zd',
-        respond: async route => {
-            await route.fulfill({ json: transactionResponse });
-        },
-    },
-    //handler to mock stake account info, starts empty
-    getProgramAccounts: {
-        enabled: true,
-        predicate: params => params?.[0] === 'Stake11111111111111111111111111111111111111',
-        respond: async (route, body) => {
-            await fulfillWithResult(route, body, []);
-        },
-    },
-    getRecentPrioritizationFees: {
-        enabled: true,
-        respond: async (route, body) => {
-            await fulfillWithResult(route, body, [
-                {
-                    prioritizationFee: 0,
-                    slot: 394770899,
-                },
-            ]);
-        },
-    },
-    getFeeForMessage: {
-        enabled: true,
-        respond: async (route, body) => {
-            await fulfillWithResult(route, body, {
-                value: 5000,
-            });
-        },
-    },
-    getMinimumBalanceForRentExemption: {
-        enabled: true,
-        respond: async (route, body) => {
-            await fulfillWithResult(route, body, 2282880);
-        },
-    },
+const buildEpochInfo = (epoch: number) => ({
+    absoluteSlot: epoch * SLOTS_IN_EPOCH + SLOT_INDEX,
+    blockHeight: 359120112,
+    epoch,
+    slotIndex: SLOT_INDEX,
+    slotsInEpoch: SLOTS_IN_EPOCH,
+    transactionCount: 464794163561,
 });
 
-const hasEnabledHandler = (
-    handlers: SolanaRouteHandlers,
-    method: string,
-): method is keyof SolanaRouteHandlers =>
-    Object.hasOwn(handlers, method) &&
-    (handlers as Record<string, SolanaRouteHandler>)[method]?.enabled === true;
-
 export class SolanaStakingMock {
-    readonly handlers: SolanaRouteHandlers;
-    protected currentEpoch: number = BASE_EPOCH;
+    private readonly server = new SolanaRpcServerMock(UPSTREAM_URL);
+    private readonly balances = new Map<string, number>([
+        [ACCOUNT_ADDRESS, ACCOUNT_BALANCE_LAMPORTS],
+    ]);
+    private epoch = INITIAL_EPOCH;
+    private stakeAccounts: SolanaStakingAccount[] = [];
+    private simulatedTransaction: unknown = solSimulateStakeTransaction;
+    private transactionConfirmed = false;
+
     readonly stakeFeeFormatted = '0.002298742 SOL';
     readonly unstakeFeeFormatted = '0.000015862 SOL';
     readonly claimFeeFormatted = '0.000008605 SOL';
 
-    constructor(
-        private readonly page: Page,
-        handlers: SolanaRouteHandlers = createDefaultHandlers(),
-    ) {
-        this.handlers = handlers;
-    }
+    constructor(private target: PlaywrightTarget) {}
 
-    async routeSolana(routeHandlers: SolanaRouteHandlers = this.handlers) {
-        await this.page.route(solanaUrlPattern, route => this.handle(route, routeHandlers));
+    get url(): string {
+        return this.server.url;
     }
 
     @step()
-    enableRoutes(methods: SolanaRouteMethod[]) {
-        methods.forEach(method => {
-            this.getHandler(method).enabled = true;
-        });
+    async start() {
+        this.registerHandlers();
+        await this.server.start();
     }
 
     @step()
-    disableRoutes(methods: SolanaRouteMethod[]) {
-        methods.forEach(method => {
-            this.getHandler(method).enabled = false;
-        });
+    async stop() {
+        await this.server.stop();
     }
 
     @step()
-    enableRoutesForTransactions() {
-        // necessary routes for sending and finalizing transactions
-        // cannot be enabled during discovery as they would interfere with it
-        this.enableRoutes(['getTransaction', 'getSignaturesForAddress']);
+    setBalance(address: string, lamports: number) {
+        this.balances.set(address, lamports);
     }
 
     @step()
-    async replaceRoute(method: SolanaRouteMethod, overrides: Partial<SolanaRouteHandler>) {
-        this.handlers[method] = {
-            ...this.getHandler(method),
-            ...overrides,
-        };
-        await this.routeSolana();
+    setStakeAccounts(accounts: SolanaStakingAccount[]) {
+        this.stakeAccounts = accounts;
     }
 
     @step()
-    async setProgramAccounts(accounts: SolanaStakingAccount[]) {
-        await this.replaceRoute('getProgramAccounts', {
-            respond: async (route, body) => {
-                await fulfillWithResult(route, body, accounts);
-            },
-        });
+    setEpoch(epoch: number) {
+        this.applyEpoch(epoch);
     }
 
     @step()
-    async setEpoch(epoch: number) {
-        const slotIndex = 376284;
-        const slotsInEpoch = 432000;
-        await this.replaceRoute('getEpochInfo', {
-            respond: async (route, body) => {
-                await fulfillWithResult(route, body, {
-                    absoluteSlot: epoch * slotsInEpoch + slotIndex,
-                    blockHeight: 359120112,
-                    epoch,
-                    slotIndex,
-                    slotsInEpoch,
-                    transactionCount: 464794163561,
-                });
-            },
-        });
-        this.currentEpoch = epoch;
+    advanceEpoch() {
+        this.applyEpoch(this.epoch + 1);
     }
 
-    @step()
-    async advanceEpoch() {
-        await this.setEpoch(this.currentEpoch + 1);
-    }
-
-    private getHandler(method: SolanaRouteMethod): SolanaRouteHandler {
-        if (!this.handlers[method]) {
-            throw new Error(`Unknown Solana route method: ${method}`);
+    private applyEpoch(epoch: number) {
+        this.epoch = epoch;
+        // Terminating all connections forces a restart of a worker with clean cache (which includes epoch)
+        if (isDesktopProject(this.target)) {
+            this.server.dropConnections();
         }
-
-        return this.handlers[method];
     }
 
-    private async handle(route: Route, routeHandlers: SolanaRouteHandlers) {
-        const body = route.request().postDataJSON() as JsonRequestBody;
-        const { method } = body;
-        // Continue if no handler is enabled for intercepted request's method
-        if (!method || !hasEnabledHandler(routeHandlers, method)) {
-            return route.continue();
-        }
-
-        const methodHandler = routeHandlers[method];
-        // Continue if predicate does not match intercepted request's params
-        if (methodHandler.predicate && !methodHandler.predicate(body.params)) {
-            return route.continue();
-        }
-
-        await methodHandler.respond(route, body);
+    // Makes the broadcasted transaction discoverable, simulating its on-chain confirmation. Kept off
+    // during discovery, where a phantom signature would be mistaken for existing account history.
+    @step()
+    confirmTransaction() {
+        this.transactionConfirmed = true;
     }
 
     @step()
-    async setupStakedAccount() {
-        await this.setProgramAccounts([solStakingAccountFirst.payload]);
-        const epochAfterActivation = solStakingAccountFirst.activationEpoch + 1;
-        await this.setEpoch(epochAfterActivation);
+    setSimulatedTransaction(simulation: unknown) {
+        this.simulatedTransaction = simulation;
     }
 
     @step()
-    async setupUnstakingAccount() {
-        await this.setProgramAccounts([solStakingAccountDeactivating.payload]);
-        const { deactivationEpoch } = solStakingAccountDeactivating;
-        await this.setEpoch(deactivationEpoch);
+    setupStakedAccount() {
+        this.setStakeAccounts([solStakingAccountFirst.payload]);
+        this.setEpoch(solStakingAccountFirst.activationEpoch + 1);
+    }
+
+    @step()
+    setupUnstakingAccount() {
+        this.setStakeAccounts([solStakingAccountDeactivating.payload]);
+        this.setEpoch(solStakingAccountDeactivating.deactivationEpoch);
+    }
+
+    private registerHandlers() {
+        this.server.setHandler('getEpochInfo', () => buildEpochInfo(this.epoch));
+        this.server.setHandler('getBalance', ([address]) => {
+            const lamports = this.balances.get(String(address));
+
+            return lamports === undefined ? PASSTHROUGH : { context: { slot: 0 }, value: lamports };
+        });
+        this.server.setHandler('getProgramAccounts', ([programAddress]) =>
+            programAddress === STAKE_PROGRAM_ADDRESS ? this.stakeAccounts : PASSTHROUGH,
+        );
+        this.server.setHandler('simulateTransaction', () => ({ value: this.simulatedTransaction }));
+        this.server.setHandler('sendTransaction', () => TRANSACTION_SIGNATURE);
+        this.server.setHandler('getSignatureStatuses', () => ({
+            value: [
+                {
+                    slot: 48,
+                    confirmations: null,
+                    err: null,
+                    status: { Ok: null },
+                    confirmationStatus: 'finalized',
+                },
+            ],
+        }));
+        this.server.setHandler('getRecentPrioritizationFees', () => [
+            { prioritizationFee: 0, slot: 394770899 },
+        ]);
+        this.server.setHandler('getFeeForMessage', () => ({ value: 5000 }));
+        this.server.setHandler('getMinimumBalanceForRentExemption', () => 2282880);
+        this.server.setHandler('getSignaturesForAddress', ([address]) =>
+            this.transactionConfirmed && address === ACCOUNT_ADDRESS
+                ? [
+                      {
+                          blockTime: 1758796808,
+                          confirmationStatus: 'finalized',
+                          err: null,
+                          memo: null,
+                          signature: TRANSACTION_SIGNATURE,
+                          slot: 369150991,
+                      },
+                  ]
+                : PASSTHROUGH,
+        );
+        this.server.setHandler('getTransaction', ([signature]) =>
+            this.transactionConfirmed && signature === TRANSACTION_SIGNATURE
+                ? solStakeTransaction
+                : PASSTHROUGH,
+        );
     }
 }

--- a/suite/e2e/support/pageObjects/settings/coinsTab.ts
+++ b/suite/e2e/support/pageObjects/settings/coinsTab.ts
@@ -20,7 +20,7 @@ export class CoinsTab {
         this.page.getByTestId(`@settings/wallet/network/${symbol}/advance`);
     readonly coinBackendSelector: Locator;
     readonly coinBackendSelectorOption = (backend: BackendType) =>
-        this.page.getByTestId(`@settings/advance/${backend}`);
+        this.page.getByTestId(`@settings/advance/select-type/option/${backend}`);
     readonly coinAddressInput: Locator;
     readonly coinAdvanceSettingSaveButton: Locator;
     readonly modal: Locator;

--- a/suite/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/suite/e2e/support/pageObjects/settings/settingsPage.ts
@@ -1,7 +1,7 @@
 import { Locator, Page, test } from '@playwright/test';
 
 import type { LabelingSelectValue } from '@suite/labeling';
-import type { NetworkSymbol } from '@suite-common/wallet-config';
+import type { BackendType, NetworkSymbol } from '@suite-common/wallet-config';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
@@ -272,6 +272,21 @@ export class SettingsPage {
             await this.coinsTab.disableNetwork(network);
         }
 
+        await this.coinsTab.activateCoinsButton.click();
+        await this.page.discoveryShouldFinish();
+    }
+
+    @step()
+    async enableNetworkWithCustomBackend(
+        symbol: NetworkSymbol,
+        backendType: BackendType,
+        backendUrl: string,
+    ) {
+        await this.navigateTo('coins');
+        await this.coinsTab.enableNetwork(symbol);
+        await this.coinsTab.openNetworkAdvanceSettings(symbol);
+        await this.coinsTab.changeBackend(backendType, backendUrl);
+        await expect(this.coinsTab.modal).toBeHidden();
         await this.coinsTab.activateCoinsButton.click();
         await this.page.discoveryShouldFinish();
     }

--- a/suite/e2e/support/pageObjects/staking/stakingSection.ts
+++ b/suite/e2e/support/pageObjects/staking/stakingSection.ts
@@ -210,8 +210,16 @@ export class StakingSection {
                 await this.page.clock.fastForward(options.fastForward);
             }
 
-            const getStatus = async (locator: Locator) =>
-                (await locator.isVisible()) ? locator.innerText() : 'hidden';
+            const getStatus = async (locator: Locator) => {
+                if ((await locator.count()) === 0) return 'hidden';
+                try {
+                    return await locator.innerText({ timeout: 100 });
+                } catch (error) {
+                    // Unmounted mid-read -> 'hidden'; any other error must surface.
+                    if ((await locator.count()) === 0) return 'hidden';
+                    throw error;
+                }
+            };
 
             const [pending, staked, rewards, unstaking] = await Promise.all([
                 getStatus(this.pendingAmount),

--- a/suite/e2e/tests/staking/sol/initial-stake.test.ts
+++ b/suite/e2e/tests/staking/sol/initial-stake.test.ts
@@ -8,7 +8,7 @@ import { createTestAnnotation } from '../../../support/reporters/annotations';
 const stakedAmount = solStakingAccountFirst.stakeInSol;
 const stakedAndRentFormatted = `${solStakingAccountFirst.stakeAndRentInSol} SOL`;
 
-test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+test.describe('sol staking', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({
         deviceSetup: {
             mnemonic: 'access juice claim special truth ugly swarm rabbit hair man error bar',
@@ -16,9 +16,8 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
     });
 
     test.beforeEach(async ({ onboardingPage, settingsPage, solanaStakingMock }) => {
-        await solanaStakingMock.routeSolana();
         await onboardingPage.completeOnboarding();
-        await settingsPage.changeNetworks({ enableNetworks: ['sol'] });
+        await settingsPage.enableNetworkWithCustomBackend('sol', 'solana', solanaStakingMock.url);
     });
 
     test(
@@ -102,8 +101,8 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
             });
 
             await test.step('Stake', async () => {
-                solanaStakingMock.enableRoutesForTransactions();
-                await solanaStakingMock.setProgramAccounts([solStakingAccountFirst.payload]);
+                solanaStakingMock.confirmTransaction();
+                solanaStakingMock.setStakeAccounts([solStakingAccountFirst.payload]);
                 await devicePrompt.sendButton.click();
                 await expect(stakingSection.stakedToastAccount).toContainText('Solana #1');
                 await expect(stakingSection.stakedToastAmount).toContainText(
@@ -126,7 +125,7 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
             });
 
             await test.step('Wait an epoch and amount moved from pending to staked', async () => {
-                await solanaStakingMock.advanceEpoch();
+                solanaStakingMock.advanceEpoch();
                 await page.clock.fastForward(stakingSection.solanaEpochCachePeriod);
                 await stakingSection.expectStakingAmounts({
                     expected: {

--- a/suite/e2e/tests/staking/sol/rewards.test.ts
+++ b/suite/e2e/tests/staking/sol/rewards.test.ts
@@ -22,7 +22,7 @@ const stakingAccountTotal = new BigNumber(
 const stakingAccountTotalFormatted = `${stakingAccountTotal}… SOL`;
 const totalRewardsInSol = (Number(totalReward.response.total) / 1_000_000_000).toFixed(9);
 
-test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+test.describe('sol staking', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({
         deviceSetup: {
             mnemonic: 'access juice claim special truth ugly swarm rabbit hair man error bar',
@@ -30,14 +30,14 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
     });
 
     test.beforeEach(async ({ onboardingPage, settingsPage, solanaStakingMock }) => {
-        await solanaStakingMock.setProgramAccounts([
+        solanaStakingMock.setStakeAccounts([
             solStakingAccountFirst.payload,
             solStakingAccountSecond.payload,
             solStakingAccountDeactivating.payload,
         ]);
-        await solanaStakingMock.setEpoch(solStakingAccountDeactivating.deactivationEpoch);
+        solanaStakingMock.setEpoch(solStakingAccountDeactivating.deactivationEpoch);
         await onboardingPage.completeOnboarding();
-        await settingsPage.changeNetworks({ enableNetworks: ['sol'] });
+        await settingsPage.enableNetworkWithCustomBackend('sol', 'solana', solanaStakingMock.url);
     });
 
     test(
@@ -50,7 +50,7 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                 stream: TestStream.Trends,
             }),
         },
-        async ({ page, walletPage, tradingPage, stakingSection, solanaStakingMock }) => {
+        async ({ page, walletPage, tradingPage, stakingSection }) => {
             await test.step('Check staking dashboard', async () => {
                 await page.clock.install();
                 await walletPage.openAccount({ symbol: 'sol', type: 'normal', atIndex: 0 });
@@ -74,7 +74,7 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                 await expect(stakingSection.stakeMoreButton).toBeEnabled();
             });
 
-            await test.step('Mock rewards and advance epoch', async () => {
+            await test.step('Mock rewards and expire the rewards query cache', async () => {
                 await page.route(rewards.url, async route => {
                     const url = new URL(route.request().url());
                     const limit = Number(url.searchParams.get('limit') ?? 10);
@@ -91,7 +91,6 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                 await page.route(totalReward.url, async route => {
                     await route.fulfill({ json: totalReward.response });
                 });
-                await solanaStakingMock.advanceEpoch();
                 await page.clock.fastForward(stakingSection.solanaEpochCachePeriod);
             });
 

--- a/suite/e2e/tests/staking/sol/stake-more.test.ts
+++ b/suite/e2e/tests/staking/sol/stake-more.test.ts
@@ -1,12 +1,11 @@
 import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 
-import solSimulateStakeTransactionResponse from '../../../fixtures/staking/sol-simulate-stake-more-transaction.json';
+import solSimulateStakeMoreTransaction from '../../../fixtures/staking/sol-simulate-stake-more-transaction.json';
 import {
     solStakingAccountFirst,
     solStakingAccountSecond,
 } from '../../../fixtures/staking/sol-staking-accounts';
 import { expect, test } from '../../../support/fixtures';
-import { fulfillWithResult } from '../../../support/mocks/solanaStakingMock';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 // Expected values based on our mocked responses
@@ -15,7 +14,7 @@ const stakeMoreAmount = solStakingAccountSecond.stakeInSol;
 const stakeMoreAndRentFormatted = `${solStakingAccountSecond.stakeAndRentInSol} SOL`;
 const totalStakedAmount = (Number(stakedAmount) + Number(stakeMoreAmount)).toFixed(9);
 
-test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+test.describe('sol staking', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({
         deviceSetup: {
             mnemonic: 'access juice claim special truth ugly swarm rabbit hair man error bar',
@@ -23,18 +22,11 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
     });
 
     test.beforeEach(async ({ onboardingPage, settingsPage, solanaStakingMock }) => {
-        await solanaStakingMock.setupStakedAccount();
-        await solanaStakingMock.setEpoch(solStakingAccountSecond.activationEpoch);
-        // Mock simulate stake-more transaction response
-        await solanaStakingMock.replaceRoute('simulateTransaction', {
-            respond: async (route, body) => {
-                await fulfillWithResult(route, body, {
-                    value: solSimulateStakeTransactionResponse,
-                });
-            },
-        });
+        solanaStakingMock.setupStakedAccount();
+        solanaStakingMock.setEpoch(solStakingAccountSecond.activationEpoch);
+        solanaStakingMock.setSimulatedTransaction(solSimulateStakeMoreTransaction);
         await onboardingPage.completeOnboarding();
-        await settingsPage.changeNetworks({ enableNetworks: ['sol'] });
+        await settingsPage.enableNetworkWithCustomBackend('sol', 'solana', solanaStakingMock.url);
     });
 
     test(
@@ -121,8 +113,8 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
             });
 
             await test.step('Stake', async () => {
-                solanaStakingMock.enableRoutesForTransactions();
-                await solanaStakingMock.setProgramAccounts([
+                solanaStakingMock.confirmTransaction();
+                solanaStakingMock.setStakeAccounts([
                     solStakingAccountFirst.payload,
                     solStakingAccountSecond.payload,
                 ]);
@@ -148,7 +140,7 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
             });
 
             await test.step('Wait an epoch and amount moved from pending to staked', async () => {
-                await solanaStakingMock.advanceEpoch();
+                solanaStakingMock.advanceEpoch();
                 await page.clock.fastForward(stakingSection.solanaEpochCachePeriod);
                 await stakingSection.expectStakingAmounts({
                     expected: {

--- a/suite/e2e/tests/staking/sol/unstake.test.ts
+++ b/suite/e2e/tests/staking/sol/unstake.test.ts
@@ -1,13 +1,12 @@
 import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 
-import solSimulateClaimTransactionResponse from '../../../fixtures/staking/sol-simulate-claim-transaction.json';
-import solSimulateUnstakeTransactionResponse from '../../../fixtures/staking/sol-simulate-unstake-transaction.json';
+import solSimulateClaimTransaction from '../../../fixtures/staking/sol-simulate-claim-transaction.json';
+import solSimulateUnstakeTransaction from '../../../fixtures/staking/sol-simulate-unstake-transaction.json';
 import {
     solStakingAccountDeactivating,
     solStakingAccountFirst,
 } from '../../../fixtures/staking/sol-staking-accounts';
 import { expect, test } from '../../../support/fixtures';
-import { fulfillWithResult } from '../../../support/mocks/solanaStakingMock';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 // Expected values based on our mocked responses
@@ -17,7 +16,7 @@ const unstakingAmount = solStakingAccountDeactivating.stakeInSol;
 const unstakingAmountFormatted = `${unstakingAmount} SOL`;
 const unstakingAndRentFormatted = `${solStakingAccountDeactivating.stakeAndRentInSol} SOL`;
 
-test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+test.describe('sol staking', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({
         deviceSetup: {
             mnemonic: 'access juice claim special truth ugly swarm rabbit hair man error bar',
@@ -25,17 +24,10 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
     });
 
     test.beforeEach(async ({ onboardingPage, settingsPage, solanaStakingMock }) => {
-        await solanaStakingMock.setupStakedAccount();
-        // Mock simulate unstake transaction response
-        await solanaStakingMock.replaceRoute('simulateTransaction', {
-            respond: async (route, body) => {
-                await fulfillWithResult(route, body, {
-                    value: solSimulateUnstakeTransactionResponse,
-                });
-            },
-        });
+        solanaStakingMock.setupStakedAccount();
+        solanaStakingMock.setSimulatedTransaction(solSimulateUnstakeTransaction);
         await onboardingPage.completeOnboarding();
-        await settingsPage.changeNetworks({ enableNetworks: ['sol'] });
+        await settingsPage.enableNetworkWithCustomBackend('sol', 'solana', solanaStakingMock.url);
     });
 
     test(
@@ -116,13 +108,13 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
             });
 
             await test.step('Send Unstake and verify on dashboard', async () => {
-                solanaStakingMock.enableRoutesForTransactions();
+                solanaStakingMock.confirmTransaction();
                 await devicePrompt.sendButton.click();
                 await expect(stakingSection.unstakedToastAccount).toContainText('Solana #1');
                 await expect(stakingSection.unstakedToastAmount).toContainText(
                     stakedAmountFormatted,
                 );
-                await solanaStakingMock.setupUnstakingAccount();
+                solanaStakingMock.setupUnstakingAccount();
                 await stakingSection.expectStakingAmounts({
                     expected: {
                         pending: 'hidden',
@@ -136,17 +128,10 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                 await expect(stakingSection.stakeMoreButton).toBeEnabled();
             });
 
-            // Mock simulate claim transaction response
-            await solanaStakingMock.replaceRoute('simulateTransaction', {
-                respond: async (route, body) => {
-                    await fulfillWithResult(route, body, {
-                        value: solSimulateClaimTransactionResponse,
-                    });
-                },
-            });
+            solanaStakingMock.setSimulatedTransaction(solSimulateClaimTransaction);
 
             await test.step('Wait few epochs for claim to be available', async () => {
-                await solanaStakingMock.advanceEpoch();
+                solanaStakingMock.advanceEpoch();
                 await stakingSection.expectStakingAmounts({
                     expected: {
                         pending: 'hidden',
@@ -210,7 +195,7 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
                     },
                 });
                 await devicePrompt.waitForFinalPromptAndConfirm();
-                await solanaStakingMock.setProgramAccounts([]);
+                solanaStakingMock.setStakeAccounts([]);
                 await devicePrompt.sendButton.click();
                 await expect(stakingSection.claimedToastAccount).toContainText('Solana #1');
                 await expect(stakingSection.claimedToastAmount).toContainText(
@@ -219,7 +204,7 @@ test.describe('sol staking', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
             });
 
             await test.step('Verify dashboard is back to initial state', async () => {
-                await solanaStakingMock.advanceEpoch();
+                solanaStakingMock.advanceEpoch();
                 await expect(async () => {
                     await page.clock.fastForward(stakingSection.solanaEpochCachePeriod);
                     await expect(stakingSection.stakingEmptyCard).toBeVisible();

--- a/suite/e2e/tests/trading/sell-inputs.test.ts
+++ b/suite/e2e/tests/trading/sell-inputs.test.ts
@@ -2,14 +2,13 @@ import { messages } from '@suite/intl';
 import { localizeNumber } from '@suite-common/wallet-utils';
 
 import { expect, test } from '../../support/fixtures';
-import { fulfillWithResult } from '../../support/mocks/solanaStakingMock';
 
 const solanaBalanceAddress = '41baq3croaLZEj8dPWZnXn8e6xdAtvtWu2h941vm3Ngw';
 const customFeeRate = 1;
 let bitcoinBalance: string | null;
 let solanaBalance: string | null;
 
-test.describe('Trading - Sell inputs', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+test.describe('Trading - Sell inputs', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({
         deviceSetup: { mnemonic: 'mnemonic_academic', passphrase_protection: true },
     });
@@ -17,20 +16,16 @@ test.describe('Trading - Sell inputs', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, 
     test.beforeEach(async ({ onboardingPage, dashboardPage, settingsPage, solanaStakingMock }) => {
         await onboardingPage.completeOnboarding();
 
-        await test.step('Mock Solana account to have 5 SOL', async ({}) => {
-            await solanaStakingMock.replaceRoute('getBalance', {
-                predicate: params => params?.[0] === solanaBalanceAddress,
-                respond: async (route, body) => {
-                    await fulfillWithResult(route, body, {
-                        context: { slot: 0 },
-                        value: 5_000_000_000,
-                    });
-                },
-            });
-        });
+        solanaStakingMock.setBalance(solanaBalanceAddress, 5_000_000_000);
 
         await test.step('Enable Bitcoin and Solana', async () => {
-            await settingsPage.changeNetworks({ enableNetworks: ['btc', 'sol'] });
+            await settingsPage.navigateTo('coins');
+            await settingsPage.coinsTab.enableNetwork('btc');
+            await settingsPage.enableNetworkWithCustomBackend(
+                'sol',
+                'solana',
+                solanaStakingMock.url,
+            );
             await dashboardPage.deviceSwitchingOpenButton.click();
             await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Refactors Solana mock from playwright route intercepting to a RpcServerMock that is set as a custom BE.
The main benefit is this works even on desktop. In previous solution, playwright was not able to intercept the communication on Desktop as it was not handled by UI rendered but a worker in nodejs

The only problem this solution faced was one cache of a worker I was not able to cleanly skip or move time forward with clock.fastForward (a playwright method that manipulates browser time). So I have modify the cache time to be conditional by process.env.PLAYWRIGHT_RUN which we already used in few places. Please review this part :pray: 

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor-solana-mock/web/](https://dev.suite.sldev.cz/suite-web/refactor-solana-mock/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-solana-mock&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-solana-mock&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-08T13:22:40.491Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T13:20:26.044Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->