### PR TITLE
Chore: tighten resolveDirectoryInUserDataDir

### DIFF
--- a/packages/suite-desktop-core/src/__tests__/user-data.test.ts
+++ b/packages/suite-desktop-core/src/__tests__/user-data.test.ts
@@ -51,6 +51,15 @@ describe('resolveDirectoryInUserDataDir', () => {
             error: 'Path traversal attempt detected, directory: "../../OtherApp"',
         });
     });
+
+    it('rejects directory path traversal partially matching the user-data path', () => {
+        const result = resolveDirectoryInUserDataDir('../user-data-but-now-different');
+
+        expect(result).toStrictEqual({
+            success: false,
+            error: 'Path traversal attempt detected, directory: "../user-data-but-now-different"',
+        });
+    });
 });
 
 describe('resolvePathInUserDataDir', () => {

--- a/packages/suite-desktop-core/src/__tests__/user-data.test.ts
+++ b/packages/suite-desktop-core/src/__tests__/user-data.test.ts
@@ -1,6 +1,16 @@
 import fs from 'fs';
+import path from 'path';
 
-import { clearAppData, open, read, readDir, rename, save } from '../libs/user-data';
+import {
+    clearAppData,
+    open,
+    read,
+    readDir,
+    rename,
+    resolveDirectoryInUserDataDir,
+    resolvePathInUserDataDir,
+    save,
+} from '../libs/user-data';
 
 jest.mock('electron', () => ({
     app: {
@@ -11,6 +21,79 @@ jest.mock('electron', () => ({
 jest.mock('@suite-common/suite-utils', () => ({
     isDevEnv: false,
 }));
+
+describe('resolveDirectoryInUserDataDir', () => {
+    it('resolves a directory inside the user data directory', () => {
+        const metadataResult = resolveDirectoryInUserDataDir('metadata');
+
+        expect(metadataResult).toStrictEqual({
+            success: true,
+            payload: {
+                dir: path.resolve('/tmp/user-data', 'metadata'),
+            },
+        });
+
+        const rootDirResult = resolveDirectoryInUserDataDir('');
+
+        expect(rootDirResult).toStrictEqual({
+            success: true,
+            payload: {
+                dir: path.resolve('/tmp/user-data'),
+            },
+        });
+    });
+
+    it('rejects directory path traversal', () => {
+        const result = resolveDirectoryInUserDataDir('../../OtherApp');
+
+        expect(result).toStrictEqual({
+            success: false,
+            error: 'Path traversal attempt detected, directory: "../../OtherApp"',
+        });
+    });
+});
+
+describe('resolvePathInUserDataDir', () => {
+    it('resolves a file inside the user data directory', () => {
+        const metadataResult = resolvePathInUserDataDir('metadata', 'labels.json');
+
+        expect(metadataResult).toStrictEqual({
+            success: true,
+            payload: {
+                dir: path.resolve('/tmp/user-data', 'metadata'),
+                file: path.resolve('/tmp/user-data', 'metadata', 'labels.json'),
+            },
+        });
+
+        const rootDirResult = resolvePathInUserDataDir('', 'labels.json');
+
+        expect(rootDirResult).toStrictEqual({
+            success: true,
+            payload: {
+                dir: path.resolve('/tmp/user-data'),
+                file: path.resolve('/tmp/user-data', 'labels.json'),
+            },
+        });
+    });
+
+    it('rejects directory path traversal', () => {
+        const result = resolvePathInUserDataDir('../../OtherApp', 'labels.json');
+
+        expect(result).toStrictEqual({
+            success: false,
+            error: 'Path traversal attempt detected, directory: "../../OtherApp"',
+        });
+    });
+
+    it('rejects file path traversal', () => {
+        const result = resolvePathInUserDataDir('metadata', '../outside.txt');
+
+        expect(result).toStrictEqual({
+            success: false,
+            error: 'Path traversal attempt detected, file: "../outside.txt"',
+        });
+    });
+});
 
 describe('user-data path traversal protection', () => {
     beforeEach(() => {

--- a/packages/suite-desktop-core/src/libs/user-data.ts
+++ b/packages/suite-desktop-core/src/libs/user-data.ts
@@ -8,7 +8,9 @@ import type { Result } from '@trezor/type-utils';
 
 import { setAutoStartEnabled } from './auto-start';
 
-const resolveDirectoryInUserDataDir = (directory: string): Result<{ dir: string }, string> => {
+export const resolveDirectoryInUserDataDir = (
+    directory: string,
+): Result<{ dir: string }, string> => {
     const userDataDir = path.resolve(app.getPath('userData'));
     const dir = path.resolve(path.join(userDataDir, directory));
 
@@ -22,7 +24,7 @@ const resolveDirectoryInUserDataDir = (directory: string): Result<{ dir: string 
     return { success: true, payload: { dir } };
 };
 
-const resolvePathInUserDataDir = (
+export const resolvePathInUserDataDir = (
     directory: string,
     filename: string,
 ): Result<{ dir: string; file: string }, string> => {

--- a/packages/suite-desktop-core/src/libs/user-data.ts
+++ b/packages/suite-desktop-core/src/libs/user-data.ts
@@ -14,14 +14,14 @@ export const resolveDirectoryInUserDataDir = (
     const userDataDir = path.resolve(app.getPath('userData'));
     const dir = path.resolve(path.join(userDataDir, directory));
 
-    if (!dir.startsWith(userDataDir)) {
-        return {
-            success: false,
-            error: `Path traversal attempt detected, directory: "${directory}"`,
-        };
+    if (dir.startsWith(userDataDir + path.sep) || dir === userDataDir) {
+        return { success: true, payload: { dir } };
     }
 
-    return { success: true, payload: { dir } };
+    return {
+        success: false,
+        error: `Path traversal attempt detected, directory: "${directory}"`,
+    };
 };
 
 export const resolvePathInUserDataDir = (


### PR DESCRIPTION
## Description

[Security report here](https://app.notion.com/p/satoshilabs/Path-confinement-bypass-in-Trezor-Suite-desktop-391dc526060680c49c69d3da119b4bbf)

Tighten `resolveDirectoryInUserDataDir` to prevent a new kind of path traversal that has not been sanitized before.

- a03b1f49b134f5fe89653e985ddfea46a69d869f new tests for the atomic functions (before, only the wrappers had tests) 
- bda41eb52d686aa52cdf64e78c277712acfbf3b0 the fix :wrench: 

### Notes

But severity is very low, this is not exploitable.
That’s because we never pass `directory` param from Renderer to Main, we only pass `filenames` (those are therefore very important to sanitize).
But the `directory` parameter is always a constant string set in Main, so it is not exploitable from Renderer, [e.g. here](https://github.com/trezor/trezor-suite/blob/7f01bc15c82d67915071e9ba172edf53458c7062/packages/suite-desktop-core/src/modules/metadata.ts#L30)

Still, fixing it, beacuse it’s not guaranteeed it will stay that way – in future if we could introduce some new feature relying on directory passed from Renderer, and that would create vulnerability.

## Notes for QA

The only features on Suite Desktop that rely on filesystem operations are:
- Caching FW – if you start with fresh Suite, and install latest FW
  - The latest FW is never bundled, so Suite downloads it and caches into its data folder
- legacy metadata with local filesystem provider: create, edit, delete

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to `packages/suite-desktop-core/src/libs/user-data.ts` and its corresponding unit test file. This module handles user data/directory management in the Electron desktop core layer. None of the 109 candidate E2E tests directly exercise or reference user-data utilities based on the LLM analysis — they focus on UI flows, analytics, trading, staking, metadata, and wallet operations. The unit test file (`user-data.test.ts`) itself provides direct coverage of the changed logic. No E2E tests are recommended because there is no concrete evidence any of them would be affected by changes to this low-level desktop-core utility.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite-desktop-core/src/__tests__/user-data.test.ts`
- `packages/suite-desktop-core/src/libs/user-data.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/suite-desktop-core/src/libs/user-data.ts`
- `packages/suite-desktop-core/src/__tests__/user-data.test.ts`

_Updated: 2026-07-03T11:38:29.884Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/tighten-resolveDirectoryInUserDataDir/web/](https://dev.suite.sldev.cz/suite-web/chore/tighten-resolveDirectoryInUserDataDir/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/tighten-resolveDirectoryInUserDataDir&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/tighten-resolveDirectoryInUserDataDir&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-03T11:44:06.291Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-03T11:42:12.296Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->