### PR TITLE
fix(suite-common): include cardano change output in pending account utxo set

### DIFF
--- a/suite-common/wallet-utils/src/__fixtures__/accountUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/accountUtils.ts
@@ -160,6 +160,87 @@ export const getUtxoFromSignedTransaction = [
         ],
     },
     {
+        description: 'cardano tx, 1 new change utxo',
+        params: {
+            account: {
+                addresses: {
+                    used: [],
+                    unused: [],
+                    change: [
+                        { path: "m/1852'/1815'/0'/1/0", address: 'A-change' },
+                        { path: "m/1852'/1815'/0'/1/1", address: 'B-change' },
+                    ],
+                },
+                utxo: [
+                    { txid: '0000', vout: 0, amount: '4' },
+                    { txid: '0000', vout: 1, amount: '5' },
+                ],
+            },
+            tx: {
+                type: 'final',
+                inputs: [{ prev_hash: '0000', prev_index: 1 }],
+                outputs: [
+                    { address: 'external', amount: '2' },
+                    {
+                        addressParameters: { addressType: 0, path: "m/1852'/1815'/0'/1/1" },
+                        amount: '1',
+                    },
+                ],
+            },
+            txid: 'ABCD',
+        },
+        result: [
+            {
+                txid: 'ABCD',
+                vout: 1,
+                amount: '1',
+                address: 'B-change',
+                path: "m/1852'/1815'/0'/1/1",
+            },
+            { txid: '0000', vout: 0, amount: '4' },
+        ],
+    },
+    {
+        description: 'cardano tx, change utxo with token bundle keeps lovelace amount',
+        params: {
+            account: {
+                addresses: {
+                    used: [],
+                    unused: [],
+                    change: [{ path: "m/1852'/1815'/0'/1/0", address: 'A-change' }],
+                },
+                utxo: [{ txid: '0000', vout: 0, amount: '10' }],
+            },
+            tx: {
+                type: 'final',
+                inputs: [{ prev_hash: '0000', prev_index: 0 }],
+                outputs: [
+                    { address: 'external', amount: '2' },
+                    {
+                        addressParameters: { addressType: 0, path: "m/1852'/1815'/0'/1/0" },
+                        amount: '3',
+                        tokenBundle: [
+                            {
+                                policyId: 'policy',
+                                tokenAmounts: [{ assetNameBytes: '', amount: '7' }],
+                            },
+                        ],
+                    },
+                ],
+            },
+            txid: 'ABCD',
+        },
+        result: [
+            {
+                txid: 'ABCD',
+                vout: 1,
+                amount: '3',
+                address: 'A-change',
+                path: "m/1852'/1815'/0'/1/0",
+            },
+        ],
+    },
+    {
         description: 'regular tx, multiple outputs, multiple new utxos',
         params: {
             account: {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -937,6 +937,10 @@ export const getUtxoFromSignedTransaction = ({
             const serialized = output.address_n.slice(3, 5).join('/');
             addr = account.addresses?.change.find(a => a.path.endsWith(serialized));
         }
+        if (!receivingAccount && 'addressParameters' in output && output.addressParameters) {
+            // find cardano change address
+            addr = account.addresses?.change.find(a => a.path === output.addressParameters.path);
+        }
         if ('address' in output) {
             // find self address
             addr = addresses.find(a => a.address === output.address);


### PR DESCRIPTION
## Description

`getUtxoFromSignedTransaction` matched outputs only via `address_n` (bitcoin change) or `address` (external), but Cardano change outputs carry `addressParameters` — so the pending change UTXO was dropped from the locally projected account. With few UTXOs this left zero usable inputs while a tx was pending, and since the send form composes even when empty, `UTXO_BALANCE_INSUFFICIENT` surfaced as "You don't have enough funds". A new branch matches Cardano change outputs by `addressParameters.path`. Fixture tests cover the cardano change UTXO (with and without token bundle) and guard the shared bitcoin/RBF paths.

## Notes for QA
Send a Cardano transaction, then immediately open the Send form again while the first tx is pending — no "not enough funds" error with empty fields, and a follow-up send composes using the pending change.

## Related Issue
Resolve #23744

## Screenshots:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch suite-common/wallet-utils account utilities, a broad dependency used across wallet, discovery, metadata, and trading flows. Because 133 tests statically reference the file, I selected a tight subset that directly stress account identity, labeling, derivation paths, discovery, and account search—areas most likely to regress. Run the four high-priority tests unconditionally; add the medium-priority tests if CI bandwidth allows broader confidence.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-utils/src/__fixtures__/accountUtils.ts`
- `suite-common/wallet-utils/src/accountUtils.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/wallet/account-search.test.ts` — This test directly exercises account search and filtering (hiding/showing BTC and LTC account buttons). accountUtils.ts likely contains the account list/search predicates and account normalization logic, so a regression here would be immediately visible.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — The test adds accounts of different types (normal, taproot, segwit, legacy) and asserts correct derivation paths, symbols, and analytics events. accountUtils.ts typically defines account type metadata and derivation paths, making this a direct coverage point.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — It verifies account labels rendered from derivation paths and indexes (e.g., LABELING_ACCOUNT with networkName and index) in the global receive/send asset picker. accountUtils.ts is the likely source of account label/account index computation.
- `suite/e2e/tests/wallet/public-keys.test.ts` — Opens account details and asserts displayed XPUB values for BTC, LTC, and ADA. accountUtils.ts is involved in account identification and public-key extraction/formatting for the account details view.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — The account details tab asserts Cardano account type description, derivation path, and xpub display. These metadata fields are commonly derived or formatted by accountUtils.ts, so changes there could alter what is shown.
- `suite/e2e/tests/wallet/discovery.test.ts` — Activates many networks and verifies that each discovered coin account appears with a visible balance on the dashboard. accountUtils.ts participates in how discovered accounts are represented and matched to coins.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Ejects/adds a standard wallet and checks that the BTC account balance is discovered. This shares the discovery and account representation code path with accountUtils.ts.
- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — Edits account labels and asserts they persist. accountUtils.ts likely provides the account identity/labeling target used by the metadata layer, so a change could break label association.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Configures custom Blockbook backends and verifies account discovery completes and the portfolio graph appears. Discovery results flow through accountUtils.ts for account representation.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-utils/src/__fixtures__/accountUtils.ts`

_Updated: 2026-08-01T14:27:35.989Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/23744-cardano-pending-change-utxo&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/23744-cardano-pending-change-utxo&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/23744-cardano-pending-change-utxo&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/23744-cardano-pending-change-utxo/web/](https://dev.suite.sldev.cz/suite-web/fix/23744-cardano-pending-change-utxo/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-01T14:30:00.954Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-01T14:29:21.895Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

