### PR TITLE
feat(suite): fetch only missing tail when refetching account graph

### DIFF
--- a/packages/suite/src/actions/wallet/graphActions.ts
+++ b/packages/suite/src/actions/wallet/graphActions.ts
@@ -1,4 +1,5 @@
 import { createThunk } from '@suite-common/redux-utils';
+import { resetTime } from '@suite-common/suite-utils';
 import { selectBaseCurrency, selectIsElectrumBackendSelected } from '@suite-common/wallet-core';
 import { type AccountKey, createAccountKey } from '@suite-common/wallet-types';
 import { isTrezorConnectBackendType, tryGetAccountIdentity } from '@suite-common/wallet-utils';
@@ -15,6 +16,7 @@ import {
     enhanceBlockchainAccountHistory,
     ensureHistoryRates,
     isNetworkWithGraphFeature,
+    mergeAccountBalanceHistory,
 } from 'src/utils/wallet/graph';
 
 import {
@@ -25,6 +27,16 @@ import {
     AGGREGATED_GRAPH_SUCCESS,
     SET_SELECTED_RANGE,
 } from './constants/graphConstants';
+
+const DAY_IN_SECONDS = 3600 * 24;
+
+const selectAccountGraphData = (state: ReturnType<GetState>, account: Account) =>
+    state.wallet.graph.data.find(
+        d =>
+            d.account.deviceState === account.deviceState &&
+            d.account.descriptor === account.descriptor &&
+            d.account.symbol === account.symbol,
+    )?.data;
 
 export type GraphAction =
     | {
@@ -80,11 +92,18 @@ export const fetchAccountGraphData =
         });
 
         const baseCurrencyCode = selectBaseCurrency(getState());
+
+        const cachedData = selectAccountGraphData(getState(), account);
+        // refetch one day earlier than the last cached point so the last cached bucket is always
+        // recomputed, regardless of how backend bucket boundaries align with the local timezone
+        const lastCachedPoint = cachedData && cachedData.length > 2 ? cachedData.at(-1) : undefined;
+
         const response = await TrezorConnect.blockchainGetAccountBalanceHistory({
             coin: account.symbol,
             identity: tryGetAccountIdentity(account),
             descriptor: account.descriptor,
-            groupBy: 3600 * 24, // day
+            from: lastCachedPoint ? lastCachedPoint.time - DAY_IN_SECONDS : undefined,
+            groupBy: DAY_IN_SECONDS, // day
         });
 
         options.abortSignal?.throwIfAborted();
@@ -99,10 +118,31 @@ export const fetchAccountGraphData =
                 isElectrumBackend,
             );
 
+            const firstFreshTime = responseWithRates[0]
+                ? resetTime(responseWithRates[0].time)
+                : undefined;
+            const balanceBeforeFirstFreshPoint =
+                lastCachedPoint && firstFreshTime !== undefined
+                    ? cachedData?.filter(point => point.time < firstFreshTime).at(-1)?.balance
+                    : undefined;
+
             const enhancedResponse = enhanceBlockchainAccountHistory(
                 responseWithRates,
                 account.symbol,
+                balanceBeforeFirstFreshPoint,
             );
+
+            const getData = () => {
+                if (!lastCachedPoint || !cachedData) {
+                    return enhancedResponse;
+                }
+                if (responseWithRates.length === 0 || balanceBeforeFirstFreshPoint === undefined) {
+                    return cachedData;
+                }
+
+                return mergeAccountBalanceHistory(cachedData, enhancedResponse);
+            };
+            const data = getData();
 
             dispatch({
                 type: ACCOUNT_GRAPH_SUCCESS,
@@ -112,7 +152,7 @@ export const fetchAccountGraphData =
                         descriptor: account.descriptor,
                         symbol: account.symbol,
                     },
-                    data: enhancedResponse,
+                    data,
                     isLoading: false,
                     error: false,
                 },

--- a/packages/suite/src/utils/wallet/graph/utils.test.ts
+++ b/packages/suite/src/utils/wallet/graph/utils.test.ts
@@ -1,0 +1,36 @@
+import { type AccountHistoryWithBalance } from 'src/types/wallet/graph';
+import { mergeAccountBalanceHistory } from 'src/utils/wallet/graph';
+
+const point = (time: number, balance: string): AccountHistoryWithBalance => ({
+    time,
+    txs: 1,
+    received: '1',
+    sent: '0',
+    rates: {},
+    balance,
+});
+
+describe('mergeAccountBalanceHistory', () => {
+    it('returns fresh data when cache is empty', () => {
+        const fresh = [point(2, '2'), point(1, '1')];
+
+        expect(mergeAccountBalanceHistory([], fresh)).toEqual([point(1, '1'), point(2, '2')]);
+    });
+
+    it('returns cached data when fresh is empty', () => {
+        const cached = [point(1, '1'), point(2, '2')];
+
+        expect(mergeAccountBalanceHistory(cached, [])).toEqual(cached);
+    });
+
+    it('replaces the overlapping day with the fresh value and appends new days sorted', () => {
+        const cached = [point(1, '1'), point(2, '2')];
+        const fresh = [point(2, '5'), point(3, '6')];
+
+        expect(mergeAccountBalanceHistory(cached, fresh)).toEqual([
+            point(1, '1'),
+            point(2, '5'),
+            point(3, '6'),
+        ]);
+    });
+});

--- a/packages/suite/src/utils/wallet/graph/utils.ts
+++ b/packages/suite/src/utils/wallet/graph/utils.ts
@@ -12,11 +12,12 @@ import { type Account } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import type { BlockchainAccountBalanceHistory, StaticSessionId } from '@trezor/connect';
-import { BigNumber } from '@trezor/utils';
+import { BigNumber, arrayToDictionary } from '@trezor/utils';
 
 import { type AppState } from 'src/reducers/store';
 import { type GraphState } from 'src/reducers/wallet/graphReducer';
 import {
+    type AccountHistoryWithBalance,
     type CommonAggregatedHistory,
     type GraphData,
     type GraphRange,
@@ -112,6 +113,15 @@ export const enhanceBlockchainAccountHistory = (
     });
 
     return enhancedResponse;
+};
+
+export const mergeAccountBalanceHistory = (
+    cached: AccountHistoryWithBalance[],
+    fresh: AccountHistoryWithBalance[],
+) => {
+    const pointsByTime = arrayToDictionary([...cached, ...fresh], point => point.time);
+
+    return Object.values(pointsByTime).sort((a, b) => a.time - b.time);
 };
 
 /**


### PR DESCRIPTION
## Description

NOT READY FOR REVIEW

Stacked on #13361 (retarget to develop after it merges). Graph refetches always requested the whole balance history; the supported `from` parameter was never passed. With ≥3 cached points the thunk now fetches from one day before the last cached point (robust to local-midnight vs UTC bucket alignment — `resetTime` day keys are local while blockbook buckets are epoch-aligned), resolves the balance baseline from the last cached point preceding the first returned bucket, and merges the fresh tail into the cache deduped by day (fresh wins). Falls back to a full fetch for small caches and keeps cached data if the tail can't be merged safely. Known tradeoff (same as the existing skip-if-unchanged gate): backend corrections older than the refetched tail aren't picked up.

## Notes for QA
Revisit an account graph after new transactions arrive — the graph matches a full refetch, including the boundary day, and loads noticeably less data. Please verify in a UTC-negative timezone as well.

## Related Issue
Resolve #22043

## Screenshots:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

