### PR TITLE
chore(suite): update earn table rate tooltip text

### DIFF
--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingRateTooltip.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingRateTooltip.tsx
@@ -34,7 +34,7 @@ export const EarnStakingRateTooltip = ({ networkType, rate }: EarnStakingRateToo
                     }
                 />
             }
-            maxWidth={600}
+            tooltipMaxWidth={280}
             placement="top"
         >
             <Abbr>

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9995,11 +9995,12 @@ export const messages = defineMessages({
     },
     TR_EARN_STAKING_APY_TOOLTIP: {
         id: 'TR_EARN_STAKING_APY_TOOLTIP',
-        defaultMessage: 'Annual percentage yield (APY)',
+        defaultMessage:
+            'This is the annual percentage yield (APY). It includes compounded returns.',
     },
     TR_EARN_STAKING_APR_TOOLTIP: {
         id: 'TR_EARN_STAKING_APR_TOOLTIP',
-        defaultMessage: 'Annual percentage rate (APR)',
+        defaultMessage: "This is the annual percentage rate (APR). It doesn't include compounding.",
     },
     TR_EARN_YIELD_AMOUNT_TO_WITHDRAW: {
         id: 'TR_EARN_YIELD_AMOUNT_TO_WITHDRAW',


### PR DESCRIPTION
## Description

Update `APY`/`APR` tooltip text + tooltip max width.

## Screenshots:

<img width="100%" alt="Screenshot 2026-07-06 at 11 26 43" src="https://github.com/user-attachments/assets/34b6aa3f-131b-41c6-9c5e-ef30073e29ab" />

<img width="100%" alt="Screenshot 2026-07-06 at 11 26 49" src="https://github.com/user-attachments/assets/9942f6f4-3944-469e-87ac-2c9e1b4246ca" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch an earn/staking dashboard tooltip component (EarnStakingRateTooltip) and the global intl messages file. The tooltip component is narrowly scoped to the staking dashboard UI, so ETH staking tests are highest priority as they most directly exercise this component's rendering context. SOL and ADA staking tests share the same dashboard infrastructure and are medium priority. The messages.ts change is a broad shared file, but since it's paired with a staking-specific component change, the risk is concentrated in staking flows rather than the entire application. No static coverage mapping was available, so all recommendations are inferred from LLM analysis of test behaviors and source hints.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/earn/dashboard/staking/EarnStakingRateTooltip.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — EarnStakingRateTooltip is a component within the earn/staking dashboard. This test exercises the full ETH initial staking flow including the staking dashboard display, staking amounts, and progress indicators — the exact UI surface where EarnStakingRateTooltip would render.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test exercises the ETH staking dashboard with staked amounts, rewards, pending amounts, and progress indicators. The EarnStakingRateTooltip component is part of this staking dashboard view and would be rendered when displaying staking rate information.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Tests the ETH staking dashboard view with staked, pending, rewards, and unstaking amounts. The staking rate tooltip component lives in the same dashboard UI and would be visible during these interactions.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL staking uses the same earn/staking dashboard components. If EarnStakingRateTooltip is shared across staking networks, changes could affect the SOL staking dashboard display.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Displays the Solana staking dashboard with staked amounts and rewards. The staking rate tooltip could appear alongside reward/rate information on this dashboard.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Tests SOL staking dashboard and stake-more flow which renders the same earn/staking dashboard components where EarnStakingRateTooltip lives.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstaking test exercises the staking dashboard view. If the rate tooltip is rendered on the staking dashboard for SOL, this test would catch regressions.
- `suite/e2e/tests/staking/staking-form.test.ts` — Tests the ETH staking form including balance display and input validation. The staking form is closely related to the staking dashboard where EarnStakingRateTooltip renders.
- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking test uses the earn staking UI components. If the rate tooltip is rendered for Cardano staking, changes to it or its translation keys in messages.ts could affect this flow.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — ADA claim test exercises the staking dashboard with reward amounts and claim flow. The rate tooltip may be visible on this screen, though claim-specific behavior is less likely affected.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — ADA unstake test interacts with the staking dashboard where the rate tooltip component may render. Lower priority since unstaking-specific assertions are unlikely affected by tooltip changes.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-07-06T09:31:51.616Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/earn-rate-tooltip-text/web/](https://dev.suite.sldev.cz/suite-web/chore/earn-rate-tooltip-text/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/earn-rate-tooltip-text&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/earn-rate-tooltip-text&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-06T09:37:51.536Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-06T09:35:25.295Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->