### PR TITLE
fix(suite): allow cardano token send when total spent equals balance

### DIFF
--- a/packages/suite/src/views/wallet/send/Outputs/CardanoMinAmountInfo.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/CardanoMinAmountInfo.tsx
@@ -44,7 +44,7 @@ export const CardanoMinAmountInfo = () => {
                   .plus(unitsToSubunits({ symbol, value: asAmountUnit(totalAdaAmount) })),
     );
 
-    const hasEnoughADA = new BigNumber(balance).minus(minAdaAmount).gt(0);
+    const hasEnoughADA = new BigNumber(balance).minus(minAdaAmount).gte(0);
     const networkDisplaySymbol = getNetworkDisplaySymbol(symbol);
 
     return (


### PR DESCRIPTION
## Description

Sending a Cardano token while spending exactly 100 % of the ADA balance showed "Not enough ADA for the transaction" even though compose succeeded — `hasEnoughADA` used a strict `.gt(0)` comparison against `transactionInfo.totalSpent` from the successful compose, failing on equality. Changed to `.gte(0)`, matching what compose itself enforces (`totalSpent <= balance`).

## Notes for QA
Send a Cardano token using the full ADA balance (Min ADA equals balance). The error banner must not appear while the transaction composes and Review & send is enabled. Partial-balance sends behave as before.

- it is hard to replicate, probably you will not be able to

## Related Issue
Resolve #22704

## Screenshots:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Although CardanoMinAmountInfo.tsx is statically mapped to ten tests, it is a Cardano-specific send-form component, so most mapped tests are false positives from shared send-form imports. The wallet/cardano.test.ts is the only one that exercises the Cardano send form directly, making it the minimal, high-value test to run. No changed files lack coverage.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/send/Outputs/CardanoMinAmountInfo.tsx`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — The changed file CardanoMinAmountInfo.tsx is part of the Cardano send form Outputs, so the Cardano wallet test is the only test that opens and renders that send form. A regression in Cardano min-amount UI would be directly visible there.

</details>

_Updated: 2026-08-01T19:56:33.454Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/22704-cardano-token-send-ada-validation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/22704-cardano-token-send-ada-validation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-01T20:00:26.059Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-01T19:59:45.560Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/22704-cardano-token-send-ada-validation/web/](https://dev.suite.sldev.cz/suite-web/fix/22704-cardano-token-send-ada-validation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

