### PR TITLE
fix(suite-native-29359): use trade-specific failure copy in trading history alerts

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -3541,8 +3541,12 @@ export const messages = {
                 orderId: 'Order id:',
                 errorAlert: {
                     title: 'Transaction failed',
-                    description:
+                    buyDescription:
                         "Your transaction failed or was rejected. Your payment method hasn't been charged.",
+                    sellDescription:
+                        'The transaction didn’t go through. We’re looking into it, but your funds are safe in your account.',
+                    swapDescription:
+                        'The transaction didn’t go through. We’re looking into it, but your funds are safe in your account.',
                 },
                 waitingAlert: {
                     title: 'Waiting for your payment ...',

--- a/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailAlert.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailAlert.tsx
@@ -28,19 +28,44 @@ type TradeDetailAlertProps = {
     onOpenedBrowser?: () => void;
 };
 
+type GetAlertConfigParams = {
+    alertType: TradeStatusStep;
+    tradeType?: TradingTransaction['tradeType'];
+};
+
 const isBuyOrSell = (
     trade?: TradingTransaction,
 ): trade is TradingTransactionBuy | TradingTransactionSell =>
     !!trade && ['buy', 'sell'].includes(trade.tradeType);
 
-const getAlertConfig = (alertType: TradeStatusStep): AlertConfig | undefined => {
+const getErrorAlertDescriptionKey = (tradeType: TradingTransaction['tradeType']): TxKeyPath => {
+    switch (tradeType) {
+        case 'buy':
+            return 'moduleTrading.tradeHistory.detail.errorAlert.buyDescription';
+        case 'sell':
+            return 'moduleTrading.tradeHistory.detail.errorAlert.sellDescription';
+        case 'exchange':
+            return 'moduleTrading.tradeHistory.detail.errorAlert.swapDescription';
+        default:
+            return exhaustive(tradeType);
+    }
+};
+
+const getAlertConfig = ({
+    alertType,
+    tradeType,
+}: GetAlertConfigParams): AlertConfig | undefined => {
     switch (alertType) {
         case 'error':
+            if (!tradeType) {
+                return undefined;
+            }
+
             return {
                 iconName: 'warningCircle',
                 intent: 'critical',
                 titleKey: 'moduleTrading.tradeHistory.detail.errorAlert.title',
-                descriptionKey: 'moduleTrading.tradeHistory.detail.errorAlert.description',
+                descriptionKey: getErrorAlertDescriptionKey(tradeType),
             };
         case 'waiting':
             return {
@@ -92,12 +117,12 @@ export const TradeDetailAlert = ({
     const { translate } = useTranslate();
 
     const trade = useSelector((state: TradingRootState) =>
-        orderId ? selectTradingTradeByOrderId(state, orderId) : undefined,
+        selectTradingTradeByOrderId(state, orderId),
     );
 
-    const alertConfig = getAlertConfig(alertType);
-
     const { openBrowser } = useBrowserAuth(trade?.tradeType);
+
+    const alertConfig = getAlertConfig({ alertType, tradeType: trade?.tradeType });
 
     if (!alertConfig || !trade) {
         return null;

--- a/suite-native/trading-history/src/components/TradeDetailSheet/__tests__/TradeDetailAlert.test.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/__tests__/TradeDetailAlert.test.tsx
@@ -1,7 +1,12 @@
 import { type TradingTransaction } from '@suite-common/trading';
 import { type TxKeyPath, getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
-import { getBuyTrade, getInitializedTradingState } from '@suite-native/trading-fixtures';
+import {
+    getBuyTrade,
+    getExchangeTrade,
+    getInitializedTradingState,
+    getSellTrade,
+} from '@suite-native/trading-fixtures';
 import { type TradeStatusStep } from '@suite-native/trading-quote-utils';
 
 import { TradeDetailAlert } from '../TradeDetailAlert';
@@ -25,7 +30,7 @@ const alertLabelsCases: AlertLabelsCase[] = [
     {
         alertType: 'error',
         titleKey: 'moduleTrading.tradeHistory.detail.errorAlert.title',
-        descriptionKey: 'moduleTrading.tradeHistory.detail.errorAlert.description',
+        descriptionKey: 'moduleTrading.tradeHistory.detail.errorAlert.buyDescription',
     },
     {
         alertType: 'waiting',
@@ -91,5 +96,24 @@ describe('TradeDetailAlert', () => {
         expect(
             getByText(getTranslation('moduleTrading.tradeHistory.detail.waitingAlert.button')),
         ).toBeOnTheScreen();
+    });
+
+    it.each([
+        [
+            getBuyTrade({ status: 'ERROR' }),
+            'moduleTrading.tradeHistory.detail.errorAlert.buyDescription',
+        ],
+        [
+            getSellTrade({ status: 'ERROR' }),
+            'moduleTrading.tradeHistory.detail.errorAlert.sellDescription',
+        ],
+        [
+            getExchangeTrade({ status: 'ERROR' }),
+            'moduleTrading.tradeHistory.detail.errorAlert.swapDescription',
+        ],
+    ] as const)('should use trade-specific error description key', (trade, key) => {
+        const { getByText } = renderAlert({ alertType: 'error', trade });
+
+        expect(getByText(getTranslation(key))).toBeOnTheScreen();
     });
 });


### PR DESCRIPTION
## Description
- Split the trading history error alert copy by trade type.

## Notes for QA
- Verify the trading history detail sheet shows the correct failure copy for each trade type.

## Related Issue
Resolve: https://github.com/trezor/trezor-suite/issues/29359

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/29359-trade-failure-copy-uses-buy-specific-payment-method-wording-for-sellswap&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->