### PR TITLE
feat(suite-native): surface failed discovery with warning and retry

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsSelectors.ts
+++ b/suite-common/wallet-core/src/accounts/accountsSelectors.ts
@@ -105,7 +105,7 @@ export const selectDeviceAccountForNetworkSymbolAndAccountTypeWithIndex = create
     (accounts, accountIndex) => {
         if (accountIndex === undefined || accountIndex < 0) return undefined;
 
-        return accounts[accountIndex];
+        return accounts.find(account => account.index === accountIndex);
     },
 );
 

--- a/suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts
+++ b/suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts
@@ -2,12 +2,13 @@ import type { DeviceRootState } from '@suite-common/device';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { networks } from '@suite-common/wallet-config';
-import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
 import { type AccountsRootState } from '../accountsReducer';
 import {
     selectAddressByNetworkAndPath,
+    selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex,
     selectVisibleDeviceAccountsMap,
 } from '../accountsSelectors';
 
@@ -229,6 +230,108 @@ describe('accountsSelectors', () => {
             expect(result.get(btcAccount.key)).toEqual(
                 expect.objectContaining({ key: btcAccount.key }),
             );
+        });
+    });
+
+    describe('selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex', () => {
+        const mockSolAccount = (override: Partial<Account>): Account =>
+            ({
+                symbol: 'sol',
+                accountType: 'normal',
+                index: 0,
+                deviceState: BTC_DEVICE_SSID,
+                visible: true,
+                key: mockAccountKey({
+                    descriptor: `descriptor${override.index ?? 0}`,
+                    symbol: 'sol',
+                    deviceStaticSessionId: BTC_DEVICE_SSID,
+                }),
+                ...override,
+            }) as unknown as Account;
+
+        const createState = (accounts: Account[]): AccountsRootState & DeviceRootState =>
+            getStateWithSelectedDevice(
+                {
+                    wallet: { accounts },
+                    device: { devices: [BTC_DEVICE], persistentDeviceData: [] },
+                },
+                BTC_DEVICE,
+            );
+
+        it('matches by account index field even when indexes are not contiguous', () => {
+            const account = mockSolAccount({ index: 2 });
+            const state = createState([mockSolAccount({ index: 0 }), account]);
+
+            expect(
+                selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex(
+                    state,
+                    'sol',
+                    'normal',
+                    2,
+                ),
+            ).toBe(account.key);
+        });
+
+        it('resolves the replacement key after a failed account is replaced in place', () => {
+            const failedAccount = mockSolAccount({
+                key: mockAccountKey({
+                    descriptor: 'failed:0:sol:normal',
+                    symbol: 'sol',
+                    deviceStaticSessionId: BTC_DEVICE_SSID,
+                }),
+                failed: true,
+            });
+            const replacementAccount = mockSolAccount({ visible: false });
+
+            expect(
+                selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex(
+                    createState([failedAccount]),
+                    'sol',
+                    'normal',
+                    0,
+                ),
+            ).toBe(failedAccount.key);
+            expect(
+                selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex(
+                    createState([replacementAccount]),
+                    'sol',
+                    'normal',
+                    0,
+                ),
+            ).toBe(replacementAccount.key);
+        });
+
+        it('does not match an account of another device', () => {
+            const otherDeviceAccount = mockSolAccount({
+                deviceState: ETH_DEVICE_SSID,
+                key: mockAccountKey({
+                    descriptor: 'descriptor0',
+                    symbol: 'sol',
+                    deviceStaticSessionId: ETH_DEVICE_SSID,
+                }),
+            });
+
+            expect(
+                selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex(
+                    createState([otherDeviceAccount]),
+                    'sol',
+                    'normal',
+                    0,
+                ),
+            ).toBeUndefined();
+        });
+
+        it('does not match an account of another account type with the same index', () => {
+            const legacyAccount = mockSolAccount({ accountType: 'legacy' });
+
+            expect(
+                selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex(
+                    createState([legacyAccount]),
+                    'sol',
+                    'normal',
+                    0,
+                ),
+            ).toBeUndefined();
         });
     });
 });

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -10,6 +10,7 @@ import { type Account, type ReviewOutput } from '@suite-common/wallet-types';
 import {
     findAccountsByAddress,
     isAccountDiscoverable,
+    isAccountFailed,
     tryGetAccountIdentity,
 } from '@suite-common/wallet-utils';
 import { type ContractInfoProtocol } from '@trezor/blockchain-link-types/src/blockbook';
@@ -93,7 +94,7 @@ const getDeviceAccountsPerEnabledNetwork = (
     return symbols.map(symbol => ({ symbol, accounts: symbolMap[symbol] }));
 };
 
-const getLastAccountsPerAccountType = (accounts: Account[]) =>
+const getAccountChainsPerAccountType = (accounts: Account[]) =>
     Object.entries(arrayToDictionary(accounts, acc => acc.accountType, true)).map(
         ([type, accs]) => ({
             type,
@@ -101,6 +102,13 @@ const getLastAccountsPerAccountType = (accounts: Account[]) =>
             lastAccount: accs.reduce((last, current) =>
                 current.index > last.index ? current : last,
             ),
+            // failed account with the lowest index; a failed account may sit below other known
+            // accounts when a known-accounts refresh fails for some of them (e.g. flaky backend)
+            firstFailedAccount: accs
+                .filter(isAccountFailed)
+                .reduce<
+                    Account | undefined
+                >((first, current) => (!first || current.index < first.index ? current : first), undefined),
         }),
     );
 
@@ -126,14 +134,16 @@ export const selectDiscoveryAccountsParam = (
                 gap: bitcoinGap,
             } as DiscoveryAccountsParam[number];
 
-        const known = getLastAccountsPerAccountType(accounts).map(({ type, lastAccount }) => {
-            // last account is a failed one; try to discover it again
-            if (lastAccount.failed) return { type, skip: lastAccount.index };
-            // last account is a used one; skip it and try to discover next one
-            else if (!lastAccount.empty) return { type, skip: lastAccount.index + 1 };
-            // last account is an empty one; skip this type completely
-            else return { type };
-        });
+        const known = getAccountChainsPerAccountType(accounts).map(
+            ({ type, lastAccount, firstFailedAccount }) => {
+                // some account failed; rediscover the whole chain from the first failed one
+                if (firstFailedAccount) return { type, skip: firstFailedAccount.index };
+                // last account is a used one; skip it and try to discover next one
+                else if (!lastAccount.empty) return { type, skip: lastAccount.index + 1 };
+                // last account is an empty one; skip this type completely
+                else return { type };
+            },
+        );
 
         return {
             symbol,
@@ -175,7 +185,7 @@ export const selectShouldRediscover = (
     return getDeviceAccountsPerEnabledNetwork(state, staticSessionId).some(
         ({ accounts }) =>
             !accounts ||
-            getLastAccountsPerAccountType(accounts).some(
+            getAccountChainsPerAccountType(accounts).some(
                 ({ lastAccount }) => !lastAccount.failed && !lastAccount.empty,
             ),
     );

--- a/suite-common/wallet-core/src/tests/selectors.test.ts
+++ b/suite-common/wallet-core/src/tests/selectors.test.ts
@@ -1,0 +1,75 @@
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { type Account } from '@suite-common/wallet-types';
+
+import { selectDiscoveryAccountsParam } from '../selectors';
+
+const STATIC_SESSION_ID: `${string}@${string}:${number}` =
+    'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@ABC123:1';
+const DEVICE = mockSuiteDevice({ state: { staticSessionId: STATIC_SESSION_ID } });
+
+const mockSolAccount = (override: Partial<Account>): Account =>
+    ({
+        symbol: 'sol',
+        accountType: 'normal',
+        index: 0,
+        deviceState: STATIC_SESSION_ID,
+        empty: false,
+        visible: true,
+        ...override,
+    }) as unknown as Account;
+
+const getState = (accounts: Account[]) =>
+    ({
+        wallet: {
+            accounts,
+            settings: { enabledNetworks: ['sol'] },
+            blockchain: {},
+        },
+        device: { devices: [DEVICE], selectedDevice: DEVICE, persistentDeviceData: [] },
+    }) as any;
+
+const getSolKnown = (accounts: Account[]) =>
+    selectDiscoveryAccountsParam(getState(accounts), STATIC_SESSION_ID).find(
+        coin => coin.symbol === 'sol',
+    )?.known;
+
+describe('selectDiscoveryAccountsParam', () => {
+    it('rediscovers from a failed account at the end of the chain', () => {
+        expect(getSolKnown([mockSolAccount({ failed: true, empty: true })])).toEqual([
+            { type: 'normal', skip: 0 },
+        ]);
+    });
+
+    it('rediscovers from the first failed account even when it sits below other accounts', () => {
+        expect(
+            getSolKnown([
+                mockSolAccount({ index: 0 }),
+                mockSolAccount({ index: 1, failed: true, empty: true }),
+                mockSolAccount({ index: 2 }),
+                mockSolAccount({ index: 3, empty: true, visible: false }),
+            ]),
+        ).toEqual([{ type: 'normal', skip: 1 }]);
+    });
+
+    it('continues discovery after the last used account when nothing failed', () => {
+        expect(getSolKnown([mockSolAccount({ index: 0 })])).toEqual([{ type: 'normal', skip: 1 }]);
+    });
+
+    it('skips a completely discovered account type', () => {
+        expect(
+            getSolKnown([
+                mockSolAccount({ index: 0 }),
+                mockSolAccount({ index: 1, empty: true, visible: false }),
+            ]),
+        ).toEqual([{ type: 'normal' }]);
+    });
+
+    it('handles each account type independently', () => {
+        expect(
+            getSolKnown([
+                mockSolAccount({ index: 0, empty: true }),
+                mockSolAccount({ accountType: 'ledger', index: 0, failed: true, empty: true }),
+            ]),
+        ).toEqual([{ type: 'normal' }, { type: 'ledger', skip: 0 }]);
+    });
+});

--- a/suite-native/accounts/src/components/AccountDetailsCard.tsx
+++ b/suite-native/accounts/src/components/AccountDetailsCard.tsx
@@ -83,7 +83,6 @@ export const AccountDetailsCard = ({
                 ) : (
                     <AccountsListItem
                         account={account}
-                        isCryptoBalancePrimary={isStakeVariant}
                         titleLabel={titleLabel}
                         cryptoAmount={cryptoAmount}
                     />

--- a/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { type AccountsRootState, selectFormattedAccountType } from '@suite-common/wallet-core';
 import { type Account, type AccountKey } from '@suite-common/wallet-types';
+import { isAccountFailed } from '@suite-common/wallet-utils';
 import { Badge } from '@suite-native/atoms';
 import {
     BaseCurrencyAmountFormatter,
@@ -10,7 +11,7 @@ import {
     CryptoToFiatAmountFormatter,
     NetworkDisplaySymbolNameFormatter,
 } from '@suite-native/formatters';
-import { CryptoIcon, CryptoIconWithNetwork } from '@suite-native/icons';
+import { CryptoIcon, CryptoIconWithNetwork, Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { type NativeStakingRootState, selectAccountHasStaking } from '@suite-native/staking';
 import { isNetworkWithTokens } from '@suite-native/tokens';
@@ -138,6 +139,11 @@ const AccountsListItemComponent = ({
         />
     );
 
+    const isFailed = isAccountFailed(account);
+    const [primaryBalanceValue, secondaryBalanceValue] = isCryptoBalancePrimary
+        ? [cryptoBalanceValue, fiatBalanceValue]
+        : [fiatBalanceValue, cryptoBalanceValue];
+
     const getTitle = () => {
         if (titleLabel) {
             return titleLabel;
@@ -175,8 +181,14 @@ const AccountsListItemComponent = ({
                     {shouldShowTokenBadge && <TokenBadge accountKey={account.key} />}
                 </>
             }
-            mainValue={isCryptoBalancePrimary ? cryptoBalanceValue : fiatBalanceValue}
-            secondaryValue={isCryptoBalancePrimary ? fiatBalanceValue : cryptoBalanceValue}
+            mainValue={
+                isFailed ? (
+                    <Icon name="warning" color="contentWarning" size="medium" />
+                ) : (
+                    primaryBalanceValue
+                )
+            }
+            secondaryValue={isFailed ? undefined : secondaryBalanceValue}
         />
     );
 };

--- a/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
@@ -35,15 +35,9 @@ type AccountListItemProps = {
     isFirst?: boolean;
     isLast?: boolean;
     showDivider?: boolean;
-    isCryptoBalancePrimary?: boolean;
     titleLabel?: React.ReactNode;
     cryptoAmount?: string;
 };
-
-const CRYPTO_PRIMARY_BALANCE_TEXT_PROPS = [
-    { variant: 'body-md-strong' as const, color: 'contentPrimary' as const },
-    { variant: 'body-sm' as const, color: 'contentSecondary' as const },
-];
 
 const TokenBadge = React.memo(({ accountKey }: { accountKey: AccountKey }) => {
     const numberOfTokens = useSelector((state: NativeAccountsRootState) =>
@@ -67,7 +61,6 @@ const AccountsListItemComponent = ({
     isFirst = false,
     isLast = false,
     showDivider = false,
-    isCryptoBalancePrimary = false,
     titleLabel,
     cryptoAmount,
 }: AccountListItemProps) => {
@@ -105,13 +98,8 @@ const AccountsListItemComponent = ({
 
     const isNetworkSupportingTokens = isNetworkWithTokens(account.symbol);
     const shouldShowAccountLabel = !isNetworkSupportingTokens || !isNativeCoinOnly;
-    const shouldShowTokenBadge =
-        accountHasKnownTokensWithBalance && !isNativeCoinOnly && !isCryptoBalancePrimary;
-    const shouldShowStakingBadge =
-        accountHasStaking && !isNativeCoinOnly && !isCryptoBalancePrimary;
-    const [primaryBalanceTextProps, secondaryBalanceTextProps] = isCryptoBalancePrimary
-        ? CRYPTO_PRIMARY_BALANCE_TEXT_PROPS
-        : [undefined, undefined];
+    const shouldShowTokenBadge = accountHasKnownTokensWithBalance && !isNativeCoinOnly;
+    const shouldShowStakingBadge = accountHasStaking && !isNativeCoinOnly;
     const balanceValue = cryptoAmount ?? account.formattedBalance;
     const fiatBalanceValue =
         shouldShowTokenBadge && fiatBalance !== undefined ? (
@@ -119,14 +107,12 @@ const AccountsListItemComponent = ({
                 numberOfLines={1}
                 adjustsFontSizeToFit
                 value={fiatBalance}
-                {...secondaryBalanceTextProps}
             />
         ) : (
             <CryptoToFiatAmountFormatter
                 value={balanceValue}
                 isBalance={true}
                 symbol={account.symbol}
-                {...secondaryBalanceTextProps}
             />
         );
     const cryptoBalanceValue = (
@@ -135,14 +121,10 @@ const AccountsListItemComponent = ({
             symbol={account.symbol}
             numberOfLines={1}
             adjustsFontSizeToFit
-            {...primaryBalanceTextProps}
         />
     );
 
     const isFailed = isAccountFailed(account);
-    const [primaryBalanceValue, secondaryBalanceValue] = isCryptoBalancePrimary
-        ? [cryptoBalanceValue, fiatBalanceValue]
-        : [fiatBalanceValue, cryptoBalanceValue];
 
     const getTitle = () => {
         if (titleLabel) {
@@ -185,10 +167,10 @@ const AccountsListItemComponent = ({
                 isFailed ? (
                     <Icon name="warning" color="contentWarning" size="medium" />
                 ) : (
-                    primaryBalanceValue
+                    fiatBalanceValue
                 )
             }
-            secondaryValue={isFailed ? undefined : secondaryBalanceValue}
+            secondaryValue={isFailed ? undefined : cryptoBalanceValue}
         />
     );
 };

--- a/suite-native/accounts/src/hooks/useResolvedAccountKey.ts
+++ b/suite-native/accounts/src/hooks/useResolvedAccountKey.ts
@@ -1,0 +1,69 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+
+import { type DeviceRootState } from '@suite-common/device';
+import { type AccountType, type NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type AccountsRootState,
+    selectAccountByKey,
+    selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex,
+} from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+import { isAccountFailed } from '@suite-common/wallet-utils';
+
+type AccountIdentity = {
+    networkSymbol: NetworkSymbol;
+    accountType: AccountType;
+    accountIndex: number;
+};
+
+type UseResolvedAccountKeyArgs = Partial<AccountIdentity> & {
+    accountKey?: AccountKey;
+    setParams: (identity: AccountIdentity) => void;
+};
+
+/**
+ * Resolves the account key from the route params. The route's account key wins while its account
+ * exists; once it disappears, the account identity (symbol + type + index) of the selected device
+ * takes over. While a failed account is displayed, its identity is persisted to the route params,
+ * so that after a discovery retry replaces the account under a new key, the screen re-resolves to
+ * the replacement automatically (mirroring desktop routing).
+ */
+export const useResolvedAccountKey = ({
+    accountKey: routeAccountKey,
+    networkSymbol,
+    accountType,
+    accountIndex,
+    setParams,
+}: UseResolvedAccountKeyArgs) => {
+    const identityAccountKey = useSelector((state: AccountsRootState & DeviceRootState) =>
+        selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex(
+            state,
+            networkSymbol,
+            accountType,
+            accountIndex,
+        ),
+    );
+
+    const routeKeyAccount = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, routeAccountKey),
+    );
+
+    const accountKey = routeKeyAccount ? routeAccountKey : (identityAccountKey ?? routeAccountKey);
+
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+
+    useEffect(() => {
+        if (account && isAccountFailed(account) && networkSymbol === undefined) {
+            setParams({
+                networkSymbol: account.symbol,
+                accountType: account.accountType,
+                accountIndex: account.index,
+            });
+        }
+    }, [account, networkSymbol, setParams]);
+
+    return accountKey;
+};

--- a/suite-native/accounts/src/index.ts
+++ b/suite-native/accounts/src/index.ts
@@ -13,6 +13,7 @@ export * from './components/AccountLabelFieldHint';
 export * from './components/AccountDetailsCard';
 export * from './components/TokenReceiveCard';
 export * from './hooks/useAccountLabelForm';
+export * from './hooks/useResolvedAccountKey';
 export * from './selectors';
 export * from './hooks/useAccountAlerts';
 export * from './utils';

--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -48,6 +48,7 @@ import {
     getAccountFiatBalance,
     getAccountTotalStakingBalance,
     getFiatRateKey,
+    isAccountFailed,
     isCardanoStakingActive,
     isErc4626,
     isStakingSymbol,
@@ -433,6 +434,20 @@ export const selectFreshAccountAddress = createMemoizedSelector(
     [selectAccountByKey, selectPendingAccountAddresses, selectIsAccountUtxoBased],
     (account, pendingAddresses, isAccountUtxoBased) =>
         account ? getFirstFreshAddress(account, [], pendingAddresses, isAccountUtxoBased) : null,
+);
+
+export const selectIsAccountDiscoveryFailed = createMemoizedSelector(
+    [selectAccountByKey],
+    account => !!account && isAccountFailed(account),
+);
+
+export const selectHasDeviceAnyFailedAccountForNetworkSymbol = createMemoizedSelector(
+    [
+        selectVisibleDeviceAccounts,
+        (_state: NativeAccountsRootState, networkSymbol: NetworkSymbol) => networkSymbol,
+    ],
+    (accounts, networkSymbol) =>
+        accounts.some(account => account.symbol === networkSymbol && isAccountFailed(account)),
 );
 
 export const selectHasDeviceAnySendAvailableAccount = createMemoizedSelector(

--- a/suite-native/accounts/src/tests/selectors.test.ts
+++ b/suite-native/accounts/src/tests/selectors.test.ts
@@ -6,7 +6,12 @@ import {
 } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
-import { getAccountListSections, selectFreshAccountAddress } from '../selectors';
+import {
+    getAccountListSections,
+    selectFreshAccountAddress,
+    selectHasDeviceAnyFailedAccountForNetworkSymbol,
+    selectIsAccountDiscoveryFailed,
+} from '../selectors';
 import { isFilterValueMatchingAccount, sortAccountsByNetworksAndAccountTypes } from '../utils';
 
 let mockStakingBalance = '0';
@@ -347,5 +352,78 @@ describe('getAccountListSections', () => {
         expect(sections[1]?.type).toBe('staking');
         expect(sections[2]?.type).toBe('token');
         expect(sections[3]?.type).toBe('token');
+    });
+});
+
+describe('selectIsAccountDiscoveryFailed', () => {
+    const staticSessionId = 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@ABC123:1';
+
+    const failedAccount = {
+        key: `failed:0:sol:normal-sol-${staticSessionId}`,
+        descriptor: 'failed:0:sol:normal',
+        symbol: 'sol',
+        accountType: 'normal',
+        index: 0,
+        deviceState: staticSessionId,
+        visible: true,
+        failed: true,
+        error: 'Network request failed',
+    } as unknown as Account;
+
+    const normalAccount = {
+        key: `descriptor1-sol-${staticSessionId}`,
+        descriptor: 'descriptor1',
+        symbol: 'sol',
+        accountType: 'normal',
+        index: 0,
+        deviceState: staticSessionId,
+        visible: true,
+    } as unknown as Account;
+
+    const getState = (accounts: Account[]) =>
+        ({
+            wallet: { accounts },
+            device: { selectedDevice: { state: { staticSessionId } }, devices: [] },
+        }) as any;
+
+    it('returns true for a failed account', () => {
+        expect(selectIsAccountDiscoveryFailed(getState([failedAccount]), failedAccount.key)).toBe(
+            true,
+        );
+    });
+
+    it('returns false for a normal account', () => {
+        expect(selectIsAccountDiscoveryFailed(getState([normalAccount]), normalAccount.key)).toBe(
+            false,
+        );
+    });
+
+    it('returns false for an unknown account key', () => {
+        expect(selectIsAccountDiscoveryFailed(getState([normalAccount]), failedAccount.key)).toBe(
+            false,
+        );
+    });
+
+    describe('selectHasDeviceAnyFailedAccountForNetworkSymbol', () => {
+        it('returns true when any account of the network failed', () => {
+            expect(
+                selectHasDeviceAnyFailedAccountForNetworkSymbol(
+                    getState([normalAccount, failedAccount]),
+                    'sol',
+                ),
+            ).toBe(true);
+        });
+
+        it('returns false when no account of the network failed', () => {
+            expect(
+                selectHasDeviceAnyFailedAccountForNetworkSymbol(getState([normalAccount]), 'sol'),
+            ).toBe(false);
+        });
+
+        it('returns false for another network', () => {
+            expect(
+                selectHasDeviceAnyFailedAccountForNetworkSymbol(getState([failedAccount]), 'btc'),
+            ).toBe(false);
+        });
     });
 });

--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -4,7 +4,12 @@ import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { AccountsListItemBase } from '@suite-native/accounts';
+import {
+    AccountsListItemBase,
+    type NativeAccountsRootState,
+    selectHasDeviceAnyFailedAccountForNetworkSymbol,
+} from '@suite-native/accounts';
+import { Icon } from '@suite-native/icons';
 import {
     AccountsStackRoutes,
     type AppTabsParamList,
@@ -48,6 +53,9 @@ export const AssetItem = memo(({ cryptoCurrencySymbol }: AssetItemProps) => {
     const hasAnyAccountsWithStaking = useSelector((state: NativeStakingRootState) =>
         selectHasAnyDeviceAccountsWithStaking(state, cryptoCurrencySymbol),
     );
+    const hasAnyFailedAccount = useSelector((state: NativeAccountsRootState) =>
+        selectHasDeviceAnyFailedAccountForNetworkSymbol(state, cryptoCurrencySymbol),
+    );
 
     const handleAssetPress = useCallback(() => {
         // A single tokenless account opens its detail directly; anything else opens the list.
@@ -78,8 +86,16 @@ export const AssetItem = memo(({ cryptoCurrencySymbol }: AssetItemProps) => {
             icon={<PercentageIcon symbol={cryptoCurrencySymbol} />}
             title={<AssetItemTitle symbol={cryptoCurrencySymbol} />}
             badges={<AssetItemBadges symbol={cryptoCurrencySymbol} />}
-            mainValue={<FiatAmount symbol={cryptoCurrencySymbol} />}
-            secondaryValue={<CryptoAmount symbol={cryptoCurrencySymbol} />}
+            mainValue={
+                hasAnyFailedAccount ? (
+                    <Icon name="warning" color="contentWarning" size="medium" />
+                ) : (
+                    <FiatAmount symbol={cryptoCurrencySymbol} />
+                )
+            }
+            secondaryValue={
+                hasAnyFailedAccount ? undefined : <CryptoAmount symbol={cryptoCurrencySymbol} />
+            }
         />
     );
 });

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1874,6 +1874,12 @@ export const messages = {
         },
     },
     moduleAccountManagement: {
+        discoveryFailedBanner: {
+            title: 'Account couldn’t be loaded',
+            description:
+                'Something went wrong while loading this account. Check your internet connection and try again.',
+            retryButton: 'Retry',
+        },
         accountsScreen: {
             title: 'My assets',
             networkFilter: {

--- a/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsScreenHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsScreenHeader.tsx
@@ -4,6 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
+import { isAccountFailed } from '@suite-common/wallet-utils';
 import {
     AccountLabel,
     type NativeAccountsRootState,
@@ -52,11 +53,13 @@ const AccountAssetsScreenHeaderContent = ({ accountKey }: Omit<Props, 'flowType'
                     numberOfLines={1}
                     showAccountTypeBadge
                 />
-                <BaseCurrencyAmountFormatter
-                    value={fiatBalance}
-                    variant="body-sm"
-                    color="contentSecondary"
-                />
+                {!isAccountFailed(account) && (
+                    <BaseCurrencyAmountFormatter
+                        value={fiatBalance}
+                        variant="body-sm"
+                        color="contentSecondary"
+                    />
+                )}
             </VStack>
         </HStack>
     );

--- a/suite-native/module-accounts-management/src/components/AccountBanners/AccountDiscoveryFailedBanner.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountBanners/AccountDiscoveryFailedBanner.tsx
@@ -1,0 +1,42 @@
+import { useDispatch, useSelector } from 'react-redux';
+
+import { selectHasRunningDiscovery, startOrRestartDiscoveryThunk } from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+import {
+    type NativeAccountsRootState,
+    selectIsAccountDiscoveryFailed,
+} from '@suite-native/accounts';
+import { FullAlertBox } from '@suite-native/atoms';
+import { useTranslate } from '@suite-native/intl';
+
+type AccountDiscoveryFailedBannerProps = {
+    accountKey: AccountKey;
+};
+
+export const AccountDiscoveryFailedBanner = ({ accountKey }: AccountDiscoveryFailedBannerProps) => {
+    const { translate } = useTranslate();
+    const dispatch = useDispatch();
+
+    const isDiscoveryFailed = useSelector((state: NativeAccountsRootState) =>
+        selectIsAccountDiscoveryFailed(state, accountKey),
+    );
+    const hasRunningDiscovery = useSelector(selectHasRunningDiscovery);
+
+    if (!isDiscoveryFailed) {
+        return null;
+    }
+
+    return (
+        <FullAlertBox
+            marginHorizontal="sp16"
+            intent="warning"
+            title={translate('moduleAccountManagement.discoveryFailedBanner.title')}
+            description={translate('moduleAccountManagement.discoveryFailedBanner.description')}
+            primaryButtonLabel={translate(
+                'moduleAccountManagement.discoveryFailedBanner.retryButton',
+            )}
+            onPressPrimaryButton={() => dispatch(startOrRestartDiscoveryThunk())}
+            primaryButtonProps={{ isLoading: hasRunningDiscovery }}
+        />
+    );
+};

--- a/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
@@ -30,6 +30,7 @@ import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/toke
 import { selectHasAccountAnyTransactions } from '@suite-native/transactions';
 
 import { selectIsNetworkSendFlowEnabled, selectIsUnrecognizedToken } from '../selectors';
+import { AccountDiscoveryFailedBanner } from './AccountBanners/AccountDiscoveryFailedBanner';
 import { SolanaLimitedHistoryBanner } from './AccountBanners/SolanaLimitedHistoryBanner';
 import { StellarLimitedHistoryBanner } from './AccountBanners/StellarLimitedHistoryBanner';
 import { AccountDetailCryptoValue } from './AccountDetailCryptoValue';
@@ -182,6 +183,7 @@ export const TransactionListHeader = memo(
         return (
             <>
                 <VStack spacing="sp24">
+                    <AccountDiscoveryFailedBanner accountKey={accountKey} />
                     <TransactionListHeaderContent
                         accountKey={accountKey}
                         tokenContract={tokenContract}

--- a/suite-native/module-accounts-management/src/screens/AccountAssetsScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountAssetsScreen.tsx
@@ -10,9 +10,11 @@ import {
     selectAccountDefiTokensCount,
     selectAccountManuallyHiddenTokensCount,
 } from '@suite-common/wallet-core';
+import { isAccountFailed } from '@suite-common/wallet-utils';
 import {
     type NativeAccountsRootState,
     selectAccountListSectionsWithZeroBalanceGroup,
+    useResolvedAccountKey,
 } from '@suite-native/accounts';
 import { VStack } from '@suite-native/atoms';
 import { type RootStackParamList, type RootStackRoutes, Screen } from '@suite-native/navigation';
@@ -21,11 +23,20 @@ import { AccountAssetsScreenHeader } from '../components/AccountAssets/AccountAs
 import { AccountAssetsTabBar } from '../components/AccountAssets/AccountAssetsTabBar';
 import { AccountAssetsTabContent } from '../components/AccountAssets/AccountAssetsTabContent';
 import { type AccountAssetsTab } from '../components/AccountAssets/types';
+import { AccountDiscoveryFailedBanner } from '../components/AccountBanners/AccountDiscoveryFailedBanner';
 
 export const AccountAssetsScreen = ({
     route: {
-        params: { accountKey, tab, flowType = 'assets' },
+        params: {
+            accountKey: routeAccountKey,
+            tab,
+            flowType = 'assets',
+            networkSymbol,
+            accountType,
+            accountIndex,
+        },
     },
+    navigation,
 }: NativeStackScreenProps<RootStackParamList, RootStackRoutes.AccountAssets>) => {
     const [activeTab, setActiveTab] = useState<AccountAssetsTab>(tab ?? 'tokens');
 
@@ -34,6 +45,15 @@ export const AccountAssetsScreen = ({
             setActiveTab(tab);
         }
     }, [tab]);
+
+    const accountKey =
+        useResolvedAccountKey({
+            accountKey: routeAccountKey,
+            networkSymbol,
+            accountType,
+            accountIndex,
+            setParams: navigation.setParams,
+        }) ?? routeAccountKey;
 
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
@@ -50,24 +70,29 @@ export const AccountAssetsScreen = ({
 
     const tokenCount = sections.filter(item => item.type === 'token').length;
     const showInactiveTab = account?.networkType === 'stellar' && flowType === 'assets';
+    const isFailed = !!account && isAccountFailed(account);
 
     return (
         <Screen header={<AccountAssetsScreenHeader accountKey={accountKey} flowType={flowType} />}>
-            <VStack spacing="sp32">
-                <AccountAssetsTabBar
-                    activeTab={activeTab}
-                    tokenCount={tokenCount}
-                    defiTokenCount={defiTokenCount}
-                    hiddenTokenCount={manuallyHiddenTokens}
-                    showInactiveTab={showInactiveTab}
-                    onTabChange={setActiveTab}
-                />
-                <AccountAssetsTabContent
-                    accountKey={accountKey}
-                    activeTab={activeTab}
-                    flowType={flowType}
-                />
-            </VStack>
+            {isFailed ? (
+                <AccountDiscoveryFailedBanner accountKey={accountKey} />
+            ) : (
+                <VStack spacing="sp32">
+                    <AccountAssetsTabBar
+                        activeTab={activeTab}
+                        tokenCount={tokenCount}
+                        defiTokenCount={defiTokenCount}
+                        hiddenTokenCount={manuallyHiddenTokens}
+                        showInactiveTab={showInactiveTab}
+                        onTabChange={setActiveTab}
+                    />
+                    <AccountAssetsTabContent
+                        accountKey={accountKey}
+                        activeTab={activeTab}
+                        flowType={flowType}
+                    />
+                </VStack>
+            )}
         </Screen>
     );
 };

--- a/suite-native/module-accounts-management/src/screens/AccountDetailScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountDetailScreen.tsx
@@ -1,14 +1,11 @@
 import { memo } from 'react';
 import { useSelector } from 'react-redux';
 
-import { type RouteProp, useRoute } from '@react-navigation/native';
+import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { type NativeStackNavigationProp } from '@react-navigation/native-stack';
 
-import type { DeviceRootState } from '@suite-common/device';
-import {
-    type AccountsRootState,
-    selectAccountByKey,
-    selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex,
-} from '@suite-common/wallet-core';
+import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
+import { useResolvedAccountKey } from '@suite-native/accounts';
 import { type RootStackParamList, type RootStackRoutes } from '@suite-native/navigation';
 
 import { AccountDetailContentScreen } from './AccountDetailContentScreen';
@@ -16,6 +13,10 @@ import { AccountDetailLoadingScreen } from './AccountDetailLoadingScreen';
 
 export const AccountDetailScreen = memo(() => {
     const route = useRoute<RouteProp<RootStackParamList, RootStackRoutes.AccountDetail>>();
+    const navigation =
+        useNavigation<
+            NativeStackNavigationProp<RootStackParamList, RootStackRoutes.AccountDetail>
+        >();
     const {
         accountKey: routeAccountKey,
         tokenContract,
@@ -24,16 +25,13 @@ export const AccountDetailScreen = memo(() => {
         accountIndex,
     } = route.params;
 
-    const foundAccountKey = useSelector((state: AccountsRootState & DeviceRootState) =>
-        selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex(
-            state,
-            networkSymbol,
-            accountType,
-            accountIndex,
-        ),
-    );
-
-    const accountKey = routeAccountKey ?? foundAccountKey;
+    const accountKey = useResolvedAccountKey({
+        accountKey: routeAccountKey,
+        networkSymbol,
+        accountType,
+        accountIndex,
+        setParams: navigation.setParams,
+    });
 
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -49,7 +49,7 @@ import {
 } from './routes';
 import { type NavigateParameters } from './types';
 
-type AddCoinFlowParams = RequireAllOrNone<
+type AccountIdentityParams = RequireAllOrNone<
     { networkSymbol: NetworkSymbol; accountType: AccountType; accountIndex: number },
     'networkSymbol' | 'accountType' | 'accountIndex'
 >;
@@ -75,7 +75,7 @@ type AccountDetailParams = {
     accountKey?: AccountKey;
     tokenContract?: TokenAddress;
     closeActionType: CloseActionType;
-} & AddCoinFlowParams;
+} & AccountIdentityParams;
 
 export type AccountsStackParamList = {
     [AccountsStackRoutes.Accounts]: { networksFilter?: NetworkSymbol[] } | undefined;
@@ -447,7 +447,7 @@ export type RootStackParamList = {
         accountKey: AccountKey;
         tab?: AccountAssetsTab;
         flowType?: AccountAssetsFlow;
-    };
+    } & AccountIdentityParams;
     [RootStackRoutes.AccountDetail]: AccountDetailParams;
     [RootStackRoutes.StakingDetail]: { accountKey: AccountKey };
     [RootStackRoutes.StakingManagement]: { accountKey: AccountKey };


### PR DESCRIPTION
## Description

When discovery fails for a network (e.g. Solana backend unreachable), mobile showed nothing — a zero-balance account row and empty screens. Now, mirroring desktop: the accounts list and the Home assets list show a warning icon in place of the balance for failed accounts (`isAccountFailed`), and both account landing flows (`AccountAssetsScreen` for token/staking networks — the reported Solana path — and the transaction-list header for the rest) show an `AccountDiscoveryFailedBanner` with a Retry button dispatching `startOrRestartDiscoveryThunk` (same thunk as desktop; spinner from `selectHasRunningDiscovery`). 

## Notes for QA

Manual: force a discovery failure (e.g. unreachable Solana backend / airplane mode during discovery) → accounts list and Home show the warning icon; opening the account shows only the header and the banner; Retry with connectivity restored reloads the account (and any accounts above it in the chain) and the screen recovers without re-navigation. Banner copy is a proposal — happy to adjust.

## Related Issue

Resolve #29151

## Screenshots:

<img width="438" height="893" alt="Screenshot 2026-07-13 at 15 29 08" src="https://github.com/user-attachments/assets/919dd203-45d2-4815-953d-7dcc03e9f66f" />

<img width="443" height="493" alt="Screenshot 2026-07-13 at 15 29 14" src="https://github.com/user-attachments/assets/b2a1a07f-37cf-4838-937f-dfdab707d795" />
<img width="430" height="481" alt="Screenshot 2026-07-13 at 16 04 20" src="https://github.com/user-attachments/assets/9173ebb9-c30f-4fd1-8929-9ce50b10bf85" />
<img width="405" height="536" alt="Screenshot 2026-07-13 at 16 58 26" src="https://github.com/user-attachments/assets/13c78bcc-c471-44dc-85ba-a7346b6b202c" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily modifies account selectors in the shared wallet-core package and a large number of suite-native (mobile) components. The wallet-core selector changes (accountsSelectors.ts, selectors.ts) are broad shared dependencies used by 131 E2E tests, but most tests only transitively import them. The suite-native changes (16 files across accounts, assets, navigation, and accounts-management modules) are mobile-only and have zero E2E test coverage since the Playwright E2E suite targets the web/desktop app. The recommended strategy focuses on a small set of tests that most directly exercise account listing, discovery, and account type management — the behaviors most likely affected by selector logic changes.

<details><summary><b>Changed files (18)</b></summary>

- `suite-common/wallet-core/src/accounts/accountsSelectors.ts`
- `suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts`
- `suite-common/wallet-core/src/selectors.ts`
- `suite-common/wallet-core/src/tests/selectors.test.ts`
- `suite-native/accounts/src/components/AccountDetailsCard.tsx`
- `suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx`
- `suite-native/accounts/src/hooks/useResolvedAccountKey.ts`
- `suite-native/accounts/src/index.ts`
- `suite-native/accounts/src/selectors.ts`
- `suite-native/accounts/src/tests/selectors.test.ts`
- `suite-native/assets/src/components/AssetItem.tsx`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsScreenHeader.tsx`
- `suite-native/module-accounts-management/src/components/AccountBanners/AccountDiscoveryFailedBanner.tsx`
- `suite-native/module-accounts-management/src/components/TransactionListHeader.tsx`
- `suite-native/module-accounts-management/src/screens/AccountAssetsScreen.tsx`
- `suite-native/module-accounts-management/src/screens/AccountDetailScreen.tsx`
- `suite-native/navigation/src/navigators.ts`

</details>

**Recommended tests (6)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test exercises the assets section on the dashboard including enabling new coins and verifying asset contents in grid/table views. Changes to accountsSelectors.ts could affect how accounts are resolved and displayed in the assets section, and the discovery completion logic depends on account selectors.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coins and verifies discovery completes with all account balances visible. Account selectors are used to determine discovery status and account visibility, so changes to accountsSelectors.ts could cause discovery to report incorrect completion or accounts to be missing.
- `suite/e2e/tests/wallet/account-search.test.ts` — This test searches and filters accounts by name. Account selectors determine which accounts are visible and how they are listed, making it directly relevant to changes in accountsSelectors.ts.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds different account types and verifies account counts increment correctly. The account counting logic (getAccountsInTypeCount, getAccountsForCoinInTypeCount) likely relies on accountsSelectors, so changes there could break account type enumeration.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test ejects and re-discovers wallets, verifying BTC balance visibility after adding a standard wallet. Account selectors are involved in determining account state after discovery, though this is a simpler flow than the full discovery test.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies account balance display after receiving BTC on regtest. Account selectors are involved in resolving which account's balance to display, so selector changes could affect balance rendering.

</details>

⚠️ **Changes with no test coverage (16)**
- `suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts`
- `suite-common/wallet-core/src/tests/selectors.test.ts`
- `suite-native/accounts/src/components/AccountDetailsCard.tsx`
- `suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx`
- `suite-native/accounts/src/hooks/useResolvedAccountKey.ts`
- `suite-native/accounts/src/index.ts`
- `suite-native/accounts/src/selectors.ts`
- `suite-native/accounts/src/tests/selectors.test.ts`
- `suite-native/assets/src/components/AssetItem.tsx`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsScreenHeader.tsx`
- `suite-native/module-accounts-management/src/components/AccountBanners/AccountDiscoveryFailedBanner.tsx`
- `suite-native/module-accounts-management/src/components/TransactionListHeader.tsx`
- `suite-native/module-accounts-management/src/screens/AccountAssetsScreen.tsx`
- `suite-native/module-accounts-management/src/screens/AccountDetailScreen.tsx`
- `suite-native/navigation/src/navigators.ts`

_Updated: 2026-07-13T17:14:06.137Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/29151-discovery-failed-retry/web/](https://dev.suite.sldev.cz/suite-web/feat/29151-discovery-failed-retry/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/29151-discovery-failed-retry&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/29151-discovery-failed-retry&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-13T17:17:10.623Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-13T17:16:59.549Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->