### PR TITLE
fix(suite-native): truncate long token names in transaction list and token settings

### DIFF
--- a/suite-native/module-earn/src/components/TokenSettingsBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/TokenSettingsBottomSheet.tsx
@@ -66,7 +66,7 @@ const detailRowStyle = prepareNativeStyle(({ spacings }) => ({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    height: spacings.sp40,
+    minHeight: spacings.sp40,
 }));
 
 const cardStyle = prepareNativeStyle(({ colors, borders, boxShadows, spacings }) => ({
@@ -266,35 +266,43 @@ export const TokenSettingsBottomSheet = forwardRef(
                                     <Translation id="moduleAccountManagement.tokenSettings.balance" />
                                 }
                             >
-                                <VStack spacing={0} alignItems="flex-end">
-                                    <TokenAmountFormatter
-                                        value={balance}
-                                        tokenSymbol={token?.symbol ?? toTokenSymbol(account.symbol)}
-                                        variant="body-sm"
-                                        color="contentPrimary"
-                                    />
-
-                                    {!isUnrecognized && (
-                                        <>
-                                            {tokenContract ? (
-                                                <TokenToFiatAmountFormatter
-                                                    symbol={symbol}
-                                                    value={balance}
-                                                    contract={tokenContract}
-                                                    variant="body-sm"
-                                                    color="contentSecondary"
-                                                />
-                                            ) : (
-                                                <CoinToFiatAmountFormatter
-                                                    accountKey={accountKey}
-                                                    value={balance}
-                                                    variant="body-sm"
-                                                    color="contentSecondary"
-                                                />
+                                <Box flex={1} alignItems="flex-end" marginLeft="sp8">
+                                    <VStack spacing={0} alignItems="flex-end">
+                                        <TokenAmountFormatter
+                                            value={balance}
+                                            tokenSymbol={toTokenSymbol(
+                                                getDisplaySymbol(
+                                                    token?.symbol ?? toTokenSymbol(account.symbol),
+                                                ),
                                             )}
-                                        </>
-                                    )}
-                                </VStack>
+                                            variant="body-sm"
+                                            color="contentPrimary"
+                                            numberOfLines={1}
+                                            ellipsizeMode="tail"
+                                        />
+
+                                        {!isUnrecognized && (
+                                            <>
+                                                {tokenContract ? (
+                                                    <TokenToFiatAmountFormatter
+                                                        symbol={symbol}
+                                                        value={balance}
+                                                        contract={tokenContract}
+                                                        variant="body-sm"
+                                                        color="contentSecondary"
+                                                    />
+                                                ) : (
+                                                    <CoinToFiatAmountFormatter
+                                                        accountKey={accountKey}
+                                                        value={balance}
+                                                        variant="body-sm"
+                                                        color="contentSecondary"
+                                                    />
+                                                )}
+                                            </>
+                                        )}
+                                    </VStack>
+                                </Box>
                             </DetailRow>
                         </VStack>
                     </Card>

--- a/suite-native/module-send/src/components/CryptoAmountInput.tsx
+++ b/suite-native/module-send/src/components/CryptoAmountInput.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useFormatters } from '@suite-common/formatters';
+import { getDisplaySymbol } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectIsBaseCurrencyInSats } from '@suite-common/wallet-core';
 import { getDecimalsForBaseCurrency } from '@suite-common/wallet-utils';
 import { Input, Text } from '@suite-native/atoms';
@@ -102,7 +103,9 @@ export const CryptoAmountInput = ({
             hasError={!isDisabled && hasError}
             rightIcon={
                 <SendAmountCurrencyLabelWrapper isDisabled={isDisabled}>
-                    {tokenSymbol ?? formatter.format(symbol)}
+                    {tokenSymbol !== null
+                        ? getDisplaySymbol(tokenSymbol, tokenContract)
+                        : formatter.format(symbol)}
                 </SendAmountCurrencyLabelWrapper>
             }
         />

--- a/suite-native/transactions/src/components/TokenTransferListItem.tsx
+++ b/suite-native/transactions/src/components/TokenTransferListItem.tsx
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
+import { getDisplaySymbol } from '@suite-common/wallet-config';
 import {
     type FiatRatesRootState,
     type PhishingRootState,
@@ -8,7 +9,7 @@ import {
     type WalletSettingsRootState,
     selectIsPhishingTransaction,
 } from '@suite-common/wallet-core';
-import { type AccountKey } from '@suite-common/wallet-types';
+import { type AccountKey, toTokenSymbol } from '@suite-common/wallet-types';
 import { TokenAmountFormatter, TokenToFiatAmountFormatter } from '@suite-native/formatters';
 import { type TypedTokenTransfer, type WalletAccountTransaction } from '@suite-native/tokens';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
@@ -73,7 +74,7 @@ export const TokenTransferListItemValues = ({
             />
             <TokenAmountFormatter
                 value={tokenTransfer.amount}
-                tokenSymbol={tokenTransfer.symbol}
+                tokenSymbol={toTokenSymbol(getDisplaySymbol(tokenTransfer.symbol))}
                 decimals={tokenTransfer.decimals}
                 numberOfLines={1}
                 ellipsizeMode="tail"


### PR DESCRIPTION
## Description

Quick polish of symbol/name on some places. Definitely not perfect. Has to be handled systematically. This is quick fix to avoid broken ui

## Notes for QA
Manual, with a long-name scam-style token: transaction list row ellipsizes instead of overflowing; token settings (gear) Balance row doesn't overlap its label; token header still truncates (regression); Contract address/Network rows unaffected; send flow for such a token shows a truncated symbol next to the amount instead of overlapping it.

## Related Issue
Resolve #29086

## Screenshots:


<img width="386" height="448" alt="Screenshot 2026-08-20 at 16 20 27" src="https://github.com/user-attachments/assets/7d1f86a9-5267-43af-a176-f9dcce5ffc0b" />
<img width="393" height="713" alt="Screenshot 2026-08-20 at 16 20 21" src="https://github.com/user-attachments/assets/bfa6e44d-cd99-4b8a-ad88-6d622116f94d" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/29086-long-token-names&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

