### PR TITLE
Enrich unknown btc tx diagnostics with backend/context fields

### DIFF
--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -211,6 +211,9 @@ const getTronStakingClassification = (
 export const transformTransaction = (
     tx: BlockbookTransaction,
     addressesOrDescriptor?: TransformAddresses | string,
+    // [btc-unknown-tx-debug] response-level context, supplied only by transformAccountInfo; used purely
+    // to enrich the temporary unknown-tx diagnostics below. Non-PII (a boolean and a page index).
+    debugContext?: { isEVM: boolean; page: number | undefined },
 ): Transaction => {
     const [addresses, descriptor] =
         typeof addressesOrDescriptor === 'object'
@@ -310,21 +313,29 @@ export const transformTransaction = (
         amount = tx.value;
         targets = [];
         // [btc-unknown-tx-debug] 'unknown' is the catch-all the categorizer falls back to when it cannot
-        // tell whether the tx is recv/sent/self for this account — for an account's own tx that is never a
-        // desired outcome, it is a hole in our categorization (we show "something" rather than dropping it).
-        // We log every such case EXCEPT calls that pass no account context at all — transformTransaction(tx)
-        // by id (prev/ref-tx during signing, CoinControl UTXO detail): there is no account to compare
-        // against, so `type` is an unused placeholder that is never shown, not a categorization miss, and
-        // logging it would only flood Sentry. When account context WAS provided (an addresses object or a
-        // descriptor), an 'unknown' is a genuine gap worth capturing — including the anomalous case where
-        // the supplied addresses were empty (myAddressesCount === 0).
+        // tell whether the tx is recv/sent/self — for an account's own tx that is a hole in categorization.
+        // Fire whenever account context was provided (addresses object OR descriptor string); skip only the
+        // no-context calls (transformTransaction(tx) by id: prev/ref-tx during signing, CoinControl UTXO
+        // detail), where `type` is an unused placeholder that is never shown. addressesSource + isEVM +
+        // isXpubDescriptor let a benign EVM / single-address descriptor case be told apart from a UTXO
+        // xpub-fallback (empty tokens), instead of dropping descriptor mode wholesale.
         // Intentionally no txid / addresses / descriptor: these reach Sentry and could deanonymize the user.
-        if (addresses !== undefined) {
+        if (addressesOrDescriptor !== undefined) {
             console.error('[btc-unknown-tx-debug] transformTransaction → type=unknown', {
+                isEVM: debugContext?.isEVM,
+                page: debugContext?.page,
+                addressesSource: addresses !== undefined ? 'addresses' : 'descriptor',
+                // length-only heuristic (xpub ~111 chars vs any single address <64); descriptor never emitted
+                isXpubDescriptor:
+                    addresses === undefined && typeof descriptor === 'string'
+                        ? descriptor.length >= 100
+                        : undefined,
+                knownUsedCount: addresses?.used.length,
+                knownUnusedCount: addresses?.unused.length,
+                knownChangeCount: addresses?.change.length,
                 isPending: !tx.blockHeight || tx.blockHeight <= 0,
-                knownUsedCount: addresses.used.length,
-                knownUnusedCount: addresses.unused.length,
-                knownChangeCount: addresses.change.length,
+                confirmations: tx.confirmations,
+                hasBlockHash: Boolean(tx.blockHash),
                 vinCount: inputs.length,
                 voutCount: outputs.length,
                 vinWithAddressesCount: inputs.filter(
@@ -333,6 +344,8 @@ export const transformTransaction = (
                 voutWithAddressesCount: outputs.filter(
                     v => Array.isArray(v.addresses) && v.addresses.length > 0,
                 ).length,
+                tokenTransferCount: Array.isArray(tx.tokenTransfers) ? tx.tokenTransfers.length : 0,
+                internalTransferCount: tx.ethereumSpecific?.internalTransfers?.length ?? 0,
             });
         }
     }
@@ -479,9 +492,10 @@ export const transformAccountInfo = (payload: BlockbookAccountInfo): AccountInfo
         payload.unconfirmedTxs === 0 &&
         new BigNumber(availableBalance).isZero();
 
-    const unfilteredTransactions = payload.transactions
-        ? payload.transactions.map(t => transformTransaction(t, addresses ?? descriptor))
-        : undefined;
+    const debugContext = { isEVM, page: page?.index };
+    const unfilteredTransactions = payload.transactions?.map(t =>
+        transformTransaction(t, addresses ?? descriptor, debugContext),
+    );
 
     const transactions =
         isEVM && unfilteredTransactions

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -179,6 +179,42 @@ export const fetchAndUpdateAccountThunk = createThunk(
 
         if (response.success) {
             const { payload } = response;
+
+            // [btc-unknown-tx-debug] response-level context the low-level blockbook.ts transform cannot
+            // see (symbol / accountType / backendType / details). Fires once per response that carries any
+            // 'unknown' tx; pair with the per-tx blockbook.ts log to tell an expected descriptor case
+            // (EVM, single-address, non-blockbook backend) apart from a genuine gap on a default backend.
+            // Non-PII: low-cardinality enums and counts only — no descriptor / addresses / txids / amounts.
+            try {
+                const unknownTxs = (payload.history.transactions ?? []).filter(
+                    tx => tx.type === 'unknown',
+                );
+                if (unknownTxs.length > 0) {
+                    console.error(
+                        '[btc-unknown-tx-debug] getAccountInfo response contains unknown txs',
+                        {
+                            symbol: account.symbol,
+                            accountType: account.accountType,
+                            backendType: account.backendType,
+                            networkType: account.networkType,
+                            details: 'txs',
+                            page: payload.page?.index,
+                            totalTxs: payload.history.transactions?.length ?? 0,
+                            unknownCount: unknownTxs.length,
+                            unknownConfirmedCount: unknownTxs.filter(
+                                tx => (tx.blockHeight ?? 0) > 0,
+                            ).length,
+                            responseHasAddresses: Boolean(payload.addresses),
+                            knownUsedCount: payload.addresses?.used.length,
+                            knownUnusedCount: payload.addresses?.unused.length,
+                            knownChangeCount: payload.addresses?.change.length,
+                        },
+                    );
+                }
+            } catch {
+                // diagnostics must never break the sync
+            }
+
             const blockHeight = selectBlockchainHeightBySymbol(getState(), account.symbol);
 
             const analyze = analyzeTransactions(payload.history.transactions || [], accountTxs, {


### PR DESCRIPTION
## Description

Stacked on top of #29471 (`chore/btc-unknown-pt2`). Further enriches the temporary `[btc-unknown-tx-debug]` diagnostics so the collected Sentry data can actually answer the open question.

The reports gathered so far show the user-visible "Unknown transaction" comes from the `transformTransaction` / `getAccountInfo` path (the send-path logs never escalate to a visible unknown). But the current payload cannot distinguish a **benign** descriptor case (EVM, single-address, or a non-blockbook backend where a tokens-less response is expected) from a **genuine** categorization gap on the default backend — the discriminating context simply isn't logged. This PR adds it.

### `transformTransaction` (`blockchain-link-utils/src/blockbook.ts`)

- Keeps logging descriptor mode (reverts the `addresses !== undefined` guard back to firing whenever any account context was provided) but adds `addressesSource` + `isXpubDescriptor`, so EVM / single-address noise can be filtered in Sentry instead of dropping the UTXO xpub-fallback signal wholesale. `isXpubDescriptor` is a length-only heuristic — the descriptor string itself is never emitted.
- Adds `isEVM` and `page` (threaded from `transformAccountInfo`), `confirmations` + `hasBlockHash` (the blockbook mempool-lag race signature: `blockHeight > 0` with `confirmations === 0` and no block hash), and `tokenTransferCount` / `internalTransferCount` (to catch the EVM attribution gaps where the account only appears in a dropped internal transfer).

### `fetchAndUpdateAccountThunk` (`wallet-core/src/accounts/accountsThunks.ts`)

- Adds a response-level log carrying the context the low-level transform cannot see: `symbol`, `accountType`, `backendType`, `networkType`, `details`, `page`, and per-response `unknownCount` / `totalTxs` / confirmed-unknown counts. It fires once per resync response that contains any `unknown` tx. `backendType` in particular is what settles whether a tokens-less (descriptor-fallback) response is expected for that backend or anomalous on the default one.

All added fields are non-PII: low-cardinality enums, counts, booleans, and a length-only xpub check. No descriptor / xpub / addresses / txids / amounts are emitted, consistent with the existing diagnostics.

## Related

- Builds on #29471
- Diagnostics originally added in #27350; removal drafted in #28290 (to land once a fix exists)

## Notes for QA

No QA needed — diagnostics only, no behaviour change. The added code is pure logging guarded by `try/catch` (the Suite-level scan) and an optional, backward-compatible parameter (the transform), so existing callers are unaffected. Worth a sanity check that account discovery, resync, and the BTC/LTC/DOGE send + transaction list still behave exactly as before.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/btc-unknown-pt3&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->