### PR TITLE
fix(trading): wait for fees before enabling exchange actions

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -221,16 +221,22 @@ export const useTradingExchangeForm = ({
         setValue,
     });
 
-    const { composedLevels, feeInfo, changeFeeLevel, setComposedLevels, composeRequest } =
-        useTradingComposeTransaction<TradingExchangeFormProps>({
-            type: 'exchange',
-            account,
-            network,
-            values,
-            methods,
-            estimateFeeForUnknownRecipient: isFormPage,
-            setShowReserveBanner,
-        });
+    const {
+        isComposing,
+        composedLevels,
+        feeInfo,
+        changeFeeLevel,
+        setComposedLevels,
+        composeRequest,
+    } = useTradingComposeTransaction<TradingExchangeFormProps>({
+        type: 'exchange',
+        account,
+        network,
+        values,
+        methods,
+        estimateFeeForUnknownRecipient: isFormPage,
+        setShowReserveBanner,
+    });
 
     const isFormLoading = isInitialDataLoading || formState.isSubmitting || isLoading;
     const isFormInvalid = !(formIsValid && hasValues) || !isReceiveAddressFormValid;
@@ -724,6 +730,7 @@ export const useTradingExchangeForm = ({
         dexQuotes,
         cexQuotes,
         quotesRequest,
+        isComposing,
         composedLevels,
         defaultCurrency,
         feeInfo,

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -206,6 +206,7 @@ export interface TradingExchangeFormContextProps
     exchangeInfo?: TradingExchangeInfoSelector;
     defaultCurrency: TradingFiatCurrencyOption;
     amountLimits?: CryptoAmountLimitProps;
+    isComposing: boolean;
     composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
     composedTransactionInfo: TradingComposedTransactionInfo;
     quotes: ExchangeTrade[];

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
@@ -12,7 +12,7 @@ import {
     useApprovalStep,
     useTradingUtils,
 } from '@suite-common/trading';
-import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { selectAreFeesLoading, selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Banner, Button, Column } from '@trezor/components';
 import { PendingTransactionInfo } from '@trezor/product-components';
 import { useAsyncClickHandler } from '@trezor/react-utils';
@@ -49,8 +49,9 @@ export const TradingFormApproval = () => {
         resetSelectedOffer,
         selectedQuote,
         isScheduledQuotesRefresh,
+        isComposing,
         form: {
-            state: { isFormLoading },
+            state: { isFormLoading, isFormInvalid },
         },
         account,
     } = context;
@@ -58,6 +59,7 @@ export const TradingFormApproval = () => {
     const getCryptoInfo = useTradingExchangeCryptoAndProviderInfo();
 
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
+    const areFeesLoading = useSelector(state => selectAreFeesLoading(state, account.symbol));
 
     const { handleClick: handleApproveClick, disabled: isApproveButtonLoading } =
         useAsyncClickHandler();
@@ -160,29 +162,26 @@ export const TradingFormApproval = () => {
         await refreshQuotes();
     };
 
-    const isApproveButtonDisabled =
-        isApproveButtonLoading ||
-        (approvalStep === 'LOADING' && allowanceState.approvalType === 'REVOKE') ||
+    const isCommonButtonBusy =
         isFormLoading ||
+        isFormInvalid ||
+        areFeesLoading ||
+        isComposing ||
         isScheduledQuotesRefresh ||
         isDiscoveryRunning ||
         allowanceState.isWaitingForDevice;
 
-    const isSwapButtonDisabled =
-        isSwapButtonLoading ||
-        (approvalStep === 'LOADING' && allowanceState.approvalType === 'APPROVE') ||
-        isFormLoading ||
-        isScheduledQuotesRefresh ||
-        isDiscoveryRunning ||
-        allowanceState.isWaitingForDevice;
+    const isActionButtonDisabled = (
+        isButtonLoading: boolean,
+        blockingApprovalType: 'APPROVE' | 'REVOKE',
+    ) =>
+        isButtonLoading ||
+        (approvalStep === 'LOADING' && allowanceState.approvalType === blockingApprovalType) ||
+        isCommonButtonBusy;
 
-    const isRevokeButtonDisabled =
-        isRevokeButtonLoading ||
-        (approvalStep === 'LOADING' && allowanceState.approvalType === 'APPROVE') ||
-        isFormLoading ||
-        isScheduledQuotesRefresh ||
-        isDiscoveryRunning ||
-        allowanceState.isWaitingForDevice;
+    const isApproveButtonDisabled = isActionButtonDisabled(isApproveButtonLoading, 'REVOKE');
+    const isSwapButtonDisabled = isActionButtonDisabled(isSwapButtonLoading, 'APPROVE');
+    const isRevokeButtonDisabled = isActionButtonDisabled(isRevokeButtonLoading, 'APPROVE');
 
     const isRefreshButtonDisabled =
         isRefreshButtonLoading || isFormLoading || isScheduledQuotesRefresh || isDiscoveryRunning;
@@ -232,7 +231,9 @@ export const TradingFormApproval = () => {
                                         isLoading={
                                             isApproveButtonLoading ||
                                             isRevokeButtonLoading ||
-                                            isFormLoading
+                                            isFormLoading ||
+                                            areFeesLoading ||
+                                            isComposing
                                         }
                                         isDisabled={
                                             isApproveButtonDisabled || isRevokeButtonDisabled
@@ -265,7 +266,7 @@ export const TradingFormApproval = () => {
                             intent="brand"
                             size="large"
                             width="100%"
-                            isLoading={isApproveButtonLoading}
+                            isLoading={isApproveButtonLoading || areFeesLoading || isComposing}
                             isDisabled={isApproveButtonDisabled}
                         >
                             <Translation id="TR_EXCHANGE_APPROVAL_FORM_APPROVE_BUTTON" />
@@ -281,7 +282,13 @@ export const TradingFormApproval = () => {
                         intent="brand"
                         size="large"
                         width="100%"
-                        isLoading={isSwapButtonLoading || isRevokeButtonLoading || isFormLoading}
+                        isLoading={
+                            isSwapButtonLoading ||
+                            isRevokeButtonLoading ||
+                            isFormLoading ||
+                            areFeesLoading ||
+                            isComposing
+                        }
                         isDisabled={isSwapButtonDisabled || isRevokeButtonDisabled}
                     >
                         <Translation id="TR_TRADING_SWAP" />

--- a/packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx
@@ -33,6 +33,7 @@ export const TradingFormOfferExchangeActions = () => {
         isLoadingQuote,
         setIsLoadingQuote,
         confirmTrade,
+        isComposing,
         form: { state },
     } = context;
 
@@ -76,7 +77,7 @@ export const TradingFormOfferExchangeActions = () => {
         : state.isFormLoading || isLoadingQuote;
 
     const isButtonDisabled =
-        isBaseButtonDisabled || amountTooHigh || isNetworkFeeMissing || isLoading;
+        isBaseButtonDisabled || amountTooHigh || isNetworkFeeMissing || isComposing || isLoading;
 
     useEffect(() => {
         const initConfirmTrade = async () => {
@@ -135,7 +136,7 @@ export const TradingFormOfferExchangeActions = () => {
                     intent="brand"
                     margin={{ top: 16 }}
                     isDisabled={isButtonDisabled}
-                    isLoading={areFeesLoading || state.isFormLoading}
+                    isLoading={areFeesLoading || state.isFormLoading || isComposing}
                     size="large"
                     minWidth={160}
                     width="100%"
@@ -156,6 +157,7 @@ export const TradingFormOfferExchangeActions = () => {
         return (
             <TradingFormOfferConfirmButton
                 {...confirmButtonData}
+                isLoading={confirmButtonData.isLoading || isComposing}
                 onClick={onSelectQuote}
                 isDisabled={isButtonDisabled}
                 testId="@trading/form/exchange-button"


### PR DESCRIPTION
## Description

- expose exchange form composing state through the trading exchange form context
- disable exchange form action buttons while fees are still loading or transaction composition is still running
- keep the exchange CTA in loading state until fees are loaded, so the form button waits for fee loading before it can continue
- apply the same busy-state guard to the approval, revoke, and swap actions in the exchange approval step

## Notes for QA

- In Wallet > Trade > Swap on a Solana account, enter a valid swap and verify the main form button stays loading and disabled until network fees are loaded.
- Continue to the approval step and verify Approve, Revoke, and Swap stay disabled while fees are loading, then become clickable once fees are available.

## Related Issue

Resolve #27425

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on the trading/exchange (swap) functionality: the exchange form hook, form types, approval component, and exchange-specific action buttons. The primary risk is breaking swap flows — form filling, quote selection, transaction approval, and device confirmation. The buy and sell trading flows share TradingFormApproval but the changes to useTradingExchangeForm and TradingFormOfferExchangeActions are exchange-specific, so swap tests should be prioritized. The type file (tradingForm.ts) is a shared dependency but type changes typically manifest through the components that consume them, which are already covered.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts`
- `packages/suite/src/types/trading/tradingForm.ts`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx`
- `packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test exercises the full swap flow including form filling, quote confirmation, and transaction sending. It directly touches the TradingFormApproval component and the exchange form hook (useTradingExchangeForm) which are both changed. The swap flow is the primary user path for exchange/swap functionality.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Tests swapping SOL to BTC through the full exchange flow including form, quotes, device confirmation, and transaction status polling. Directly exercises the exchange form logic and approval UI changed in this PR.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests swap from BTC to ETH with custom fee settings, exercising the exchange form hook and the swap confirmation flow. Changes to useTradingExchangeForm could affect fee calculation and composed transaction info used in this test.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests swap from ETH to BTC with custom Ethereum gas fees, directly exercising the exchange form hook for fee handling and the swap confirmation flow. Changes to form state management could break fee display.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping USDT token to BTC, including token confirmation step which specifically exercises TradingFormOfferExchangeActions (the exchange actions component changed in this PR) and the approval flow.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests swapping between two SPL tokens (USDT to USDC), exercising the exchange form and swap confirmation flow. Token-to-token swaps exercise exchange-specific logic in useTradingExchangeForm.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swap form with a disabled network buy asset, verifying that provider info still renders. This exercises the exchange form hook and quote display logic which could be affected by form state changes.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form input validation, fraction buttons, and asset selection. While primarily an input test, it exercises the swap form infrastructure that useTradingExchangeForm provides, and validates quote syncing behavior.
- `suite/e2e/tests/trading/swap-history.test.ts` — Tests swap trade history display and detail pages. While not directly testing form submission, changes to exchange form types (tradingForm.ts) could affect how trade data is structured and displayed in history.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation to swap/buy/sell forms from various entry points. The swap form rendering depends on the exchange form hook, and changes could affect whether the form renders correctly after navigation.
- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — Live swap test exercising the real exchange flow. Changes to the exchange form hook and approval component could break the live swap confirmation path. Uses TradingFormApproval directly.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Live swap test for SPL token to coin, exercising the exchange approval and confirmation flow. Changes to TradingFormOfferExchangeActions could affect the token swap confirmation path.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx`

_Updated: 2026-07-08T12:38:27.277Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/27425-wait-for-fee-loading&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/27425-wait-for-fee-loading&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-08T12:44:02.068Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T12:42:03.282Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/27425-wait-for-fee-loading/web/](https://dev.suite.sldev.cz/suite-web/fix/27425-wait-for-fee-loading/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->