### PR TITLE
Tron Staking - Include fee in crypto/fiat input validation

### DIFF
--- a/packages/suite/src/components/earn/staking/tron/freeze/TronFreezeAmount.tsx
+++ b/packages/suite/src/components/earn/staking/tron/freeze/TronFreezeAmount.tsx
@@ -125,7 +125,7 @@ export const TronFreezeAmount = () => {
                 rate: currentRate.rate,
             })?.toFixed(2, BigNumber.ROUND_FLOOR);
 
-            setValue('fiatAmount', fiatValue ?? '', { shouldDirty: true });
+            setValue('fiatAmount', fiatValue ?? '', { shouldDirty: true, shouldValidate: true });
         }
     };
 

--- a/packages/suite/src/components/earn/staking/tron/freeze/TronFreezeAmount.tsx
+++ b/packages/suite/src/components/earn/staking/tron/freeze/TronFreezeAmount.tsx
@@ -1,9 +1,11 @@
+import { useMemo } from 'react';
 import { useFormState } from 'react-hook-form';
 
 import { Translation, useTranslation } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
 import { formInputsMaxLength } from '@suite-common/validators';
 import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { composeTronFreezeFeeLevelsThunk } from '@suite-common/wallet-core';
 import {
     asAmountSubunit,
     getStakingLimitsByNetworkSymbol,
@@ -16,7 +18,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
-import { useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import {
     validateDecimals,
     validateMin,
@@ -27,10 +29,11 @@ import { TronCurrencySwitchButton } from '../TronCurrencySwitchButton';
 import { useTronStakeContext } from '../TronStakeContext';
 
 export const TronFreezeAmount = () => {
+    const dispatch = useDispatch();
     const locale = useSelector(selectLanguage);
     const { translationString } = useTranslation();
     const { account, form, actions, amountInput } = useTronStakeContext();
-    const { control, getValues, setValue } = form.methods;
+    const { control, setValue } = form.methods;
     const { errors } = useFormState({ control });
     const isDisabled = !!actions.pendingTxid;
 
@@ -53,6 +56,31 @@ export const TronFreezeAmount = () => {
 
     const networkDisplaySymbol = getNetworkDisplaySymbol(account.symbol);
 
+    const resourceType = form.methods.watch('resourceType');
+
+    const maxFreezeAmount = useMemo(async () => {
+        const availableBalance = subunitsToUnits({
+            value: asAmountSubunit(new BigNumber(account.availableBalance)),
+            symbol: account.symbol,
+        }).toString();
+
+        const levels = await dispatch(
+            composeTronFreezeFeeLevelsThunk({ account, amount: availableBalance, resourceType }),
+        )
+            .unwrap()
+            .catch(() => undefined);
+
+        const feeInSun = levels?.normal?.type === 'final' ? levels.normal.fee : '0';
+        const maxInSun = BigNumber.max(new BigNumber(account.availableBalance).minus(feeInSun), 0);
+
+        const maxAmount = subunitsToUnits({
+            value: asAmountSubunit(maxInSun),
+            symbol: account.symbol,
+        }).toString();
+
+        return maxAmount;
+    }, [account, resourceType, dispatch]);
+
     const cryptoInputRules = {
         required: translationString('AMOUNT_IS_NOT_SET'),
         validate: {
@@ -68,7 +96,24 @@ export const TronFreezeAmount = () => {
             decimals: validateDecimals(translationString, {
                 decimals: getNetwork(account.symbol).decimals,
             }),
-            reserveOrBalance: validateReserveOrBalance(translationString, { account }),
+            reserveOrBalance: async (value: string) => {
+                const reserveOrBalanceResult = validateReserveOrBalance(translationString, {
+                    account,
+                })(value);
+
+                if (reserveOrBalanceResult) {
+                    return reserveOrBalanceResult;
+                }
+
+                const maxFreezeAmountInUnits = await maxFreezeAmount;
+
+                if (
+                    maxFreezeAmountInUnits &&
+                    new BigNumber(value).isGreaterThan(maxFreezeAmountInUnits)
+                ) {
+                    return translationString('AMOUNT_IS_NOT_ENOUGH');
+                }
+            },
         },
     };
 
@@ -95,19 +140,22 @@ export const TronFreezeAmount = () => {
                 }
             },
             decimals: validateDecimals(translationString, { decimals: 2 }),
-            balance: (value: string) => {
+            balance: async (value: string) => {
                 if (!currentRate?.rate) return true;
 
-                const availableFiat = toFiatCurrency({
-                    amount: availableBalance,
+                const maxFreezeAmountInUnits = await maxFreezeAmount;
+
+                const maxFreezeAmountInFiat = toFiatCurrency({
+                    amount: maxFreezeAmountInUnits,
                     rate: currentRate.rate,
                 })?.toFixed(2, BigNumber.ROUND_FLOOR);
 
-                return (
-                    !availableFiat ||
-                    new BigNumber(value || 0).lte(availableFiat) ||
-                    translationString('AMOUNT_IS_NOT_ENOUGH')
-                );
+                if (
+                    maxFreezeAmountInFiat &&
+                    new BigNumber(value).isGreaterThan(maxFreezeAmountInFiat)
+                ) {
+                    return translationString('AMOUNT_IS_NOT_ENOUGH');
+                }
             },
         },
     };
@@ -115,11 +163,11 @@ export const TronFreezeAmount = () => {
     const handleSetMax = async () => {
         form.methods.clearErrors(['amount', 'fiatAmount']);
 
-        await actions.setMax();
+        const maxAmount = await maxFreezeAmount;
+
+        form.methods.setValue('amount', maxAmount, { shouldValidate: true });
 
         if (currentRate?.rate) {
-            const maxAmount = getValues('amount');
-
             const fiatValue = toFiatCurrency({
                 amount: maxAmount,
                 rate: currentRate.rate,

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
@@ -4,7 +4,6 @@ import {
     type TronFlow,
     type TronStakeError,
     type TronStakeStepId,
-    composeTronFreezeFeeLevelsThunk,
     selectTronStakeSession,
     submitTronClaimThunk,
     submitTronFreezeThunk,
@@ -14,20 +13,14 @@ import {
     tronStakeActions,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
-import {
-    asAmountSubunit,
-    getTronStakingRewards,
-    getTronWithdrawableBalance,
-    subunitsToUnits,
-} from '@suite-common/wallet-utils';
+import { getTronStakingRewards, getTronWithdrawableBalance } from '@suite-common/wallet-utils';
 import { exhaustive } from '@trezor/type-utils';
-import { BigNumber } from '@trezor/utils';
 
 import { setConnectionModal, setConnectionMode } from 'src/actions/device/deviceSlice';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
-import { type useTronStakeForm } from './useTronStakeForm';
 import { resolveVotedRepresentativeAddress } from '../voteUtils';
+import { type useTronStakeForm } from './useTronStakeForm';
 
 interface UseTronStakeActionsProps {
     account: Account;
@@ -39,7 +32,6 @@ export interface TronStakeActions {
     step: TronStakeStepId;
     goToStep: (step: TronStakeStepId) => void;
     submitAction: () => void;
-    setMax: () => Promise<void>;
     isSubmitting: boolean;
     error: TronStakeError | null;
     pendingTxid: string | null;
@@ -64,31 +56,6 @@ export const useTronStakeActions = ({
             dispatch(setConnectionMode('bluetooth'));
         }
         dispatch(setConnectionModal(true));
-    };
-
-    const setMax = async () => {
-        const resourceType = form.methods.getValues('resourceType');
-
-        const availableBalance = subunitsToUnits({
-            value: asAmountSubunit(new BigNumber(account.availableBalance)),
-            symbol: account.symbol,
-        }).toString();
-
-        const levels = await dispatch(
-            composeTronFreezeFeeLevelsThunk({ account, amount: availableBalance, resourceType }),
-        )
-            .unwrap()
-            .catch(() => undefined);
-
-        const feeInSun = levels?.normal?.type === 'final' ? levels.normal.fee : '0';
-        const maxInSun = BigNumber.max(new BigNumber(account.availableBalance).minus(feeInSun), 0);
-
-        const maxAmount = subunitsToUnits({
-            value: asAmountSubunit(maxInSun),
-            symbol: account.symbol,
-        }).toString();
-
-        form.methods.setValue('amount', maxAmount, { shouldValidate: true });
     };
 
     const submitAction = () => {
@@ -194,5 +161,12 @@ export const useTronStakeActions = ({
         }
     };
 
-    return { step, goToStep, submitAction, setMax, isSubmitting, error, pendingTxid };
+    return {
+        step,
+        goToStep,
+        submitAction,
+        isSubmitting,
+        error,
+        pendingTxid,
+    };
 };


### PR DESCRIPTION
## Description

During Tron freezing, include fee for max crypto/fiat input validation.

## Related Issue

Resolve #29397 

## Screenshots:

https://github.com/user-attachments/assets/69311ad2-bfb7-4c80-a22e-36cf4535761e

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to Tron-specific staking components (TronFreezeAmount.tsx and useTronStakeActions.ts). No E2E tests in the candidate suite directly cover Tron staking freeze/stake flows — the available staking tests cover ETH, ADA, and SOL networks only. The check-links test covers /earn/tron/* routes but only validates that pages load and links are reachable, not staking form functionality. The staking-form test is the closest match as it tests staking form UX patterns that may share components with the Tron freeze form. The risk of undetected regression is moderate since these changes lack direct E2E coverage.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/earn/staking/tron/freeze/TronFreezeAmount.tsx`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — This test exercises the staking form UI including amount input, validation, fraction buttons, and max amount calculations. While it targets ETH specifically, the TronFreezeAmount component likely shares similar form patterns (crypto input, validation, balance display) from the earn/staking module. Changes to useTronStakeActions hooks could affect shared staking form infrastructure.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/earn/staking/tron/freeze/TronFreezeAmount.tsx`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts`

_Updated: 2026-07-06T07:40:12.613Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tron-stake-inputs&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tron-stake-inputs&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-06T07:46:36.607Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-06T07:43:59.479Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tron-stake-inputs/web/](https://dev.suite.sldev.cz/suite-web/fix/tron-stake-inputs/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->