### PR TITLE
fix(suite-common): prioritize native coin fiat rates over token rates

### DIFF
--- a/suite-common/wallet-core/src/fiat-rates/__tests__/fiatRatesSelectors.test.ts
+++ b/suite-common/wallet-core/src/fiat-rates/__tests__/fiatRatesSelectors.test.ts
@@ -24,16 +24,26 @@ const ethAccount = (deviceState: string, tokenContract: TokenAddress): Account =
         tokens: [{ contract: tokenContract, balance: '1000000', protocols: [] }],
     }) as unknown as Account;
 
+const xrpAccount = (deviceState: string): Account =>
+    ({
+        symbol: 'xrp',
+        deviceState,
+        tokens: [],
+    }) as unknown as Account;
+
 type State = FiatRatesRootState & TokenDefinitionsRootState & AccountsRootState & DeviceRootState;
 
-const getState = (selectedDevice: TrezorDevice): State =>
+const getState = (
+    selectedDevice: TrezorDevice,
+    accounts: Account[] = [
+        ethAccount(STANDARD_WALLET_SSID, USDT),
+        ethAccount(PASSPHRASE_WALLET_SSID, USDC),
+    ],
+): State =>
     ({
         wallet: {
             fiat: { current: {}, lastWeek: {}, historic: {} },
-            accounts: [
-                ethAccount(STANDARD_WALLET_SSID, USDT),
-                ethAccount(PASSPHRASE_WALLET_SSID, USDC),
-            ],
+            accounts,
         },
         tokenDefinitions: {
             eth: { coin: { data: [USDT, USDC], error: false, isLoading: false } },
@@ -62,5 +72,25 @@ describe('selectTickerFromAccounts', () => {
             [...tickers].map(ticker => `${ticker.symbol}-${ticker.tokenAddress ?? ''}`).sort();
 
         expect(sortByKey(fromStandard)).toEqual(sortByKey(fromPassphrase));
+    });
+
+    it('orders all native coin tickers before token tickers', () => {
+        const result = selectTickerFromAccounts(
+            getState(STANDARD_WALLET, [
+                ethAccount(STANDARD_WALLET_SSID, USDT),
+                xrpAccount(STANDARD_WALLET_SSID),
+            ]),
+        );
+
+        const nativeIndexes = result.flatMap((ticker, index) =>
+            ticker.tokenAddress ? [] : [index],
+        );
+        const tokenIndexes = result.flatMap((ticker, index) =>
+            ticker.tokenAddress ? [index] : [],
+        );
+
+        expect(result.map(ticker => ticker.symbol)).toContain('xrp');
+        expect(tokenIndexes.length).toBeGreaterThan(0);
+        expect(Math.max(...nativeIndexes)).toBeLessThan(Math.min(...tokenIndexes));
     });
 });

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesMiddleware.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesMiddleware.ts
@@ -113,8 +113,8 @@ export const prepareFiatRatesMiddleware = createMiddlewareWithExtraDeps(
                 tokenAddress: token.contract as TokenAddress,
                 protocols: token.protocols,
             })) satisfies TickerId[];
-            // include main account fiat rate ticker
-            const tickers = [...tokenTickers, { symbol }];
+            // include main account fiat rate ticker first so its rate is fetched before tokens
+            const tickers = [{ symbol }, ...tokenTickers];
 
             dispatch(
                 updateFiatRatesThunk({

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts
@@ -120,6 +120,7 @@ export const selectTickerFromAccounts = (
         A.uniqBy(ticker =>
             ticker.tokenAddress ? `${ticker.symbol}-${ticker.tokenAddress}` : ticker.symbol,
         ),
+        A.sortBy(ticker => (ticker.tokenAddress ? 1 : 0)),
         F.toMutable,
     );
 };


### PR DESCRIPTION
## Description

`selectTickerFromAccounts` flattened per-account `[native, ...tokens]` in account insertion order, and `fetchFiatRatesThunk` processes chunks of 4 sequentially through a shared 1-req/s CoinGecko rate limiter — so with Solana enabled, dozens of SPL-token tickers queued ahead of e.g. XRP's native ticker, leaving $0 fiat for minutes. A stable `A.sortBy` now orders all native tickers before token tickers, and the new-account fetch in `fiatRatesMiddleware` puts the native ticker first. New selector test locks the ordering.

## Notes for QA
Launch with Solana (many tokens) + XRP enabled: XRP fiat value should appear promptly instead of after minutes. Token rates still arrive, just after natives.

## Related Issue
Resolve #17871

## Screenshots:

<img width="400" height="681" alt="Screenshot 2026-07-08 at 10 21 54" src="https://github.com/user-attachments/assets/af8717ef-2952-4b45-b78c-e7870b741d73" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch fiat rates selectors and middleware, which are broadly imported (121 tests each) but have specific impact on features that display or convert fiat values. The unit test file (fiatRatesSelectors.test.ts) has no E2E coverage mapping, which is expected since it's a unit test itself. The recommended strategy focuses on tests that explicitly assert fiat-denominated values, currency conversion, or balance display — these are the most likely to regress from selector/middleware logic changes. Most of the 121 statically-mapped tests only transitively import this code and are unlikely to be affected.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/wallet-core/src/fiat-rates/__tests__/fiatRatesSelectors.test.ts`
- `suite-common/wallet-core/src/fiat-rates/fiatRatesMiddleware.ts`
- `suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test explicitly checks fiat balance values ('$0.00', '$###') on the dashboard, asset cards, asset rows, and portfolio. Fiat rates selectors are directly responsible for computing these displayed fiat amounts, so changes to fiatRatesSelectors.ts or fiatRatesMiddleware.ts could cause fiat values to render incorrectly or not at all.
- `suite/e2e/tests/settings/general.test.ts` — This test changes fiat currency from USD to EUR and asserts the dashboard displays the correct fiat symbol ('$0.00' → '€0.00'). The fiat rates selectors and middleware directly power currency conversion and display, making this a direct regression target for these changes.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test verifies asset contents in grid and table views and interacts with the buy button for BTC. Asset display typically involves fiat rate lookups via selectors to show fiat-denominated values alongside crypto balances, so fiat rate selector changes could affect asset rendering.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test checks account balance display after receiving BTC on regtest. While it primarily checks crypto balances, the fiat rates middleware triggers rate fetching on account discovery/balance changes, so a broken middleware could affect the discovery or balance update flow.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test explicitly switches between crypto (ETH) and fiat (USD) input modes with value conversion, checking that fiat values convert correctly at a mocked 0.5 ratio. The fiat rates selectors are used to look up exchange rates for this conversion, making this directly sensitive to selector changes.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test uses percentage buttons and max button to calculate fractions of account balance, and validates fiat-denominated error messages. Fiat rate selectors are used for crypto-to-fiat conversion in sell forms, so selector changes could affect these calculations.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test validates swap form behavior including fiat amount validation ('entering an excessively large fiat amount triggers exceeds-balance validation'). The fiat rate selectors power the crypto↔fiat conversion logic in swap forms, so changes could affect validation thresholds.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/fiat-rates/__tests__/fiatRatesSelectors.test.ts`

_Updated: 2026-07-05T17:36:27.694Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/17871-prioritize-native-fiat-rates/web/](https://dev.suite.sldev.cz/suite-web/fix/17871-prioritize-native-fiat-rates/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/17871-prioritize-native-fiat-rates&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/17871-prioritize-native-fiat-rates&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/17871-prioritize-native-fiat-rates&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-05T17:41:47.653Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-05T17:39:35.323Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

