### PR TITLE
fix(suite): use standard transaction notification for raw tx broadcast

### DIFF
--- a/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
@@ -125,6 +125,16 @@ const transactionNotificationConfig: Record<
             },
         },
     },
+    'raw-tx-sent': {
+        toastIcon: 'arrowUp',
+        intent: 'brand',
+        message: 'Raw transaction sent from Ethereum #1',
+        amount: '',
+        transaction: {
+            notificationType: 'raw-tx-sent',
+            symbol: 'eth',
+        },
+    },
     'tx-yield-deposit': {
         toastIcon: 'arrowUp',
         intent: 'brand',

--- a/packages/product-components/src/components/Notifications/notificationsTypes.ts
+++ b/packages/product-components/src/components/Notifications/notificationsTypes.ts
@@ -18,6 +18,7 @@ export type ExchangeInfoAsset = Pick<ExchangeToastAssetData, 'symbol' | 'contrac
 
 export type TransactionNotificationType =
     | 'tx-sent'
+    | 'raw-tx-sent'
     | 'tx-received'
     | 'tx-confirmed'
     | 'tx-staked'

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -164,12 +164,18 @@ export const NotificationRenderer = ({
             });
 
         case 'raw-tx-sent':
-            return renderNotificationView(render, notification, {
-                variant: 'success',
-                message: 'TOAST_RAW_TX_SENT',
-                icon: 'arrowUp',
-                values: { txid: notification.txid },
-            });
+            return (
+                <TransactionRenderer
+                    render={render}
+                    notification={notification}
+                    icon="arrowUp"
+                    variant="success"
+                    message="TOAST_TX_SENT"
+                    messageValues={{
+                        account: notification.descriptor,
+                    }}
+                />
+            );
 
         case 'cardano-delegate-error':
             return renderNotificationView(render, notification, {

--- a/packages/suite/src/views/wallet/send/SendRaw.tsx
+++ b/packages/suite/src/views/wallet/send/SendRaw.tsx
@@ -59,6 +59,7 @@ export const SendRaw = ({ account }: SendRawProps) => {
             pushSendFormRawTransactionThunk({
                 tx: inputValue,
                 symbol: account.symbol,
+                descriptor: account.descriptor,
                 identity: tryGetAccountIdentity(account),
                 isMevProtectionEnabled: isMevProtectionEnabled && isMevProtectionFeatureEnabled,
             }),

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -32,6 +32,10 @@ type SentTransactionNotification = {
     token?: TokenInfo;
 } & TransactionNotificationPayload;
 
+type RawSentTransactionNotification = {
+    type: 'raw-tx-sent';
+} & BaseTransactionNotificationPayload;
+
 type RevokeTransactionNotification = {
     type: 'tx-revoked';
     token: TokenInfo;
@@ -148,10 +152,7 @@ export type ToastPayload<TranslationKey extends UnknownTranslationKey = UnknownT
     | ApproveTransactionNotification
     | RevokeTransactionNotification
     | ExchangeTransactionNotification
-    | {
-          type: 'raw-tx-sent';
-          txid: string;
-      }
+    | RawSentTransactionNotification
     | ErrorToastPayload
     | {
           type: 'trading-error';

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -475,10 +475,11 @@ export const pushSendFormRawTransactionThunk = createThunk(
         payload: {
             tx: string;
             symbol: NetworkSymbol;
+            descriptor: string;
             identity?: string;
             isMevProtectionEnabled: boolean;
         },
-        { dispatch, fulfillWithValue, rejectWithValue },
+        { dispatch, getState, fulfillWithValue, rejectWithValue },
     ) => {
         const txData = getMevProtectedTxData(
             payload.symbol,
@@ -496,7 +497,11 @@ export const pushSendFormRawTransactionThunk = createThunk(
             dispatch(
                 notificationsActions.addToast({
                     type: 'raw-tx-sent',
+                    device: selectSelectedDevice(getState()),
+                    descriptor: payload.descriptor,
+                    symbol: payload.symbol,
                     txid: sentTx.payload.txid,
+                    style: { maxWidth: 'auto' },
                 }),
             );
             dispatch(syncAccountsWithBlockchainThunk(payload.symbol));

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -4132,10 +4132,6 @@ export const messages = defineMessages({
         defaultMessage:
             'Swap transaction from {sendAccount} to {receiveAccount} has been broadcast',
     },
-    TOAST_RAW_TX_SENT: {
-        id: 'TOAST_RAW_TX_SENT',
-        defaultMessage: 'Transaction sent. Tx ID: {txid}',
-    },
     TOAST_TX_RECEIVED: {
         id: 'TOAST_TX_RECEIVED',
         defaultMessage: 'Received to {account}',


### PR DESCRIPTION
## Description

Broadcasting a raw transaction showed a bare "Transaction sent. Tx ID: …" toast. It now dispatches the same rich transaction notification as normal sends (`TransactionRenderer`, "Sent from {account}" + view-details), reusing the existing amount-less payload pattern from the yield toasts. The orphaned `TOAST_RAW_TX_SENT` message was removed. The payload now carries `descriptor`/`device` — identical to the existing `tx-sent` payload class, local-only. Note: "view details" activates once the broadcast tx appears via account sync (raw sends have no composed data to synthesize a pending tx from).

## Notes for QA
Broadcast a raw transaction (Send raw) — the notification matches normal send notifications, no txid in the message; details available shortly after broadcast.

## Related Issue
Resolve #29265

## Screenshots:

<img width="556" height="235" alt="Screenshot 2026-07-08 at 8 01 38" src="https://github.com/user-attachments/assets/ea19f695-ac35-4fb0-baac-a450a8378380" />
<img width="1090" height="471" alt="Screenshot 2026-07-08 at 8 01 59" src="https://github.com/user-attachments/assets/c6e01d86-0e37-456d-860d-4e2cdae0df52" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes center on the send transaction flow (SendRaw.tsx, sendFormThunks.ts), notification/toast rendering (NotificationRenderer.tsx, toast types), and internationalization messages. The highest risk is in send form functionality where both the raw send component and the thunks were modified — tests that actually send transactions and verify device prompts or toast notifications should be prioritized. The notification type and renderer changes are broadly imported but only tests that explicitly assert on toast notifications need targeted coverage. The stories file and product-component notification types have no E2E coverage.

<details><summary><b>Changed files (7)</b></summary>

- `packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx`
- `packages/product-components/src/components/Notifications/notificationsTypes.ts`
- `packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx`
- `packages/suite/src/views/wallet/send/SendRaw.tsx`
- `suite-common/toast-notifications/src/types.ts`
- `suite-common/wallet-core/src/send/sendFormThunks.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test exercises the send form including broadcast mode (SendRaw.tsx), OP_RETURN outputs, and locktime — directly touching the changed SendRaw.tsx component and sendFormThunks.ts. It also validates toast notifications after sending, which are affected by NotificationRenderer and toast-notifications types.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test sends a DOGE transaction and specifically asserts on a toast error notification (@toast/sign-tx-error with TOAST_SIGN_TX_ERROR message) when signing fails. Changes to sendFormThunks.ts, NotificationRenderer, toast notification types, and intl messages directly affect this error path.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Directly tests ETH send form flow end-to-end including device prompt confirmation, which exercises sendFormThunks.ts for transaction composition. The send form and transaction confirmation flow are core to the changes in sendFormThunks.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Tests LTC send flow using broadcast mode (SendRaw.tsx component) with a MimbleWimble peg-out transaction. Directly exercises the changed SendRaw.tsx and sendFormThunks.ts for transaction sending.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/wallet/send-sol.test.ts` — Tests SOL send max flow with device confirmation and review modal. Exercises sendFormThunks for transaction composition. While SOL-specific, the send thunks are shared infrastructure that was changed.
- `suite/e2e/tests/wallet/send-base.test.ts` — Tests Base network (EVM L2) send flow including custom fees, device confirmation, and verifies toast notification '@toast/tx-sent' after sending. This exercises sendFormThunks and the notification/toast pipeline.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — Tests sending multiple BTC transactions and verifying pending/confirmed states. Uses sendFormThunks for transaction sending and validates transaction-related notifications and labels affected by intl messages.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — Tests CSV import into the send form with multiple outputs. The send form header dropdown and output handling are closely related to SendRaw.tsx and the send form infrastructure.
- `suite/e2e/tests/wallet/without-device.test.ts` — Tests send form behavior when device is disconnected, including the review button triggering a connection modal. Exercises the send form view (SendRaw.tsx is part of this view) and device disconnection handling.
- `suite/e2e/tests/backup/t2t1-fail.test.ts` — Specifically asserts on toast notifications (@toast/backup-failed) and notification error banners after backup failure. Changes to NotificationRenderer and toast notification types could affect these toast rendering paths.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/settings/passphrase.test.ts` — Asserts on @toast/settings-applied toast notification visibility and auto-dismissal. Changes to NotificationRenderer or toast types could affect this specific toast rendering behavior.
- `suite/e2e/tests/settings/t1b1-device-settings.test.ts` — Asserts on @toast/pin-changed and pin-mismatch toast notifications. Changes to NotificationRenderer or toast types could affect these specific toast rendering paths.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx`
- `packages/product-components/src/components/Notifications/notificationsTypes.ts`

_Updated: 2026-07-08T06:40:15.406Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/29265-raw-tx-sent-notification/web/](https://dev.suite.sldev.cz/suite-web/fix/29265-raw-tx-sent-notification/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/29265-raw-tx-sent-notification&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/29265-raw-tx-sent-notification&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/29265-raw-tx-sent-notification&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-08T06:45:25.398Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T06:43:00.966Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

