### PR TITLE
Honor Solana minimum stake delegation when unstaking

### DIFF
--- a/coins/coins-solana/src/constants/common.ts
+++ b/coins/coins-solana/src/constants/common.ts
@@ -21,7 +21,8 @@ export const MEMO_PROGRAM_PUBLIC_KEY_V1 = 'Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQ
 export const MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT = 16;
 export const MAX_DEACTIVATE_ACCOUNTS = 22;
 export const MAX_CLAIM_ACCOUNTS = 16;
-export const MIN_AMOUNT = 10000000; // 0.01 SOL
+
+export const MIN_STAKE_DELEGATION = 1_000_000_000n;
 
 export const tokenProgramNames = ['spl-token', 'spl-token-2022'] as const;
 

--- a/coins/coins-solana/src/runtime/staking.ts
+++ b/coins/coins-solana/src/runtime/staking.ts
@@ -19,7 +19,7 @@ import {
     MAX_CLAIM_ACCOUNTS,
     MAX_DEACTIVATE_ACCOUNTS,
     MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT,
-    MIN_AMOUNT,
+    MIN_STAKE_DELEGATION,
     STAKE_ACCOUNT_V2_SIZE,
     StakeState,
 } from '../constants';
@@ -188,7 +188,6 @@ export const unstake = async ({
         const epoch = params?.epoch || (await connection.getEpochInfo().send()).epoch;
         const tm = timestampInSec();
 
-        let unstakeAmount = lamports;
         let totalActiveStake: bigint = 0n;
         const activeStakeAccounts = stakeAccounts.filter(acc => {
             if (acc.data.state.__kind !== 'Stake') {
@@ -224,8 +223,10 @@ export const unstake = async ({
         const accountsToDeactivate: Delegations = [];
         const accountsToSplit: [Account<StakeStateAccount, Address>, bigint][] = [];
 
+        let remaining = lamports;
+        let unstakeAmount = 0n;
         let i = 0;
-        while (lamports > 0n && i < activeStakeAccounts.length) {
+        while (remaining > 0n && i < activeStakeAccounts.length) {
             const acc = activeStakeAccounts[i];
             if (acc === undefined || !isStake(acc.data.state)) {
                 i++;
@@ -234,16 +235,15 @@ export const unstake = async ({
 
             const stakeAmount = acc.data.state.fields[1].delegation.stake;
 
-            // If reminder amount less than min stake amount stake account automatically become disabled
-            const isBelowThreshold = stakeAmount <= lamports || stakeAmount - lamports < MIN_AMOUNT;
-            if (isBelowThreshold) {
+            // The whole account is needed to reach the requested amount: deactivate it entirely.
+            if (stakeAmount <= remaining) {
                 accountsToDeactivate.push(acc);
-                lamports = lamports - stakeAmount;
+                unstakeAmount += stakeAmount;
+                remaining -= stakeAmount;
                 i++;
 
                 // Max num of deactivate instructions reached
                 if (accountsToDeactivate.length === MAX_DEACTIVATE_ACCOUNTS) {
-                    unstakeAmount -= lamports;
                     break;
                 }
                 continue;
@@ -251,11 +251,19 @@ export const unstake = async ({
 
             // Max num of deactivate instructions with split reached
             if (accountsToDeactivate.length > MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT) {
-                unstakeAmount -= lamports;
                 break;
             }
 
-            accountsToSplit.push([acc, lamports]);
+            // Split `remaining` off only if both legs stay above the minimum; otherwise deactivate the whole account.
+            const splitProducesValidAccount = remaining >= MIN_STAKE_DELEGATION;
+            const splitLeavesValidRemainder = stakeAmount - remaining >= MIN_STAKE_DELEGATION;
+            if (splitProducesValidAccount && splitLeavesValidRemainder) {
+                accountsToSplit.push([acc, remaining]);
+                unstakeAmount += remaining;
+            } else {
+                accountsToDeactivate.push(acc);
+                unstakeAmount += stakeAmount;
+            }
             break;
         }
 

--- a/suite-common/staking/src/actions/solanaStakeFormActions.ts
+++ b/suite-common/staking/src/actions/solanaStakeFormActions.ts
@@ -108,12 +108,14 @@ const estimateSolanaStakeFee = async (
 ): Promise<EstimatedFee> => {
     if (!txData?.success) return { success: false };
 
+    const createsStakeAccount = txData.solanaTxMeta.rentLamports !== '0';
+
     const estimatedFee = await TrezorConnect.blockchainEstimateFee({
         coin: symbol,
         request: {
             specific: {
                 data: txData.txShim.serialize(),
-                newAccountProgramName: 'staking',
+                ...(createsStakeAccount ? { newAccountProgramName: 'staking' } : {}),
             },
         },
     });

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -140,6 +140,13 @@ export type PrecomposedTransactionError = PrecomposedTransactionErrorExtended & 
 type PrecomposedTransactionCardanoError = PrecomposedTransactionCardanoConnectResponseError &
     ComposeError;
 
+export type SolanaTxMeta = {
+    deviceAmountLamports: string;
+    feeLamports: string;
+    rentLamports: string;
+    feeIncludingRentLamports: string;
+};
+
 type PrecomposedTransactionNonFinal = PrecomposedTransactionConnectResponseNonFinal & {
     max: string | undefined;
     feeLimit?: string;
@@ -148,6 +155,7 @@ type PrecomposedTransactionNonFinal = PrecomposedTransactionConnectResponseNonFi
     energyConsumed?: number;
     accountActivationFee?: string;
     memoFee?: string;
+    solanaTxMeta?: SolanaTxMeta;
 };
 
 // base of PrecomposedTransactionFinal
@@ -166,6 +174,7 @@ type PrecomposedTransactionBase = PrecomposedTransactionConnectResponseFinal & {
     createdTimestamp?: number;
     maxFeePerGas?: string;
     maxPriorityFeePerGas?: string;
+    solanaTxMeta?: SolanaTxMeta;
 };
 
 // base of PrecomposedTransactionFinal

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2664,6 +2664,7 @@ export const messages = {
             validation: {
                 amountIsZero: 'Amount must be greater than 0.',
                 amountExceedsMax: 'The amount exceeds the maximum allowed value of {maxAmount}.',
+                amountBelowMin: 'The minimum amount to unstake is {minAmount} {networkSymbol}.',
                 insufficientBalance: 'You don’t have enough staked balance to unstake this amount.',
                 tooManyDecimals: 'Too many decimals.',
             },

--- a/suite-native/module-earn/src/__tests__/unstakeFormSchema.test.ts
+++ b/suite-native/module-earn/src/__tests__/unstakeFormSchema.test.ts
@@ -1,0 +1,30 @@
+import { type UnstakeFormContext, unstakeFormValidationSchema } from '../unstakeFormSchema';
+
+const translate = ((id: string) => id) as UnstakeFormContext['translate'];
+
+const validate = (amount: string, context: Omit<UnstakeFormContext, 'translate'>) =>
+    unstakeFormValidationSchema.validate(
+        { amount, fiat: '' },
+        { context: { translate, ...context } },
+    );
+
+describe('unstakeFormValidationSchema — Solana minimum unstake amount', () => {
+    const solContext = { symbol: 'sol', stakedBalance: '10', decimals: 9 } as const;
+
+    it('rejects a Solana amount below the 1 SOL minimum delegation', async () => {
+        await expect(validate('0.5', solContext)).rejects.toThrow(
+            'earn.unstakeFormScreen.validation.amountBelowMin',
+        );
+    });
+
+    it('accepts a Solana amount at or above the 1 SOL minimum', async () => {
+        await expect(validate('1', solContext)).resolves.toBeDefined();
+        await expect(validate('1.1', solContext)).resolves.toBeDefined();
+    });
+
+    it('does not apply the Solana minimum to other networks (e.g. Ethereum)', async () => {
+        await expect(
+            validate('0.5', { symbol: 'eth', stakedBalance: '10', decimals: 18 }),
+        ).resolves.toBeDefined();
+    });
+});

--- a/suite-native/module-earn/src/components/UnstakeTransactionDataReviewStepList.tsx
+++ b/suite-native/module-earn/src/components/UnstakeTransactionDataReviewStepList.tsx
@@ -50,10 +50,12 @@ export const UnstakeTransactionDataReviewStepList = () => {
         return null;
     }
 
-    const amountInBaseUnits = unitsToSubunits({
-        value: asAmountUnit(new BigNumber(amount)),
-        symbol: accountSymbol,
-    }).toString();
+    const amountInBaseUnits =
+        selectedPrecomposed?.solanaTxMeta?.deviceAmountLamports ??
+        unitsToSubunits({
+            value: asAmountUnit(new BigNumber(amount)),
+            symbol: accountSymbol,
+        }).toString();
 
     return (
         <View>

--- a/suite-native/module-earn/src/components/__tests__/UnstakeTransactionDataReviewStepList.test.tsx
+++ b/suite-native/module-earn/src/components/__tests__/UnstakeTransactionDataReviewStepList.test.tsx
@@ -11,6 +11,7 @@ const mockEarnSummaryOutputItem = jest.fn();
 let mockIsTransactionAlreadySigned: boolean;
 let mockSummaryOutput: ReviewSummaryOutput | null;
 let mockAccountNetworkSymbol: string | null;
+let mockPrecomposed: { fee: string; solanaTxMeta?: { deviceAmountLamports: string } };
 
 const accountKey = mockAccountKey({ symbol: 'eth', descriptor: 'ethAccount' });
 
@@ -47,7 +48,7 @@ jest.mock('../EarnSummaryOutputItem', () => ({
 }));
 
 jest.mock('../../hooks/useEarnSelectedPrecomposedTransaction', () => ({
-    useEarnSelectedPrecomposedTransaction: () => ({ fee: '21000' }),
+    useEarnSelectedPrecomposedTransaction: () => mockPrecomposed,
 }));
 
 const renderStepList = () => renderWithStoreProvider(<UnstakeTransactionDataReviewStepList />);
@@ -58,6 +59,7 @@ describe('UnstakeTransactionDataReviewStepList', () => {
         mockIsTransactionAlreadySigned = false;
         mockSummaryOutput = null;
         mockAccountNetworkSymbol = 'eth';
+        mockPrecomposed = { fee: '21000' };
     });
 
     it('renders nothing until the account network symbol is known', () => {
@@ -123,5 +125,26 @@ describe('UnstakeTransactionDataReviewStepList', () => {
         const { getByTestId } = renderStepList();
 
         expect(getByTestId('sliding-footer-overlay')).toBeOnTheScreen();
+    });
+
+    it('converts the entered amount to base units when there is no Solana tx meta (e.g. Ethereum)', () => {
+        renderStepList();
+
+        // Route amount '1' ETH -> 1e18 wei.
+        expect(mockEarnSummaryOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ amount: '1000000000000000000' }),
+        );
+    });
+
+    it('shows the Solana device amount, not the entered one, when the split logic adjusts the amount', () => {
+        // User typed 1 SOL but the min-delegation split logic deactivates a whole 2 SOL account.
+        mockAccountNetworkSymbol = 'sol';
+        mockPrecomposed = { fee: '5000', solanaTxMeta: { deviceAmountLamports: '2000000000' } };
+
+        renderStepList();
+
+        expect(mockEarnSummaryOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ amount: '2000000000' }),
+        );
     });
 });

--- a/suite-native/module-earn/src/unstakeFormSchema.ts
+++ b/suite-native/module-earn/src/unstakeFormSchema.ts
@@ -1,6 +1,10 @@
 import { yup } from '@suite-common/validators';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { getStakingLimitsByNetworkSymbol, isDecimalsValid } from '@suite-common/wallet-utils';
+import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import {
+    getStakingLimitsByNetworkSymbol,
+    isDecimalsValid,
+    isSupportedSolStakingNetworkSymbol,
+} from '@suite-common/wallet-utils';
 import { type Translate } from '@suite-native/intl';
 import { BigNumber } from '@trezor/utils';
 
@@ -41,6 +45,26 @@ export const unstakeFormValidationSchema = yup.object({
                 return this.createError({
                     message: translate('earn.unstakeFormScreen.validation.amountExceedsMax', {
                         maxAmount: limits.MAX_AMOUNT_FOR_STAKING.toString(),
+                    }),
+                });
+            }
+
+            return true;
+        })
+        .test('min-amount', 'Amount is below the minimum.', function (value) {
+            const { symbol, translate } = this.options.context as UnstakeFormContext;
+
+            // Solana can't split off an unstake below its minimum delegation; other networks have no such floor.
+            if (!value || !symbol || !isSupportedSolStakingNetworkSymbol(symbol)) return true;
+
+            const limits = getStakingLimitsByNetworkSymbol(symbol);
+            if (!limits) return true;
+
+            if (new BigNumber(value).lt(limits.MIN_AMOUNT_FOR_STAKING)) {
+                return this.createError({
+                    message: translate('earn.unstakeFormScreen.validation.amountBelowMin', {
+                        minAmount: limits.MIN_AMOUNT_FOR_STAKING.toString(),
+                        networkSymbol: getNetworkDisplaySymbol(symbol),
                     }),
                 });
             }

--- a/suite-native/staking/src/__tests__/stakeFormSolanaNativeThunks.test.ts
+++ b/suite-native/staking/src/__tests__/stakeFormSolanaNativeThunks.test.ts
@@ -149,6 +149,7 @@ const buildSolanaPrecomposedTransaction = (): PrecomposedTransactionFinal =>
 
 const solanaSignTransactionMock = TrezorConnect.solanaSignTransaction as jest.Mock;
 const blockchainGetInfoMock = TrezorConnect.blockchainGetInfo as jest.Mock;
+const blockchainEstimateFeeMock = TrezorConnect.blockchainEstimateFee as jest.Mock;
 
 const dispatchCompose = async (
     store: ReturnType<typeof buildStore>,
@@ -185,6 +186,8 @@ beforeEach(() => {
         success: false,
         payload: { error: 'backend not connected' },
     });
+
+    blockchainEstimateFeeMock.mockClear();
 
     prepareStakeSolTxMock.mockReset();
     prepareStakeSolTxMock.mockResolvedValue({
@@ -280,6 +283,45 @@ describe('composeSolanaStakingTransactionFeeLevelsNativeThunk', () => {
         // applySolanaTxMeta overrides the fee with feeIncludingRentLamports
         expect(levels.normal.fee).toBe('2287880');
         expect(levels.normal.solanaTxMeta.feeIncludingRentLamports).toBe('2287880');
+    });
+
+    it('omits newAccountProgramName when an unstake only deactivates (creates no stake account)', async () => {
+        // A plain deactivate reserves no rent, so the fee estimate must not add a phantom rent reserve.
+        prepareUnstakeSolTxMock.mockResolvedValue({
+            success: true,
+            txShim: solanaTxShim,
+            solanaTxMeta: { ...solanaTxMetaMock, rentLamports: '0' },
+        });
+        const store = buildStore();
+
+        await dispatchCompose(store, {
+            accountKey: SOL_ACCOUNT_KEY,
+            stakeType: 'unstake',
+            amount: '1',
+        });
+
+        expect(blockchainEstimateFeeMock).toHaveBeenCalled();
+        const request = blockchainEstimateFeeMock.mock.calls.at(-1)?.[0];
+        expect(request.request.specific).not.toHaveProperty('newAccountProgramName');
+    });
+
+    it('passes newAccountProgramName when an unstake splits a stake account (reserves rent)', async () => {
+        // A split creates a new rent-exempt stake account, so that reserve must be counted.
+        prepareUnstakeSolTxMock.mockResolvedValue({
+            success: true,
+            txShim: solanaTxShim,
+            solanaTxMeta: { ...solanaTxMetaMock, rentLamports: '2282880' },
+        });
+        const store = buildStore();
+
+        await dispatchCompose(store, {
+            accountKey: SOL_ACCOUNT_KEY,
+            stakeType: 'unstake',
+            amount: '1',
+        });
+
+        const request = blockchainEstimateFeeMock.mock.calls.at(-1)?.[0];
+        expect(request.request.specific.newAccountProgramName).toBe('staking');
     });
 });
 


### PR DESCRIPTION
## Description

Fractional Solana unstakes could fail with a misleading "insufficient fee" error, caused by leftover stake accounts falling below Solana's 1 SOL minimum delegation and by the fee estimate reserving rent for stake accounts that were never created. Unstaking now keeps both the withdrawn and leftover amounts above the minimum, stops reserving unnecessary rent, and on mobile rejects sub-minimum amounts while showing the exact on-device amount.

## Related Issue


