### PR TITLE
chore(scripts): support nix shells and wayland for slack PR script

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,7 @@
 
         commonBuildInputs = [
           pkgs.bash
+          pkgs.jq
           pkgs.git
           pkgs.git-lfs
           pkgs.gnupg

--- a/scripts/generate-slack-pr-message.sh
+++ b/scripts/generate-slack-pr-message.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 show_help() {
     cat << EOF
@@ -44,6 +44,9 @@ copy_to_clipboard() {
     if command -v pbcopy &> /dev/null; then
         echo -e "$content" | pbcopy
         return 0
+    elif command -v wl-copy &> /dev/null; then
+        echo -e "$content" | wl-copy
+        return 0
     elif command -v xsel &> /dev/null; then
         echo -e "$content" | xsel --clipboard --input
         return 0
@@ -51,7 +54,7 @@ copy_to_clipboard() {
         echo -e "$content" | xclip -selection clipboard
         return 0
     else
-        echo -e "\033[0;33mWarning: No clipboard utility found (pbcopy, xsel, or xclip).\033[0m" >&2
+        echo -e "\033[0;33mWarning: No clipboard utility found (pbcopy, wl-copy, xsel, or xclip).\033[0m" >&2
         echo -e "\033[0;33mSkipping clipboard copy. Please copy the message manually.\033[0m" >&2
         return 1
     fi

--- a/shell.nix
+++ b/shell.nix
@@ -34,6 +34,7 @@ in
     name = "trezor-suite-dev";
     buildInputs = [
       bash
+      jq
       git
       git-lfs
       gnupg


### PR DESCRIPTION

## Description

The `generate-slack-pr-message.sh` helper didn't work on NixOS/Wayland setups. This makes it portable across NixOS, macOS, and standard Linux:

- **Shebang** — switched `#!/bin/bash` → `#!/usr/bin/env bash`, since NixOS has no `/bin/bash`. This also benefits macOS devs, where it now resolves the modern Homebrew bash instead of the ancient system `/bin/bash` 3.2.
- **`jq` dependency** — added `jq` to both dev shells (`flake.nix` for `nix develop`, `shell.nix` for `nix-shell`), so the script's JSON parsing dependency is available out of the box.
- **Wayland clipboard** — added `wl-copy` support to the clipboard helper (ordered after `pbcopy`, before `xsel`/`xclip`), so auto-copy works on Wayland sessions without needing XWayland + `xclip`.

### Test
tested on NixOS; on macOS: same script still runs and copies via `pbcopy`.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-07-03T13:25:09.820Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=slack-PR-wayland-nixos-fix&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=slack-PR-wayland-nixos-fix&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/slack-PR-wayland-nixos-fix/web/](https://dev.suite.sldev.cz/suite-web/slack-PR-wayland-nixos-fix/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-03T13:31:08.028Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-03T13:28:40.208Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->