### PR TITLE
feat(suite-common): search transactions by native coin symbol

### DIFF
--- a/suite-common/transaction-search/src/simpleSearchTransactions.test.ts
+++ b/suite-common/transaction-search/src/simpleSearchTransactions.test.ts
@@ -1,0 +1,135 @@
+import { testMocks } from '@suite-common/test-utils';
+
+import { type SearchAccountLabels } from './searchLabels';
+import { simpleSearchTransactions } from './simpleSearchTransactions';
+
+const { getWalletTransaction } = testMocks;
+
+const emptyLabels: SearchAccountLabels = {
+    outputLabels: new Map(),
+    addressLabels: new Map(),
+    accountLabel: null,
+};
+
+describe(simpleSearchTransactions.name, () => {
+    it('finds transactions with native balance change by native display symbol', () => {
+        const transaction = getWalletTransaction({ txid: 'aaa1' });
+
+        const result = simpleSearchTransactions([transaction], emptyLabels, 'BTC');
+
+        expect(result).toEqual([transaction]);
+    });
+
+    it('does not match token-only transactions by native display symbol', () => {
+        const transaction = getWalletTransaction({
+            symbol: 'eth',
+            txid: 'aaa2',
+            amount: '0',
+            tokens: [
+                {
+                    type: 'sent',
+                    standard: 'ERC20',
+                    contract: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+                    name: 'Tether',
+                    symbol: 'USDT',
+                    decimals: 6,
+                    amount: '100',
+                    from: '0x1',
+                    to: '0x2',
+                },
+            ],
+        });
+
+        expect(simpleSearchTransactions([transaction], emptyLabels, 'ETH')).toEqual([]);
+    });
+
+    it('does not match token-only transactions by native display symbol even when token symbol or name contain it', () => {
+        const transaction = getWalletTransaction({
+            symbol: 'eth',
+            txid: 'aaa6',
+            type: 'contract',
+            amount: '0',
+            tokens: [
+                {
+                    type: 'sent',
+                    standard: 'ERC20',
+                    contract: '0xfc36ca4a35b0a10a521bd08bfe4e26df94e364f5',
+                    name: 'Trezor Staked ETH',
+                    symbol: 'trSHETHp',
+                    decimals: 18,
+                    amount: '0.00033333',
+                    from: '0x1',
+                    to: '0x2',
+                },
+                {
+                    type: 'recv',
+                    standard: 'ERC20',
+                    contract: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+                    name: 'Wrapped Ether',
+                    symbol: 'WETH',
+                    decimals: 18,
+                    amount: '0.000334',
+                    from: '0x2',
+                    to: '0x1',
+                },
+            ],
+        });
+
+        expect(simpleSearchTransactions([transaction], emptyLabels, 'ETH')).toEqual([]);
+    });
+
+    it('matches contract transactions with native amount by native display symbol', () => {
+        const transaction = getWalletTransaction({
+            symbol: 'eth',
+            txid: 'aaa7',
+            type: 'contract',
+            amount: '1.5',
+        });
+
+        expect(simpleSearchTransactions([transaction], emptyLabels, 'ETH')).toEqual([transaction]);
+    });
+
+    it('does not match fee-only self transactions by native display symbol', () => {
+        const transaction = getWalletTransaction({ txid: 'aaa3', type: 'self', amount: '144' });
+
+        expect(simpleSearchTransactions([transaction], emptyLabels, 'BTC')).toEqual([]);
+    });
+
+    it('matches transactions with native internal transfers by native display symbol', () => {
+        const transaction = getWalletTransaction({
+            symbol: 'eth',
+            txid: 'aaa4',
+            amount: '0',
+            internalTransfers: [{ type: 'recv', from: '0x1', to: '0x2', amount: '5' }],
+        });
+
+        const result = simpleSearchTransactions([transaction], emptyLabels, 'ETH');
+
+        expect(result).toEqual([transaction]);
+    });
+
+    it('still finds token transactions by token symbol', () => {
+        const transaction = getWalletTransaction({
+            symbol: 'eth',
+            txid: 'aaa5',
+            amount: '0',
+            tokens: [
+                {
+                    type: 'sent',
+                    standard: 'ERC20',
+                    contract: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+                    name: 'Tether',
+                    symbol: 'USDT',
+                    decimals: 6,
+                    amount: '100',
+                    from: '0x1',
+                    to: '0x2',
+                },
+            ],
+        });
+
+        const result = simpleSearchTransactions([transaction], emptyLabels, 'USDT');
+
+        expect(result).toEqual([transaction]);
+    });
+});

--- a/suite-common/transaction-search/src/simpleSearchTransactions.ts
+++ b/suite-common/transaction-search/src/simpleSearchTransactions.ts
@@ -1,6 +1,8 @@
 import { type WalletAccountTransaction } from '@suite-common/wallet-types';
 import {
     isFunctionSelectorMatchesSearch,
+    isNativeDisplaySymbolSearch,
+    isNativeTransferMatchesSearch,
     isTokenTransferMatchesSearch,
 } from '@suite-common/wallet-utils';
 import { BigNumber, typedObjectKeys, unique } from '@trezor/utils';
@@ -188,9 +190,15 @@ export const simpleSearchTransactions = (
 
     // Find by token name, symbol or contract
     const foundTxsForToken = transactions.flatMap(transaction => {
+        const isNativeSymbolSearch = isNativeDisplaySymbolSearch(
+            transaction.symbol,
+            search.toLowerCase(),
+        );
         const hasMatchingToken = transaction.tokens.some(
             token =>
-                isTokenTransferMatchesSearch(token, search.toLowerCase()) ||
+                (isNativeSymbolSearch
+                    ? token.symbol?.toLowerCase() === search.toLowerCase()
+                    : isTokenTransferMatchesSearch(token, search.toLowerCase())) ||
                 token.to?.toLowerCase().includes(search.toLowerCase()) ||
                 token.from?.toLowerCase().includes(search.toLowerCase()),
         );
@@ -202,6 +210,16 @@ export const simpleSearchTransactions = (
         return [];
     });
     txsToSearch.push(...foundTxsForToken);
+
+    // Find by native coin symbol
+    const foundTxsForNativeSymbol = transactions.flatMap(transaction => {
+        if (isNativeTransferMatchesSearch(transaction, search.toLowerCase())) {
+            return transaction.txid;
+        }
+
+        return [];
+    });
+    txsToSearch.push(...foundTxsForNativeSymbol);
 
     // Find by evm parsed function selector
     const foundTxsForFunctionSelector = transactions.flatMap(transaction => {

--- a/suite-common/wallet-utils/src/tokenUtils.test.ts
+++ b/suite-common/wallet-utils/src/tokenUtils.test.ts
@@ -1,13 +1,39 @@
-import type { TokenInfo } from '@trezor/blockchain-link-types';
+import type { TokenInfo, TokenTransfer } from '@trezor/blockchain-link-types';
 
 import { getContractAddressForNetworkSymbolFixtures } from './__fixtures__/tokenUtils';
 import {
     getAssetLogoContractAddresses,
     getContractAddressForNetworkSymbol,
     getErc4626Contracts,
+    isTokenTransferMatchesSearch,
     isWrappedNativeToken,
     sortTokensByName,
 } from './tokenUtils';
+
+describe('isTokenTransferMatchesSearch', () => {
+    const usdt = {
+        type: 'sent',
+        contract: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+        name: 'Tether USD',
+        symbol: 'USDT',
+        decimals: 6,
+        amount: '100',
+    } as TokenTransfer;
+
+    it('matches token name by word prefix', () => {
+        expect(isTokenTransferMatchesSearch(usdt, 'teth')).toBe(true);
+        expect(isTokenTransferMatchesSearch(usdt, 'usd')).toBe(true);
+    });
+
+    it('does not match token name by word infix', () => {
+        expect(isTokenTransferMatchesSearch(usdt, 'eth')).toBe(false);
+    });
+
+    it('matches token symbol and contract by substring', () => {
+        expect(isTokenTransferMatchesSearch(usdt, 'sdt')).toBe(true);
+        expect(isTokenTransferMatchesSearch(usdt, 'dac17f')).toBe(true);
+    });
+});
 
 describe('getContractAddressForNetworkSymbol', () => {
     getContractAddressForNetworkSymbolFixtures.forEach(

--- a/suite-common/wallet-utils/src/tokenUtils.ts
+++ b/suite-common/wallet-utils/src/tokenUtils.ts
@@ -110,9 +110,15 @@ export const isTokenMatchesSearch = (token: TokenInfo, rawSearch: string) => {
     );
 };
 
+const isTokenNameMatchesSearch = (name: string | undefined, search: string) =>
+    name
+        ?.toLowerCase()
+        .split(/\s+/)
+        .some(word => word.startsWith(search)) ?? false;
+
 export const isTokenTransferMatchesSearch = (token: TokenTransfer, search: string) =>
     token.symbol?.toLowerCase().includes(search) ||
-    token.name?.toLowerCase().includes(search) ||
+    isTokenNameMatchesSearch(token.name, search) ||
     token.contract.toLowerCase().includes(search);
 
 export const isNativeDisplaySymbolSearch = (symbol: NetworkSymbol, search: string) =>

--- a/suite-common/wallet-utils/src/tokenUtils.ts
+++ b/suite-common/wallet-utils/src/tokenUtils.ts
@@ -4,8 +4,10 @@ import {
     type NetworkSymbolExtended,
     type NetworkType,
     getExplorerUrl,
+    getNetworkDisplaySymbol,
     getNetworkType,
 } from '@suite-common/wallet-config';
+import { type WalletAccountTransaction } from '@suite-common/wallet-types';
 import {
     type EthereumSpecific,
     type TokenInfo,
@@ -112,6 +114,27 @@ export const isTokenTransferMatchesSearch = (token: TokenTransfer, search: strin
     token.symbol?.toLowerCase().includes(search) ||
     token.name?.toLowerCase().includes(search) ||
     token.contract.toLowerCase().includes(search);
+
+export const isNativeDisplaySymbolSearch = (symbol: NetworkSymbol, search: string) =>
+    getNetworkDisplaySymbol(symbol).toLowerCase() === search;
+
+export const isNativeTransferMatchesSearch = (
+    transaction: WalletAccountTransaction,
+    search: string,
+) => {
+    if (!isNativeDisplaySymbolSearch(transaction.symbol, search)) {
+        return false;
+    }
+
+    const hasNativeInternalTransfer = transaction.internalTransfers.some(
+        transfer => transfer.type === 'sent' || transfer.type === 'recv',
+    );
+    const hasNativeAmount =
+        ['sent', 'recv', 'joint', 'contract'].includes(transaction.type) &&
+        transaction.amount !== '0';
+
+    return hasNativeInternalTransfer || hasNativeAmount;
+};
 
 export const isNftMatchesSearch = (token: TokenInfo, search: string) =>
     token.symbol?.toLowerCase().includes(search) ||


### PR DESCRIPTION
## Description

Transaction search matched token symbols/names but not the native coin. First commit adds native-symbol search: an exact, case-insensitive match on the network's display symbol filters txs with an actual native balance change — sent/recv/joint with non-zero amount or native internal transfers — excluding fee-only self txs and token-only txs (amount 0), respecting `displaySymbol`. Second commit tightens token NAME matching to word-prefix so "ETH" no longer matches T-eth-er (`teth`, `usd`, `chain`→ChainLink still work); symbol and contract substring matching are unchanged. AND/OR search operators work with the native term for free.

## Notes for QA
On an account with tokens: searching `BNB`/`ETH`/`SOL` returns txs where the native balance changed (including internal transfers), not fee-only or token-only txs; searching `ETH` no longer returns Tether transfers; `USDT`/partial symbol searches unchanged.

## Related Issue
Resolve #16116

## Screenshots:

<img width="1075" height="780" alt="Screenshot 2026-08-02 at 22 25 45" src="https://github.com/user-attachments/assets/ebe4b205-97f1-41a8-bd83-be7644878035" />
<img width="1082" height="921" alt="Screenshot 2026-08-02 at 22 25 34" src="https://github.com/user-attachments/assets/a4737533-8ca3-42da-a05d-923e821ce672" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies two broad shared utilities. The highest-confidence E2E coverage comes from the transaction search test, which directly exercises simpleSearchTransactions.ts behavior, and a representative token trading inputs test that validates token balance/amount handling likely impacted by tokenUtils.ts changes. Both changed implementation files map to many tests, so the list is intentionally narrow and focused on the most direct behavioral paths.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/transaction-search/src/simpleSearchTransactions.test.ts`
- `suite-common/transaction-search/src/simpleSearchTransactions.ts`
- `suite-common/wallet-utils/src/tokenUtils.test.ts`
- `suite-common/wallet-utils/src/tokenUtils.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly exercises transaction search functionality by searching for a transaction by its address, which is the core behavior of simpleSearchTransactions.ts. A regression here would be immediately user-visible and directly tied to the changed code.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test directly exercises token balance handling: selecting a sell token (USDC on ETH), calculating fractional amounts of the token balance, filling the max token balance, and validating amounts. Changes in tokenUtils.ts could plausibly affect token balance/amount formatting or comparison logic used by the swap form.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/transaction-search/src/simpleSearchTransactions.test.ts`
- `suite-common/wallet-utils/src/tokenUtils.test.ts`

_Updated: 2026-08-02T07:50:20.503Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/16116-search-by-native-symbol&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/16116-search-by-native-symbol&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/16116-search-by-native-symbol&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-02T07:50:49.018Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-02T07:50:58.709Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/16116-search-by-native-symbol/web/](https://dev.suite.sldev.cz/suite-web/feat/16116-search-by-native-symbol/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

