### PR TITLE
fix(suite): resolve own account name for received token transfers

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TokenTransferAddressLabel.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TokenTransferAddressLabel.tsx
@@ -1,28 +1,29 @@
 import { Address } from '@suite/address';
 import { Translation } from '@suite/intl';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
-import { type ArrayElement } from '@trezor/type-utils';
+import { type ArrayElement, exhaustive } from '@trezor/type-utils';
 
 import { AccountLabelForOwnAddress } from 'src/components/suite/labeling/AccountLabelForOwnAddress';
 import { type WalletAccountTransaction } from 'src/types/wallet';
 
+type TokenTransfer = ArrayElement<WalletAccountTransaction['tokens']>;
+
 interface TokenTransferAddressLabelProps {
     symbol: NetworkSymbol;
-    transfer: ArrayElement<WalletAccountTransaction['tokens']>;
-    type: WalletAccountTransaction['type'];
+    transfer: TokenTransfer;
 }
 
-export const TokenTransferAddressLabel = ({
-    symbol,
-    transfer,
-    type,
-}: TokenTransferAddressLabelProps) => {
-    if (type === 'self') {
-        return <Translation id="TR_SENT_TO_SELF" />;
+export const TokenTransferAddressLabel = ({ symbol, transfer }: TokenTransferAddressLabelProps) => {
+    switch (transfer.type) {
+        case 'sent':
+            return <AccountLabelForOwnAddress address={transfer.to} symbol={symbol} />;
+        case 'recv':
+            return <AccountLabelForOwnAddress address={transfer.from} symbol={symbol} />;
+        case 'self':
+            return <Translation id="TR_SENT_TO_SELF" />;
+        case 'unknown':
+            return <Address value={transfer.to} isTruncated />;
+        default:
+            return exhaustive(transfer.type);
     }
-    if (type === 'sent') {
-        return <AccountLabelForOwnAddress address={transfer.to} symbol={symbol} />;
-    }
-
-    return <Address value={transfer.to} isTruncated />;
 };

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -177,13 +177,7 @@ export const TransactionTarget = ({
                     />
                 );
             case 'token':
-                return (
-                    <TokenTransferAddressLabel
-                        symbol={transaction.symbol}
-                        transfer={payload}
-                        type={transaction.type}
-                    />
-                );
+                return <TokenTransferAddressLabel symbol={transaction.symbol} transfer={payload} />;
             case 'internal':
                 return (
                     <AccountLabelForOwnAddress address={payload.to} symbol={transaction.symbol} />

--- a/suite-common/wallet-core/src/transactions/target/createTargets.test.ts
+++ b/suite-common/wallet-core/src/transactions/target/createTargets.test.ts
@@ -3,6 +3,7 @@ import {
     type Target as BlockchainTarget,
     type InternalTransfer,
     type TokenTransfer,
+    type Transaction,
 } from '@trezor/blockchain-link-types';
 
 import { createTargets } from './createTargets';
@@ -202,6 +203,67 @@ describe(createTargets.name, () => {
         expect(r0.targetId).toBe('42');
         expect(r1.targetId).toBe('token-0xDeadBeef');
         expect(r2.targetId).toBe('internal-0xCafe');
+    });
+
+    it('preserves type, from and to of a "recv" token transfer in the TokenTarget payload', () => {
+        const tokens = [
+            makeTokenTransfer({
+                type: 'recv',
+                contract: '0xA',
+                from: '0xCounterparty',
+                to: '0xMe',
+            }),
+        ];
+
+        const result = createTargets({
+            transaction: { targets: [], tokens, internalTransfers: [] },
+            account,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toEqual({
+            type: 'token',
+            targetId: 'token-0xA',
+            payload: expect.objectContaining({
+                type: 'recv',
+                from: '0xCounterparty',
+                to: '0xMe',
+            }),
+        });
+    });
+
+    it('keeps each token transfer type independent of the overall transaction type (swap-like tx)', () => {
+        // Transaction-level type is 'sent', but the tx contains both an outgoing (token A)
+        // and an incoming (token B) transfer, as in a swap. Each TokenTarget payload must
+        // reflect its own transfer type, not the transaction's.
+        const transaction: Pick<Transaction, 'type' | 'targets' | 'tokens' | 'internalTransfers'> =
+            {
+                type: 'sent',
+                targets: [],
+                tokens: [
+                    makeTokenTransfer({ type: 'sent', contract: '0xTokenA' }),
+                    makeTokenTransfer({ type: 'recv', contract: '0xTokenB' }),
+                ],
+                internalTransfers: [],
+            };
+
+        const result = createTargets({ transaction, account });
+
+        expect(result).toHaveLength(2);
+        expect(result[0]).toEqual(
+            expect.objectContaining({
+                type: 'token',
+                targetId: 'token-0xTokenA',
+                payload: expect.objectContaining({ type: 'sent', contract: '0xTokenA' }),
+            }),
+        );
+        expect(result[1]).toEqual(
+            expect.objectContaining({
+                type: 'token',
+                targetId: 'token-0xTokenB',
+                payload: expect.objectContaining({ type: 'recv', contract: '0xTokenB' }),
+            }),
+        );
     });
 
     it('preserves the original payload references', () => {

--- a/suite-common/wallet-utils/src/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/accountUtils.test.ts
@@ -8,6 +8,7 @@ import {
     accountSearchFn,
     enhanceAddresses,
     findAccountDevice,
+    findAccountsByAddress,
     getAccountIdentifier,
     getBip43Type,
     getNetworkAccountFeatures,
@@ -106,6 +107,18 @@ describe('account utils', () => {
                 state: { staticSessionId: '1stTestnet@device_id:0' },
             }),
         );
+    });
+
+    it('findAccountsByAddress matches an ethereum-style account by descriptor equality', () => {
+        // Ethereum-style accounts have no `addresses` (used/unused/change) list,
+        // so matching must fall back to comparing the address against the descriptor.
+        const account = mockWalletAccount({
+            symbol: 'eth',
+            descriptor: asAccountDescriptor('0xAccountAddress'),
+        });
+
+        expect(findAccountsByAddress('eth', '0xAccountAddress', [account])).toEqual([account]);
+        expect(findAccountsByAddress('eth', '0xOtherAddress', [account])).toEqual([]);
     });
 
     it('getAccountKey', () => {


### PR DESCRIPTION
## Description

Received token transfers from an own account showed the raw address: `TokenTransferAddressLabel` rendered `transfer.to` (the user's own address) for the recv branch without resolving own accounts, and received the whole-transaction `type` instead of the per-transfer `transfer.type` (wrong for multi-transfer txs like swaps). It now switches exhaustively on `transfer.type`: sent → own-account label for `transfer.to`, recv → own-account label for `transfer.from`, self → "Sent to myself", unknown → raw address. New tests cover recv/multi-transfer target creation and descriptor-based `findAccountsByAddress` matching.

## Notes for QA
Send a token between two own accounts — the receiving account's history shows the sending account's name instead of the raw address (matching native coin behavior). Swap-like txs label each transfer row by its own direction.

## Related Issue
Resolve #11537

## Screenshots:
Before:
<img width="1080" height="261" alt="Screenshot 2026-08-02 at 22 32 40" src="https://github.com/user-attachments/assets/64b7963f-4e6d-485f-a5bb-5ca005e7b7ca" />
<img width="1078" height="387" alt="Screenshot 2026-08-02 at 22 32 44" src="https://github.com/user-attachments/assets/9de13e0d-2347-4698-a181-af6d6277356b" />

After:
<img width="1075" height="244" alt="Screenshot 2026-08-02 at 22 32 10" src="https://github.com/user-attachments/assets/a832599e-3e5f-4ad0-94ad-c555b61945cb" />
<img width="1071" height="273" alt="Screenshot 2026-08-02 at 22 31 49" src="https://github.com/user-attachments/assets/ffcf8eb8-9e49-409c-9572-0c215cf80f1b" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The runtime changes focus on transaction target rendering (TransactionTarget and TokenTransferAddressLabel), so the highest risk is incorrect address or label display in transaction lists and detail views. The recommended high-priority tests cover output labels, pending transaction headings, address search, and OP_RETURN target rendering. A small set of medium-priority token trading tests provide additional confidence for token-transfer-specific rendering. The two changed unit-test files have no e2e coverage.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TokenTransferAddressLabel.tsx`
- `packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx`
- `suite-common/wallet-core/src/transactions/target/createTargets.test.ts`
- `suite-common/wallet-utils/src/accountUtils.test.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test adds, edits, and exports labels on transaction outputs, so it directly exercises how TransactionTarget renders output target labels in the transaction list.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — It creates and verifies transaction output labels synced via Suite Sync, meaning it relies on TransactionTarget correctly displaying output target labels after a sync.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — It updates and removes output labels and asserts their rendered text in the account transaction view, directly covering TransactionTarget label rendering paths.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — It checks pending transaction group headings such as 'Sending to self' and 'Receiving' in the transaction list, which are produced by the transaction target rendering logic.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — It asserts that an OP_RETURN output appears as 'OP_RETURN (meow)' in the transaction list target address, directly testing non-standard target address label rendering.
- `suite/e2e/tests/wallet/transactions.test.ts` — It searches and verifies transaction addresses in the account transaction list, so a regression in how TransactionTarget displays target addresses would be caught here.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This flow buys an SPL token and lands on a transaction detail view where token-transfer target addresses are rendered, so it can surface regressions in TokenTransferAddressLabel on token transactions.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — It sells an ERC-20 token and inspects the resulting transaction detail, exercising the token-transfer target rendering path that TokenTransferAddressLabel handles.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — It performs an SPL token-to-token swap and verifies the transaction detail page, where token transfer targets are displayed and could be affected by TokenTransferAddressLabel changes.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/wallet-core/src/transactions/target/createTargets.test.ts`
- `suite-common/wallet-utils/src/accountUtils.test.ts`

_Updated: 2026-08-01T20:32:59.430Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/11537-token-transfer-own-account-label&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/11537-token-transfer-own-account-label&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/11537-token-transfer-own-account-label&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/11537-token-transfer-own-account-label/web/](https://dev.suite.sldev.cz/suite-web/fix/11537-token-transfer-own-account-label/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-01T19:24:21.916Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-01T19:24:10.824Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

