### PR TITLE
fix(suite-native): use medium size of THP help icon button

### DIFF
--- a/suite-native/thp/src/components/ThpPairingInfoHelpButton.tsx
+++ b/suite-native/thp/src/components/ThpPairingInfoHelpButton.tsx
@@ -15,9 +15,10 @@ export const ThpPairingInfoHelpButton = () => {
     return (
         <Box>
             <IconButton
+                iconName="question"
                 intent="neutral"
                 priority="secondary"
-                iconName="question"
+                size="medium"
                 onPress={openModal}
             />
             <BottomSheetModal ref={bottomSheetRef} isCloseDisplayed={false}>


### PR DESCRIPTION
## Description

Medium size of THP help icon button used.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/thp-pairing-info-help-button&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->