### PR TITLE
fix(connect): redact confidential fields from device id mismatch log

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -825,11 +825,28 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
         if (feat.device_id !== oldId) {
             // during wipe device, the same device (same path) changes id. This also ignores rare transport-level errors of mismatched response
             if (feat.initialized === this.features?.initialized) {
-                const oldDevice = this.toMessageObject();
+                // This is logged to Sentry via captureConsoleIntegration, so confidential fields
+                // (device id, label, session id) must be stripped first. The mismatch itself plus the
+                // firmware/model info left in features is enough to diagnose the transport-level bug.
+                const stripConfidential = (f: Features) => ({
+                    ...f,
+                    device_id: undefined,
+                    session_id: undefined,
+                    label: undefined,
+                });
+                // this.features is overwritten with feat right after this method returns, so capture
+                // the old features reference synchronously; it is redacted at the log site below.
+                const oldFeatures = this.features;
+                const { uniquePath: path } = this;
                 // transport descriptors are useful debug info, but no need to await, the side-effect to log to Sentry can run async
                 this.transport.enumerate().then(res => {
                     const descriptors = res.success ? res.payload : undefined;
-                    console.error('getFeatures device id mismatch', oldDevice, feat, descriptors);
+                    console.error('getFeatures device id mismatch', {
+                        path,
+                        oldFeatures: oldFeatures && stripConfidential(oldFeatures),
+                        newFeatures: stripConfidential(feat),
+                        descriptors,
+                    });
                 });
             }
 


### PR DESCRIPTION
## Description

`Device.deviceVersionCheck` logs a `"getFeatures device id mismatch"` via `console.error` when a device reports a different `device_id` for the same transport path — a rare transport-level bug worth surfacing to Sentry. On desktop, web and native this `console.error` is auto-captured and sent to Sentry via `captureConsoleIntegration({ levels: ['error'] })`.

The problem: the log passed the full device object (`toMessageObject()`) and the raw `Features` protobuf, which carry **`device_id`, `label` and `session_id`** — confidential data that must never leave the device. This violated the repo's "confidential data never leaves the device" rule.

This change strips `device_id`, `session_id` and `label` from both the old and new `Features` before logging, and drops the full device object in favour of just the (non-confidential) transport `path`. The redacted field set mirrors `redactDevice` in `@suite-common/logger`. The diagnostic value of the log is preserved: the mismatch itself plus the remaining firmware/model info is exactly what's needed to investigate the transport-level bug, and transport descriptors (path/session/product/vendor — not the device static session) are still included.

This is the targeted point fix at the log site. A broader defense-in-depth option (a central scrubber in the shared `redactSentryEvent` `beforeSend` chokepoint, plus a couple of other latent per-site leaks) was scoped separately and is not part of this PR.

## Notes for QA

No user-facing behaviour change and no functional change to device handling — this only alters the shape of a diagnostic `console.error` that fires exclusively on a rare transport-level `device_id` mismatch (normally never hit). No QA needed. If anything, the mismatch log is only reachable in edge/transport-error scenarios and the change is limited to what gets serialized into that one log line.

## Related Issue

Security finding: unredacted `console.error` in `deviceVersionCheck` leaks device id / label / session id to Sentry via `captureConsoleIntegration`.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to packages/connect/src/device/Device.ts affects the core device communication and state management layer used by virtually all E2E tests (121 tests statically mapped). Since this is a broad foundational dependency, the recommended strategy focuses on tests that most directly exercise Device.ts's critical responsibilities: device connection/disconnection handling, session management, passphrase state, recovery persistence across interruptions, and device command execution (backup, firmware, settings). Tests involving device disconnect/reconnect scenarios and multi-session handling are prioritized highest as they are most likely to surface regressions in Device.ts changes. Routine UI tests that merely require a connected device are omitted since they exercise Device.ts only as passive infrastructure.

<details><summary><b>Changed files (1)</b></summary>

- `packages/connect/src/device/Device.ts`

</details>

**Recommended tests (20)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test directly exercises DeviceConnect and DeviceDisconnect events which rely on Device.ts for device state (mode, firmware version, model, pin/passphrase protection, backup type). Changes to Device.ts could alter how device properties are reported in analytics events.
- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test exercises device disconnect/reconnect during backup, which directly depends on Device.ts for device connection state management, power off/on handling, and device status transitions.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test simulates entropy check failures during wallet creation which directly interacts with Device.ts's resetDevice flow and entropy verification logic. The setSimulatedEntropyCheckFail action dispatches through device state managed by Device.ts.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test exercises Bridge session acquisition, theft, and reclamation between tabs — core Device.ts responsibilities around session management and device enumeration. Changes here could break multi-session handling.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test covers wallet discovery including ejecting and re-adding wallets, which exercises Device.ts's device state management, standard wallet addition, and the core device-to-account discovery pipeline.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test exercises device disconnect/reconnect with passphrase caching — directly testing Device.ts's passphrase state preservation across connection cycles and session re-establishment.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — This test validates that recovery mode persists across page reloads and device disconnects, directly exercising Device.ts's device state persistence and reconnection logic during active recovery sessions.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test triggers account discovery across 8 coin networks with a random-delay page reload mid-discovery, directly stressing Device.ts's session management and device communication resilience during interruptions.

</details>

<details><summary>🟡 <b>Medium priority (12)</b></summary>

- `suite/e2e/tests/backup/t2t1-misc.test.ts` — Tests backup behavior when device is disconnected (remembered device state), exercising Device.ts's handling of device power-off during active operations and remembered device logic.
- `suite/e2e/tests/backup/t2t1-success.test.ts` — Tests the full backup flow requiring device communication for seed creation confirmation, exercising Device.ts's command execution and device prompt handling.
- `suite/e2e/tests/firmware/custom-firmware.test.ts` — Custom firmware installation involves device mode transitions (normal → bootloader → reconnect) managed by Device.ts. Changes could affect firmware installation flow and device reconnection detection.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts` — Tests device disconnection during recovery and retry flow, which exercises Device.ts's disconnect detection and reconnection handling during an active device operation.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — Tests device disconnect/reconnect with passphrase re-entry for Cardano address verification, exercising Device.ts's connection state management and passphrase handling across reconnections.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Exercises passphrase handling including mismatch detection and retry flows, which rely on Device.ts's passphrase confirmation logic and device state management for hidden wallets.
- `suite/e2e/tests/recovery/dry-run.test.ts` — Tests recovery dry run with bridge stop/start (simulating disconnect) and page reload, directly exercising Device.ts's session recovery and reinitialization after transport interruptions.
- `suite/e2e/tests/settings/passphrase.test.ts` — Tests enabling passphrase protection on the device via Device.ts's applySettings command, including device confirmation flow and settings-applied notification.
- `suite/e2e/tests/suite/initial-run.test.ts` — Tests device connection state persistence across page reloads during onboarding, including THP pairing code flow which is handled at the Device.ts level.
- `suite/e2e/tests/wallet/without-device.test.ts` — Tests the send flow when device is disconnected, verifying Device.ts correctly reports disconnected state and the connection modal appears, directly exercising device status management.
- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — Tests wallet creation with Shamir backup and PIN setup, which requires Device.ts to manage the resetDevice flow, seed type selection, and device confirmation sequences.
- `suite/e2e/tests/settings/safety-checks.test.ts` — Tests changing device safety checks level which calls Device.ts's applySettings to communicate the change to the hardware device.

</details>

_Updated: 2026-07-06T11:05:49.325Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dili&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dili&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dili&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-06T11:11:31.882Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-06T11:08:49.402Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dili/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dili/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->