### PR TITLE
Fix/suite native storybook navigation

### DIFF
--- a/suite-native/navigation/src/stories/Navigation/ScreenHeader.stories.tsx
+++ b/suite-native/navigation/src/stories/Navigation/ScreenHeader.stories.tsx
@@ -44,18 +44,23 @@ export const ScreenHeaderWithCustomContent: StoryObj<typeof ScreenHeaderComponen
     name: 'ScreenHeader with custom content',
     args: {
         closeActionType: 'back',
-        customContent: <ScreenHeaderCustomContent />,
-        rightIcon: (
-            <IconButton
-                intent="neutral"
-                priority="secondary"
-                size="medium"
-                iconName="gear"
-                onPress={() => {}}
-            />
-        ),
     },
     argTypes: {
         title: { table: { disable: true } },
     },
+    render: args => (
+        <ScreenHeaderComponent
+            {...args}
+            customContent={<ScreenHeaderCustomContent />}
+            rightIcon={
+                <IconButton
+                    intent="neutral"
+                    priority="secondary"
+                    size="medium"
+                    iconName="gear"
+                    onPress={() => {}}
+                />
+            }
+        />
+    ),
 };

--- a/suite-native/navigation/src/stories/Navigation/TabBarItem.stories.tsx
+++ b/suite-native/navigation/src/stories/Navigation/TabBarItem.stories.tsx
@@ -14,7 +14,9 @@ const meta: Meta<typeof TabBarItemComponent> = {
             const [args, updateArgs] = useArgs();
 
             return (
-                <Box style={{ width: 100 }}>
+                // TabBarItem uses `flex: 1`. A row wrapper lets it fill the fixed width on the main
+                // axis while its height stays content-driven (like it does inside the real tab bar).
+                <Box style={{ width: 100, flexDirection: 'row' }}>
                     <Story
                         args={{
                             ...args,

--- a/suite-native/storybook/decorators/navigationDecorator.tsx
+++ b/suite-native/storybook/decorators/navigationDecorator.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 
 import { NavigationContainer, NavigationIndependentTree } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
-// Separated navigation container is needed to not mess up with the global app one.
+const Stack = createNativeStackNavigator();
+
+// Wrap every story in an isolated navigator so components using react-navigation hooks (e.g.
+// useNavigation in GoBackIcon) have a full navigation context.
+// NavigationIndependentTree keeps this container separate from the app's global one, because
+// Storybook itself runs inside the app's NavigationContainer.
 export const navigationDecorator = (Story: React.FC) => (
     <NavigationIndependentTree>
         <NavigationContainer>
-            <Story />
+            <Stack.Navigator screenOptions={{ headerShown: false }}>
+                <Stack.Screen name="StorybookStory">{() => <Story />}</Stack.Screen>
+            </Stack.Navigator>
         </NavigationContainer>
     </NavigationIndependentTree>
 );

--- a/suite-native/storybook/package.json
+++ b/suite-native/storybook/package.json
@@ -19,6 +19,7 @@
         "@react-native-community/datetimepicker": "^8.6.0",
         "@react-native-community/slider": "^5.1.2",
         "@react-navigation/native": "7.1.28",
+        "@react-navigation/native-stack": "7.12.0",
         "@shopify/react-native-skia": "2.5.1",
         "@storybook/addon-ondevice-controls": "^10.2.1",
         "@storybook/react": "^10.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14068,6 +14068,7 @@ __metadata:
     "@react-native-community/datetimepicker": "npm:^8.6.0"
     "@react-native-community/slider": "npm:^5.1.2"
     "@react-navigation/native": "npm:7.1.28"
+    "@react-navigation/native-stack": "npm:7.12.0"
     "@shopify/react-native-skia": "npm:2.5.1"
     "@storybook/addon-ondevice-controls": "npm:^10.2.1"
     "@storybook/react": "npm:^10.3.4"


### PR DESCRIPTION
## Description
Fixing multiple storybook problems:

- **Navigation context**: the global `navigationDecorator` wrapped stories in a bare
  `NavigationContainer`, which does not establish a full navigation context. Stories whose
  components use react-navigation hooks (e.g. `useNavigation` in `GoBackIcon`) threw and,
  with no error boundary in the on-device Storybook, took down the whole UI. The decorator
  now wraps stories in a minimal `native-stack` navigator so the context is complete. It
  stays a global decorator.
  ```
   ERROR  [Error: Uncaught (in promise, id: 0): "Error: Couldn't find a navigation context. Have you wrapped your app with 'NavigationContainer'? See https://reactnavigation.org/docs/getting-started for setup instructions."]
  ```
  
- **ScreenHeader story warning**: moved element-valued props (`customContent`, `rightIcon`)
  out of `args` into a `render` function to clear Storybook's "mapping feature / fully
  custom args" warning.
  
  ```
   WARN  We've detected a cycle in arg 'navigation-screenheader--screen-header-with-custom-content.customContent'. Args should be JSON-serializable.

    Consider using the mapping feature or fully custom args:
    - Mapping: https://storybook.js.org/docs/writing-stories/args#mapping-to-complex-arg-values
    - Custom args: https://storybook.js.org/docs/essentials/controls#fully-custom-args
  ```
  
- **TabBarItem story**: it uses `flex: 1` and collapsed to zero height in the column
  wrapper so the tab bar item was never visible; the wrapper is now a row so the item fills its fixed width with content-driven height.

## Notes for QA

- Open DevUtils → Storybook on the mobile app; the story list should load.
- Plain atom stories render normally.
- `Navigation/ScreenHeader` and `Navigation/Tabs` render without the navigation-context error;
  the back button and tab bar are interactive; `TabBarItem` is visible.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All four changed files are within the `suite-native` package scope — specifically Storybook stories (`ScreenHeader.stories.tsx`, `TabBarItem.stories.tsx`), a Storybook decorator (`navigationDecorator.tsx`), and a Storybook `package.json`. These are exclusively related to the React Native mobile Storybook setup and have no connection to the Trezor Suite web/desktop E2E test suite. None of the 106 candidate E2E tests exercise any suite-native or Storybook functionality, so no E2E tests need to be run for this change. The risk of regression in the web/desktop application is effectively zero.

<details><summary><b>Changed files (4)</b></summary>

- `suite-native/navigation/src/stories/Navigation/ScreenHeader.stories.tsx`
- `suite-native/navigation/src/stories/Navigation/TabBarItem.stories.tsx`
- `suite-native/storybook/decorators/navigationDecorator.tsx`
- `suite-native/storybook/package.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (4)**
- `suite-native/navigation/src/stories/Navigation/ScreenHeader.stories.tsx`
- `suite-native/navigation/src/stories/Navigation/TabBarItem.stories.tsx`
- `suite-native/storybook/decorators/navigationDecorator.tsx`
- `suite-native/storybook/package.json`

_Updated: 2026-07-03T12:39:26.850Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/suite-native-storybook-navigation/web/](https://dev.suite.sldev.cz/suite-web/fix/suite-native-storybook-navigation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-native-storybook-navigation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-native-storybook-navigation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-native-storybook-navigation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-03T12:45:58.000Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-03T12:43:30.080Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->