### PR TITLE
Revert "feat(suite-common): disable nfts support for tron"

### DIFF
--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -342,7 +342,7 @@ export const networks = {
         bip43Path: "m/44'/195'/0'/0/i",
         decimals: 6,
         testnet: false,
-        features: ['tokens', 'coin-definitions', 'graph', 'staking'],
+        features: ['tokens', 'coin-definitions', 'graph', 'nfts', 'staking'],
         explorer: getExplorerUrls('https://tronscan.org/#', 'tron'),
         support: {
             [DeviceModelInternal.T2T1]: '2.11.0',
@@ -713,7 +713,7 @@ export const networks = {
         bip43Path: "m/44'/195'/0'/0/i",
         decimals: 6,
         testnet: true,
-        features: ['tokens', 'graph'],
+        features: ['tokens', 'graph', 'nfts'],
         explorer: getExplorerUrls('https://nile.tronscan.org/#', 'tron'),
         backendOptions: [{ type: 'blockbook' }],
         accountTypes: {},


### PR DESCRIPTION
## Description
Reverts trezor/trezor-suite#29472

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to networksConfig.ts is a modification to a foundational configuration file that defines all supported cryptocurrency networks, their parameters (symbols, decimals, derivation paths, backend types), and default states. Since this file maps to 121 tests, the broad-utility heuristic applies — only tests that directly exercise network configuration, discovery, or network-dependent functionality are prioritized. The recommended strategy focuses on: (1) tests that directly manipulate network settings and activation (coins.test.ts, assets.test.ts), (2) tests that verify discovery across multiple networks, and (3) tests that depend on specific network parameters like derivation paths, address formats, or decimals. Most backup, onboarding, metadata, and browser tests are omitted as they only transitively import network config without meaningfully depending on its specific values.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/wallet-config/src/networksConfig.ts`

</details>

**Recommended tests (15)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — This test directly exercises network/coin configuration including enabling mainnet and testnet networks, activating assets via modal, and verifying network states. Changes to networksConfig.ts directly affect which networks are available, their default states, and how they appear in the coins settings UI.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test enables specific coin networks (BTC, ETH) and configures custom backends, directly depending on network configuration from networksConfig.ts including NetworkSymbol types, BackendType, and network enable/disable logic.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple cryptocurrency coins (BTC, ETH, LTC, ETC, BCH, DOGE, XRP, ZEC) and triggers account discovery, directly testing that network configurations from networksConfig.ts are valid and discovery works for each configured network.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test exercises the Activate Assets modal which enables new networks (ETH) and verifies asset display in grid/table views. It directly depends on network configuration to show available coins and activate them correctly.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds different account types (normal, taproot, segwit, legacy) for multiple coins (BTC, LTC, ETH, Base, ADA), directly depending on networksConfig.ts for available account types, derivation paths, and network symbols.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/wallet/public-keys.test.ts` — This test verifies correct XPUBs for BTC, LTC, and ADA networks. Changes to networksConfig.ts could affect derivation paths or network parameters that determine the generated public keys.
- `suite/e2e/tests/wallet/receive.test.ts` — This test verifies receive addresses for BTC, ETH, SOL, and TRX networks. Network configuration changes could affect address derivation, formatting, or network-specific parameters used in address generation.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends for BTC and LTC and verifies discovery completes. It depends on network configuration for backend type definitions and network-specific discovery parameters.
- `suite/e2e/tests/wallet/cardano.test.ts` — This test enables ADA network and verifies account details including type description, derivation path, and xpub display. Changes to networksConfig.ts could affect Cardano-specific network parameters.
- `suite/e2e/tests/analytics/events.test.ts` — The SuiteReady analytics event captures enabled networks and their configuration. Changes to networksConfig.ts directly affect the enabledNetworks and customBackends values reported in analytics events.
- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates buy/sell/swap forms for multiple networks (BTC, LTC, ETH) and tokens. Network configuration changes could affect how coins appear in trading flows and asset pickers.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test enables regtest network and verifies balance display. Changes to networksConfig.ts could affect testnet/regtest network definitions, decimals, or display parameters.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test enables ETH network with a custom backend for staking. Network configuration changes to ETH parameters (decimals, symbols, backend types) could break the staking flow.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test uses getNetwork('sol') from wallet-config to retrieve SOL decimals for amount calculations. Changes to SOL network configuration would directly affect send amount computations.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This test enables ADA with a custom Blockfrost backend and performs staking operations. Changes to ADA network configuration could affect backend settings or network-specific staking parameters.

</details>

_Updated: 2026-07-06T17:13:15.418Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=revert-29472-feat/tron-disable-nft&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=revert-29472-feat/tron-disable-nft&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=revert-29472-feat/tron-disable-nft&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-06T17:17:52.804Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-06T17:16:11.171Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/revert-29472-feat/tron-disable-nft/web/](https://dev.suite.sldev.cz/suite-web/revert-29472-feat/tron-disable-nft/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->