### PR TITLE
fix(suite): enforce custom gap limit validation and propagate it to tx paging

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
@@ -101,6 +101,7 @@ export const AdvancedCoinSettingsModal = ({
     const isSubmitButtonDisabled =
         (isEditable && !!backendsForm.input.error) ||
         !explorerForm.isValid ||
+        (isBitcoinNetwork && isGapLimitEnabled && !!gapLimitForm.error) ||
         backendsForm.isValidating;
 
     if (torModalOpen) {

--- a/packages/suite/src/hooks/settings/__tests__/useGapLimitForm.test.tsx
+++ b/packages/suite/src/hooks/settings/__tests__/useGapLimitForm.test.tsx
@@ -1,0 +1,63 @@
+import { act } from '@testing-library/react';
+
+import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { blockchainActions } from '@suite-common/wallet-core';
+
+import { useGapLimitForm } from '../useGapLimitForm';
+
+const SYMBOL = 'btc';
+
+const renderGapLimitForm = (savedGapLimit?: number) => {
+    const store = configureMockStore({
+        preloadedState: {
+            wallet: {
+                blockchain: {
+                    [SYMBOL]: { backends: { gapLimit: savedGapLimit } },
+                },
+            },
+        },
+    });
+    const { result } = renderHookWithStoreProvider(() => useGapLimitForm(SYMBOL), { store });
+
+    return { store, result };
+};
+
+const gapLimitActions = (store: ReturnType<typeof renderGapLimitForm>['store']) =>
+    store.getActions().filter(action => action.type === blockchainActions.setBackendGapLimit.type);
+
+describe('useGapLimitForm', () => {
+    it('persists a valid gap limit', () => {
+        const { store, result } = renderGapLimitForm();
+
+        act(() => result.current.setValue('30'));
+        act(() => result.current.save());
+
+        expect(gapLimitActions(store)).toEqual([
+            blockchainActions.setBackendGapLimit({ symbol: SYMBOL, gapLimit: 30 }),
+        ]);
+    });
+
+    it('does not persist a gap limit below the minimum despite the button click', () => {
+        const { store, result } = renderGapLimitForm();
+
+        act(() => result.current.setValue('5'));
+
+        expect(result.current.error?.id).toBe('TR_GAP_LIMIT_ERROR_TOO_LOW');
+
+        act(() => result.current.save());
+
+        expect(gapLimitActions(store)).toEqual([]);
+    });
+
+    it('does not persist an empty or non-positive gap limit', () => {
+        const { store, result } = renderGapLimitForm();
+
+        act(() => result.current.setValue(''));
+        act(() => result.current.save());
+
+        act(() => result.current.setValue('0'));
+        act(() => result.current.save());
+
+        expect(gapLimitActions(store)).toEqual([]);
+    });
+});

--- a/packages/suite/src/hooks/settings/useGapLimitForm.ts
+++ b/packages/suite/src/hooks/settings/useGapLimitForm.ts
@@ -33,6 +33,7 @@ export const useGapLimitForm = (symbol: NetworkSymbol) => {
     const isSame = value.trim() === String(savedGapLimit ?? DEFAULT_GAP_LIMIT);
 
     const save = () => {
+        if (error) return;
         dispatch(blockchainActions.setBackendGapLimit({ symbol, gapLimit: Number(value.trim()) }));
     };
 

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -45,7 +45,7 @@ import {
 } from './transactionsSelectors';
 import { accountsActions } from '../accounts/accountsActions';
 import { selectAccountByKey, selectAccounts } from '../accounts/accountsSelectors';
-import { selectBlockchainHeightBySymbol } from '../blockchain/blockchainReducer';
+import { selectBlockchainHeightBySymbol, selectGapLimit } from '../blockchain/blockchainReducer';
 import { selectRawNetworkFeeInfo } from '../fees/feesReducer';
 import { ethereumGetCurrentNonceThunk } from '../send/sendFormEthereumThunks';
 import { selectSendSignedTx } from '../send/sendFormSelectors';
@@ -585,6 +585,10 @@ export const fetchTransactionsPageThunk = createThunk(
             ...(marker && !isFirstPage ? { marker } : {}),
             suppressBackupWarning: true,
             protocols: account.networkType === 'ethereum' ? ['erc4626'] : undefined,
+            gap:
+                account.networkType === 'bitcoin'
+                    ? selectGapLimit(getState(), account.symbol)
+                    : undefined,
         });
 
         // Account might have changed during async getAccountInfo call, so we fetch current state


### PR DESCRIPTION
## Description

Two related defects in the experimental custom gap limit feature (`gap-limit`) for Bitcoin accounts.

### 1. Gap limit validation was cosmetic

`useGapLimitForm` computes an error for values below the minimum (20), as well as empty / non-positive input, and the modal renders that error under the input. But `save()` dispatched `setBackendGapLimit` unconditionally and the modal's submit button did not factor the error into its disabled state, so an invalid gap — including `0`/`NaN` from `Number('')` — was persisted anyway. Now `save()` bails out when the value is invalid and the submit button is disabled while a gap error is present, giving the user real feedback instead of a silent bad save.

### 2. `fetchTransactionsPageThunk` never propagated the custom gap

Discovery (`selectDiscoveryAccountsParam`) and the periodic account sync (`fetchAndUpdateAccountThunk`) both pass the custom gap to `TrezorConnect.getAccountInfo` for Bitcoin, but `fetchTransactionsPageThunk` did not. When a page-1 fetch runs (`fetchAllTransactionsForAccountThunk` / `fetchTransactionsFromNowUntilTimestamp` both start at `page = 1`), `updateAccount` overwrites the account from a payload derived with the default gap of 20 — via `enhanceAddresses`, the page-1 branch replaces `addresses`, and `updateAccount` also overwrites `balance`/`availableBalance`/`utxo`/`history`. For exactly the wallets this feature targets (used addresses spread across gaps larger than 20), that regresses the account state until the next full sync re-runs with the custom gap, so the state oscillates. The thunk now passes the custom gap, matching the other call sites.

## Notes for QA

Impact is scoped to Bitcoin accounts with the experimental `gap-limit` feature enabled (Settings → experimental features), so blast radius on the default build is minimal.

- With the feature on, open a coin's advanced settings, expand "Custom gap limit", enter a value below 20 (or empty/0): the error shows and Save is disabled; a valid value (>= 20) saves as before.
- With a custom gap set on a Bitcoin account that has used addresses beyond index 20, confirm the balance / address list stays stable after opening the transaction history and after "fetch all" — it should no longer shrink back to the default-gap view between syncs.
- Non-Bitcoin accounts and default (feature-off) behavior are unaffected.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies four files: the AdvancedCoinSettingsModal (used for custom backend configuration including gap limit settings), a new useGapLimitForm hook with its unit test, and transactionsThunks (core transaction management logic). The AdvancedCoinSettingsModal and transactionsThunks each map to 121 tests due to being broadly imported, so only tests with direct functional relevance are recommended. The gap limit form hook and its unit test have no E2E coverage — the AdvancedCoinSettingsModal tests serve as the closest integration-level coverage for the gap limit UI. The highest risk areas are custom backend configuration flows (AdvancedCoinSettingsModal) and transaction listing/pending transaction behavior (transactionsThunks).

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx`
- `packages/suite/src/hooks/settings/__tests__/useGapLimitForm.test.tsx`
- `packages/suite/src/hooks/settings/useGapLimitForm.ts`
- `suite-common/wallet-core/src/transactions/transactionsThunks.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test directly exercises the AdvancedCoinSettingsModal by opening network advanced settings and configuring custom backends. Changes to AdvancedCoinSettingsModal.tsx could break the backend configuration UI, network enable/disable toggles, and the custom backend indicator display tested here.
- `suite/e2e/tests/settings/coins.test.ts` — This test configures custom backends via network advanced settings (openNetworkAdvanceSettings, changeBackend) which directly invokes the AdvancedCoinSettingsModal. It also tests the custom backend indicator display, making it highly sensitive to changes in AdvancedCoinSettingsModal.tsx.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test directly exercises transaction sending, pending transaction display, and transaction confirmation/mining workflows. Changes to transactionsThunks.ts could affect how pending transactions are tracked, how confirmed transactions are processed, and how transaction groups are updated.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test searches and displays transaction history on a BTC account. Changes to transactionsThunks.ts directly affect transaction fetching, filtering, and display logic that this test validates.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — Transaction export relies on transaction data fetched and managed by transactionsThunks. Changes to how transactions are stored or structured could affect export output formats (PDF, CSV, JSON).
- `suite/e2e/tests/wallet/pagination.test.ts` — Paginated transaction browsing depends on transaction fetching logic in transactionsThunks.ts. Changes to pagination-related thunks or transaction page loading could break page navigation and address display.
- `suite/e2e/tests/settings/electrum.test.ts` — This test configures a custom Electrum backend via the coins settings tab, which likely uses the AdvancedCoinSettingsModal for backend type selection and URL input. Changes to the modal could affect Electrum backend configuration.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test opens advanced network settings and changes the backend type to blockbook with a custom URL, directly using the AdvancedCoinSettingsModal. Changes to the modal could break custom backend configuration flow.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test sends transactions on regtest and verifies pending OP_RETURN transactions appear correctly. Changes to transactionsThunks could affect how sent transactions are tracked and displayed in the pending list.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/hooks/settings/__tests__/useGapLimitForm.test.tsx`
- `packages/suite/src/hooks/settings/useGapLimitForm.ts`

_Updated: 2026-07-06T11:20:18.190Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/gap-limit-validation-bug&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/gap-limit-validation-bug&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/gap-limit-validation-bug&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-06T11:26:21.671Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-06T11:23:49.517Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/gap-limit-validation-bug/web/](https://dev.suite.sldev.cz/suite-web/mroz22/gap-limit-validation-bug/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->