### PR TITLE
feat(suite-native): show independent-providers info on Earn staking list

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2488,6 +2488,7 @@ export const messages = {
         staking: 'Staking',
         stablecoinYield: 'Stablecoin yield',
         poweredBy: 'Powered by',
+        stakingOperatedByProviders: 'Staking is operated by independent providers',
         portfolioTracker: {
             alert: {
                 title: 'Staking is disabled in the portfolio tracker',

--- a/suite-native/module-earn/src/components/EarnStakingProvidersInfo.tsx
+++ b/suite-native/module-earn/src/components/EarnStakingProvidersInfo.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { Box, HStack, Text } from '@suite-native/atoms';
+import { Icon } from '@suite-native/icons';
+import { Translation } from '@suite-native/intl';
+
+export const EarnStakingProvidersInfo = React.memo(() => (
+    <Box alignItems="center" marginBottom="sp24">
+        <HStack alignItems="center" spacing="sp8">
+            <Icon name="info" size="medium" color="contentSecondary" />
+            <Text variant="body-sm" color="contentSecondary">
+                <Translation id="earn.stakingOperatedByProviders" />
+            </Text>
+        </HStack>
+    </Box>
+));

--- a/suite-native/module-earn/src/hooks/useStakingListData.ts
+++ b/suite-native/module-earn/src/hooks/useStakingListData.ts
@@ -13,15 +13,14 @@ import { selectAreTestnetsEnabled } from '@suite-native/settings';
 
 import {
     type EarnPromoListDataItem,
-    type EarnProviderListItem,
+    type EarnStakingProvidersInfoListItem,
     type StakingEarnItem,
 } from '../types';
 
-export const EVERSTAKE_PROVIDER_LIST_ITEM = {
-    id: 'everstake-provider',
-    type: 'provider',
-    provider: 'everstake',
-} as const satisfies EarnProviderListItem;
+export const STAKING_PROVIDERS_INFO_LIST_ITEM = {
+    id: 'staking-providers-info',
+    type: 'staking-providers-info',
+} as const satisfies EarnStakingProvidersInfoListItem;
 
 type UseStakingListDataReturn = {
     activeItems: StakingEarnItem[];
@@ -79,7 +78,7 @@ export const useStakingListData = () => {
         const promoListData: EarnPromoListDataItem[] = [
             'staking',
             ...promoItems,
-            EVERSTAKE_PROVIDER_LIST_ITEM,
+            STAKING_PROVIDERS_INFO_LIST_ITEM,
         ];
 
         return {

--- a/suite-native/module-earn/src/screens/EarnScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnScreen.tsx
@@ -21,6 +21,7 @@ import {
     EarnPromoListSkeletonRow,
 } from '../components/EarnPromoListRow';
 import { EarnScreenListHeader } from '../components/EarnScreenListHeader';
+import { EarnStakingProvidersInfo } from '../components/EarnStakingProvidersInfo';
 import { EnableNetworkForEarnBottomSheet } from '../components/EnableNetworkForEarnBottomSheet';
 import { StablecoinYieldLoadErrorAlert } from '../components/StablecoinYieldLoadErrorAlert';
 import { useStablecoinYieldListData } from '../hooks/useStablecoinYieldListData';
@@ -36,7 +37,10 @@ const getEarnListItemKey = (item: EarnPromoListDataItem) =>
     typeof item === 'string' ? item : item.id;
 
 const isSectionBoundaryItem = (item: EarnPromoListDataItem | undefined) =>
-    item === undefined || typeof item === 'string' || item.type === 'provider';
+    item === undefined ||
+    typeof item === 'string' ||
+    item.type === 'provider' ||
+    item.type === 'staking-providers-info';
 
 const EarnScreenContent = () => {
     const { analytics } = useServices(selectNativeAnalyticsDep);
@@ -101,6 +105,10 @@ const EarnScreenContent = () => {
 
             if (item.type === 'provider') {
                 return <EarnPoweredByProvider provider={item.provider} />;
+            }
+
+            if (item.type === 'staking-providers-info') {
+                return <EarnStakingProvidersInfo />;
             }
 
             const nextItem = earnListData[index + 1];

--- a/suite-native/module-earn/src/types.ts
+++ b/suite-native/module-earn/src/types.ts
@@ -93,12 +93,18 @@ export type EarnProviderListItem = {
     provider: EarnProvider;
 };
 
+export type EarnStakingProvidersInfoListItem = {
+    type: 'staking-providers-info';
+    id: string;
+};
+
 export type EarnPromoListDataItem =
     | EarnPromoItem
     | EarnPromoSectionType
     | SkeletonLoaderItem
     | StablecoinYieldLoadErrorListItem
-    | EarnProviderListItem;
+    | EarnProviderListItem
+    | EarnStakingProvidersInfoListItem;
 
 export type EarnDepositsCardActiveItem =
     | {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description


## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve  #28992

## Screenshots:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/19d63819-8d4f-4b18-8b2d-f904cad79519" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/earn-table-provider-info-mobile&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->