### PR TITLE
fix(suite-native): use intent prop on InlineAlertBox in unstake claim alert

### DIFF
--- a/suite-native/module-earn/src/components/UnstakeCanClaimAlert.tsx
+++ b/suite-native/module-earn/src/components/UnstakeCanClaimAlert.tsx
@@ -13,7 +13,7 @@ export const UnstakeCanClaimAlert = ({ claimableAmount, symbol }: UnstakeCanClai
 
     return (
         <InlineAlertBox
-            variant="info"
+            intent="info"
             title={
                 <Translation
                     id="earn.unstakeFlowScreen.canClaimWarning"


### PR DESCRIPTION
## Description

`develop` currently fails `Type Checking` on the whole `@suite-native/module-earn` project:

```
UnstakeCanClaimAlert.tsx:16 - error TS2322: Property 'variant' does not exist on type 'InlineAlertBoxProps'.
```

`InlineAlertBox` exposes an `intent` prop (`'brand' | 'neutral' | 'critical' | 'warning' | 'info'`), not `variant` — the prop was renamed in the Alert Box design-system update (`999ff090508`). `UnstakeCanClaimAlert` was added in a parallel PR (`6e46036111e`) still using `variant="info"`. Each PR was green against its own base, but once both landed on develop the combination broke type-check. Because develop pushes don't run the full `Type Checking` job (it runs on PRs), nothing caught it on merge, and it now blocks Type Checking for every open PR whose nx graph includes `module-earn`.

Fix: rename the single usage `variant="info"` → `intent="info"`. It is the only broken `InlineAlertBox` usage in the repo (the other `variant=` hits are `<Text>` / `<PictogramTitleHeader>`, which legitimately have a `variant` prop).

## Notes for QA

Impact: unblocks CI `Type Checking` on develop and on all open PRs. Runtime effect is a minor visual correction — the unknown `variant` prop was silently ignored, so the "you can claim" alert in the unstake flow was rendering with the default neutral intent; it now renders with the intended `info` intent (blue). Worth a quick visual check of the unstake flow claim alert on suite-native; no logic change.

## Related Issue

Fixes a develop-blocking type error introduced by the interaction of #? (Alert Box DS rename) and the unstake-claim feature.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fix-unstake-alert-intent&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->