### PR TITLE
Prevent bottom cut-off on staking and account lists

### DIFF
--- a/suite-native/module-accounts-management/src/screens/AccountDetailContentScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountDetailContentScreen.tsx
@@ -59,6 +59,8 @@ export const AccountDetailContentScreen = ({
                 )
             }
             noHorizontalPadding
+            noBottomPadding
+            hasBottomInset={false}
         >
             <TransactionList
                 account={account}

--- a/suite-native/module-earn/package.json
+++ b/suite-native/module-earn/package.json
@@ -74,6 +74,7 @@
         "react": "19.2.3",
         "react-native": "0.85.3",
         "react-native-reanimated": "4.3.1",
+        "react-native-safe-area-context": "5.6.2",
         "react-redux": "9.3.0"
     },
     "devDependencies": {

--- a/suite-native/module-earn/src/components/SolanaStakingRewardsList.tsx
+++ b/suite-native/module-earn/src/components/SolanaStakingRewardsList.tsx
@@ -1,4 +1,5 @@
 import { type JSX, useCallback, useState } from 'react';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { FlashList } from '@shopify/flash-list';
 
@@ -8,6 +9,7 @@ import {
 } from '@suite-common/earn-staking-api';
 import { type Account } from '@suite-common/wallet-types';
 import { Box, ListItemSkeleton, Loader, VStack } from '@suite-native/atoms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { SolanaStakingRewardItem } from './SolanaStakingRewardItem';
 import { SolanaStakingRewardsEmptyState } from './SolanaStakingRewardsEmptyState';
@@ -18,6 +20,10 @@ type SolanaStakingRewardsListProps = {
     account: Account;
     listHeaderComponent: JSX.Element;
 };
+
+const listFooterStyle = prepareNativeStyle<{ insetBottom: number }>((utils, { insetBottom }) => ({
+    paddingBottom: insetBottom + utils.spacings.sp32,
+}));
 
 const RewardsSkeleton = () => (
     <VStack marginTop="sp24" marginHorizontal="sp16" spacing="sp24">
@@ -31,6 +37,8 @@ export const SolanaStakingRewardsList = ({
     account,
     listHeaderComponent,
 }: SolanaStakingRewardsListProps) => {
+    const { applyStyle } = useNativeStyles();
+    const { bottom: insetBottom } = useSafeAreaInsets();
     const [limit, setLimit] = useState(SOL_REWARDS_PAGE_SIZE);
 
     const rewardsQuery = useSolanaRewardsHistory(account, { limit, offset: 0 });
@@ -72,8 +80,11 @@ export const SolanaStakingRewardsList = ({
                         <VStack marginVertical="sp24" alignItems="center">
                             <Loader />
                         </VStack>
-                    ) : null
+                    ) : (
+                        <Box />
+                    )
                 }
+                ListFooterComponentStyle={applyStyle(listFooterStyle, { insetBottom })}
                 onEndReached={handleEndReached}
                 onEndReachedThreshold={0.5}
             />

--- a/suite-native/module-earn/src/screens/StakingManagementScreen.tsx
+++ b/suite-native/module-earn/src/screens/StakingManagementScreen.tsx
@@ -93,6 +93,8 @@ export const StakingManagementScreen = () => {
             <Screen
                 header={<StakingManagementScreenHeader />}
                 noHorizontalPadding
+                noBottomPadding
+                hasBottomInset={false}
                 /** Adding scrollable wraps content in ScrollView which is unwanted for this screen because list component already adds the scrollview **/
                 isScrollable={false}
             >

--- a/suite-native/transactions/src/components/TransactionList.tsx
+++ b/suite-native/transactions/src/components/TransactionList.tsx
@@ -72,6 +72,10 @@ const sectionListContainerStyle = prepareNativeStyle(utils => ({
     paddingTop: utils.spacings.sp8,
 }));
 
+const listFooterStyle = prepareNativeStyle(utils => ({
+    paddingBottom: utils.spacings.sp32,
+}));
+
 const sortKeysPendingFirst = (a: string, b: string) => {
     if (a === 'pending' && b === 'pending') return 0;
     if (a === 'pending') return -1;
@@ -301,6 +305,7 @@ export const TransactionList = ({
                         onButtonPress={handleOnLoadMore}
                     />
                 }
+                ListFooterComponentStyle={applyStyle(listFooterStyle)}
                 refreshControl={
                     <RefreshControl
                         refreshing={isRefreshing}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13277,6 +13277,7 @@ __metadata:
     react: "npm:19.2.3"
     react-native: "npm:0.85.3"
     react-native-reanimated: "npm:4.3.1"
+    react-native-safe-area-context: "npm:5.6.2"
     react-redux: "npm:9.3.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

The rewards/staking history lists and the coin detail transaction list were cut off at the bottom by an unscrollable padding strip that the screen reserved beneath them. This removes that padding so the list fills the screen and adds a small end-of-list inset so the last row clears the bottom edge.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29307

## Screenshots:
<img width="1290" height="2459" alt="Simulator Screenshot - iPhone 16 Plus - 2026-07-04 at 22 58 09" src="https://github.com/user-attachments/assets/a729e114-67bb-49a5-9036-a59420f813de" />
<img width="1290" height="2468" alt="Simulator Screenshot - iPhone 16 Plus - 2026-07-04 at 22 57 54" src="https://github.com/user-attachments/assets/30e1f9d6-149e-4c3c-85f2-b1f0a3a8c2a8" />
