### PR TITLE
fix(suite-native): swipeable walkthrough buttons size

### DIFF
--- a/suite-native/swipeable-walkthrough/src/components/SwipeableWalkthroughCloseButton.tsx
+++ b/suite-native/swipeable-walkthrough/src/components/SwipeableWalkthroughCloseButton.tsx
@@ -46,6 +46,7 @@ export const SwipeableWalkthroughCloseButton = ({
                 onPress={onPressBack}
                 accessibilityRole="button"
                 accessibilityLabel="Go back"
+                size="medium"
                 style={animatedCaretStyle}
             />
             <IconButton
@@ -56,6 +57,7 @@ export const SwipeableWalkthroughCloseButton = ({
                 onPress={onPressBack}
                 accessibilityRole="button"
                 accessibilityLabel="Go back"
+                size="medium"
             />
         </Animated.View>
     );

--- a/suite-native/swipeable-walkthrough/src/components/SwipeableWalkthroughStep.tsx
+++ b/suite-native/swipeable-walkthrough/src/components/SwipeableWalkthroughStep.tsx
@@ -104,6 +104,7 @@ export const SwipeableWalkthroughStep = ({
                             iconName="caretDown"
                             intent="neutral"
                             priority="secondary"
+                            size="medium"
                             onPress={handleNextButtonPress}
                             testID={`@swipeableWalkthroughStep/${stepId}/nextButton`}
                         />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fixes the incorrect button size in the swipeable walkthrough screens.



## Screenshots:

### BEFORE
<img width="400" alt="image" src="https://github.com/user-attachments/assets/3b19e320-a999-4c46-8431-9dbf00529c92" />



### AFTER

https://github.com/user-attachments/assets/81841bb5-74a3-4bd2-af15-614989cc5585



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/swipeable-screen-button-size&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->