### PR TITLE
fix(device-mutex): make prioritizedLock enqueue the task at the front

### DIFF
--- a/suite-native/device-mutex/src/DeviceAccessMutex.ts
+++ b/suite-native/device-mutex/src/DeviceAccessMutex.ts
@@ -11,9 +11,9 @@ class DeviceAccessMutex {
 
     prioritizedLock() {
         if (this.isLocked) {
-            return new Promise(resolve => {
+            return new Promise<boolean>(resolve => {
                 // Put prioritized task at the beginning of the queue.
-                this.taskQueue.unshift(() => resolve(true));
+                this.taskQueue.unshift(resolve);
             });
         }
         this.isLocked = true;

--- a/suite-native/device-mutex/src/DeviceAccessMutex.ts
+++ b/suite-native/device-mutex/src/DeviceAccessMutex.ts
@@ -13,7 +13,7 @@ class DeviceAccessMutex {
         if (this.isLocked) {
             return new Promise(resolve => {
                 // Put prioritized task at the beginning of the queue.
-                this.taskQueue.splice(1, 0, () => resolve(true));
+                this.taskQueue.unshift(() => resolve(true));
             });
         }
         this.isLocked = true;

--- a/suite-native/device-mutex/src/tests/DeviceAccessMutex.test.ts
+++ b/suite-native/device-mutex/src/tests/DeviceAccessMutex.test.ts
@@ -137,4 +137,26 @@ describe('clearAndUnlockDeviceAccessQueue', () => {
         expect(deviceAccessMutex.isLocked).toBe(false);
         expect(deviceAccessMutex.taskQueue.length).toBe(0);
     });
+
+    test('prioritized task is cancelled by clearing the queue', async () => {
+        // Reset shared singleton state possibly left over from previous tests.
+        clearAndUnlockDeviceAccessQueue();
+
+        // Hold the lock so the prioritized request has to wait in the queue. Locking
+        // synchronously (no timer callback) keeps the setup free of leaked timers and
+        // lets us reach the clearing call without an await where a stray task could run.
+        void deviceAccessMutex.lock();
+        const prioritizedTask = requestPrioritizedDeviceAccess(deviceAccessCallbackMock);
+
+        expect(deviceAccessMutex.isLocked).toBe(true);
+        expect(deviceAccessMutex.taskQueue.length).toBe(1);
+
+        clearAndUnlockDeviceAccessQueue();
+
+        // The prioritized waiter must be rejected like any other queued task instead of
+        // resolving `true` and running its device callback after the queue was cleared.
+        expect(await prioritizedTask).toBe(DEVICE_ACCESS_ERROR);
+        expect(deviceAccessMutex.isLocked).toBe(false);
+        expect(deviceAccessMutex.taskQueue.length).toBe(0);
+    });
 });

--- a/suite-native/device-mutex/src/tests/DeviceAccessMutex.test.ts
+++ b/suite-native/device-mutex/src/tests/DeviceAccessMutex.test.ts
@@ -105,10 +105,12 @@ describe('RequestPrioritizedDeviceAccess', () => {
         // Execute prioritized task.
         await requestPrioritizedDeviceAccess(deviceAccessCallbackMock);
 
-        // The prioritized task should be put at the beginning of the queue, so after its execution,
-        // so there should be still the rest of the tasks in the queue.
+        // The prioritized task was put at the beginning of the queue (position 0), so it ran
+        // right after task 0 finished, skipping all previously queued tasks.
+        // After the prioritized task finishes: task 1 has been dequeued and is running,
+        // tasks 2, 3, 4 remain in the queue.
         expect(deviceAccessMutex.isLocked).toBe(true);
-        expect(deviceAccessMutex.taskQueue.length).toBe(2);
+        expect(deviceAccessMutex.taskQueue.length).toBe(3);
     });
 });
 


### PR DESCRIPTION
## Description

Split out from the bug-fix sweep umbrella #29735. Two related fixes in `DeviceAccessMutex`, both about how `prioritizedLock()` enqueues its waiter.

### 1. Prioritized task now goes to the front of the queue

`prioritizedLock()` is meant to put a prioritized task at the **front** of the queue (its own comment says so), so it runs as the very next task once the mutex unlocks. It used `this.taskQueue.splice(1, 0, ...)`, which inserts at **index 1** — i.e. second in line — so one already-queued task would still run before the "prioritized" one.

The fix uses `unshift(...)`, inserting at index 0. This is correct given the queue model: only *waiting* tasks live in `taskQueue` (the running task holds the lock and is not in the queue), and `unlock()` dequeues from the front via `shift()`. So `unshift` makes the prioritized task the next to be dequeued (it runs right after the already-running task, which cannot be preempted). The existing prioritization test is updated accordingly (queue length `2 → 3`).

### 2. `clearQueue()` can now cancel a prioritized waiter

Follow-up from Copilot review. `prioritizedLock()` enqueued a wrapper `() => resolve(true)` that ignored the boolean passed to the resolver. `clearQueue()` cancels waiting tasks by resolving them with `false` (so `requestDeviceAccess` returns `DEVICE_ACCESS_ERROR` without running the callback), but the wrapper swallowed that `false` and resolved `true` — so a prioritized task would still run its device callback after the queue was cleared on disconnect/reload. Now the resolver is enqueued directly and the promise is typed `Promise<boolean>`, matching `lock()`. Covered by a new regression test.

## Related PRs

Part of the #29735 sweep, alongside:
- #28995 — `fix(connect)`: size bare uint/int EIP-712 fields as 256-bit

## Notes for QA

`@suite-native` only (device access serialization on mobile). Blast radius is limited to ordering and cancellation of concurrent device operations:
- A prioritized device access requested while the device is busy now runs first (previously it could be preempted by one earlier queued request).
- Clearing the queue (disconnect/reload) now also cancels a pending prioritized request instead of letting its callback run afterwards.

No change to non-prioritized (`lock`) or single-request paths. Both behaviors are covered by unit tests in `DeviceAccessMutex.test.ts`.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fix-device-mutex-prioritized-lock&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->