### PR TITLE
fix(suite-common): show default account type for non-bitcoin networks

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsConstants.ts
+++ b/suite-common/wallet-core/src/accounts/accountsConstants.ts
@@ -2,56 +2,42 @@ import { type AccountType, type NetworkType } from '@suite-common/wallet-config'
 
 export const ACCOUNTS_MODULE_PREFIX = '@common/wallet-core/accounts';
 
-type AccountTypeMap = Partial<Record<NetworkType, Partial<Record<AccountType, string>>>>;
-
-export const formattedAccountTypeMap: AccountTypeMap = {
-    bitcoin: {
-        normal: 'SegWit',
-        taproot: 'Taproot',
-        segwit: 'Legacy SegWit',
-        legacy: 'Legacy',
-    },
-    cardano: {
-        legacy: 'Legacy',
-        ledger: 'Ledger',
-    },
-    ethereum: {
-        legacy: 'Legacy',
-        ledger: 'Ledger',
-    },
-    solana: {
-        ledger: 'Ledger',
-    },
+const bitcoinFormattedAccountTypeMap: Record<AccountType, string | null> = {
+    normal: 'SegWit',
+    taproot: 'Taproot',
+    segwit: 'Legacy SegWit',
+    legacy: 'Legacy',
+    coinjoin: null,
+    ledger: null,
+    imported: null,
+    placeholder: null,
 };
 
-export const formattedAccountTypeWithDefaultMap: AccountTypeMap = {
-    bitcoin: {
-        normal: 'SegWit',
-        taproot: 'Taproot',
-        segwit: 'Legacy SegWit',
-        legacy: 'Legacy',
-    },
-    cardano: {
-        normal: 'Default',
-        legacy: 'Legacy',
-        ledger: 'Ledger',
-    },
-    ethereum: {
-        normal: 'Default',
-        legacy: 'Legacy',
-        ledger: 'Ledger',
-    },
-    solana: {
-        normal: 'Default',
-        ledger: 'Ledger',
-    },
-    ripple: {
-        normal: 'Default',
-    },
-    stellar: {
-        normal: 'Default',
-    },
-    tron: {
-        normal: 'Default',
-    },
+const formattedAccountTypeMap: Record<AccountType, string | null> = {
+    normal: null,
+    legacy: 'Legacy',
+    ledger: 'Ledger',
+    coinjoin: null,
+    segwit: null,
+    taproot: null,
+    imported: null,
+    placeholder: null,
 };
+
+const formattedAccountTypeWithDefaultMap: Record<AccountType, string | null> = {
+    ...formattedAccountTypeMap,
+    normal: 'Default',
+};
+
+export const getFormattedAccountType = (networkType: NetworkType, accountType: AccountType) =>
+    (networkType === 'bitcoin' ? bitcoinFormattedAccountTypeMap : formattedAccountTypeMap)[
+        accountType
+    ];
+
+export const getFormattedAccountTypeWithDefault = (
+    networkType: NetworkType,
+    accountType: AccountType,
+) =>
+    (networkType === 'bitcoin'
+        ? bitcoinFormattedAccountTypeMap
+        : formattedAccountTypeWithDefaultMap)[accountType];

--- a/suite-common/wallet-core/src/accounts/accountsSelectors.ts
+++ b/suite-common/wallet-core/src/accounts/accountsSelectors.ts
@@ -12,7 +12,7 @@ import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import { isCardanoStakingActive, isTestnet, isUtxoBased } from '@suite-common/wallet-utils';
 import { type DeviceState, type StaticSessionId } from '@trezor/connect';
 
-import { formattedAccountTypeMap, formattedAccountTypeWithDefaultMap } from './accountsConstants';
+import { getFormattedAccountType, getFormattedAccountTypeWithDefault } from './accountsConstants';
 import { type AccountsRootState } from './accountsReducer';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<
@@ -241,20 +241,16 @@ export const selectAccountFormattedBalance = createMemoizedSelector(
 
 export const selectFormattedAccountType = createMemoizedSelector([selectAccountByKey], account => {
     if (!account) return null;
-    const { networkType, accountType } = account;
-    const formattedType = formattedAccountTypeMap[networkType]?.[accountType];
 
-    return formattedType ?? null;
+    return getFormattedAccountType(account.networkType, account.accountType);
 });
 
 export const selectFormattedAccountTypeWithDefault = createMemoizedSelector(
     [selectAccountByKey],
     account => {
         if (!account) return null;
-        const { networkType, accountType } = account;
-        const formattedType = formattedAccountTypeWithDefaultMap[networkType]?.[accountType];
 
-        return formattedType ?? null;
+        return getFormattedAccountTypeWithDefault(account.networkType, account.accountType);
     },
 );
 

--- a/suite-native/accounts/src/components/AccountTypeBadge.test.tsx
+++ b/suite-native/accounts/src/components/AccountTypeBadge.test.tsx
@@ -37,7 +37,7 @@ describe('AccountTypeBadge', () => {
         expect(getByText('Ledger')).toBeOnTheScreen();
     });
 
-    it('should render nothing for an account type without a formatted name', () => {
+    it('should render nothing for a normal non-bitcoin account', () => {
         const { toJSON } = renderAccountTypeBadge(ethNormalAccount.key);
 
         expect(toJSON()).toBeNull();

--- a/suite-native/accounts/src/utils.ts
+++ b/suite-native/accounts/src/utils.ts
@@ -8,7 +8,7 @@ import {
     networkSymbolCollection,
     networks,
 } from '@suite-common/wallet-config';
-import { formattedAccountTypeMap } from '@suite-common/wallet-core';
+import { getFormattedAccountType } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { orderedAccountTypes, sendDisabledNetworkTypes } from '@suite-native/config';
 
@@ -41,8 +41,10 @@ export const isFilterValueMatchingAccount = (
     const isBitcoinNetworkType = networks[account.symbol].networkType === 'bitcoin';
     const lowercasedSectionHeader = accountTypeToSectionHeader[account.accountType]?.toLowerCase();
 
-    const lowerCasedAccountType =
-        formattedAccountTypeMap[account.networkType]?.[account.accountType]?.toLowerCase();
+    const lowerCasedAccountType = getFormattedAccountType(
+        account.networkType,
+        account.accountType,
+    )?.toLowerCase();
 
     const isMatchingAccountType =
         (lowercasedSectionHeader?.includes(filterValue) ||

--- a/suite-native/module-accounts-management/src/components/AccountDetailScreenHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailScreenHeader.tsx
@@ -28,7 +28,7 @@ type AccountDetailNavigationProps = StackToStackCompositeNavigationProps<
     RootStackParamList
 >;
 
-const AccountDetailScreenHeaderContent = ({ account }: AccountDetailScreenHeaderProps) => (
+export const AccountDetailScreenHeaderContent = ({ account }: AccountDetailScreenHeaderProps) => (
     <HStack alignItems="center" flexShrink={1}>
         <TokenIcon symbol={account.symbol} size="small" showNetworkIcon />
         <VStack spacing={0} flexShrink={1}>

--- a/suite-native/module-accounts-management/src/screens/AccountSettingsScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountSettingsScreen.tsx
@@ -11,7 +11,6 @@ import {
     selectFormattedAccountTypeWithDefault,
     selectIsAccountUtxoBased,
 } from '@suite-common/wallet-core';
-import { AccountLabel } from '@suite-native/accounts';
 import { Box, Card, HStack, Text, VStack } from '@suite-native/atoms';
 import { Bip329ManageLabelsCard } from '@suite-native/bip329';
 import { TokenIcon } from '@suite-native/icons';
@@ -24,6 +23,7 @@ import {
     type StackProps,
 } from '@suite-native/navigation';
 
+import { AccountDetailScreenHeaderContent } from '../components/AccountDetailScreenHeader';
 import { AccountRenameButton } from '../components/AccountRenameButton';
 import { AccountSettingsRemoveCoinButton } from '../components/AccountSettingsRemoveCoinButton';
 import { AccountSettingsShowXpubButton } from '../components/AccountSettingsShowXpubButton';
@@ -85,7 +85,7 @@ export const AccountSettingsScreen = ({
         <Screen
             header={
                 <ScreenHeader
-                    title={<AccountLabel account={account} />}
+                    customContent={<AccountDetailScreenHeaderContent account={account} />}
                     rightIcon={<AccountRenameButton accountKey={accountKey} />}
                 />
             }

--- a/suite-native/module-receive/src/components/ReceiveFreshAddressHeader.tsx
+++ b/suite-native/module-receive/src/components/ReceiveFreshAddressHeader.tsx
@@ -57,14 +57,14 @@ export const ReceiveFreshAddressHeader = ({
                         )}
                     </Text>
                     <HStack spacing="sp8" alignItems="center">
-                        <Text variant="body-md-strong">
-                            <AccountLabel
-                                accountDescriptor={accountDescriptor}
-                                networkSymbol={networkSymbol}
-                                deviceStaticSessionId={deviceStaticSessionId}
-                            />
-                            {tokenSymbol && ` - ${tokenSymbol}`}
-                        </Text>
+                        <AccountLabel
+                            variant="body-md-strong"
+                            accountDescriptor={accountDescriptor}
+                            networkSymbol={networkSymbol}
+                            deviceStaticSessionId={deviceStaticSessionId}
+                            showAccountTypeBadge
+                        />
+                        {tokenSymbol && <Text variant="body-md-strong">{` - ${tokenSymbol}`}</Text>}
                     </HStack>
                 </>
             }


### PR DESCRIPTION
## Description

`formattedAccountTypeMap` had no `normal` entry for cardano/ethereum/solana and no entries at all for ripple/stellar/tron, so `selectFormattedAccountType` returned `null` and the "Account type" row was silently omitted on mobile for ordinary non-bitcoin accounts.

- Replaced the per-network maps with `getFormattedAccountType(networkType, accountType)` mirroring desktop's `getAccountTypeName`: a bitcoin map (SegWit/Taproot/Legacy SegWit/Legacy) and one shared non-bitcoin map (Legacy/Ledger). Both are exhaustive `Record<AccountType, string | null>`, so adding a new account type fails to compile until the maps take a stance.
- Badges stay hidden for ordinary accounts: `selectFormattedAccountType` returns `null` for non-bitcoin `normal` (no "Normal" chips in account lists).
- The account-detail "Account type" row uses the new `selectFormattedAccountTypeWithDefault`, which labels non-bitcoin `normal` accounts "Default" — same wording as desktop's `TR_ACCOUNT_TYPE_DEFAULT`.
- Account settings screen header now reuses the account-detail header content (coin icon + label + account-type badge), so ledger/legacy accounts show their badge there too.
- Receive flow header shows the account-type badge next to the account label.

## Notes for QA

- Account settings (detail) screen shows an "Account type" row for every account; ordinary non-bitcoin accounts say "Default" (ETH/ADA/SOL/XRP/XLM/TRX). Account lists show no badge for these; ledger/legacy badges unchanged.
- Account settings screen header and Receive screen header now include the coin icon / account-type badge.

## Screenshots

Before:

- those were ledger
<img width="405" height="229" alt="Screenshot 2026-08-02 at 22 44 55" src="https://github.com/user-attachments/assets/e9d03a54-c91d-4fca-8e36-87371ee32faa" />
<img width="405" height="328" alt="Screenshot 2026-08-02 at 22 45 01" src="https://github.com/user-attachments/assets/b2410493-8c94-492e-a39d-1989b0ec168c" />
<img width="1178" height="662" alt="IMG_4146" src="https://github.com/user-attachments/assets/6b151907-565f-4b6a-b074-404279689a92" />


After:
<img width="394" height="283" alt="Screenshot 2026-08-02 at 23 02 32" src="https://github.com/user-attachments/assets/5e38fa9d-dab0-4c67-ad5e-1d89f6ff19e0" />
<img width="404" height="151" alt="Screenshot 2026-08-02 at 23 02 17" src="https://github.com/user-attachments/assets/3d659b86-33bd-43a3-aa14-1a22cddbafa4" />
<img width="399" height="155" alt="Screenshot 2026-08-02 at 23 02 07" src="https://github.com/user-attachments/assets/cf33440b-6f8c-4915-965d-fa079523dd97" />
<img width="393" height="305" alt="Screenshot 2026-08-02 at 23 01 56" src="https://github.com/user-attachments/assets/2077f89d-7112-4ea8-9cc3-337dcb30ad4f" />
<img width="406" height="171" alt="Screenshot 2026-08-02 at 23 01 50" src="https://github.com/user-attachments/assets/49d03e73-3238-496e-a38d-76045e9aa868" />

After:


## Related Issue

Resolve #27973

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed mobile files have no web/desktop E2E coverage, so the risk is concentrated in suite-common/wallet-core account constants/selectors. Those files are global dependencies, so only a few tests that directly exercise account type, search, discovery, and account detail behavior are recommended. Running these focused account tests gives high confidence while avoiding an overly broad run.

<details><summary><b>Changed files (7)</b></summary>

- `suite-common/wallet-core/src/accounts/accountsConstants.ts`
- `suite-common/wallet-core/src/accounts/accountsSelectors.ts`
- `suite-native/accounts/src/components/AccountTypeBadge.test.tsx`
- `suite-native/accounts/src/utils.ts`
- `suite-native/module-accounts-management/src/components/AccountDetailScreenHeader.tsx`
- `suite-native/module-accounts-management/src/screens/AccountSettingsScreen.tsx`
- `suite-native/module-receive/src/components/ReceiveFreshAddressHeader.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/wallet/account-search.test.ts` — This test directly exercises account list filtering and search visibility, which depends on account selectors and account constants to enumerate and match accounts. A regression in shared accounts selectors/constants would likely break these assertions.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — The test adds accounts of different types (normal, taproot, segwit, legacy) and asserts account counts, type labels, and analytics events with account type metadata. Changes to accounts constants/selectors directly influence account type resolution and the add-account flow.
- `suite/e2e/tests/wallet/cardano.test.ts` — It verifies the Cardano account type description (TR_ACCOUNT_TYPE_NORMAL_CARDANO_DESC) and account detail metadata, which are derived from account type definitions in the shared accounts core.
- `suite/e2e/tests/wallet/discovery.test.ts` — Multi-coin discovery and the resulting account list visibility rely on account selectors and constants to map discovered networks to account entries. A regression here would be user-visible on the dashboard.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — It covers standard wallet discovery and account balance display after ejecting/adding wallets, a flow that depends on account enumeration but is less directly tied to account types than add-account-types.
- `suite/e2e/tests/wallet/public-keys.test.ts` — Opening specific coin accounts and showing public keys uses account selection/navigation paths that may rely on the shared accounts selectors to resolve the active account.

</details>

⚠️ **Changes with no test coverage (5)**
- `suite-native/accounts/src/components/AccountTypeBadge.test.tsx`
- `suite-native/accounts/src/utils.ts`
- `suite-native/module-accounts-management/src/components/AccountDetailScreenHeader.tsx`
- `suite-native/module-accounts-management/src/screens/AccountSettingsScreen.tsx`
- `suite-native/module-receive/src/components/ReceiveFreshAddressHeader.tsx`

_Updated: 2026-08-03T10:30:37.975Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/27973-account-type-badge/web/](https://dev.suite.sldev.cz/suite-web/fix/27973-account-type-badge/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/27973-account-type-badge&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/27973-account-type-badge&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T10:32:45.315Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T10:33:25.940Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->