### PR TITLE
feat(suite): add session-only option to disable suspicious transaction blurring

### DIFF
--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -11,6 +11,8 @@ export const ADD_DEVICE_ID_TO_SEEN_DISCONNECT_NOTIFICATION =
 export const ONLINE_STATUS = '@suite/online-status';
 export const SET_SEND_FORM_PREFILL = '@suite/set-send-form-prefill';
 export const SET_TRANSACTION_HISTORY_PREFILL = '@suite/set-transaction-history-prefill';
+export const SET_SUSPICIOUS_TRANSACTIONS_BLURRING_DISABLED =
+    '@suite/set-suspicious-transactions-blurring-disabled';
 export const SET_DEFAULT_WALLET_LOADING = '@suite/set-default-wallet-loading';
 export const EVM_CONFIRM_EXPLANATION_MODAL = '@suite/evm-confirm-explanation-modal';
 export const EVM_CLOSE_EXPLANATION_BANNER = '@suite/evm-close-explanation-banner';

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -23,6 +23,15 @@ export const setSendFormPrefill = createAction<
 
 type SetSendFormPrefillAction = ReturnType<typeof setSendFormPrefill>;
 
+export const setSuspiciousTransactionsBlurringDisabled = createAction<
+    boolean,
+    typeof SUITE.SET_SUSPICIOUS_TRANSACTIONS_BLURRING_DISABLED
+>(SUITE.SET_SUSPICIOUS_TRANSACTIONS_BLURRING_DISABLED);
+
+type SetSuspiciousTransactionsBlurringDisabledAction = ReturnType<
+    typeof setSuspiciousTransactionsBlurringDisabled
+>;
+
 export type SuiteAction =
     | { type: typeof SUITE.INIT }
     | { type: typeof SUITE.READY }
@@ -55,7 +64,8 @@ export type SuiteAction =
           payload: string;
       }
     | { type: typeof deviceActions.requestDeviceReconnect.type }
-    | SetSendFormPrefillAction;
+    | SetSendFormPrefillAction
+    | SetSuspiciousTransactionsBlurringDisabledAction;
 
 export const desktopHandshake = (payload: HandshakeElectron): SuiteAction => ({
     type: SUITE.DESKTOP_HANDSHAKE,

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
@@ -4,6 +4,8 @@ import { getTxHeaderSymbol, isSupportedEthStakingNetworkSymbol } from '@suite-co
 import { Row, TextButton, Tooltip } from '@trezor/components';
 import { HELP_CENTER_ZERO_VALUE_ATTACKS } from '@trezor/urls';
 
+import { useSelector } from 'src/hooks/suite';
+import { selectIsSuspiciousTransactionsBlurringDisabled } from 'src/selectors/suite/suiteSelectors';
 import { type WalletAccountTransaction } from 'src/types/wallet';
 
 import { InstantStakeBadge } from './InstantStakeBadge';
@@ -43,6 +45,7 @@ export const TransactionHeading = ({
     dataTestBase,
 }: TransactionHeadingProps) => {
     const symbol = getTxHeaderSymbol(transaction);
+    const isBlurringDisabled = useSelector(selectIsSuspiciousTransactionsBlurringDisabled);
 
     return (
         <Tooltip
@@ -67,7 +70,7 @@ export const TransactionHeading = ({
             isActive={isPhishingTransaction}
             hasIcon
         >
-            <BlurWrapper $isBlurred={isPhishingTransaction}>
+            <BlurWrapper $isBlurred={isPhishingTransaction && !isBlurringDisabled}>
                 <Row gap={4} data-testid={`${dataTestBase}/heading`}>
                     <TransactionHeader transaction={transaction} isPending={isPending} />
                     {isSupportedEthStakingNetworkSymbol(transaction.symbol) && (

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTargetLayout.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTargetLayout.tsx
@@ -3,7 +3,9 @@ import { type ReactNode } from 'react';
 import { Column, Text } from '@trezor/components';
 
 import { HiddenPlaceholder } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
 import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
+import { selectIsSuspiciousTransactionsBlurringDisabled } from 'src/selectors/suite/suiteSelectors';
 
 import { BlurWrapper } from './TransactionItemBlurWrapper';
 
@@ -23,6 +25,7 @@ export const TransactionTargetLayout = ({
     isPhishingTransaction,
 }: TransactionTargetLayoutProps) => {
     const { isBelowTablet } = useLayoutSize();
+    const isBlurringDisabled = useSelector(selectIsSuspiciousTransactionsBlurringDisabled);
 
     const commonProps = {
         typographyStyle: 'body-md',
@@ -40,7 +43,11 @@ export const TransactionTargetLayout = ({
         <>
             <Text {...cryptoAmountProps} align="end">
                 {amount && (
-                    <BlurWrapper $isBlurred={isPhishingTransaction ?? false}>{amount}</BlurWrapper>
+                    <BlurWrapper
+                        $isBlurred={(isPhishingTransaction ?? false) && !isBlurringDisabled}
+                    >
+                        {amount}
+                    </BlurWrapper>
                 )}
             </Text>
             <Text {...commonProps} isTabular align="end">

--- a/packages/suite/src/reducers/suite/suiteReducer.test.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.test.ts
@@ -1,0 +1,36 @@
+import { STORAGE } from 'src/actions/suite/constants';
+import { setSuspiciousTransactionsBlurringDisabled } from 'src/actions/suite/suiteActions';
+import type { Action } from 'src/types/suite';
+
+import suiteReducer from './suiteReducer';
+
+describe('suiteReducer', () => {
+    it('has suspicious transactions blurring enabled by default', () => {
+        const state = suiteReducer(undefined, { type: 'foo' } as unknown as Action);
+
+        expect(state.isSuspiciousTransactionsBlurringDisabled).toBe(false);
+    });
+
+    it('toggles suspicious transactions blurring', () => {
+        const disabled = suiteReducer(undefined, setSuspiciousTransactionsBlurringDisabled(true));
+        expect(disabled.isSuspiciousTransactionsBlurringDisabled).toBe(true);
+
+        const enabled = suiteReducer(disabled, setSuspiciousTransactionsBlurringDisabled(false));
+        expect(enabled.isSuspiciousTransactionsBlurringDisabled).toBe(false);
+    });
+
+    it('does not restore the blurring flag from storage', () => {
+        const disabled = suiteReducer(undefined, setSuspiciousTransactionsBlurringDisabled(true));
+
+        const state = suiteReducer(disabled, {
+            type: STORAGE.LOAD,
+            payload: {
+                suiteSettings: {
+                    isSuspiciousTransactionsBlurringDisabled: false,
+                },
+            },
+        } as unknown as Action);
+
+        expect(state.isSuspiciousTransactionsBlurringDisabled).toBe(true);
+    });
+});

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -45,6 +45,7 @@ export type SuiteState = {
     evmSettings: EvmSettings;
     countryCode: CountryCode | null;
     prefillFields: PrefillFields;
+    isSuspiciousTransactionsBlurringDisabled: boolean;
     recentlyConnectedDeviceRef: string | null; // TODO use type DeviceRef from suite-types; currently WIP in https://github.com/trezor/trezor-suite/pull/20955
     recentlyDisconnectedDevice: string | null;
     seenDisconnectNotificationForDeviceIds: string[];
@@ -61,6 +62,7 @@ const initialState: SuiteState = {
         sendForm: '',
         transactionHistory: '',
     },
+    isSuspiciousTransactionsBlurringDisabled: false,
     countryCode: null,
     recentlyConnectedDeviceRef: null,
     recentlyDisconnectedDevice: null,
@@ -141,6 +143,10 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
 
             case SUITE.SET_TRANSACTION_HISTORY_PREFILL:
                 draft.prefillFields.transactionHistory = action.payload;
+                break;
+
+            case SUITE.SET_SUSPICIOUS_TRANSACTIONS_BLURRING_DISABLED:
+                draft.isSuspiciousTransactionsBlurringDisabled = action.payload;
                 break;
 
             case TRANSPORT.START: {

--- a/packages/suite/src/selectors/suite/suiteSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteSelectors.ts
@@ -8,6 +8,9 @@ import { getPrerequisiteName, isPrerequisiteGloballyExcluded } from 'src/utils/s
 
 export const selectIsSuiteOnline = (state: SuiteRootState) => state.suite.online;
 
+export const selectIsSuspiciousTransactionsBlurringDisabled = (state: SuiteRootState) =>
+    state.suite.isSuspiciousTransactionsBlurringDisabled;
+
 export const selectSuiteTransports = (state: SuiteRootState) =>
     state.suite.transport?.transports.map(({ type, version }) => ({ type, version }));
 export const selectIsTransportInitialized = (state: SuiteRootState) => !!state.suite.transport;

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
@@ -1,5 +1,4 @@
 import { type ReactNode } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
 
 import { selectFlags, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
@@ -12,6 +11,7 @@ import {
     Badge,
     Box,
     Button,
+    Checkbox,
     Column,
     ComponentWithSubIcon,
     Divider,
@@ -25,6 +25,10 @@ import {
 } from '@trezor/components';
 import { FunnelSimpleIcon } from '@trezor/icons';
 import { zIndices } from '@trezor/theme';
+
+import { setSuspiciousTransactionsBlurringDisabled } from 'src/actions/suite/suiteActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectIsSuspiciousTransactionsBlurringDisabled } from 'src/selectors/suite/suiteSelectors';
 
 type FilterValue = boolean | string;
 
@@ -62,6 +66,7 @@ const getSectionDefaultValue = (section: FilterSection) =>
 export const FilterAction = () => {
     const { suspiciousTransactionsTooltipClosed } = useSelector(selectFlags);
     const suspiciousTransactionsHidden = useSelector(selectIsHideSuspiciousTransactions);
+    const isBlurringDisabled = useSelector(selectIsSuspiciousTransactionsBlurringDisabled);
     const hasActiveModal = useSelector(selectHasActiveModal);
     const dispatch = useDispatch();
 
@@ -203,6 +208,34 @@ export const FilterAction = () => {
                                     })}
                                 </Column>
                             ))}
+                            {!suspiciousTransactionsHidden && (
+                                <Checkbox
+                                    isChecked={isBlurringDisabled}
+                                    onChange={() =>
+                                        dispatch(
+                                            setSuspiciousTransactionsBlurringDisabled(
+                                                !isBlurringDisabled,
+                                            ),
+                                        )
+                                    }
+                                    data-testid={`${dataTest}/disable-blur`}
+                                    verticalAlignment="center"
+                                >
+                                    <Column>
+                                        <Text typographyStyle="body-sm-strong">
+                                            <Translation id="TR_SHOW_SUSPICIOUS_TRANSACTIONS_UNBLURRED" />
+                                        </Text>
+                                        <Paragraph
+                                            typographyStyle="body-xs"
+                                            intent="neutral"
+                                            priority="secondary"
+                                            textWrap="pretty"
+                                        >
+                                            <Translation id="TR_SHOW_SUSPICIOUS_TRANSACTIONS_UNBLURRED_DESCRIPTION" />
+                                        </Paragraph>
+                                    </Column>
+                                </Checkbox>
+                            )}
                         </Column>
                     }
                     data-testid={`${dataTest}/dropdown`}

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -139,6 +139,14 @@ export const messages = defineMessages({
         defaultMessage: 'Crypto moves fast. Our filters may not always be 100% up to date.',
         id: 'TR_HIDE_SUSPICIOUS_TRANSACTIONS_DESCRIPTION',
     },
+    TR_SHOW_SUSPICIOUS_TRANSACTIONS_UNBLURRED: {
+        defaultMessage: 'Disable blurring',
+        id: 'TR_SHOW_SUSPICIOUS_TRANSACTIONS_UNBLURRED',
+    },
+    TR_SHOW_SUSPICIOUS_TRANSACTIONS_UNBLURRED_DESCRIPTION: {
+        defaultMessage: 'Suspicious transactions stay marked. Applies until you close the app.',
+        id: 'TR_SHOW_SUSPICIOUS_TRANSACTIONS_UNBLURRED_DESCRIPTION',
+    },
     TR_ACCOUNT_IS_EMPTY_TITLE: {
         defaultMessage: 'No transactions',
         id: 'TR_ACCOUNT_IS_EMPTY_TITLE',


### PR DESCRIPTION
## Description

NOT READY FOR REVIEW

Adds a "Disable blurring" checkbox to the suspicious-transactions filter dropdown (visible only while suspicious txs are shown). It disables the blur on the heading and amounts so phishing txs can be analysed, while the danger icon, warning tooltip, fiat suppression, disabled labeling/copy protections and scam-URL blurring in token names all stay. The flag lives in the suite reducer (like `prefillFields`), is intentionally excluded from every persistence path, and resets when the app restarts — reducer tests assert it isn't restored via `STORAGE.LOAD`.

## Notes for QA
Manual: enable the checkbox — blurred txs become readable, danger icon stays; restart the app — blurring is on again and the checkbox unchecked. Copy for the two new strings is a proposal, happy to adjust.

## Related Issue

## Screenshots:

<img width="1129" height="413" alt="Screenshot 2026-07-08 at 22 28 46" src="https://github.com/user-attachments/assets/3912c64a-eeb9-4173-9305-24f8640998b5" />
<img width="358" height="305" alt="Screenshot 2026-07-08 at 22 28 40" src="https://github.com/user-attachments/assets/3442ef08-42e4-48de-af31-c9d5f71ffdbe" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies core Suite state management (constants, actions, reducer, selectors) plus transaction list rendering and filtering components. The highest-risk regressions are visible Suite settings (theme/language/fiat/analytics) and transaction list rendering/filtering. Run the high-priority tests first for direct coverage, then the medium-priority tests for shared state and transaction-label rendering paths. Broadly mapped files like suiteReducer are global dependencies, so only tests with concrete behavioral overlap are included.

<details><summary><b>Changed files (9)</b></summary>

- `packages/suite/src/actions/suite/constants/suiteConstants.ts`
- `packages/suite/src/actions/suite/suiteActions.ts`
- `packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx`
- `packages/suite/src/components/wallet/TransactionItem/TransactionTargetLayout.tsx`
- `packages/suite/src/reducers/suite/suiteReducer.test.ts`
- `packages/suite/src/reducers/suite/suiteReducer.ts`
- `packages/suite/src/selectors/suite/suiteSelectors.ts`
- `packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/settings/autodetect.test.ts` — Tests Suite's auto-detection of browser color scheme and locale, which directly exercises theme and language state managed by suiteReducer, suiteActions, and suiteSelectors. A regression here would be immediately visible to users on first load.
- `suite/e2e/tests/settings/general.test.ts` — Verifies changing fiat currency, theme, language, and analytics toggle—settings persisted and selected via the suite state layer changed in this PR. Also asserts the corresponding analytics events fire correctly.
- `suite/e2e/tests/wallet/pagination.test.ts` — Navigates paginated BTC transaction lists and asserts specific transaction addresses are displayed on each page, directly exercising TransactionHeading and TransactionTargetLayout rendering logic.
- `suite/e2e/tests/wallet/transactions.test.ts` — Cycles through transaction overview time-range filters and searches transactions by address, touching FilterAction as well as the TransactionHeading/TargetLayout components that render transaction items.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/analytics/toggle.test.ts` — Covers enabling/disabling analytics consent and the resulting analytics event state, which flows through the suite actions/reducer layer changed in this PR.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — Creates and edits transaction output labels and verifies they appear on the account transaction view, meaning it renders transaction items through TransactionTargetLayout/TransactionHeading.
- `suite/e2e/tests/suite/db-migration.test.ts` — Validates persistence and migration of Suite settings (auto-eject flag) across versions, which depends on the suite reducer state shape and selectors touched in this change set.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/reducers/suite/suiteReducer.test.ts`
- `suite/intl/src/messages.ts`

_Updated: 2026-08-01T14:18:32.477Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/28747-disable-phishing-blur&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/28747-disable-phishing-blur&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-01T14:20:46.854Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-01T14:20:32.184Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/28747-disable-phishing-blur/web/](https://dev.suite.sldev.cz/suite-web/feat/28747-disable-phishing-blur/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

