### PR TITLE
Reduce size of the Solana "Try again" transaction button

### DIFF
--- a/suite-native/transaction-management/src/components/TxValidityTimer.tsx
+++ b/suite-native/transaction-management/src/components/TxValidityTimer.tsx
@@ -37,7 +37,7 @@ export const TxValidityTimer = ({
         <HStack paddingVertical="sp8" justifyContent="space-between" alignItems="center">
             <Badge intent="warning" size="medium" label={getLabel()} />
             <Button
-                size="large"
+                size="medium"
                 intent="neutral"
                 priority="secondary"
                 iconLeft="arrowsCounterClockwise"


### PR DESCRIPTION
## Description

The "Try again" button shown when a Solana transaction's validity window expires was rendered at the largest button size in the mobile app. This reduces it to the medium size so it fits better alongside the countdown badge in the review screen. The button is shared by the Solana staking review (stake, unstake, and claim) and the Solana send review, so all of those show the smaller retry button.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29312

## Screenshots:
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2026-07-03 at 16 35 17" src="https://github.com/user-attachments/assets/4098749e-d60c-49ba-94b8-ba948db07673" />
