### PR TITLE
feat(suite-native): warn about unverified xpub when device is disconnected

### DIFF
--- a/suite-common/wallet-core/src/device/deviceAddressUtils.ts
+++ b/suite-common/wallet-core/src/device/deviceAddressUtils.ts
@@ -49,8 +49,6 @@ export const getPublicKeyForNetworkType = ({
             return TrezorConnect.getPublicKey(params);
         case 'cardano':
             return TrezorConnect.cardanoGetPublicKey({ ...params, derivationType });
-        case 'solana':
-            return TrezorConnect.solanaGetPublicKey(params);
         default:
             return methodNotDefinedError('getPublicKey');
     }

--- a/suite-native/device-authorization/src/utils.ts
+++ b/suite-native/device-authorization/src/utils.ts
@@ -35,6 +35,7 @@ export const flowEndingButtonRequests = [
     'ButtonRequest_ConfirmOutput',
     'ButtonRequest_SignTx',
     'ButtonRequest_Address',
+    'ButtonRequest_PublicKey',
 ] as const;
 
 export const isFlowEndingButtonRequest = (action: UnknownAction) =>

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2018,6 +2018,17 @@ export const messages = {
                     copyMessage: 'XPUB copied',
                 },
                 copyButton: 'Copy',
+                viewOnlyWarning: {
+                    title: 'Public key (XPUB) can’t be verified',
+                    description: 'To confirm the public key (XPUB), connect your Trezor.',
+                    primaryButton: 'Continue without verifying',
+                    secondaryButton: 'Back',
+                },
+                unverifiedWarning: {
+                    title: 'Verify the public key (XPUB) on your Trezor',
+                    subtitle:
+                        'To prevent phishing attacks, verify the public key (XPUB) on your Trezor.',
+                },
             },
             renameForm: {
                 title: 'Rename account',

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2015,19 +2015,21 @@ export const messages = {
                 xpub: {
                     title: 'Public key (XPUB)',
                     showButton: 'Show public key (XPUB)',
+                    confirmOnTrezorButton: 'Confirm on Trezor',
                     copyMessage: 'XPUB copied',
                 },
                 copyButton: 'Copy',
                 viewOnlyWarning: {
-                    title: 'Public key (XPUB) can’t be verified',
-                    description: 'To confirm the public key (XPUB), connect your Trezor.',
-                    primaryButton: 'Continue without verifying',
+                    title: 'Your Trezor isn’t connected',
+                    description:
+                        'To prevent phishing attacks, verify the public key on your Trezor. Connect it to continue with the verification process.',
+                    primaryButton: 'Show unverified public key',
                     secondaryButton: 'Back',
                 },
                 unverifiedWarning: {
-                    title: 'Verify the public key (XPUB) on your Trezor',
+                    title: 'Public key not verified',
                     subtitle:
-                        'To prevent phishing attacks, verify the public key (XPUB) on your Trezor.',
+                        'To prevent phishing attacks, verify the public key on your Trezor once it’s connected.',
                 },
             },
             renameForm: {

--- a/suite-native/module-accounts-management/src/screens/AccountSettingsScreen.test.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountSettingsScreen.test.tsx
@@ -33,6 +33,7 @@ const buildRoute = (accountKey: string) =>
 
 const buildPreloadedState = (account: ReturnType<typeof mockWalletAccount>) => ({
     device: { devices: [], selectedDevice: undefined },
+    deviceAuthorization: { deviceAuthorizationStep: 'Idle' },
     messageSystem: {
         config: null,
         currentSequence: 0,

--- a/suite-native/qr-code/package.json
+++ b/suite-native/qr-code/package.json
@@ -16,6 +16,7 @@
         "@suite-common/wallet-types": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/clipboard": "workspace:*",
+        "@suite-native/device-authorization": "workspace:*",
         "@suite-native/icons": "workspace:*",
         "@suite-native/intl": "workspace:*",
         "@suite-native/toasts": "workspace:*",

--- a/suite-native/qr-code/src/components/XpubQRCodeBottomSheet.tsx
+++ b/suite-native/qr-code/src/components/XpubQRCodeBottomSheet.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import { selectSelectedDevice } from '@suite-common/device';
+import { selectIsDeviceInViewOnlyMode, selectSelectedDevice } from '@suite-common/device';
 import {
     type AccountsRootState,
     selectAccountByKey,
@@ -17,10 +17,21 @@ import {
 } from '@suite-native/atoms';
 import { useCopyToClipboard } from '@suite-native/clipboard';
 import { Translation, useTranslate } from '@suite-native/intl';
+import { useToast } from '@suite-native/toasts';
 import TrezorConnect from '@trezor/connect';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { XpubQRCodeCard } from './XpubQRCodeCard';
+import { XpubUnverifiedWarning } from './XpubUnverifiedWarning';
+import { XpubViewOnlyWarning } from './XpubViewOnlyWarning';
+
+const USER_CANCELLED_ERROR_CODES = [
+    'Failure_ActionCancelled',
+    'Failure_PinCancelled',
+    'Failure_PinInvalid',
+    'Method_Cancel',
+    'Method_Interrupted',
+];
 
 type XpubQRCodeBottomSheetProps = {
     onClose: () => void;
@@ -43,14 +54,18 @@ export const XpubQRCodeBottomSheet = ({
     const { translate } = useTranslate();
     const { applyStyle } = useNativeStyles();
     const copyToClipboard = useCopyToClipboard();
+    const { showToast } = useToast();
 
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
     const device = useSelector(selectSelectedDevice);
+    const isDeviceInViewOnlyMode = useSelector(selectIsDeviceInViewOnlyMode);
 
     const isImported = account?.imported ?? false;
     const [isXpubShown, setIsXpubShown] = useState(isImported);
+    const [isViewOnlyWarningShown, setIsViewOnlyWarningShown] = useState(false);
+    const [isXpubUnverified, setIsXpubUnverified] = useState(false);
 
     if (!qrCodeData) return null;
 
@@ -64,16 +79,35 @@ export const XpubQRCodeBottomSheet = ({
     const handleShowXpub = async () => {
         if (!device || !account) return;
 
+        if (!isImported && isDeviceInViewOnlyMode) {
+            setIsViewOnlyWarningShown(true);
+
+            return;
+        }
+
         setConfirmationInProgress(true);
         const xpubResponse = await showXpubOnDevice(device, account);
 
         if (xpubResponse.success) {
             setIsXpubShown(true);
         } else {
+            if (!USER_CANCELLED_ERROR_CODES.includes(xpubResponse.error.code ?? '')) {
+                showToast({
+                    intent: 'critical',
+                    message: xpubResponse.error.message,
+                    icon: 'warningCircle',
+                });
+            }
             onClose();
         }
 
         setConfirmationInProgress(false);
+    };
+
+    const handleShowUnverifiedXpub = () => {
+        setIsViewOnlyWarningShown(false);
+        setIsXpubUnverified(true);
+        setIsXpubShown(true);
     };
 
     const handleCopyXpub = async () => {
@@ -93,21 +127,29 @@ export const XpubQRCodeBottomSheet = ({
             }
             onClose={handleCancelConfirmation}
         >
-            <VStack spacing="sp24">
-                <XpubQRCodeCard isXpubShown={isXpubShown} qrCodeData={qrCodeData} />
+            {isViewOnlyWarningShown ? (
+                <XpubViewOnlyWarning
+                    onContinue={handleShowUnverifiedXpub}
+                    onBack={() => setIsViewOnlyWarningShown(false)}
+                />
+            ) : (
+                <VStack spacing="sp24">
+                    {isXpubUnverified && <XpubUnverifiedWarning />}
+                    <XpubQRCodeCard isXpubShown={isXpubShown} qrCodeData={qrCodeData} />
 
-                <Box style={applyStyle(buttonStyle)}>
-                    {isXpubShown ? (
-                        <Button onPress={handleCopyXpub}>
-                            <Translation id="moduleAccountManagement.accountSettingsScreen.xpubBottomSheet.copyButton" />
-                        </Button>
-                    ) : (
-                        <Button iconLeft="eye" onPress={handleShowXpub}>
-                            <Translation id="moduleAccountManagement.accountSettingsScreen.xpubBottomSheet.xpub.showButton" />
-                        </Button>
-                    )}
-                </Box>
-            </VStack>
+                    <Box style={applyStyle(buttonStyle)}>
+                        {isXpubShown ? (
+                            <Button onPress={handleCopyXpub}>
+                                <Translation id="moduleAccountManagement.accountSettingsScreen.xpubBottomSheet.copyButton" />
+                            </Button>
+                        ) : (
+                            <Button iconLeft="eye" onPress={handleShowXpub}>
+                                <Translation id="moduleAccountManagement.accountSettingsScreen.xpubBottomSheet.xpub.showButton" />
+                            </Button>
+                        )}
+                    </Box>
+                </VStack>
+            )}
         </BottomSheetModal>
     );
 };

--- a/suite-native/qr-code/src/components/XpubQRCodeBottomSheet.tsx
+++ b/suite-native/qr-code/src/components/XpubQRCodeBottomSheet.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { selectIsDeviceInViewOnlyMode, selectSelectedDevice } from '@suite-common/device';
@@ -16,6 +16,10 @@ import {
     VStack,
 } from '@suite-native/atoms';
 import { useCopyToClipboard } from '@suite-native/clipboard';
+import {
+    DeviceAuthorizationStep,
+    selectDeviceAuthorizationStep,
+} from '@suite-native/device-authorization';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { useToast } from '@suite-native/toasts';
 import TrezorConnect from '@trezor/connect';
@@ -50,7 +54,9 @@ export const XpubQRCodeBottomSheet = ({
     ref,
     accountKey,
 }: XpubQRCodeBottomSheetProps) => {
-    const [confirmationInProgress, setConfirmationInProgress] = useState(false);
+    const showRequestIdRef = useRef(0);
+    const isConfirmationPendingRef = useRef(false);
+    const isTakenOverByDeviceAuthorizationRef = useRef(false);
     const { translate } = useTranslate();
     const { applyStyle } = useNativeStyles();
     const copyToClipboard = useCopyToClipboard();
@@ -61,35 +67,77 @@ export const XpubQRCodeBottomSheet = ({
     );
     const device = useSelector(selectSelectedDevice);
     const isDeviceInViewOnlyMode = useSelector(selectIsDeviceInViewOnlyMode);
+    const deviceAuthorizationStep = useSelector(selectDeviceAuthorizationStep);
 
     const isImported = account?.imported ?? false;
     const [isXpubShown, setIsXpubShown] = useState(isImported);
     const [isViewOnlyWarningShown, setIsViewOnlyWarningShown] = useState(false);
     const [isXpubUnverified, setIsXpubUnverified] = useState(false);
+    const [isConfirmationPending, setIsConfirmationPending] = useState(false);
+
+    const isDeviceAuthorizationActive =
+        deviceAuthorizationStep !== DeviceAuthorizationStep.Idle && isConfirmationPending;
+
+    // The passphrase/PIN screens are pushed UNDER the bottom sheet (sheets render in a root-level
+    // portal), so the sheet has to yield to them and come back once the authorization finishes.
+    // The in-flight request stays alive the whole time (handleDismiss skips the cancel).
+    useEffect(() => {
+        if (!ref || !('current' in ref)) return;
+
+        if (isDeviceAuthorizationActive && !isTakenOverByDeviceAuthorizationRef.current) {
+            isTakenOverByDeviceAuthorizationRef.current = true;
+            ref.current?.dismiss();
+        } else if (!isDeviceAuthorizationActive && isTakenOverByDeviceAuthorizationRef.current) {
+            isTakenOverByDeviceAuthorizationRef.current = false;
+            ref.current?.present();
+        }
+    }, [isDeviceAuthorizationActive, ref]);
 
     if (!qrCodeData) return null;
 
-    const handleCancelConfirmation = () => {
-        if (!confirmationInProgress) return;
-
-        setConfirmationInProgress(false);
-        TrezorConnect.cancel();
-    };
-
     const handleShowXpub = async () => {
-        if (!device || !account) return;
+        if (!device || !account || isConfirmationPendingRef.current) return;
 
-        if (!isImported && isDeviceInViewOnlyMode) {
+        // Desktop parity: a device that is disconnected or unavailable (e.g. passphrase settings
+        // changed since the wallet instance was created) cannot confirm the XPUB on-device.
+        if (!isImported && (!device.connected || !device.available || isDeviceInViewOnlyMode)) {
             setIsViewOnlyWarningShown(true);
 
             return;
         }
 
-        setConfirmationInProgress(true);
-        const xpubResponse = await showXpubOnDevice(device, account);
+        const requestId = ++showRequestIdRef.current;
+        isConfirmationPendingRef.current = true;
+        setIsConfirmationPending(true);
+
+        let xpubResponse;
+        try {
+            xpubResponse = await showXpubOnDevice(device, account);
+        } catch (error) {
+            xpubResponse = {
+                success: false as const,
+                error: {
+                    message: error instanceof Error ? error.message : String(error),
+                    code: 'Failure_UnknownCode',
+                },
+            };
+        }
+
+        // A dismissal invalidated this request and already reset the sheet — the response
+        // (even a successful one) must not touch the state anymore.
+        if (showRequestIdRef.current !== requestId) return;
+
+        isConfirmationPendingRef.current = false;
+        setIsConfirmationPending(false);
+
+        const wasTakenOverByDeviceAuthorization = isTakenOverByDeviceAuthorizationRef.current;
+        isTakenOverByDeviceAuthorizationRef.current = false;
 
         if (xpubResponse.success) {
             setIsXpubShown(true);
+            if (wasTakenOverByDeviceAuthorization && ref && 'current' in ref) {
+                ref.current?.present();
+            }
         } else {
             if (!USER_CANCELLED_ERROR_CODES.includes(xpubResponse.error.code ?? '')) {
                 showToast({
@@ -100,8 +148,6 @@ export const XpubQRCodeBottomSheet = ({
             }
             onClose();
         }
-
-        setConfirmationInProgress(false);
     };
 
     const handleShowUnverifiedXpub = () => {
@@ -118,6 +164,24 @@ export const XpubQRCodeBottomSheet = ({
         onClose();
     };
 
+    // The sheet stays mounted across open/close cycles, so the revealed XPUB must be reset on
+    // every dismissal — desktop parity, where each opening requires a new on-device confirmation.
+    const handleDismiss = () => {
+        // The sheet only yielded to the passphrase/PIN screen — the request stays alive and the
+        // sheet re-presents itself once the authorization finishes.
+        if (isTakenOverByDeviceAuthorizationRef.current) return;
+
+        showRequestIdRef.current += 1;
+        if (isConfirmationPendingRef.current) {
+            isConfirmationPendingRef.current = false;
+            TrezorConnect.cancel();
+        }
+        setIsConfirmationPending(false);
+        setIsXpubShown(isImported);
+        setIsViewOnlyWarningShown(false);
+        setIsXpubUnverified(false);
+    };
+
     return (
         <BottomSheetModal
             ref={ref}
@@ -125,7 +189,7 @@ export const XpubQRCodeBottomSheet = ({
             title={
                 <Translation id="moduleAccountManagement.accountSettingsScreen.xpubBottomSheet.xpub.title" />
             }
-            onClose={handleCancelConfirmation}
+            onDismiss={handleDismiss}
         >
             {isViewOnlyWarningShown ? (
                 <XpubViewOnlyWarning
@@ -135,7 +199,10 @@ export const XpubQRCodeBottomSheet = ({
             ) : (
                 <VStack spacing="sp24">
                     {isXpubUnverified && <XpubUnverifiedWarning />}
-                    <XpubQRCodeCard isXpubShown={isXpubShown} qrCodeData={qrCodeData} />
+                    <XpubQRCodeCard
+                        isXpubShown={isXpubShown || isConfirmationPending}
+                        qrCodeData={qrCodeData}
+                    />
 
                     <Box style={applyStyle(buttonStyle)}>
                         {isXpubShown ? (
@@ -143,8 +210,18 @@ export const XpubQRCodeBottomSheet = ({
                                 <Translation id="moduleAccountManagement.accountSettingsScreen.xpubBottomSheet.copyButton" />
                             </Button>
                         ) : (
-                            <Button iconLeft="eye" onPress={handleShowXpub}>
-                                <Translation id="moduleAccountManagement.accountSettingsScreen.xpubBottomSheet.xpub.showButton" />
+                            <Button
+                                iconLeft="eye"
+                                onPress={handleShowXpub}
+                                isLoading={isConfirmationPending}
+                            >
+                                <Translation
+                                    id={
+                                        isConfirmationPending
+                                            ? 'moduleAccountManagement.accountSettingsScreen.xpubBottomSheet.xpub.confirmOnTrezorButton'
+                                            : 'moduleAccountManagement.accountSettingsScreen.xpubBottomSheet.xpub.showButton'
+                                    }
+                                />
                             </Button>
                         )}
                     </Box>

--- a/suite-native/qr-code/src/components/XpubUnverifiedWarning.tsx
+++ b/suite-native/qr-code/src/components/XpubUnverifiedWarning.tsx
@@ -1,0 +1,16 @@
+import { Box, PictogramTitleHeader } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+export const XpubUnverifiedWarning = () => (
+    <Box paddingHorizontal="sp16">
+        <PictogramTitleHeader
+            variant="warning"
+            title={
+                <Translation id="moduleAccountManagement.accountSettingsScreen.xpubBottomSheet.unverifiedWarning.title" />
+            }
+            subtitle={
+                <Translation id="moduleAccountManagement.accountSettingsScreen.xpubBottomSheet.unverifiedWarning.subtitle" />
+            }
+        />
+    </Box>
+);

--- a/suite-native/qr-code/src/components/XpubViewOnlyWarning.tsx
+++ b/suite-native/qr-code/src/components/XpubViewOnlyWarning.tsx
@@ -1,0 +1,37 @@
+import { Button, Text, VStack } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+type XpubViewOnlyWarningProps = {
+    onContinue: () => void;
+    onBack: () => void;
+};
+
+const buttonWrapperStyle = prepareNativeStyle(() => ({
+    width: '100%',
+}));
+
+export const XpubViewOnlyWarning = ({ onContinue, onBack }: XpubViewOnlyWarningProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <VStack spacing="sp24">
+            <VStack alignItems="center">
+                <Text variant="headline-sm">
+                    <Translation id="moduleAccountManagement.accountSettingsScreen.xpubBottomSheet.viewOnlyWarning.title" />
+                </Text>
+                <Text color="contentSecondary">
+                    <Translation id="moduleAccountManagement.accountSettingsScreen.xpubBottomSheet.viewOnlyWarning.description" />
+                </Text>
+            </VStack>
+            <VStack spacing="sp16" style={applyStyle(buttonWrapperStyle)}>
+                <Button intent="warning" priority="primary" onPress={onContinue}>
+                    <Translation id="moduleAccountManagement.accountSettingsScreen.xpubBottomSheet.viewOnlyWarning.primaryButton" />
+                </Button>
+                <Button intent="warning" priority="secondary" onPress={onBack}>
+                    <Translation id="moduleAccountManagement.accountSettingsScreen.xpubBottomSheet.viewOnlyWarning.secondaryButton" />
+                </Button>
+            </VStack>
+        </VStack>
+    );
+};

--- a/suite-native/qr-code/tsconfig.json
+++ b/suite-native/qr-code/tsconfig.json
@@ -11,6 +11,7 @@
         },
         { "path": "../atoms" },
         { "path": "../clipboard" },
+        { "path": "../device-authorization" },
         { "path": "../icons" },
         { "path": "../intl" },
         { "path": "../toasts" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13965,6 +13965,7 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/clipboard": "workspace:*"
+    "@suite-native/device-authorization": "workspace:*"
     "@suite-native/icons": "workspace:*"
     "@suite-native/intl": "workspace:*"
     "@suite-native/toasts": "workspace:*"


### PR DESCRIPTION
## Description

- user is now warned when device is not connected
- user can now see xpub when device is not connected, device has pin, device has passphrase

## Related Issue
Resolve #10360
Resolve #27194
Resolve #20959

## Screenshots:

No device

https://github.com/user-attachments/assets/ec5370d4-2728-414e-9aad-af34354beb21

Passphrase wallet

https://github.com/user-attachments/assets/5960342c-ba0d-4e3f-aa91-82e9cd18d497

<img width="1055" height="938" alt="Screenshot 2026-08-23 at 11 12 02" src="https://github.com/user-attachments/assets/5f3d0353-ec1e-43f7-9fe3-c00beaf0d523" />


Pin device

https://github.com/user-attachments/assets/a970e020-f50d-469d-8078-22058b353961


Standard wallet

https://github.com/user-attachments/assets/95b596bd-a4d4-41c5-86c2-443f7d1ef13a


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is dominated by suite-native mobile files (XPUB QR code components, device authorization, intl) which are not covered by the desktop/web E2E suite listed. The only shared source is suite-common/wallet-core/src/device/deviceAddressUtils.ts, a broad utility. The recommended strategy is to run a tight set of address/XPUB-focused E2E tests that directly exercise the shared utility, led by receive flows, public key display, and TrezorConnect getAddress.

<details><summary><b>Changed files (9)</b></summary>

- `suite-common/wallet-core/src/device/deviceAddressUtils.ts`
- `suite-native/device-authorization/src/utils.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-accounts-management/src/screens/AccountSettingsScreen.test.tsx`
- `suite-native/qr-code/package.json`
- `suite-native/qr-code/src/components/XpubQRCodeBottomSheet.tsx`
- `suite-native/qr-code/src/components/XpubUnverifiedWarning.tsx`
- `suite-native/qr-code/src/components/XpubViewOnlyWarning.tsx`
- `suite-native/qr-code/tsconfig.json`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Directly exercises TrezorConnect.getAddress and address confirmation UI across single, bundle, and forced on-device confirmation flows. A regression in shared device address utilities would surface here immediately.
- `suite/e2e/tests/wallet/public-keys.test.ts` — Verifies showing and confirming XPUB/public keys for BTC, LTC, and ADA accounts. This is the closest desktop analog to the native XPUB QR code feature and directly relies on device address derivation utilities.
- `suite/e2e/tests/wallet/receive.test.ts` — Covers receive address generation, device verification, clipboard matching, and QR code encoding for BTC, ETH, SOL, and TRX. QR code path is especially relevant given the native QR code XPUB changes.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — Validates Cardano receive address verification against expected tetragram-formatted addresses. Changes to cross-coin address utilities could affect ADA address derivation/display.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — Tests global receive flow including account filtering, new account creation, and address verification on device. Shares address generation and verification infrastructure with the changed utilities.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Uses address selection dropdown and BIP84 address derivation for Bitcoin message signing. Address formatting/selection paths could be impacted by device address utility changes.

</details>

⚠️ **Changes with no test coverage (8)**
- `suite-native/device-authorization/src/utils.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-accounts-management/src/screens/AccountSettingsScreen.test.tsx`
- `suite-native/qr-code/package.json`
- `suite-native/qr-code/src/components/XpubQRCodeBottomSheet.tsx`
- `suite-native/qr-code/src/components/XpubUnverifiedWarning.tsx`
- `suite-native/qr-code/src/components/XpubViewOnlyWarning.tsx`
- `suite-native/qr-code/tsconfig.json`

_Updated: 2026-08-23T09:01:24.528Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/10360-xpub-unverified-warning/web/](https://dev.suite.sldev.cz/suite-web/feat/10360-xpub-unverified-warning/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/10360-xpub-unverified-warning&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/10360-xpub-unverified-warning&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-23T09:03:15.576Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-23T09:03:48.006Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->
