### PR TITLE
perf(suite-native): reduce asset list rerenders

### DIFF
--- a/suite-native/assets/src/assetsSelectors.ts
+++ b/suite-native/assets/src/assetsSelectors.ts
@@ -4,6 +4,7 @@ import {
     type AssetFiatBalanceWithPercentage,
     calculateAssetsPercentage,
 } from '@suite-common/assets';
+import { selectIsDeviceAuthorized } from '@suite-common/device';
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { type NetworkSymbol, networkSymbolCollection } from '@suite-common/wallet-config';
 import {
@@ -143,4 +144,14 @@ export const selectAssetFiatValuePercentage = createMemoizedSelector(
             fiatPercentageOffset: Math.floor(asset?.fiatPercentageOffset ?? 0),
         };
     },
+);
+
+export const selectIsAssetListLoading = createMemoizedSelector(
+    [selectHasRunningDiscovery, selectIsDeviceAuthorized],
+    (hasDiscovery, isDeviceAuthorized): boolean => hasDiscovery || !isDeviceAuthorized,
+);
+
+export const selectIsAssetListEmpty = createMemoizedSelector(
+    [selectDeviceNetworkSymbolsWithAssets],
+    (deviceNetworkSymbols): boolean => deviceNetworkSymbols.length === 0,
 );

--- a/suite-native/assets/src/components/AccountsCount.tsx
+++ b/suite-native/assets/src/components/AccountsCount.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
@@ -8,7 +9,7 @@ import { type AssetsRootState } from '../types';
 
 type AccountsCountProps = { symbol: NetworkSymbol };
 
-export const AccountsCount = ({ symbol }: AccountsCountProps) => {
+export const AccountsCount = memo(({ symbol }: AccountsCountProps) => {
     const accountsCount = useSelector(
         (state: AssetsRootState) =>
             selectVisibleDeviceAccountsByNetworkSymbol(state, symbol).length,
@@ -19,4 +20,6 @@ export const AccountsCount = ({ symbol }: AccountsCountProps) => {
             {accountsCount}
         </Text>
     );
-};
+});
+
+AccountsCount.displayName = 'AccountsCount';

--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -1,14 +1,10 @@
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { useFormatters } from '@suite-common/formatters';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { AccountsListItemBase, StakingBadge } from '@suite-native/accounts';
-import { Badge, Box } from '@suite-native/atoms';
-import { Icon } from '@suite-native/icons';
-import { Translation } from '@suite-native/intl';
+import { AccountsListItemBase } from '@suite-native/accounts';
 import {
     AccountsStackRoutes,
     type AppTabsParamList,
@@ -24,11 +20,12 @@ import {
 import { type TokensRootState, selectHasDeviceAnyTokensForNetwork } from '@suite-native/tokens';
 
 import { selectSingleDeviceAccountKeyForNetworkSymbol } from '../assetsSelectors';
-import { AccountsCount } from './AccountsCount';
+import { type AssetsRootState } from '../types';
+import { AssetItemBadges } from './AssetItemBadges';
+import { AssetItemTitle } from './AssetItemTitle';
 import { CryptoAmount } from './CryptoAmount';
 import { FiatAmount } from './FiatAmount';
 import { PercentageIcon } from './PercentageIcon';
-import { type AssetsRootState } from '../types';
 
 type AssetItemProps = {
     cryptoCurrencySymbol: NetworkSymbol;
@@ -40,11 +37,8 @@ type NavigationType = TabToStackCompositeNavigationProp<
     RootStackParamList
 >;
 
-// Memoized so existing rows bail when `Assets` re-renders to add a newly discovered network.
-// Sub-components aren't memoized: each subscribes to its own value, and this rarely re-renders.
 export const AssetItem = memo(({ cryptoCurrencySymbol }: AssetItemProps) => {
     const navigation = useNavigation<NavigationType>();
-    const { NetworkNameFormatter } = useFormatters();
     const singleAccountKey = useSelector((state: AssetsRootState) =>
         selectSingleDeviceAccountKeyForNetworkSymbol(state, cryptoCurrencySymbol),
     );
@@ -55,40 +49,35 @@ export const AssetItem = memo(({ cryptoCurrencySymbol }: AssetItemProps) => {
         selectHasAnyDeviceAccountsWithStaking(state, cryptoCurrencySymbol),
     );
 
-    const handleAssetPress = () => {
+    const handleAssetPress = useCallback(() => {
         // A single tokenless account opens its detail directly; anything else opens the list.
         if (singleAccountKey && !hasAnyTokens && !hasAnyAccountsWithStaking) {
             navigation.navigate(RootStackRoutes.AccountDetail, {
                 accountKey: singleAccountKey,
                 closeActionType: 'back',
             });
-        } else {
-            navigation.navigate(AppTabsRoutes.AccountsStack, {
-                screen: AccountsStackRoutes.Accounts,
-                params: { networksFilter: [cryptoCurrencySymbol] },
-            });
+
+            return;
         }
-    };
+
+        navigation.navigate(AppTabsRoutes.AccountsStack, {
+            screen: AccountsStackRoutes.Accounts,
+            params: { networksFilter: [cryptoCurrencySymbol] },
+        });
+    }, [
+        cryptoCurrencySymbol,
+        hasAnyAccountsWithStaking,
+        hasAnyTokens,
+        navigation,
+        singleAccountKey,
+    ]);
 
     return (
         <AccountsListItemBase
             onPress={handleAssetPress}
             icon={<PercentageIcon symbol={cryptoCurrencySymbol} />}
-            title={<NetworkNameFormatter value={cryptoCurrencySymbol} />}
-            badges={
-                <>
-                    <Box>
-                        <Icon size="medium" color="contentSecondary" name="wallet" />
-                    </Box>
-                    <AccountsCount symbol={cryptoCurrencySymbol} />
-                    {hasAnyAccountsWithStaking && (
-                        <StakingBadge networkSymbol={cryptoCurrencySymbol} />
-                    )}
-                    {hasAnyTokens && (
-                        <Badge size="small" label={<Translation id="generic.tokens" />} />
-                    )}
-                </>
-            }
+            title={<AssetItemTitle symbol={cryptoCurrencySymbol} />}
+            badges={<AssetItemBadges symbol={cryptoCurrencySymbol} />}
             mainValue={<FiatAmount symbol={cryptoCurrencySymbol} />}
             secondaryValue={<CryptoAmount symbol={cryptoCurrencySymbol} />}
         />

--- a/suite-native/assets/src/components/AssetItemBadges.tsx
+++ b/suite-native/assets/src/components/AssetItemBadges.tsx
@@ -1,0 +1,26 @@
+import { memo } from 'react';
+
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { Box } from '@suite-native/atoms';
+import { Icon } from '@suite-native/icons';
+
+import { AccountsCount } from './AccountsCount';
+import { AssetItemStakingBadge } from './AssetItemStakingBadge';
+import { AssetItemTokensBadge } from './AssetItemTokensBadge';
+
+type AssetItemBadgesProps = {
+    symbol: NetworkSymbol;
+};
+
+export const AssetItemBadges = memo(({ symbol }: AssetItemBadgesProps) => (
+    <>
+        <Box>
+            <Icon size="medium" color="contentSecondary" name="wallet" />
+        </Box>
+        <AccountsCount symbol={symbol} />
+        <AssetItemStakingBadge symbol={symbol} />
+        <AssetItemTokensBadge symbol={symbol} />
+    </>
+));
+
+AssetItemBadges.displayName = 'AssetItemBadges';

--- a/suite-native/assets/src/components/AssetItemStakingBadge.tsx
+++ b/suite-native/assets/src/components/AssetItemStakingBadge.tsx
@@ -1,0 +1,27 @@
+import { memo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { StakingBadge } from '@suite-native/accounts';
+import {
+    type NativeStakingRootState,
+    selectHasAnyDeviceAccountsWithStaking,
+} from '@suite-native/staking';
+
+type AssetItemStakingBadgeProps = {
+    symbol: NetworkSymbol;
+};
+
+export const AssetItemStakingBadge = memo(({ symbol }: AssetItemStakingBadgeProps) => {
+    const hasAnyAccountsWithStaking = useSelector((state: NativeStakingRootState) =>
+        selectHasAnyDeviceAccountsWithStaking(state, symbol),
+    );
+
+    if (!hasAnyAccountsWithStaking) {
+        return null;
+    }
+
+    return <StakingBadge networkSymbol={symbol} />;
+});
+
+AssetItemStakingBadge.displayName = 'AssetItemStakingBadge';

--- a/suite-native/assets/src/components/AssetItemTitle.tsx
+++ b/suite-native/assets/src/components/AssetItemTitle.tsx
@@ -1,0 +1,16 @@
+import { memo } from 'react';
+
+import { useFormatters } from '@suite-common/formatters';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+
+type AssetItemTitleProps = {
+    symbol: NetworkSymbol;
+};
+
+export const AssetItemTitle = memo(({ symbol }: AssetItemTitleProps) => {
+    const { NetworkNameFormatter } = useFormatters();
+
+    return <NetworkNameFormatter value={symbol} />;
+});
+
+AssetItemTitle.displayName = 'AssetItemTitle';

--- a/suite-native/assets/src/components/AssetItemTokensBadge.tsx
+++ b/suite-native/assets/src/components/AssetItemTokensBadge.tsx
@@ -1,0 +1,25 @@
+import { memo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { Badge } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import { type TokensRootState, selectHasDeviceAnyTokensForNetwork } from '@suite-native/tokens';
+
+type AssetItemTokensBadgeProps = {
+    symbol: NetworkSymbol;
+};
+
+export const AssetItemTokensBadge = memo(({ symbol }: AssetItemTokensBadgeProps) => {
+    const hasAnyTokens = useSelector((state: TokensRootState) =>
+        selectHasDeviceAnyTokensForNetwork(state, symbol),
+    );
+
+    if (!hasAnyTokens) {
+        return null;
+    }
+
+    return <Badge size="small" label={<Translation id="generic.tokens" />} />;
+});
+
+AssetItemTokensBadge.displayName = 'AssetItemTokensBadge';

--- a/suite-native/assets/src/components/AssetList.tsx
+++ b/suite-native/assets/src/components/AssetList.tsx
@@ -1,0 +1,24 @@
+import Animated, { FadeInDown, LinearTransition } from 'react-native-reanimated';
+import { useSelector } from 'react-redux';
+
+import { selectDeviceNetworkSymbolsWithAssets, selectIsAssetListLoading } from '../assetsSelectors';
+import { AssetItem } from './AssetItem';
+
+export const AssetList = () => {
+    const isAssetListLoading = useSelector(selectIsAssetListLoading);
+    const deviceNetworkSymbols = useSelector(selectDeviceNetworkSymbolsWithAssets);
+
+    return (
+        <>
+            {deviceNetworkSymbols.map(symbol => (
+                <Animated.View
+                    entering={isAssetListLoading ? FadeInDown : undefined}
+                    layout={LinearTransition}
+                    key={symbol}
+                >
+                    <AssetItem cryptoCurrencySymbol={symbol} />
+                </Animated.View>
+            ))}
+        </>
+    );
+};

--- a/suite-native/assets/src/components/Assets.tsx
+++ b/suite-native/assets/src/components/Assets.tsx
@@ -1,41 +1,19 @@
-import Animated, { FadeInDown, LinearTransition } from 'react-native-reanimated';
-import { useSelector } from 'react-redux';
+import { LinearTransition } from 'react-native-reanimated';
 
-import { selectIsDeviceAuthorized } from '@suite-common/device';
-import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { AnimatedContainerCard } from '@suite-native/atoms';
 import { AccountsRediscoveryNeededWarning } from '@suite-native/discovery';
 import { FiveBinariesHomeBanner } from '@suite-native/module-earn';
 
-import { selectDeviceNetworkSymbolsWithAssets } from '../assetsSelectors';
-import { AssetItem } from './AssetItem';
+import { AssetList } from './AssetList';
 import { DiscoveryAssetsLoader } from './DiscoveryAssetsLoader';
 
-export const Assets = () => {
-    const deviceNetworkSymbols = useSelector(selectDeviceNetworkSymbolsWithAssets);
-
-    const hasDiscovery = useSelector(selectHasRunningDiscovery);
-    const isDeviceAuthorized = useSelector(selectIsDeviceAuthorized);
-    const isLoading = hasDiscovery || !isDeviceAuthorized;
-
-    return (
-        <>
-            <FiveBinariesHomeBanner />
-            <AnimatedContainerCard noPadding layout={LinearTransition}>
-                <AccountsRediscoveryNeededWarning hasPadding />
-                {deviceNetworkSymbols.map(symbol => (
-                    <Animated.View
-                        entering={isLoading ? FadeInDown : undefined}
-                        layout={LinearTransition}
-                        key={symbol}
-                    >
-                        <AssetItem cryptoCurrencySymbol={symbol} />
-                    </Animated.View>
-                ))}
-                {isLoading && (
-                    <DiscoveryAssetsLoader isListEmpty={deviceNetworkSymbols.length < 1} />
-                )}
-            </AnimatedContainerCard>
-        </>
-    );
-};
+export const Assets = () => (
+    <>
+        <FiveBinariesHomeBanner />
+        <AnimatedContainerCard noPadding layout={LinearTransition}>
+            <AccountsRediscoveryNeededWarning hasPadding />
+            <AssetList />
+            <DiscoveryAssetsLoader />
+        </AnimatedContainerCard>
+    </>
+);

--- a/suite-native/assets/src/components/CryptoAmount.tsx
+++ b/suite-native/assets/src/components/CryptoAmount.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS } from '@suite-common/formatters';
@@ -9,7 +10,7 @@ import { type AssetsRootState } from '../types';
 
 type CryptoAmountProps = { symbol: NetworkSymbol };
 
-export const CryptoAmount = ({ symbol }: CryptoAmountProps) => {
+export const CryptoAmount = memo(({ symbol }: CryptoAmountProps) => {
     const cryptoValue = useSelector((state: AssetsRootState) =>
         selectAssetCryptoValue(state, symbol),
     );
@@ -23,4 +24,6 @@ export const CryptoAmount = ({ symbol }: CryptoAmountProps) => {
             testID={`@assets/cryptoAmount/${symbol}`}
         />
     );
-};
+});
+
+CryptoAmount.displayName = 'CryptoAmount';

--- a/suite-native/assets/src/components/DiscoveryAssetsLoader.tsx
+++ b/suite-native/assets/src/components/DiscoveryAssetsLoader.tsx
@@ -1,27 +1,34 @@
-import React from 'react';
 import Animated, { FadeInDown, LinearTransition } from 'react-native-reanimated';
+import { useSelector } from 'react-redux';
 
 import { HStack, ListItemSkeleton, Text } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 
-export const DiscoveryAssetsLoader = ({ isListEmpty }: { isListEmpty: boolean }) => {
-    const discoveryProgressText = (
-        <Translation
-            id={
-                isListEmpty
-                    ? 'assets.dashboard.discoveryProgress.loading'
-                    : 'assets.dashboard.discoveryProgress.stillWorking'
-            }
-        />
-    );
+import { selectIsAssetListEmpty, selectIsAssetListLoading } from '../assetsSelectors';
+
+export const DiscoveryAssetsLoader = () => {
+    const isAssetListLoading = useSelector(selectIsAssetListLoading);
+    const isAssetListEmpty = useSelector(selectIsAssetListEmpty);
+
+    if (!isAssetListLoading) {
+        return null;
+    }
 
     return (
         <Animated.View entering={FadeInDown} layout={LinearTransition}>
             <ListItemSkeleton />
             <HStack justifyContent="center" marginBottom="sp16">
                 <Icon size="mediumLarge" name="trezorLogo" />
-                <Text variant="body-sm-strong">{discoveryProgressText}</Text>
+                <Text variant="body-sm-strong">
+                    <Translation
+                        id={
+                            isAssetListEmpty
+                                ? 'assets.dashboard.discoveryProgress.loading'
+                                : 'assets.dashboard.discoveryProgress.stillWorking'
+                        }
+                    />
+                </Text>
             </HStack>
         </Animated.View>
     );

--- a/suite-native/assets/src/components/FiatAmount.tsx
+++ b/suite-native/assets/src/components/FiatAmount.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
@@ -10,7 +11,7 @@ import { type AssetsRootState } from '../types';
 
 type FiatAmountProps = { symbol: NetworkSymbol };
 
-export const FiatAmount = ({ symbol }: FiatAmountProps) => {
+export const FiatAmount = memo(({ symbol }: FiatAmountProps) => {
     const fiatValue = useSelector((state: AssetsRootState) => selectAssetFiatValue(state, symbol));
 
     return (
@@ -19,4 +20,6 @@ export const FiatAmount = ({ symbol }: FiatAmountProps) => {
             value={fiatValue !== null ? asBaseCurrencyAmount(new BigNumber(fiatValue)) : null}
         />
     );
-};
+});
+
+FiatAmount.displayName = 'FiatAmount';

--- a/suite-native/assets/src/components/PercentageIcon.tsx
+++ b/suite-native/assets/src/components/PercentageIcon.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
@@ -8,7 +9,7 @@ import { type AssetsRootState } from '../types';
 
 type PercentageIconProps = { symbol: NetworkSymbol };
 
-export const PercentageIcon = ({ symbol }: PercentageIconProps) => {
+export const PercentageIcon = memo(({ symbol }: PercentageIconProps) => {
     const assetPercentages = useSelector((state: AssetsRootState) =>
         selectAssetFiatValuePercentage(state, symbol),
     );
@@ -20,4 +21,6 @@ export const PercentageIcon = ({ symbol }: PercentageIconProps) => {
             percentageOffset={assetPercentages.fiatPercentageOffset}
         />
     );
-};
+});
+
+PercentageIcon.displayName = 'PercentageIcon';


### PR DESCRIPTION
## Description

Reduces Home asset-list rerenders during discovery.

- Reorganize asset package components to be minimalistic and select values only in real subscribers so that parent - child rerenders are minimized. 

Left is old, right is new
<img width="974" height="1079" alt="image" src="https://github.com/user-attachments/assets/9aa97f4f-370d-4fdb-b5cb-db67caa8848a" />

This PR minimized rerenders just very slightly, but it's a good code hygiene and bullet proofing for future changes. 