### PR TITLE
Refined unknown btc tx diagnostics

### DIFF
--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -319,10 +319,12 @@ export const transformTransaction = (
         // descriptor), an 'unknown' is a genuine gap worth capturing — including the anomalous case where
         // the supplied addresses were empty (myAddressesCount === 0).
         // Intentionally no txid / addresses / descriptor: these reach Sentry and could deanonymize the user.
-        if (addressesOrDescriptor !== undefined) {
-            console.error('[btc-unknown-tx-debug] transformTransaction → type=unknown', {
+        if (addresses !== undefined) {
+            console.error('[btc-unknown-tx-debug-v2] transformTransaction', {
                 isPending: !tx.blockHeight || tx.blockHeight <= 0,
-                myAddressesCount: myAddresses.length,
+                knownUsedCount: addresses.used.length,
+                knownUnusedCount: addresses.unused.length,
+                knownChangeCount: addresses.change.length,
                 vinCount: inputs.length,
                 voutCount: outputs.length,
                 vinWithAddressesCount: inputs.filter(

--- a/packages/connect/src/api/bitcoin/createPendingTx.ts
+++ b/packages/connect/src/api/bitcoin/createPendingTx.ts
@@ -2,7 +2,7 @@ import type { AccountAddresses, PROTO } from '@trezor/connect-common';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import type { Transaction as BitcoinJsTransaction } from '@trezor/utxo-lib';
 
-import { getSerializedPath } from '../../utils/pathUtils';
+import { __btcUnknownTxDebug__, getSerializedPath } from '../../utils/pathUtils';
 
 export const createPendingTransaction = (
     tx: BitcoinJsTransaction,
@@ -33,36 +33,7 @@ export const createPendingTransaction = (
             .map(address => address.address);
     };
 
-    const vin = inputs.map((ins, n) => {
-        const matched = findAddress(ins);
-        const hasAddressN = Array.isArray(ins.address_n) && ins.address_n.length > 0;
-
-        // [btc-unknown-tx-debug] address_n on this input did not match any address in
-        // account.addresses (unused/used/change). Downstream, blockbookUtils.transformTransaction
-        // will not recognize the input as ours, which can cascade to type='unknown' for the
-        // optimistic pending tx created right after signing. See addFakePendingTxThunk in
-        // suite-common/wallet-core/src/transactions/transactionsThunks.ts.
-        // Intentionally no txid / address_n / addresses: these reach Sentry and could deanonymize the user.
-        if (hasAddressN && matched.length === 0) {
-            console.error(
-                '[btc-unknown-tx-debug] createPendingTransaction → input has no matching address',
-                {
-                    inputIndex: n,
-                    knownAddressesCount: allAddresses.length,
-                },
-            );
-        }
-
-        return {
-            n,
-            txid: ins.prev_hash,
-            vout: ins.prev_index,
-            isAddress: true,
-            addresses: matched,
-            value: ins.amount.toString(),
-            sequence: ins.sequence,
-        };
-    });
+    __btcUnknownTxDebug__('createPendingTransaction', inputs, addresses);
 
     return {
         txid: tx.getId(),
@@ -75,7 +46,15 @@ export const createPendingTransaction = (
         value: valueOut.toString(),
         valueIn: valueIn.toString(),
         fees: valueIn.minus(valueOut).toString(),
-        vin,
+        vin: inputs.map((ins, n) => ({
+            n,
+            txid: ins.prev_hash,
+            vout: ins.prev_index,
+            isAddress: true,
+            addresses: findAddress(ins),
+            value: ins.amount.toString(),
+            sequence: ins.sequence,
+        })),
         vout: outputs.map((out, n) => {
             let transformedAddresses: string[] = [];
 

--- a/packages/connect/src/utils/pathUtils.ts
+++ b/packages/connect/src/utils/pathUtils.ts
@@ -14,6 +14,7 @@ import {
     getHDPath as parseHDPath,
     toHardenedPathPart,
 } from '@trezor/crypto-utils';
+import { arrayPartition } from '@trezor/utils';
 
 export const getSlip44ByPath = (path: number[]) => {
     // @ts-expect-error: indexing with noUncheckedIndexedAccess
@@ -212,4 +213,54 @@ export const getLabel = (label: string, coinInfo?: CoinInfo) => {
     }
 
     return label.replace('#NETWORK', '');
+};
+
+/** @deprecated Temporary diagnostic method */
+export const __btcUnknownTxDebug__ = (
+    description: string,
+    inputs: { address_n?: number[]; orig_hash?: any }[],
+    addresses:
+        | { used: { path: string }[]; unused: { path: string }[]; change: { path: string }[] }
+        | undefined,
+) => {
+    try {
+        if (inputs.some(i => i.orig_hash)) {
+            // In RBF, account's change addresses are modified so the right change address is selected,
+            // therefore it's expected that the inputs can't be found in account's addresses.
+            return;
+        }
+
+        const accountAddressPaths = new Set(
+            addresses
+                ? addresses.change.concat(addresses.used, addresses.unused).map(({ path }) => path)
+                : [],
+        );
+
+        const [matched, unmatched] = arrayPartition(
+            inputs
+                .map(input => input.address_n)
+                .filter((addr): addr is number[] => Array.isArray(addr) && addr.length > 0),
+            addr => accountAddressPaths.has(getSerializedPath(addr)),
+        );
+
+        const toReadable = (address_n: number[]) =>
+            `${address_n[address_n.length - 2] ? 'change' : 'receive'}/${address_n[address_n.length - 1]}`;
+
+        if (unmatched.length) {
+            // [btc-unknown-tx-debug] the selected account does not contain paths used by the tx inputs.
+            // This can make Connect build a pending tx with wrong or empty vin addresses, which can then
+            // classify the optimistic pending tx incorrectly before the backend response arrives.
+            // Intentionally no paths / addresses / descriptor / txid: these reach Sentry and could
+            // deanonymize the user. accountType + symbol are low-cardinality, non-PII.
+            console.error(`[btc-unknown-tx-debug-v2] ${description}`, {
+                knownUsedCount: addresses?.used.length,
+                knownUnusedCount: addresses?.unused.length,
+                knownChangeCount: addresses?.change.length,
+                matchedInputs: matched.map(toReadable),
+                unmatchedInputs: unmatched.map(toReadable),
+            });
+        }
+    } catch {
+        // empty
+    }
 };

--- a/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
@@ -27,8 +27,8 @@ import TrezorConnect, {
     type SignTransaction,
     type SignedTransaction,
 } from '@trezor/connect';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- temporary diagnostic; getSerializedPath is not re-exported from the @trezor/connect public barrel
-import { getSerializedPath } from '@trezor/connect/src/utils/pathUtils';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- temporary diagnostic
+import { __btcUnknownTxDebug__ } from '@trezor/connect/src/utils/pathUtils';
 import { BigNumber, isArrayMember } from '@trezor/utils';
 
 import { SEND_MODULE_PREFIX } from './sendFormConstants';
@@ -338,39 +338,11 @@ export const signBitcoinSendFormTransactionThunk = createThunk<
             signEnhancement.version = 2;
         }
 
-        const accountAddressPaths = new Set(
-            selectedAccount.addresses
-                ? selectedAccount.addresses.change
-                      .concat(selectedAccount.addresses.used, selectedAccount.addresses.unused)
-                      .map(({ path }) => path)
-                : [],
+        __btcUnknownTxDebug__(
+            'signBitcoin',
+            (signEnhancement.inputs as { address_n?: number[] }[]) ?? precomposedTransaction.inputs,
+            selectedAccount.addresses,
         );
-        const inputPaths = precomposedTransaction.inputs
-            .map(input =>
-                Array.isArray(input.address_n) && input.address_n.length > 0
-                    ? getSerializedPath(input.address_n)
-                    : undefined,
-            )
-            .filter((path): path is string => typeof path === 'string');
-        const unmatchedInputPathCount = inputPaths.filter(
-            path => !accountAddressPaths.has(path),
-        ).length;
-
-        if (unmatchedInputPathCount > 0) {
-            // [btc-unknown-tx-debug] the selected account does not contain paths used by the tx inputs.
-            // This can make Connect build a pending tx with wrong or empty vin addresses, which can then
-            // classify the optimistic pending tx incorrectly before the backend response arrives.
-            // Intentionally no paths / addresses / descriptor / txid: these reach Sentry and could
-            // deanonymize the user. accountType + symbol are low-cardinality, non-PII.
-            console.error('[btc-unknown-tx-debug] signBitcoin → input paths missing in account', {
-                accountType: selectedAccount.accountType,
-                symbol: selectedAccount.symbol,
-                inputCount: precomposedTransaction.inputs.length,
-                inputsWithAddressNCount: inputPaths.length,
-                knownAddressesCount: accountAddressPaths.size,
-                unmatchedInputPathCount,
-            });
-        }
 
         const signPayload: Params<SignTransaction> = {
             device: {

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -33,6 +33,8 @@ import TrezorConnect, {
     type AccountTransaction,
     type TokenTransfer,
 } from '@trezor/connect';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- temporary diagnostic
+import { __btcUnknownTxDebug__ } from '@trezor/connect/src/utils/pathUtils';
 
 import { TRANSACTIONS_MODULE_PREFIX, transactionsActions } from './transactionsActions';
 import {
@@ -180,32 +182,10 @@ export const addFakePendingTxThunk = createThunk(
                     affectedAccount.addresses ?? affectedAccount.descriptor,
                 );
                 if (affectedAccountTransaction.type === 'unknown') {
-                    const unusedCount = affectedAccount.addresses?.unused.length ?? 0;
-                    const usedCount = affectedAccount.addresses?.used.length ?? 0;
-                    const changeCount = affectedAccount.addresses?.change.length ?? 0;
-                    // [btc-unknown-tx-debug] the just-signed BTC tx was classified as 'unknown' before
-                    // even reaching the backend. The user will see "Unknown transaction" in the list
-                    // until the backend response replaces this entry. This is the clean, send-path-only
-                    // smoking gun (see also the createPendingTx.ts and blockbook.ts logs for upstream
-                    // detail). The payload reaches Sentry as event.extra.arguments[1]; the bug is rare
-                    // enough to triage per-event, and mobile-vs-desktop frequency is already split by
-                    // Sentry project (native vs desktop/web DSN), so tags are not needed here.
-                    // emptyAddresses separates the two leading hypotheses at a glance:
-                    //   true  -> no addresses at classification time (account addresses absent)
-                    //   false -> addresses present but nothing matched (path mismatch: gap-limit / taproot)
-                    // Intentionally no txid / accountKey / descriptor / raw addresses: these reach Sentry
-                    // and could deanonymize the user. accountType + symbol are low-cardinality, non-PII.
-                    console.error(
-                        '[btc-unknown-tx-debug] addFakePendingTxThunk → prepending tx has type=unknown',
-                        {
-                            accountType: affectedAccount.accountType,
-                            symbol: affectedAccount.symbol,
-                            hasAddresses: Boolean(affectedAccount.addresses),
-                            emptyAddresses: unusedCount + usedCount + changeCount === 0,
-                            unusedCount,
-                            usedCount,
-                            changeCount,
-                        },
+                    __btcUnknownTxDebug__(
+                        'addFakePendingTxThunk',
+                        precomposedTransaction.inputs,
+                        affectedAccount.addresses,
                     );
                 }
                 const prependingTx = { ...affectedAccountTransaction, deadline: blockHeight + 2 };


### PR DESCRIPTION
## Description

Diagnostic reports from #27350 were improved a bit, based on received reports.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files affect core Bitcoin/UTXO transaction sending (sendFormBitcoinThunks), pending transaction creation (createPendingTx), derivation path utilities (pathUtils), blockbook data parsing (blockbook.ts), and transaction processing (transactionsThunks). All five files map to 121 tests each, indicating they are deeply shared infrastructure. The highest risk is in Bitcoin send flows, so tests that actually compose, sign, or display BTC/UTXO transactions should be prioritized. Secondary risk is in transaction display, discovery, and account handling that depends on blockbook parsing or path utilities.

<details><summary><b>Changed files (5)</b></summary>

- `packages/blockchain-link-utils/src/blockbook.ts`
- `packages/connect/src/api/bitcoin/createPendingTx.ts`
- `packages/connect/src/utils/pathUtils.ts`
- `suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts`
- `suite-common/wallet-core/src/transactions/transactionsThunks.ts`

</details>

**Recommended tests (16)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test exercises the Bitcoin send form end-to-end including filling amounts, adding outputs, OP_RETURN, and submitting transactions on regtest. It directly exercises sendFormBitcoinThunks (composing/signing BTC transactions), createPendingTx (pending transaction creation after send), transactionsThunks (transaction processing), and pathUtils (BTC derivation paths).
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test sends a DOGE transaction (a Bitcoin-like UTXO coin) with an extremely large amount, exercising sendFormBitcoinThunks for transaction composition, createPendingTx for pending tx handling, and blockbook.ts for DOGE backend data parsing. It specifically tests sign transaction error handling which is directly relevant to these changed files.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test sends LTC (a Bitcoin-like coin) using broadcast mode with a MimbleWimble peg-out transaction, directly exercising sendFormBitcoinThunks for composing the transaction, createPendingTx, and blockbook.ts for LTC backend data parsing.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies BTC account balance display after receiving transactions on regtest, which exercises transactionsThunks for processing incoming transactions and blockbook.ts for parsing blockbook backend responses to derive balances.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test searches and displays BTC transactions, exercising transactionsThunks for fetching/processing transaction data and blockbook.ts for parsing blockbook transaction responses.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test exports transaction history in PDF/CSV/JSON formats for BTC, LTC, ETH, and ADA accounts. It relies on transactionsThunks for loading transaction data and blockbook.ts for parsing blockbook responses that populate the export content.
- `suite/e2e/tests/wallet/pagination.test.ts` — This test navigates paginated transaction pages on a legacy BTC account, relying on transactionsThunks for fetching paginated transaction data and blockbook.ts for parsing the blockbook responses.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coins (BTC, ETH, LTC, ETC, BCH, DOGE, XRP, ZEC) and runs discovery with page reload resilience. pathUtils is used for derivation path handling during discovery, and blockbook.ts parses backend data for multiple UTXO coins.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends for BTC and LTC and verifies discovery completes. Changes to blockbook.ts directly affect how blockbook responses are parsed during discovery.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test configures custom blockbook backend URLs for BTC and ETH, then verifies discovery and account loading. Changes to blockbook.ts affect how data from these backends is parsed.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — This test imports a BTC CSV file into the send form to populate multiple outputs. The send form composition logic in sendFormBitcoinThunks processes these imported outputs for Bitcoin transactions.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test performs a full sell BTC flow including initiating a send transaction from the confirmation screen. The BTC send transaction composition uses sendFormBitcoinThunks, and createPendingTx handles the resulting pending transaction.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test performs a BTC-to-ETH swap with custom Bitcoin fee settings, directly exercising sendFormBitcoinThunks for composing the Bitcoin transaction with custom fee rate, and verifying fee calculations on the device prompt.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds different BTC account types (normal, taproot, segwit, legacy) which exercises pathUtils for derivation path handling. Changes to path utilities could affect account type derivation.
- `suite/e2e/tests/wallet/public-keys.test.ts` — This test verifies XPUB display for BTC, LTC, and ADA accounts. pathUtils changes could affect derivation path construction used to derive these public keys.
- `suite/e2e/tests/wallet/without-device.test.ts` — This test fills in a regtest send form and clicks review while device is disconnected, which touches sendFormBitcoinThunks for the send form composition path, though the main assertion is about the connection modal.

</details>

_Updated: 2026-07-06T15:51:29.999Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/btc-unknown-pt2/web/](https://dev.suite.sldev.cz/suite-web/chore/btc-unknown-pt2/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/btc-unknown-pt2&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/btc-unknown-pt2&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/btc-unknown-pt2&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-06T15:56:27.635Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-06T15:53:50.841Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->