### PR TITLE
fix(suite-native): group pending transactions with known time by date

### DIFF
--- a/suite-native/transactions/src/components/TransactionList.tsx
+++ b/suite-native/transactions/src/components/TransactionList.tsx
@@ -15,7 +15,7 @@ import {
     selectIsPageAlreadyFetched,
 } from '@suite-common/wallet-core';
 import { type Account, type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
-import { type MonthKey, groupTransactionsByDate, isPending } from '@suite-common/wallet-utils';
+import { type MonthKey } from '@suite-common/wallet-utils';
 import { Box } from '@suite-native/atoms';
 import { useScrollDivider } from '@suite-native/scrollview';
 import {
@@ -27,7 +27,6 @@ import {
     selectAccountYieldTypeTransactionsWithTokenTransfers,
 } from '@suite-native/tokens';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
-import { arrayPartition } from '@trezor/utils';
 
 import { TokenTransferListItem } from './TokenTransferListItem';
 import { TransactionListGroupTitle } from './TransactionListGroupTitle';
@@ -35,6 +34,7 @@ import { TransactionListItem } from './TransactionListItem';
 import { TransactionsEmptyState } from './TransactionsEmptyState';
 import { TransactionsListFooter } from './TransactionsListFooter';
 import { useFetchMissingTransactionFiatRates } from '../hooks/useFetchMissingTransactionFiatRates';
+import { groupTransactionsByMonthWithPending } from '../utils';
 
 type RenderSectionHeaderParams = {
     section: {
@@ -78,14 +78,6 @@ const sortKeysPendingFirst = (a: string, b: string) => {
     const dateB = new Date(b);
 
     return dateB.getTime() - dateA.getTime();
-};
-
-const sortPendingTransactions = (a: WalletAccountTransaction, b: WalletAccountTransaction) => {
-    if (a.blockTime === undefined && b.blockTime === undefined) return 0;
-    if (a.blockTime === undefined) return -1;
-    if (b.blockTime === undefined) return 1;
-
-    return a.blockTime - b.blockTime;
 };
 
 const renderTransactionItem = ({
@@ -219,18 +211,7 @@ export const TransactionList = ({
     }, [dispatch, accountKey, txnsPerPage]);
 
     const data = useMemo((): TransactionListItem[] => {
-        // groupTransactionsByDate now sorts also pending transactions, if they have blockTime set.
-        // This is here to keep the original behavior of having pending transactions in one group
-        // at the beginning of the list.
-        const [pendingTxs, confirmedTxs] = arrayPartition(transactions, isPending);
-        const accountTransactionsByMonth = groupTransactionsByDate(confirmedTxs, 'month');
-        if (pendingTxs.length || accountTransactionsByMonth['no-blocktime']) {
-            accountTransactionsByMonth['pending'] = [
-                ...(accountTransactionsByMonth['no-blocktime'] ?? []),
-                ...pendingTxs.sort(sortPendingTransactions),
-            ];
-            delete accountTransactionsByMonth['no-blocktime'];
-        }
+        const accountTransactionsByMonth = groupTransactionsByMonthWithPending(transactions);
 
         const transactionMonthKeys = Object.keys(accountTransactionsByMonth).sort(
             sortKeysPendingFirst,

--- a/suite-native/transactions/src/utils.test.ts
+++ b/suite-native/transactions/src/utils.test.ts
@@ -8,6 +8,7 @@ import {
 import { type VinVoutAddress } from './types';
 import {
     groupTargetOutputs,
+    groupTransactionsByMonthWithPending,
     mapTransactionInputsOutputsToAddresses,
     sortTargetAddressesToBeginning,
 } from './utils';
@@ -245,5 +246,59 @@ describe(groupTargetOutputs.name, () => {
         };
         const result = groupTargetOutputs([noAmount, makeSimpleTarget('500', 1)]);
         expect(result[0]).toMatchObject({ type: 'target', payload: { amount: '500' } });
+    });
+});
+
+describe(groupTransactionsByMonthWithPending.name, () => {
+    const confirmedTransaction = transactionWithTargetInOutputs;
+
+    const pendingWithBlockTime = {
+        ...transactionWithTargetInOutputs,
+        txid: 'pending-with-blocktime',
+        blockHeight: undefined,
+        blockTime: 1639707387,
+    };
+
+    const pendingWithoutBlockTime = {
+        ...transactionWithTargetInOutputs,
+        txid: 'pending-without-blocktime',
+        blockHeight: undefined,
+        blockTime: undefined,
+    };
+
+    test('groups pending transaction with blockTime into its real month', () => {
+        const groups = groupTransactionsByMonthWithPending([
+            confirmedTransaction,
+            pendingWithBlockTime,
+        ]);
+
+        expect(groups['pending']).toBeUndefined();
+        const monthGroup = Object.values(groups).find(transactions =>
+            transactions.some(transaction => transaction.txid === 'pending-with-blocktime'),
+        );
+        expect(monthGroup).toBeDefined();
+        expect(monthGroup).toContainEqual(
+            expect.objectContaining({ txid: confirmedTransaction.txid }),
+        );
+    });
+
+    test('groups pending transaction without blockTime into a leading pending group', () => {
+        const groups = groupTransactionsByMonthWithPending([
+            confirmedTransaction,
+            pendingWithoutBlockTime,
+        ]);
+
+        expect(groups['pending']).toEqual([
+            expect.objectContaining({ txid: 'pending-without-blocktime' }),
+        ]);
+        expect(Object.keys(groups)[0]).toBe('pending');
+    });
+
+    test('returns only month groups when nothing is pending', () => {
+        const groups = groupTransactionsByMonthWithPending([confirmedTransaction]);
+
+        expect(groups['pending']).toBeUndefined();
+        expect(groups['no-blocktime']).toBeUndefined();
+        expect(Object.keys(groups)).toHaveLength(1);
     });
 });

--- a/suite-native/transactions/src/utils.ts
+++ b/suite-native/transactions/src/utils.ts
@@ -4,9 +4,11 @@ import { type SignValue } from '@suite-common/suite-types';
 import { type Target as ProcessedTarget, createSimpleTargetId } from '@suite-common/wallet-core';
 import { type TransactionType, type WalletAccountTransaction } from '@suite-common/wallet-types';
 import {
+    type GroupedTransactionsByDate,
     getTxStakeNameByDataHex,
     getTxStakeType,
     getUnstakeAmountByEthereumDataHex,
+    groupTransactionsByDate,
 } from '@suite-common/wallet-utils';
 import { type EnhancedVinVout, type Target } from '@trezor/blockchain-link-types';
 import { BigNumber, isNotNullOrUndefined } from '@trezor/utils';
@@ -98,4 +100,19 @@ export const getUnstakeTxAmount = (tx: WalletAccountTransaction) => {
     }
 
     return getUnstakeAmountByEthereumDataHex(tx.ethereumSpecific?.data) ?? undefined;
+};
+
+export const groupTransactionsByMonthWithPending = (
+    transactions: WalletAccountTransaction[],
+): GroupedTransactionsByDate => {
+    const { 'no-blocktime': pendingTransactions, ...monthGroups } = groupTransactionsByDate(
+        transactions,
+        'month',
+    );
+
+    if (!pendingTransactions) {
+        return monthGroups;
+    }
+
+    return { pending: pendingTransactions, ...monthGroups };
 };


### PR DESCRIPTION
> [!IMPORTANT]
> NOT READY FOR REVIEW

## Description

Mobile forced every pending transaction into a single "Pending" section via a local monkey-patch, while desktop (intentionally, since 2024) groups pending txs that carry a known time under their real date headers. Mobile now adopts the desktop semantics: the monkey-patch is removed and grouping goes through a new pure `groupTransactionsByMonthWithPending` util — pending txs with a known time land in their real month sections, and the leading "Pending" section remains only for txs with no time at all. Pending row indicators are unaffected (they key off `isPending` per transaction, not the section). Covered by unit tests for all three grouping cases.

## Notes for QA
Compare the same account with pending txs on mobile and desktop — a just-broadcast tx (known time) appears under today's date section on both; a mempool tx without a time sits in "Pending" first. Note: the 12/24-hour format difference (desktop hard-codes 24 h, mobile follows the app setting) is pre-existing and out of scope.

## Related Issue

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/8419-pending-tx-date-groups&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->
