### PR TITLE
feat(suite-common): disable nfts support for tron

### DIFF
--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -342,7 +342,7 @@ export const networks = {
         bip43Path: "m/44'/195'/0'/0/i",
         decimals: 6,
         testnet: false,
-        features: ['tokens', 'coin-definitions', 'graph', 'nfts', 'staking'],
+        features: ['tokens', 'coin-definitions', 'graph', 'staking'],
         explorer: getExplorerUrls('https://tronscan.org/#', 'tron'),
         support: {
             [DeviceModelInternal.T2T1]: '2.11.0',
@@ -713,7 +713,7 @@ export const networks = {
         bip43Path: "m/44'/195'/0'/0/i",
         decimals: 6,
         testnet: true,
-        features: ['tokens', 'graph', 'nfts'],
+        features: ['tokens', 'graph'],
         explorer: getExplorerUrls('https://nile.tronscan.org/#', 'tron'),
         backendOptions: [{ type: 'blockbook' }],
         accountTypes: {},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Blockbook currently doesn't support Tron NFTs so it doesn't make sense to show it in Suite.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to suite-common/wallet-config/src/networksConfig.ts affects the central network/coin configuration used across the entire Trezor Suite application. Since this file maps to 121 tests (virtually all E2E tests), it is a broad global dependency. The recommended strategy focuses on tests that directly exercise network configuration, coin activation, discovery, and multi-network functionality — where changes to network definitions (symbols, backends, derivation paths, default states) would most visibly manifest as regressions. Tests involving coin settings, wallet discovery, asset activation, and multi-coin operations are prioritized highest.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/wallet-config/src/networksConfig.ts`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — This test directly exercises network/coin configuration — enabling mainnet and testnet networks, activating assets via modal, and configuring custom backends. Changes to networksConfig.ts directly affect which networks are available, their default states, and their properties, all of which this test validates.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test enables specific coin networks (BTC, ETH) and configures custom blockbook backends, directly depending on network configuration properties like backend types and network symbols defined in networksConfig.ts.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple cryptocurrency coins (BTC, ETH, LTC, ETC, BCH, DOGE, XRP, ZEC) and triggers account discovery. It directly validates that all these networks defined in networksConfig.ts are discoverable and produce visible account balances.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test enables networks (BTC, ETH) via the 'Activate Assets' modal and verifies they appear correctly in grid/table views. It directly validates network activation UI which reads from networksConfig.ts to populate available assets.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends for BTC and LTC and validates discovery completes. Network backend configuration (types, URLs) is defined in networksConfig.ts, making this test sensitive to changes in backend-related network properties.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds different account types (normal, taproot, segwit, legacy) for multiple coins (BTC, LTC, ETH, Base, ADA). Account type definitions and derivation paths come from networksConfig.ts, so changes could affect available account types.
- `suite/e2e/tests/wallet/public-keys.test.ts` — This test activates BTC, LTC, and ADA networks and verifies the correct XPUBs are displayed. Network configuration changes (e.g., derivation paths, network symbols) in networksConfig.ts could affect public key derivation and display.
- `suite/e2e/tests/wallet/cardano.test.ts` — This test enables ADA network and verifies account details including type description, derivation path, and xpub. Cardano-specific network configuration in networksConfig.ts directly affects these displayed properties.
- `suite/e2e/tests/wallet/receive.test.ts` — This test enables and receives on BTC, ETH, SOL, and TRX networks, validating address formats. Network-specific properties like address formats and derivation paths defined in networksConfig.ts are directly exercised.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test enables BTC, LTC, ETH, and ADA networks and exports transactions in multiple formats. It validates that multiple networks are functional end-to-end, which depends on correct network configuration.
- `suite/e2e/tests/analytics/events.test.ts` — The SuiteReady analytics event explicitly reports enabledNetworks, customBackends, and network-related settings. Changes to networksConfig.ts could alter default enabled networks or network symbols reported in analytics payloads.
- `suite/e2e/tests/trading/navigation.test.ts` — This test enables BTC, ETH, and LTC networks and navigates to buy/sell/swap forms for various coins and tokens. Network availability and symbols from networksConfig.ts determine which assets appear in trading forms.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test enables regtest network via testnet toggle and verifies balance display. Testnet/regtest network definitions in networksConfig.ts directly affect whether this network is available and how it behaves.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test covers every application route and checks links. It uses router-config which may reference network-related routes. Changes to networksConfig.ts could indirectly affect available routes or pages, but the link-checking behavior itself is unlikely to break.

</details>

_Updated: 2026-07-06T12:33:17.390Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-disable-nft/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-disable-nft/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-disable-nft&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-disable-nft&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-disable-nft&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-06T12:38:57.580Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-06T12:37:54.365Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->