### PR TITLE
test(suite): improve logging of quarantine job

### DIFF
--- a/.github/workflows/check-test-health-nightly.yml
+++ b/.github/workflows/check-test-health-nightly.yml
@@ -50,4 +50,4 @@ jobs:
           E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK: ${{ secrets.E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
-          yarn workspace @trezor/e2e-utils test-health --nightlyUnquarantine --verbose
+          yarn workspace @trezor/e2e-utils test-health --nightlyUnquarantine

--- a/.github/workflows/check-test-health.yml
+++ b/.github/workflows/check-test-health.yml
@@ -62,4 +62,4 @@ jobs:
           E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK: ${{ secrets.E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
-          yarn workspace @trezor/e2e-utils test-health --verbose
+          yarn workspace @trezor/e2e-utils test-health

--- a/packages/e2e-utils/src/currentsApi/api.ts
+++ b/packages/e2e-utils/src/currentsApi/api.ts
@@ -13,7 +13,9 @@ import type {
     TestResultsResponse,
     TestsExplorerResponse,
 } from './types';
-import { debug, warn } from '../logger';
+import { createLogger } from '../logger';
+
+const logger = createLogger('currents-api');
 
 function getApiKey(): string {
     const key = process.env.CURRENTS_API_KEY;
@@ -28,7 +30,7 @@ export async function currentsRequest<T>(
     retries = 3,
 ): Promise<T> {
     const url = `${CURRENTS_API_BASE}${path}`;
-    debug(`  → ${options.method ?? 'GET'} ${url}`);
+    logger.trace(`→ ${options.method ?? 'GET'} ${url}`);
     const res = await fetch(url, {
         ...options,
         headers: {
@@ -42,8 +44,8 @@ export async function currentsRequest<T>(
     if (res.status === 429 && retries > 0) {
         const retryAfter = res.headers.get('Retry-After');
         const waitMs = retryAfter ? parseInt(retryAfter, 10) * 1000 : 10_000 * (4 - retries);
-        warn(
-            `  [rate-limit] 429 received for ${url}. Waiting ${waitMs}ms before retry (${retries} left)…`,
+        logger.warn(
+            `429 rate-limit for ${url}. Waiting ${waitMs}ms before retry (${retries} left)…`,
         );
         await new Promise(resolve => setTimeout(resolve, waitMs));
 
@@ -56,7 +58,8 @@ export async function currentsRequest<T>(
     }
 
     const json = (await res.json()) as T;
-    debug(`  ← ${res.status} ${options.method ?? 'GET'} ${url}`, JSON.stringify(json));
+    // Never dump the full response body — it floods the log. A status line is enough at TRACE.
+    logger.trace(`← ${res.status} ${options.method ?? 'GET'} ${url}`);
 
     return json;
 }
@@ -83,7 +86,7 @@ export async function* paginateTestResults(
 
     do {
         const queryParts = [...baseParams, ...(cursor ? [`starting_after=${cursor}`] : [])];
-        debug(
+        logger.trace(
             `  paginateTestResults: signature=${signature.slice(0, 20)}… page=${pageIndex}`,
             cursor ? `cursor=${cursor.slice(0, 16)}…` : '(first page)',
         );
@@ -91,7 +94,7 @@ export async function* paginateTestResults(
             `/test-results/${signature}?${queryParts.join('&')}`,
         );
         const completed = response.data.filter(r => r.status !== 'pending');
-        debug(
+        logger.trace(
             `  paginateTestResults: page=${pageIndex} raw=${response.data.length} completed=${completed.length} has_more=${response.has_more}`,
         );
         yield completed;
@@ -140,14 +143,14 @@ export async function getLastNResultsFromDistinctBranches(
             if (branch === DEVELOP_BRANCH || branchNotIncludedYet) {
                 uniqueBranchesSet.add(branch);
                 picked.push(result);
-                debug(
+                logger.trace(
                     `  getLastNResultsFromDistinctBranches: picked branch=${branch} picked=${picked.length}/${numberOfResults}`,
                 );
                 if (picked.length >= numberOfResults) {
                     return picked;
                 }
             } else {
-                debug(
+                logger.trace(
                     `  getLastNResultsFromDistinctBranches: skipped branch=${branch} (already included)`,
                 );
             }
@@ -186,13 +189,15 @@ export async function getActiveTests(
             `limit=${limit}`,
         ].join('&');
 
-        debug(`  getActiveTests: project=${projectId} page=${page} (${items.length} items so far)`);
+        logger.trace(
+            `  getActiveTests: project=${projectId} page=${page} (${items.length} items so far)`,
+        );
         response = await currentsRequest<TestsExplorerResponse>(
             `/tests/${projectId}?${queryString}`,
         );
 
         items.push(...response.data.list);
-        debug(
+        logger.trace(
             `  getActiveTests: page=${page} items=${response.data.list.length} nextPage=${response.data.nextPage} cumulative=${items.length}`,
         );
         page++;
@@ -287,7 +292,7 @@ export async function getRunById(runId: string, mode: SpecFetchMode): Promise<Ru
         return true;
     });
 
-    debug(
+    logger.trace(
         `  getRunById: runId=${runId} mode=${mode}`,
         `total specs=${run.specs.length} fetching=${specsToFetch.length}`,
     );
@@ -343,13 +348,13 @@ export async function getResultsFromRun(
         // Once we see a non-empty page with no matching entries the run has
         // scrolled out of view — no need to paginate further.
         if (page.length > 0 && matching.length === 0) {
-            debug(
+            logger.trace(
                 `  getResultsFromRun: early exit after ${pagesScanned} page(s) — no matches in last page`,
             );
             break;
         }
     }
-    debug(
+    logger.trace(
         `  getResultsFromRun: signature=${signature.slice(0, 20)}… runId=${runId}`,
         `pages=${pagesScanned} results=${results.length}`,
     );

--- a/packages/e2e-utils/src/logger.ts
+++ b/packages/e2e-utils/src/logger.ts
@@ -1,23 +1,24 @@
 /* eslint-disable no-console */
-let verbose = false;
 
-export function setVerbose(enabled: boolean): void {
-    verbose = enabled;
-}
+const PRIORITY = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 } as const;
+type Level = keyof typeof PRIORITY;
 
-/** Progress/info log — always printed to stderr. */
-export function log(...args: unknown[]): void {
-    console.error(...args);
-}
+const isLevel = (name: string | undefined): name is Level => name !== undefined && name in PRIORITY;
 
-/** Error log — always printed to stderr, prefixed with [error]. */
-export function error(...args: unknown[]): void {
-    console.error('[error]', ...args);
-}
+// Default level is debug: decisions and their reasoning are shown, raw HTTP (trace) is not.
+const envLevel = process.env.LOG_LEVEL?.toLowerCase();
+let currentLevel: Level = isLevel(envLevel) ? envLevel : 'debug';
 
-/** Warn log — always printed to stderr, prefixed with [warn]. */
-export function warn(...args: unknown[]): void {
-    console.warn('[warn]', ...args);
+const isGithubActions = process.env.GITHUB_ACTIONS === 'true';
+
+export function configureLogLevelFromArgs(args: string[]): void {
+    const flagIndex = args.indexOf('--log-level');
+    if (flagIndex === -1) return;
+
+    const requested = args[flagIndex + 1]?.toLowerCase();
+    if (isLevel(requested)) {
+        currentLevel = requested;
+    }
 }
 
 function safeFormat(input: unknown): string {
@@ -31,14 +32,78 @@ function safeFormat(input: unknown): string {
     }
 }
 
+interface Problem {
+    level: 'error' | 'warn';
+    category: string;
+    message: string;
+}
+
+const problems: Problem[] = [];
+
+function emit(level: Level, category: string, args: unknown[]): void {
+    const message = args.map(safeFormat).join(' ');
+
+    // Collect errors/warnings for a summary at the end of the run
+    if (level === 'error' || level === 'warn') {
+        problems.push({ level, category, message });
+    }
+
+    if (PRIORITY[level] > PRIORITY[currentLevel]) return;
+
+    // INFO is the human-readable stream — keep it clean (headers already carry context).
+    if (level === 'info') {
+        process.stderr.write(`${message}\n`);
+    } else {
+        process.stderr.write(`[${level}] ${category} ${message}\n`);
+    }
+}
+
+export function createLogger(category = '') {
+    return {
+        error: (...args: unknown[]) => emit('error', category, args),
+        warn: (...args: unknown[]) => emit('warn', category, args),
+        /** INFO — headers and decisions. */
+        log: (...args: unknown[]) => emit('info', category, args),
+        debug: (...args: unknown[]) => emit('debug', category, args),
+        trace: (...args: unknown[]) => emit('trace', category, args),
+        groupEnd: () => {
+            if (isGithubActions) process.stderr.write('::endgroup::\n');
+        },
+    };
+}
+
+// Backward compatibility export
+export const { error, warn, log } = createLogger();
+
 /**
- * Debug log — only printed when --verbose is active. Goes to stderr.
- * Prefixed with [debug] to distinguish from normal log output.
+ * Print the collected warnings/errors as a dedicated end-of-run section and,
+ * in GitHub Actions, emit them as workflow annotations. Returns the count.
  */
-export function debug(...args: unknown[]): void {
-    if (!verbose) return;
-    const msg = args.map(safeFormat).join(' ');
-    process.stderr.write(`[debug] ${msg}\n`);
+export function printProblemSummary(): number {
+    const errorCount = problems.filter(p => p.level === 'error').length;
+    const warnCount = problems.length - errorCount;
+
+    if (problems.length === 0) {
+        process.stderr.write('\n✓ No problems.\n');
+
+        return 0;
+    }
+
+    // Condensed digest of collected problems
+    process.stderr.write(`\n=== Problems (${errorCount} error, ${warnCount} warn) ===\n`);
+    for (const p of problems) {
+        const cat = p.category ? ` [${p.category}]` : '';
+        const firstLine = p.message.split('\n', 1)[0];
+        process.stderr.write(`[${p.level}]${cat} ${firstLine}\n`);
+        if (isGithubActions) {
+            const command = p.level === 'error' ? 'error' : 'warning';
+            process.stderr.write(
+                `::${command}::${p.category ? `[${p.category}] ` : ''}${firstLine}\n`,
+            );
+        }
+    }
+
+    return errorCount;
 }
 
 /** Write data output to stdout. Use only for machine-readable command output (e.g. JSON reports). */

--- a/packages/e2e-utils/src/quarantineBot/actions.ts
+++ b/packages/e2e-utils/src/quarantineBot/actions.ts
@@ -41,6 +41,38 @@ export function extractKeyFromAction(action: Action): string | undefined {
     return titlePathCond ? JSON.stringify(titlePathCond.value) : undefined;
 }
 
+const EVIDENCE_STATUS_LABEL: Record<TestResultItem['status'], string> = {
+    passed: 'PASS',
+    failed: 'FAIL',
+    skipped: 'SKIP',
+    pending: 'PEND',
+};
+
+const EVIDENCE_BRANCH_MAX_WIDTH = 40;
+
+export function formatEvidence(results: TestResultItem[]): string {
+    const branchWidth = Math.min(
+        EVIDENCE_BRANCH_MAX_WIDTH,
+        Math.max(0, ...results.map(r => r.commit.branch.length)),
+    );
+
+    const fitBranch = (branch: string) =>
+        (branch.length > branchWidth ? `${branch.slice(0, branchWidth - 1)}…` : branch).padEnd(
+            branchWidth,
+        );
+
+    return results
+        .map(r => {
+            const status = EVIDENCE_STATUS_LABEL[r.status];
+            const branch = fitBranch(r.commit.branch);
+            const sha = r.commit.sha.slice(0, 7);
+            const flaky = r.flaky ? '  flaky' : '';
+
+            return `     ${status}  ${branch}  ${sha}  run ${r.runId}${flaky}`;
+        })
+        .join('\n');
+}
+
 /**
  * Compute failure stats from a list of individual execution results.
  */

--- a/packages/e2e-utils/src/quarantineBot/api.ts
+++ b/packages/e2e-utils/src/quarantineBot/api.ts
@@ -6,7 +6,9 @@ import {
 } from './config';
 import { createAction, currentsRequest, getActions } from '../currentsApi/api';
 import type { Action, TestExplorerItem, TestsExplorerResponse } from '../currentsApi/types';
-import { debug } from '../logger';
+import { createLogger } from '../logger';
+
+const logger = createLogger('quarantine-api');
 
 export async function getAutoQuarantineActions(projectId: string): Promise<Action[]> {
     const actions = await getActions(projectId, 'active');
@@ -108,7 +110,7 @@ export async function findSignaturesForTitleKeys(
             `limit=${limit}`,
         ].join('&');
 
-        debug(
+        logger.trace(
             `  findSignaturesForTitleKeys: fetching page ${page}`,
             `(found ${found.size}/${titleKeys.size} so far)`,
         );
@@ -124,7 +126,7 @@ export async function findSignaturesForTitleKeys(
                 found.set(key, item.signature);
             }
         }
-        debug(
+        logger.trace(
             `  page ${page}: ${response.data.list.length} item(s),`,
             `resolved ${found.size - beforeSize} new signature(s)`,
         );

--- a/packages/e2e-utils/src/quarantineBot/index.ts
+++ b/packages/e2e-utils/src/quarantineBot/index.ts
@@ -8,7 +8,6 @@ import {
     UNQUARANTINE_LAST_N_EXECUTIONS,
 } from './config';
 import { listAllQuarantinedTests } from './list';
-import { debug, error, log, setVerbose } from '../logger';
 import { quarantineFromRun } from './manualQuarantine';
 import { nightlyUnquarantineFromLatestRun } from './nightlyUnquarantine';
 import { quarantineFailingTests, unquarantinePassingTests } from './quarantine';
@@ -16,17 +15,40 @@ import { buildSlackSummary, sendSlackNotification } from './slack';
 import type { SlackEvent } from './types';
 import { wipeAllAutoQuarantineActions } from './wipe';
 import { getActiveTests } from '../currentsApi/api';
+import { configureLogLevelFromArgs, createLogger, printProblemSummary } from '../logger';
+
+const logger = createLogger('healthcheck');
+
+/**
+ * Print a per-project outcome table followed by the collected problems section.
+ * Returns the number of errors so the caller can set the exit code.
+ */
+function logRunSummary(
+    projects: Array<{ id: string; label: string }>,
+    events: SlackEvent[],
+): number {
+    logger.log('\n=== Summary ===');
+    for (const project of projects) {
+        const quarantined = events.filter(
+            e => e.projectId === project.id && e.kind === 'quarantined',
+        ).length;
+        const restored = events.filter(
+            e => e.projectId === project.id && e.kind === 'unquarantined',
+        ).length;
+        logger.log(`  ${project.label}: ${quarantined} quarantined, ${restored} restored`);
+    }
+
+    return printProblemSummary();
+}
 
 async function main(): Promise<void> {
     const args = process.argv.slice(2);
 
-    // Parse --verbose first so debug() works for everything that follows.
-    if (args.includes('--verbose')) {
-        setVerbose(true);
-    }
+    // Resolve the log level first so every subsequent log honours it.
+    configureLogLevelFromArgs(args);
 
-    debug('args:', args);
-    debug(
+    logger.debug('args:', args);
+    logger.debug(
         'env: CURRENTS_API_KEY',
         process.env.CURRENTS_API_KEY ? 'present' : 'MISSING',
         '| E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK',
@@ -36,7 +58,7 @@ async function main(): Promise<void> {
     );
 
     if (args.includes('--help') || args.includes('-h')) {
-        log(
+        logger.log(
             [
                 'Usage: yarn workspace @trezor/e2e-utils test-health [options]',
                 '',
@@ -66,9 +88,10 @@ async function main(): Promise<void> {
                 '                             each monitored project and unquarantine all auto-quarantined',
                 '                             tests that passed in that run.',
                 '',
-                '  --verbose                  Enable debug logging for all features and CLI switches.',
-                '                             Debug output goes to stderr so stdout (e.g. --list JSON) is',
-                '                             unaffected.',
+                '  --log-level <level>        Set logging verbosity: error | warn | info | debug | trace.',
+                '                             Default: debug. Raw HTTP requests/responses are only shown at',
+                '                             trace. All logging goes to stderr (stdout stays reserved for',
+                '                             machine-readable output such as --list JSON).',
                 '',
                 '  --help, -h                 Show this help message and exit.',
                 '',
@@ -76,6 +99,7 @@ async function main(): Promise<void> {
                 '  CURRENTS_API_KEY                          (required) API key for the Currents.dev API.',
                 '  E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK     (optional) Slack incoming-webhook URL for',
                 '                                            quarantine/unquarantine notifications.',
+                '  LOG_LEVEL                                 (optional) Default log level (see --log-level).',
             ].join('\n'),
         );
 
@@ -85,7 +109,7 @@ async function main(): Promise<void> {
     if (args.includes('--list')) {
         const projectFlagIndex = args.indexOf('--project');
         const projectNameFilter = projectFlagIndex !== -1 ? args[projectFlagIndex + 1] : undefined;
-        debug(
+        logger.debug(
             'operation: list',
             projectNameFilter ? `project=${projectNameFilter}` : '(all projects)',
         );
@@ -95,28 +119,26 @@ async function main(): Promise<void> {
     }
 
     if (args.includes('--wipeAutoQuarantine')) {
-        debug('operation: wipeAutoQuarantine');
+        logger.debug('operation: wipeAutoQuarantine');
         await wipeAllAutoQuarantineActions();
 
         return;
     }
 
     if (args.includes('--nightlyUnquarantine')) {
-        debug('operation: nightlyUnquarantine');
-        log('=== Nightly Unquarantine ===');
-        log(`Timestamp: ${new Date().toISOString()}`);
-        log(`Projects: ${PROJECTS.map(p => `${p.label} (${p.id})`).join(', ')}`);
-        log('');
+        logger.debug('operation: nightlyUnquarantine');
+        logger.log('=== Nightly Unquarantine ===');
+        logger.log(`Timestamp: ${new Date().toISOString()}`);
+        logger.log(`Projects: ${PROJECTS.map(p => `${p.label} (${p.id})`).join(', ')}`);
+        logger.log('');
 
-        let hasError = false;
         const slackEvents: SlackEvent[] = [];
 
         for (const project of PROJECTS) {
             try {
                 await nightlyUnquarantineFromLatestRun(project.id, project.label, slackEvents);
             } catch (err) {
-                error(`\nFailed processing project ${project.label} (${project.id}):`, err);
-                hasError = true;
+                logger.error(`Failed processing project ${project.label} (${project.id}):`, err);
             }
         }
 
@@ -127,9 +149,10 @@ async function main(): Promise<void> {
             await sendSlackNotification(summary);
         }
 
-        log('\n=== Done ===');
+        const errorCount = logRunSummary(PROJECTS, slackEvents);
+        logger.log('\n=== Done ===');
 
-        if (hasError) {
+        if (errorCount > 0) {
             process.exit(1);
         }
 
@@ -140,12 +163,12 @@ async function main(): Promise<void> {
     if (quarantineFlagIndex !== -1) {
         const runId = args[quarantineFlagIndex + 1];
         if (!runId || runId.startsWith('-')) {
-            error('--quarantine requires a run ID argument.');
+            logger.error('--quarantine requires a run ID argument.');
             process.exit(1);
         }
 
         const interactive = args.includes('-i') || args.includes('--interactive');
-        debug('operation: quarantine', `runId=${runId}`, `interactive=${interactive}`);
+        logger.debug('operation: quarantine', `runId=${runId}`, `interactive=${interactive}`);
         const slackEvents: SlackEvent[] = [];
 
         const { projectId, projectLabel } = await quarantineFromRun(
@@ -163,33 +186,36 @@ async function main(): Promise<void> {
             await sendSlackNotification(summary);
         }
 
-        log('\n=== Done ===');
+        const errorCount = logRunSummary([projectEntry], slackEvents);
+        logger.log('\n=== Done ===');
+
+        if (errorCount > 0) {
+            process.exit(1);
+        }
 
         return;
     }
 
-    debug('operation: healthcheck');
-    log('=== Currents Test Health Check ===');
-    log(`Timestamp: ${new Date().toISOString()}`);
-    log(`Projects: ${PROJECTS.map(p => `${p.label} (${p.id})`).join(', ')}`);
-    log(
+    logger.debug('operation: healthcheck');
+    logger.log('=== Currents Test Health Check ===');
+    logger.log(`Timestamp: ${new Date().toISOString()}`);
+    logger.log(`Projects: ${PROJECTS.map(p => `${p.label} (${p.id})`).join(', ')}`);
+    logger.log(
         `Thresholds: quarantine ≥${QUARANTINE_FAILURE_RATE * 100}% failures over last ${QUARANTINE_LAST_N_EXECUTIONS} executions, ` +
             `unquarantine ≤${UNQUARANTINE_FAILURE_RATE * 100}% failures over last ${UNQUARANTINE_LAST_N_EXECUTIONS} executions (using Test Results API)`,
     );
-    log('');
+    logger.log('');
 
-    let hasError = false;
     const slackEvents: SlackEvent[] = [];
 
     for (const project of PROJECTS) {
-        debug(`processing project: ${project.label} (${project.id})`);
         try {
             const [existingActions, activeTests] = await Promise.all([
                 getAutoQuarantineActions(project.id),
                 getActiveTests(project.id, EXPLORER_LOOKBACK_DAYS),
             ]);
-            debug(
-                `  project ${project.label}: ${existingActions.length} existing auto-quarantine action(s),`,
+            logger.debug(
+                `project ${project.label}: ${existingActions.length} existing auto-quarantine action(s),`,
                 `${activeTests.length} active test(s) in explorer window`,
             );
             await quarantineFailingTests(
@@ -207,8 +233,7 @@ async function main(): Promise<void> {
                 slackEvents,
             );
         } catch (err) {
-            error(`\nFailed processing project ${project.label} (${project.id}):`, err);
-            hasError = true;
+            logger.error(`Failed processing project ${project.label} (${project.id}):`, err);
         }
     }
 
@@ -217,14 +242,15 @@ async function main(): Promise<void> {
         await sendSlackNotification(summary);
     }
 
-    log('\n=== Done ===');
+    const errorCount = logRunSummary(PROJECTS, slackEvents);
+    logger.log('\n=== Done ===');
 
-    if (hasError) {
+    if (errorCount > 0) {
         process.exit(1);
     }
 }
 
 main().catch(err => {
-    error('[FATAL]', err);
+    logger.error('[FATAL]', err);
     process.exit(1);
 });

--- a/packages/e2e-utils/src/quarantineBot/list.ts
+++ b/packages/e2e-utils/src/quarantineBot/list.ts
@@ -2,7 +2,9 @@ import { extractKeyFromAction } from './actions';
 import { AUTO_QUARANTINE_PREFIX, PROJECTS } from './config';
 import { getAllQuarantineActions } from '../currentsApi/api';
 import type { Action } from '../currentsApi/types';
-import { debug, error, log, output } from '../logger';
+import { createLogger, output } from '../logger';
+
+const logger = createLogger('list');
 
 interface QuarantinedTestEntry {
     name: string;
@@ -30,16 +32,16 @@ export async function listAllQuarantinedTests(projectNameFilter?: string): Promi
         : PROJECTS;
 
     if (projectNameFilter && projects.length === 0) {
-        error(
+        logger.error(
             `No project found with name "${projectNameFilter}". Known names: ${PROJECTS.map(p => p.name).join(', ')}`,
         );
         process.exit(1);
     }
 
-    log('=== Currents Quarantine List ===');
-    log(`Timestamp: ${new Date().toISOString()}`);
-    log(`Projects: ${projects.map(p => `${p.label} (${p.id})`).join(', ')}`);
-    log('');
+    logger.log('=== Currents Quarantine List ===');
+    logger.log(`Timestamp: ${new Date().toISOString()}`);
+    logger.log(`Projects: ${projects.map(p => `${p.label} (${p.id})`).join(', ')}`);
+    logger.log('');
 
     const report: ProjectQuarantineReport[] = [];
     let hasError = false;
@@ -70,14 +72,14 @@ export async function listAllQuarantinedTests(projectNameFilter?: string): Promi
                 tests,
             });
 
-            log(`[${project.label}] ${tests.length} quarantined test(s)`);
+            logger.log(`[${project.label}] ${tests.length} quarantined test(s)`);
             for (const t of tests) {
                 const tag = t.isAutoQuarantine ? ' [auto]' : ' [manual]';
-                log(`  - ${t.name}${tag}`);
-                debug(`    spec=${t.spec ?? '(none)'} isAuto=${t.isAutoQuarantine}`);
+                logger.log(`  - ${t.name}${tag}`);
+                logger.debug(`    spec=${t.spec ?? '(none)'} isAuto=${t.isAutoQuarantine}`);
             }
         } catch (err) {
-            error(`Failed fetching quarantine actions for ${project.label}: ${err}`);
+            logger.error(`Failed fetching quarantine actions for ${project.label}: ${err}`);
             hasError = true;
         }
     }

--- a/packages/e2e-utils/src/quarantineBot/manualQuarantine.ts
+++ b/packages/e2e-utils/src/quarantineBot/manualQuarantine.ts
@@ -3,10 +3,12 @@ import * as readline from 'readline';
 import { extractKeyFromAction } from './actions';
 import { createManualQuarantineAction } from './api';
 import { PROJECTS } from './config';
-import { debug, log } from '../logger';
 import type { FailedTestFromRun, SlackEvent } from './types';
 import { getAllQuarantineActions, getRunById } from '../currentsApi/api';
 import { SpecFetchMode } from '../currentsApi/types';
+import { createLogger } from '../logger';
+
+const logger = createLogger('manual-quarantine');
 
 function promptUser(question: string): Promise<boolean> {
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
@@ -32,19 +34,19 @@ export async function quarantineFromRun(
     interactive: boolean,
     slackEvents: SlackEvent[],
 ): Promise<{ projectId: string; projectLabel: string }> {
-    log(`\n=== Manual Quarantine from Run ${runId} ===`);
-    log(`Timestamp: ${new Date().toISOString()}`);
+    logger.log(`\n=== Manual Quarantine from Run ${runId} ===`);
+    logger.log(`Timestamp: ${new Date().toISOString()}`);
 
     // Fetch run — only populate specs that had at least one failure.
-    log('\nFetching run data...');
+    logger.log('\nFetching run data...');
     const run = await getRunById(runId, SpecFetchMode.FailuresOnly);
     const { projectId } = run;
 
     const project = PROJECTS.find(p => p.id === projectId);
     const projectLabel = project?.label ?? projectId;
 
-    log(`Project: ${projectLabel} (${projectId})`);
-    debug(
+    logger.log(`Project: ${projectLabel} (${projectId})`);
+    logger.debug(
         `run ${runId}: ${run.specs.length} total spec(s),`,
         `${run.specs.filter(s => (s.results?.stats?.failures ?? 0) > 0).length} with failure(s)`,
         `(SpecFetchMode.FailuresOnly — only those were fetched in detail)`,
@@ -64,12 +66,12 @@ export async function quarantineFromRun(
     }
 
     if (failedTests.length === 0) {
-        log('\n  ✓ No failed tests found in this run.');
+        logger.log('\n  ✓ No failed tests found in this run.');
 
         return { projectId, projectLabel };
     }
 
-    log(`\nFound ${failedTests.length} failed test(s).`);
+    logger.log(`\nFound ${failedTests.length} failed test(s).`);
 
     // Fetch existing quarantine actions so we can skip already-quarantined tests.
     // We also track keys we quarantine during this run to avoid creating duplicates
@@ -78,7 +80,7 @@ export async function quarantineFromRun(
     const existingTitleKeys = new Set(
         existingActions.map(a => extractKeyFromAction(a)).filter(Boolean),
     );
-    debug(`existing quarantine actions for project: ${existingActions.length}`);
+    logger.debug(`existing quarantine actions for project: ${existingActions.length}`);
 
     let quarantinedCount = 0;
     let skippedCount = 0;
@@ -92,24 +94,24 @@ export async function quarantineFromRun(
         const testTitle = normalizedTitlePath.join(' > ');
 
         if (existingTitleKeys.has(titleKey)) {
-            log(`  ↳ Already quarantined: "${testTitle.slice(0, 80)}"`);
+            logger.log(`  ↳ Already quarantined: "${testTitle.slice(0, 80)}"`);
             skippedCount++;
             continue;
         }
 
         if (interactive) {
-            log(`\n  Test: "${testTitle.slice(0, 100)}"`);
-            log(`  Spec: ${test.spec}`);
+            logger.log(`\n  Test: "${testTitle.slice(0, 100)}"`);
+            logger.log(`  Spec: ${test.spec}`);
             const confirmed = await promptUser('  Quarantine this test?');
             if (!confirmed) {
-                log('  ↳ Skipped.');
+                logger.log('  ↳ Skipped.');
                 skippedCount++;
                 continue;
             }
         } else {
-            log(`  ↳ Quarantining: "${testTitle.slice(0, 80)}"`);
+            logger.log(`  ↳ Quarantining: "${testTitle.slice(0, 80)}"`);
         }
-        debug(`  spec: ${test.spec}`);
+        logger.debug(`  spec: ${test.spec}`);
 
         const action = await createManualQuarantineAction(
             projectId,
@@ -117,7 +119,7 @@ export async function quarantineFromRun(
             test.spec,
             runId,
         );
-        debug(`  created action: actionId=${action.actionId}`);
+        logger.debug(`  created action: actionId=${action.actionId}`);
         quarantinedCount++;
         // Track the key so a duplicate failure of the same test within this run
         // is not quarantined a second time.
@@ -135,7 +137,7 @@ export async function quarantineFromRun(
         });
     }
 
-    log(`\n  Summary: ${quarantinedCount} quarantined, ${skippedCount} skipped.`);
+    logger.log(`\n  Summary: ${quarantinedCount} quarantined, ${skippedCount} skipped.`);
 
     return { projectId, projectLabel };
 }

--- a/packages/e2e-utils/src/quarantineBot/nightlyUnquarantine.ts
+++ b/packages/e2e-utils/src/quarantineBot/nightlyUnquarantine.ts
@@ -1,9 +1,11 @@
-import { extractKeyFromAction } from './actions';
+import { extractKeyFromAction, formatEvidence } from './actions';
 import { findSignaturesForTitleKeys, getAutoQuarantineActions } from './api';
 import { DEVELOP_BRANCH, EXPLORER_LOOKBACK_DAYS } from './config';
-import { debug, log, warn } from '../logger';
+import { createLogger } from '../logger';
 import type { SlackEvent } from './types';
 import { deleteAction, getLatestRunIdOnBranch, getResultsFromRun } from '../currentsApi/api';
+
+const logger = createLogger('nightly-unquarantine');
 
 /**
  * Unquarantine auto-quarantined tests that passed in the latest run on the
@@ -31,19 +33,21 @@ export async function nightlyUnquarantineFromLatestRun(
     projectLabel: string,
     slackEvents: SlackEvent[],
 ): Promise<void> {
-    log(`\n── [${projectLabel}] Nightly unquarantine from latest "${DEVELOP_BRANCH}" run ──`);
+    logger.log(
+        `\n── [${projectLabel}] Nightly unquarantine from latest "${DEVELOP_BRANCH}" run ──`,
+    );
 
     // Load the smaller set first: only the currently auto-quarantined tests.
     // This lets us bail early when there is nothing to do and avoids fetching
     // the full run just to find out there are no candidates.
     const existingActions = await getAutoQuarantineActions(projectId);
     if (existingActions.length === 0) {
-        log('  ✓ No auto-quarantined tests to check.');
+        logger.log('  ✓ No auto-quarantined tests to check.');
 
         return;
     }
 
-    log(`  ${existingActions.length} auto-quarantined test(s) to evaluate.`);
+    logger.log(`  ${existingActions.length} auto-quarantined test(s) to evaluate.`);
 
     // Build titleKey → action map and collect the set of keys we need signatures for.
     const quarantinedByKey = new Map<string, (typeof existingActions)[number]>();
@@ -54,10 +58,13 @@ export async function nightlyUnquarantineFromLatestRun(
             quarantinedByKey.set(key, action);
             titleKeys.add(key);
         } else {
-            warn(`  ↳ Could not extract title from action "${action.name}", skipping.`);
+            logger.warn(
+                `Could not extract titlePath from action "${action.name}" (${action.actionId}), skipping.`,
+            );
+            logger.debug(`  matcher: ${JSON.stringify(action.matcher)}`);
         }
     }
-    debug(`  resolving signatures for ${titleKeys.size} title key(s)`);
+    logger.debug(`  resolving signatures for ${titleKeys.size} title key(s)`);
 
     // Resolve the latest develop runId and each test's signature in parallel.
     // The explorer pagination stops as soon as signatures for all quarantined
@@ -67,21 +74,27 @@ export async function nightlyUnquarantineFromLatestRun(
         findSignaturesForTitleKeys(projectId, titleKeys),
     ]);
 
-    debug(
-        `  signatures resolved: ${signatureByKey.size}/${titleKeys.size}`,
-        signatureByKey.size < titleKeys.size
-            ? `(${titleKeys.size - signatureByKey.size} not found in explorer window)`
-            : '',
-    );
+    logger.debug(`  signatures resolved: ${signatureByKey.size}/${titleKeys.size}`);
+
+    const unresolved = [...titleKeys].filter(k => !signatureByKey.has(k));
+    if (unresolved.length > 0) {
+        logger.warn(
+            `${unresolved.length} quarantined test(s) have no signature in the last ` +
+                `${EXPLORER_LOOKBACK_DAYS}d explorer window — cannot be auto-unquarantined:\n` +
+                unresolved.map(k => `    • ${(JSON.parse(k) as string[]).join(' > ')}`).join('\n'),
+        );
+    }
 
     if (!runId) {
-        log(`  No run found on branch "${DEVELOP_BRANCH}" for this project.`);
+        logger.log(`  No run found on branch "${DEVELOP_BRANCH}" for this project.`);
 
         return;
     }
 
-    log(`  Found run: ${runId}`);
-    debug(`  fetching per-test results from run ${runId} for ${quarantinedByKey.size} test(s)`);
+    logger.log(`  Found run: ${runId}`);
+    logger.debug(
+        `  fetching per-test results from run ${runId} for ${quarantinedByKey.size} test(s)`,
+    );
 
     // For each quarantined test, fetch only its own results filtered to the
     // latest run. One API call per test — no unrelated spec data is loaded.
@@ -90,12 +103,12 @@ export async function nightlyUnquarantineFromLatestRun(
         [...quarantinedByKey.keys()].map(async key => {
             const signature = signatureByKey.get(key);
             if (!signature) {
-                debug(`  no signature for key ${key} — leaving quarantined`);
+                logger.debug(`  no signature for key ${key} — leaving quarantined`);
 
                 return; // test not seen in the explorer lookback window — leave quarantined
             }
             const results = await getResultsFromRun(signature, runId, EXPLORER_LOOKBACK_DAYS);
-            debug(
+            logger.debug(
                 `  key ${key.slice(0, 60)}: ${results.length} result(s) in run`,
                 results.length > 0
                     ? `(${results.filter(r => r.status === 'passed').length} passed)`
@@ -104,6 +117,7 @@ export async function nightlyUnquarantineFromLatestRun(
             if (results.length === 0) {
                 return;
             }
+            logger.debug(`  evidence for ${key.slice(0, 60)}:\n${formatEvidence(results)}`);
             instanceStats.set(key, {
                 total: results.length,
                 passed: results.filter(r => r.status === 'passed').length,
@@ -118,22 +132,22 @@ export async function nightlyUnquarantineFromLatestRun(
         const stats = instanceStats.get(testKey);
 
         if (!stats || stats.total === 0) {
-            log(`  ↳ Not seen in run: "${testTitle.slice(0, 80)}" — keeping quarantine.`);
+            logger.log(`  ↳ Not seen in run: "${testTitle.slice(0, 80)}" — keeping quarantine.`);
             continue;
         }
 
         if (stats.passed < stats.total) {
-            log(
+            logger.log(
                 `  ↳ Not all instances passed (${stats.passed}/${stats.total}): "${testTitle.slice(0, 80)}" — keeping quarantine.`,
             );
             continue;
         }
 
-        log(
+        logger.log(
             `  ↳ Unquarantining: "${testTitle.slice(0, 80)}" (${stats.total} instance(s) all passed) ✓`,
         );
         await deleteAction(action.actionId);
-        debug(`  deleted action: actionId=${action.actionId}`);
+        logger.debug(`  deleted action: actionId=${action.actionId}`);
         unquarantinedCount++;
 
         slackEvents.push({
@@ -147,6 +161,6 @@ export async function nightlyUnquarantineFromLatestRun(
     }
 
     if (unquarantinedCount === 0) {
-        log('  ✓ No quarantined tests found passing in all instances of the latest run.');
+        logger.log('  ✓ No quarantined tests found passing in all instances of the latest run.');
     }
 }

--- a/packages/e2e-utils/src/quarantineBot/quarantine.ts
+++ b/packages/e2e-utils/src/quarantineBot/quarantine.ts
@@ -1,4 +1,10 @@
-import { computeStats, extractKeyFromAction, getTestKey, normalizeTitlePath } from './actions';
+import {
+    computeStats,
+    extractKeyFromAction,
+    formatEvidence,
+    getTestKey,
+    normalizeTitlePath,
+} from './actions';
 import { createQuarantineAction } from './api';
 import {
     EXPLORER_LOOKBACK_DAYS,
@@ -8,7 +14,6 @@ import {
     UNQUARANTINE_FAILURE_RATE,
     UNQUARANTINE_LAST_N_EXECUTIONS,
 } from './config';
-import { debug, log, warn } from '../logger';
 import type { SlackEvent } from './types';
 import {
     deleteAction,
@@ -16,6 +21,9 @@ import {
     getLastNResultsFromDistinctBranches,
 } from '../currentsApi/api';
 import type { Action, TestExplorerItem } from '../currentsApi/types';
+import { createLogger } from '../logger';
+
+const logger = createLogger('quarantine');
 
 export async function quarantineFailingTests(
     projectId: string,
@@ -24,12 +32,12 @@ export async function quarantineFailingTests(
     activeTests: TestExplorerItem[],
     slackEvents: SlackEvent[],
 ): Promise<void> {
-    log(`\n── [${projectLabel}] Checking for failing tests to quarantine ──`);
+    logger.log(`\n── [${projectLabel}] Checking for failing tests to quarantine ──`);
 
     const alreadyQuarantinedKeys = new Set(
         existingActions.map(a => extractKeyFromAction(a)).filter(Boolean) as string[],
     );
-    debug(`  already quarantined keys: ${alreadyQuarantinedKeys.size}`);
+    logger.debug(`  already quarantined keys: ${alreadyQuarantinedKeys.size}`);
 
     const candidateTests = activeTests.filter(
         t =>
@@ -37,25 +45,26 @@ export async function quarantineFailingTests(
             t.metrics.executions >= QUARANTINE_LAST_N_EXECUTIONS &&
             t.metrics.failureRate >= PRE_FILTER_FAILURE_RATE,
     );
-    debug(
+    logger.debug(
         `  pre-filter: ${activeTests.length} active test(s) total,`,
         `${activeTests.length - candidateTests.length} filtered out (no signature / <${QUARANTINE_LAST_N_EXECUTIONS} executions / <${Math.round(PRE_FILTER_FAILURE_RATE * 100)}% failure rate),`,
         `${candidateTests.length} candidate(s) remain`,
     );
 
-    log(
+    logger.log(
         `  Found ${activeTests.length} active test(s) in the last ${EXPLORER_LOOKBACK_DAYS} days. ` +
             `${candidateTests.length} candidate(s) have ≥${Math.round(PRE_FILTER_FAILURE_RATE * 100)}% failure rate in the explorer window. ` +
             `Fetching last ${QUARANTINE_LAST_N_EXECUTIONS} individual results for each candidate...`,
     );
 
+    let quarantinedCount = 0;
     for (const test of candidateTests) {
         if (!test.signature) {
             continue;
         }
 
         if (alreadyQuarantinedKeys.has(getTestKey(test))) {
-            log(`  ↳ Already quarantined: "${test.title.slice(0, 80)}"`);
+            logger.log(`  ↳ Already quarantined: "${test.title.slice(0, 80)}"`);
             continue;
         }
 
@@ -66,32 +75,34 @@ export async function quarantineFailingTests(
         );
 
         if (results.length < QUARANTINE_LAST_N_EXECUTIONS) {
-            log(
+            logger.log(
                 `  ↳ Skipping "${test.title.slice(0, 80)}" — only ${results.length}/${QUARANTINE_LAST_N_EXECUTIONS} executions found.`,
             );
             continue;
         }
 
         const stats = computeStats(results);
-        debug(
+        logger.debug(
             `  candidate "${test.title.slice(0, 80)}":`,
             `failureRate=${Math.round(stats.failureRate * 100)}%,`,
             `failures=${stats.failures}, passes=${stats.passes}, executions=${stats.executions}`,
             `(threshold: ≥${Math.round(QUARANTINE_FAILURE_RATE * 100)}%)`,
         );
+        logger.debug(`  evidence (newest first):\n${formatEvidence(results)}`);
 
         if (stats.failureRate < QUARANTINE_FAILURE_RATE) {
             continue;
         }
 
         const failurePercent = Math.round(stats.failureRate * 100);
-        log(
+        logger.log(
             `  ↳ Quarantining: "${test.title.slice(0, 80)}" ` +
                 `(${failurePercent}% fail rate, ${stats.failures}/${stats.executions} latest runs)`,
         );
 
         const action = await createQuarantineAction(projectId, test, stats);
-        debug(`  created action: actionId=${action.actionId}`);
+        logger.debug(`  created action: actionId=${action.actionId}`);
+        quarantinedCount++;
         slackEvents.push({
             kind: 'quarantined',
             projectId,
@@ -104,9 +115,8 @@ export async function quarantineFailingTests(
         });
     }
 
-    const quarantinedCount = slackEvents.filter(e => e.kind === 'quarantined').length;
     if (quarantinedCount === 0) {
-        log('  ✓ No new tests to quarantine.');
+        logger.log('  ✓ No new tests to quarantine.');
     }
 }
 
@@ -117,23 +127,26 @@ export async function unquarantinePassingTests(
     activeTests: TestExplorerItem[],
     slackEvents: SlackEvent[],
 ): Promise<void> {
-    log(`\n── [${projectLabel}] Checking quarantined tests for recovery ──`);
+    logger.log(`\n── [${projectLabel}] Checking quarantined tests for recovery ──`);
 
     if (existingActions.length === 0) {
-        log('  ✓ No auto-quarantined tests to check.');
+        logger.log('  ✓ No auto-quarantined tests to check.');
 
         return;
     }
 
-    log(`  Found ${existingActions.length} auto-quarantined test(s).`);
+    logger.log(`  Found ${existingActions.length} auto-quarantined test(s).`);
 
     const testsByKey = new Map(activeTests.map(t => [getTestKey(t), t]));
-    debug(`  active tests index: ${testsByKey.size} entries`);
+    logger.debug(`  active tests index: ${testsByKey.size} entries`);
 
     for (const action of existingActions) {
         const testKey = extractKeyFromAction(action);
         if (!testKey) {
-            warn(`  ↳ Could not extract title from action "${action.name}", skipping.`);
+            logger.warn(
+                `Could not extract titlePath from action "${action.name}" (${action.actionId}), skipping.`,
+            );
+            logger.debug(`  matcher: ${JSON.stringify(action.matcher)}`);
             continue;
         }
 
@@ -144,8 +157,9 @@ export async function unquarantinePassingTests(
         const test = testsByKey.get(testKey);
 
         if (!test?.signature) {
-            log(
-                `  ↳ "${testTitle.slice(0, 80)}" — not found in explorer (may not have run recently), keeping quarantine.`,
+            logger.warn(
+                `Quarantined test not seen in explorer window, cannot evaluate for recovery ` +
+                    `(kept quarantined): "${testTitle.slice(0, 80)}"`,
             );
             continue;
         }
@@ -157,7 +171,7 @@ export async function unquarantinePassingTests(
         );
 
         if (results.length < UNQUARANTINE_LAST_N_EXECUTIONS) {
-            log(
+            logger.log(
                 `  ↳ "${testTitle.slice(0, 80)}" — only ${results.length}/${UNQUARANTINE_LAST_N_EXECUTIONS} executions found, keeping quarantine.`,
             );
             continue;
@@ -166,21 +180,22 @@ export async function unquarantinePassingTests(
         const stats = computeStats(results);
         const failurePercent = Math.round(stats.failureRate * 100);
         const passPercent = 100 - failurePercent;
-        debug(
+        logger.debug(
             `  quarantined "${testTitle.slice(0, 80)}":`,
             `failureRate=${failurePercent}%,`,
             `failures=${stats.failures}, passes=${stats.passes}, executions=${stats.executions}`,
             `(unquarantine threshold: ≤${Math.round(UNQUARANTINE_FAILURE_RATE * 100)}%)`,
         );
+        logger.debug(`  evidence (newest first):\n${formatEvidence(results)}`);
 
         if (stats.failureRate <= UNQUARANTINE_FAILURE_RATE) {
-            log(
+            logger.log(
                 `  ↳ Unquarantining: "${testTitle.slice(0, 80)}" ` +
                     `(${passPercent}% pass rate, ${stats.passes}/${stats.executions} latest runs) ✓`,
             );
 
             await deleteAction(action.actionId);
-            debug(`  deleted action: actionId=${action.actionId}`);
+            logger.debug(`  deleted action: actionId=${action.actionId}`);
             slackEvents.push({
                 kind: 'unquarantined',
                 projectId,
@@ -191,7 +206,7 @@ export async function unquarantinePassingTests(
                 executions: stats.executions,
             });
         } else {
-            log(
+            logger.log(
                 `  ↳ Still failing: "${testTitle.slice(0, 80)}" ` +
                     `(${failurePercent}% failure rate, ${stats.failures}/${stats.executions} latest runs) — keeping quarantine.`,
             );

--- a/packages/e2e-utils/src/quarantineBot/slack.ts
+++ b/packages/e2e-utils/src/quarantineBot/slack.ts
@@ -1,6 +1,8 @@
 import { SLACK_TITLE_MAX_LENGTH } from './config';
-import { debug, log, warn } from '../logger';
+import { createLogger } from '../logger';
 import type { SlackEvent } from './types';
+
+const logger = createLogger('slack');
 
 export function getSlackWebhook(): string | undefined {
     return process.env.E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK;
@@ -106,18 +108,20 @@ export function buildSlackSummary(
 export async function sendSlackNotification(message: string): Promise<void> {
     const webhook = getSlackWebhook();
     if (!webhook) {
-        log('[slack] No E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK configured, skipping notification.');
-        log(`[slack] Message would have been:\n${message}`);
+        logger.log(
+            '[slack] No E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK configured, skipping notification.',
+        );
+        logger.log(`[slack] Message would have been:\n${message}`);
 
         return;
     }
-    debug(`[slack] Sending notification (${message.length} chars) to webhook`);
+    logger.debug(`Sending notification (${message.length} chars) to webhook`);
     const res = await fetch(webhook, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text: message }),
     });
     if (!res.ok) {
-        warn(`[slack] Failed to send Slack notification: ${res.status}`);
+        logger.warn(`Failed to send Slack notification: ${res.status}`);
     }
 }

--- a/packages/e2e-utils/src/quarantineBot/wipe.ts
+++ b/packages/e2e-utils/src/quarantineBot/wipe.ts
@@ -2,46 +2,48 @@ import { extractKeyFromAction } from './actions';
 import { getAutoQuarantineActions } from './api';
 import { PROJECTS } from './config';
 import { deleteAction } from '../currentsApi/api';
-import { debug, error, log } from '../logger';
+import { createLogger } from '../logger';
+
+const logger = createLogger('wipe');
 
 export async function wipeAllAutoQuarantineActions(): Promise<void> {
-    log('=== Wipe Auto-Quarantine Actions ===');
-    log(`Timestamp: ${new Date().toISOString()}`);
-    log(`Projects: ${PROJECTS.map(p => `${p.label} (${p.id})`).join(', ')}`);
-    log('');
+    logger.log('=== Wipe Auto-Quarantine Actions ===');
+    logger.log(`Timestamp: ${new Date().toISOString()}`);
+    logger.log(`Projects: ${PROJECTS.map(p => `${p.label} (${p.id})`).join(', ')}`);
+    logger.log('');
 
     let hasError = false;
 
     for (const project of PROJECTS) {
         try {
-            log(`\n── [${project.label}] Fetching auto-quarantine actions ──`);
+            logger.log(`\n── [${project.label}] Fetching auto-quarantine actions ──`);
             const actions = await getAutoQuarantineActions(project.id);
 
             if (actions.length === 0) {
-                log('  ✓ No auto-quarantine actions found.');
+                logger.log('  ✓ No auto-quarantine actions found.');
                 continue;
             }
 
-            log(`  Found ${actions.length} auto-quarantine action(s). Deleting...`);
+            logger.log(`  Found ${actions.length} auto-quarantine action(s). Deleting...`);
 
             for (const action of actions) {
                 const testKey = extractKeyFromAction(action);
                 const testTitle = testKey
                     ? (JSON.parse(testKey) as string[]).join(' > ')
                     : action.name;
-                log(`  ↳ Deleting: "${testTitle.slice(0, 80)}"`);
-                debug(`    actionId=${action.actionId} name="${action.name}"`);
+                logger.log(`  ↳ Deleting: "${testTitle.slice(0, 80)}"`);
+                logger.debug(`    actionId=${action.actionId} name="${action.name}"`);
                 await deleteAction(action.actionId);
             }
 
-            log(`  ✓ Deleted ${actions.length} action(s) for [${project.label}].`);
+            logger.log(`  ✓ Deleted ${actions.length} action(s) for [${project.label}].`);
         } catch (err) {
-            error(`\nFailed wiping project ${project.label} (${project.id}):`, err);
+            logger.error(`\nFailed wiping project ${project.label} (${project.id}):`, err);
             hasError = true;
         }
     }
 
-    log('\n=== Done ===');
+    logger.log('\n=== Done ===');
 
     if (hasError) {
         process.exit(1);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

ATM logging is flooded with REST responses and does not server its purposes.
This PR does overhault refactoring and brings:
## What changed

Reworked the quarantine bot's logging to cut noise and surface actionable signal.

### Logging infrastructure
- **Leveled logger** (`ERROR < WARN < INFO < DEBUG < TRACE`), configurable via `--log-level` / `LOG_LEVEL`; default `DEBUG`. 
- **Demoted raw HTTP noise to TRACE** 
- **End-of-run summary + problem digest**: warnings/errors are collected and printed
- **Collapsible GitHub Actions log groups** per project (`::group::`).

### Troubleshooting signal
- **Decision evidence**: each quarantine/unquarantine
- **Stuck-quarantine warnings**: tests that can't be auto-unquarantined (signature not resolvable / not seen in the explorer window) are now `warn` (were `debug`/`info`) and listed by name

### Fixes
- **Per-project quarantine counter**: the "No new tests to quarantine" line was counting across all projects (shared array), so it was wrong for the 2nd/3rd project — now counted per project.


```
=== Currents Test Health Check ===
Projects: Trezor Suite (web), Trezor Suite (desktop), Trezor Suite Native (Android)
Thresholds: quarantine ≥60% failures over last 5 executions, unquarantine ≤0% over last 10

── [Trezor Suite (desktop)] Checking for failing tests to quarantine ──
  Found 166 active test(s) in the last 2 days. 9 candidate(s) have ≥2% failure rate...
[debug] [quarantine] candidate "Staking - Cardano > Stake Cardano": failureRate=40%, failures=2, passes=3, executions=5 (threshold: ≥60%)
[debug] [quarantine] evidence (newest first):
     PASS  dex-swap-test                           c790ed9  run a92126cb49e6e1ae
     PASS  refactor-solana-mock                    e60896a  run 413f55e19df899a5
     PASS  feat/sidebar-flat-account-list          be9c404  run 6948af1969bcf575
     FAIL  chore/connect-web-interface             34c14f5  run 8f818929bdfc379f
     FAIL  mroz22/fix-webext-popup-response-route  2239298  run 740b7c3887bb338d
  ✓ No new tests to quarantine.

── [Trezor Suite Native (Android)] Checking quarantined tests for recovery ──
  Found 1 auto-quarantined test(s).
[warn] [nightly-unquarantine] 2 quarantined test(s) have no signature in the last 2d explorer window — cannot be auto-unquarantined:
    • Settings > Change passphrase > enable
    • Onboarding > Recover wallet > 24 words

=== Summary ===
  Trezor Suite (web):     0 quarantined, 0 restored
  Trezor Suite (desktop): 1 quarantined, 0 restored
  Trezor Suite Native (Android): 0 quarantined, 2 restored

=== Problems (0 error, 2 warn) ===
[warn] [nightly-unquarantine] 2 quarantined test(s) have no signature in the last 2d explorer window — cannot be auto-unquarantined
```

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-quarantine-logging&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-quarantine-logging&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-07T14:21:13.303Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-07T14:18:45.809Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor-quarantine-logging/web/](https://dev.suite.sldev.cz/suite-web/refactor-quarantine-logging/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->