### PR TITLE
feat(suite-native-23054): add e2e coverage for trading residence selection on iOS

### DIFF
--- a/suite-native/app/e2e/pageObjects/tabBarActions.ts
+++ b/suite-native/app/e2e/pageObjects/tabBarActions.ts
@@ -40,6 +40,10 @@ class TabBarActions {
         await detoxExpect(element(by.id('@screen/Trading'))).toBeVisible();
     }
 
+    async assertTradingIsNotVisible() {
+        await detoxExpect(element(by.id('@screen/Trading'))).not.toBeVisible();
+    }
+
     async assertHomeTabBarItemTitle(title: string) {
         await detoxExpect(element(by.id('@tabBar/HomeStack/title'))).toHaveText(title);
     }

--- a/suite-native/app/e2e/pageObjects/trading/tradingResidenceActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/tradingResidenceActions.ts
@@ -1,0 +1,87 @@
+import { expect as detoxExpect } from 'detox';
+
+import { inputTextToElement, waitForVisible } from '../../support/utils';
+
+type CountrySelection = {
+    searchValue: string;
+    countryName: string;
+    countryCodeAlpha3: string;
+};
+
+class TradingResidenceActions {
+    private readonly countryPicker = element(by.id('@trading-residence/country'));
+    private readonly countryValue = element(by.id('@trading-residence/country/value'));
+
+    private readonly subdivisionPicker = element(by.id('@trading-residence/country-subdivision'));
+    private readonly subdivisionValue = element(
+        by.id('@trading-residence/country-subdivision/value'),
+    );
+
+    private readonly countrySearchInput = element(by.id('@trading-residence/country/search-input'));
+    private readonly subdivisionSearchInput = element(
+        by.id('@trading-residence/country-subdivision/search-input'),
+    );
+
+    private readonly confirmOnboardingButton = element(by.id('@onboarding/confirmLocation'));
+    private readonly skipOnboardingButton = element(by.id('@onboarding/skipLocation'));
+    private readonly confirmSettingsButton = element(by.id('@settings/confirmLocation'));
+
+    async expectOnboardingScreenVisible() {
+        await waitForVisible(by.id('@screen/TradingLocation'));
+        await detoxExpect(element(by.id('@onboarding/confirmLocation'))).toBeVisible();
+        await detoxExpect(element(by.id('@onboarding/skipLocation'))).toBeVisible();
+    }
+
+    async selectCountry({ searchValue, countryName, countryCodeAlpha3 }: CountrySelection) {
+        await waitForVisible(this.countryPicker);
+        await this.countryPicker.tap();
+
+        await waitForVisible(by.id('@trading-residence/country/bottom-sheet'));
+        await waitForVisible(this.countrySearchInput);
+        await inputTextToElement(this.countrySearchInput, searchValue);
+
+        const countryListItem = element(by.text(countryName));
+        await waitForVisible(countryListItem);
+        await countryListItem.tap();
+
+        await detoxExpect(this.countryValue).toHaveText(countryCodeAlpha3);
+    }
+
+    async selectSubdivision({
+        subdivisionName,
+        searchValue,
+    }: {
+        subdivisionName: string;
+        searchValue: string;
+    }) {
+        await waitForVisible(this.subdivisionPicker);
+        await this.subdivisionPicker.tap();
+
+        await waitForVisible(by.id('@trading-residence/country-subdivision/bottom-sheet'));
+        await waitForVisible(this.subdivisionSearchInput);
+        await inputTextToElement(this.subdivisionSearchInput, searchValue);
+
+        const countrySubdivisionListItem = element(by.text(subdivisionName));
+        await waitForVisible(countrySubdivisionListItem);
+        await countrySubdivisionListItem.tap();
+
+        await detoxExpect(this.subdivisionValue).toHaveText(subdivisionName);
+    }
+
+    async skipOnboardingCountrySelection() {
+        await waitForVisible(this.skipOnboardingButton);
+        await this.skipOnboardingButton.tap();
+    }
+
+    async confirmSettingsCountrySelection() {
+        await waitForVisible(this.confirmSettingsButton);
+        await this.confirmSettingsButton.tap();
+    }
+
+    async confirmOnboardingCountrySelection() {
+        await waitForVisible(this.confirmOnboardingButton);
+        await this.confirmOnboardingButton.tap();
+    }
+}
+
+export const onTradingResidence = new TradingResidenceActions();

--- a/suite-native/app/e2e/tests/tradingCountryResidence.test.ts
+++ b/suite-native/app/e2e/tests/tradingCountryResidence.test.ts
@@ -1,0 +1,49 @@
+import { onOnboarding } from '../pageObjects/onboardingActions';
+import { onSettings } from '../pageObjects/settingsActions';
+import { onTabBar } from '../pageObjects/tabBarActions';
+import { onTradingResidence } from '../pageObjects/trading/tradingResidenceActions';
+import { openApp } from '../support/setup';
+
+describe('Country selection onboarding [@noDevice @iosOnly]', () => {
+    beforeEach(async () => {
+        await openApp({ args: { isTradingResidenceCheckEnabled: true } });
+        await onOnboarding.finishOnboarding();
+        await onTradingResidence.expectOnboardingScreenVisible();
+    });
+
+    it('Selects country during onboarding on a fresh app', async () => {
+        await onTradingResidence.selectCountry({
+            searchValue: 'USA',
+            countryName: 'United States of America',
+            countryCodeAlpha3: 'USA',
+        });
+
+        await onTradingResidence.selectSubdivision({
+            subdivisionName: 'California',
+            searchValue: 'Calif',
+        });
+
+        await onTradingResidence.confirmOnboardingCountrySelection();
+
+        await onTabBar.navigateToTrade();
+    });
+
+    it('Sets residence in Settings after skipping onboarding country selection', async () => {
+        await onTradingResidence.skipOnboardingCountrySelection();
+
+        await onTabBar.navigateToHome();
+        await onTabBar.assertTradingIsNotVisible();
+        await onTabBar.navigateToSettings();
+
+        await onSettings.openSection('trading');
+
+        await onTradingResidence.selectCountry({
+            searchValue: 'Czech',
+            countryName: 'Czechia',
+            countryCodeAlpha3: 'CZE',
+        });
+        await onTradingResidence.confirmSettingsCountrySelection();
+
+        await onTabBar.navigateToTrade();
+    });
+});

--- a/suite-native/trading-residence/src/components/ConfirmLocationButton.tsx
+++ b/suite-native/trading-residence/src/components/ConfirmLocationButton.tsx
@@ -14,9 +14,10 @@ import { getPreferredCountryOption } from '../utils/getPreferredCountryOption';
 
 export type ConfirmLocationButtonProps = {
     afterConfirm: () => void;
+    testId?: string;
 };
 
-export const ConfirmLocationButton = ({ afterConfirm }: ConfirmLocationButtonProps) => {
+export const ConfirmLocationButton = ({ afterConfirm, testId }: ConfirmLocationButtonProps) => {
     const countryCode = useFormCountryCode();
     const { watch } = useFormContext<TradingLocationFormValues>();
     const countrySubdivision = watch('countrySubdivision');
@@ -42,7 +43,7 @@ export const ConfirmLocationButton = ({ afterConfirm }: ConfirmLocationButtonPro
     const handlePress = isSubdivisionMissing ? showCountrySubdivisionPicker : confirmLocation;
 
     return (
-        <Button intent="brand" priority="primary" onPress={handlePress}>
+        <Button intent="brand" priority="primary" onPress={handlePress} testID={testId}>
             <Translation
                 id={
                     isSubdivisionMissing

--- a/suite-native/trading-residence/src/components/OnboardingButtons.tsx
+++ b/suite-native/trading-residence/src/components/OnboardingButtons.tsx
@@ -19,8 +19,11 @@ export const OnboardingButtons = ({ afterPress }: OnboardingButtonsProps) => {
 
     return (
         <>
-            <ConfirmLocationButton afterConfirm={handleOnboardingComplete} />
-            <SkipButton onPress={handleOnboardingComplete} />
+            <ConfirmLocationButton
+                afterConfirm={handleOnboardingComplete}
+                testId="@onboarding/confirmLocation"
+            />
+            <SkipButton onPress={handleOnboardingComplete} testId="@onboarding/skipLocation" />
         </>
     );
 };

--- a/suite-native/trading-residence/src/components/SkipButton.tsx
+++ b/suite-native/trading-residence/src/components/SkipButton.tsx
@@ -5,9 +5,10 @@ import { useCountrySelectionAnalyticsReport } from '../hooks/useCountrySelection
 
 export type SkipButtonProps = {
     onPress: () => void;
+    testId?: string;
 };
 
-export const SkipButton = ({ onPress }: SkipButtonProps) => {
+export const SkipButton = ({ onPress, testId }: SkipButtonProps) => {
     const analyticsReport = useCountrySelectionAnalyticsReport();
 
     const skipLocation = () => {
@@ -16,7 +17,7 @@ export const SkipButton = ({ onPress }: SkipButtonProps) => {
     };
 
     return (
-        <Button intent="neutral" priority="secondary" onPress={skipLocation}>
+        <Button intent="neutral" priority="secondary" onPress={skipLocation} testID={testId}>
             <Translation id="tradingResidence.locationSettings.skipButton" />
         </Button>
     );

--- a/suite-native/trading-residence/src/screens/SettingsTradingLocationScreen.tsx
+++ b/suite-native/trading-residence/src/screens/SettingsTradingLocationScreen.tsx
@@ -26,7 +26,10 @@ export const SettingsTradingLocationScreen = () => {
     return (
         <Screen header={<ScreenHeader closeAction={reportCancelAndGoBack} />}>
             <TradingLocationSettings context="settings">
-                <ConfirmLocationButton afterConfirm={navigation.goBack} />
+                <ConfirmLocationButton
+                    afterConfirm={navigation.goBack}
+                    testId="@settings/confirmLocation"
+                />
             </TradingLocationSettings>
         </Screen>
     );


### PR DESCRIPTION
## Description
- Add iOS-only Detox coverage for the trading residence flow in both onboarding and Settings.
- Cover the full country selection path, including subdivision selection, onboarding confirmation, and the Settings-based confirmation flow after skipping onboarding.

## Notes for QA


## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/23054

## Screenshots:
<!--- Keep just title, empty for later add -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/23054-mobile-trade-write-e2e-tests-for-country-of-residence-selection-on-ios&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->