### PR TITLE
feat(suite): unify account and receive address labels for address based accounts

### DIFF
--- a/suite/e2e/tests/wallet/global-receive-send.test.ts
+++ b/suite/e2e/tests/wallet/global-receive-send.test.ts
@@ -43,9 +43,10 @@ test.describe('Global receive and send', { tag: ['@T3T1', '@T3W1'] }, () => {
                 values: { networkName: 'Ethereum', index: '3' },
             });
             // The address is rendered on the receive screen itself, so there is no modal to read
-            // it from; the labeling container is keyed by the address it renders.
+            // it from; account and receive address labels are unified on account based networks,
+            // so the labeling container is keyed by the account path.
             await expect(
-                page.getByTestId(`@metadata/addressLabel/${ETHEREUM_ADDRESS_3}/hover-container`),
+                page.getByTestId("@metadata/receiveAccountLabel/m/44'/60'/0'/0/2/hover-container"),
             ).toBeVisible();
             await walletPage.verifyAddressButton.click();
             const addressDisplayedOnDevice = await devicePrompt.getAddressFromDisplay();

--- a/suite/receive/package.json
+++ b/suite/receive/package.json
@@ -8,6 +8,7 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "yarn g:jest",
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {

--- a/suite/receive/src/AddressCardDetail.tsx
+++ b/suite/receive/src/AddressCardDetail.tsx
@@ -1,8 +1,16 @@
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { AddressLabeling, copyAddressToClipboard } from '@suite/address';
+import { type SelectAccountLabelState, selectAccountLabel } from '@suite/account';
+import {
+    Address,
+    type SelectAddressLabelState,
+    copyAddressToClipboard,
+    selectAddressLabel,
+} from '@suite/address';
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
-import { Translation } from '@suite/intl';
+import { Translation, useTranslation } from '@suite/intl';
+import { Labeling, processLegacyMetadataIntoSuiteSyncThunk } from '@suite/labeling';
 import { useServices } from '@suite-common/dependency-injection';
 import { type ReceiveRootState, selectCurrentFreshAddress } from '@suite-common/receive';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
@@ -14,9 +22,15 @@ import { belowBreakpoint, breakpoints } from '@trezor/theme';
 
 import { CoinQrCode } from './CoinQrCode';
 import { type ReceiveAddressItem } from './address/buildReceiveAddressItems';
+import { getReceiveAddressLabelPayload } from './getReceiveAddressLabelPayload';
 import { canShareAddress, shareAddress } from './sharing/share';
 
 const QR_SIZE = 148;
+
+type AddressCardDetailRootState = AccountsRootState &
+    ReceiveRootState &
+    SelectAccountLabelState &
+    SelectAddressLabelState;
 
 type AddressCardDetailProps = {
     item: ReceiveAddressItem;
@@ -46,6 +60,73 @@ export const AddressCardDetail = ({
     );
     const isBelowTablet = useMediaQuery(belowBreakpoint(breakpoints.tablet));
     const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const { translationString } = useTranslation();
+
+    const isAccountBased = account !== null && !isUtxoBased(account);
+
+    const currentFreshAddressLabel = useSelector((state: AddressCardDetailRootState) =>
+        currentFreshAddress?.address && account
+            ? selectAddressLabel(state, {
+                  address: currentFreshAddress.address,
+                  deviceStaticId: account.deviceState,
+              })
+            : undefined,
+    );
+
+    const accountLabel = useSelector((state: AddressCardDetailRootState) =>
+        account && isAccountBased
+            ? selectAccountLabel(state, {
+                  accountDescriptor: account.descriptor,
+                  accountKey: account.key,
+                  deviceStaticId: account.deviceState,
+                  networkSymbol: account.symbol,
+              })
+            : null,
+    );
+
+    // accounts on account based networks have a single receive address, its label and the account label are unified;
+    // adopt a previously set address label as the account label and clear it from storage
+    useEffect(() => {
+        if (
+            !account ||
+            !isAccountBased ||
+            !currentFreshAddress?.address ||
+            !currentFreshAddressLabel
+        ) {
+            return;
+        }
+
+        if (!accountLabel) {
+            dispatch(
+                processLegacyMetadataIntoSuiteSyncThunk({
+                    payload: getReceiveAddressLabelPayload(account, currentFreshAddress.address),
+                    deviceStaticSessionId: account.deviceState,
+                    value: currentFreshAddressLabel,
+                }),
+            );
+        }
+
+        dispatch(
+            processLegacyMetadataIntoSuiteSyncThunk({
+                payload: {
+                    type: 'addressLabel',
+                    entityKey: account.key,
+                    defaultValue: currentFreshAddress.address,
+                    networkSymbol: account.symbol,
+                    accountDescriptor: account.descriptor,
+                },
+                deviceStaticSessionId: account.deviceState,
+                value: undefined,
+            }),
+        );
+    }, [
+        isAccountBased,
+        currentFreshAddress?.address,
+        currentFreshAddressLabel,
+        accountLabel,
+        account,
+        dispatch,
+    ]);
 
     const handleCopy = () => {
         dispatch(copyAddressToClipboard(item.address));
@@ -93,13 +174,22 @@ export const AddressCardDetail = ({
                             </Text>
                         )}
                         <Text typographyStyle="headline-md" data-testid="@wallet/receive/address">
-                            <AddressLabeling
-                                accountDescriptor={account.descriptor}
-                                networkSymbol={account.symbol}
+                            <Labeling
+                                payload={getReceiveAddressLabelPayload(account, item.address)}
+                                {...(!isUtxo && {
+                                    'data-testid': `@metadata/receiveAccountLabel/${account.path}/hover-container`,
+                                })}
                                 deviceStaticSessionId={account.deviceState}
-                                address={item.address}
-                                label={item.label}
-                            />
+                                displayValue={<Address value={item.address} isTruncated />}
+                                placeholder={translationString(
+                                    isUtxo
+                                        ? 'TR_LABELING_ADDRESS_LABEL'
+                                        : 'TR_LABELING_ACCOUNT_LABEL',
+                                )}
+                                minHeight={28}
+                            >
+                                {isUtxo ? item.label : accountLabel}
+                            </Labeling>
                         </Text>
                     </Column>
                     <Row gap={12} flexWrap="wrap">

--- a/suite/receive/src/getReceiveAddressLabelPayload.test.ts
+++ b/suite/receive/src/getReceiveAddressLabelPayload.test.ts
@@ -1,0 +1,37 @@
+import { type Account } from '@suite-common/wallet-types';
+
+import { getReceiveAddressLabelPayload } from './getReceiveAddressLabelPayload';
+
+const getAccount = (symbol: string): Account =>
+    ({
+        key: 'descriptor-symbol-device',
+        symbol,
+        path: "m/44'/60'/0'/0/0",
+        descriptor: 'accountDescriptor',
+    }) as unknown as Account;
+
+const address = 'freshAddress';
+
+describe('getReceiveAddressLabelPayload', () => {
+    (['eth', 'pol', 'sol', 'xrp', 'trx'] as const).forEach(symbol => {
+        it(`returns account label payload for address based network ${symbol}`, () => {
+            expect(getReceiveAddressLabelPayload(getAccount(symbol), address)).toEqual({
+                type: 'accountLabel',
+                entityKey: 'descriptor-symbol-device',
+                defaultValue: "m/44'/60'/0'/0/0",
+            });
+        });
+    });
+
+    (['btc', 'ada'] as const).forEach(symbol => {
+        it(`returns address label payload for utxo based network ${symbol}`, () => {
+            expect(getReceiveAddressLabelPayload(getAccount(symbol), address)).toEqual({
+                type: 'addressLabel',
+                entityKey: 'descriptor-symbol-device',
+                defaultValue: address,
+                networkSymbol: symbol,
+                accountDescriptor: 'accountDescriptor',
+            });
+        });
+    });
+});

--- a/suite/receive/src/getReceiveAddressLabelPayload.ts
+++ b/suite/receive/src/getReceiveAddressLabelPayload.ts
@@ -1,0 +1,17 @@
+import { isAccountBasedNetwork } from '@suite-common/wallet-config';
+import { type Account } from '@suite-common/wallet-types';
+
+export const getReceiveAddressLabelPayload = (account: Account, address: string) =>
+    isAccountBasedNetwork(account.symbol)
+        ? ({
+              type: 'accountLabel',
+              entityKey: account.key,
+              defaultValue: account.path,
+          } as const)
+        : ({
+              type: 'addressLabel',
+              entityKey: account.key,
+              defaultValue: address,
+              networkSymbol: account.symbol,
+              accountDescriptor: account.descriptor,
+          } as const);


### PR DESCRIPTION
> [!IMPORTANT]
> **NOT READY FOR REVIEW**

https://dev.suite.sldev.cz/suite-web/feat/26069-unify-address-account-labels/web


## Description

On account-based networks (EVM, Solana, Ripple, Stellar, Tron) an account has exactly one receive address, yet the account and the receive address could carry two divergent labels. The receive page now displays and edits the account label on these networks: the label payload is built by a small pure helper (tested for both network classes) and used by the address card of the redesigned receive screen (AddressCardDetail, which renders for all networks; NewestAddressCard is untouched).

Migration is lazy and uses the standard label write path: when the receive page renders an account-based account with an old address label, the label is adopted into the account label if that one is empty, then cleared from storage — so no user text is lost and storage converges to a single value. UTXO-based networks (btc, ada) are untouched. Other consumers of address labels stop seeing the old rows only after the cleanup runs for that account; remaining divergent rows elsewhere (e.g. bip329 export) converge the same way.

## Notes for QA

On an ETH/SOL/XRP account: editing the label on the receive page and in the account header edits the same value; an account that previously had a separate receive-address label shows it adopted as the account label (if none was set) after visiting the receive page. btc/ada receive labeling unchanged.

## Related Issue


## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies the receive address card UI and the helper that builds receive-address label payloads, plus the global receive/send E2E test itself. The highest-risk regressions are in receive address display/verification and address labeling, so the minimal confident set targets those flows. Other broad suites (onboarding, trading, staking, settings) do not plausibly exercise these specific receive paths and are omitted.

<details><summary><b>Changed files (5)</b></summary>

- `suite/e2e/tests/wallet/global-receive-send.test.ts`
- `suite/receive/package.json`
- `suite/receive/src/AddressCardDetail.tsx`
- `suite/receive/src/getReceiveAddressLabelPayload.test.ts`
- `suite/receive/src/getReceiveAddressLabelPayload.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This exact E2E test file was modified, and it directly exercises the global receive flow (adding accounts, verifying receive addresses, copying addresses) that touches AddressCardDetail and receive-address label helpers.
- `suite/e2e/tests/wallet/receive.test.ts` — Covers the core receive-address flow for BTC, ETH, SOL and TRX, including copying addresses and on-device verification, which is the primary surface affected by changes to AddressCardDetail and receive-address label payload logic.
- `suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — Focuses on adding and editing Bitcoin address labels in the receive flow, which is the most likely E2E consumer of getReceiveAddressLabelPayload and the address card UI.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — Creates a new address label on the receive screen and verifies it syncs to the Evolu relay; it shares the address-labeling path with the changed payload helper and address card.
- `suite/e2e/tests/wallet/cardano.test.ts` — Includes verifying and copying a Cardano receive address, which likely renders through the shared AddressCardDetail component; a regression in the address card could affect ADA receive display.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/receive/package.json`

_Updated: 2026-08-19T09:50:00.022Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/26069-unify-address-account-labels/web/](https://dev.suite.sldev.cz/suite-web/feat/26069-unify-address-account-labels/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/26069-unify-address-account-labels&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/26069-unify-address-account-labels&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-19T09:51:26.165Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-19T09:51:27.211Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->


