### PR TITLE
Show Solana reward frequency instead of next reward

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2510,6 +2510,7 @@ export const messages = {
             totalRewardsLabel: 'Total rewards',
             autoRestakedBadge: 'Automatically restaked',
             nextRewardLabel: 'Next reward in {value, plural, one {# day} other {# days}}',
+            solRewardsFrequencyLabel: 'Rewards every ~{value, plural, one {# day} other {# days}}',
             unstakeButton: 'Unstake',
             stakeButton: 'Stake',
             stakeMoreButton: 'Stake more',

--- a/suite-native/module-earn/src/components/StakingManagementStakedCard.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementStakedCard.tsx
@@ -159,7 +159,11 @@ export const StakingManagementStakedCard = ({
                 {nextRewardPayout != null && (
                     <Text variant="body-sm">
                         <Translation
-                            id="earn.stakingManagementScreen.nextRewardLabel"
+                            id={
+                                isSolanaStaking
+                                    ? 'earn.stakingManagementScreen.solRewardsFrequencyLabel'
+                                    : 'earn.stakingManagementScreen.nextRewardLabel'
+                            }
                             values={{ value: nextRewardPayout }}
                         />
                     </Text>


### PR DESCRIPTION
## Description

On the mobile staking management screen, Ethereum and Solana shared the same "Next reward in N days" label, but that phrasing doesn't fit Solana, whose rewards accrue every epoch rather than at a single upcoming payout. This splits the label by network so Solana now reads "Rewards every ~2 days" while Ethereum keeps its existing "Next reward in N days" text. The value is still sourced per network (Solana's epoch length, Ethereum's next payout estimate), so both remain accurate.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29309

## Screenshots:
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2026-07-03 at 17 00 10" src="https://github.com/user-attachments/assets/663e99f8-3062-4b69-950c-fb11c76a575f" />
