### PR TITLE
fix(suite-native): sort accounts in choose accounts bottom sheet modal

### DIFF
--- a/suite-native/module-earn/src/hooks/useStablecoinYieldPromoNavigation.ts
+++ b/suite-native/module-earn/src/hooks/useStablecoinYieldPromoNavigation.ts
@@ -7,6 +7,7 @@ import { selectIsDeviceInViewOnlyMode } from '@suite-common/device';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectVisibleDeviceAccounts } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
+import { sortByCoin } from '@suite-common/wallet-utils';
 import { useAccountAlerts } from '@suite-native/accounts';
 import { type BottomSheetModalRef, useBottomSheetModal } from '@suite-native/atoms';
 import {
@@ -135,6 +136,7 @@ export const useStablecoinYieldPromoNavigation = (): UseStablecoinYieldPromoNavi
             const accountsForNetwork = accounts.filter(
                 account => account.symbol === item.networkSymbol,
             );
+            sortByCoin(accountsForNetwork);
 
             if (accountsForNetwork.length === 0) {
                 setPendingEnableSymbol(item.networkSymbol);

--- a/suite-native/module-earn/src/hooks/useStakingPromoNavigation.ts
+++ b/suite-native/module-earn/src/hooks/useStakingPromoNavigation.ts
@@ -8,6 +8,7 @@ import { selectIsDeviceInViewOnlyMode } from '@suite-common/device';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectVisibleDeviceAccounts } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
+import { sortByCoin } from '@suite-common/wallet-utils';
 import { useAccountAlerts } from '@suite-native/accounts';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { useBottomSheetModal } from '@suite-native/atoms';
@@ -140,6 +141,7 @@ export const useStakingPromoNavigation = () => {
             }
 
             const accountsForSymbol = accounts.filter(acc => acc.symbol === item.symbol);
+            sortByCoin(accountsForSymbol);
 
             if (isPortfolioTrackerDevice) {
                 openPortfolioTrackerSheet();


### PR DESCRIPTION
## Description

Sort accounts properly in the `Choose account` bottom sheet modal on Earn screen.

## Related Issue

Resolve #29339 

## Screenshots:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-03 at 12 31 50" src="https://github.com/user-attachments/assets/3ece1963-d97e-429a-b02e-838bad89f222" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/earn-accounts-sorting&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->