### PR TITLE
feat(suite): unify account sorting across the app

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimSelectAccountModal.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimSelectAccountModal.tsx
@@ -7,6 +7,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import { type YieldAccountsRewards } from '@suite-common/earn-stablecoin-api';
 import { useFormatters } from '@suite-common/formatters';
 import { selectBaseCurrency } from '@suite-common/wallet-core';
+import { compareAccountsByCoin } from '@suite-common/wallet-utils';
 import { CardList, Column, Modal, Row, Text, Tooltip } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
 
@@ -27,6 +28,10 @@ export const EarnYieldClaimSelectAccountModal = ({
     const { BaseCurrencyAmountFormatter } = useFormatters();
     const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const baseCurrency = useSelector(selectBaseCurrency);
+
+    const sortedAccountsRewards = [...accountsRewards].sort((a, b) =>
+        compareAccountsByCoin(a.account, b.account),
+    );
 
     const handleOnSelect = (account: YieldAccountsRewards[number]) => {
         analytics.report({
@@ -62,7 +67,7 @@ export const EarnYieldClaimSelectAccountModal = ({
             onCancel={handleOnCancel}
         >
             <CardList>
-                {accountsRewards.map(accountRewards => (
+                {sortedAccountsRewards.map(accountRewards => (
                     <CardList.Item
                         key={accountRewards.account.key}
                         onClick={() => handleOnSelect(accountRewards)}

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts
@@ -10,10 +10,7 @@ import {
     selectVisibleDeviceAccounts,
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import {
-    accountsFiatBalanceInDescOrderComparator,
-    filterAccountsByNetworkSymbol,
-} from '@suite-common/wallet-utils';
+import { filterAccountsByNetworkSymbol, sortByCoin } from '@suite-common/wallet-utils';
 import { type StaticSessionId } from '@trezor/connect';
 import { useCurrentRef } from '@trezor/react-utils';
 
@@ -59,7 +56,7 @@ export function useAccountWithTokensOptions({
     const throttledAccounts = useThrottle(accounts, 1000);
     const fiatRatesRef = useCurrentRef(fiatRates);
 
-    const accountsAndTokensSortedByFiatBalance = useMemo(() => {
+    const accountsAndTokensSortedByCoin = useMemo(() => {
         const fiatRates = fiatRatesRef.current;
 
         if (!fiatRates) {
@@ -71,48 +68,39 @@ export function useAccountWithTokensOptions({
             networkSymbolFilter,
         );
 
-        return networkAccounts
-            .toSorted(function sortByFiatBalanceInDescOrder(accountA, accountB) {
-                return accountsFiatBalanceInDescOrderComparator({
-                    accountA,
-                    accountB,
-                    baseCurrencyCode,
-                    fiatRates,
-                });
-            })
-            .map(account => {
-                const { shownWithBalance, hiddenWithBalance } = getTokens({
-                    tokens: account.tokens ?? [],
-                    symbol: account.symbol,
-                    tokenDefinitions: tokenDefinitions?.[account.symbol]?.coin,
-                });
-
-                const sortedTokensByFiatBalance = enhanceTokensWithRates(
-                    shownWithBalance,
-                    baseCurrencyCode,
-                    account.symbol,
-                    fiatRates,
-                ).sort(sortTokensWithRates);
-
-                const sortedHiddenTokensByFiatBalance = enhanceTokensWithRates(
-                    hiddenWithBalance,
-                    baseCurrencyCode,
-                    account.symbol,
-                    fiatRates,
-                ).sort(sortTokensWithRates);
-
-                return {
-                    account,
-                    tokens: sortedTokensByFiatBalance,
-                    hiddenTokens: sortedHiddenTokensByFiatBalance,
-                };
+        return sortByCoin(networkAccounts).map(account => {
+            const { shownWithBalance, hiddenWithBalance } = getTokens({
+                tokens: account.tokens ?? [],
+                symbol: account.symbol,
+                tokenDefinitions: tokenDefinitions?.[account.symbol]?.coin,
             });
+
+            const sortedTokensByFiatBalance = enhanceTokensWithRates(
+                shownWithBalance,
+                baseCurrencyCode,
+                account.symbol,
+                fiatRates,
+            ).sort(sortTokensWithRates);
+
+            const sortedHiddenTokensByFiatBalance = enhanceTokensWithRates(
+                hiddenWithBalance,
+                baseCurrencyCode,
+                account.symbol,
+                fiatRates,
+            ).sort(sortTokensWithRates);
+
+            return {
+                account,
+                tokens: sortedTokensByFiatBalance,
+                hiddenTokens: sortedHiddenTokensByFiatBalance,
+            };
+        });
     }, [fiatRatesRef, throttledAccounts, networkSymbolFilter, baseCurrencyCode, tokenDefinitions]);
 
     return useMemo(() => {
         const accountsWithTokens: AccountWithTokensOption[] = [];
 
-        for (const { account, tokens, hiddenTokens } of accountsAndTokensSortedByFiatBalance) {
+        for (const { account, tokens, hiddenTokens } of accountsAndTokensSortedByCoin) {
             accountsWithTokens.push(createAccountOption(account));
 
             tokens.forEach(token => {
@@ -127,5 +115,5 @@ export function useAccountWithTokensOptions({
         }
 
         return accountsWithTokens;
-    }, [accountsAndTokensSortedByFiatBalance, expandedHiddenTokensGroups]);
+    }, [accountsAndTokensSortedByCoin, expandedHiddenTokensGroups]);
 }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
@@ -10,6 +10,7 @@ import { TxSimulationBanner } from '@suite/tx-simulation/src/common';
 import { useDappScan } from '@suite-common/tx-simulation';
 import { selectAllAccountsToList } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
+import { sortByCoin } from '@suite-common/wallet-utils';
 import {
     selectPendingProposal,
     sessionProposalApproveThunk,
@@ -52,11 +53,13 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
     const accounts = useSelector(selectAllAccountsToList);
     const selectableAccounts = useMemo<Account[]>(
         () =>
-            pendingProposal?.networks
-                .filter(network => network.status === 'active')
-                .flatMap(network =>
-                    accounts.filter(account => account.symbol === network.symbol),
-                ) ?? [],
+            sortByCoin(
+                pendingProposal?.networks
+                    .filter(network => network.status === 'active')
+                    .flatMap(network =>
+                        accounts.filter(account => account.symbol === network.symbol),
+                    ) ?? [],
+            ),
         [accounts, pendingProposal?.networks],
     );
     const [selectedDefaultAccount, setSelectedDefaultAccount] = useState<Account | null>(

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx
@@ -6,6 +6,7 @@ import { Translation } from '@suite/intl';
 import { closeModal } from '@suite/modal';
 import { selectAllAccountsToList } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
+import { sortByCoin } from '@suite-common/wallet-utils';
 import {
     getSessionNetworks,
     selectSessions,
@@ -33,11 +34,13 @@ export const WalletConnectSwitchAccountModal = ({
     const selectableAccounts = useMemo<Account[]>(
         () =>
             session
-                ? getSessionNetworks(session)
-                      .filter(network => network.status === 'active')
-                      .flatMap(network =>
-                          accounts.filter(account => account.symbol === network.symbol),
-                      )
+                ? sortByCoin(
+                      getSessionNetworks(session)
+                          .filter(network => network.status === 'active')
+                          .flatMap(network =>
+                              accounts.filter(account => account.symbol === network.symbol),
+                          ),
+                  )
                 : [],
         [accounts, session],
     );

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts
@@ -14,11 +14,7 @@ import {
     selectVisibleDeviceAccounts,
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import {
-    accountsFiatBalanceInDescOrderComparator,
-    filterAccountsByNetworkSymbol,
-    isTestnet,
-} from '@suite-common/wallet-utils';
+import { filterAccountsByNetworkSymbol, isTestnet, sortByCoin } from '@suite-common/wallet-utils';
 import { type TokenInfo } from '@trezor/blockchain-link-types';
 import { useCurrentRef } from '@trezor/react-utils';
 import { BigNumber } from '@trezor/utils';
@@ -133,51 +129,42 @@ export function useAccountWithTokensOptions({
             Array.from(includedCryptoIds).filter(cryptoId => !excludedCryptoIds.has(cryptoId)),
         );
 
-        const accountsAndTokensSortedByFiatBalance = supportedNetworkAccounts
-            .toSorted(function sortByFiatBalanceInDescOrder(accountA, accountB) {
-                return accountsFiatBalanceInDescOrderComparator({
-                    accountA,
-                    accountB,
-                    baseCurrencyCode,
-                    fiatRates,
-                });
-            })
-            .map(account => {
-                const { shownWithBalance, hiddenWithBalance } = getTokens({
-                    tokens: account.tokens ?? [],
-                    symbol: account.symbol,
-                    tokenDefinitions: tokenDefinitions?.[account.symbol]?.coin,
-                });
-
-                const { supportedTokens, unsupportedTokens } = getSupportedAndUnsupportedTokens({
-                    networkSymbol: account.symbol,
-                    tokens: shownWithBalance.concat(hiddenWithBalance),
-                    supportedCryptoIds,
-                });
-
-                const sortedSupportedTokensByFiatBalance = enhanceTokensWithRates(
-                    supportedTokens,
-                    baseCurrencyCode,
-                    account.symbol,
-                    fiatRates,
-                ).sort(sortTokensWithRates);
-
-                const sortedUnsupportedTokensByFiatBalance = enhanceTokensWithRates(
-                    unsupportedTokens,
-                    baseCurrencyCode,
-                    account.symbol,
-                    fiatRates,
-                ).sort(sortTokensWithRates);
-
-                return {
-                    account,
-                    tokens: sortedSupportedTokensByFiatBalance,
-                    nonTradableTokens: sortedUnsupportedTokensByFiatBalance,
-                };
+        const accountsAndTokensSortedByCoin = sortByCoin(supportedNetworkAccounts).map(account => {
+            const { shownWithBalance, hiddenWithBalance } = getTokens({
+                tokens: account.tokens ?? [],
+                symbol: account.symbol,
+                tokenDefinitions: tokenDefinitions?.[account.symbol]?.coin,
             });
 
+            const { supportedTokens, unsupportedTokens } = getSupportedAndUnsupportedTokens({
+                networkSymbol: account.symbol,
+                tokens: shownWithBalance.concat(hiddenWithBalance),
+                supportedCryptoIds,
+            });
+
+            const sortedSupportedTokensByFiatBalance = enhanceTokensWithRates(
+                supportedTokens,
+                baseCurrencyCode,
+                account.symbol,
+                fiatRates,
+            ).sort(sortTokensWithRates);
+
+            const sortedUnsupportedTokensByFiatBalance = enhanceTokensWithRates(
+                unsupportedTokens,
+                baseCurrencyCode,
+                account.symbol,
+                fiatRates,
+            ).sort(sortTokensWithRates);
+
+            return {
+                account,
+                tokens: sortedSupportedTokensByFiatBalance,
+                nonTradableTokens: sortedUnsupportedTokensByFiatBalance,
+            };
+        });
+
         return {
-            accountsWithTokens: accountsAndTokensSortedByFiatBalance,
+            accountsWithTokens: accountsAndTokensSortedByCoin,
             networks: orderedNetworks,
             supportedCryptoIds,
         };

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -264,34 +264,37 @@ export const getAccountTypeUrl = (path: string) => {
 };
 
 /**
- * Sort accounts as they are defined in `networksConfig`, by two criteria:
+ * Compare accounts as they are defined in `networksConfig`, by two criteria:
  * - primary: by network `symbol`
  * - secondary: by `accountType`
- *
- * Returns a new array, the input is not mutated.
+ */
+export const compareAccountsByCoin = (a: Account, b: Account) => {
+    // primary sorting: by order of network keys
+    const aSymbolIndex = networkSymbolCollection.indexOf(a.symbol);
+    const bSymbolIndex = networkSymbolCollection.indexOf(b.symbol);
+    if (aSymbolIndex !== bSymbolIndex) return aSymbolIndex - bSymbolIndex;
+
+    // when it is sorted by network, sort by order of accountType keys within the same network
+    const network = networks[a.symbol];
+    // `network` is a union over all networks (some declare `accountTypes: {}`), which would collapse
+    // `keyof` to `never`; widening to the field's declared keyset yields `AccountType[]` soundly.
+    const orderedAccountTypes = typedObjectKeys(
+        network.accountTypes as Partial<Record<AccountType, unknown>>,
+    );
+    const aAccountTypeIndex = orderedAccountTypes.indexOf(a.accountType);
+    const bAccountTypeIndex = orderedAccountTypes.indexOf(b.accountType);
+
+    if (aAccountTypeIndex !== bAccountTypeIndex) return aAccountTypeIndex - bAccountTypeIndex;
+
+    // if both are same, sort by account index
+    return a.index - b.index;
+};
+
+/**
+ * Sort accounts with `compareAccountsByCoin`. Returns a new array, the input is not mutated.
  */
 export const sortByCoin = <T extends Account>(accounts: T[]) =>
-    accounts.toSorted((a, b) => {
-        // primary sorting: by order of network keys
-        const aSymbolIndex = networkSymbolCollection.indexOf(a.symbol);
-        const bSymbolIndex = networkSymbolCollection.indexOf(b.symbol);
-        if (aSymbolIndex !== bSymbolIndex) return aSymbolIndex - bSymbolIndex;
-
-        // when it is sorted by network, sort by order of accountType keys within the same network
-        const network = networks[a.symbol];
-        // `network` is a union over all networks (some declare `accountTypes: {}`), which would collapse
-        // `keyof` to `never`; widening to the field's declared keyset yields `AccountType[]` soundly.
-        const orderedAccountTypes = typedObjectKeys(
-            network.accountTypes as Partial<Record<AccountType, unknown>>,
-        );
-        const aAccountTypeIndex = orderedAccountTypes.indexOf(a.accountType);
-        const bAccountTypeIndex = orderedAccountTypes.indexOf(b.accountType);
-
-        if (aAccountTypeIndex !== bAccountTypeIndex) return aAccountTypeIndex - bAccountTypeIndex;
-
-        // if both are same, keep the original order in `accounts`
-        return a.index - b.index;
-    });
+    accounts.toSorted(compareAccountsByCoin);
 
 export const findAccountsByNetwork = <T extends Account>(symbol: NetworkSymbol, accounts: T[]) =>
     accounts.filter(a => a.symbol === symbol);
@@ -1176,48 +1179,6 @@ export const prepareNewAccountPayload = async ({
         backendType,
     };
 };
-
-interface FiatBalanceInDescComparatorProps {
-    accountA: Account;
-    accountB: Account;
-    baseCurrencyCode: BaseCurrencyCode;
-    fiatRates: RatesByKey;
-}
-
-export function accountsFiatBalanceInDescOrderComparator({
-    accountA,
-    accountB,
-    baseCurrencyCode,
-    fiatRates,
-}: FiatBalanceInDescComparatorProps) {
-    const accountAFiatBalance =
-        getAccountFiatBalance({
-            account: accountA,
-            baseCurrencyCode,
-            rates: fiatRates,
-            shouldIncludeTokens: true,
-            shouldIncludeStaking: false,
-        }) ?? new BigNumber(0);
-
-    const accountBFiatBalance =
-        getAccountFiatBalance({
-            account: accountB,
-            baseCurrencyCode,
-            rates: fiatRates,
-            shouldIncludeTokens: true,
-            shouldIncludeStaking: false,
-        }) ?? new BigNumber(0);
-
-    if (accountBFiatBalance.gt(accountAFiatBalance)) {
-        return 1;
-    }
-
-    if (accountAFiatBalance.gt(accountBFiatBalance)) {
-        return -1;
-    }
-
-    return 0;
-}
 
 export const isProgramDerivedAccount = (data: AccountInfo) =>
     !(data?.misc?.owner === SYSTEM_PROGRAM_PUBLIC_KEY || data?.misc?.owner === undefined);


### PR DESCRIPTION
## Description

- **Global send** — accounts were sorted by fiat balance descending, now by coin.
- **Sell + swap** — the shared `TradingFormInputSellAsset` asset picker, same change (tokens within an account keep their fiat-balance order).
- **WalletConnect** proposal + switch-account modals — accounts were grouped by session network order, now canonical.
- **Yield claim select-account modal** — was in Merkl API response order, now by coin (via new `compareAccountsByCoin`, extracted from `sortByCoin`).
- Cleanup: `accountsFiatBalanceInDescOrderComparator` had no remaining callers and is removed.

Intentionally **not** changed:

- **Buy asset picker** — it lists aggregated assets (one row per coin + aggregated tokens), not accounts; "biggest holdings first" there is an asset-ordering decision, not account sorting. Say the word and I'll switch it to network order too.
- **Staking dashboard** — the main card list is a by-value display ordering, not an account picker (its insufficient-funds section already uses `sortByCoin`).
- **Device-confirmation `SelectAccountModal`** — single coin with per-type tabs; rows are already in account-index order, nothing to sort.

Stacked on #29430 (needs the non-mutating `sortByCoin` from there).

## Notes for QA

- Global send, sell, and swap account pickers should list accounts in the same order as global receive and the sidebar (BTC first, then next coins; within a coin: default type first).
- WalletConnect connect/switch-account selects follow the same order.
- Yield claim modal (multiple accounts with claimable rewards) sorted by coin.

## Related Issue

Resolve #26843


## Screenshots:

Before:
<img width="534" height="692" alt="Screenshot 2026-07-08 at 11 29 26" src="https://github.com/user-attachments/assets/d6ca657c-bdd5-49c8-8e61-c7d04c26afac" />

Now:

<img width="638" height="672" alt="Screenshot 2026-07-08 at 11 22 10" src="https://github.com/user-attachments/assets/453fcef8-512b-459d-8ead-e12dbfb4abdc" />

Before:
<img width="548" height="736" alt="Screenshot 2026-07-08 at 11 30 11" src="https://github.com/user-attachments/assets/f6077459-3319-4f22-bfed-b58fce1d4408" />
<img width="530" height="755" alt="Screenshot 2026-07-08 at 11 30 35" src="https://github.com/user-attachments/assets/2745c8e1-e9f2-4378-a4be-4d5d1f4c72b5" />


Now:
<img width="674" height="780" alt="Screenshot 2026-07-08 at 11 22 44" src="https://github.com/user-attachments/assets/26ef7979-fe99-4d57-a201-3927239add28" />
<img width="655" height="731" alt="Screenshot 2026-07-08 at 11 23 04" src="https://github.com/user-attachments/assets/ca429f7d-1fdf-4c3c-a7c7-f0fc2973c837" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/unify-account-sorting&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/unify-account-sorting&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/unify-account-sorting&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies account-with-tokens option hooks used in two places (Global Send modal and Trading/Swap sell asset picker), WalletConnect modal components, an earn yield claim modal, and the core accountUtils utility. The highest risk is in the Global Send flow and WalletConnect proposal flows where changes directly affect user-facing modals. The trading swap asset picker hook changes affect all swap form tests. accountUtils is a broadly imported utility (121 tests), but changes there are best validated through the tests that directly exercise account listing/selection flows rather than all transitive consumers. The EarnYieldClaimSelectAccountModal has no test coverage.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimSelectAccountModal.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts`
- `suite-common/wallet-utils/src/accountUtils.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test directly exercises the Global Send modal flow, which uses the changed useAccountWithTokensOptions hook in GlobalSendModal. It tests filtering, searching, and selecting accounts in the asset picker — exactly the functionality that hook provides.
- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — This test directly exercises WalletConnect proposal approval and rejection flows. The changed WalletConnectProposalModal.tsx is the modal component rendered during these interactions, making this test a direct coverage path for that change.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test fills a swap form with sell/buy asset selection via the asset picker modal, which uses the changed useAccountWithTokensOptions hook in TradingFormInputSellAsset. It verifies the swap form works end-to-end including account/token selection.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test fills a swap form selecting sell/buy assets and a receive address, exercising the asset picker modal that uses the changed useAccountWithTokensOptions hook for the sell asset selection.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test explicitly selects sell assets (USDC on ETH) and buy assets through the asset picker, directly exercising the useAccountWithTokensOptions hook in the trading form. It also validates fraction buttons and balance calculations that depend on accountUtils.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — This test swaps a Solana USDT token to Bitcoin, selecting token assets in the swap form's sell asset picker that relies on the changed useAccountWithTokensOptions hook.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — This test swaps between two SPL tokens (USDT to USDC), exercising token-level asset selection in the sell asset picker modal that uses the changed hook.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test selects a sell asset (USDT on Solana) and a buy asset on a disabled network through the asset picker. While simpler than other swap tests, it still exercises the changed useAccountWithTokensOptions hook's asset listing logic.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test fills a swap form for BTC→ETH which uses the sell asset picker. While the test focuses on fee settings, the form initialization path goes through the changed hook.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test fills a swap form for ETH→BTC which uses the sell asset picker. While the test focuses on Ethereum fee settings, the form initialization path goes through the changed hook.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimSelectAccountModal.tsx`

_Updated: 2026-07-08T09:14:56.462Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/unify-account-sorting/web/](https://dev.suite.sldev.cz/suite-web/feat/unify-account-sorting/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-08T09:20:39.183Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T09:18:07.325Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->