### PR TITLE
refactor(suite): inject THP hostName via composition roots

### DIFF
--- a/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
+++ b/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
@@ -15,7 +15,13 @@ export const createSuiteDesktopCompositionRoot = (
     const reloadApp = desktopApi.appRestart;
 
     return initStore(
-        { history, platformEncryption, createConnectLoggerFactory: undefined, reloadApp },
+        {
+            history,
+            platformEncryption,
+            createConnectLoggerFactory: undefined,
+            reloadApp,
+            thpHostName: undefined,
+        },
         preloadStoreAction,
         { statePatch },
     );

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -18,11 +18,13 @@
     "dependencies": {
         "@sentry/browser": "10.53.1",
         "@suite-common/dependency-injection": "workspace:*",
+        "@suite-common/suite-utils": "workspace:*",
         "@suite/debug": "workspace:*",
         "@suite/platform-encryption-webauthn": "workspace:*",
         "@suite/router": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/suite": "workspace:*",
+        "@trezor/utils": "workspace:*",
         "core-js": "^3.49.0",
         "history": "^5.3.0",
         "react": "19.2.3",

--- a/packages/suite-web/src/createSuiteWebCompositionRoot.ts
+++ b/packages/suite-web/src/createSuiteWebCompositionRoot.ts
@@ -6,13 +6,21 @@ import { initStore } from 'src/reducers/store';
 import { createConnectLoggerFactory } from 'src/support/createConnectLoggerFactory';
 import { type PreloadStoreAction } from 'src/support/suite/preloadStore';
 
+import { getWebThpHostName } from './support/getWebThpHostName';
+
 export const createSuiteWebCompositionRoot = (preloadStoreAction?: PreloadStoreAction) => {
     const history = createBrowserHistory();
     const platformEncryption = createWebauthnPlatformEncryption();
     const reloadApp = () => window.location.reload();
 
     return initStore(
-        { history, platformEncryption, createConnectLoggerFactory, reloadApp },
+        {
+            history,
+            platformEncryption,
+            createConnectLoggerFactory,
+            reloadApp,
+            thpHostName: getWebThpHostName(),
+        },
         preloadStoreAction,
     );
 };

--- a/packages/suite-web/src/support/getWebThpHostName.ts
+++ b/packages/suite-web/src/support/getWebThpHostName.ts
@@ -1,0 +1,4 @@
+import { getBrowserName } from '@suite-common/suite-utils';
+import { capitalizeFirstLetter } from '@trezor/utils';
+
+export const getWebThpHostName = () => capitalizeFirstLetter(getBrowserName());

--- a/packages/suite-web/tsconfig.json
+++ b/packages/suite-web/tsconfig.json
@@ -9,6 +9,9 @@
         {
             "path": "../../suite-common/dependency-injection"
         },
+        {
+            "path": "../../suite-common/suite-utils"
+        },
         { "path": "../../suite/debug" },
         {
             "path": "../../suite/platform-encryption-webauthn"
@@ -16,6 +19,7 @@
         { "path": "../../suite/router" },
         { "path": "../connect" },
         { "path": "../suite" },
+        { "path": "../utils" },
         { "path": "../../suite/sentry" },
         { "path": "../eslint" }
     ]

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -21,6 +21,7 @@ import { addLog } from '@suite-common/logger';
 import { type PlatformEncryptionDep } from '@suite-common/platform-encryption';
 import {
     type ExtraDependencies,
+    type ThpHostNameDep,
     castExtraStore,
     createStoreWithExtraStoreMiddleware,
 } from '@suite-common/redux-utils';
@@ -133,7 +134,8 @@ type InferredAction = Parameters<RootReducerShape>[1];
 export type SuiteStoreDeps = HistoryDep &
     PlatformEncryptionDep &
     CreateConnectLoggerFactoryDep &
-    ReloadAppDep;
+    ReloadAppDep &
+    ThpHostNameDep;
 
 export const initStore = (
     deps: SuiteStoreDeps,
@@ -164,6 +166,7 @@ export const initStore = (
             platformEncryption: deps.platformEncryption,
             reloadApp: deps.reloadApp,
             createLogger: deps.createConnectLoggerFactory?.({ getState: api.getState }),
+            thpHostName: deps.thpHostName,
         }),
     });
 

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -35,6 +35,7 @@ import {
     type CommonServices,
     type ConnectInitSettings,
     type ExtraDependenciesStatic,
+    type ThpHostNameDep,
 } from '@suite-common/redux-utils';
 import { createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot } from '@suite-common/suite-rbf-labels-migrations';
 import {
@@ -96,7 +97,8 @@ export type SuiteAppDeps = StoreAPIDep &
     HistoryDep &
     PlatformEncryptionDep &
     CreateLoggerDep &
-    ReloadAppDep;
+    ReloadAppDep &
+    ThpHostNameDep;
 
 export type SuiteServices = CommonServices &
     DesktopAnalyticsDep &
@@ -173,6 +175,7 @@ export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteSer
         connectInitSettings,
         connectInitHooks,
         createLogger: deps.createLogger,
+        thpHostName: deps.thpHostName,
         migrateSuiteSyncLabelsForRbfTransaction:
             createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot({
                 dispatch: deps.dispatch,

--- a/suite-common/connect-init/package.json
+++ b/suite-common/connect-init/package.json
@@ -19,7 +19,6 @@
         "@suite-common/firmware": "workspace:*",
         "@suite-common/message-system": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
-        "@suite-common/suite-utils": "workspace:*",
         "@suite-common/test-utils": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@trezor/connect": "workspace:*",

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -12,7 +12,6 @@ import {
     selectFeatureConfig,
 } from '@suite-common/message-system';
 import { createThunk } from '@suite-common/redux-utils';
-import { getBrowserName } from '@suite-common/suite-utils';
 import {
     defaultTrezorUIEventHandlerThunk,
     deviceConnectThunks,
@@ -25,9 +24,9 @@ import TrezorConnect, {
     TRANSPORT_EVENT,
     UI_EVENT,
 } from '@trezor/connect';
-import { isDesktop, isWeb } from '@trezor/env-utils';
+import { isDesktop } from '@trezor/env-utils';
 import { DATA_URL } from '@trezor/urls';
-import { capitalizeFirstLetter, getSynchronize, isArrayMember } from '@trezor/utils';
+import { getSynchronize, isArrayMember } from '@trezor/utils';
 
 import { blacklist } from './blacklist';
 import { type ConnectKey } from './types';
@@ -43,7 +42,13 @@ export const connectInitThunk = createThunk<void, void, void>(
         const {
             selectors: { selectDebugSettings, selectThpSettings },
             actions: { lockDevice },
-            services: { connectInitSettings, connectInitHooks, analytics, createLogger },
+            services: {
+                connectInitSettings,
+                connectInitHooks,
+                analytics,
+                createLogger,
+                thpHostName,
+            },
         } = extra;
 
         const getEffectiveFirmwareChannel = selectEffectiveFirmwareChannel(
@@ -137,8 +142,8 @@ export const connectInitThunk = createThunk<void, void, void>(
         const { transports, showConnectLogs, definitionsChannel } = selectDebugSettings(getState());
         const thp = selectThpSettings(getState());
         // desktop thp appName/hostName enhanced in ./packages/suite-desktop-core/src/modules/trezor-connect.ts
-        if (isWeb()) {
-            thp.hostName = capitalizeFirstLetter(getBrowserName());
+        if (thpHostName !== undefined) {
+            thp.hostName = thpHostName;
         }
 
         try {

--- a/suite-common/connect-init/tsconfig.json
+++ b/suite-common/connect-init/tsconfig.json
@@ -7,7 +7,6 @@
         { "path": "../firmware" },
         { "path": "../message-system" },
         { "path": "../redux-utils" },
-        { "path": "../suite-utils" },
         { "path": "../test-utils" },
         { "path": "../wallet-core" },
         { "path": "../../packages/connect" },

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -43,6 +43,8 @@ export type ConnectInitSettings = {
     manifest: Manifest;
 } & Partial<ConnectSettings>;
 
+export type ThpHostNameDep = { thpHostName?: string };
+
 export type CommonServices = SuiteSyncDep &
     Bip329Dep &
     EnsureDelegatedIdentityKeyDep &
@@ -54,7 +56,8 @@ export type CommonServices = SuiteSyncDep &
     } & ReportSecurityCheckDep &
     ReloadAppDep &
     MigrateSuiteSyncLabelsForRbfTransactionDep &
-    CreateLoggerDep;
+    CreateLoggerDep &
+    ThpHostNameDep;
 
 export type ExtraDependenciesStatic = {
     /** @deprecated Do not add any thunks here, this is antipattern. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -10551,7 +10551,6 @@ __metadata:
     "@suite-common/firmware": "workspace:*"
     "@suite-common/message-system": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
-    "@suite-common/suite-utils": "workspace:*"
     "@suite-common/test-utils": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@trezor/connect": "workspace:*"
@@ -16948,6 +16947,7 @@ __metadata:
   dependencies:
     "@sentry/browser": "npm:10.53.1"
     "@suite-common/dependency-injection": "workspace:*"
+    "@suite-common/suite-utils": "workspace:*"
     "@suite/debug": "workspace:*"
     "@suite/platform-encryption-webauthn": "workspace:*"
     "@suite/router": "workspace:*"
@@ -16955,6 +16955,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/eslint": "workspace:*"
     "@trezor/suite": "workspace:*"
+    "@trezor/utils": "workspace:*"
     "@types/react": "npm:19.2.14"
     "@types/react-dom": "npm:19.2.3"
     core-js: "npm:^3.49.0"


### PR DESCRIPTION
## Description

The web-only `thp.hostName = capitalizeFirstLetter(getBrowserName())` branch lived inside the platform-agnostic `@suite-common/connect-init` thunk behind an `isWeb()` check. This moves the browser-name derivation into the web composition root (`createSuiteWebCompositionRoot`) and injects the resulting `thpHostName` through `extra.services`, mirroring the existing `createConnectLoggerFactory` dependency-injection pattern.

**Why:** `@suite-common/connect-init` is platform-agnostic, yet it imported `isWeb` (`@trezor/env-utils`) and `getBrowserName` (`@suite-common/suite-utils`) purely to compute a web-only value. The composition roots are where the web/desktop/native split already happens (`history`, `platformEncryption`, `createConnectLoggerFactory`), so the host-specific hostName belongs there too. This is the same seam previously used for the Connect logger factory.

All three platforms keep their existing behaviour:

- **web** – browser name, now injected from `createSuiteWebCompositionRoot`
- **desktop** – still overridden with the computer name in the main process (`packages/suite-desktop-core/src/modules/trezor-connect.ts`), so the value passed from the renderer is irrelevant
- **native** – still set to the device name in its own `selectThpSettings`

As a side effect `@suite-common/suite-utils` is no longer a dependency of `@suite-common/connect-init` (removed from `package.json` + TS project references; lockfile updated in the same PR).

## Follow-up

#29514 adds an ESLint rule forbidding `isWeb` in platform-agnostic `suite-common` code, locking in this invariant so it cannot regress. It depends on this PR: it is intentionally red on `develop` until this one lands, then goes green on rebase — which also confirms this PR removed the last `isWeb` call site.

## Not in scope: `showConnectLogs`

The adjacent `selectDebugSettings(getState()).showConnectLogs` read in the same thunk was considered but intentionally left as-is. Unlike the browser-derived hostName, `showConnectLogs` is dynamic user-toggleable Redux state read through the already-injected, per-host `selectDebugSettings` selector — there is no `isWeb()` env branch or platform util leaking into the common package, so the DI seam is already in place. Moving it would either freeze it at store-creation time (a behaviour change) or just re-wrap the selector that is already injected.

## Notes for QA

Pure dependency-injection refactor with **no intended behaviour change**. Blast radius is limited to the hostName shown on the Trezor screen during THP pairing on **Suite web**. If sanity-checked: pair a THP-capable device on web and confirm the host name displayed on the device is the capitalized browser name (e.g. `Chrome`, `Firefox`), exactly as before. Desktop and native are unaffected. Validated by `type-check` (connect-init, redux-utils, suite, suite-web, suite-desktop-ui, suite-native/state), the existing `connectInitThunks` unit tests, eslint and prettier — no dedicated QA is required.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect core infrastructure: app composition roots (web and desktop), Redux store setup, extraDependencies type and implementation, and TrezorConnect initialization thunks. Since all 4 statically-mapped files are global dependencies (121 tests each), the risk is broad but shallow — most likely a breaking change would manifest as app boot failure or connect initialization failure rather than feature-specific regressions. The recommended strategy focuses on app initialization, connect lifecycle, and discovery tests that directly exercise the bootstrapping pipeline, plus TrezorConnect API tests that validate both web and desktop composition roots. Package.json and tsconfig changes are low-risk (dependency/build configuration).

<details><summary><b>Changed files (11)</b></summary>

- `packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts`
- `packages/suite-web/package.json`
- `packages/suite-web/src/createSuiteWebCompositionRoot.ts`
- `packages/suite-web/src/support/getWebThpHostName.ts`
- `packages/suite-web/tsconfig.json`
- `packages/suite/src/reducers/store.ts`
- `packages/suite/src/support/extraDependencies.ts`
- `suite-common/connect-init/package.json`
- `suite-common/connect-init/src/connectInitThunks.ts`
- `suite-common/connect-init/tsconfig.json`
- `suite-common/redux-utils/src/extraDependenciesType.ts`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/suite/initial-run.test.ts` — This test validates the full app initialization flow including analytics consent, onboarding completion, and page reload persistence. Changes to store.ts, extraDependencies.ts, connectInitThunks.ts, and createSuiteWebCompositionRoot.ts directly affect app bootstrapping and could break initial load/reload behavior.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — Firmware check during onboarding exercises connectInitThunks (TrezorConnect initialization) and the composition root. A regression in connect initialization would manifest as a failure to detect firmware readiness, which this test directly asserts.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Wallet discovery depends on TrezorConnect initialization (connectInitThunks), Redux store setup (store.ts), and extraDependencies for the discovery thunks. This test verifies the core post-onboarding wallet discovery flow which would break if connect init or store wiring is incorrect.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coins and triggers discovery with a mid-discovery page reload. It directly exercises store hydration, connect initialization resilience, and extraDependencies wiring across many networks — a comprehensive smoke test for the changed infrastructure.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises TrezorConnect.getAddress through the Suite Web popup flow, directly testing connectInitThunks, the web composition root (createSuiteWebCompositionRoot), and getWebThpHostName for THP hostname resolution. Changes to these files could break the connect popup initialization path.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Tests TrezorConnect.getAddress in suite-desktop core mode, directly exercising connectInitThunks initialization, the desktop composition root, and extraDependencies. This validates that connect initialization works correctly in the desktop path complementary to the web popup test.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/trezor-connect/error.test.ts` — Tests TrezorConnect error handling after initialization in suite-desktop core mode. Changes to connectInitThunks could affect how errors are surfaced post-init. This is a focused test that validates the error path specifically.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests TrezorConnect permissions granting and revoking in suite-desktop mode. The permissions flow depends on proper connect initialization and store setup. Changes to connectInitThunks and the composition roots affect the connect session lifecycle.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Tests Bridge session management across multiple tabs/windows. This exercises connectInitThunks for session acquisition and the web composition root for multi-window scenarios. Changes to connect initialization could affect session stealing/reclaiming behavior.
- `suite/e2e/tests/analytics/events.test.ts` — Tests SuiteReady, DeviceConnect, and TransportType analytics events which fire during app initialization. Changes to connectInitThunks affect when/how TrezorConnect reports transport type and device connection, which could alter event timing or content.
- `suite/e2e/tests/suite/bridge.test.ts` — Tests WebUSB fallback from the Bridge page. The bridge/transport selection depends on connectInitThunks and the web composition root for transport configuration. Changes here could affect how transport alternatives are offered.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Tests TrezorConnect via webextension popup flow through Suite Web. This exercises the web composition root and connectInitThunks in the popup/webextension context, complementing the standard web popup test.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Tests bridge spawning and device reconnection in the desktop Electron app. Changes to createSuiteDesktopCompositionRoot and connectInitThunks affect bridge lifecycle management and reconnection behavior.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — Tests analytics consent during onboarding with navigation to /accounts, exercising the app initialization path including store setup and connect initialization when entering from a non-standard route.

</details>

⚠️ **Changes with no test coverage (6)**
- `packages/suite-web/package.json`
- `packages/suite-web/src/support/getWebThpHostName.ts`
- `packages/suite-web/tsconfig.json`
- `suite-common/connect-init/package.json`
- `suite-common/connect-init/tsconfig.json`
- `suite-common/redux-utils/src/extraDependenciesType.ts`

_Updated: 2026-07-09T05:12:30.477Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/thp-hostname-composition-root&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/thp-hostname-composition-root&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/thp-hostname-composition-root&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-09T05:18:20.942Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-09T05:16:08.043Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/thp-hostname-composition-root/web/](https://dev.suite.sldev.cz/suite-web/mroz22/thp-hostname-composition-root/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

