### PR TITLE
fix(suite): pin webextension popup response target to the opening extension

### DIFF
--- a/packages/suite/src/support/suite/useConnectPopupWebextension.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupWebextension.tsx
@@ -38,6 +38,7 @@ const postMessageToExtension = (message: ConnectPopupOutgoingMessage, extensionI
 
 export const useConnectPopupWebextension = () => {
     const [extensionId, setExtensionId] = useState<string | null>(null);
+    const extensionIdRef = useRef<string | null>(null);
     const lastProcessedMessageIdRef = useRef<number | undefined>(undefined);
     const [incomingMessages, setIncomingMessages] = useState<ConnectPopupMessage[]>([]);
 
@@ -69,8 +70,25 @@ export const useConnectPopupWebextension = () => {
     // Read messages from URL hash (webextension link).
     const readUrl = useCallback(() => {
         const hash = new URLSearchParams(window.location.hash.replace('#', '?'));
-        const newExtensionId = hash.get('extension-id');
+        const hashExtensionId = hash.get('extension-id');
         const message = hash.get('message');
+
+        // A popup session belongs to exactly one extension. Its service worker
+        // writes its own chrome.runtime.id into the hash, which never changes
+        // for the session. Pin the first id we see and reject any hash write
+        // carrying a different id: the response route is `chrome.runtime.sendMessage(extensionId)`,
+        // so another extension able to write this tab's hash (host_permissions
+        // for the popup origin) must not be able to repoint it and receive the
+        // method result (address / xpub / signed tx), nor inject calls into the session.
+        if (hashExtensionId) {
+            if (extensionIdRef.current === null) {
+                extensionIdRef.current = hashExtensionId;
+                setExtensionId(hashExtensionId);
+            } else if (hashExtensionId !== extensionIdRef.current) {
+                return;
+            }
+        }
+
         let parsedMessage: ConnectPopupMessage | null = null;
         if (message) {
             try {
@@ -79,10 +97,6 @@ export const useConnectPopupWebextension = () => {
                 // Malformed message in hash — ignore.
                 return;
             }
-        }
-
-        if (newExtensionId) {
-            setExtensionId(newExtensionId);
         }
 
         if (parsedMessage) {


### PR DESCRIPTION
## Description

The Suite Web connect popup (`suite.trezor.io/web/connect-popup`) that serves `@trezor/connect-webextension` callers reads the target extension id from `window.location.hash` on every `hashchange` / `popstate` and sends every outgoing message — including `RESPONSE_EVENT`, whose payload is the method result (address, xpub, signed transaction) — to that id via `chrome.runtime.sendMessage(extensionId, ...)`.

The hash is written by the calling extension's own service worker ([`serviceworker-window-ext-connectable.ts#L150-L153`](https://github.com/trezor/trezor-suite/blob/mroz22/fix-webext-popup-response-route/packages/connect-common/src/messageChannel/serviceworker-window-ext-connectable.ts#L150-L153), always its `chrome.runtime.id`), but nothing binds the extension that opened the popup to the id the response is delivered to. Any other extension installed in the same browser that holds `host_permissions` for `*.trezor.io` (a common grant) can call `chrome.tabs.update` on the popup tab and overwrite the hash with its own extension id; the popup's `hashchange` handler then re-points the response route to the attacker, who receives the account secret via `onMessageExternal`. The same primitive can inject calls into the session. This is exactly the concern flagged by the pre-existing `// todo: we should negotiate some token …` note in that file.

### Fix

A popup session belongs to exactly one extension. [`useConnectPopupWebextension.tsx`](https://github.com/trezor/trezor-suite/blob/mroz22/fix-webext-popup-response-route/packages/suite/src/support/suite/useConnectPopupWebextension.tsx#L71-L90) now pins the first `extension-id` observed for the session and drops any hash write that carries a different id. Because that id is the service worker's own `chrome.runtime.id` and is constant for a session, legitimate single- and multi-call flows are unaffected; only a foreign id (a second extension racing the hash) is rejected.

This closes the demonstrated mid-session redirect. A per-session negotiated token (the TODO above) would additionally close the residual first-hash-write race and is left as a follow-up.

Found during a security review of the connect host/transport layers.

## Notes for QA

Impact / blast radius: only the Suite Web connect popup path used by `@trezor/connect-webextension` (a browser extension calling TrezorConnect through the externally-connectable / offscreen flow). The desktop, web-dApp (iframe), and mobile popup paths do not touch this code and are unaffected.

What to test: with a webextension integration (e.g. the connect-explorer webextension example), run the full popup flow — channel handshake, then `getAddress` / `getPublicKey` / `signTransaction` — and confirm the extension still receives the response and the popup closes normally. A single extension re-using the popup for consecutive calls must keep working (same `chrome.runtime.id`, so the pin is a no-op). No user-visible UI change.

## Related Issue

n/a — found during the connect layer security review.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `packages/suite/src/support/suite/useConnectPopupWebextension.tsx`, which is a React hook specifically handling the Connect popup flow for the web extension context. It maps to 121 tests via static coverage, indicating it is a broadly imported global utility (likely part of the Suite app shell/provider tree). None of the 121 candidate E2E tests described in the LLM analysis exercise functionality related to the Connect popup or web extension behavior — they all test standard Suite features (analytics, backup, settings, trading, wallet operations, etc.) running in a browser/desktop context, not the web extension popup flow. Since no test specifically exercises the Connect popup web extension behavior, and the change is narrowly scoped to that context, no E2E tests need to be run. The risk of regression in these E2E tests is negligible.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/support/suite/useConnectPopupWebextension.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/support/suite/useConnectPopupWebextension.tsx`

_Updated: 2026-07-04T09:43:30.103Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-webext-popup-response-route&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-webext-popup-response-route&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-04T09:49:43.126Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-04T09:47:05.073Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-webext-popup-response-route/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-webext-popup-response-route/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->