### PR TITLE
fix(suite): wrap fees in card in tx simulation modals to prevent overflow

### DIFF
--- a/packages/suite/src/components/tx-simulation/connect-popup/ConnectPopupTxSimulationModalInner.tsx
+++ b/packages/suite/src/components/tx-simulation/connect-popup/ConnectPopupTxSimulationModalInner.tsx
@@ -17,7 +17,7 @@ import {
     useTxSimulation,
 } from '@suite-common/tx-simulation';
 import { type Account, type TxSimulationAction } from '@suite-common/wallet-types';
-import { Column, Modal } from '@trezor/components';
+import { Card, Column, Modal } from '@trezor/components';
 import { ERRORS } from '@trezor/connect-common';
 
 import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
@@ -162,14 +162,16 @@ export function ConnectPopupTxSimulationModalInner({
 
                         {areTxSimulationMethods(TX_METHODS_WITH_FEES, action) && (
                             <FormProvider {...form}>
-                                <Fees
-                                    account={account}
-                                    feeInfo={feeInfo}
-                                    changeFeeLevel={changeFeeLevel}
-                                    composedLevels={
-                                        txSimulationQuery.isSuccess ? composedLevels : null
-                                    }
-                                />
+                                <Card>
+                                    <Fees
+                                        account={account}
+                                        feeInfo={feeInfo}
+                                        changeFeeLevel={changeFeeLevel}
+                                        composedLevels={
+                                            txSimulationQuery.isSuccess ? composedLevels : null
+                                        }
+                                    />
+                                </Card>
                             </FormProvider>
                         )}
 

--- a/packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModalInner.tsx
+++ b/packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModalInner.tsx
@@ -18,7 +18,7 @@ import {
     useTxSimulation,
 } from '@suite-common/tx-simulation';
 import { type Account, type TxSimulationAction } from '@suite-common/wallet-types';
-import { Banner, Column, Modal } from '@trezor/components';
+import { Banner, Card, Column, Modal } from '@trezor/components';
 
 import { Fees } from 'src/components/wallet/Fees/Fees';
 
@@ -156,14 +156,16 @@ export function EarnYieldTxSimulationModalInner({
 
                         {areTxSimulationMethods(TX_METHODS_WITH_FEES, action) && (
                             <FormProvider {...form}>
-                                <Fees
-                                    account={account}
-                                    feeInfo={feeInfo}
-                                    changeFeeLevel={changeFeeLevel}
-                                    composedLevels={
-                                        txSimulationQuery.isSuccess ? composedLevels : null
-                                    }
-                                />
+                                <Card>
+                                    <Fees
+                                        account={account}
+                                        feeInfo={feeInfo}
+                                        changeFeeLevel={changeFeeLevel}
+                                        composedLevels={
+                                            txSimulationQuery.isSuccess ? composedLevels : null
+                                        }
+                                    />
+                                </Card>
                             </FormProvider>
                         )}
 

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/FeeCard.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/FeeCard.tsx
@@ -39,8 +39,12 @@ export const FeeCard = ({
     isLoading,
     'data-testid': dataTestId,
 }: FeeCardProps) => (
-    <Box data-testid={dataTestId} minWidth={FEE_CARD_MIN_WIDTH}>
-        <Tooltip content={tooltipContent} delayShow={TOOLTIP_DELAY_NORMAL}>
+    <Box
+        data-testid={dataTestId}
+        minWidth={FEE_CARD_MIN_WIDTH}
+        flex={`1 1 ${FEE_CARD_MIN_WIDTH}px`}
+    >
+        <Tooltip content={tooltipContent} delayShow={TOOLTIP_DELAY_NORMAL} display="block">
             <RadioCard onClick={() => changeFeeLevel(value)} isSelected={isSelected}>
                 <Column>
                     <Row justifyContent="space-between">

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/StandardFee.styles.ts
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/StandardFee.styles.ts
@@ -2,15 +2,12 @@ import styled from 'styled-components';
 
 import { spacingsPx } from '@trezor/theme';
 
-import { FEE_CARD_MIN_WIDTH } from './FeeCard';
-
 // Can't be in `StandardFee` component because of circular dependency:
 // - `StandardFee` imports `BitcoinFeeCards`, `EthereumFeeCards`, `MiscFeeCards`
 // - `BitcoinFeeCards`, `EthereumFeeCards`, `MiscFeeCards` import `FeeCardsWrapper`
 export const FeeCardsWrapper = styled.div`
     width: 100%;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(${FEE_CARD_MIN_WIDTH}px, 1fr));
+    display: flex;
     flex-wrap: wrap;
     gap: ${spacingsPx.sm};
     align-items: stretch;


### PR DESCRIPTION

## Description

The two tx-simulation modals (`ConnectPopupTxSimulationModalInner`, `EarnYieldTxSimulationModalInner`) rendered `Fees` without the `Card` wrapper every other caller uses, so the fee cards overflowed the modal — both now wrap `Fees` in `Card`. That exposed a layout bug in the shared `FeeCardsWrapper`: its CSS grid left an empty cell when tiles wrapped. It now uses `flex-wrap` with `flex: 1 1 170px` so tiles fill the row and reflow with no gaps, and a `display="block"` on the fee-card tooltip lets each tile fill its cell in debug mode.

## Notes for QA
Expand fee selection in a Yield deposit/claim and the Connect-popup simulation: no scrollbars or overflow, tiles wrap cleanly and fill the width (check debug mode and custom fee too). It's a shared component, so spot-check allowance approve/revoke, stake/unstake, and the wide send form.

## Related Issue
Resolve #29267

## Screenshots:


https://github.com/user-attachments/assets/56fcbb15-38bb-4e9f-b26a-fd4af440f509


https://github.com/user-attachments/assets/7968e206-fdb5-4591-9aaa-70d7a8df342d



🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two distinct areas: (1) the StandardFee/FeeCard UI components used in send forms and trading fee sections across the app, and (2) tx-simulation modal components for connect popup and earn/staking flows. The FeeCard.tsx and StandardFee.styles.ts are broadly imported (121 tests) but only directly exercised by tests that interact with send forms and trading fee UIs. The tx-simulation components have no static test coverage but are inferred to be relevant to staking and TrezorConnect popup tests. The highest risk is in send form flows (BTC, ETH, SOL, DOGE, LTC, Base) where fee rendering is directly tested, followed by trading flows with fee display, and staking/connect popup flows for the simulation modals.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/components/tx-simulation/connect-popup/ConnectPopupTxSimulationModalInner.tsx`
- `packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModalInner.tsx`
- `packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/FeeCard.tsx`
- `packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/StandardFee.styles.ts`

</details>

**Recommended tests (19)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — This test directly exercises Ethereum send form with custom fee parameters (gas limit, max fee per gas, max priority fee per gas). The FeeCard.tsx and StandardFee.styles.ts changes are core to the fee selection UI that this test validates on both the app UI and hardware device display.
- `suite/e2e/tests/wallet/send-base.test.ts` — This test sends ETH on the Base network with custom Ethereum fees and validates fee display (gas limit, max fee per gas, max priority fee per gas) on both the UI and device screen. The FeeCard and StandardFee style changes directly affect the fee selection component used in this flow.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test exercises the Bitcoin send form including locktime options, OP_RETURN outputs, and amount/address filling. The StandardFee components are part of the send form fee UI rendered in this flow.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test validates the Solana send form including fee display (max fee field), send max calculation, and review modal. The FeeCard component is part of the fee selection UI rendered in the send form.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test sends DOGE and validates transaction confirmation details including fee display on the device prompt. The FeeCard component renders the fee selection UI in the send form used here.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test exercises the LTC send form with broadcast mode and max amount setting. The fee card component is part of the send form fee UI that renders during this flow.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — The sell BTC flow includes Bitcoin fee calculation and display on the sell form. The FeeCard component is used within the fee section that this test asserts is calculated correctly.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test exercises the sell ETH flow with custom gas fee parameters. The fee section component that renders FeeCard is directly tested when setting custom Ethereum fees.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test validates the sell SOL flow including fee display (maxFee, maxFeeFiat) on the sell form. The fee components are rendered and asserted in this flow.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test specifically validates custom Bitcoin fee settings in the swap flow, including fee rate display. The FeeCard component is the UI element for selecting fee levels.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test validates custom Ethereum gas fee parameters (gas limit, max fee per gas, max priority fee per gas) in the swap flow. The FeeCard component renders these fee options.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test exercises the sell form including switching to custom fee rate for Bitcoin. The FeeCard is rendered as part of the fee selection within the sell form.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — The EarnYieldTxSimulationModalInner.tsx change relates to earn/staking flows. This ETH staking test validates the full staking flow including fee display, which may render simulation modals.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test exercises staking more ETH including fee display and device confirmation. The EarnYieldTxSimulationModalInner may render during the staking confirmation flow.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test covers ETH unstaking and claiming flows with fee display. The EarnYieldTxSimulationModalInner component may be rendered during the unstaking/claiming confirmation modals.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates the ETH staking form including amount validation and max staking with withdrawal buffer. The earn yield simulation modal component may render during this staking form flow.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — This test sells an ERC-20 token with fee display on the confirmation screen. The fee components are involved but this is a less direct path than native ETH send tests.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — The ConnectPopupTxSimulationModalInner.tsx change affects the TrezorConnect popup flow. This test exercises the connect popup with getAddress and cardanoGetAddress, which may trigger the tx simulation modal in certain flows.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This test signs an Ethereum transaction via TrezorConnect which could potentially trigger the ConnectPopupTxSimulationModalInner during the signing confirmation flow.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/tx-simulation/connect-popup/ConnectPopupTxSimulationModalInner.tsx`
- `packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModalInner.tsx`

_Updated: 2026-07-08T07:13:28.017Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/29267-yield-fee-selection-overflow/web/](https://dev.suite.sldev.cz/suite-web/fix/29267-yield-fee-selection-overflow/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/29267-yield-fee-selection-overflow&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/29267-yield-fee-selection-overflow&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-08T07:18:17.379Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T07:16:09.865Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->



