### PR TITLE
feat(suite-sync): support registration proof rotation index

### DIFF
--- a/suite-common/suite-sync-quota-manager/src/device/createRegisterDevice.ts
+++ b/suite-common/suite-sync-quota-manager/src/device/createRegisterDevice.ts
@@ -13,7 +13,9 @@ import {
     type TrezorDeviceWithState,
 } from '@suite-common/suite-types';
 import { type TrezorConnect } from '@trezor/connect';
+import { getFirmwareVersionArray } from '@trezor/device-utils';
 import { type Result, err, ok } from '@trezor/type-utils';
+import { versionUtils } from '@trezor/utils';
 
 import { DEFAULT_DEVICE_SIZE_QUOTA } from '../constants';
 import { QuotaManagerCommunicationFailed } from '../errors';
@@ -23,6 +25,7 @@ import { prepareMessageBufferEvoluSignRegistrationRequest } from './prepareMessa
 import { type PrepareChallengeSessionFetchDep } from '../challenge/createPrepareChallengeSessionFetch';
 
 const EVOLU_SIGN_REGISTRATION_REQUEST_HEADER = 'EvoluSignRegistrationRequest';
+const EVOLU_SIGN_REGISTRATION_REQUEST_V2_MIN_FIRMWARE_VERSION = '2.12.2';
 
 export type RegisterDeviceParams = {
     device: TrezorDeviceWithState;
@@ -46,6 +49,18 @@ export type RegisterDeviceDeps = {
 
 export type RegisterDeviceDep = {
     registerDevice: RegisterDevice;
+};
+
+const getIsEvoluSignRegistrationRequestV2Supported = (device: TrezorDeviceWithState): boolean => {
+    const firmwareVersion = getFirmwareVersionArray(device);
+
+    return (
+        firmwareVersion !== null &&
+        versionUtils.isNewerOrEqual(
+            firmwareVersion,
+            EVOLU_SIGN_REGISTRATION_REQUEST_V2_MIN_FIRMWARE_VERSION,
+        )
+    );
 };
 
 export const createRegisterDevice =
@@ -83,6 +98,8 @@ export const createRegisterDevice =
         }
 
         const { certificate_chain } = registrationRequestResult.payload;
+        const { rotation_index } = registrationRequestResult.payload;
+
         // @ts-expect-error: noUncheckedIndexedAccess
         const deviceCert: (typeof certificate_chain)[number] = certificate_chain[0];
         // @ts-expect-error: noUncheckedIndexedAccess
@@ -99,6 +116,9 @@ export const createRegisterDevice =
             sessionId: sessionChallenge.payload.sessionId,
             deviceModel: device.features.internal_model,
             publicKey: delegatedKeyPublic,
+            ...(getIsEvoluSignRegistrationRequestV2Supported(device)
+                ? { rotationIndex: rotation_index ?? 0 }
+                : {}),
         });
 
         if (!registerDeviceResult.success) {

--- a/suite-common/suite-sync-quota-manager/src/device/createRegisterDeviceFetch.ts
+++ b/suite-common/suite-sync-quota-manager/src/device/createRegisterDeviceFetch.ts
@@ -9,6 +9,7 @@ export type RegisterDeviceFetchParams = {
     deviceId: string;
     publicKey: string;
     size: number;
+    rotationIndex?: number;
     proof: string;
     certificateChain: {
         deviceCert: string;

--- a/suite-common/suite-sync-quota-manager/src/device/tests/createRegisterDevice.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/device/tests/createRegisterDevice.test.ts
@@ -8,9 +8,23 @@ import { err, ok } from '@trezor/type-utils';
 import { DEFAULT_DEVICE_SIZE_QUOTA } from '../../constants';
 import { type RegisterDeviceDeps, createRegisterDevice } from '../createRegisterDevice';
 
-const device = mockSuiteDevice(
-    { id: 'device-id' },
-    { internal_model: DeviceModelInternal.T2T1 },
+const deviceWithLegacyRegistrationRequest = mockSuiteDevice(
+    { id: 'device-id-v1' },
+    {
+        internal_model: DeviceModelInternal.T2T1,
+        major_version: 2,
+        minor_version: 12,
+        patch_version: 1,
+    },
+) as TrezorDeviceWithState;
+const deviceWithV2RegistrationRequest = mockSuiteDevice(
+    { id: 'device-id-v2' },
+    {
+        internal_model: DeviceModelInternal.T2T1,
+        major_version: 2,
+        minor_version: 12,
+        patch_version: 2,
+    },
 ) as TrezorDeviceWithState;
 
 describe(createRegisterDevice.name, () => {
@@ -34,7 +48,7 @@ describe(createRegisterDevice.name, () => {
 
         const result = await createRegisterDevice(deps)({
             delegatedKey: DELEGATED_IDENTITY_KEY,
-            device,
+            device: deviceWithLegacyRegistrationRequest,
         });
 
         expect(result).toEqual(ok());
@@ -46,7 +60,7 @@ describe(createRegisterDevice.name, () => {
                 '9d40167d8ec7ce7949f1675d60a4d5c2a6ec5f16152bdc6c7959af99c856d31570c0d262996917cf424a3e638a7ee10b57aa2864c06895b0728d09f040496177',
         });
         expect(deps.registerDeviceFetch).toHaveBeenCalledWith({
-            deviceId: 'device-id',
+            deviceId: 'device-id-v1',
             size: DEFAULT_DEVICE_SIZE_QUOTA,
             certificateChain: {
                 deviceCert: 'device-cert',
@@ -59,6 +73,69 @@ describe(createRegisterDevice.name, () => {
             publicKey:
                 '0428a3cefc19b41ff56795e371aab72d6d85a3ca2200bd46c54e611a36222295a88b44d6f23ce94025b6010f9eb0f9168ad35d8396dc865fa0a16f2f5471816a45',
         });
+    });
+
+    it('registers device with rotation index returned by firmware', async () => {
+        const deps = createMockDeps<RegisterDeviceDeps>({
+            prepareChallengeSessionFetch: () =>
+                Promise.resolve(ok({ sessionId: 'session-123', challenge: 'aa55' })),
+            registerDeviceFetch: () =>
+                Promise.resolve(ok({ totalStorageSize: 5000, unspentStorageSize: 1200 })),
+            trezorConnect: {
+                evoluSignRegistrationRequest: () =>
+                    Promise.resolve(
+                        ok({
+                            certificate_chain: ['device-cert', 'ca-cert'],
+                            signature: 'device-signature',
+                            rotation_index: 42,
+                        }),
+                    ),
+            },
+            dispatch: jest.fn(),
+        });
+
+        const result = await createRegisterDevice(deps)({
+            delegatedKey: DELEGATED_IDENTITY_KEY,
+            device: deviceWithV2RegistrationRequest,
+        });
+
+        expect(result).toEqual(ok());
+        expect(deps.registerDeviceFetch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                rotationIndex: 42,
+            }),
+        );
+    });
+
+    it('falls back to zero rotation index when V2 firmware does not return rotation index', async () => {
+        const deps = createMockDeps<RegisterDeviceDeps>({
+            prepareChallengeSessionFetch: () =>
+                Promise.resolve(ok({ sessionId: 'session-123', challenge: 'aa55' })),
+            registerDeviceFetch: () =>
+                Promise.resolve(ok({ totalStorageSize: 5000, unspentStorageSize: 1200 })),
+            trezorConnect: {
+                evoluSignRegistrationRequest: () =>
+                    Promise.resolve(
+                        ok({
+                            certificate_chain: ['device-cert', 'ca-cert'],
+                            signature: 'device-signature',
+                        }),
+                    ),
+            },
+            dispatch: jest.fn(),
+        });
+
+        const result = await createRegisterDevice(deps)({
+            delegatedKey: DELEGATED_IDENTITY_KEY,
+            device: deviceWithV2RegistrationRequest,
+        });
+
+        expect(result).toEqual(ok());
+        expect(deps.registerDeviceFetch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                rotationIndex: 0,
+            }),
+        );
     });
 
     it('maps challenge session failure to quota manager communication failure', async () => {
@@ -74,7 +151,7 @@ describe(createRegisterDevice.name, () => {
 
         const result = await createRegisterDevice(deps)({
             delegatedKey: DELEGATED_IDENTITY_KEY,
-            device,
+            device: deviceWithLegacyRegistrationRequest,
         });
 
         expect(result).toEqual(


### PR DESCRIPTION
## Description

Adds Suite Sync quota-manager caller support for registration proofs that include a firmware-returned rotation index.

Depends on protobuf support from:
- https://github.com/trezor/trezor-suite/pull/29453

Changes in this PR:
- Forwards firmware-returned `rotation_index` to the quota-manager backend as `rotationIndex` so the backend can verify V2 registration proofs.
- Keeps legacy backend registration requests unchanged by omitting `rotationIndex` when firmware does not return it.
- Guards firmware `2.12.2+` registration responses so missing `rotation_index` fails before sending an invalid backend registration request.
- Adds unit coverage for legacy registration, V2 forwarding, and missing V2 rotation index handling.

## Notes for QA

Focus on Suite Sync registration against the Trezor relay/quota-manager backend:

- Older firmware should still register with the legacy request body, without `rotationIndex`.
- Firmware `2.12.2+` should register successfully and include the returned rotation index in the backend registration request.
- Suite Sync should surface a device error if a `2.12.2+` firmware response lacks the rotation index.

## Related Issue

Related PRs:
- https://github.com/trezor/trezor-suite/pull/29453
- https://github.com/trezor/trezor-suite-sync/pull/133
- https://github.com/trezor/trezor-suite-firmware-release/pull/203
- https://github.com/trezor/trezor-firmware/pull/6772

resolves https://github.com/trezor/trezor-suite/issues/29340
## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are scoped to the suite-sync-quota-manager package's device registration logic (createRegisterDevice and createRegisterDeviceFetch) plus its unit test. There is no static test mapping available, but the LLM analysis reveals that Suite Sync tests are the primary consumers of quota manager functionality. The risk is moderate — these are internal implementation changes to device registration that could break Suite Sync initialization. The unit test file change suggests active development with self-contained testing, but E2E coverage of the Suite Sync flows should be verified to catch integration-level regressions.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/suite-sync-quota-manager/src/device/createRegisterDevice.ts`
- `suite-common/suite-sync-quota-manager/src/device/createRegisterDeviceFetch.ts`
- `suite-common/suite-sync-quota-manager/src/device/tests/createRegisterDevice.test.ts`

</details>

**Recommended tests (8)**

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test exercises the Suite Sync flow end-to-end including enabling Suite Sync which involves quota manager setup (setupQuotaManager). The changed createRegisterDevice module is part of the suite-sync-quota-manager package which is used during Suite Sync initialization, so changes could affect device registration during sync setup.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test enables Suite Sync for multiple wallets independently, each requiring quota manager and device registration. The createRegisterDevice changes could affect how devices are registered with the quota manager across different wallet contexts.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test seeds quota manager data and enables Suite Sync to pull labels from the Evolu relay. The quota manager's device registration flow (createRegisterDevice) is exercised during the sync enablement step.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test explicitly calls setupQuotaManager and initiateSuiteSyncSetup, which are the primary consumers of the quota manager device registration logic. Changes to createRegisterDevice/createRegisterDeviceFetch could directly break the sync-from-relay flow.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — This test seeds quota manager data (seedQuotaManagerData) and enables Suite Sync, exercising the device registration path in the quota manager. Changes to the register device logic could affect initial sync setup.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — This test migrates from legacy labeling to Suite Sync, which involves enabling Suite Sync and the quota manager device registration flow. The migration path indirectly depends on successful device registration.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test seeds Evolu relay data including quota manager data before switching to Suite Sync. The quota manager device registration path is exercised during the migration from legacy Dropbox labels to Suite Sync.
- `suite/e2e/tests/metadata/suite-sync/unsupported-device.test.ts` — This test sets up Suite Sync including quota manager initialization on an unsupported device. While it tests the banner behavior rather than registration directly, the setup path still invokes the quota manager device registration code.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/suite-sync-quota-manager/src/device/tests/createRegisterDevice.test.ts`

_Updated: 2026-07-08T09:30:22.460Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/suite-sync-registration-signing/web/](https://dev.suite.sldev.cz/suite-web/suite-sync-registration-signing/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=suite-sync-registration-signing&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=suite-sync-registration-signing&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-08T09:36:03.365Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T09:33:36.005Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->