### PR TITLE
fix(suite): show fiat value of token total in send form summary

### DIFF
--- a/packages/suite/src/views/wallet/send/TotalSent/TotalSentFeeContent.tsx
+++ b/packages/suite/src/views/wallet/send/TotalSent/TotalSentFeeContent.tsx
@@ -1,12 +1,17 @@
 import { useTranslation } from '@suite/intl';
 import { type NetworkSymbol, type NetworkType } from '@suite-common/wallet-config';
 import { useDisplayBaseCurrency } from '@suite-common/wallet-core';
-import { type GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
-import { type TronFeeBreakdown, formatNetworkAmount } from '@suite-common/wallet-utils';
+import { type GeneralPrecomposedTransaction, type TokenAddress } from '@suite-common/wallet-types';
+import {
+    type TronFeeBreakdown,
+    convertAmountSubunitsToUnits,
+    formatNetworkAmount,
+} from '@suite-common/wallet-utils';
 import { Column, Text } from '@trezor/components';
 import { type TokenInfo } from '@trezor/connect';
 
 import { BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
+import { useFiatFromCryptoValue } from 'src/hooks/suite/useFiatFromCryptoValue';
 
 type TotalSentFeeContentProps = {
     transactionInfo: GeneralPrecomposedTransaction;
@@ -25,6 +30,24 @@ export function TotalSentFeeContent({
 }: TotalSentFeeContentProps) {
     const { translationString } = useTranslation();
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(networkSymbol);
+
+    const hasTransactionInfo = transactionInfo.type !== 'error';
+    const feeAmount = formatNetworkAmount(
+        hasTransactionInfo ? transactionInfo.fee : '0',
+        networkSymbol,
+    );
+    const { fiatAmount: tokenFiatAmount } = useFiatFromCryptoValue({
+        amount:
+            hasTransactionInfo && tokenInfo
+                ? convertAmountSubunitsToUnits(transactionInfo.totalSpent, tokenInfo.decimals)
+                : '0',
+        symbol: networkSymbol,
+        tokenAddress: tokenInfo?.contract as TokenAddress,
+    });
+    const { fiatAmount: feeFiatAmount } = useFiatFromCryptoValue({
+        amount: feeAmount,
+        symbol: networkSymbol,
+    });
 
     if (transactionInfo.type === 'error') return null;
 
@@ -57,12 +80,27 @@ export function TotalSentFeeContent({
     }
 
     if (tokenInfo) {
+        const totalFiatIncludingFee =
+            shallDisplayBaseCurrency && tokenFiatAmount && feeFiatAmount
+                ? tokenFiatAmount.plus(feeFiatAmount)
+                : null;
+
         return (
-            <FormattedCryptoAmount
-                disableHiddenPlaceholder
-                value={formatNetworkAmount(transactionInfo.fee, networkSymbol)}
-                symbol={networkSymbol}
-            />
+            <Column alignItems="flex-end" gap={4}>
+                <FormattedCryptoAmount
+                    disableHiddenPlaceholder
+                    value={feeAmount}
+                    symbol={networkSymbol}
+                />
+                {totalFiatIncludingFee !== null && (
+                    <BaseCurrencyValue
+                        disableHiddenPlaceholder
+                        shouldConvert={false}
+                        amount={totalFiatIncludingFee.toFixed()}
+                        symbol={networkSymbol}
+                    />
+                )}
+            </Column>
         );
     }
 


### PR DESCRIPTION


## Description

The originally reported rate drift (Amount + Fee ≠ Total in fiat after a background rate refresh) is no longer reproducible on develop, so the previous fix was dropped.

What remains inconsistent is the send form summary for token transfers: a native send shows the fiat value of the total including fee (the "Including fee" row), but a token send showed only the token amount and the native fee with no fiat at all. `TotalSentFeeContent` now renders, below the native fee, the fiat value of the whole transaction — the sent token amount converted with the token rate plus the fee converted with the native rate — under the same `useDisplayBaseCurrency` gating as the native fiat total. Native sends, Tron fee breakdown, Cardano token rows and zero-value transactions are untouched.

## Notes for QA

- ETH (or any EVM) token send, e.g. USDT/MORPHO: the summary shows Total in the token, Fee in the native coin, and below the fee a fiat value covering token amount + fee (e.g. $51.29 token + $0.01 fee → $51.30).
- Native sends (BTC/ETH/…): unchanged — Total in crypto, fiat in the "Including fee" row.
- Tokens without a known fiat rate show no fiat value at all (fee fiat alone would be misleading).
- Testnets show no fiat (same rule as native).

## Related Issue

Resolve #6974

## Screenshots:
<img width="1133" height="951" alt="Screenshot 2026-08-19 at 12 42 39" src="https://github.com/user-attachments/assets/105b0f0a-c4ce-4083-a92f-de1e4283636a" />
<img width="1133" height="573" alt="Screenshot 2026-08-19 at 11 14 39" src="https://github.com/user-attachments/assets/a2f287a5-9bb8-40f2-aac8-fa581fb911bc" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to the send total/fee display component. The biggest risk is incorrect or malformed rendering of total and fee amounts in the send review flow. Run send-sol (high) because it directly asserts those modal fields, and run send-doge and send-eth (medium) because they validate total/fee formatting in related device prompts. The remaining mapped tests do not inspect this component's output and can be skipped.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/send/TotalSent/TotalSentFeeContent.tsx`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/send-sol.test.ts` — The test explicitly asserts on the Review & Send modal's total sent, fee, and crypto amounts for 'total' and 'fee', which are rendered by TotalSentFeeContent. A regression here would be immediately user-visible.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/wallet/send-doge.test.ts` — This test verifies the total and fee amounts shown in the device prompt for a Dogecoin send, including a very large total that exercises fee-content formatting. It shares the send review display path but focuses on a signing-error edge case.
- `suite/e2e/tests/wallet/send-eth.test.ts` — The test checks total and maximum fee values in the device prompt/emulator for an Ethereum send, so it touches the same fee/total display logic. However, its primary focus is EVM-specific gas and emulator formatting.

</details>

_Updated: 2026-08-19T09:47:07.084Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/6974-send-form-fiat-rate-drift/web/](https://dev.suite.sldev.cz/suite-web/fix/6974-send-form-fiat-rate-drift/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/6974-send-form-fiat-rate-drift&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/6974-send-form-fiat-rate-drift&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-19T09:48:44.456Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-19T09:48:17.810Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->



