### PR TITLE
chore(suite-native): disable DEV tools button by default

### DIFF
--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -187,6 +187,12 @@ const getPlugins = (): ExpoPlugins => {
                 useSQLCipher: true,
             },
         ],
+        [
+            'expo-dev-client',
+            {
+                toolsButton: false,
+            },
+        ],
     ];
 
     return [


### PR DESCRIPTION
## Screenshots:
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/48d8af59-8ec1-4dd9-a4cf-0c43140724cb" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/tools-button&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->