### PR TITLE
chore(scripts): add declaration size report

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
         "generate-package": "yarn workspace @trezor/scripts generate-package",
         "deps": "rimraf **/node_modules && yarn",
         "list-outdated": "./scripts/list-outdated-dependencies/list-outdated-dependencies.sh",
+        "list-largest-dts-files": "yarn workspace @trezor/scripts list-largest-dts-files",
         "message-system-sign-config": "yarn workspace @suite-common/message-system sign-config",
         "update-submodules": "./scripts/update-submodules.sh",
         "update-coins": "./scripts/update-coins.sh",

--- a/scripts/listLargestDTSFiles.ts
+++ b/scripts/listLargestDTSFiles.ts
@@ -1,0 +1,102 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+type FileSize = {
+    bytes: number;
+    path: string;
+};
+
+const rootDir = path.resolve(import.meta.dirname, '..');
+
+const excludedDirectoryNames = new Set(['.git', '.nx', '.yarn', 'coverage', 'node_modules', 'tmp']);
+
+const parseLimit = (args: string[]): number => {
+    const limitArg = args.find(arg => arg.startsWith('--limit='));
+    if (!limitArg) {
+        return 20;
+    }
+
+    const limit = Number(limitArg.replace('--limit=', ''));
+    if (!Number.isInteger(limit) || limit < 1) {
+        throw new Error(`Invalid --limit value: ${limitArg}`);
+    }
+
+    return limit;
+};
+
+const formatBytes = (bytes: number): string => {
+    if (bytes < 1024) {
+        return `${bytes} B`;
+    }
+
+    const units = ['KiB', 'MiB', 'GiB'] as const;
+    let value = bytes / 1024;
+    let unitIndex = 0;
+
+    while (value >= 1024 && unitIndex < units.length - 1) {
+        value /= 1024;
+        unitIndex++;
+    }
+
+    return `${value.toFixed(2)} ${units[unitIndex]}`;
+};
+
+const isDTSFile = (filePath: string): boolean =>
+    filePath.endsWith('.d.ts') || filePath.endsWith('.d.mts') || filePath.endsWith('.d.cts');
+
+const collectDTSFiles = (directory: string, files: FileSize[] = []): FileSize[] => {
+    const entries = fs.readdirSync(directory, { withFileTypes: true });
+
+    entries.forEach(entry => {
+        const fullPath = path.join(directory, entry.name);
+
+        if (entry.isDirectory()) {
+            if (!excludedDirectoryNames.has(entry.name)) {
+                collectDTSFiles(fullPath, files);
+            }
+
+            return;
+        }
+
+        if (entry.isFile() && isDTSFile(fullPath)) {
+            files.push({
+                bytes: fs.statSync(fullPath).size,
+                path: path.relative(rootDir, fullPath).replaceAll('\\', '/'),
+            });
+        }
+    });
+
+    return files;
+};
+
+const printLargestFiles = (files: FileSize[], limit: number) => {
+    const largestFiles = files.sort((a, b) => b.bytes - a.bytes).slice(0, limit);
+    const sizeColumnWidth = Math.max(...largestFiles.map(file => formatBytes(file.bytes).length));
+    const bytesColumnWidth = Math.max(...largestFiles.map(file => file.bytes.toString().length));
+
+    console.log(`Largest declaration files in ${rootDir}`);
+    console.log(`Showing ${largestFiles.length} of ${files.length} files\n`);
+
+    largestFiles.forEach((file, index) => {
+        const rank = `${index + 1}.`.padStart(3, ' ');
+        const size = formatBytes(file.bytes).padStart(sizeColumnWidth, ' ');
+        const bytes = `${file.bytes} bytes`.padStart(bytesColumnWidth + ' bytes'.length, ' ');
+
+        console.log(`${rank} ${size}  ${bytes}  ${file.path}`);
+    });
+};
+
+try {
+    const limit = parseLimit(process.argv.slice(2));
+    const dtsFiles = collectDTSFiles(rootDir);
+
+    if (dtsFiles.length === 0) {
+        console.log(`No declaration files found in ${rootDir}`);
+        process.exit(0);
+    }
+
+    printLargestFiles(dtsFiles, limit);
+} catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -7,7 +7,8 @@
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "generate-package": "tsx generatePackage.ts"
+        "generate-package": "tsx generatePackage.ts",
+        "list-largest-dts-files": "tsx listLargestDTSFiles.ts"
     },
     "devDependencies": {
         "@babel/cli": "7.29.7",


### PR DESCRIPTION
```
 1.   2.97 MiB  3115921 bytes  suite-common/wallet-core/libDev/src/stablecoin-yield/stablecoinYieldReducer.d.ts
 2.   1.80 MiB  1892676 bytes  suite-native/transaction-management/libDev/src/sendFormSlice.d.ts
 3.   1.61 MiB  1693421 bytes  suite-common/wallet-core/libDev/src/stake/tron/tronStakeReducer.d.ts
 4.   1.02 MiB  1071661 bytes  suite-native/trading-state/libDev/src/reducers/tradingSlice.d.ts
 5. 859.33 KiB   879951 bytes  suite-common/trading/libDev/src/reducers/tradingCommonReducer.d.ts
 6. 738.80 KiB   756532 bytes  suite/e2e/libDev/fixtures/invity/index.d.ts
 7. 622.68 KiB   637623 bytes  suite-common/earn-stablecoin-defs/libDev/src/api/index.d.ts
 8. 591.56 KiB   605756 bytes  suite-common/logger/libDev/src/utils.d.ts
 9. 541.67 KiB   554670 bytes  suite/intl/libDev/src/messages.d.ts
10. 478.08 KiB   489552 bytes  suite-common/device/libDev/src/deviceSelectors.d.ts
11. 385.32 KiB   394566 bytes  packages/suite/libDev/src/utils/suite/notification.d.ts
12. 335.26 KiB   343308 bytes  packages/suite/libDev/src/reducers/suite/index.d.ts
13. 266.96 KiB   273368 bytes  suite-common/trading/libDev/src/reducers/exchangeReducer.d.ts
14. 260.92 KiB   267179 bytes  packages/suite/libDev/src/reducers/store.d.ts
15. 233.30 KiB   238903 bytes  packages/transport/libDev/src/transports/bridge.d.ts
16. 228.16 KiB   233639 bytes  packages/transport-common/libDev/src/transports/abstractApi.d.ts
17. 205.69 KiB   210627 bytes  suite-common/earn-stablecoin-defs/libDev/src/api/schemas/index.d.ts
18. 204.31 KiB   209209 bytes  packages/protobuf/libDev/src/definitions/index.d.ts
19. 176.76 KiB   181000 bytes  suite-common/wallet-core/libDev/src/transactions/transactionsSelectors.d.ts
20. 165.52 KiB   169489 bytes  suite-common/trading/libDev/src/reducers/buyReducer.d.ts
21. 144.19 KiB   147655 bytes  packages/suite/libDev/src/actions/device/deviceSlice.d.ts
22. 131.43 KiB   134584 bytes  suite-common/message-system/libDev/files/config.v1.d.ts
23. 127.81 KiB   130877 bytes  suite-common/trading/libDev/src/selectors/tradingSelectors.d.ts
24. 126.41 KiB   129439 bytes  packages/suite/libDev/src/views/settings/SettingsDevice/ForgetDevice/useForgetDevice.d.ts
25. 124.93 KiB   127927 bytes  packages/suite/libDev/src/selectors/suite/selectAccountLabelsForSearch.d.ts
26. 113.13 KiB   115848 bytes  packages/protobuf/libDev/src/definitions/messages-bitcoin.d.ts
27. 113.01 KiB   115724 bytes  packages/suite/libDev/src/hooks/wallet/useRbfForm.d.ts
28. 112.35 KiB   115046 bytes  suite-common/message-system/libDev/src/messageSystemSelectors.d.ts
29. 110.95 KiB   113611 bytes  suite-native/intl/libDev/src/messages.d.ts
30. 110.31 KiB   112957 bytes  suite-common/trading/libDev/src/reducers/sellReducer.d.ts
31. 102.58 KiB   105040 bytes  packages/connect-cli/libDev/src/transport.d.ts
32.  99.26 KiB   101647 bytes  packages/transport-common/libDev/src/utils/receive.d.ts
33.  91.39 KiB    93584 bytes  packages/suite/libDev/src/actions/wallet/__fixtures__/coinjoinAccountActions.d.ts
34.  90.88 KiB    93066 bytes  packages/connect-data/libDev/src/map-releases.d.ts
35.  89.49 KiB    91633 bytes  packages/suite/libDev/src/actions/wallet/__fixtures__/coinjoinClientActions.d.ts
36.  85.49 KiB    87537 bytes  suite-common/icons/libDev/src/icons.d.ts
37.  84.79 KiB    86829 bytes  suite/receive/libDev/src/receiveReducer.d.ts
38.  80.31 KiB    82240 bytes  packages/connect/libDev/e2e/__fixtures__/cardanoSignTransaction.d.ts
39.  79.80 KiB    81714 bytes  suite-native/trading-state/libDev/src/reducers/exchangeSlice.d.ts
40.  77.87 KiB    79736 bytes  packages/connect/libDev/tests/typedCall.type-test.d.ts
41.  76.24 KiB    78072 bytes  packages/connect-common/libDev/src/types/api/stellar/common.d.ts
42.  72.99 KiB    74746 bytes  suite-common/wallet-core/libDev/src/accounts/accountsSelectors.d.ts
43.  69.77 KiB    71441 bytes  packages/suite/libDev/src/middlewares/suite/sentryMiddleware.d.ts
44.  63.77 KiB    65301 bytes  packages/connect-common/libDev/src/types/api/cardano/common.d.ts
45.  62.51 KiB    64014 bytes  packages/suite/libDev/src/actions/wallet/__fixtures__/blockchainActions.d.ts
46.  59.78 KiB    61218 bytes  suite-native/trading-state/libDev/src/reducers/buySlice.d.ts
47.  59.09 KiB    60508 bytes  packages/suite/libDev/src/actions/wallet/__fixtures__/selectedAccountActions.d.ts
48.  58.89 KiB    60302 bytes  suite-common/earn-stablecoin-api/libDev/src/services/yieldxyz.d.ts
49.  58.52 KiB    59929 bytes  suite-common/wallet-core/libDev/src/selectors.d.ts
50.  52.88 KiB    54150 bytes  suite-common/wallet-utils/libDev/src/accountUtils.d.ts
```