### PR TITLE
fix(product-components): prevent asset logo overflow when image fails to load

### DIFF
--- a/packages/product-components/src/components/AssetLogo/AssetLogoWithId.tsx
+++ b/packages/product-components/src/components/AssetLogo/AssetLogoWithId.tsx
@@ -64,17 +64,25 @@ const Container = styled.div<TransientProps<AllowedFrameProps> & { $size: number
     ${withFrameProps}
 `;
 
-const Logo = styled.img<{ $size: number; $isBordered: boolean }>`
+const LogoWrapper = styled.div<{ $size: number; $isBordered: boolean }>`
     width: ${({ $size }) => $size}px;
     height: ${({ $size }) => $size}px;
     border-radius: ${borders.radii.full};
-    background-color: ${({ theme }) => theme.elementFillElevated};
+    overflow: hidden;
 
     ${({ $isBordered }) =>
         $isBordered &&
         css`
             box-shadow: ${({ theme }) => theme.elementShadowElevated};
         `}
+`;
+
+const Logo = styled.img<{ $size: number }>`
+    display: block;
+    width: ${({ $size }) => $size}px;
+    height: ${({ $size }) => $size}px;
+    border-radius: ${borders.radii.full};
+    background-color: ${({ theme }) => theme.elementFillElevated};
 `;
 
 export const AssetLogoWithId = ({
@@ -243,18 +251,19 @@ export const AssetLogoWithId = ({
                 </AssetInitials>
             )}
             {!showPlaceholder && current && (
-                <Logo
-                    src={current.src}
-                    srcSet={current.srcSet}
-                    loading="lazy"
-                    decoding="async"
-                    $size={size}
-                    $isBordered={isBordered}
-                    data-testid={dataTest}
-                    alt={placeholder}
-                    onLoad={handleOnLoad}
-                    onError={handleLoadError}
-                />
+                <LogoWrapper $size={size} $isBordered={isBordered}>
+                    <Logo
+                        src={current.src}
+                        srcSet={current.srcSet}
+                        loading="lazy"
+                        decoding="async"
+                        $size={size}
+                        data-testid={dataTest}
+                        alt={placeholder}
+                        onLoad={handleOnLoad}
+                        onError={handleLoadError}
+                    />
+                </LogoWrapper>
             )}
         </>
     );


### PR DESCRIPTION
## Description

The `<img>` is now wrapped in a circular clipping wrapper that itself carries the `isBordered` shadow, so nothing spills while the elevation shadow and the `NetworkIconBadge` overlay stay intact. 

## Notes for QA
Open tx simulation and block image addresses in networks tab

## Related Issue
Resolve #28969

## Screenshots:

<img width="1296" height="1106" alt="image" src="https://github.com/user-attachments/assets/794a6b45-0f01-4229-b75f-ddc31fa94a30" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to `AssetLogoWithId.tsx`, a UI component in `product-components` that renders asset/coin logos. This is a presentational component likely used broadly across the app (dashboard, wallet, trading, staking views), but no static test coverage mapping exists for it, and none of the 48 candidate E2E tests specifically exercise or assert on asset logo rendering behavior. The component is visual in nature, and E2E tests in this suite focus on functional flows (transactions, staking, trading, onboarding) rather than visual logo rendering. No E2E tests are recommended — visual regression testing or unit/component tests would be more appropriate for this change.

<details><summary><b>Changed files (1)</b></summary>

- `packages/product-components/src/components/AssetLogo/AssetLogoWithId.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/product-components/src/components/AssetLogo/AssetLogoWithId.tsx`

_Updated: 2026-07-08T08:19:22.031Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/28969-asset-logo-overflow&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/28969-asset-logo-overflow&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-08T08:25:25.491Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T08:22:30.855Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/28969-asset-logo-overflow/web/](https://dev.suite.sldev.cz/suite-web/fix/28969-asset-logo-overflow/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

