### PR TITLE
fix(suite): keep account graph data visible while refetching

### DIFF
--- a/packages/suite/src/actions/wallet/graphActions.ts
+++ b/packages/suite/src/actions/wallet/graphActions.ts
@@ -1,4 +1,5 @@
 import { createThunk } from '@suite-common/redux-utils';
+import { resetTime } from '@suite-common/suite-utils';
 import { selectBaseCurrency, selectIsElectrumBackendSelected } from '@suite-common/wallet-core';
 import { type AccountKey, createAccountKey } from '@suite-common/wallet-types';
 import { isTrezorConnectBackendType, tryGetAccountIdentity } from '@suite-common/wallet-utils';
@@ -15,6 +16,7 @@ import {
     enhanceBlockchainAccountHistory,
     ensureHistoryRates,
     isNetworkWithGraphFeature,
+    mergeAccountBalanceHistory,
 } from 'src/utils/wallet/graph';
 
 import {
@@ -25,6 +27,16 @@ import {
     AGGREGATED_GRAPH_SUCCESS,
     SET_SELECTED_RANGE,
 } from './constants/graphConstants';
+
+const DAY_IN_SECONDS = 3600 * 24;
+
+const selectAccountGraphData = (state: ReturnType<GetState>, account: Account) =>
+    state.wallet.graph.data.find(
+        d =>
+            d.account.deviceState === account.deviceState &&
+            d.account.descriptor === account.descriptor &&
+            d.account.symbol === account.symbol,
+    )?.data;
 
 export type GraphAction =
     | {
@@ -80,11 +92,18 @@ export const fetchAccountGraphData =
         });
 
         const baseCurrencyCode = selectBaseCurrency(getState());
+
+        const cachedData = selectAccountGraphData(getState(), account);
+        // refetch one day earlier than the last cached point so the last cached bucket is always
+        // recomputed, regardless of how backend bucket boundaries align with the local timezone
+        const lastCachedPoint = cachedData && cachedData.length > 2 ? cachedData.at(-1) : undefined;
+
         const response = await TrezorConnect.blockchainGetAccountBalanceHistory({
             coin: account.symbol,
             identity: tryGetAccountIdentity(account),
             descriptor: account.descriptor,
-            groupBy: 3600 * 24, // day
+            from: lastCachedPoint ? lastCachedPoint.time - DAY_IN_SECONDS : undefined,
+            groupBy: DAY_IN_SECONDS, // day
         });
 
         options.abortSignal?.throwIfAborted();
@@ -99,10 +118,31 @@ export const fetchAccountGraphData =
                 isElectrumBackend,
             );
 
+            const firstFreshTime = responseWithRates[0]
+                ? resetTime(responseWithRates[0].time)
+                : undefined;
+            const balanceBeforeFirstFreshPoint =
+                lastCachedPoint && firstFreshTime !== undefined
+                    ? cachedData?.filter(point => point.time < firstFreshTime).at(-1)?.balance
+                    : undefined;
+
             const enhancedResponse = enhanceBlockchainAccountHistory(
                 responseWithRates,
                 account.symbol,
+                balanceBeforeFirstFreshPoint,
             );
+
+            const getData = () => {
+                if (!lastCachedPoint || !cachedData) {
+                    return enhancedResponse;
+                }
+                if (responseWithRates.length === 0 || balanceBeforeFirstFreshPoint === undefined) {
+                    return cachedData;
+                }
+
+                return mergeAccountBalanceHistory(cachedData, enhancedResponse);
+            };
+            const data = getData();
 
             dispatch({
                 type: ACCOUNT_GRAPH_SUCCESS,
@@ -112,7 +152,7 @@ export const fetchAccountGraphData =
                         descriptor: account.descriptor,
                         symbol: account.symbol,
                     },
-                    data: enhancedResponse,
+                    data,
                     isLoading: false,
                     error: false,
                 },

--- a/packages/suite/src/actions/wallet/graphActions.ts
+++ b/packages/suite/src/actions/wallet/graphActions.ts
@@ -33,11 +33,11 @@ export type GraphAction =
       }
     | {
           type: typeof ACCOUNT_GRAPH_START;
-          payload: GraphData;
+          payload: Omit<GraphData, 'data'>;
       }
     | {
           type: typeof ACCOUNT_GRAPH_FAIL;
-          payload: GraphData;
+          payload: Omit<GraphData, 'data'>;
       }
     | {
           type: typeof AGGREGATED_GRAPH_START;
@@ -74,7 +74,6 @@ export const fetchAccountGraphData =
                     descriptor: account.descriptor,
                     symbol: account.symbol,
                 },
-                data: [],
                 isLoading: true,
                 error: false,
             },
@@ -127,7 +126,6 @@ export const fetchAccountGraphData =
                         descriptor: account.descriptor,
                         symbol: account.symbol,
                     },
-                    data: [],
                     isLoading: false,
                     error: true,
                 },

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.test.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.test.tsx
@@ -1,0 +1,101 @@
+import { configureMockStore } from '@suite-common/test-utils';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+
+import { type AppState } from 'src/reducers/store';
+import { renderWithProviders } from 'src/support/test-utils/hooksHelper';
+import { type AggregatedAccountHistory, type GraphRange } from 'src/types/wallet/graph';
+
+import { TransactionsGraph } from './TransactionsGraph';
+import { extraDependenciesDesktopMock } from '../../../../../mocks/extraDependenciesDesktopMock';
+import { mockInitialAppState } from '../../../../../mocks/mockInitialAppState';
+
+global.ResizeObserver = class MockedResizeObserver {
+    observe = jest.fn();
+    unobserve = jest.fn();
+    disconnect = jest.fn();
+};
+
+const ACCOUNT = mockWalletAccount({ symbol: 'btc' });
+
+// A single day interval (the '1d' range), which is empty for any account without a transaction today.
+const DAY_RANGE: GraphRange = {
+    label: 'day',
+    startDate: new Date('2026-01-01T00:00:00.000Z'),
+    endDate: new Date('2026-01-01T23:59:59.999Z'),
+    groupBy: 'day',
+};
+const DAY_TICKS = [1767225600]; // 2026-01-01T00:00:00Z
+
+const DATA_POINT: AggregatedAccountHistory = {
+    time: DAY_TICKS[0]!,
+    txs: 1,
+    sent: '0.1',
+    received: '0.2',
+    balance: '0.5',
+    sentFiat: {},
+    receivedFiat: {},
+    balanceFiat: {},
+};
+
+const renderTransactionsGraph = ({
+    data,
+    isLoading,
+}: {
+    data: AggregatedAccountHistory[];
+    isLoading: boolean;
+}) => {
+    const store = configureMockStore({
+        preloadedState: {
+            ...mockInitialAppState,
+            wallet: {
+                ...mockInitialAppState.wallet,
+                transactions: { transactions: {}, phishing: {}, fetchStatusDetail: {} },
+            },
+        } as AppState,
+    });
+
+    const { container } = renderWithProviders(
+        store,
+        extraDependenciesDesktopMock.services,
+        <TransactionsGraph
+            variant="one-asset"
+            account={ACCOUNT}
+            data={data}
+            isLoading={isLoading}
+            localCurrency="usd"
+            minMaxValues={[0, 0]}
+            selectedRange={DAY_RANGE}
+            xTicks={DAY_TICKS}
+            receivedValueFn={entry => entry.received}
+            sentValueFn={entry => entry.sent}
+            balanceValueFn={entry => entry.balance}
+        />,
+    );
+
+    return {
+        isGraphRendered: container.querySelector('.recharts-responsive-container') !== null,
+    };
+};
+
+describe('TransactionsGraph', () => {
+    it('renders the graph for an interval without transactions', () => {
+        const { isGraphRendered } = renderTransactionsGraph({ data: [], isLoading: false });
+
+        expect(isGraphRendered).toBe(true);
+    });
+
+    it('renders the loading skeleton instead of the graph when there is nothing to show yet', () => {
+        const { isGraphRendered } = renderTransactionsGraph({ data: [], isLoading: true });
+
+        expect(isGraphRendered).toBe(false);
+    });
+
+    it('keeps the graph visible while it is being refetched', () => {
+        const { isGraphRendered } = renderTransactionsGraph({
+            data: [DATA_POINT],
+            isLoading: true,
+        });
+
+        expect(isGraphRendered).toBe(true);
+    });
+});

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx
@@ -164,9 +164,9 @@ export const TransactionsGraph = memo(
         return (
             <Wrapper>
                 <Description>
-                    {isLoading && <GraphSkeleton animate />}
+                    {isLoading && !data?.length && <GraphSkeleton animate />}
 
-                    {!isLoading && data && (
+                    {!!data?.length && (
                         <GraphResponsiveContainer height="100%" width="100%">
                             <ComposedChart
                                 data={extendedDataForInterval}

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx
@@ -5,6 +5,7 @@ import styled, { useTheme } from 'styled-components';
 
 import { selectAccountTransactionsWithNulls } from '@suite-common/wallet-core';
 import { isPending } from '@suite-common/wallet-utils';
+import { useFreshRef } from '@trezor/react-utils';
 import { typography, zIndices } from '@trezor/theme';
 
 import { GraphSkeleton } from 'src/components/suite/graph/GraphSkeleton';
@@ -78,6 +79,8 @@ const useTransactionGraphUpdater = ({
 
     const promiseId = newestTransactions.map(tx => tx.txid).join('-');
 
+    const onRequestGraphUpdateRef = useFreshRef(onRequestGraphUpdate);
+
     useEffect(() => {
         if (promiseId !== currentPromise?.promiseId && account) {
             const nextAbortController = new AbortController();
@@ -99,7 +102,9 @@ const useTransactionGraphUpdater = ({
                     .then(() => {
                         nextAbortController.signal.throwIfAborted();
 
-                        return Promise.resolve(onRequestGraphUpdate(nextAbortController));
+                        return Promise.resolve(
+                            onRequestGraphUpdateRef.current(nextAbortController),
+                        );
                     }),
             });
         }
@@ -109,7 +114,7 @@ const useTransactionGraphUpdater = ({
         currentPromise?.promise,
         currentPromise?.promiseId,
         promiseId,
-        onRequestGraphUpdate,
+        onRequestGraphUpdateRef,
     ]);
 };
 

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx
@@ -1,17 +1,12 @@
-import { memo, useEffect, useState } from 'react';
+import { memo, useState } from 'react';
 
 import { Bar, CartesianGrid, Cell, ComposedChart, Line, Tooltip, XAxis, YAxis } from 'recharts';
 import styled, { useTheme } from 'styled-components';
 
-import { selectAccountTransactionsWithNulls } from '@suite-common/wallet-core';
-import { isPending } from '@suite-common/wallet-utils';
-import { useFreshRef } from '@trezor/react-utils';
 import { typography, zIndices } from '@trezor/theme';
 
 import { GraphSkeleton } from 'src/components/suite/graph/GraphSkeleton';
 import type { TransactionsGraphProps } from 'src/components/suite/graph/types';
-import { useSelector } from 'src/hooks/suite';
-import { type Account, type WalletAccountTransaction } from 'src/types/wallet';
 import { calcFakeGraphDataForTimestamps, calcXDomain, calcYDomain } from 'src/utils/wallet/graph';
 
 import { GraphBar } from './GraphBar';
@@ -20,6 +15,7 @@ import { GraphTooltipAccount } from './GraphTooltipAccount';
 import { GraphTooltipDashboard } from './GraphTooltipDashboard';
 import { GraphXAxisTick } from './GraphXAxisTick';
 import { GraphYAxisTick } from './GraphYAxisTick';
+import { useTransactionGraphUpdater } from './hooks/useTransactionGraphUpdater';
 
 const Wrapper = styled.div`
     display: flex;
@@ -52,72 +48,6 @@ const Description = styled.div`
     flex: 1;
 `;
 
-const emptyList: ReturnType<typeof selectAccountTransactionsWithNulls>[] = [];
-const useTransactionGraphUpdater = ({
-    onRequestGraphUpdate,
-    account,
-}: {
-    onRequestGraphUpdate: (abortController: AbortController) => Promise<unknown> | undefined;
-    account: Account | undefined;
-}) => {
-    const [currentPromise, setCurrentPromise] = useState<{
-        promiseId: string;
-        promise: Promise<unknown>;
-        abortController: AbortController;
-    } | null>(null);
-
-    const allTransactions = useSelector(state =>
-        account ? selectAccountTransactionsWithNulls(state, account.key) : emptyList,
-    );
-
-    const newestTransactions = allTransactions
-        .slice(0, 3)
-        .flat()
-        .filter((tx): tx is WalletAccountTransaction =>
-            Boolean(Boolean(tx) && tx && !isPending(tx)),
-        );
-
-    const promiseId = newestTransactions.map(tx => tx.txid).join('-');
-
-    const onRequestGraphUpdateRef = useFreshRef(onRequestGraphUpdate);
-
-    useEffect(() => {
-        if (promiseId !== currentPromise?.promiseId && account) {
-            const nextAbortController = new AbortController();
-
-            currentPromise?.abortController.abort();
-
-            setCurrentPromise({
-                promiseId,
-                abortController: nextAbortController,
-                promise: Promise.resolve()
-                    .then(() =>
-                        currentPromise?.promise?.then(
-                            result => result,
-                            _ => {
-                                // NOTE: swallow this error as we want to continue on with the next promise
-                            },
-                        ),
-                    )
-                    .then(() => {
-                        nextAbortController.signal.throwIfAborted();
-
-                        return Promise.resolve(
-                            onRequestGraphUpdateRef.current(nextAbortController),
-                        );
-                    }),
-            });
-        }
-    }, [
-        account,
-        currentPromise?.abortController,
-        currentPromise?.promise,
-        currentPromise?.promiseId,
-        promiseId,
-        onRequestGraphUpdateRef,
-    ]);
-};
-
 export const TransactionsGraph = memo(
     ({
         account,
@@ -134,8 +64,15 @@ export const TransactionsGraph = memo(
         xTicks,
     }: TransactionsGraphProps) => {
         const [maxYTickWidth, setMaxYTickWidth] = useState(20);
+        const [hovered, setHovered] = useState(-1);
 
         const theme = useTheme();
+
+        useTransactionGraphUpdater({
+            accountKey: account?.key,
+            onRequestGraphUpdate: onRefresh,
+        });
+
         const yDomain = calcYDomain(minMaxValues, account?.formattedBalance);
 
         const setWidth = (n: number) => {
@@ -150,8 +87,6 @@ export const TransactionsGraph = memo(
                 ? calcFakeGraphDataForTimestamps(xTicks, data, account.formattedBalance)
                 : calcFakeGraphDataForTimestamps(xTicks, data);
 
-        const hoveredIndex = -1;
-        const [hovered, setHovered] = useState(hoveredIndex);
         const isBarColored = (index: number) => [-1, index].includes(hovered);
 
         const tooltipContentProps = {
@@ -161,17 +96,17 @@ export const TransactionsGraph = memo(
             onShow: (index: number) => setHovered(index),
         };
 
-        useTransactionGraphUpdater({
-            onRequestGraphUpdate: abortController => onRefresh?.(abortController),
-            account,
-        });
+        // While there is data to show, the graph stays visible during a refetch instead of falling
+        // back to the skeleton. An empty interval (e.g. a day without transactions) is not a loading
+        // state — it renders as a graph with no bars, so the axes and the balance stay readable.
+        const isSkeletonShown = isLoading && !data?.length;
 
         return (
             <Wrapper>
                 <Description>
-                    {isLoading && !data?.length && <GraphSkeleton animate />}
-
-                    {!!data?.length && (
+                    {isSkeletonShown ? (
+                        <GraphSkeleton animate />
+                    ) : (
                         <GraphResponsiveContainer height="100%" width="100%">
                             <ComposedChart
                                 data={extendedDataForInterval}

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/hooks/useTransactionGraphUpdater.test.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/hooks/useTransactionGraphUpdater.test.tsx
@@ -1,0 +1,155 @@
+import { type PropsWithChildren } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@suite-common/react-query';
+import { type AnyAction } from '@suite-common/redux-utils';
+import {
+    act,
+    configureMockStore,
+    renderHookWithStoreProvider,
+    testMocks,
+    waitFor,
+} from '@suite-common/test-utils';
+import {
+    type WalletAccountTransaction,
+    asAccountDescriptor,
+    createAccountKey,
+} from '@suite-common/wallet-types';
+
+import { useTransactionGraphUpdater } from './useTransactionGraphUpdater';
+
+const ACCOUNT_KEY = createAccountKey({
+    accountDescriptor: asAccountDescriptor('descriptor'),
+    networkSymbol: 'btc',
+    deviceStaticSessionId: 'wallet@device:0',
+});
+
+const SET_TRANSACTIONS = 'test/set-transactions';
+
+type WalletState = { transactions: { transactions: Record<string, WalletAccountTransaction[]> } };
+
+const initialWalletState: WalletState = { transactions: { transactions: {} } };
+
+const setTransactions = (transactions: WalletAccountTransaction[]) => ({
+    type: SET_TRANSACTIONS,
+    payload: transactions,
+});
+
+const walletReducer = (state: WalletState = initialWalletState, action: AnyAction): WalletState =>
+    action.type === SET_TRANSACTIONS
+        ? { transactions: { transactions: { [ACCOUNT_KEY]: action.payload } } }
+        : state;
+
+const confirmedTransaction = (txid: string) =>
+    testMocks.getWalletTransaction({ txid, blockHeight: 590093 });
+
+const pendingTransaction = (txid: string) =>
+    testMocks.getWalletTransaction({ txid, blockHeight: undefined });
+
+const renderTransactionGraphUpdater = ({
+    transactions = [],
+    hasAccount = true,
+}: {
+    transactions?: WalletAccountTransaction[];
+    hasAccount?: boolean;
+} = {}) => {
+    const store = configureMockStore({ reducer: { wallet: walletReducer } });
+    store.dispatch(setTransactions(transactions));
+
+    const abortSignals: AbortSignal[] = [];
+    const onRequestGraphUpdate = jest.fn((abortSignal: AbortSignal) => {
+        abortSignals.push(abortSignal);
+
+        return new Promise<never>(() => {
+            // The requested update never settles, so it can be observed while still in flight.
+        });
+    });
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    const { unmount } = renderHookWithStoreProvider(
+        () =>
+            useTransactionGraphUpdater({
+                accountKey: hasAccount ? ACCOUNT_KEY : undefined,
+                onRequestGraphUpdate,
+            }),
+        {
+            store,
+            wrapper: ({ children }: PropsWithChildren) => (
+                <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+            ),
+        },
+    );
+
+    return { store, onRequestGraphUpdate, abortSignals, unmount };
+};
+
+describe('useTransactionGraphUpdater', () => {
+    it('requests a graph update for the account', async () => {
+        const { onRequestGraphUpdate, abortSignals } = renderTransactionGraphUpdater({
+            transactions: [confirmedTransaction('txid1')],
+        });
+
+        await waitFor(() => expect(onRequestGraphUpdate).toHaveBeenCalledTimes(1));
+        expect(abortSignals[0]?.aborted).toBe(false);
+    });
+
+    it('requests no graph update when there is no account (graph of all assets)', async () => {
+        const { onRequestGraphUpdate } = renderTransactionGraphUpdater({
+            hasAccount: false,
+            transactions: [confirmedTransaction('txid1')],
+        });
+
+        await act(async () => {});
+
+        expect(onRequestGraphUpdate).not.toHaveBeenCalled();
+    });
+
+    it('requests another update once a transaction is confirmed and aborts the outdated one', async () => {
+        const { store, onRequestGraphUpdate, abortSignals } = renderTransactionGraphUpdater({
+            transactions: [pendingTransaction('txid2'), confirmedTransaction('txid1')],
+        });
+
+        await waitFor(() => expect(onRequestGraphUpdate).toHaveBeenCalledTimes(1));
+
+        act(() => {
+            store.dispatch(
+                setTransactions([confirmedTransaction('txid2'), confirmedTransaction('txid1')]),
+            );
+        });
+
+        await waitFor(() => expect(onRequestGraphUpdate).toHaveBeenCalledTimes(2));
+        expect(abortSignals[0]?.aborted).toBe(true);
+        expect(abortSignals[1]?.aborted).toBe(false);
+    });
+
+    it('requests no update for an incoming pending transaction', async () => {
+        const { store, onRequestGraphUpdate, abortSignals } = renderTransactionGraphUpdater({
+            transactions: [confirmedTransaction('txid1')],
+        });
+
+        await waitFor(() => expect(onRequestGraphUpdate).toHaveBeenCalledTimes(1));
+
+        act(() => {
+            store.dispatch(
+                setTransactions([pendingTransaction('txid2'), confirmedTransaction('txid1')]),
+            );
+        });
+        // Give an update, would there be any requested, a chance to start.
+        await act(async () => {});
+
+        expect(onRequestGraphUpdate).toHaveBeenCalledTimes(1);
+        expect(abortSignals[0]?.aborted).toBe(false);
+    });
+
+    it('aborts the update in flight when the graph is unmounted', async () => {
+        const { onRequestGraphUpdate, abortSignals, unmount } = renderTransactionGraphUpdater({
+            transactions: [confirmedTransaction('txid1')],
+        });
+
+        await waitFor(() => expect(onRequestGraphUpdate).toHaveBeenCalledTimes(1));
+
+        unmount();
+
+        expect(abortSignals[0]?.aborted).toBe(true);
+    });
+});

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/hooks/useTransactionGraphUpdater.ts
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/hooks/useTransactionGraphUpdater.ts
@@ -1,0 +1,69 @@
+import { useMemo } from 'react';
+
+import { desktopQueryKeys, useQuery } from '@suite-common/react-query';
+import { selectAccountTransactionsWithNulls } from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+import { isPending } from '@suite-common/wallet-utils';
+
+import { useSelector } from 'src/hooks/suite';
+
+// Only the newest transactions can still move the graph, the ones behind them are already part of
+// the graph data cached in the store. Watching a longer window would only churn the cache key.
+const WATCHED_TRANSACTIONS_COUNT = 3;
+
+type UseTransactionGraphUpdaterParams = {
+    /** Graph of all assets (dashboard) belongs to no single account, hence optional. */
+    accountKey: AccountKey | undefined;
+    onRequestGraphUpdate: ((abortSignal: AbortSignal) => Promise<unknown>) | undefined;
+};
+
+/**
+ * Keeps the account graph in sync with the transaction list: an update is requested on mount and
+ * then whenever the newest confirmed transactions change, meaning a transaction that the graph data
+ * doesn't include yet got mined.
+ *
+ * The update runs as a query so that an update which became outdated is aborted as soon as a newer
+ * one is needed (or the graph is unmounted) instead of racing it — `fetchAccountGraphData` then
+ * stops before dispatching its result.
+ *
+ * `accountKey` is the only part of the account that takes part in this: other account changes
+ * (balance, tokens, nonce, ...) never require the graph to be refetched on their own, the
+ * transaction behind such a change appears in the transaction list as well.
+ */
+export const useTransactionGraphUpdater = ({
+    accountKey,
+    onRequestGraphUpdate,
+}: UseTransactionGraphUpdaterParams) => {
+    const allTransactions = useSelector(state =>
+        selectAccountTransactionsWithNulls(state, accountKey ?? null),
+    );
+
+    // Transactions of not-yet-fetched pages are null placeholders and a pending transaction is not
+    // part of the graph data yet, so neither of them may take part in the identity.
+    const newestConfirmedTxids = useMemo(
+        () =>
+            allTransactions
+                .slice(0, WATCHED_TRANSACTIONS_COUNT)
+                .filter(transaction => Boolean(transaction) && !isPending(transaction))
+                .map(transaction => transaction.txid)
+                .join('-'),
+        [allTransactions],
+    );
+
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- onRequestGraphUpdate is the fetcher itself, not a cache input; what identifies the data is the account and the transactions the graph is synced to
+    useQuery({
+        queryKey: desktopQueryKeys.accountGraphUpdate(accountKey, newestConfirmedTxids),
+        queryFn: async ({ signal }) => {
+            await onRequestGraphUpdate?.(signal);
+
+            // The graph data itself lives in redux, there is nothing to cache here — but `undefined`
+            // is not an allowed query result.
+            return null;
+        },
+        enabled: accountKey !== undefined && onRequestGraphUpdate !== undefined,
+        // Refetching is driven by new transactions, which arrive over the blockchain subscription
+        // regardless of the window being focused, so a refetch on focus would only ever repeat the
+        // very same update.
+        refetchOnWindowFocus: false,
+    });
+};

--- a/packages/suite/src/components/suite/graph/types.ts
+++ b/packages/suite/src/components/suite/graph/types.ts
@@ -13,7 +13,7 @@ export interface CommonGraphProps {
     xTicks: number[];
     localCurrency: string;
     minMaxValues: [number, number];
-    onRefresh?: (abortController?: AbortController) => Promise<unknown>;
+    onRefresh?: (abortSignal?: AbortSignal) => Promise<unknown>;
 }
 
 export interface CryptoGraphProps extends CommonGraphProps {

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -240,8 +240,17 @@ const rememberedDeviceHandlers: RememberedDeviceHandler[] = [
             selectDevices(state).find(
                 device => device.state?.staticSessionId === action.payload.account.deviceState,
             ),
-        save: ({ action }) => {
-            storageActions.saveGraph([action.payload]);
+        save: ({ action }, { getState }) => {
+            const { account } = action.payload;
+            const graphEntry = getState().wallet.graph.data.find(
+                d =>
+                    d.account.deviceState === account.deviceState &&
+                    d.account.descriptor === account.descriptor &&
+                    d.account.symbol === account.symbol,
+            );
+            if (graphEntry) {
+                storageActions.saveGraph([graphEntry]);
+            }
         },
     }),
     defineRememberedDeviceHandler({

--- a/packages/suite/src/reducers/wallet/graphReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/graphReducer.test.ts
@@ -1,0 +1,79 @@
+import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { type StaticSessionId } from '@trezor/connect';
+
+import { GRAPH } from 'src/actions/wallet/constants';
+import { type AccountHistoryWithBalance, type AccountIdentifier } from 'src/types/wallet/graph';
+
+import graphReducer from './graphReducer';
+
+const account: AccountIdentifier = {
+    deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@ABC123:1' as StaticSessionId,
+    descriptor: asAccountDescriptor('xpub123'),
+    symbol: 'btc',
+};
+
+const dataPoint: AccountHistoryWithBalance = {
+    time: 1720000000,
+    txs: 2,
+    received: '1',
+    sent: '0',
+    rates: {},
+    balance: '1',
+};
+
+const getStateWithData = () =>
+    graphReducer(undefined, {
+        type: GRAPH.ACCOUNT_GRAPH_SUCCESS,
+        payload: { account, data: [dataPoint], isLoading: false, error: false },
+    });
+
+describe('graphReducer', () => {
+    it('ACCOUNT_GRAPH_START keeps existing data while loading', () => {
+        const state = graphReducer(getStateWithData(), {
+            type: GRAPH.ACCOUNT_GRAPH_START,
+            payload: { account, isLoading: true, error: false },
+        });
+
+        expect(state.data[0]?.data).toEqual([dataPoint]);
+        expect(state.data[0]?.isLoading).toBe(true);
+        expect(state.data[0]?.error).toBe(false);
+    });
+
+    it('ACCOUNT_GRAPH_FAIL keeps existing data and sets error', () => {
+        const state = graphReducer(getStateWithData(), {
+            type: GRAPH.ACCOUNT_GRAPH_FAIL,
+            payload: { account, isLoading: false, error: true },
+        });
+
+        expect(state.data[0]?.data).toEqual([dataPoint]);
+        expect(state.data[0]?.isLoading).toBe(false);
+        expect(state.data[0]?.error).toBe(true);
+        expect(state.error).toEqual([account]);
+    });
+
+    it('ACCOUNT_GRAPH_START creates an empty entry for an unknown account', () => {
+        const state = graphReducer(undefined, {
+            type: GRAPH.ACCOUNT_GRAPH_START,
+            payload: { account, isLoading: true, error: false },
+        });
+
+        expect(state.data[0]).toEqual({ account, data: [], isLoading: true, error: false });
+    });
+
+    it('ACCOUNT_GRAPH_SUCCESS replaces data and clears error', () => {
+        const failedState = graphReducer(getStateWithData(), {
+            type: GRAPH.ACCOUNT_GRAPH_FAIL,
+            payload: { account, isLoading: false, error: true },
+        });
+
+        const newDataPoint = { ...dataPoint, time: 1720100000 };
+        const state = graphReducer(failedState, {
+            type: GRAPH.ACCOUNT_GRAPH_SUCCESS,
+            payload: { account, data: [newDataPoint], isLoading: false, error: false },
+        });
+
+        expect(state.data[0]?.data).toEqual([newDataPoint]);
+        expect(state.data[0]?.error).toBe(false);
+        expect(state.error).toBeNull();
+    });
+});

--- a/packages/suite/src/reducers/wallet/graphReducer.ts
+++ b/packages/suite/src/reducers/wallet/graphReducer.ts
@@ -32,14 +32,17 @@ const updateError = (draft: GraphState) => {
     }
 };
 
-const update = (draft: GraphState, payload: GraphData) => {
-    const { account, data, error, isLoading } = payload;
-    const dataIndex = draft.data.findIndex(
+const findEntryIndex = (draft: GraphState, account: AccountIdentifier) =>
+    draft.data.findIndex(
         d =>
             d.account.deviceState === account.deviceState &&
             d.account.descriptor === account.descriptor &&
             d.account.symbol === account.symbol,
     );
+
+const update = (draft: GraphState, payload: GraphData) => {
+    const { account, data, error, isLoading } = payload;
+    const dataIndex = findEntryIndex(draft, account);
     if (dataIndex !== -1) {
         const entry = draft.data[dataIndex];
         if (entry) {
@@ -53,6 +56,27 @@ const update = (draft: GraphState, payload: GraphData) => {
             isLoading,
             error,
             data,
+        });
+    }
+
+    updateError(draft);
+};
+
+const updateProgress = (draft: GraphState, payload: Omit<GraphData, 'data'>) => {
+    const { account, error, isLoading } = payload;
+    const dataIndex = findEntryIndex(draft, account);
+    if (dataIndex !== -1) {
+        const entry = draft.data[dataIndex];
+        if (entry) {
+            entry.error = error;
+            entry.isLoading = isLoading;
+        }
+    } else {
+        draft.data.push({
+            account,
+            isLoading,
+            error,
+            data: [],
         });
     }
 
@@ -90,13 +114,13 @@ const graphReducer = (
                 loadFromStorage(draft, action.payload.graph);
                 break;
             case GRAPH.ACCOUNT_GRAPH_START:
-                update(draft, action.payload);
+                updateProgress(draft, action.payload);
                 break;
             case GRAPH.ACCOUNT_GRAPH_SUCCESS:
                 update(draft, action.payload);
                 break;
             case GRAPH.ACCOUNT_GRAPH_FAIL:
-                update(draft, action.payload);
+                updateProgress(draft, action.payload);
                 break;
             case GRAPH.AGGREGATED_GRAPH_START:
                 draft.isLoading = true;

--- a/packages/suite/src/utils/wallet/graph/utils.test.ts
+++ b/packages/suite/src/utils/wallet/graph/utils.test.ts
@@ -1,0 +1,36 @@
+import { type AccountHistoryWithBalance } from 'src/types/wallet/graph';
+import { mergeAccountBalanceHistory } from 'src/utils/wallet/graph';
+
+const point = (time: number, balance: string): AccountHistoryWithBalance => ({
+    time,
+    txs: 1,
+    received: '1',
+    sent: '0',
+    rates: {},
+    balance,
+});
+
+describe('mergeAccountBalanceHistory', () => {
+    it('returns fresh data when cache is empty', () => {
+        const fresh = [point(2, '2'), point(1, '1')];
+
+        expect(mergeAccountBalanceHistory([], fresh)).toEqual([point(1, '1'), point(2, '2')]);
+    });
+
+    it('returns cached data when fresh is empty', () => {
+        const cached = [point(1, '1'), point(2, '2')];
+
+        expect(mergeAccountBalanceHistory(cached, [])).toEqual(cached);
+    });
+
+    it('replaces the overlapping day with the fresh value and appends new days sorted', () => {
+        const cached = [point(1, '1'), point(2, '2')];
+        const fresh = [point(2, '5'), point(3, '6')];
+
+        expect(mergeAccountBalanceHistory(cached, fresh)).toEqual([
+            point(1, '1'),
+            point(2, '5'),
+            point(3, '6'),
+        ]);
+    });
+});

--- a/packages/suite/src/utils/wallet/graph/utils.ts
+++ b/packages/suite/src/utils/wallet/graph/utils.ts
@@ -12,11 +12,12 @@ import { type Account } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import type { BlockchainAccountBalanceHistory, StaticSessionId } from '@trezor/connect';
-import { BigNumber } from '@trezor/utils';
+import { BigNumber, arrayToDictionary } from '@trezor/utils';
 
 import { type AppState } from 'src/reducers/store';
 import { type GraphState } from 'src/reducers/wallet/graphReducer';
 import {
+    type AccountHistoryWithBalance,
     type CommonAggregatedHistory,
     type GraphData,
     type GraphRange,
@@ -112,6 +113,15 @@ export const enhanceBlockchainAccountHistory = (
     });
 
     return enhancedResponse;
+};
+
+export const mergeAccountBalanceHistory = (
+    cached: AccountHistoryWithBalance[],
+    fresh: AccountHistoryWithBalance[],
+) => {
+    const pointsByTime = arrayToDictionary([...cached, ...fresh], point => point.time);
+
+    return Object.values(pointsByTime).sort((a, b) => a.time - b.time);
 };
 
 /**

--- a/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
@@ -80,11 +80,11 @@ export const TransactionSummary = ({ account }: TransactionSummaryProps) => {
               ]
             : [getUnixTime(selectedRange.startDate), getUnixTime(selectedRange.endDate)];
 
-    const onRefresh = (abortController?: AbortController) =>
+    const onRefresh = (abortSignal?: AbortSignal) =>
         dispatch(
             updateGraphData({
                 accounts: [account],
-                abortSignal: abortController?.signal,
+                abortSignal,
             }),
         ).unwrap();
     const onSelectedRange = () =>

--- a/suite-common/react-query/src/constants/queryKeys.ts
+++ b/suite-common/react-query/src/constants/queryKeys.ts
@@ -43,6 +43,14 @@ export const desktopQueryKeys = {
         descriptor,
         lastKnownNonce,
     ],
+    // The fetched graph data is stored in redux (`wallet.graph`), the query itself only drives the
+    // fetching — `newestConfirmedTxids` is what makes it refetch once a transaction the graph data
+    // doesn't include yet gets mined. See `useTransactionGraphUpdater`.
+    accountGraphUpdate: (accountKey: string | undefined, newestConfirmedTxids: string) => [
+        'account-graph-update',
+        accountKey,
+        newestConfirmedTxids,
+    ],
 } as const satisfies Record<string, AllowedQueryKey>;
 
 export const tradingQueryKeys = {


### PR DESCRIPTION
## Description

Account graph data disappeared after idle/wake: `ACCOUNT_GRAPH_START`/`FAIL` dispatched `data: []` and the reducer overwrote the existing entry, while the chart swaps to a skeleton whenever `isLoading` — so the discovery-triggered refetch after reconnect wiped a perfectly valid graph. START/FAIL now only touch `isLoading`/`error` (stale-while-revalidate), the chart renders whenever data exists (skeleton only on first load), and `storageMiddleware` persists the post-reducer entry instead of the slimmed action payload. Reducer tests cover data retention on START/FAIL, first-load, and SUCCESS replacement.

Second commit makes refetches incremental: graph refetches always requested the whole balance history — the supported `from` parameter was never passed. With ≥3 cached points the thunk now fetches from one day before the last cached point (robust to local-midnight vs UTC bucket alignment — `resetTime` day keys are local while blockbook buckets are epoch-aligned), resolves the balance baseline from the last cached point preceding the first returned bucket, and merges the fresh tail into the cache deduped by day (fresh wins). Falls back to a full fetch for small caches and keeps cached data if the tail can't be merged safely. Known tradeoff (same as the existing skip-if-unchanged gate): backend corrections older than the refetched tail aren't picked up.

## Notes for QA
Leave an account open for a while / sleep-wake the machine: the graph should keep showing data while it silently refreshes instead of going blank. A failed refresh keeps the old data.

Revisit an account graph after new transactions arrive — the graph matches a full refetch, including the boundary day, and loads noticeably less data. Please verify in a UTC-negative timezone as well.

## Related Issue
Resolve #13361
Resolve #22043

## Screenshots:

After 1 hour, graph is still there
<img width="1189" height="804" alt="Screenshot 2026-08-02 at 10 14 23" src="https://github.com/user-attachments/assets/6be10cf5-0906-41ab-afa8-798cd2c92435" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is focused on the wallet graph stack (actions, reducer, TransactionsGraph, TransactionSummary, and graph utilities). Risk is concentrated on graph rendering and account/dashboard summary behavior. The targeted E2E tests above cover the graph time-range filters and dashboard/account graph visibility, which should catch user-visible regressions without running the entire broad static coverage set.

<details><summary><b>Changed files (13)</b></summary>

- `packages/suite/src/actions/wallet/graphActions.ts`
- `packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.test.tsx`
- `packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx`
- `packages/suite/src/components/suite/graph/TransactionsGraph/hooks/useTransactionGraphUpdater.test.tsx`
- `packages/suite/src/components/suite/graph/TransactionsGraph/hooks/useTransactionGraphUpdater.ts`
- `packages/suite/src/components/suite/graph/types.ts`
- `packages/suite/src/middlewares/wallet/storageMiddleware.ts`
- `packages/suite/src/reducers/wallet/graphReducer.test.ts`
- `packages/suite/src/reducers/wallet/graphReducer.ts`
- `packages/suite/src/utils/wallet/graph/utils.test.ts`
- `packages/suite/src/utils/wallet/graph/utils.ts`
- `packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx`
- `suite-common/react-query/src/constants/queryKeys.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — Directly exercises TransactionSummary/TransactionsGraph behavior by cycling every graph time-range filter and asserting the summary date label updates, so a regression in graph state or rendering would be immediately visible.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Verifies the portfolio graph is visible after discovery completes with a custom Blockbook backend, which depends on the graph reducer/actions rendering correctly for the dashboard graph.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — Checks that the portfolio graph is visible on the dashboard after receiving regtest BTC, exercising graph data loading and rendering tied to the changed graph stack.

</details>

⚠️ **Changes with no test coverage (6)**
- `packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.test.tsx`
- `packages/suite/src/components/suite/graph/TransactionsGraph/hooks/useTransactionGraphUpdater.test.tsx`
- `packages/suite/src/components/suite/graph/TransactionsGraph/hooks/useTransactionGraphUpdater.ts`
- `packages/suite/src/components/suite/graph/types.ts`
- `packages/suite/src/reducers/wallet/graphReducer.test.ts`
- `packages/suite/src/utils/wallet/graph/utils.test.ts`

_Updated: 2026-08-05T07:00:03.056Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/13361-graph-stale-while-revalidate/web/](https://dev.suite.sldev.cz/suite-web/fix/13361-graph-stale-while-revalidate/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/13361-graph-stale-while-revalidate&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/13361-graph-stale-while-revalidate&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/13361-graph-stale-while-revalidate&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T07:02:19.798Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T07:02:22.163Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->


