### PR TITLE
Tron Staking - Introduce Voting Terms of Service Modal

### DIFF
--- a/packages/suite/src/components/earn/index.ts
+++ b/packages/suite/src/components/earn/index.ts
@@ -21,6 +21,7 @@ export { TronStakePageHeader } from './staking/tron/TronStakePageHeader';
 export { TronStake } from './staking/tron/TronStake';
 export { TronUnstake } from './staking/tron/TronUnstake';
 export { TronVote } from './staking/tron/TronVote';
+export { TronVoteConsentModal } from './staking/tron/vote/TronVoteConsentModal';
 export { TronWithdraw } from './staking/tron/TronWithdraw';
 export { TronClaim } from './staking/tron/TronClaim';
 export { YieldDeposit } from './yield/deposit/YieldDeposit';

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
@@ -1,5 +1,7 @@
 import { useDevice } from '@suite/device';
 import { closeModal, openDeferredModal, preserveModal } from '@suite/modal';
+import { useTronStakingStats } from '@suite-common/earn-staking-api';
+import { TRON_REPRESENTATIVE_TERMS_OF_SERVICE_URLS } from '@suite-common/wallet-constants';
 import {
     type TronFlow,
     type TronStakeError,
@@ -44,6 +46,7 @@ export const useTronStakeActions = ({
 }: UseTronStakeActionsProps): TronStakeActions => {
     const dispatch = useDispatch();
     const { device } = useDevice();
+    const { stats } = useTronStakingStats();
     const { step, isSubmitting, error, pendingTxid } = useSelector(state =>
         selectTronStakeSession(state, account.key, flow),
     );
@@ -90,12 +93,35 @@ export const useTronStakeActions = ({
                 const representativeAddress = resolveVotedRepresentativeAddress(
                     form.methods.getValues(),
                 );
+                const representative = stats.data?.find(
+                    ({ address }) => address === representativeAddress,
+                );
+                const representativeName = representative?.name ?? representativeAddress;
+
+                const termsOfServiceUrl =
+                    TRON_REPRESENTATIVE_TERMS_OF_SERVICE_URLS[representativeAddress];
+
+                const requestVoteConsent =
+                    representative && termsOfServiceUrl
+                        ? async () =>
+                              Boolean(
+                                  await dispatch(
+                                      openDeferredModal({
+                                          type: 'tron-vote-consent',
+                                          representativeName,
+                                          termsOfServiceUrl,
+                                      }),
+                                  ),
+                              )
+                        : undefined;
+
                 dispatch(
                     submitTronVoteThunk({
                         account,
                         device,
                         flow,
                         representativeAddress,
+                        requestVoteConsent,
                         requestPushApproval: async () =>
                             Boolean(
                                 await dispatch(openDeferredModal({ type: 'review-transaction' })),

--- a/packages/suite/src/components/earn/staking/tron/vote/TronVoteConsentModal.tsx
+++ b/packages/suite/src/components/earn/staking/tron/vote/TronVoteConsentModal.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+
+import { TrezorLink } from '@suite/external-links';
+import { Translation } from '@suite/intl';
+import { Banner, Card, Checkbox, Column, Modal } from '@trezor/components';
+import { type Deferred } from '@trezor/utils';
+
+interface TronVoteConsentModalProps {
+    representativeName: string;
+    termsOfServiceUrl: string;
+    decision: Deferred<boolean>;
+    onCancel: () => void;
+}
+
+export const TronVoteConsentModal = ({
+    representativeName,
+    termsOfServiceUrl,
+    decision,
+    onCancel,
+}: TronVoteConsentModalProps) => {
+    const [isConsentGiven, setIsConsentGiven] = useState(false);
+
+    const onSubmit = (value: boolean) => {
+        decision.resolve(value);
+        onCancel();
+    };
+
+    const onConfirm = () => onSubmit(true);
+
+    const onDecline = () => onSubmit(false);
+
+    const onConsentToggle = () => {
+        setIsConsentGiven(!isConsentGiven);
+    };
+
+    return (
+        <Modal
+            heading={
+                <Translation
+                    id="TR_TRON_VOTE_CONSENT_MODAL_HEADING"
+                    values={{ representativeName }}
+                />
+            }
+            description={<Translation id="TR_TRON_VOTE_CONSENT_MODAL_DESCRIPTION" />}
+            onCancel={onDecline}
+            width={600}
+            bottomContent={
+                <>
+                    <Modal.Button isDisabled={!isConsentGiven} onClick={onConfirm}>
+                        <Translation id="TR_CONFIRM" />
+                    </Modal.Button>
+
+                    <Modal.Button intent="neutral" priority="secondary" onClick={onDecline}>
+                        <Translation id="TR_CANCEL" />
+                    </Modal.Button>
+                </>
+            }
+        >
+            <Column gap={12} margin={{ top: 8, bottom: 20 }}>
+                <Banner
+                    icon="fileFilled"
+                    intent="info"
+                    description={
+                        <Translation
+                            id="TR_TRON_VOTE_CONSENT_MODAL_BANNER_1_TEXT"
+                            values={{ representativeName }}
+                        />
+                    }
+                />
+
+                <Banner
+                    icon="shieldWarningFilled"
+                    intent="info"
+                    description={
+                        <Translation
+                            id="TR_TRON_VOTE_CONSENT_MODAL_BANNER_2_TEXT"
+                            values={{ representativeName }}
+                        />
+                    }
+                />
+            </Column>
+
+            <Column gap={12}>
+                <Card>
+                    <Checkbox
+                        verticalAlignment="center"
+                        onChange={onConsentToggle}
+                        isChecked={isConsentGiven}
+                    >
+                        <Translation
+                            id="TR_TRON_VOTE_CONSENT_MODAL_CONSENT_TEXT"
+                            values={{
+                                representativeName,
+                                a: children =>
+                                    termsOfServiceUrl ? (
+                                        <TrezorLink href={termsOfServiceUrl}>{children}</TrezorLink>
+                                    ) : (
+                                        children
+                                    ),
+                            }}
+                        />
+                    </Checkbox>
+                </Card>
+            </Column>
+        </Modal>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -10,6 +10,7 @@ import {
     EarnProviderConsentModal,
     StakeModal,
     TronStakeInANutshellModal,
+    TronVoteConsentModal,
     UnstakeModal,
 } from 'src/components/earn';
 import { ConnectPopupTxSimulationModal } from 'src/components/tx-simulation/connect-popup';
@@ -153,6 +154,8 @@ export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL_CONTE
             return <EarnInANutshellModal {...payload} onCancel={onCancel} />;
         case 'tron-stake-in-a-nutshell':
             return <TronStakeInANutshellModal {...payload} onCancel={onCancel} />;
+        case 'tron-vote-consent':
+            return <TronVoteConsentModal {...payload} onCancel={onCancel} />;
         case 'earn-provider-consent':
             return <EarnProviderConsentModal {...payload} onCancel={onCancel} />;
         case 'stake':

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -171,6 +171,12 @@ export type UserContextPayload =
           actionType?: EarnModalAction;
       }
     | {
+          type: 'tron-vote-consent';
+          representativeName: string;
+          termsOfServiceUrl: string;
+          decision: Deferred<boolean>;
+      }
+    | {
           type: 'stake';
           flow: StakeModalFlow;
           account: Account;

--- a/suite-common/wallet-constants/src/tronStakingConstants.ts
+++ b/suite-common/wallet-constants/src/tronStakingConstants.ts
@@ -11,3 +11,12 @@ export const MIN_TRON_BALANCE_FOR_STAKING =
 // source: https://earn.trezor.io/staking/v1/trx/stats
 export const LUGANODES_TRON_SRS = ['TGyrSc9ZmTdbYziuk1SKEmdtCdETafewJ9'];
 export const P2P_ORG_TRON_SRS = ['TH7Fe1W8CcLeqN4LGfqX1R9EpsnrJBQJij'];
+
+// TODO: return these from the API
+export const LUGANODES_TERMS_OF_SERVICE_URL = 'https://luganodes.com/terms-of-service';
+export const P2P_ORG_TERMS_OF_SERVICE_URL = 'https://www.p2p.org/terms-of-use';
+
+export const TRON_REPRESENTATIVE_TERMS_OF_SERVICE_URLS: Record<string, string> = {
+    [LUGANODES_TRON_SRS[0] as string]: LUGANODES_TERMS_OF_SERVICE_URL,
+    [P2P_ORG_TRON_SRS[0] as string]: P2P_ORG_TERMS_OF_SERVICE_URL,
+};

--- a/suite-common/wallet-core/src/stake/tron/actions/vote/submitVote.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/vote/submitVote.ts
@@ -14,6 +14,7 @@ import { type TronFlow } from '../../tronStakeTypes';
 interface SubmitVoteThunkArguments extends VoteThunkArguments {
     device: TrezorDevice;
     flow: TronFlow;
+    requestVoteConsent?: () => Promise<boolean>;
     requestPushApproval: () => Promise<boolean>;
     onSigningStart?: () => void;
     onSettled?: () => void;
@@ -27,6 +28,7 @@ export const submitTronVoteThunk = createThunk<void, SubmitVoteThunkArguments>(
             device,
             flow,
             representativeAddress,
+            requestVoteConsent,
             requestPushApproval,
             onSigningStart,
             onSettled,
@@ -34,6 +36,14 @@ export const submitTronVoteThunk = createThunk<void, SubmitVoteThunkArguments>(
         { dispatch },
     ) => {
         const { key: accountKey } = account;
+
+        if (requestVoteConsent) {
+            const isConsentGiven = await requestVoteConsent();
+
+            if (!isConsentGiven) {
+                return;
+            }
+        }
 
         if (account.networkType !== 'tron') {
             dispatch(

--- a/suite-native/module-earn/src/components/UnstakeCanClaimAlert.tsx
+++ b/suite-native/module-earn/src/components/UnstakeCanClaimAlert.tsx
@@ -13,7 +13,7 @@ export const UnstakeCanClaimAlert = ({ claimableAmount, symbol }: UnstakeCanClai
 
     return (
         <InlineAlertBox
-            variant="info"
+            intent="info"
             title={
                 <Translation
                     id="earn.unstakeFlowScreen.canClaimWarning"

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -5559,6 +5559,29 @@ export const messages = defineMessages({
         id: 'TR_EXPERIMENTAL_SUITE_SYNC_TITLE',
         defaultMessage: 'Suite Sync',
     },
+    TR_TRON_VOTE_CONSENT_MODAL_HEADING: {
+        id: 'TR_TRON_VOTE_CONSENT_MODAL_HEADING',
+        defaultMessage: 'Vote for {representativeName}',
+    },
+    TR_TRON_VOTE_CONSENT_MODAL_DESCRIPTION: {
+        id: 'TR_TRON_VOTE_CONSENT_MODAL_DESCRIPTION',
+        defaultMessage: 'You retain full ownership of your TRX — only your votes are delegated.',
+    },
+    TR_TRON_VOTE_CONSENT_MODAL_CONSENT_TEXT: {
+        id: 'TR_TRON_VOTE_CONSENT_MODAL_CONSENT_TEXT',
+        defaultMessage:
+            "I acknowledge <a>{representativeName}'s Terms of Service</a> and consent to delegate my votes to {representativeName}.",
+    },
+    TR_TRON_VOTE_CONSENT_MODAL_BANNER_1_TEXT: {
+        id: 'TR_TRON_VOTE_CONSENT_MODAL_BANNER_1_TEXT',
+        defaultMessage:
+            'Vote for {representativeName} to receive TRX rewards and help support the security and stability of the Tron network.',
+    },
+    TR_TRON_VOTE_CONSENT_MODAL_BANNER_2_TEXT: {
+        id: 'TR_TRON_VOTE_CONSENT_MODAL_BANNER_2_TEXT',
+        defaultMessage:
+            'With Trezor Suite, securely delegate your voting rights to {representativeName}. Enjoy competitive rewards, rely on a trusted Super Representative, and keep full ownership of your TRX at all times.',
+    },
     TR_TRON_BANDWIDTH: {
         id: 'TR_TRON_BANDWIDTH',
         defaultMessage: 'Bandwidth',

--- a/suite/modal/src/modalActions.ts
+++ b/suite/modal/src/modalActions.ts
@@ -96,7 +96,8 @@ type DeferredModals = Extract<
             | 'tor-loading'
             | 'review-transaction'
             | 'import-transaction'
-            | 'earn-yield-tx-simulation';
+            | 'earn-yield-tx-simulation'
+            | 'tron-vote-consent';
     }
 >;
 // extract single modal by `type` util


### PR DESCRIPTION
## Description

Introduce Tron Voting Terms of Service modal with consent.

## Related Issue

Resolve #29415 

## Screenshots:

https://github.com/user-attachments/assets/7ae14539-52a7-4c47-870d-76fbd23eb22d

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily adds/modifies Tron staking functionality (vote consent modal, vote submission, staking hooks, constants) and touches shared modal infrastructure (UserContextModal, modal types, modal actions). The Tron-specific changes have no E2E test coverage since no Tron staking E2E tests exist in the suite. The modal infrastructure changes (UserContextModal.tsx maps to 121 tests) are broad but the actual code change likely adds a new modal case for TronVoteConsent, which would only affect Tron staking flows. ETH/ADA/SOL staking tests are the most relevant since they exercise the earn component tree and modal confirmation flows most directly. The intl messages change likely adds new translation keys for Tron staking UI.

<details><summary><b>Changed files (10)</b></summary>

- `packages/suite/src/components/earn/index.ts`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts`
- `packages/suite/src/components/earn/staking/tron/vote/TronVoteConsentModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx`
- `suite-common/suite-types/src/modal.ts`
- `suite-common/wallet-constants/src/tronStakingConstants.ts`
- `suite-common/wallet-core/src/stake/tron/actions/vote/submitVote.ts`
- `suite-native/module-earn/src/components/UnstakeCanClaimAlert.tsx`
- `suite/intl/src/messages.ts`
- `suite/modal/src/modalActions.ts`

</details>

**Recommended tests (9)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — The earn/staking components were modified (index.ts, hooks, modal). While this test focuses on ETH staking rather than Tron, it exercises the staking UI infrastructure including modals and the earn component tree that was changed in packages/suite/src/components/earn/index.ts.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Exercises the staking flow including modal confirmations. Changes to UserContextModal, modal types, and modalActions could affect how staking confirmation modals render and function.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — The unstake flow exercises claim modals and staking UI components. Changes to the earn component exports, modal types, and UserContextModal could affect the unstake/claim confirmation dialogs.
- `suite/e2e/tests/staking/staking-form.test.ts` — Tests the staking form validation and input logic. The earn component index re-export and modal infrastructure changes could affect how the staking form renders and interacts with modals.

</details>

<details><summary>🟢 <b>Low priority (5)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — The claim flow uses modal infrastructure (UserContextModal, modalActions) for confirmation dialogs. Changes to modal type definitions and actions could affect how claim confirmation modals are dispatched and rendered.
- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking involves the Everstake consent modal flow which is rendered through UserContextModal. Changes to modal types and the earn component tree could affect this flow.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — ADA unstaking uses confirmation modals rendered through the changed UserContextModal infrastructure. A regression in modal rendering could break the unstake confirmation flow.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL staking involves the Everstake consent modal and staking confirmation modals. Changes to UserContextModal and modal action dispatching could affect these modal flows.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstake and claim flows use modal confirmations rendered through UserContextModal. The claim modal could be affected by changes to modal types and actions.

</details>

⚠️ **Changes with no test coverage (5)**
- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts`
- `packages/suite/src/components/earn/staking/tron/vote/TronVoteConsentModal.tsx`
- `suite-common/wallet-constants/src/tronStakingConstants.ts`
- `suite-common/wallet-core/src/stake/tron/actions/vote/submitVote.ts`
- `suite-native/module-earn/src/components/UnstakeCanClaimAlert.tsx`

_Updated: 2026-07-06T10:05:55.596Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-vote-tos-modal/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-vote-tos-modal/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-vote-tos-modal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-vote-tos-modal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-vote-tos-modal&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-06T10:11:37.128Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-06T10:08:18.623Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->