### PR TITLE
refactor(suite): import tor types from tor package

### DIFF
--- a/packages/suite/src/components/suite/TorLoader/TorLoader.tsx
+++ b/packages/suite/src/components/suite/TorLoader/TorLoader.tsx
@@ -2,7 +2,7 @@ import { type ComponentType, type ReactNode, useEffect, useState } from 'react';
 
 import { Translation } from '@suite/intl';
 import { selectModalType } from '@suite/modal';
-import { selectTorState } from '@suite/tor';
+import { TorStatus, selectTorState } from '@suite/tor';
 import {
     Banner,
     Card,
@@ -18,7 +18,6 @@ import { spacings } from '@trezor/theme';
 
 import { toggleTor, updateTorStatus } from 'src/actions/suite/suiteActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { TorStatus } from 'src/types/suite';
 
 type TorLoadingScreenProps = {
     ModalWrapper?: ComponentType<{ children: ReactNode }>;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Tor.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Tor.tsx
@@ -1,12 +1,11 @@
 import { Translation, type TranslationKey } from '@suite/intl';
 import { SettingsAnchor, goto } from '@suite/router';
-import { selectTorState } from '@suite/tor';
+import { TorStatus, selectTorState } from '@suite/tor';
 import { Column, Icon, type IconName, type UIIntent } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
 import { QuickActionButton, TooltipRow } from '@trezor/product-components';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { TorStatus } from 'src/types/suite';
 
 const torStatusTranslationMap: Record<TorStatus, TranslationKey> = {
     [TorStatus.Enabled]: 'TR_TOR_ENABLED',

--- a/packages/suite/src/support/suite/useTor.tsx
+++ b/packages/suite/src/support/suite/useTor.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { getIsTorDomain, selectTorState } from '@suite/tor';
+import { TorStatus, getIsTorDomain, selectTorState } from '@suite/tor';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getLocationHostname, isDesktop, isWeb } from '@trezor/env-utils';
 import { type BootstrapTorEvent, type TorStatusEvent, desktopApi } from '@trezor/suite-desktop-api';
@@ -11,7 +11,6 @@ import {
     updateTorStatus,
 } from 'src/actions/suite/suiteActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { TorStatus } from 'src/types/suite';
 
 export const useTor = () => {
     const { torBootstrap, isTorEnabling } = useSelector(selectTorState);

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -13,7 +13,7 @@ import type { recoveryActions } from '@suite/recovery';
 import { type Route, type RouterAction } from '@suite/router';
 import { type suiteSettingsActions } from '@suite/settings';
 import { type suiteSyncSlice } from '@suite/suite-sync';
-import { type torActions } from '@suite/tor';
+import { type TorAction } from '@suite/tor';
 import { type analyticsActions } from '@suite-common/analytics-redux';
 import { type bluetoothActions } from '@suite-common/bluetooth';
 import { type deviceActions } from '@suite-common/device';
@@ -134,7 +134,6 @@ type BackupAction = ReturnType<(typeof backupActions)[keyof typeof backupActions
 type DiscreetModeAction = ReturnType<
     (typeof discreetModeActions)[keyof typeof discreetModeActions]
 >;
-type TorAction = ReturnType<(typeof torActions)[keyof typeof torActions]>;
 type DebugAction = ReturnType<(typeof debugActions)[keyof typeof debugActions]>;
 type DesktopUpdateAction = ReturnType<
     (typeof desktopUpdateActions)[keyof typeof desktopUpdateActions]
@@ -205,9 +204,6 @@ export type ForegroundAppProps = {
 };
 
 export type ToastNotificationVariant = 'success' | 'info' | 'warning' | 'error' | 'transparent';
-
-export { TorStatus } from '@suite/tor';
-export type { TorBootstrap } from '@suite/tor';
 
 export enum DisplayMode {
     CHUNKS = 1,

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -3,7 +3,7 @@ import { Translation } from '@suite/intl';
 import { LabelingSettings } from '@suite/labeling';
 import { selectIsLegacyLabelingVisible, selectSelectedProviderForLabels } from '@suite/metadata';
 import { selectHasExperimentalFeature } from '@suite/settings';
-import { selectTorState } from '@suite/tor';
+import { TorStatus, selectTorState } from '@suite/tor';
 import { Context } from '@suite-common/message-system';
 import { selectIsMevProtectionSettingsVisible } from '@suite-common/mev';
 import { getNetwork } from '@suite-common/wallet-config';
@@ -19,7 +19,6 @@ import { SettingsLayout } from 'src/components/settings/SettingsLayout';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useSelector } from 'src/hooks/suite';
 import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
-import { TorStatus } from 'src/types/suite';
 
 import { AddressDisplay } from './AddressDisplay';
 import { Analytics } from './Analytics';

--- a/packages/suite/src/views/settings/SettingsGeneral/Tor.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Tor.tsx
@@ -4,7 +4,7 @@ import { LearnMoreButton } from '@suite/external-links';
 import { Translation } from '@suite/intl';
 import { openDeferredModal, selectModalType } from '@suite/modal';
 import { Anchor, SettingsAnchor } from '@suite/router';
-import { getIsTorEnabled, getIsTorLoading } from '@suite/tor';
+import { TorStatus, getIsTorEnabled, getIsTorLoading } from '@suite/tor';
 import { Switch } from '@trezor/components';
 import { ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 import { HELP_CENTER_TOR_URL } from '@trezor/urls';
@@ -12,7 +12,6 @@ import { HELP_CENTER_TOR_URL } from '@trezor/urls';
 import { toggleTor } from 'src/actions/suite/suiteActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectCoinjoinAccounts } from 'src/reducers/wallet/coinjoinReducer';
-import { TorStatus } from 'src/types/suite';
 
 export const Tor = () => {
     const [hasTorError, setHasTorError] = useState(false);

--- a/suite/tor/src/index.ts
+++ b/suite/tor/src/index.ts
@@ -1,4 +1,4 @@
 export { type TorBootstrap, TorStatus } from './torSlice';
 export { getIsTorDomain, getIsTorEnabled, getIsTorLoading, isOnionUrl } from './torUtils';
 export { selectIsTorEnabled, selectTorState } from './torSelectors';
-export { type TorRootState, torActions, torReducer } from './torSlice';
+export { type TorAction, type TorRootState, torActions, torReducer } from './torSlice';

--- a/suite/tor/src/torSlice.ts
+++ b/suite/tor/src/torSlice.ts
@@ -43,4 +43,5 @@ export type TorRootState = {
 };
 
 export const torActions = torSlice.actions;
+export type TorAction = ReturnType<(typeof torActions)[keyof typeof torActions]>;
 export const torReducer = torSlice.reducer;


### PR DESCRIPTION
## Notes for QA

Non, only code moving between packaged

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set focuses on Tor-related functionality: the Tor toggle in the sidebar, the Tor loader component, the useTor hook, the Tor settings section on the General settings page, the tor Redux slice, and the tor module entry point. Most changed files (TorLoader, Sidebar/Tor, useTor) are broadly imported across 121 tests as part of the SuiteLayout, but only tests that specifically interact with Tor settings, analytics reporting of Tor state, or desktop bridge/Tor infrastructure are meaningfully affected. The recommended strategy is to focus on the Settings General test (which directly renders the changed Tor component), the analytics events test (which asserts tor state), and the desktop bridge-tor tests (which exercise the tor module).

<details><summary><b>Changed files (8)</b></summary>

- `packages/suite/src/components/suite/TorLoader/TorLoader.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Tor.tsx`
- `packages/suite/src/support/suite/useTor.tsx`
- `packages/suite/src/types/suite/index.ts`
- `packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx`
- `packages/suite/src/views/settings/SettingsGeneral/Tor.tsx`
- `suite/tor/src/index.ts`
- `suite/tor/src/torSlice.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — This test directly exercises the SettingsGeneral page where the Tor toggle component lives. It tests changing settings (fiat, theme, language, analytics toggle) on the same page where Tor.tsx is rendered. Changes to SettingsGeneral.tsx or Tor.tsx could break the settings page layout or functionality.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — The SuiteReady analytics event explicitly asserts 'tor false' as a default setting. Changes to torSlice.ts or the Tor state management could affect the default tor value reported in analytics events, causing this assertion to fail.
- `suite/e2e/tests/settings/autodetect.test.ts` — This test loads the onboarding/settings page and checks theme colors and locale detection. Since SettingsGeneral.tsx was modified, any rendering regression on the settings page could be caught here. The test specifically validates the visual rendering of settings-adjacent components.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This desktop-only test exercises bridge spawning and app initialization which involves Tor-related infrastructure. Changes to suite/tor/src/index.ts and torSlice.ts could affect how the app initializes bridge/Tor integration on startup.
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test validates the bridge daemon lifecycle in the Electron app. The tor module (suite/tor/src/index.ts, torSlice.ts) is part of the desktop infrastructure that manages network connectivity, and changes here could affect daemon initialization paths.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test crawls all settings pages including SettingsGeneral. If the Tor component change introduces a broken link or crashes the settings page render, this test would catch it.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/types/suite/index.ts`
- `suite/tor/src/index.ts`
- `suite/tor/src/torSlice.ts`

_Updated: 2026-07-03T15:10:45.680Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=extract-tor&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=extract-tor&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-03T15:16:17.323Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-03T15:14:24.730Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/extract-tor/web/](https://dev.suite.sldev.cz/suite-web/extract-tor/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->