### PR TITLE
fix(suite-common): dont echo fee on cardano sent-to-self target row

### DIFF
--- a/suite-common/wallet-utils/src/transactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.test.ts
@@ -786,5 +786,46 @@ describe('transaction utils', () => {
 
             expect(getTargetAmount(selfTarget, transaction)).toBeNull();
         });
+
+        it('returns null for a cardano "sent to self" target even when there is no external target', () => {
+            const selfTarget = buildTarget({ amount: '1000', isAccountTarget: true, n: 1 });
+            const transaction = getWalletTransaction({
+                symbol: 'ada',
+                type: 'self',
+                amount: '1000',
+                cardanoSpecific: {},
+                targets: [selfTarget],
+            });
+
+            expect(getTargetAmount(selfTarget, transaction)).toBeNull();
+        });
+
+        it('returns null for a cardano tx where the amount only echoes the fee (self-send misclassified by blockfrost)', () => {
+            const selfTarget = buildTarget({ amount: '144', isAccountTarget: true, n: 1 });
+            const transaction = getWalletTransaction({
+                symbol: 'ada',
+                type: 'sent',
+                amount: '144',
+                fee: '144',
+                cardanoSpecific: {},
+                targets: [selfTarget],
+            });
+
+            expect(getTargetAmount(selfTarget, transaction)).toBeNull();
+        });
+
+        it('returns null for a cardano "sent to self" target when an external target is also present', () => {
+            const selfTarget = buildTarget({ amount: '1000', isAccountTarget: true, n: 1 });
+            const externalTarget = buildTarget({ amount: '2000', isAccountTarget: false, n: 0 });
+            const transaction = getWalletTransaction({
+                symbol: 'ada',
+                type: 'sent',
+                amount: '1000',
+                cardanoSpecific: {},
+                targets: [externalTarget, selfTarget],
+            });
+
+            expect(getTargetAmount(selfTarget, transaction)).toBeNull();
+        });
     });
 });

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -854,6 +854,7 @@ export const getTargetAmountRaw = (
     }
 
     if (
+        !transaction.cardanoSpecific &&
         target === transaction.targets.find(t => t.isAccountTarget) &&
         !transaction.targets.find(t => !t.isAccountTarget) &&
         validTxAmount


### PR DESCRIPTION
## Description

NOT READY FOR REVIEW

Cardano sent-to-myself transactions sometimes showed the fee twice: blockfrost classifies all-own-input/output txs as `self` (amount = fee), but structurally similar self-sends (token or certificate txs) land on `sent`, where `getTargetAmount`'s self-target fallback echoed `tx.amount` (≈ the fee) on the target row while `isTxFeePaid` always renders a dedicated Cardano fee row. Cardano self-targets now return `null` from that fallback — the dedicated fee row already covers the fee. Non-cardano behavior unchanged (covered by tests; the two new regression tests fail without the fix).

## Notes for QA
Check Cardano tx history: stake delegation/deregistration and token self-sends show the fee exactly once (fee row only, no amount on the "Sent to myself" row, no phantom fiat value). Bitcoin sent-to-self unchanged.

## Related Issue
Resolve #21899

## Screenshots:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** transactionUtils.ts is a broad shared utility referenced by 133 E2E tests, so the recommendation is narrowly scoped to tests that explicitly exercise transaction display, export, state transitions, and output handling. The companion unit test file transactionUtils.test.ts has no E2E coverage and should be covered by its own unit test run rather than E2E tests.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-utils/src/transactionUtils.test.ts`
- `suite-common/wallet-utils/src/transactionUtils.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test directly exercises transaction export functionality (PDF/CSV/JSON) across multiple networks, which likely relies on transactionUtils.ts for formatting transaction data into exported files.
- `suite/e2e/tests/wallet/pagination.test.ts` — This test navigates paginated transaction lists on a BTC legacy account and verifies that specific transaction addresses appear on the correct pages, directly exercising transaction list rendering and address extraction logic from transactionUtils.ts.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test validates pending vs confirmed transaction grouping, pending counts, and transaction labels (Sending/Receiving/Sent/Received), all of which depend on transaction state and type classification utilities likely in transactionUtils.ts.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test covers transaction list filtering by time range and searching transactions by address, directly exercising transaction retrieval, display, and address handling logic from transactionUtils.ts.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test labels transaction outputs and exports transactions as CSV to verify labels are included, touching transaction output identification and export formatting paths shared with transactionUtils.ts.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — This test imports a CSV file into the send form to populate transaction outputs with addresses, amounts, and labels, exercising transaction output parsing and construction logic that may be affected by changes to transactionUtils.ts.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-utils/src/transactionUtils.test.ts`

_Updated: 2026-08-01T19:56:24.826Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/21899-cardano-self-target-fee-echo/web/](https://dev.suite.sldev.cz/suite-web/fix/21899-cardano-self-target-fee-echo/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/21899-cardano-self-target-fee-echo&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/21899-cardano-self-target-fee-echo&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/21899-cardano-self-target-fee-echo&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-01T19:58:34.146Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-01T19:58:29.417Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

