### PR TITLE
Tokens - Fiat Prices & Graph

### DIFF
--- a/suite-native/module-accounts-management/src/components/AccountDetailGraph.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailGraph.tsx
@@ -53,6 +53,9 @@ export const AccountDetailGraph = ({ accountKey, tokenContract }: AccountDetailG
             totalFiatBalance,
         });
 
+    const isTokenPriceUnavailable = !isLoading && (!!error || graphPoints.length <= 1);
+    const isGraphHidden = !!tokenContract && isTokenPriceUnavailable;
+
     return (
         <VStack spacing="sp24">
             <AccountDetailHeader
@@ -61,7 +64,7 @@ export const AccountDetailGraph = ({ accountKey, tokenContract }: AccountDetailG
                 totalFiatBalance={totalFiatBalance}
             />
 
-            {isHistoryEnabledAccount && (
+            {isHistoryEnabledAccount && !isGraphHidden && (
                 <>
                     <Graph<FiatGraphPointWithCryptoBalance>
                         onPointSelected={setSelectedPoint}

--- a/suite-native/module-accounts-management/src/components/CoinPriceCard.tsx
+++ b/suite-native/module-accounts-management/src/components/CoinPriceCard.tsx
@@ -66,9 +66,13 @@ export const CoinPriceCard = ({ accountKey, tokenContract }: CoinPriceCardProps)
     const token = useSelector((state: TokensRootState) =>
         selectAccountTokenInfo(state, accountKey, tokenContract),
     );
-    const { currentValue, valuePercentageChange } = useDayCoinPriceChange(symbol, tokenContract);
+    const { currentValue, valuePercentageChange, isLoading } = useDayCoinPriceChange(
+        symbol,
+        tokenContract,
+    );
 
     if (!symbol) return null;
+    if (!isLoading && currentValue === null) return null;
 
     const tokenName = token?.name ?? token?.symbol;
     const mainnetName = getNetworkDisplaySymbolName(symbol);

--- a/suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx
+++ b/suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx
@@ -6,6 +6,7 @@ import { type BottomSheetModalMethods } from '@gorhom/bottom-sheet/lib/typescrip
 
 import {
     DefinitionType,
+    type TokenDefinitionsRootState,
     TokenManagementAction,
     tokenDefinitionsActions,
 } from '@suite-common/token-definitions';
@@ -40,6 +41,8 @@ import {
     selectAccountTokenInfo,
 } from '@suite-native/tokens';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+import { selectIsUnrecognizedToken } from '../selectors';
 
 const detailRowStyle = prepareNativeStyle(({ spacings }) => ({
     flexDirection: 'row',
@@ -97,11 +100,15 @@ export const TokenSettingsBottomSheet = forwardRef(
         const hiddenTokens = useSelector((state: TokensRootState) =>
             selectAccountHiddenTokens(state, accountKey),
         );
+        const isUnrecognized = useSelector((state: TokenDefinitionsRootState & AccountsRootState) =>
+            selectIsUnrecognizedToken(state, accountKey, tokenContract),
+        );
 
         if (!token || !account || !symbol) return null;
 
         const balance = token.balance ?? '0';
         const networkName = getNetwork(symbol).name;
+
         const isHidden = hiddenTokens.some(
             t => t.contract.toLowerCase() === tokenContract.toLowerCase(),
         );
@@ -159,13 +166,15 @@ export const TokenSettingsBottomSheet = forwardRef(
                                         variant="body-sm"
                                         color="contentPrimary"
                                     />
-                                    <TokenToFiatAmountFormatter
-                                        symbol={symbol}
-                                        value={balance}
-                                        contract={tokenContract}
-                                        variant="body-sm"
-                                        color="contentSecondary"
-                                    />
+                                    {!isUnrecognized && (
+                                        <TokenToFiatAmountFormatter
+                                            symbol={symbol}
+                                            value={balance}
+                                            contract={tokenContract}
+                                            variant="body-sm"
+                                            color="contentSecondary"
+                                        />
+                                    )}
                                 </VStack>
                             </DetailRow>
                         </VStack>

--- a/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
@@ -86,6 +86,7 @@ const TransactionListHeaderContent = ({
             <AccountDetailCryptoValue value={account.formattedBalance} symbol={account.symbol} />
         );
     }
+
     if (token && isUnrecognizedToken) {
         const { balance = '0', symbol: tokenSymbol } = token;
 

--- a/suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts
+++ b/suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts
@@ -28,6 +28,7 @@ export const useDayCoinPriceChange = (
     const [currentValue, setCurrentValue] = useState<BaseCurrencyAmount | null>(null);
     const [weekAgoValue, setWeekAgoValue] = useState<number | null>(null);
     const [valuePercentageChange, setValuePercentageChange] = useState<number | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
 
     const fiatCurrencyCode = useSelector(selectBaseCurrency);
     const isElectrumBackend = useSelector((state: BlockchainRootState) =>
@@ -40,30 +41,36 @@ export const useDayCoinPriceChange = (
     useEffect(() => {
         const getPrices = async () => {
             if (!symbol) return;
+
+            setIsLoading(true);
+
             const currentTimestamp = getUnixTime(Date.now());
             const weekAgoTimestamp = currentTimestamp - 7 * UNIX_DAY;
 
-            const timestampedFiatRates = await getFiatRatesForTimestamps(
-                { symbol, tokenAddress: tokenContract },
-                [weekAgoTimestamp, currentTimestamp],
-                fiatCurrencyCode,
-                isElectrumBackend,
-                isCoingeckoForce,
-            );
+            try {
+                const timestampedFiatRates = await getFiatRatesForTimestamps(
+                    { symbol, tokenAddress: tokenContract },
+                    [weekAgoTimestamp, currentTimestamp],
+                    fiatCurrencyCode,
+                    isElectrumBackend,
+                    isCoingeckoForce,
+                );
 
-            if (!timestampedFiatRates) return;
+                const [weekAgo, today] = timestampedFiatRates?.tickers ?? [];
 
-            const { tickers } = timestampedFiatRates;
-            // @ts-expect-error: noUncheckedIndexedAccess
-            const weekAgo: TimestampedFiatRate = tickers[0];
-            // @ts-expect-error: noUncheckedIndexedAccess
-            const today: TimestampedFiatRate = tickers[1];
-
-            setWeekAgoValue(weekAgo?.rates[fiatCurrencyCode] ?? null);
-            const currentRate = today?.rates[fiatCurrencyCode];
-            setCurrentValue(
-                currentRate !== undefined ? asBaseCurrencyAmount(new BigNumber(currentRate)) : null,
-            );
+                setWeekAgoValue(weekAgo?.rates[fiatCurrencyCode] ?? null);
+                const currentRate = today?.rates[fiatCurrencyCode];
+                setCurrentValue(
+                    currentRate !== undefined
+                        ? asBaseCurrencyAmount(new BigNumber(currentRate))
+                        : null,
+                );
+            } catch {
+                setWeekAgoValue(null);
+                setCurrentValue(null);
+            } finally {
+                setIsLoading(false);
+            }
         };
 
         getPrices();
@@ -75,8 +82,10 @@ export const useDayCoinPriceChange = (
     useEffect(() => {
         if (isNotNullOrUndefined(currentValue) && isNotNullOrUndefined(weekAgoValue)) {
             setValuePercentageChange(percentageDiff(weekAgoValue, currentValue.toNumber()));
+        } else {
+            setValuePercentageChange(null);
         }
     }, [currentValue, weekAgoValue]);
 
-    return { currentValue, valuePercentageChange };
+    return { currentValue, valuePercentageChange, isLoading };
 };


### PR DESCRIPTION
## Description

This PR is a hotfix of two issues:
1. don't fetch fiat rate for an unrecognized token
2. don't show graph if it can't be fetched and loaded

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28397
Resolve https://github.com/trezor/trezor-suite/issues/27939

## Screenshots:

Show only crypto balance for an unrecognized token:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 08 56 29" src="https://github.com/user-attachments/assets/6663c28c-8a5d-4afe-8309-5b2a68148331" />

Show graph (and the price card) if it can be fetched and loaded:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 09 22 43" src="https://github.com/user-attachments/assets/f238e735-4d09-41d3-b737-b6d4e66242ef" />

Hide the graph (and the price card) otherwise:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 09 40 10" src="https://github.com/user-attachments/assets/ff13ad1d-3dfc-4292-96d4-fbfad6179e4b" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/tokens&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->