### PR TITLE
fix(blockchain-link): show solana balance changes from contract transactions

### DIFF
--- a/packages/blockchain-link-utils/src/__fixtures__/solana.ts
+++ b/packages/blockchain-link-utils/src/__fixtures__/solana.ts
@@ -450,7 +450,8 @@ export const fixtures = {
             expectedOutput: 'contract',
         },
         {
-            description: 'should return "unknown" if all transfer instruction are not parsed',
+            description:
+                'should return "sent" if all transfer instruction are not parsed but the account balance decreased by more than the fee',
             input: {
                 transaction: {
                     transaction: {
@@ -463,7 +464,73 @@ export const fixtures = {
                 accountAddress: effects.negative.address,
                 tokenEffects: [],
             },
+            expectedOutput: 'sent',
+        },
+        {
+            description:
+                'should return "recv" if all transfer instruction are not parsed but the account balance increased',
+            input: {
+                transaction: {
+                    transaction: {
+                        message: {
+                            instructions: [instructions.tokenTransferNotParsed],
+                        },
+                    },
+                },
+                effects: [effects.positive],
+                accountAddress: effects.positive.address,
+                tokenEffects: [],
+            },
+            expectedOutput: 'recv',
+        },
+        {
+            description:
+                'should return "unknown" if all transfer instruction are not parsed and the account balance only decreased by the fee',
+            input: {
+                transaction: {
+                    transaction: {
+                        message: {
+                            instructions: [instructions.tokenTransferNotParsed],
+                        },
+                    },
+                    meta: {
+                        fee: effects.negative.amount.abs().toString(),
+                    },
+                },
+                effects: [effects.negative],
+                accountAddress: effects.negative.address,
+                tokenEffects: [],
+            },
             expectedOutput: 'unknown',
+        },
+        {
+            description:
+                'should return "sent" if all transfer instruction are not parsed but there are token effects',
+            input: {
+                transaction: {
+                    transaction: {
+                        message: {
+                            instructions: [instructions.tokenTransferNotParsed],
+                        },
+                    },
+                },
+                effects: [],
+                accountAddress: 'myAddress',
+                tokenEffects: [
+                    {
+                        type: 'sent',
+                        standard: 'SPL',
+                        from: 'myAddress',
+                        to: '',
+                        contract: 'someMint',
+                        decimals: 6,
+                        name: 'someMint',
+                        symbol: 'someMint',
+                        amount: '100',
+                    },
+                ],
+            },
+            expectedOutput: 'sent',
         },
         {
             description: 'should return "self" if it matches a self-transaction with fee',
@@ -604,6 +671,111 @@ export const fixtures = {
                 effects: [effects.positive, effects.negative],
                 txType: 'unknown',
                 accountAddress: 'someOtherAddress',
+            },
+            expectedOutput: [],
+        },
+        {
+            description: 'should return an empty array for "contract" transaction type',
+            input: {
+                effects: [effects.positive, effects.negative],
+                txType: 'contract',
+                accountAddress: effects.negative.address,
+            },
+            expectedOutput: [],
+        },
+    ],
+    getInternalTransfers: [
+        {
+            description:
+                'should return a sent internal transfer for "contract" transaction type with a negative account effect',
+            input: {
+                transaction: {
+                    transaction: { message: { accountKeys: [{ pubkey: 'foreignFeePayer' }] } },
+                    meta: { fee: 5 },
+                },
+                effects: [effects.negative, effects.positiveForeign],
+                txType: 'contract',
+                accountAddress: effects.negative.address,
+            },
+            expectedOutput: [
+                {
+                    type: 'sent',
+                    from: effects.negative.address,
+                    to: '',
+                    amount: effects.negative.amount.abs().toString(),
+                },
+            ],
+        },
+        {
+            description:
+                'should return a recv internal transfer for "contract" transaction type with a positive account effect',
+            input: {
+                transaction: {
+                    transaction: { message: { accountKeys: [{ pubkey: 'foreignFeePayer' }] } },
+                    meta: { fee: 5 },
+                },
+                effects: [effects.positive],
+                txType: 'contract',
+                accountAddress: effects.positive.address,
+            },
+            expectedOutput: [
+                {
+                    type: 'recv',
+                    from: '',
+                    to: effects.positive.address,
+                    amount: effects.positive.amount.abs().toString(),
+                },
+            ],
+        },
+        {
+            description:
+                'should exclude the fee from the internal transfer when the account is the fee payer',
+            input: {
+                transaction: {
+                    transaction: {
+                        message: { accountKeys: [{ pubkey: effects.negative.address }] },
+                    },
+                    meta: { fee: 5 },
+                },
+                effects: [effects.negative],
+                txType: 'contract',
+                accountAddress: effects.negative.address,
+            },
+            expectedOutput: [
+                {
+                    type: 'sent',
+                    from: effects.negative.address,
+                    to: '',
+                    amount: effects.negative.amount.abs().minus(5).toString(),
+                },
+            ],
+        },
+        {
+            description:
+                'should return an empty array when the fee payer balance decreased only by the fee',
+            input: {
+                transaction: {
+                    transaction: {
+                        message: { accountKeys: [{ pubkey: effects.negative.address }] },
+                    },
+                    meta: { fee: effects.negative.amount.abs().toNumber() },
+                },
+                effects: [effects.negative],
+                txType: 'contract',
+                accountAddress: effects.negative.address,
+            },
+            expectedOutput: [],
+        },
+        {
+            description: 'should return an empty array for non-contract transaction types',
+            input: {
+                transaction: {
+                    transaction: { message: { accountKeys: [{ pubkey: 'foreignFeePayer' }] } },
+                    meta: { fee: 5 },
+                },
+                effects: [effects.negative],
+                txType: 'sent',
+                accountAddress: effects.negative.address,
             },
             expectedOutput: [],
         },
@@ -753,6 +925,86 @@ export const fixtures = {
                 tokenAccountsInfos: [],
             },
             expectedOutput: [],
+        },
+        {
+            description:
+                'derives a sent token transfer from the token balance change when there is no parsed transfer instruction',
+            input: {
+                transaction: {
+                    transaction: {
+                        message: {
+                            accountKeys: [{ pubkey: 'myTokenAccount' }],
+                            instructions: [instructions.nonTransfer],
+                        },
+                    },
+                    meta: {
+                        preTokenBalances: [{ accountIndex: 0, uiTokenAmount: { amount: '500' } }],
+                        postTokenBalances: [{ accountIndex: 0, uiTokenAmount: { amount: '200' } }],
+                    },
+                },
+                accountAddress: 'myAddress',
+                map: sampleMintToDetailMap,
+                tokenAccountsInfos: [
+                    {
+                        address: 'myTokenAccount',
+                        mint: 'DH1nKg3QZStnVh4bjm8kyWfsRJkiweXcnL4j7Ug3PfYA',
+                        decimals: 2,
+                    },
+                ],
+            },
+            expectedOutput: [
+                {
+                    type: 'sent',
+                    standard: 'SPL',
+                    from: 'myAddress',
+                    to: '',
+                    contract: 'DH1nKg3QZStnVh4bjm8kyWfsRJkiweXcnL4j7Ug3PfYA',
+                    decimals: 2,
+                    name: 'DH1nKg3QZStnVh4bjm8kyWfsRJkiweXcnL4j7Ug3PfYA',
+                    symbol: 'DH1nKg3QZStnVh4bjm8kyWfsRJkiweXcnL4j7Ug3PfYA',
+                    amount: '300',
+                },
+            ],
+        },
+        {
+            description:
+                'derives a recv token transfer from the token balance change when there is no parsed transfer instruction',
+            input: {
+                transaction: {
+                    transaction: {
+                        message: {
+                            accountKeys: [{ pubkey: 'myTokenAccount' }],
+                            instructions: [instructions.nonTransfer],
+                        },
+                    },
+                    meta: {
+                        preTokenBalances: [{ accountIndex: 0, uiTokenAmount: { amount: '0' } }],
+                        postTokenBalances: [{ accountIndex: 0, uiTokenAmount: { amount: '700' } }],
+                    },
+                },
+                accountAddress: 'myAddress',
+                map: sampleMintToDetailMap,
+                tokenAccountsInfos: [
+                    {
+                        address: 'myTokenAccount',
+                        mint: 'DH1nKg3QZStnVh4bjm8kyWfsRJkiweXcnL4j7Ug3PfYA',
+                        decimals: 2,
+                    },
+                ],
+            },
+            expectedOutput: [
+                {
+                    type: 'recv',
+                    standard: 'SPL',
+                    from: '',
+                    to: 'myAddress',
+                    contract: 'DH1nKg3QZStnVh4bjm8kyWfsRJkiweXcnL4j7Ug3PfYA',
+                    decimals: 2,
+                    name: 'DH1nKg3QZStnVh4bjm8kyWfsRJkiweXcnL4j7Ug3PfYA',
+                    symbol: 'DH1nKg3QZStnVh4bjm8kyWfsRJkiweXcnL4j7Ug3PfYA',
+                    amount: '700',
+                },
+            ],
         },
         {
             description: 'parses a single token transfer',

--- a/packages/blockchain-link-utils/src/__fixtures__/solana.ts
+++ b/packages/blockchain-link-utils/src/__fixtures__/solana.ts
@@ -1,4 +1,7 @@
-import { TOKEN_PROGRAM_PUBLIC_KEY } from '@trezor/network-solana/constants';
+import {
+    STAKE_PROGRAM_PUBLIC_KEY,
+    TOKEN_PROGRAM_PUBLIC_KEY,
+} from '@trezor/network-solana/constants';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 const instructions = {
@@ -13,6 +16,13 @@ const instructions = {
         parsed: {
             type: 'nonTransfer',
         },
+    },
+    stakeWithdraw: {
+        parsed: {
+            type: 'withdraw',
+        },
+        program: 'stake',
+        programId: STAKE_PROGRAM_PUBLIC_KEY,
     },
     tokenTransferNotParsed: {
         program: 'spl-token',
@@ -434,11 +444,13 @@ export const fixtures = {
             expectedOutput: 'failed',
         },
         {
-            description: 'should return "contract" if instructions are not transfer',
+            description:
+                'should return "sent" for an unknown program interaction decreasing the account balance',
             input: {
                 transaction: {
                     transaction: {
                         message: {
+                            accountKeys: [{ pubkey: 'feePayer1' }],
                             instructions: [instructions.nonTransfer],
                         },
                     },
@@ -447,7 +459,45 @@ export const fixtures = {
                 accountAddress: effects.negative.address,
                 tokenEffects: [],
             },
-            expectedOutput: 'contract',
+            expectedOutput: 'sent',
+        },
+        {
+            description:
+                'should return "sent" for an unknown program interaction when the account is the fee payer even if its balance increased',
+            input: {
+                transaction: {
+                    transaction: {
+                        message: {
+                            accountKeys: [{ pubkey: effects.positive.address }],
+                            instructions: [instructions.nonTransfer],
+                        },
+                    },
+                    meta: { fee: 5 },
+                },
+                effects: [effects.positive],
+                accountAddress: effects.positive.address,
+                tokenEffects: [],
+            },
+            expectedOutput: 'sent',
+        },
+        {
+            description:
+                'should return "recv" for an unknown program interaction increasing the balance of an account that is not the fee payer',
+            input: {
+                transaction: {
+                    transaction: {
+                        message: {
+                            accountKeys: [{ pubkey: 'feePayer1' }],
+                            instructions: [instructions.nonTransfer],
+                        },
+                    },
+                    meta: { fee: 5 },
+                },
+                effects: [effects.positive],
+                accountAddress: effects.positive.address,
+                tokenEffects: [],
+            },
+            expectedOutput: 'recv',
         },
         {
             description:
@@ -456,6 +506,7 @@ export const fixtures = {
                 transaction: {
                     transaction: {
                         message: {
+                            accountKeys: [{ pubkey: 'feePayer1' }],
                             instructions: [instructions.tokenTransferNotParsed],
                         },
                     },
@@ -473,6 +524,7 @@ export const fixtures = {
                 transaction: {
                     transaction: {
                         message: {
+                            accountKeys: [{ pubkey: 'feePayer1' }],
                             instructions: [instructions.tokenTransferNotParsed],
                         },
                     },
@@ -490,6 +542,7 @@ export const fixtures = {
                 transaction: {
                     transaction: {
                         message: {
+                            accountKeys: [{ pubkey: 'feePayer1' }],
                             instructions: [instructions.tokenTransferNotParsed],
                         },
                     },
@@ -510,6 +563,7 @@ export const fixtures = {
                 transaction: {
                     transaction: {
                         message: {
+                            accountKeys: [{ pubkey: 'feePayer1' }],
                             instructions: [instructions.tokenTransferNotParsed],
                         },
                     },
@@ -675,10 +729,12 @@ export const fixtures = {
             expectedOutput: [],
         },
         {
-            description: 'should return an empty array for "contract" transaction type',
+            description:
+                'should return an empty array when the balance change is shown as an internal transfer',
             input: {
                 effects: [effects.positive, effects.negative],
-                txType: 'contract',
+                txType: 'sent',
+                hasOwnBalanceInternalTransfers: true,
                 accountAddress: effects.negative.address,
             },
             expectedOutput: [],
@@ -687,14 +743,18 @@ export const fixtures = {
     getInternalTransfers: [
         {
             description:
-                'should return a sent internal transfer for "contract" transaction type with a negative account effect',
+                'should return a sent internal transfer for a program interaction with a negative account effect',
             input: {
                 transaction: {
-                    transaction: { message: { accountKeys: [{ pubkey: 'foreignFeePayer' }] } },
+                    transaction: {
+                        message: {
+                            accountKeys: [{ pubkey: 'foreignFeePayer' }],
+                            instructions: [instructions.nonTransfer],
+                        },
+                    },
                     meta: { fee: 5 },
                 },
                 effects: [effects.negative, effects.positiveForeign],
-                txType: 'contract',
                 accountAddress: effects.negative.address,
             },
             expectedOutput: [
@@ -708,14 +768,18 @@ export const fixtures = {
         },
         {
             description:
-                'should return a recv internal transfer for "contract" transaction type with a positive account effect',
+                'should return a recv internal transfer for a program interaction with a positive account effect',
             input: {
                 transaction: {
-                    transaction: { message: { accountKeys: [{ pubkey: 'foreignFeePayer' }] } },
+                    transaction: {
+                        message: {
+                            accountKeys: [{ pubkey: 'foreignFeePayer' }],
+                            instructions: [instructions.nonTransfer],
+                        },
+                    },
                     meta: { fee: 5 },
                 },
                 effects: [effects.positive],
-                txType: 'contract',
                 accountAddress: effects.positive.address,
             },
             expectedOutput: [
@@ -733,12 +797,14 @@ export const fixtures = {
             input: {
                 transaction: {
                     transaction: {
-                        message: { accountKeys: [{ pubkey: effects.negative.address }] },
+                        message: {
+                            accountKeys: [{ pubkey: effects.negative.address }],
+                            instructions: [instructions.nonTransfer],
+                        },
                     },
                     meta: { fee: 5 },
                 },
                 effects: [effects.negative],
-                txType: 'contract',
                 accountAddress: effects.negative.address,
             },
             expectedOutput: [
@@ -756,25 +822,57 @@ export const fixtures = {
             input: {
                 transaction: {
                     transaction: {
-                        message: { accountKeys: [{ pubkey: effects.negative.address }] },
+                        message: {
+                            accountKeys: [{ pubkey: effects.negative.address }],
+                            instructions: [instructions.nonTransfer],
+                        },
                     },
                     meta: { fee: effects.negative.amount.abs().toNumber() },
                 },
                 effects: [effects.negative],
-                txType: 'contract',
                 accountAddress: effects.negative.address,
             },
             expectedOutput: [],
         },
         {
-            description: 'should return an empty array for non-contract transaction types',
+            description:
+                'should return a recv internal transfer with the exact claimed amount for a stake claim',
             input: {
                 transaction: {
-                    transaction: { message: { accountKeys: [{ pubkey: 'foreignFeePayer' }] } },
+                    transaction: {
+                        message: {
+                            accountKeys: [{ pubkey: effects.positive.address }],
+                            instructions: [instructions.stakeWithdraw],
+                        },
+                    },
+                    meta: { fee: 5 },
+                },
+                effects: [effects.positive],
+                accountAddress: effects.positive.address,
+            },
+            expectedOutput: [
+                {
+                    type: 'recv',
+                    from: '',
+                    to: effects.positive.address,
+                    amount: effects.positive.amount.plus(5).toString(),
+                },
+            ],
+        },
+        {
+            description:
+                'should return an empty array for transactions with only known program instructions',
+            input: {
+                transaction: {
+                    transaction: {
+                        message: {
+                            accountKeys: [{ pubkey: 'foreignFeePayer' }],
+                            instructions: [instructions.transfer],
+                        },
+                    },
                     meta: { fee: 5 },
                 },
                 effects: [effects.negative],
-                txType: 'sent',
                 accountAddress: effects.negative.address,
             },
             expectedOutput: [],

--- a/packages/blockchain-link-utils/src/solana.test.ts
+++ b/packages/blockchain-link-utils/src/solana.test.ts
@@ -79,6 +79,9 @@ describe('solana/utils', () => {
                     input.effects,
                     input.txType as Transaction['type'],
                     input.accountAddress,
+                    'hasOwnBalanceInternalTransfers' in input
+                        ? input.hasOwnBalanceInternalTransfers
+                        : false,
                 );
                 expect(result).toEqual(expectedOutput);
             });
@@ -92,7 +95,6 @@ describe('solana/utils', () => {
                     // @ts-expect-error Fixtures don't fully implement this interface.
                     input.transaction,
                     input.effects,
-                    input.txType as Transaction['type'],
                     input.accountAddress,
                 );
                 expect(result).toEqual(expectedOutput);

--- a/packages/blockchain-link-utils/src/solana.test.ts
+++ b/packages/blockchain-link-utils/src/solana.test.ts
@@ -10,6 +10,7 @@ import {
     extractAccountBalanceDiff,
     getAmount,
     getDetails,
+    getInternalTransfers,
     getNativeEffects,
     getTargets,
     getTokenNameAndSymbol,
@@ -75,6 +76,21 @@ describe('solana/utils', () => {
             it(description, () => {
                 const result = getTargets(
                     // @ts-expect-error Fixtures don't fully implement this interface.
+                    input.effects,
+                    input.txType as Transaction['type'],
+                    input.accountAddress,
+                );
+                expect(result).toEqual(expectedOutput);
+            });
+        });
+    });
+
+    describe('getInternalTransfers', () => {
+        fixtures.getInternalTransfers.forEach(({ description, input, expectedOutput }) => {
+            it(description, () => {
+                const result = getInternalTransfers(
+                    // @ts-expect-error Fixtures don't fully implement this interface.
+                    input.transaction,
                     input.effects,
                     input.txType as Transaction['type'],
                     input.accountAddress,

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -264,10 +264,30 @@ export function getNativeEffects(transaction: ParsedTransactionWithMeta): Transa
         .filter(({ amount }) => !amount.isZero()); // filter out zero effects
 }
 
+const isUnknownProgramInstruction = (
+    instruction: ParsedTransactionWithMeta['transaction']['message']['instructions'][number],
+) =>
+    ![
+        SYSTEM_PROGRAM_PUBLIC_KEY,
+        ...Object.values(tokenProgramsInfo).map(info => info.publicKey),
+        ASSOCIATED_TOKEN_PROGRAM_PUBLIC_KEY,
+        STAKE_PROGRAM_PUBLIC_KEY,
+        COMPUTE_BUDGET_PROGRAM_ID,
+        // some wallets use Serum's Assert Owner program during SPL transfer transactions
+        SERUM_ASSET_OWNER_PROGRAM_ID,
+        SERUM_ASSET_OWNER_PHANTOM_DEPLOYMENT_PROGRAM_ID,
+        MEMO_PROGRAM_PUBLIC_KEY,
+        MEMO_PROGRAM_PUBLIC_KEY_V1,
+    ].includes(instruction.programId);
+
+export const hasUnknownProgramInstructions = (transaction: ParsedTransactionWithMeta) =>
+    transaction.transaction.message.instructions.some(isUnknownProgramInstruction);
+
 export const getTargets = (
     effects: TransactionEffect[],
     txType: Transaction['type'],
     accountAddress: string,
+    hasOwnBalanceInternalTransfers: boolean,
 ): Transaction['targets'] =>
     effects
         .filter(effect => {
@@ -280,8 +300,8 @@ export const getTargets = (
                 return false;
             }
 
-            // the account's own balance change for contract transactions is represented as an internal transfer
-            if (txType === 'contract') {
+            // the account's own balance change is represented as an internal transfer
+            if (hasOwnBalanceInternalTransfers) {
                 return false;
             }
 
@@ -306,13 +326,35 @@ export const getTargets = (
             return target;
         });
 
+function getTransactionStakeType(tx: ParsedTransactionWithMeta): StakeType | undefined {
+    const { instructions } = tx.transaction.message;
+
+    if (!instructions) {
+        throw new Error('Invalid transaction data');
+    }
+
+    for (const instruction of instructions) {
+        if (instruction.programId === STAKE_PROGRAM_PUBLIC_KEY && 'parsed' in instruction) {
+            const { type } = instruction.parsed || {};
+
+            if (type === 'delegate') return 'stake';
+            if (type === 'deactivate') return 'unstake';
+            if (type === 'withdraw') return 'claim';
+        }
+    }
+
+    return undefined;
+}
+
 export const getInternalTransfers = (
     transaction: ParsedTransactionWithMeta,
     effects: TransactionEffect[],
-    txType: Transaction['type'],
     accountAddress: string,
 ): InternalTransfer[] => {
-    if (txType !== 'contract') {
+    const emitsOwnBalanceChange =
+        hasUnknownProgramInstructions(transaction) ||
+        getTransactionStakeType(transaction) === 'claim';
+    if (!emitsOwnBalanceChange) {
         return [];
     }
 
@@ -392,29 +434,14 @@ export const getTxType = (
         return 'failed';
     }
 
-    const isUnknownProgramInstruction = (
-        instruction: ParsedTransactionWithMeta['transaction']['message']['instructions'][number],
-    ) =>
-        ![
-            SYSTEM_PROGRAM_PUBLIC_KEY,
-            ...Object.values(tokenProgramsInfo).map(info => info.publicKey),
-            ASSOCIATED_TOKEN_PROGRAM_PUBLIC_KEY,
-            STAKE_PROGRAM_PUBLIC_KEY,
-            COMPUTE_BUDGET_PROGRAM_ID,
-            // some wallets use Serum's Assert Owner program during SPL transfer transactions, we don't want to report these as `contract` transactions
-            SERUM_ASSET_OWNER_PROGRAM_ID,
-            SERUM_ASSET_OWNER_PHANTOM_DEPLOYMENT_PROGRAM_ID,
-            MEMO_PROGRAM_PUBLIC_KEY,
-            MEMO_PROGRAM_PUBLIC_KEY_V1,
-        ].includes(instruction.programId);
-
-    // if there are any unknown program instructions, we interpret the transaction as `contract`
-    if (transaction.transaction.message.instructions.some(isUnknownProgramInstruction)) {
-        return 'contract';
-    }
-
     // classify by balance changes when instructions alone cannot determine the type
     const getTxTypeFromBalanceChanges = (): Transaction['type'] => {
+        // the fee payer signed and funded the transaction, which matches the semantics of `sent`
+        const feePayer = transaction.transaction.message.accountKeys[0]?.pubkey;
+        if (accountAddress === feePayer) {
+            return 'sent';
+        }
+
         if (tokenTransfers.length > 0) {
             const tokenTransferType = getTokenTransferTxType(tokenTransfers);
             if (tokenTransferType !== 'unknown') {
@@ -434,6 +461,12 @@ export const getTxType = (
 
         return 'unknown';
     };
+
+    // transactions interacting with unknown programs cannot be classified from instructions,
+    // mirroring ethereum, calling a program is not a special transaction type
+    if (hasUnknownProgramInstructions(transaction)) {
+        return getTxTypeFromBalanceChanges();
+    }
 
     // then, we consider only parsed instructions because only based on them we can determine the type of transaction
     const parsedInstructions = transaction.transaction.message.instructions.filter(
@@ -716,26 +749,6 @@ export const getTokens = (
     return effects;
 };
 
-function getTransactionStakeType(tx: SolanaValidParsedTxWithMeta): StakeType | undefined {
-    const { instructions } = tx.transaction.message;
-
-    if (!instructions) {
-        throw new Error('Invalid transaction data');
-    }
-
-    for (const instruction of instructions) {
-        if (instruction.programId === STAKE_PROGRAM_PUBLIC_KEY && 'parsed' in instruction) {
-            const { type } = instruction.parsed || {};
-
-            if (type === 'delegate') return 'stake';
-            if (type === 'deactivate') return 'unstake';
-            if (type === 'withdraw') return 'claim';
-        }
-    }
-
-    return undefined;
-}
-
 const getUnstakeAmount = (tx: SolanaValidParsedTxWithMeta): string => {
     const { transaction, meta } = tx;
     const { instructions, accountKeys } = transaction.message;
@@ -784,7 +797,6 @@ const determineTransactionType = (
 
     switch (stakeType) {
         case 'claim':
-            return 'recv';
         case 'stake':
         case 'unstake':
             return 'sent';
@@ -822,20 +834,23 @@ export const transformTransaction = (
 
     const txType = determineTransactionType(type, stakeType);
 
-    const targets = getTargets(nativeEffects, txType, accountAddress);
+    const internalTransfers = getInternalTransfers(tx, nativeEffects, accountAddress);
 
-    const internalTransfers = getInternalTransfers(tx, nativeEffects, txType, accountAddress);
+    const targets = getTargets(nativeEffects, txType, accountAddress, internalTransfers.length > 0);
 
     const isUnstakeTx = stakeType === 'unstake';
 
-    const amount = isUnstakeTx
-        ? '0' // amount for unstake transactions should be hidden
-        : getAmount(
-              nativeEffects.find(({ address }) => address === accountAddress),
-              type,
-          );
+    const accountBalanceChange = getAmount(
+        nativeEffects.find(({ address }) => address === accountAddress),
+        type,
+    );
 
-    const stakeAmount = isUnstakeTx ? getUnstakeAmount(tx) : amount;
+    const amount =
+        isUnstakeTx || internalTransfers.length > 0
+            ? '0' // hidden, the movement is represented by stakeOperation or internalTransfers
+            : accountBalanceChange;
+
+    const stakeAmount = isUnstakeTx ? getUnstakeAmount(tx) : accountBalanceChange;
 
     const details = getDetails(tx, nativeEffects, accountAddress, type);
 

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -1,4 +1,5 @@
 import type {
+    InternalTransfer,
     StakeType,
     Target,
     TokenDetailByMint,
@@ -279,6 +280,11 @@ export const getTargets = (
                 return false;
             }
 
+            // the account's own balance change for contract transactions is represented as an internal transfer
+            if (txType === 'contract') {
+                return false;
+            }
+
             // Exclude effects on foreign addresses for tx types other than sent, otherwise it
             // leads to the foreign address being displayed next to user's own address which might lead to confusion.
             if (txType !== 'sent' && effect.address !== accountAddress) {
@@ -299,6 +305,40 @@ export const getTargets = (
 
             return target;
         });
+
+export const getInternalTransfers = (
+    transaction: ParsedTransactionWithMeta,
+    effects: TransactionEffect[],
+    txType: Transaction['type'],
+    accountAddress: string,
+): InternalTransfer[] => {
+    if (txType !== 'contract') {
+        return [];
+    }
+
+    const feePayer = transaction.transaction.message.accountKeys[0]?.pubkey;
+    const fee = new BigNumber(transaction.meta?.fee.toString() || 0);
+
+    return effects
+        .filter(effect => effect.address === accountAddress)
+        .flatMap(effect => {
+            // the fee payer's balance change includes the fee, which is reported separately
+            const amount = effect.address === feePayer ? effect.amount.plus(fee) : effect.amount;
+
+            if (amount.isZero()) {
+                return [];
+            }
+
+            const type = amount.isNegative() ? 'sent' : 'recv';
+
+            return {
+                type,
+                from: type === 'sent' ? accountAddress : '',
+                to: type === 'recv' ? accountAddress : '',
+                amount: amount.abs().toString(),
+            };
+        });
+};
 
 const getTokenTransferTxType = (transfers: TokenTransfer[]) => {
     if (transfers.some(transfer => transfer.to === transfer.from)) {
@@ -373,13 +413,35 @@ export const getTxType = (
         return 'contract';
     }
 
+    // classify by balance changes when instructions alone cannot determine the type
+    const getTxTypeFromBalanceChanges = (): Transaction['type'] => {
+        if (tokenTransfers.length > 0) {
+            const tokenTransferType = getTokenTransferTxType(tokenTransfers);
+            if (tokenTransferType !== 'unknown') {
+                return tokenTransferType;
+            }
+        }
+
+        const accountEffect = effects.find(({ address }) => address === accountAddress);
+        if (accountEffect?.amount.isGreaterThan(0)) {
+            return 'recv';
+        }
+
+        const fee = new BigNumber(transaction.meta?.fee.toString() || 0);
+        if (accountEffect?.amount.isNegative() && accountEffect.amount.abs().isGreaterThan(fee)) {
+            return 'sent';
+        }
+
+        return 'unknown';
+    };
+
     // then, we consider only parsed instructions because only based on them we can determine the type of transaction
     const parsedInstructions = transaction.transaction.message.instructions.filter(
         (instruction): instruction is ParsedInstruction => 'parsed' in instruction,
     );
 
     if (parsedInstructions.length === 0) {
-        return 'unknown';
+        return getTxTypeFromBalanceChanges();
     }
 
     const isInstructionCreatingTokenAccount = (instruction: ParsedInstruction) =>
@@ -402,7 +464,7 @@ export const getTxType = (
             : getNativeTransferTxType(effects, accountAddress, transaction);
     }
 
-    return 'unknown';
+    return getTxTypeFromBalanceChanges();
 };
 
 export const getDetails = (
@@ -617,6 +679,40 @@ export const getTokens = (
         })
         .filter(effect => effect.to === accountAddress || effect.from === accountAddress);
 
+    if (effects.length === 0) {
+        // no transfer instructions to parse, derive token transfers from the account token balance changes
+        return tokenAccountsInfos.flatMap(({ address, mint, decimals }) => {
+            if (!mint) {
+                return [];
+            }
+
+            const balanceDiff = extractAccountBalanceDiff(tx, address, true);
+            if (!balanceDiff) {
+                return [];
+            }
+
+            const amount = balanceDiff.postBalance.minus(balanceDiff.preBalance);
+            if (amount.isZero()) {
+                return [];
+            }
+
+            const type = amount.isNegative() ? 'sent' : 'recv';
+
+            return [
+                {
+                    type,
+                    standard: 'SPL',
+                    from: type === 'sent' ? accountAddress : '',
+                    to: type === 'recv' ? accountAddress : '',
+                    contract: mint,
+                    decimals: decimals ?? 0,
+                    ...getTokenNameAndSymbol(mint, tokenDetailByMint),
+                    amount: amount.abs().toString(),
+                },
+            ];
+        });
+    }
+
     return effects;
 };
 
@@ -728,6 +824,8 @@ export const transformTransaction = (
 
     const targets = getTargets(nativeEffects, txType, accountAddress);
 
+    const internalTransfers = getInternalTransfers(tx, nativeEffects, txType, accountAddress);
+
     const isUnstakeTx = stakeType === 'unstake';
 
     const amount = isUnstakeTx
@@ -754,7 +852,7 @@ export const transformTransaction = (
         fee: (tx.meta?.fee || 0).toString(),
         targets,
         tokens,
-        internalTransfers: [], // not relevant for solana
+        internalTransfers,
         details,
         blockHash: tx.transaction.message.recentBlockhash,
         solanaSpecific: {

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -186,7 +186,10 @@ export const TransactionTarget = ({
                 );
             case 'internal':
                 return (
-                    <AccountLabelForOwnAddress address={payload.to} symbol={transaction.symbol} />
+                    <AccountLabelForOwnAddress
+                        address={payload.to || payload.from}
+                        symbol={transaction.symbol}
+                    />
                 );
             default:
                 return exhaustive(type);

--- a/suite-common/wallet-core/src/transactions/target/createTargets.test.ts
+++ b/suite-common/wallet-core/src/transactions/target/createTargets.test.ts
@@ -179,8 +179,8 @@ describe(createTargets.name, () => {
         // @ts-expect-error: indexing with noUncheckedIndexedAccess
         const r2: (typeof result)[number] = result[2];
         expect(r0.type).toBe('target');
-        expect(r1.type).toBe('token');
-        expect(r2.type).toBe('internal');
+        expect(r1.type).toBe('internal');
+        expect(r2.type).toBe('token');
     });
 
     it('generates correct targetId format for each type', () => {
@@ -200,8 +200,8 @@ describe(createTargets.name, () => {
         // @ts-expect-error: indexing with noUncheckedIndexedAccess
         const r2: (typeof result)[number] = result[2];
         expect(r0.targetId).toBe('42');
-        expect(r1.targetId).toBe('token-0xDeadBeef');
-        expect(r2.targetId).toBe('internal-0xCafe');
+        expect(r1.targetId).toBe('internal-0xCafe');
+        expect(r2.targetId).toBe('token-0xDeadBeef');
     });
 
     it('preserves the original payload references', () => {
@@ -225,7 +225,7 @@ describe(createTargets.name, () => {
         // @ts-expect-error: indexing with noUncheckedIndexedAccess
         const r2: (typeof result)[number] = result[2];
         expect(r0.payload).toBe(target);
-        expect(r1.payload).toBe(token);
-        expect(r2.payload).toBe(internal);
+        expect(r1.payload).toBe(internal);
+        expect(r2.payload).toBe(token);
     });
 });

--- a/suite-common/wallet-core/src/transactions/target/createTargets.ts
+++ b/suite-common/wallet-core/src/transactions/target/createTargets.ts
@@ -61,7 +61,7 @@ export const createTargets = ({ transaction, account }: CreateCombineTargetsPara
 
     return [
         ...targets.map(createSimpleTarget),
-        ...tokens.filter(token => token.type !== 'self').map(createTokenTarget),
         ...filteredInternalTransfers(internalTransfers, account).map(createInternalTarget),
+        ...tokens.filter(token => token.type !== 'self').map(createTokenTarget),
     ];
 };

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -389,14 +389,14 @@ export const getCardanoStakingSignValue = (transaction: WalletAccountTransaction
 };
 
 export const isTxFeePaid = (tx: WalletAccountTransaction) => {
-    const showFeeRowForSolClaim = tx?.solanaSpecific?.stakeOperation?.type === 'claim';
+    const showFeeRowForSolSent = !!tx?.solanaSpecific && tx.type === 'sent';
     const showFeeRowForStellar = tx?.stellarSpecific?.feeSource === tx.descriptor;
     const isCardano = !!tx?.cardanoSpecific;
     const showFeeRowForCardano = isCardano && tx.type !== 'recv';
 
     return (
         (!!tx.details.vin.find(vin => vin.isOwn || vin.isAccountOwned) && tx.type !== 'joint') ||
-        showFeeRowForSolClaim ||
+        showFeeRowForSolSent ||
         showFeeRowForStellar ||
         showFeeRowForCardano
     );


### PR DESCRIPTION
## Description

Solana txs driven by unknown-program instructions showed no amount/symbol. Now:

- Program interactions are no longer typed `contract` (mirrors ethereum, where `contract` means creation only): the fee payer's txs are `sent`, others are classified from balance changes (`recv`, …); stake program txs keep their classification, so claim stays `recv`.
- The account's own SOL movement is emitted as a signed internal transfer, with the fee excluded for the fee payer — internal transfers − fee always net to the on-chain balance change (solscan shows the raw delta, we decompose).
- `amount` is `0` for program interactions (movement lives in internal transfers) and the fee row is shown for solana `sent` txs, replacing the need for a per-tx fee payer field.
- Token transfers are synthesized from the account's own pre/post token balances when no transfer instruction is parseable (counterparty unknown, WSOL filtering preserved).
- Row and detail ordering unified: native amount → internal transfers → token transfers.
- Internal-transfer rows label the own account when the counterparty is unknown (previously blank).
- Stake claims are `sent` too (you sign and pay the fee; piggy icon and "Claimed" heading are driven by `stakeOperation`, not the type) and show the exact claimed amount as an internal transfer — the `showFeeRowForSolClaim` special case in `isTxFeePaid` is gone.

## Notes for QA

- Seed tx `28ZEXv3FBe6i1JLWkNrGiNRjBahJyowv9vqpCaV5MGopNBSotYFMGmLDNADFkQqhL15cg1pXpvEH8zxEHw8sHmi7`: history row shows the signed balance change with symbol/contract info.
- All existing Solana program-interaction txs change their header from "Contract transaction" to Sent/Received.
- Regular transfers, staking and WSOL wraps unchanged.

## Related Issue

Resolve #19624

## Screenshots:

Before: 
- no sign before SOL row
<img width="1086" height="309" alt="Screenshot 2026-08-02 at 15 31 25" src="https://github.com/user-attachments/assets/9b98ac08-6c83-4d44-a10c-2df2cddf6567" />

After:
- sign before SOL now
<img width="1080" height="1100" alt="Screenshot 2026-08-02 at 20 40 15" src="https://github.com/user-attachments/assets/b429911b-0dc9-45ed-bb92-8850672c2805" />

<img width="1085" height="304" alt="Screenshot 2026-08-02 at 21 15 29" src="https://github.com/user-attachments/assets/08eb4215-f26f-4726-8d22-8d9f85f26cb3" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set touches Solana blockchain utilities and core transaction target creation/rendering logic. The highest regression risk is user-visible mis-rendering of transaction targets in wallet transaction lists and broken Solana transaction flows. The recommended tests focus narrowly on Solana send/staking and on transaction-list target rendering, especially edge cases like OP_RETURN and pending transaction labels.

<details><summary><b>Changed files (7)</b></summary>

- `packages/blockchain-link-utils/src/__fixtures__/solana.ts`
- `packages/blockchain-link-utils/src/solana.test.ts`
- `packages/blockchain-link-utils/src/solana.ts`
- `packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx`
- `suite-common/wallet-core/src/transactions/target/createTargets.test.ts`
- `suite-common/wallet-core/src/transactions/target/createTargets.ts`
- `suite-common/wallet-utils/src/transactionUtils.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test directly verifies transaction target labels in the transaction list ('Sending to self', 'Sending', 'Receiving', 'Sent', 'Received'), which is the core behavior produced by the changed createTargets.ts, transactionUtils.ts, and TransactionTarget.tsx files. A regression here would be immediately user-visible.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test explicitly checks that OP_RETURN outputs render correctly as target addresses in the transaction list ('OP_RETURN (meow)'), exercising the target creation and rendering path for a special output type. Changes to createTargets/TransactionTarget could break this edge case.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This is the most focused E2E test for Solana transactions, exercising the Suite's Solana transaction handling that depends on packages/blockchain-link-utils/src/solana.ts. Changes to Solana utilities could affect address display, amount parsing, or transaction summary rendering.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Solana staking transactions flow through the same Solana transaction parsing and target rendering utilities changed in solana.ts. This test validates the staking dashboard and confirmation prompts that rely on correctly interpreted Solana transaction data.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Solana unstaking exercises Solana transaction construction and display, which depends on the changed Solana utilities. It also verifies toast notifications and dashboard updates that reflect parsed transaction targets/amounts.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test navigates the account transaction list and exercises transaction rendering components. While it does not specifically assert target labels, it depends on the TransactionTarget component and transaction utilities to render the list correctly.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/blockchain-link-utils/src/__fixtures__/solana.ts`

_Updated: 2026-08-02T19:08:59.461Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/19624-solana-contract-balance-change/web/](https://dev.suite.sldev.cz/suite-web/fix/19624-solana-contract-balance-change/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/19624-solana-contract-balance-change&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/19624-solana-contract-balance-change&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/19624-solana-contract-balance-change&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-02T19:07:36.398Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-02T19:07:23.600Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->


