### PR TITLE
fix(suite-common): mobile attach historic fiat rates to their own timestamps in graph

### DIFF
--- a/suite-common/graph/src/graphDataFetching.ts
+++ b/suite-common/graph/src/graphDataFetching.ts
@@ -24,6 +24,7 @@ import {
     findOldestBalanceMovementTimestamp,
     getTimestampsInTimeFrame,
     mapCryptoBalanceMovementToFixedTimeFrame,
+    mapTickersToFiatRatesItems,
     mergeMultipleFiatBalanceHistories,
 } from './graphUtils';
 import type {
@@ -37,9 +38,11 @@ import type {
     FiatRatesItem,
 } from './types';
 
+// Every returned point carries the balance valid BEFORE its movement, in the same units the
+// movements and initialBalance come in (subunits for the native coin, decimal units for tokens) —
+// converting units is up to the caller.
 const addBalanceForAccountMovementHistory = (
     data: AccountMovementHistory[] | AccountHistoryMovementItem[],
-    symbol: NetworkSymbol,
     initialBalance = '0',
 ): AccountHistoryBalancePoint[] => {
     let balance = new BigNumber(initialBalance);
@@ -63,7 +66,7 @@ const addBalanceForAccountMovementHistory = (
 
         return {
             time: dataPoint.time,
-            cryptoBalance: formatNetworkAmount(balance.toFixed(), symbol),
+            cryptoBalance: balance.toFixed(),
         };
     });
 
@@ -225,11 +228,49 @@ const getAccountBalanceHistory = async ({
         getLatestAccountInfo({ symbol, identity, descriptor }),
     ]);
 
-    const accountMovementHistoryWithBalance = addBalanceForAccountMovementHistory(
-        accountMovementHistory.main,
-        symbol,
+    // Balance points carry the balance valid BEFORE their movement and the fiat-rate mapping picks
+    // the first point at-or-after each rate timestamp, so a movement newer than the end of the
+    // time frame (which is floored to whole 10 minutes) would shadow the synthetic frame-end point
+    // and read as the pre-movement balance for the entire frame. Movements past the frame end are
+    // cut off and un-applied from the present balance instead, so the history describes the state
+    // exactly as of the frame end.
+    const splitMovementsAtEndOfTimeFrame = <TMovement extends { time: number }>(
+        movements: TMovement[],
+    ) => ({
+        inFrame: movements.filter(movement => movement.time <= endTimeFrameTimestamp),
+        afterFrame: movements.filter(movement => movement.time > endTimeFrameTimestamp),
+    });
+
+    const unapplyMovements = (
+        balance: string,
+        movements: AccountMovementHistory[] | AccountHistoryMovementItem[],
+    ) =>
+        movements
+            .reduce((acc, movement) => {
+                const normalizedReceived = movement.sentToSelf
+                    ? new BigNumber(movement.received).minus(movement.sentToSelf || 0)
+                    : new BigNumber(movement.received);
+                const normalizedSent = movement.sentToSelf
+                    ? new BigNumber(movement.sent).minus(movement.sentToSelf || 0)
+                    : new BigNumber(movement.sent);
+
+                return acc.minus(normalizedReceived).plus(normalizedSent);
+            }, new BigNumber(balance))
+            .toFixed();
+
+    const mainMovements = splitMovementsAtEndOfTimeFrame(accountMovementHistory.main);
+    const mainBalanceAtEndOfTimeFrame = unapplyMovements(
         getBalanceFromAccountInfo({ accountInfo: latestAccountInfo, symbol }),
+        mainMovements.afterFrame,
     );
+
+    const accountMovementHistoryWithBalance = addBalanceForAccountMovementHistory(
+        mainMovements.inFrame,
+        mainBalanceAtEndOfTimeFrame,
+    ).map(point => ({
+        ...point,
+        cryptoBalance: formatNetworkAmount(point.cryptoBalance, symbol),
+    }));
 
     const tokens: Array<readonly [TokenAddress, AccountHistoryMovementItem[]]> = pipe(
         latestAccountInfo.tokens ?? [],
@@ -247,20 +288,25 @@ const getAccountBalanceHistory = async ({
     const tokensMovementHistoryWithBalance = D.mapWithKey(
         D.fromPairs(tokens),
         (contractId, tokenHistory) => {
-            const latestBalance = getBalanceFromAccountInfo({
-                accountInfo: latestAccountInfo,
-                symbol,
-                contractId: contractId.toString(),
-            });
+            const tokenMovements = splitMovementsAtEndOfTimeFrame(tokenHistory);
+            // Token movements and getBalanceFromAccountInfo are both already in decimal units, so
+            // unlike the native coin no subunit conversion may be applied to token points.
+            const balanceAtEndOfTimeFrame = unapplyMovements(
+                getBalanceFromAccountInfo({
+                    accountInfo: latestAccountInfo,
+                    symbol,
+                    contractId: contractId.toString(),
+                }),
+                tokenMovements.afterFrame,
+            );
             const historyWithBalance = addBalanceForAccountMovementHistory(
-                tokenHistory,
-                symbol,
-                latestBalance,
+                tokenMovements.inFrame,
+                balanceAtEndOfTimeFrame,
             );
 
             historyWithBalance.push({
                 time: endTimeFrameTimestamp,
-                cryptoBalance: latestBalance,
+                cryptoBalance: balanceAtEndOfTimeFrame,
             });
 
             return historyWithBalance;
@@ -271,10 +317,7 @@ const getAccountBalanceHistory = async ({
     // TODO: We can get value from redux account info instead of fetching it again which could cause minor inconsistency.
     accountMovementHistoryWithBalance.push({
         time: endTimeFrameTimestamp,
-        cryptoBalance: formatNetworkAmount(
-            getBalanceFromAccountInfo({ accountInfo: latestAccountInfo, symbol }),
-            symbol,
-        ),
+        cryptoBalance: formatNetworkAmount(mainBalanceAtEndOfTimeFrame, symbol),
     });
 
     const result: AccountBalanceHistoryWithTokens = {
@@ -320,12 +363,7 @@ const getFiatRatesForNetworkInTimeFrame = async ({
     );
     if (G.isNullable(fiatRates)) return null;
 
-    const formattedFiatRates: FiatRatesItem[] = fiatRates.tickers.flatMap((ticker, index) => {
-        const time = timestamps[index];
-        if (time === undefined) return [];
-
-        return [{ time, rates: ticker.rates }];
-    });
+    const formattedFiatRates = mapTickersToFiatRatesItems(fiatRates.tickers, timestamps);
 
     fiatRatesCache[cacheKey] = formattedFiatRates;
 
@@ -424,9 +462,13 @@ export const getMultipleAccountBalanceHistoryWithFiat = async ({
 
         // findOldestBalanceMovementTimestamp returns Infinity when there are no balance movements
         // at all (Math.min of an empty list). Anchor the range to the end of the time frame so the
-        // no-movements branch below fires with a valid start date instead of an Invalid Date.
+        // no-movements branch below fires with a valid start date instead of an Invalid Date. The
+        // end of the time frame also caps the start (clock skew could produce a newer movement),
+        // because an inverted interval makes getTimestampsInTimeFrame throw.
         startOfTimeFrameDate = Number.isFinite(oldestBalanceMovementTimestamp)
-            ? fromUnixTime(oldestBalanceMovementTimestamp)
+            ? fromUnixTime(
+                  Math.min(oldestBalanceMovementTimestamp, getUnixTime(endOfTimeFrameDate)),
+              )
             : new Date(endOfTimeFrameDate);
 
         // if there were no balance movements at all,

--- a/suite-common/graph/src/graphUtils.test.ts
+++ b/suite-common/graph/src/graphUtils.test.ts
@@ -1,11 +1,13 @@
 import { fromUnixTime } from 'date-fns';
 
 import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type TimestampedRates } from '@suite-common/wallet-types';
 
 import {
     findOldestBalanceMovementTimestamp,
     getDataStepInMinutes,
     mapCryptoBalanceMovementToFixedTimeFrame,
+    mapTickersToFiatRatesItems,
     mergeMultipleFiatBalanceHistories,
 } from './graphUtils';
 import type {
@@ -17,6 +19,96 @@ import type {
 
 const btcSymbol = asNetworkSymbol('btc');
 const ethSymbol = asNetworkSymbol('eth');
+
+describe(mapTickersToFiatRatesItems.name, () => {
+    it('attaches the nearest rate to every requested timestamp when the tickers array is sparse and out of order', () => {
+        // Blockbook drops tickers it has no rate for (compacting the array) and does not
+        // guarantee response order matches the requested timestamps.
+        const tickers: TimestampedRates[] = [
+            { ts: 16, rates: { usd: 3 } },
+            { ts: 0, rates: { usd: 1 } },
+            { ts: 20, rates: { usd: 4 } },
+            { ts: 9, rates: { usd: 2 } },
+        ];
+
+        expect(mapTickersToFiatRatesItems(tickers, [0, 5, 10, 15, 20])).toStrictEqual([
+            { time: 0, rates: { usd: 1 } },
+            { time: 5, rates: { usd: 2 } },
+            { time: 10, rates: { usd: 2 } },
+            { time: 15, rates: { usd: 3 } },
+            { time: 20, rates: { usd: 4 } },
+        ] as FiatRatesItem[]);
+    });
+
+    it('keeps every coin on the requested timestamp grid so merged accounts sum values instead of interleaving them', () => {
+        // Tokens only have daily rate history while native coins have hourly rates — points keyed
+        // by the ticker `ts` would land on different grids per coin, and the merge sums only
+        // points with equal timestamps.
+        const dailyTokenTickers: TimestampedRates[] = [
+            { ts: 0, rates: { usd: 1 } },
+            { ts: 86400, rates: { usd: 2 } },
+        ];
+
+        expect(
+            mapTickersToFiatRatesItems(dailyTokenTickers, [0, 21600, 43200, 64800, 86400]),
+        ).toStrictEqual([
+            { time: 0, rates: { usd: 1 } },
+            { time: 21600, rates: { usd: 1 } },
+            { time: 43200, rates: { usd: 2 } },
+            { time: 64800, rates: { usd: 2 } },
+            { time: 86400, rates: { usd: 2 } },
+        ] as FiatRatesItem[]);
+    });
+
+    it('collapses the frame-end timestamp requested twice so merged accounts do not double the last point (regression for issue #20785)', () => {
+        // The frame end is appended to the requested timestamps and eachMinuteOfInterval emits it
+        // too whenever the time frame length divides evenly by the point step.
+        const tickers: TimestampedRates[] = [
+            { ts: 0, rates: { usd: 1 } },
+            { ts: 10, rates: { usd: 2 } },
+            { ts: 20, rates: { usd: 4 } },
+        ];
+
+        expect(mapTickersToFiatRatesItems(tickers, [0, 10, 20, 20])).toStrictEqual([
+            { time: 0, rates: { usd: 1 } },
+            { time: 10, rates: { usd: 2 } },
+            { time: 20, rates: { usd: 4 } },
+        ] as FiatRatesItem[]);
+    });
+
+    it('returns an empty array when blockbook has no rates at all', () => {
+        expect(mapTickersToFiatRatesItems([], [0, 10, 20])).toStrictEqual([]);
+    });
+
+    it('produces rates that yield varying graph values for a flat crypto balance (regression for issue #17671)', () => {
+        // Requested timestamps were [0, 5, 10, 15, 20], but the ticker for 5 was dropped.
+        // Mapping tickers positionally onto the requested timestamps would shift every
+        // following rate to an earlier, incorrect date and drop the most recent timestamp (20)
+        // entirely, making token graphs appear flat.
+        const tickers: TimestampedRates[] = [
+            { ts: 15, rates: { usd: 3 } },
+            { ts: 0, rates: { usd: 1 } },
+            { ts: 20, rates: { usd: 4 } },
+            { ts: 10, rates: { usd: 2 } },
+        ];
+        const balanceHistory: AccountHistoryBalancePoint[] = [{ time: 100, cryptoBalance: '100' }];
+
+        const fiatRates = mapTickersToFiatRatesItems(tickers, [0, 5, 10, 15, 20]);
+        const result = mapCryptoBalanceMovementToFixedTimeFrame({
+            balanceHistory,
+            fiatRates,
+            baseCurrencyCode: 'usd',
+        });
+
+        expect(result).toStrictEqual([
+            { date: fromUnixTime(0), cryptoBalance: '100', value: 100 },
+            { date: fromUnixTime(5), cryptoBalance: '100', value: 200 },
+            { date: fromUnixTime(10), cryptoBalance: '100', value: 200 },
+            { date: fromUnixTime(15), cryptoBalance: '100', value: 300 },
+            { date: fromUnixTime(20), cryptoBalance: '100', value: 400 },
+        ] as FiatGraphPointWithCryptoBalance[]);
+    });
+});
 
 describe(getDataStepInMinutes.name, () => {
     it('gets the 1m step size for 1 hour interval (60 points)', () => {

--- a/suite-common/graph/src/graphUtils.ts
+++ b/suite-common/graph/src/graphUtils.ts
@@ -8,6 +8,7 @@ import {
     subHours,
 } from 'date-fns';
 
+import { type TimestampedRates } from '@suite-common/wallet-types';
 import {
     AMOUNT_UNIT_ZERO,
     asAmountUnit,
@@ -66,6 +67,39 @@ export const getTimestampsInTimeFrame = (
     const datesInRangeUnixTime = A.map(datesInRange, date => getUnixTime(date));
 
     return datesInRangeUnixTime as number[];
+};
+
+// Blockbook drops tickers it has no rate for, so the response cannot be zipped with the request
+// by array position — it can be shorter and out of order, and each ticker carries its own
+// authoritative `ts` (the nearest stored rate, e.g. tokens only have daily rates while native
+// coins have hourly ones). Rates for all coins must also end up on the SAME timestamp grid,
+// because merging accounts sums points with equal timestamps — keying points by the ticker `ts`
+// would interleave per-coin values instead of summing them. Each requested timestamp therefore
+// gets the rates of the nearest returned ticker and keeps the requested time, deduplicated
+// because the frame end is requested twice whenever the time frame length aligns with the point
+// step, which used to double the last merged point.
+export const mapTickersToFiatRatesItems = (
+    tickers: TimestampedRates[],
+    timestamps: number[],
+): FiatRatesItem[] => {
+    const sortedTickers = tickers.toSorted((a, b) => a.ts - b.ts);
+    if (A.isEmpty(sortedTickers)) return [];
+
+    const uniqueTimestamps = [...new Set(timestamps)].toSorted((a, b) => a - b);
+
+    // Both lists are ascending, so the nearest ticker index never moves backwards.
+    let tickerIndex = 0;
+
+    return uniqueTimestamps.map(timestamp => {
+        while (tickerIndex + 1 < sortedTickers.length) {
+            const currentDistance = Math.abs(sortedTickers[tickerIndex]!.ts - timestamp);
+            const nextDistance = Math.abs(sortedTickers[tickerIndex + 1]!.ts - timestamp);
+            if (nextDistance > currentDistance) break;
+            tickerIndex += 1;
+        }
+
+        return { time: timestamp, rates: sortedTickers[tickerIndex]!.rates };
+    });
 };
 
 type MapCryptoBalanceMovementToFixedTimeFrameParams = {


### PR DESCRIPTION


## Description

The mobile graph zipped blockbook fiat-rate tickers to the requested timestamps by array position, but blockbook drops tickers it has no rate for — after the first gap every rate landed on a wrong date and token graphs stayed flat. Now each requested timestamp gets the nearest returned ticker's rates (desktop's approach), so all coins stay on one timestamp grid and the merged account/portfolio graph sums values correctly.

Also fixed along the way:
- Token history balances were divided by network decimals twice, so every historical token point read ≈ 0 — the other half of the flat graphs.
- The frame-end timestamp can be requested twice and the merge summed the duplicate — the randomly doubled last point on ALL (#20785).
- A deposit newer than the frame end (floored to 10 min) zeroed the whole graph; such movements are now cut off and un-applied from the present balance.
- An account whose only movement is newer than the frame end crashed the interval building and silently hid the token graph.

Remaining positional-ticker call sites outside the graph: #29461.

## Notes for QA
On mobile, check account, token and portfolio graphs on all timeframes for an EVM account holding tokens — they should follow fiat prices instead of staying flat, and the portfolio graph should equal the sum of the assets. Token rates only exist per day (backend limitation). A deposit made moments ago shows in the graph within ~10 minutes; the header balance updates immediately.

## Related Issue
Resolve #17671
Resolve #20785

## Screenshots:

<img width="394" height="723" alt="Screenshot 2026-08-20 at 14 52 27" src="https://github.com/user-attachments/assets/950c547d-f41f-49c9-9390-d74979ea04a0" />
<img width="395" height="718" alt="Screenshot 2026-08-20 at 14 52 07" src="https://github.com/user-attachments/assets/140ac814-4298-4d03-a1fe-e00395ea5a33" />

<img width="395" height="695" alt="Screenshot 2026-08-20 at 15 11 07" src="https://github.com/user-attachments/assets/deb37ebc-f57c-4716-b403-2184ce818b46" />



<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No static coverage mapping was available for these changes, so recommendations are inferred from the test descriptions. The changed graph utilities primarily affect dashboard portfolio graphs and account transaction graphs, so the highest-value tests are the ones that render and assert those graphs. The selected targeted tests should catch regressions in graph data fetching, range filtering, and visibility.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/graph/src/graphDataFetching.ts`
- `suite-common/graph/src/graphUtils.test.ts`
- `suite-common/graph/src/graphUtils.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test directly asserts that the dashboard portfolio graph becomes visible after discovery with custom BTC and LTC Blockbook backends, so it exercises the full graph data fetching and rendering path touched by the changed files.
- `suite/e2e/tests/wallet/transactions.test.ts` — It cycles through all account transaction graph time-range filters and verifies the corresponding date label, directly exercising the graph UI and the graph utility logic that produces range labels and data.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — The test navigates to the dashboard and uses the visibility of the portfolio graph as a load/ready indicator after label edits; a graph rendering regression would fail this assertion, though it does not validate graph data directly.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/graph/src/graphUtils.test.ts`

_Updated: 2026-08-24T06:32:33.655Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/17671-graph-token-fiat-rates/web/](https://dev.suite.sldev.cz/suite-web/fix/17671-graph-token-fiat-rates/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/17671-graph-token-fiat-rates&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/17671-graph-token-fiat-rates&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/17671-graph-token-fiat-rates&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-24T06:34:59.122Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-24T06:34:36.302Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->



