### PR TITLE
chore(trading): approvalFlow true for dex allowance check

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -363,6 +363,7 @@ export const useTradingExchangeForm = ({
     const confirmTrade = async ({
         receiveAddress,
         trade,
+        approvalFlow,
         ...props
     }: TradingExchangeConfirmTradeProps): Promise<ExchangeTrade | undefined> => {
         const commonFunctions = await getCommonFunctions(trade);
@@ -379,6 +380,7 @@ export const useTradingExchangeForm = ({
                 account,
                 extraField: props.extraField ?? extraField,
                 trade,
+                approvalFlow,
                 triggerAnalyticsTradeConfirmation,
                 processResponseData,
                 nextStep,

--- a/packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx
@@ -90,7 +90,7 @@ export const TradingFormOfferExchangeActions = () => {
 
                 setIsLoadingQuote(true);
                 try {
-                    await confirmTrade({ trade: quote, receiveAddress });
+                    await confirmTrade({ trade: quote, receiveAddress, approvalFlow: true });
                 } catch {
                     console.error('Failed to confirm trade on quote change');
                 } finally {

--- a/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
@@ -883,4 +883,89 @@ describe('confirmExchangeTradeThunk', () => {
         expect(exchange.formStep).toEqual('SEND_TRANSACTION');
         expect(!!response).toBeTruthy();
     });
+
+    describe('approvalFlow', () => {
+        it('should forward approvalFlow: true to doExchangeTrade', async () => {
+            const {
+                store,
+                returnUrl,
+                receiveAddress,
+                account,
+                trade,
+                mockProcessResponseData,
+                mockNextStep,
+                mockTriggerAnalyticsTradeConfirmation,
+            } = getMocks();
+
+            const tradeResponse = {
+                ...trade,
+                status: 'CONFIRM',
+                orderId: 'orderId',
+            } as ExchangeTrade;
+
+            const doExchangeTradeSpy = jest.fn().mockResolvedValue(tradeResponse);
+            invityAPI.doExchangeTrade = doExchangeTradeSpy;
+
+            await store
+                .dispatch(
+                    exchangeThunks.confirmTradeThunk({
+                        returnUrl,
+                        receiveAddress,
+                        account,
+                        trade,
+                        approvalFlow: true,
+                        nextStep: mockNextStep,
+                        triggerAnalyticsTradeConfirmation: mockTriggerAnalyticsTradeConfirmation,
+                        processResponseData: mockProcessResponseData,
+                    }),
+                )
+                .unwrap();
+
+            expect(doExchangeTradeSpy).toHaveBeenCalledWith(
+                expect.objectContaining({ approvalFlow: true }),
+                expect.anything(),
+            );
+        });
+
+        it('should default approvalFlow to false when omitted', async () => {
+            const {
+                store,
+                returnUrl,
+                receiveAddress,
+                account,
+                trade,
+                mockProcessResponseData,
+                mockNextStep,
+                mockTriggerAnalyticsTradeConfirmation,
+            } = getMocks();
+
+            const tradeResponse = {
+                ...trade,
+                status: 'CONFIRM',
+                orderId: 'orderId',
+            } as ExchangeTrade;
+
+            const doExchangeTradeSpy = jest.fn().mockResolvedValue(tradeResponse);
+            invityAPI.doExchangeTrade = doExchangeTradeSpy;
+
+            await store
+                .dispatch(
+                    exchangeThunks.confirmTradeThunk({
+                        returnUrl,
+                        receiveAddress,
+                        account,
+                        trade,
+                        nextStep: mockNextStep,
+                        triggerAnalyticsTradeConfirmation: mockTriggerAnalyticsTradeConfirmation,
+                        processResponseData: mockProcessResponseData,
+                    }),
+                )
+                .unwrap();
+
+            expect(doExchangeTradeSpy).toHaveBeenCalledWith(
+                expect.objectContaining({ approvalFlow: false }),
+                expect.anything(),
+            );
+        });
+    });
 });


### PR DESCRIPTION
## Description

Sends `approvalFlow: true` in the `doExchangeTrade` request when the desktop exchange form fetches allowance/approval data for a dex quote (the `initConfirmTrade` effect), so the backend can distinguish the pre-action allowance check from actual trade requests. The `approvalFlow` prop existed on `TradingExchangeConfirmTradeProps` but was dropped by the `confirmTrade` wrapper — it is now forwarded to `confirmTradeThunk`. All action calls (approve, revoke, swap, CEX) are unchanged and keep the thunk default `false`.

## Notes for QA

Desktop exchange, dex quote with an ERC-20 token (approval step shown): the quote-data request fired when entering/refreshing the approval step carries `approvalFlow: true`; approve, revoke, swap and CEX flows behave as before and send `approvalFlow: false`.

## Related Issue

## Screenshots:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies the trading/exchange (swap) form hook, the exchange offer action buttons component, and a unit test for the confirm exchange trade thunk. The risk is concentrated in the swap/exchange trading flow — form initialization, input handling, quote selection, offer confirmation, and transaction execution. The useTradingExchangeForm.ts file maps to 121 tests via static coverage, but this is because it's bundled into the main app; only swap/exchange-specific E2E tests are meaningfully affected. The recommended strategy focuses on the swap flow tests (coin-to-token, token-to-coin, token-to-token, coin-to-coin, fee customization) as high priority, with swap inputs, navigation, history, and live tests as medium priority.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts`
- `packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx`
- `suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test exercises the swap/exchange trading flow end-to-end including form filling, quote confirmation, device prompt verification, and transaction completion. The changed useTradingExchangeForm.ts hook directly powers the exchange form logic, and TradingFormOfferExchangeActions.tsx renders the exchange offer action buttons used in this flow.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test covers swapping SOL to BTC through the full trading swap flow including quote selection, device confirmation, toast notifications, and transaction status polling. It directly exercises the exchange form hook and offer actions component changed in this PR.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping an SPL token (USDT) to Bitcoin via the swap interface, exercising the exchange form submission, offer confirmation, and device prompt flows that depend on useTradingExchangeForm and TradingFormOfferExchangeActions.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests swapping between SPL tokens (USDT to USDC) through the full swap flow including form filling, best offer selection, device confirmation, and success verification. Directly exercises the exchange form hook and offer action components.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests the swap flow from BTC to ETH with custom fee settings, verifying fee calculations and device prompt amounts. The exchange form hook manages fee state and the offer actions component triggers the confirmation flow.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests ETH-to-BTC swap with custom Ethereum gas fee parameters (gas limit, max fee, priority fee). The exchange form hook handles fee state management and the offer actions trigger the confirmation, both changed in this PR.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swapping a token to an asset on a disabled network, verifying provider info display in quotes. While simpler than full swap flows, it still exercises the exchange form filling logic from useTradingExchangeForm.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form input behaviors including asset selection, amount filling, fraction buttons, and validation errors. These input interactions are managed by the useTradingExchangeForm hook that was changed.
- `suite/e2e/tests/trading/swap-history.test.ts` — Tests swap trade history display and detail views. While primarily read-only, the confirmExchangeTradeThunk (unit test changed) is responsible for creating trade records that appear in history, so changes could affect data integrity.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation to the swap form from various entry points, verifying the correct cryptocurrency is preselected. The swap form initialization depends on useTradingExchangeForm hook logic.
- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — Live swap test (SOL to USDC across chains) that exercises the full exchange flow end-to-end with real providers. Directly uses the exchange form and offer actions, but marked medium due to live test infrastructure requirements.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Live swap test (USDT to SOL via CEX) exercising the exchange form and confirmation flow with real providers. Uses the changed exchange form hook and offer actions component.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts`

_Updated: 2026-07-06T23:47:15.357Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/trading/approval-flow-for-allowance/web/](https://dev.suite.sldev.cz/suite-web/feat/trading/approval-flow-for-allowance/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading/approval-flow-for-allowance&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading/approval-flow-for-allowance&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/trading/approval-flow-for-allowance&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-06T23:52:18.261Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-06T23:50:37.011Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->