### PR TITLE
Add Solana staking account limit banner to native unstake and claim

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SolanaStakingLimitBanner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SolanaStakingLimitBanner.tsx
@@ -3,25 +3,26 @@ import { useSelector } from 'react-redux';
 
 import { Translation } from '@suite/intl';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
-import { WALLET_SDK_SOURCE } from '@suite-common/wallet-constants';
 import { selectBlockchainState } from '@suite-common/wallet-core';
 import { type Account, type PrecomposedLevels } from '@suite-common/wallet-types';
 import {
+    type SolanaStakingLimit,
+    estimateSolanaStakingLimit,
     formatNetworkAmount,
     getOutputTxAmount,
-    getSolanaStakingAccountsByStatus,
+    getSolanaDeactivatedRentReserves,
 } from '@suite-common/wallet-utils';
-import { MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT, StakeState } from '@trezor/coins-solana/constants';
-import solana from '@trezor/coins-solana/runtime';
+import { MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT } from '@trezor/coins-solana/constants';
 import { Banner } from '@trezor/components';
 import { getSuiteVersion } from '@trezor/env-utils';
-import { BigNumber } from '@trezor/utils';
 
 interface SolanaStakingLimitBannerProps {
     account: Account;
     composedLevels?: PrecomposedLevels;
     type: 'claim' | 'unstake';
 }
+
+const NO_LIMIT: SolanaStakingLimit = { isLimitExceeded: false, estimatedAmount: '0' };
 
 export const SolanaStakingLimitBanner = ({
     account,
@@ -30,8 +31,7 @@ export const SolanaStakingLimitBanner = ({
 }: SolanaStakingLimitBannerProps) => {
     const blockchain = useSelector(selectBlockchainState);
 
-    const [estimatedAmount, setEstimatedAmount] = useState<string>('0');
-    const [isAccountLimitExeeded, setIsAccountLimitExeeded] = useState<boolean>(false);
+    const [limit, setLimit] = useState<SolanaStakingLimit>(NO_LIMIT);
 
     const selectedBlockchain = blockchain[account.symbol];
 
@@ -43,58 +43,33 @@ export const SolanaStakingLimitBanner = ({
         const outputTxAmount = getOutputTxAmount(composedLevels);
         if (!outputTxAmount || !selectedBlockchain?.url) return;
 
-        const estimateTx = async () => {
-            const { selectSolanaConnection, unstake, claim } = await solana();
-            const connection = selectSolanaConnection(
-                selectedBlockchain.url,
-                `Trezor Suite ${getSuiteVersion()}`,
-            );
+        let isActive = true;
 
-            if (type === 'unstake') {
-                const { unstakeAmount } = await unstake({
-                    connection,
-                    sender: account.descriptor,
-                    lamports: BigInt(outputTxAmount),
-                    source: WALLET_SDK_SOURCE,
-                });
-                const estimatedAmount = unstakeAmount.toString();
-                setEstimatedAmount(estimatedAmount);
+        estimateSolanaStakingLimit({
+            descriptor: account.descriptor,
+            deactivatedRentReserves: getSolanaDeactivatedRentReserves(account),
+            blockchainUrl: selectedBlockchain.url,
+            userAgent: `Trezor Suite ${getSuiteVersion()}`,
+            type,
+            outputAmount: outputTxAmount.toString(),
+        })
+            .then(resolved => {
+                if (isActive) {
+                    setLimit(resolved);
+                }
+            })
+            .catch(() => {
+                if (isActive) {
+                    setLimit(NO_LIMIT);
+                }
+            });
 
-                // If the estimated transaction amount is less than the output,
-                // we assume the account limit has been exceeded
-                const isLimitExeeded = new BigNumber(estimatedAmount).lt(outputTxAmount);
-                setIsAccountLimitExeeded(isLimitExeeded);
-            }
-
-            if (type === 'claim') {
-                const { totalClaimAmount } = await claim({
-                    connection,
-                    sender: account.descriptor,
-                });
-
-                const estimatedAmount = totalClaimAmount.toString();
-                setEstimatedAmount(estimatedAmount);
-
-                const stakingAccounts = getSolanaStakingAccountsByStatus(
-                    account,
-                    StakeState.Deactivated,
-                );
-                // estimatedAmount for claims includes rent-exempt reserves.
-                // We subtract rent from each account to get the real claimable amount.
-                const claimableAmount = stakingAccounts.reduce(
-                    (acc, { rentExemptReserve }) => acc.minus(rentExemptReserve),
-                    new BigNumber(estimatedAmount),
-                );
-
-                const isLimitExeeded = claimableAmount.lt(outputTxAmount);
-                setIsAccountLimitExeeded(isLimitExeeded);
-            }
+        return () => {
+            isActive = false;
         };
-
-        estimateTx();
     }, [account, composedLevels, selectedBlockchain?.url, type]);
 
-    if (!isAccountLimitExeeded) return null;
+    if (!limit.isLimitExceeded) return null;
 
     return (
         <Banner
@@ -108,7 +83,7 @@ export const SolanaStakingLimitBanner = ({
                     }
                     values={{
                         limit: MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT,
-                        amount: formatNetworkAmount(estimatedAmount, account.symbol),
+                        amount: formatNetworkAmount(limit.estimatedAmount, account.symbol),
                         symbol: getDisplaySymbol(account.symbol),
                     }}
                 />

--- a/suite-common/wallet-utils/src/__tests__/solanaStakingLimitUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/solanaStakingLimitUtils.test.ts
@@ -1,0 +1,70 @@
+import { resolveSolanaStakingLimit } from '../solanaStakingLimitUtils';
+
+describe('resolveSolanaStakingLimit', () => {
+    describe('unstake', () => {
+        it('does not flag the limit when the whole requested amount can be unstaked', () => {
+            expect(
+                resolveSolanaStakingLimit({
+                    type: 'unstake',
+                    outputAmount: '1000',
+                    unstakeAmount: '1000',
+                }),
+            ).toEqual({ isLimitExceeded: false, estimatedAmount: '1000' });
+        });
+
+        it('flags the limit when a single transaction unstakes less than requested', () => {
+            expect(
+                resolveSolanaStakingLimit({
+                    type: 'unstake',
+                    outputAmount: '1000',
+                    unstakeAmount: '600',
+                }),
+            ).toEqual({ isLimitExceeded: true, estimatedAmount: '600' });
+        });
+    });
+
+    describe('claim', () => {
+        it('subtracts rent reserves before comparing and does not flag when everything fits', () => {
+            expect(
+                resolveSolanaStakingLimit({
+                    type: 'claim',
+                    outputAmount: '900',
+                    totalClaimAmount: '1000',
+                    rentExemptReserves: ['50', '50'],
+                }),
+            ).toEqual({ isLimitExceeded: false, estimatedAmount: '1000' });
+        });
+
+        it('flags the limit when the claimable stake after rent is below the requested amount', () => {
+            expect(
+                resolveSolanaStakingLimit({
+                    type: 'claim',
+                    outputAmount: '900',
+                    totalClaimAmount: '1000',
+                    rentExemptReserves: ['100', '100'],
+                }),
+            ).toEqual({ isLimitExceeded: true, estimatedAmount: '1000' });
+        });
+
+        it('handles an empty rent reserve list', () => {
+            expect(
+                resolveSolanaStakingLimit({
+                    type: 'claim',
+                    outputAmount: '1000',
+                    totalClaimAmount: '1000',
+                    rentExemptReserves: [],
+                }),
+            ).toEqual({ isLimitExceeded: false, estimatedAmount: '1000' });
+        });
+    });
+
+    it('treats an exactly-equal amount as within the limit', () => {
+        expect(
+            resolveSolanaStakingLimit({
+                type: 'unstake',
+                outputAmount: '1000',
+                unstakeAmount: '1000',
+            }).isLimitExceeded,
+        ).toBe(false);
+    });
+});

--- a/suite-common/wallet-utils/src/index.ts
+++ b/suite-common/wallet-utils/src/index.ts
@@ -23,6 +23,7 @@ export * from './reviewTransactionUtils';
 export * from './clearSignedSwapUtils';
 export * from './sendFormUtils';
 export * from './settingsUtils';
+export * from './solanaStakingLimitUtils';
 export * from './solanaStakingUtils';
 export * from './stakingUtils';
 export * from './tokenUtils';

--- a/suite-common/wallet-utils/src/solanaStakingLimitUtils.ts
+++ b/suite-common/wallet-utils/src/solanaStakingLimitUtils.ts
@@ -1,0 +1,102 @@
+import { WALLET_SDK_SOURCE } from '@suite-common/wallet-constants';
+import { type Account } from '@suite-common/wallet-types';
+import { StakeState } from '@trezor/coins-solana/constants';
+import solana from '@trezor/coins-solana/runtime';
+import { BigNumber } from '@trezor/utils';
+
+import { getSolanaStakingAccountsByStatus } from './solanaStakingUtils';
+
+export type SolanaStakingLimitType = 'claim' | 'unstake';
+
+type ResolveSolanaStakingLimitParams =
+    | {
+          type: 'unstake';
+          outputAmount: string;
+          unstakeAmount: string;
+      }
+    | {
+          type: 'claim';
+          outputAmount: string;
+          totalClaimAmount: string;
+          rentExemptReserves: string[];
+      };
+
+export type SolanaStakingLimit = {
+    isLimitExceeded: boolean;
+    estimatedAmount: string;
+};
+
+export const resolveSolanaStakingLimit = (
+    params: ResolveSolanaStakingLimitParams,
+): SolanaStakingLimit => {
+    if (params.type === 'unstake') {
+        const { outputAmount, unstakeAmount } = params;
+
+        return {
+            isLimitExceeded: new BigNumber(unstakeAmount).lt(outputAmount),
+            estimatedAmount: unstakeAmount,
+        };
+    }
+
+    const { outputAmount, totalClaimAmount, rentExemptReserves } = params;
+
+    const claimableAmount = rentExemptReserves.reduce(
+        (acc, reserve) => acc.minus(reserve),
+        new BigNumber(totalClaimAmount),
+    );
+
+    return {
+        isLimitExceeded: claimableAmount.lt(outputAmount),
+        estimatedAmount: totalClaimAmount,
+    };
+};
+
+export const getSolanaDeactivatedRentReserves = (account: Account): string[] =>
+    getSolanaStakingAccountsByStatus(account, StakeState.Deactivated).map(
+        ({ rentExemptReserve }) => rentExemptReserve,
+    );
+
+type EstimateSolanaStakingLimitParams = {
+    descriptor: string;
+    deactivatedRentReserves: string[];
+    blockchainUrl: string;
+    userAgent: string;
+    type: SolanaStakingLimitType;
+    outputAmount: string;
+};
+
+export const estimateSolanaStakingLimit = async ({
+    descriptor,
+    deactivatedRentReserves,
+    blockchainUrl,
+    userAgent,
+    type,
+    outputAmount,
+}: EstimateSolanaStakingLimitParams): Promise<SolanaStakingLimit> => {
+    const { selectSolanaConnection, unstake, claim } = await solana();
+    const connection = selectSolanaConnection(blockchainUrl, userAgent);
+
+    if (type === 'unstake') {
+        const { unstakeAmount } = await unstake({
+            connection,
+            sender: descriptor,
+            lamports: BigInt(outputAmount),
+            source: WALLET_SDK_SOURCE,
+        });
+
+        return resolveSolanaStakingLimit({
+            type,
+            outputAmount,
+            unstakeAmount: unstakeAmount.toString(),
+        });
+    }
+
+    const { totalClaimAmount } = await claim({ connection, sender: descriptor });
+
+    return resolveSolanaStakingLimit({
+        type,
+        outputAmount,
+        totalClaimAmount: totalClaimAmount.toString(),
+        rentExemptReserves: deactivatedRentReserves,
+    });
+};

--- a/suite-native/atoms/src/Input/BottomSheetSearchInput.tsx
+++ b/suite-native/atoms/src/Input/BottomSheetSearchInput.tsx
@@ -1,4 +1,4 @@
-import { type Ref, forwardRef } from 'react';
+import { forwardRef } from 'react';
 import { type TextInput } from 'react-native';
 
 import { SearchInput, type SearchInputProps } from './SearchInput';
@@ -13,4 +13,4 @@ export type BottomSheetSearchInputRef = TextInput | null;
 export const BottomSheetSearchInput = forwardRef<
     BottomSheetSearchInputRef,
     BottomSheetSearchInputProps
->((props, ref) => <SearchInput ref={ref as Ref<TextInput>} {...props} isBottomSheetInput />);
+>((props, ref) => <SearchInput ref={ref} {...props} isBottomSheetInput />);

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2687,6 +2687,8 @@ export const messages = {
                 infoDescription:
                     'The liquidity of the staking pool can allow for instant unstake of some funds. The remaining funds will follow the unstaking period.',
             },
+            accountLimitBanner:
+                'Due to Solana transaction size restriction, you can unstake from {limit} accounts at once. In the next transaction you can unstake up to {amount} {symbol}. To unstake more, repeat the process.',
         },
         earnScreen: {
             title: 'Earn',
@@ -3183,6 +3185,8 @@ export const messages = {
             reviewAndSignButton: 'Review & sign',
             amountLabel: 'Amount',
             instantClaimBanner: "You'll claim the {displaySymbol} instantly",
+            accountLimitBanner:
+                'Due to Solana transaction size restriction, you can claim from {limit} accounts at once. In the next transaction you can claim up to {amount} {symbol}. To claim more, repeat the process.',
             insufficientFeeBalance: {
                 title: 'Insufficient {displaySymbol} to cover the transaction fee.',
                 description: 'You only have {amount} available.',

--- a/suite-native/module-earn/src/hooks/useSolanaStakingLimit.ts
+++ b/suite-native/module-earn/src/hooks/useSolanaStakingLimit.ts
@@ -1,0 +1,119 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import {
+    type AccountsRootState,
+    type BlockchainRootState,
+    selectAccountByKey,
+    selectNetworkBlockchainInfo,
+} from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+import {
+    type SolanaStakingLimitType,
+    asAmountUnit,
+    estimateSolanaStakingLimit,
+    formatNetworkAmount,
+    getSolanaDeactivatedRentReserves,
+    unitsToSubunits,
+} from '@suite-common/wallet-utils';
+import { useDebouncedValue } from '@trezor/react-utils';
+import { BigNumber } from '@trezor/utils';
+
+const NO_LIMIT = { isLimitExceeded: false, formattedAmount: '0' };
+
+type UseSolanaStakingLimitParams = {
+    accountKey: AccountKey;
+    type: SolanaStakingLimitType;
+    amount: string | undefined;
+};
+
+export const useSolanaStakingLimit = ({
+    accountKey,
+    type,
+    amount,
+}: UseSolanaStakingLimitParams) => {
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+    const blockchainUrl = useSelector((state: BlockchainRootState) =>
+        account ? selectNetworkBlockchainInfo(state, account.symbol)?.url : undefined,
+    );
+    const isSolanaAccount = account?.networkType === 'solana';
+    const descriptor = account?.descriptor;
+    const symbol = account?.symbol;
+
+    const outputAmount = useMemo(() => {
+        if (!symbol) return undefined;
+
+        const value = new BigNumber(amount ?? '');
+        if (!value.isFinite() || value.lte(0)) return undefined;
+
+        return unitsToSubunits({ value: asAmountUnit(value), symbol }).toFixed(0);
+    }, [amount, symbol]);
+
+    const debouncedOutputAmount = useDebouncedValue(outputAmount);
+    const deactivatedRentReservesKey = useMemo(
+        () => (account ? getSolanaDeactivatedRentReserves(account).join(',') : ''),
+        [account],
+    );
+    const deactivatedRentReserves = useMemo(
+        () => (deactivatedRentReservesKey ? deactivatedRentReservesKey.split(',') : []),
+        [deactivatedRentReservesKey],
+    );
+
+    const [limit, setLimit] = useState(NO_LIMIT);
+
+    useEffect(() => {
+        if (
+            !isSolanaAccount ||
+            !descriptor ||
+            !symbol ||
+            !blockchainUrl ||
+            !debouncedOutputAmount
+        ) {
+            setLimit(NO_LIMIT);
+
+            return;
+        }
+
+        let isActive = true;
+
+        estimateSolanaStakingLimit({
+            descriptor,
+            deactivatedRentReserves,
+            blockchainUrl,
+            userAgent: 'Trezor Suite',
+            type,
+            outputAmount: debouncedOutputAmount,
+        })
+            .then(resolved => {
+                if (!isActive) {
+                    return;
+                }
+
+                setLimit({
+                    isLimitExceeded: resolved.isLimitExceeded,
+                    formattedAmount: formatNetworkAmount(resolved.estimatedAmount, symbol),
+                });
+            })
+            .catch(() => {
+                if (isActive) {
+                    setLimit(NO_LIMIT);
+                }
+            });
+
+        return () => {
+            isActive = false;
+        };
+    }, [
+        descriptor,
+        symbol,
+        isSolanaAccount,
+        blockchainUrl,
+        debouncedOutputAmount,
+        type,
+        deactivatedRentReserves,
+    ]);
+
+    return limit;
+};

--- a/suite-native/module-earn/src/screens/ClaimReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/ClaimReviewScreen.tsx
@@ -31,10 +31,12 @@ import {
     selectClaimableAmountByAccountKey,
 } from '@suite-native/staking';
 import { FeeSelector } from '@suite-native/transaction-management';
+import { MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT } from '@trezor/coins-solana/constants';
 import { BigNumber } from '@trezor/utils';
 
 import { useComposeEarnFees } from '../hooks/useComposeEarnFees';
 import { useNavigateBackAnalytics } from '../hooks/useNavigateBackAnalytics';
+import { useSolanaStakingLimit } from '../hooks/useSolanaStakingLimit';
 import { buildEarnComposeFormState } from '../utils';
 
 export const ClaimReviewScreen = () => {
@@ -86,6 +88,9 @@ export const ClaimReviewScreen = () => {
             formState: claimFormState,
             formDraftPrefix: 'claim',
         });
+
+    const { isLimitExceeded: isAccountLimitExceeded, formattedAmount: claimableLimitAmount } =
+        useSolanaStakingLimit({ accountKey, type: 'claim', amount: claimableAmount });
 
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const registerNavigateBackAnalytics = useNavigateBackAnalytics({
@@ -185,6 +190,21 @@ export const ClaimReviewScreen = () => {
                             <Translation
                                 id="earn.claimReviewScreen.instantClaimBanner"
                                 values={{ displaySymbol }}
+                            />
+                        }
+                    />
+                )}
+                {isAccountLimitExceeded && (
+                    <InlineAlertBox
+                        intent="info"
+                        title={
+                            <Translation
+                                id="earn.claimReviewScreen.accountLimitBanner"
+                                values={{
+                                    limit: MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT,
+                                    amount: claimableLimitAmount,
+                                    symbol: displaySymbol,
+                                }}
                             />
                         }
                     />

--- a/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { AccountDetailsCard } from '@suite-native/accounts';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
@@ -23,12 +24,14 @@ import {
     type StackNavigationProps,
 } from '@suite-native/navigation';
 import { FeeSelector } from '@suite-native/transaction-management';
+import { MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT } from '@trezor/coins-solana/constants';
 
 import { EarnOutputFields } from '../components/EarnOutputFields';
 import { UnstakeCanClaimAlert } from '../components/UnstakeCanClaimAlert';
 import { UnstakeFlowScreenHeader } from '../components/UnstakeFlowScreenHeader';
 import { UnstakingTimelineCard } from '../components/UnstakingTimelineCard';
 import { useNavigateBackAnalytics } from '../hooks/useNavigateBackAnalytics';
+import { useSolanaStakingLimit } from '../hooks/useSolanaStakingLimit';
 import { useUnstakeForm } from '../hooks/useUnstakeForm';
 
 export const UnstakeFlowScreen = () => {
@@ -55,6 +58,13 @@ export const UnstakeFlowScreen = () => {
             currency: currencyRef.current,
         },
     });
+
+    const { isLimitExceeded: isAccountLimitExceeded, formattedAmount: unstakeLimitAmount } =
+        useSolanaStakingLimit({
+            accountKey,
+            type: 'unstake',
+            amount: unstakeForm?.amountValue,
+        });
 
     if (!unstakeForm) return null;
 
@@ -117,6 +127,24 @@ export const UnstakeFlowScreen = () => {
                 titleLabel={<Translation id="earn.earnFormScreen.staked" />}
                 cryptoAmount={stakedBalance ?? undefined}
             />
+
+            {isAccountLimitExceeded && networkSymbol && (
+                <Box marginTop="sp16">
+                    <InlineAlertBox
+                        intent="info"
+                        title={
+                            <Translation
+                                id="earn.unstakeFlowScreen.accountLimitBanner"
+                                values={{
+                                    limit: MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT,
+                                    amount: unstakeLimitAmount,
+                                    symbol: getNetworkDisplaySymbol(networkSymbol),
+                                }}
+                            />
+                        }
+                    />
+                </Box>
+            )}
 
             <Box marginTop="sp16">
                 <UnstakingTimelineCard accountKey={accountKey} />


### PR DESCRIPTION
## Description

Adds an info banner on the native unstake and claim review screens when a Solana account has more deactivated stake accounts than fit in one transaction (capped at 16), showing how much can be unstaked/claimed next and prompting to repeat for the rest - matching desktop.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29305

## Screenshots:
<img width="1290" height="2395" alt="Simulator Screenshot - iPhone 16 Plus - 2026-07-04 at 17 07 01" src="https://github.com/user-attachments/assets/17040f20-d26c-4952-ad99-21337225f0c4" />
<img width="1290" height="2373" alt="Simulator Screenshot - iPhone 16 Plus - 2026-07-04 at 16 19 51" src="https://github.com/user-attachments/assets/ae6a9622-4abd-43f5-b849-69327bd4b373" />
