### PR TITLE
fix(suite-native): split translation string for next reward for SOL

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2511,6 +2511,7 @@ export const messages = {
             totalRewardsLabel: 'Total rewards',
             autoRestakedBadge: 'Automatically restaked',
             nextRewardLabel: 'Next reward in {value, plural, one {# day} other {# days}}',
+            rewardsEveryLabel: 'Rewards every ~{value, plural, one {# day} other {# days}}',
             unstakeButton: 'Unstake',
             stakeButton: 'Stake',
             stakeMoreButton: 'Stake more',

--- a/suite-native/intl/translations/en-US.json
+++ b/suite-native/intl/translations/en-US.json
@@ -1266,6 +1266,7 @@
     "earn.stakingManagementScreen.totalRewardsLabel": "Total rewards",
     "earn.stakingManagementScreen.autoRestakedBadge": "Automatically restaked",
     "earn.stakingManagementScreen.nextRewardLabel": "Next reward in {value, plural, one {# day} other {# days}}",
+    "earn.stakingManagementScreen.rewardsEveryLabel": "Rewards every ~{value, plural, one {# day} other {# days}}",
     "earn.stakingManagementScreen.unstakeButton": "Unstake",
     "earn.stakingManagementScreen.stakeButton": "Stake",
     "earn.stakingManagementScreen.stakeMoreButton": "Stake more",

--- a/suite-native/module-earn/src/components/StakingManagementStakedCard.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementStakedCard.tsx
@@ -159,7 +159,11 @@ export const StakingManagementStakedCard = ({
                 {nextRewardPayout != null && (
                     <Text variant="body-sm">
                         <Translation
-                            id="earn.stakingManagementScreen.nextRewardLabel"
+                            id={
+                                isSolanaStaking
+                                    ? 'earn.stakingManagementScreen.rewardsEveryLabel'
+                                    : 'earn.stakingManagementScreen.nextRewardLabel'
+                            }
                             values={{ value: nextRewardPayout }}
                         />
                     </Text>


### PR DESCRIPTION
Fixes #29309

Splits the translation string for `Next reward in X days` so that Solana can use `Rewards every ~X days` instead, keeping the original string for Ethereum. Added `rewardsEveryLabel` to messages.ts and en-US.json, and updated `StakingManagementStakedCard.tsx`.