### PR TITLE
Correct SOL staking entry and review-cancel navigation

### DIFF
--- a/suite-native/module-earn/src/hooks/useEarnReviewBackNavigation.ts
+++ b/suite-native/module-earn/src/hooks/useEarnReviewBackNavigation.ts
@@ -1,10 +1,15 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/native';
+import { CommonActions, StackActions, useNavigation } from '@react-navigation/native';
 
-import { cancelSignSendFormTransactionThunk } from '@suite-common/wallet-core';
+import {
+    type AccountsRootState,
+    cancelSignSendFormTransactionThunk,
+    selectAccountByKey,
+} from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
+import { AppTabsRoutes, RootStackRoutes } from '@suite-native/navigation';
 import {
     type TransactionReviewOutputsState,
     selectIsTransactionReviewInProgress,
@@ -12,8 +17,10 @@ import {
 } from '@suite-native/transaction-management';
 
 import { type EarnFormDraftPrefix } from '../types';
+import { resolveStakingHomeRoute } from '../utils/resolveStakingHomeRoute';
 
-const REVIEW_EXIT_ACTION_TYPES = ['GO_BACK', 'POP_TO_TOP'];
+const CLOSE_FLOW_ACTION_TYPE = StackActions.popToTop().type;
+const REVIEW_EXIT_ACTION_TYPES = ['GO_BACK', CLOSE_FLOW_ACTION_TYPE];
 
 export const useEarnReviewBackNavigation = (
     formType: EarnFormDraftPrefix,
@@ -22,6 +29,9 @@ export const useEarnReviewBackNavigation = (
     const isTransactionReviewInProgress = useSelector((state: TransactionReviewOutputsState) =>
         selectIsTransactionReviewInProgress(state, formType, accountKey),
     );
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
 
     const dispatch = useDispatch();
     const navigation = useNavigation();
@@ -29,16 +39,47 @@ export const useEarnReviewBackNavigation = (
 
     const isCancellationAlertVisibleRef = useRef(false);
 
+    const navigateToStakingHome = useCallback(() => {
+        if (!account) {
+            navigation.dispatch(StackActions.popToTop());
+
+            return;
+        }
+
+        const { name, params } = resolveStakingHomeRoute(account);
+
+        navigation.dispatch(
+            CommonActions.reset({
+                index: 1,
+                routes: [
+                    {
+                        name: RootStackRoutes.AppTabs,
+                        params: { screen: AppTabsRoutes.EarnStack },
+                    },
+                    { name, params },
+                ],
+            }),
+        );
+    }, [account, navigation]);
+
     useEffect(() => {
         const cleanup = () => {
             dispatch(cancelSignSendFormTransactionThunk());
         };
 
         const unsubscribe = navigation.addListener('beforeRemove', e => {
+            const isClosingWholeFlow = e.data.action.type === CLOSE_FLOW_ACTION_TYPE;
             const isLeavingReview = REVIEW_EXIT_ACTION_TYPES.includes(e.data.action.type);
 
             if (!isLeavingReview || !isTransactionReviewInProgress) {
                 cleanup();
+
+                // Redirect the close button to the staking home; let plain back/swipe proceed.
+                if (isClosingWholeFlow) {
+                    e.preventDefault();
+                    unsubscribe();
+                    navigateToStakingHome();
+                }
 
                 return;
             }
@@ -56,7 +97,12 @@ export const useEarnReviewBackNavigation = (
                 if (wasReviewCanceled) {
                     cleanup();
                     unsubscribe();
-                    navigation.dispatch(e.data.action);
+
+                    if (isClosingWholeFlow) {
+                        navigateToStakingHome();
+                    } else {
+                        navigation.dispatch(e.data.action);
+                    }
                 }
             });
         });
@@ -69,11 +115,16 @@ export const useEarnReviewBackNavigation = (
         showReviewCancellationAlert,
         dispatch,
         formType,
+        navigateToStakingHome,
     ]);
 
     const navigateBack = useCallback(() => {
         navigation.goBack();
     }, [navigation]);
 
-    return { navigateBack };
+    const closeReview = useCallback(() => {
+        navigation.dispatch(StackActions.popToTop());
+    }, [navigation]);
+
+    return { navigateBack, closeReview };
 };

--- a/suite-native/module-earn/src/hooks/useHandleOnEarnTransactionReview.ts
+++ b/suite-native/module-earn/src/hooks/useHandleOnEarnTransactionReview.ts
@@ -36,7 +36,7 @@ export const useHandleOnEarnTransactionReview = ({
     accountKey,
     stakeType,
 }: HandleOnEarnTransactionReviewProps) => {
-    useEarnReviewBackNavigation(stakeType, accountKey);
+    const { closeReview } = useEarnReviewBackNavigation(stakeType, accountKey);
 
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
@@ -123,5 +123,5 @@ export const useHandleOnEarnTransactionReview = ({
         stakeType,
     ]);
 
-    return { handleSign, handlePush };
+    return { handleSign, handlePush, closeReview };
 };

--- a/suite-native/module-earn/src/screens/ClaimTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/ClaimTransactionDataReviewScreen.tsx
@@ -13,7 +13,6 @@ import {
     type RootStackRoutes,
     ScreenHeader,
     type StackProps,
-    useNavigateToInitialScreen,
 } from '@suite-native/navigation';
 import {
     TxValidityTimer,
@@ -34,7 +33,6 @@ export const ClaimTransactionDataReviewScreen = ({
     const { confirmOnTrezorRef, revealConfirmOnTrezorSheet, closeSheet } =
         useConfirmOnTrezorController();
     const { accountKey } = route.params;
-    const navigateToInitialScreen = useNavigateToInitialScreen();
     const [isPushing, setIsPushing] = useState(false);
 
     const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
@@ -45,7 +43,7 @@ export const ClaimTransactionDataReviewScreen = ({
 
     const precomposedTransaction = useEarnSelectedPrecomposedTransaction('claim', accountKey);
 
-    const { handleSign, handlePush } = useHandleOnEarnTransactionReview({
+    const { handleSign, handlePush, closeReview } = useHandleOnEarnTransactionReview({
         accountKey,
         stakeType: 'claim',
     });
@@ -98,6 +96,7 @@ export const ClaimTransactionDataReviewScreen = ({
             isManualControlEnabled
             controlRef={confirmOnTrezorRef}
             closeActionType="close"
+            closeAction={closeReview}
             defaultHeader={
                 <ScreenHeader
                     customContent={
@@ -106,7 +105,7 @@ export const ClaimTransactionDataReviewScreen = ({
                         </Text>
                     }
                     closeActionType="close"
-                    closeAction={navigateToInitialScreen}
+                    closeAction={closeReview}
                 />
             }
         >

--- a/suite-native/module-earn/src/screens/EarnTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnTransactionDataReviewScreen.tsx
@@ -13,7 +13,6 @@ import {
     type RootStackRoutes,
     ScreenHeader,
     type StackProps,
-    useNavigateToInitialScreen,
 } from '@suite-native/navigation';
 import {
     TxValidityTimer,
@@ -34,7 +33,6 @@ export const EarnTransactionDataReviewScreen = ({
     const { confirmOnTrezorRef, revealConfirmOnTrezorSheet, closeSheet } =
         useConfirmOnTrezorController();
     const { accountKey, amount } = route.params;
-    const navigateToInitialScreen = useNavigateToInitialScreen();
     const [isPushing, setIsPushing] = useState(false);
 
     const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
@@ -45,7 +43,7 @@ export const EarnTransactionDataReviewScreen = ({
 
     const precomposedTransaction = useEarnSelectedPrecomposedTransaction('stake', accountKey);
 
-    const { handleSign, handlePush } = useHandleOnEarnTransactionReview({
+    const { handleSign, handlePush, closeReview } = useHandleOnEarnTransactionReview({
         accountKey,
         stakeType: 'stake',
     });
@@ -97,6 +95,7 @@ export const EarnTransactionDataReviewScreen = ({
             isManualControlEnabled
             controlRef={confirmOnTrezorRef}
             closeActionType="close"
+            closeAction={closeReview}
             defaultHeader={
                 <ScreenHeader
                     customContent={
@@ -105,7 +104,7 @@ export const EarnTransactionDataReviewScreen = ({
                         </Text>
                     }
                     closeActionType="close"
-                    closeAction={navigateToInitialScreen}
+                    closeAction={closeReview}
                 />
             }
         >

--- a/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
@@ -15,7 +15,6 @@ import {
     type RootStackRoutes,
     ScreenHeader,
     type StackProps,
-    useNavigateToInitialScreen,
 } from '@suite-native/navigation';
 import {
     type TransactionReviewOutputsState,
@@ -40,7 +39,6 @@ export const UnstakeTransactionDataReviewScreen = ({
         useConfirmOnTrezorController();
     const { accountKey } = route.params;
     const { navigateToStakingDetail } = useStakingDetailNavigation();
-    const navigateToInitialScreen = useNavigateToInitialScreen();
     const [isPushing, setIsPushing] = useState(false);
 
     const isAddressConfirmed = useSelector((state: TransactionReviewOutputsState) =>
@@ -55,7 +53,7 @@ export const UnstakeTransactionDataReviewScreen = ({
 
     const precomposedTransaction = useEarnSelectedPrecomposedTransaction('unstake', accountKey);
 
-    const { handleSign, handlePush } = useHandleOnEarnTransactionReview({
+    const { handleSign, handlePush, closeReview } = useHandleOnEarnTransactionReview({
         accountKey,
         stakeType: 'unstake',
     });
@@ -116,6 +114,7 @@ export const UnstakeTransactionDataReviewScreen = ({
             isManualControlEnabled
             controlRef={confirmOnTrezorRef}
             closeActionType="close"
+            closeAction={closeReview}
             defaultHeader={
                 <ScreenHeader
                     customContent={
@@ -124,7 +123,7 @@ export const UnstakeTransactionDataReviewScreen = ({
                         </Text>
                     }
                     closeActionType="close"
-                    closeAction={navigateToInitialScreen}
+                    closeAction={closeReview}
                 />
             }
         >

--- a/suite-native/module-earn/src/utils/__tests__/navigateByAccountState.test.ts
+++ b/suite-native/module-earn/src/utils/__tests__/navigateByAccountState.test.ts
@@ -74,14 +74,15 @@ describe('navigateByAccountState', () => {
 
         navigateByAccountState(account, mockNavigate);
 
+        // A first-time Solana staker starts at the intro, not the empty dashboard.
         expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.HowStakeWorksScreen, {
             symbol: 'sol',
             accountKey: account.key,
         });
     });
 
-    it('navigates to HowStakeWorksScreen when a Solana account has a zero balance and no stake', () => {
-        const account = createMockAccount({ symbol: 'sol', availableBalance: '0' });
+    it('navigates to HowStakeWorksScreen when a Solana account has insufficient balance and no stake', () => {
+        const account = createMockAccount({ symbol: 'sol', availableBalance: '100' });
         mockGetAccountTotalStakingBalance.mockReturnValue(null);
 
         navigateByAccountState(account, mockNavigate);

--- a/suite-native/module-earn/src/utils/__tests__/resolveStakingHomeRoute.test.ts
+++ b/suite-native/module-earn/src/utils/__tests__/resolveStakingHomeRoute.test.ts
@@ -1,0 +1,66 @@
+import { type Account } from '@suite-common/wallet-types';
+import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import { getAccountTotalStakingBalance } from '@suite-common/wallet-utils';
+import { RootStackRoutes } from '@suite-native/navigation';
+
+import { resolveStakingHomeRoute } from '../resolveStakingHomeRoute';
+
+jest.mock('@suite-common/wallet-utils', () => ({
+    ...jest.requireActual('@suite-common/wallet-utils'),
+    getAccountTotalStakingBalance: jest.fn(),
+}));
+
+const mockGetAccountTotalStakingBalance = jest.mocked(getAccountTotalStakingBalance);
+
+const createMockAccount = (overrides: Partial<Account> = {}): Account =>
+    ({
+        key: mockAccountKey({ descriptor: 'testAccountKey' }),
+        symbol: 'sol',
+        ...overrides,
+    }) as Account;
+
+describe('resolveStakingHomeRoute', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('returns the staking dashboard when the account has a staked balance', () => {
+        const account = createMockAccount();
+        mockGetAccountTotalStakingBalance.mockReturnValue('1000000000');
+
+        expect(resolveStakingHomeRoute(account)).toEqual({
+            name: RootStackRoutes.StakingManagement,
+            params: { accountKey: account.key },
+        });
+    });
+
+    it('returns StakingDetail for a Cardano account with a staked balance', () => {
+        const account = createMockAccount({ symbol: 'ada' });
+        mockGetAccountTotalStakingBalance.mockReturnValue('1000000');
+
+        expect(resolveStakingHomeRoute(account)).toEqual({
+            name: RootStackRoutes.StakingDetail,
+            params: { accountKey: account.key },
+        });
+    });
+
+    it('returns the "How staking works" intro for a first-time Solana staker', () => {
+        const account = createMockAccount({ symbol: 'sol' });
+        mockGetAccountTotalStakingBalance.mockReturnValue('0');
+
+        expect(resolveStakingHomeRoute(account)).toEqual({
+            name: RootStackRoutes.HowStakeWorksScreen,
+            params: { symbol: 'sol', accountKey: account.key },
+        });
+    });
+
+    it('returns the "How staking works" intro when the staked balance is null', () => {
+        const account = createMockAccount({ symbol: 'eth' });
+        mockGetAccountTotalStakingBalance.mockReturnValue(null);
+
+        expect(resolveStakingHomeRoute(account)).toEqual({
+            name: RootStackRoutes.HowStakeWorksScreen,
+            params: { symbol: 'eth', accountKey: account.key },
+        });
+    });
+});

--- a/suite-native/module-earn/src/utils/hasAccountStakedBalance.ts
+++ b/suite-native/module-earn/src/utils/hasAccountStakedBalance.ts
@@ -1,0 +1,8 @@
+import { type Account } from '@suite-common/wallet-types';
+import { getAccountTotalStakingBalance } from '@suite-common/wallet-utils';
+
+export const hasAccountStakedBalance = (account: Account): boolean => {
+    const stakedBalance = getAccountTotalStakingBalance(account);
+
+    return !!stakedBalance && stakedBalance !== '0';
+};

--- a/suite-native/module-earn/src/utils/navigateByAccountState.ts
+++ b/suite-native/module-earn/src/utils/navigateByAccountState.ts
@@ -1,7 +1,6 @@
 import { type Account } from '@suite-common/wallet-types';
 import {
     formatNetworkAmount,
-    getAccountTotalStakingBalance,
     getStakingLimitsByNetworkSymbol,
     isSupportedSolStakingNetworkSymbol,
 } from '@suite-common/wallet-utils';
@@ -12,6 +11,7 @@ import {
 } from '@suite-native/navigation';
 import { BigNumber } from '@trezor/utils';
 
+import { hasAccountStakedBalance } from './hasAccountStakedBalance';
 import { resolveStakingTargetRoute } from './resolveStakingTargetRoute';
 
 type StakingNavigateFn = StackNavigationProps<
@@ -20,10 +20,7 @@ type StakingNavigateFn = StackNavigationProps<
 >['navigate'];
 
 export const navigateByAccountState = (account: Account, navigate: StakingNavigateFn) => {
-    const stakedBalance = getAccountTotalStakingBalance(account);
-    const hasStakedBalance = !!stakedBalance && stakedBalance !== '0';
-
-    if (hasStakedBalance) {
+    if (hasAccountStakedBalance(account)) {
         navigate(resolveStakingTargetRoute(account.symbol), {
             accountKey: account.key,
         });

--- a/suite-native/module-earn/src/utils/resolveStakingHomeRoute.ts
+++ b/suite-native/module-earn/src/utils/resolveStakingHomeRoute.ts
@@ -1,0 +1,19 @@
+import { type Account } from '@suite-common/wallet-types';
+import { RootStackRoutes } from '@suite-native/navigation';
+
+import { hasAccountStakedBalance } from './hasAccountStakedBalance';
+import { resolveStakingTargetRoute } from './resolveStakingTargetRoute';
+
+export const resolveStakingHomeRoute = (account: Account) => {
+    if (hasAccountStakedBalance(account)) {
+        return {
+            name: resolveStakingTargetRoute(account.symbol),
+            params: { accountKey: account.key },
+        };
+    }
+
+    return {
+        name: RootStackRoutes.HowStakeWorksScreen,
+        params: { symbol: account.symbol, accountKey: account.key },
+    };
+};


### PR DESCRIPTION
## Description

Opening Solana staking with no active stake now lands on the "How SOL staking works" intro instead of an empty stake dashboard. Cancelling a stake, unstake, or claim review now returns the user to the right place - the stake dashboard if a stake exists, or the intro for a first-time stake.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29308