### PR TITLE
Makes the per-flow step sequences the single source of truth for the yield step machine

### DIFF
--- a/packages/suite/src/components/earn/yield/__tests__/yieldFlowUtils.test.ts
+++ b/packages/suite/src/components/earn/yield/__tests__/yieldFlowUtils.test.ts
@@ -1,0 +1,47 @@
+import { getYieldFlowSteps } from '../yieldFlowUtils';
+
+describe('yieldFlowUtils', () => {
+    describe('getYieldFlowSteps', () => {
+        it('describes deposit steps on the approve step', () => {
+            expect(getYieldFlowSteps('deposit', 'approve')).toEqual({
+                approve: { state: 'active', indicator: { index: 1, total: 2 } },
+                action: { state: 'pending', indicator: { index: 2, total: 2 } },
+                complete: { state: 'pending', indicator: { index: 0, total: 2 } },
+            });
+        });
+
+        it('describes deposit steps on the action step', () => {
+            expect(getYieldFlowSteps('deposit', 'action')).toEqual({
+                approve: { state: 'done', indicator: { index: 1, total: 2 } },
+                action: { state: 'active', indicator: { index: 2, total: 2 } },
+                complete: { state: 'pending', indicator: { index: 0, total: 2 } },
+            });
+        });
+
+        it('describes deposit steps on the complete step', () => {
+            expect(getYieldFlowSteps('deposit', 'complete')).toEqual({
+                approve: { state: 'done', indicator: { index: 1, total: 2 } },
+                action: { state: 'done', indicator: { index: 2, total: 2 } },
+                complete: { state: 'active', indicator: { index: 0, total: 2 } },
+            });
+        });
+
+        it('numbers the complete step when it is displayed as a list item', () => {
+            expect(
+                getYieldFlowSteps('deposit', 'approve', ['approve', 'action', 'complete']),
+            ).toEqual({
+                approve: { state: 'active', indicator: { index: 1, total: 3 } },
+                action: { state: 'pending', indicator: { index: 2, total: 3 } },
+                complete: { state: 'pending', indicator: { index: 3, total: 3 } },
+            });
+        });
+
+        it('reports steps outside the flow as passed', () => {
+            expect(getYieldFlowSteps('withdraw', 'action')).toEqual({
+                approve: { state: 'done', indicator: { index: 0, total: 1 } },
+                action: { state: 'active', indicator: { index: 1, total: 1 } },
+                complete: { state: 'pending', indicator: { index: 0, total: 1 } },
+            });
+        });
+    });
+});

--- a/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
@@ -28,6 +28,7 @@ import { YieldRewardsList } from './YieldRewardsList';
 import { useMerklRewards } from './hooks';
 import { YieldDisabledBanner } from '../common/YieldDisabledBanner';
 import { YieldFlowCompleteClaim } from '../common/YieldFlowCompleteClaim';
+import { YieldFlowStepList } from '../common/YieldFlowStepList';
 import { YieldPendingTransaction } from '../common/YieldPendingTransaction';
 import { useEnsureYieldDeviceSession } from '../hooks/useEnsureYieldDeviceSession';
 import { useYieldPendingTransactionTracking } from '../hooks/useYieldPendingTransactionTracking';
@@ -62,6 +63,9 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
     const accountRewards: YieldAccountRewards | undefined =
         merklRewardsQuery.data?.accountsRewards[0];
     const isRewardsLoading = merklRewardsQuery.isLoading || missingRateTickersQuery.isLoading;
+
+    // Completion shows the claimed-rewards snapshot; until it is available, keep the claim screen.
+    const currentStep = claimSession.step === 'complete' && accountRewards ? 'complete' : 'action';
 
     useEffect(() => {
         dispatch(stablecoinYieldActions.initSession({ flowType: 'claim', flowKey }));
@@ -146,19 +150,9 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
         [account, analytics, dispatch],
     );
 
-    if (claimSession.step === 'complete' && accountRewards) {
-        return (
-            <Column width="100%" alignItems="center">
-                <Column gap={24} width="100%" maxWidth={500}>
-                    <YieldFlowCompleteClaim accountRewards={accountRewards} />
-                </Column>
-            </Column>
-        );
-    }
-
     return (
         <Column width="100%" alignItems="center">
-            {isFirmwareModalOpen && (
+            {currentStep !== 'complete' && isFirmwareModalOpen && (
                 <FirmwareUpgradeNeededModal
                     onClose={closeFirmwareModal}
                     onUpdate={updateFirmware}
@@ -166,66 +160,96 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
                 />
             )}
             <Column gap={24} width="100%" maxWidth={500}>
-                <ContextMessage context={Context.getEarnYield('claim')} />
+                {currentStep !== 'complete' && (
+                    <>
+                        <ContextMessage context={Context.getEarnYield('claim')} />
 
-                <Text typographyStyle="headline-md">
-                    <Translation id="TR_EARN_CLAIM_REWARDS" />
-                </Text>
+                        <Text typographyStyle="headline-md">
+                            <Translation id="TR_EARN_CLAIM_REWARDS" />
+                        </Text>
+                    </>
+                )}
 
-                {isDisabled ? (
+                {isDisabled && currentStep !== 'complete' ? (
                     <YieldDisabledBanner type="claim" content={content} variant={variant} />
                 ) : (
-                    <>
-                        <Card>
-                            <Column gap={24}>
-                                <Text typographyStyle="body-md-strong">
-                                    <Translation id="TR_STAKE_REWARDS" />
-                                </Text>
+                    <YieldFlowStepList
+                        flowType="claim"
+                        currentStep={currentStep}
+                        steps={{
+                            action: {
+                                title: <Translation id="TR_EARN_CLAIM_REWARDS" />,
+                                content: () => (
+                                    <>
+                                        <Card>
+                                            <Column gap={24}>
+                                                <Text typographyStyle="body-md-strong">
+                                                    <Translation id="TR_STAKE_REWARDS" />
+                                                </Text>
 
-                                <YieldRewardsList
-                                    accountRewards={accountRewards}
-                                    isLoading={isRewardsLoading}
-                                />
-                            </Column>
-                        </Card>
+                                                <YieldRewardsList
+                                                    accountRewards={accountRewards}
+                                                    isLoading={isRewardsLoading}
+                                                />
+                                            </Column>
+                                        </Card>
 
-                        {merklRewardsQuery.isSuccess &&
-                            (accountRewards?.rewards?.length ?? 0) > 0 &&
-                            !claimSession.action.pendingTransaction && (
-                                <Banner
-                                    intent="warning"
-                                    icon="warning"
-                                    description={
-                                        <Translation id="TR_EARN_REWARDS_NETWORK_FEE_WARNING" />
-                                    }
-                                />
-                            )}
+                                        {merklRewardsQuery.isSuccess &&
+                                            (accountRewards?.rewards?.length ?? 0) > 0 &&
+                                            !claimSession.action.pendingTransaction && (
+                                                <Banner
+                                                    intent="warning"
+                                                    icon="warning"
+                                                    description={
+                                                        <Translation id="TR_EARN_REWARDS_NETWORK_FEE_WARNING" />
+                                                    }
+                                                />
+                                            )}
 
-                        {claimSession.error && (
-                            <Banner
-                                intent="warning"
-                                description={<Translation id={claimSession.error} />}
-                            />
-                        )}
+                                        {claimSession.error && (
+                                            <Banner
+                                                intent="warning"
+                                                description={
+                                                    <Translation id={claimSession.error} />
+                                                }
+                                            />
+                                        )}
 
-                        <Button
-                            size="large"
-                            width="100%"
-                            isDisabled={
-                                isRewardsLoading || !accountRewards?.rewards.length || isClaiming
-                            }
-                            isLoading={isClaimSubmitting || merklRewardsQuery.isLoading}
-                            onClick={handleClaim}
-                        >
-                            <Translation id="TR_EARN_YIELD_CLAIM" />
-                        </Button>
-                        {claimSession.action.pendingTransaction && (
-                            <YieldPendingTransaction
-                                pendingTransaction={claimSession.action.pendingTransaction}
-                                onTxClick={handleTxClick}
-                            />
-                        )}
-                    </>
+                                        <Button
+                                            size="large"
+                                            width="100%"
+                                            isDisabled={
+                                                isRewardsLoading ||
+                                                !accountRewards?.rewards.length ||
+                                                isClaiming
+                                            }
+                                            isLoading={
+                                                isClaimSubmitting || merklRewardsQuery.isLoading
+                                            }
+                                            onClick={handleClaim}
+                                        >
+                                            <Translation id="TR_EARN_YIELD_CLAIM" />
+                                        </Button>
+                                        {claimSession.action.pendingTransaction && (
+                                            <YieldPendingTransaction
+                                                pendingTransaction={
+                                                    claimSession.action.pendingTransaction
+                                                }
+                                                onTxClick={handleTxClick}
+                                            />
+                                        )}
+                                    </>
+                                ),
+                            },
+                            complete: {
+                                isListItem: false,
+                                content: () =>
+                                    accountRewards ? (
+                                        <YieldFlowCompleteClaim accountRewards={accountRewards} />
+                                    ) : null,
+                            },
+                        }}
+                    />
                 )}
             </Column>
         </Column>

--- a/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
@@ -30,7 +30,6 @@ const getApproveButtonTranslationId = (approvalAction: YieldApprovalAction) => {
 
 export type YieldApproveStepProps = {
     token: YieldFlowDisplayToken;
-    variant: 'active' | 'done';
     summaryValue: ReactNode;
     isDisabled?: boolean;
     isLoading?: boolean;
@@ -50,7 +49,6 @@ export type YieldApproveStepProps = {
 
 export const YieldApproveStep = ({
     token,
-    variant,
     summaryValue,
     isDisabled = false,
     isLoading = false,
@@ -72,69 +70,55 @@ export const YieldApproveStep = ({
         canRevokeAllowance && !isApprovedAmountLoading && !hasApprovedAmountError && !isLoading;
     const onRevokeClick = shouldEnableRevoke ? onRevoke : undefined;
 
-    switch (variant) {
-        case 'active':
-            return (
-                <Column gap={16}>
-                    <YieldApprovedAmountCard
-                        token={token}
-                        amount={approvedAmountValue}
-                        isLoading={isApprovedAmountLoading}
-                        hasError={hasApprovedAmountError}
-                        onRevoke={onRevokeClick}
-                    />
+    return (
+        <Column gap={16}>
+            <YieldApprovedAmountCard
+                token={token}
+                amount={approvedAmountValue}
+                isLoading={isApprovedAmountLoading}
+                hasError={hasApprovedAmountError}
+                onRevoke={onRevokeClick}
+            />
 
-                    <YieldAmountCard
-                        tokenSymbol={token.symbol}
-                        decimals={token.decimals}
-                        summary={{
-                            labelTranslationId: 'TR_BALANCE',
-                            value: summaryValue,
-                            onMaxClick: pendingApproveTransaction ? undefined : onMaxClick,
-                        }}
-                        heading={{
-                            amountLabelTranslationId: 'AMOUNT',
-                        }}
-                        warning={warning}
-                        isDisabled={!!pendingApproveTransaction}
-                    />
+            <YieldAmountCard
+                tokenSymbol={token.symbol}
+                decimals={token.decimals}
+                summary={{
+                    labelTranslationId: 'TR_BALANCE',
+                    value: summaryValue,
+                    onMaxClick: pendingApproveTransaction ? undefined : onMaxClick,
+                }}
+                heading={{
+                    amountLabelTranslationId: 'AMOUNT',
+                }}
+                warning={warning}
+                isDisabled={!!pendingApproveTransaction}
+            />
 
-                    <Button
-                        size="large"
-                        width="100%"
-                        onClick={onApprovalSubmit}
-                        isDisabled={isDisabled || !!pendingApproveTransaction || !onApprovalSubmit}
-                        isLoading={isLoading}
-                    >
-                        <Translation id={approveButtonId} values={{ tokenSymbol: token.symbol }} />
-                    </Button>
+            <Button
+                size="large"
+                width="100%"
+                onClick={onApprovalSubmit}
+                isDisabled={isDisabled || !!pendingApproveTransaction || !onApprovalSubmit}
+                isLoading={isLoading}
+            >
+                <Translation id={approveButtonId} values={{ tokenSymbol: token.symbol }} />
+            </Button>
 
-                    {approvalAction === 'revoke' && !isDisabled && (
-                        <Banner
-                            intent="warning"
-                            icon="warning"
-                            description={
-                                <Translation id="TR_EXCHANGE_APPROVAL_FORM_REVOKE_BANNER" />
-                            }
-                        />
-                    )}
-
-                    {pendingApproveTransaction && (
-                        <YieldPendingTransaction
-                            pendingTransaction={pendingApproveTransaction}
-                            onTxClick={onPendingTxClick}
-                        />
-                    )}
-                </Column>
-            );
-        case 'done':
-            return (
-                <YieldApprovedAmountCard
-                    token={token}
-                    amount={approvedAmountValue}
-                    isLoading={isApprovedAmountLoading}
-                    hasError={hasApprovedAmountError}
+            {approvalAction === 'revoke' && !isDisabled && (
+                <Banner
+                    intent="warning"
+                    icon="warning"
+                    description={<Translation id="TR_EXCHANGE_APPROVAL_FORM_REVOKE_BANNER" />}
                 />
-            );
-    }
+            )}
+
+            {pendingApproveTransaction && (
+                <YieldPendingTransaction
+                    pendingTransaction={pendingApproveTransaction}
+                    onTxClick={onPendingTxClick}
+                />
+            )}
+        </Column>
+    );
 };

--- a/packages/suite/src/components/earn/yield/common/YieldFlowStepList.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowStepList.tsx
@@ -1,0 +1,114 @@
+import { type ReactNode } from 'react';
+
+import { Translation } from '@suite/intl';
+import {
+    YIELD_FLOW_STEP_SEQUENCES,
+    type YieldFlowStepId,
+    type YieldFlowType,
+} from '@suite-common/wallet-core';
+import { Column, Row, StepList, Text } from '@trezor/components';
+
+import { type YieldFlowStepView, getYieldFlowSteps } from '../yieldFlowUtils';
+
+/** Steps of a given flow derived from its sequence — a new step in the sequence must be defined. */
+export type YieldFlowStepOf<TFlowType extends YieldFlowType> =
+    (typeof YIELD_FLOW_STEP_SEQUENCES)[TFlowType][number];
+
+export type YieldFlowStepDefinition = {
+    /** Label on the title row next to the step number. */
+    title?: ReactNode;
+    /** Right side of the title row (e.g. a modify action); receives the view for state-dependent actions. */
+    rightContent?: (view: YieldFlowStepView) => ReactNode;
+    /**
+     * Renders the step as a StepList item and counts it into the step numbering. A non-list
+     * step takes over the whole area while active (e.g. a final complete screen). Default true.
+     */
+    isListItem?: boolean;
+    /** Shown while the step is active. */
+    content: (view: YieldFlowStepView) => ReactNode;
+    /** Shown in the remaining step states; without it an inactive step has no content. */
+    inactiveContent?: (view: YieldFlowStepView) => ReactNode;
+};
+
+type YieldFlowStepListProps<TFlowType extends YieldFlowType> = {
+    flowType: TFlowType;
+    currentStep: YieldFlowStepId;
+    steps: Record<YieldFlowStepOf<TFlowType>, YieldFlowStepDefinition>;
+    /** Renders the steps as an ordered StepList; without it only the current step's content shows. */
+    hasStepList?: boolean;
+};
+
+export const YieldFlowStepList = <TFlowType extends YieldFlowType>({
+    flowType,
+    currentStep,
+    steps,
+    hasStepList = false,
+}: YieldFlowStepListProps<TFlowType>) => {
+    // Widened — the prop is keyed by the flow's own steps, but we index it with generic step ids.
+    const stepDefinitions: Partial<Record<YieldFlowStepId, YieldFlowStepDefinition>> = steps;
+    const sequence: readonly YieldFlowStepId[] = YIELD_FLOW_STEP_SEQUENCES[flowType];
+    const listSteps = sequence.filter(stepId => stepDefinitions[stepId]?.isListItem !== false);
+    const views = getYieldFlowSteps(flowType, currentStep, listSteps);
+
+    const renderStepContent = (stepId: YieldFlowStepId) => {
+        const definition = stepDefinitions[stepId];
+
+        if (!definition) {
+            return null;
+        }
+
+        const view = views[stepId];
+
+        if (view.state === 'active') {
+            return definition.content(view);
+        }
+
+        return definition.inactiveContent?.(view) ?? null;
+    };
+
+    const isCurrentStepListItem = stepDefinitions[currentStep]?.isListItem !== false;
+
+    if (!isCurrentStepListItem || !hasStepList) {
+        return <>{renderStepContent(currentStep)}</>;
+    }
+
+    return (
+        <StepList isOrdered bulletSize="large" bulletGap={12} gap={24} titleGap={16}>
+            {listSteps.map(stepId => {
+                const view = views[stepId];
+                const definition = stepDefinitions[stepId];
+
+                return (
+                    <StepList.Item
+                        key={stepId}
+                        state={view.state}
+                        title={
+                            <Column gap={8} width="100%">
+                                <Text
+                                    typographyStyle="body-xs"
+                                    intent="neutral"
+                                    priority="secondary"
+                                    case="uppercase"
+                                >
+                                    <Translation id="TR_STEP_OF_TOTAL" values={view.indicator} />
+                                </Text>
+
+                                <Row
+                                    justifyContent="space-between"
+                                    alignItems="center"
+                                    width="100%"
+                                    gap={16}
+                                >
+                                    {definition?.title}
+                                    {definition?.rightContent?.(view)}
+                                </Row>
+                            </Column>
+                        }
+                    >
+                        {renderStepContent(stepId)}
+                    </StepList.Item>
+                );
+            })}
+        </StepList>
+    );
+};

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -2,7 +2,7 @@ import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { splitYieldPendingTransaction } from '@suite-common/wallet-core';
-import { Banner, Button, Column, Row, StepList, Text } from '@trezor/components';
+import { Banner, Button, Column, Text } from '@trezor/components';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 
@@ -11,7 +11,9 @@ import { YieldActionStep } from '../common/YieldActionStep';
 import { YieldActionStepWarning } from '../common/YieldActionStepWarning';
 import { YieldApproveModal } from '../common/YieldApproveModal';
 import { YieldApproveStep } from '../common/YieldApproveStep';
+import { YieldApprovedAmountCard } from '../common/YieldApprovedAmountCard';
 import { YieldFlowCompleteDeposit } from '../common/YieldFlowCompleteDeposit';
+import { YieldFlowStepList } from '../common/YieldFlowStepList';
 import { getApyBreakdown } from '../yieldFlowUtils';
 
 export const YieldDepositForm = () => {
@@ -50,8 +52,6 @@ export const YieldDepositForm = () => {
         retryInitAllowance,
         flow,
     } = useYieldDepositContext();
-
-    const { approve: approveStepState, action: actionStepState } = flow.stepStates;
 
     const { approvalPendingTransaction, actionPendingTransaction: depositPendingTransaction } =
         splitYieldPendingTransaction(pendingTransaction, 'deposit');
@@ -144,21 +144,7 @@ export const YieldDepositForm = () => {
         <>
             <Column width="100%" alignItems="center">
                 <Column gap={24} width="100%" maxWidth={500}>
-                    {flow.currentStep === 'complete' ? (
-                        <YieldFlowCompleteDeposit
-                            apy={apy}
-                            vault={vault}
-                            networkSymbol={account.symbol}
-                            input={{
-                                token,
-                                amount: completedAmount,
-                            }}
-                            output={{
-                                token: receiptToken,
-                                amount: completedReceiptAmount,
-                            }}
-                        />
-                    ) : (
+                    {flow.currentStep !== 'complete' && (
                         <>
                             <Text typographyStyle="headline-md">
                                 <Translation id="TR_EARN_YIELD_DEPOSIT" />
@@ -185,57 +171,30 @@ export const YieldDepositForm = () => {
                                     }
                                 />
                             )}
+                        </>
+                    )}
 
-                            <StepList
-                                isOrdered
-                                bulletSize="large"
-                                bulletGap={12}
-                                gap={24}
-                                titleGap={16}
-                            >
-                                <StepList.Item
-                                    state={approveStepState}
-                                    title={
-                                        <Column gap={8} width="100%">
-                                            <Text
-                                                typographyStyle="body-xs"
-                                                intent="neutral"
-                                                priority="secondary"
-                                                case="uppercase"
-                                            >
-                                                <Translation
-                                                    id="TR_STEP_OF_TOTAL"
-                                                    values={{
-                                                        index: 1,
-                                                        total: 2,
-                                                    }}
-                                                />
-                                            </Text>
-
-                                            <Row
-                                                justifyContent="space-between"
-                                                alignItems="center"
-                                                width="100%"
-                                                gap={16}
-                                            >
-                                                <Translation id="TR_EARN_YIELD_SELECT_AMOUNT_AND_APPROVE" />
-                                                {approveStepState === 'done' && (
-                                                    <Button
-                                                        size="small"
-                                                        intent="neutral"
-                                                        priority="secondary"
-                                                        onClick={handleOnModify}
-                                                    >
-                                                        <Translation id="TR_MODIFY" />
-                                                    </Button>
-                                                )}
-                                            </Row>
-                                        </Column>
-                                    }
-                                >
+                    <YieldFlowStepList
+                        flowType="deposit"
+                        currentStep={flow.currentStep}
+                        hasStepList
+                        steps={{
+                            approve: {
+                                title: <Translation id="TR_EARN_YIELD_SELECT_AMOUNT_AND_APPROVE" />,
+                                rightContent: view =>
+                                    view.state === 'done' && (
+                                        <Button
+                                            size="small"
+                                            intent="neutral"
+                                            priority="secondary"
+                                            onClick={handleOnModify}
+                                        >
+                                            <Translation id="TR_MODIFY" />
+                                        </Button>
+                                    ),
+                                content: () => (
                                     <YieldApproveStep
                                         token={token}
-                                        variant={approveStepState === 'done' ? 'done' : 'active'}
                                         summaryValue={
                                             <FormattedCryptoAmount
                                                 value={maxAmount}
@@ -267,78 +226,73 @@ export const YieldDepositForm = () => {
                                         onRevoke={handleOnRevoke}
                                         onPendingTxClick={openPendingTransaction}
                                     />
-                                </StepList.Item>
-
-                                <StepList.Item
-                                    state={actionStepState}
-                                    title={
-                                        <Column gap={8} width="100%">
-                                            <Text
-                                                typographyStyle="body-xs"
-                                                intent="neutral"
-                                                priority="secondary"
-                                                case="uppercase"
-                                            >
-                                                <Translation
-                                                    id="TR_STEP_OF_TOTAL"
-                                                    values={{
-                                                        index: 2,
-                                                        total: 2,
-                                                    }}
+                                ),
+                                inactiveContent: () => (
+                                    <YieldApprovedAmountCard
+                                        token={token}
+                                        amount={allowanceAmount || '0'}
+                                        isLoading={allowanceStatus === 'loading'}
+                                        hasError={allowanceStatus === 'error'}
+                                    />
+                                ),
+                            },
+                            action: {
+                                title: <Translation id="TR_EARN_YIELD_DEPOSIT" />,
+                                content: () => (
+                                    <YieldActionStep
+                                        flowType="deposit"
+                                        token={token}
+                                        summaryValue={
+                                            <FormattedCryptoAmount
+                                                value={maxAmount}
+                                                symbol={token.symbol}
+                                            />
+                                        }
+                                        warning={
+                                            !isAmountInvalidDecimals ? (
+                                                <YieldActionStepWarning
+                                                    isInsufficientFunds={isAmountTooHigh}
+                                                    isApprovalInsufficient={isApprovalInsufficient}
+                                                    onModifyApproval={handleOnModify}
                                                 />
-                                            </Text>
-
-                                            <Row
-                                                justifyContent="space-between"
-                                                alignItems="center"
-                                                width="100%"
-                                                gap={16}
-                                            >
-                                                <Translation id="TR_EARN_YIELD_DEPOSIT" />
-                                            </Row>
-                                        </Column>
-                                    }
-                                >
-                                    {actionStepState === 'active' && (
-                                        <YieldActionStep
-                                            flowType="deposit"
-                                            token={token}
-                                            summaryValue={
-                                                <FormattedCryptoAmount
-                                                    value={maxAmount}
-                                                    symbol={token.symbol}
-                                                />
-                                            }
-                                            warning={
-                                                !isAmountInvalidDecimals ? (
-                                                    <YieldActionStepWarning
-                                                        isInsufficientFunds={isAmountTooHigh}
-                                                        isApprovalInsufficient={
-                                                            isApprovalInsufficient
-                                                        }
-                                                        onModifyApproval={handleOnModify}
-                                                    />
-                                                ) : undefined
-                                            }
-                                            isDisabled={
-                                                isAmountEmpty ||
-                                                isAmountTooHigh ||
-                                                isAmountInvalidDecimals ||
-                                                isApprovalInsufficient ||
-                                                isSubmittingAction ||
-                                                !!depositPendingTransaction
-                                            }
-                                            isPending={isSubmittingAction}
-                                            pendingTransaction={depositPendingTransaction}
-                                            onMaxClick={handleMaxClick}
-                                            onSubmit={handleOnDeposit}
-                                            onPendingTxClick={openPendingTransaction}
-                                        />
-                                    )}
-                                </StepList.Item>
-                            </StepList>
-                        </>
-                    )}
+                                            ) : undefined
+                                        }
+                                        isDisabled={
+                                            isAmountEmpty ||
+                                            isAmountTooHigh ||
+                                            isAmountInvalidDecimals ||
+                                            isApprovalInsufficient ||
+                                            isSubmittingAction ||
+                                            !!depositPendingTransaction
+                                        }
+                                        isPending={isSubmittingAction}
+                                        pendingTransaction={depositPendingTransaction}
+                                        onMaxClick={handleMaxClick}
+                                        onSubmit={handleOnDeposit}
+                                        onPendingTxClick={openPendingTransaction}
+                                    />
+                                ),
+                            },
+                            complete: {
+                                isListItem: false,
+                                content: () => (
+                                    <YieldFlowCompleteDeposit
+                                        apy={apy}
+                                        vault={vault}
+                                        networkSymbol={account.symbol}
+                                        input={{
+                                            token,
+                                            amount: completedAmount,
+                                        }}
+                                        output={{
+                                            token: receiptToken,
+                                            amount: completedReceiptAmount,
+                                        }}
+                                    />
+                                ),
+                            },
+                        }}
+                    />
                 </Column>
             </Column>
 

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -27,7 +27,6 @@ import {
     submitYieldRevokeThunk,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
-import type { StepListItemState } from '@trezor/components';
 import { useCurrentRef } from '@trezor/react-utils';
 
 import { setConnectionModal, setConnectionMode } from 'src/actions/device/deviceSlice';
@@ -42,7 +41,6 @@ import { useResolvedYieldFlowData } from './useResolvedYieldFlowData';
 import { useYieldPendingTransactionTracking } from './useYieldPendingTransactionTracking';
 import {
     type YieldApprovalAction,
-    getStepListItemStates,
     getYieldApprovalAction,
     getYieldModifyAmountInput,
     isAmountGreaterThan,
@@ -57,8 +55,6 @@ type UseYieldFlowProps = {
 
 type UseYieldFlowStepsResult = {
     currentStep: YieldFlowStepId;
-    stepStates: Record<YieldFlowStepId, StepListItemState>;
-    goToStep: (step: YieldFlowStepId) => void;
 };
 
 export type UseYieldFlowResult = {
@@ -178,10 +174,6 @@ export const useYieldFlow = ({
         dispatch(stablecoinYieldActions.initSession({ flowType, flowKey }));
         dispatch(stablecoinYieldActions.resetSession({ flowType, flowKey }));
 
-        if (isYieldWithdrawFlow(flowType)) {
-            dispatch(stablecoinYieldActions.skipApprovalStep({ flowType, flowKey }));
-        }
-
         methodsRef.current.reset({ amountInput: '' });
 
         return () => {
@@ -287,21 +279,7 @@ export const useYieldFlow = ({
         prevStepRef.current = nextStep;
     }, [session.step, session.action.amount, methodsRef, maxAmount]);
 
-    const goToStep = useCallback(
-        (step: YieldFlowStepId) => {
-            dispatch(stablecoinYieldActions.goToStep({ flowType, flowKey, step }));
-        },
-        [dispatch, flowKey, flowType],
-    );
-
-    const flow = useMemo(
-        () => ({
-            currentStep: session.step,
-            stepStates: getStepListItemStates(session.step),
-            goToStep,
-        }),
-        [session.step, goToStep],
-    );
+    const flow = useMemo(() => ({ currentStep: session.step }), [session.step]);
 
     const openPendingTransaction = useCallback(
         (txid: string) => {

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -12,6 +12,7 @@ import { useYieldWithdrawContext } from './useYieldWithdrawContext';
 import { YieldActionStep } from '../common/YieldActionStep';
 import { YieldActionStepWarning } from '../common/YieldActionStepWarning';
 import { YieldFlowCompleteWithdraw } from '../common/YieldFlowCompleteWithdraw';
+import { YieldFlowStepList } from '../common/YieldFlowStepList';
 import { getApyBreakdown } from '../yieldFlowUtils';
 
 export const YieldWithdrawForm = () => {
@@ -118,13 +119,7 @@ export const YieldWithdrawForm = () => {
     return (
         <Column width="100%" alignItems="center">
             <Column gap={24} width="100%" maxWidth={500}>
-                {flow.currentStep === 'complete' ? (
-                    <YieldFlowCompleteWithdraw
-                        input={completedInput}
-                        output={completedOutput}
-                        vaultId={vault.id}
-                    />
-                ) : (
+                {flow.currentStep !== 'complete' && (
                     <>
                         <Text typographyStyle="headline-md">
                             <Translation id="TR_EARN_YIELD_WITHDRAW" />
@@ -136,44 +131,67 @@ export const YieldWithdrawForm = () => {
                                 description={<Translation id={errorMessage} />}
                             />
                         )}
-
-                        <YieldActionStep
-                            flowType={flowType}
-                            token={flowType === 'redeem' ? receiptToken : token}
-                            summaryValue={
-                                <FormattedCryptoAmount
-                                    value={maxAmount}
-                                    symbol={inputTokenSymbol}
-                                />
-                            }
-                            warning={
-                                !isAmountInvalidDecimals && isAmountTooHigh ? (
-                                    <YieldActionStepWarning isInsufficientFunds={isAmountTooHigh} />
-                                ) : undefined
-                            }
-                            isDisabled={
-                                isAmountEmpty ||
-                                isAmountTooHigh ||
-                                isAmountInvalidDecimals ||
-                                isSubmittingAction ||
-                                !!withdrawPendingTransaction
-                            }
-                            isPending={isSubmittingAction}
-                            pendingTransaction={withdrawPendingTransaction}
-                            unitToggle={
-                                canToggleWithdrawUnit
-                                    ? {
-                                          otherTokenSymbol: otherUnitTokenSymbol,
-                                          onClick: handleToggleWithdrawInputUnit,
-                                      }
-                                    : undefined
-                            }
-                            onMaxClick={handleMaxClick}
-                            onSubmit={handleOnWithdraw}
-                            onPendingTxClick={openPendingTransaction}
-                        />
                     </>
                 )}
+
+                <YieldFlowStepList
+                    flowType={flowType}
+                    currentStep={flow.currentStep}
+                    steps={{
+                        action: {
+                            title: <Translation id="TR_EARN_YIELD_WITHDRAW" />,
+                            content: () => (
+                                <YieldActionStep
+                                    flowType={flowType}
+                                    token={flowType === 'redeem' ? receiptToken : token}
+                                    summaryValue={
+                                        <FormattedCryptoAmount
+                                            value={maxAmount}
+                                            symbol={inputTokenSymbol}
+                                        />
+                                    }
+                                    warning={
+                                        !isAmountInvalidDecimals && isAmountTooHigh ? (
+                                            <YieldActionStepWarning
+                                                isInsufficientFunds={isAmountTooHigh}
+                                            />
+                                        ) : undefined
+                                    }
+                                    isDisabled={
+                                        isAmountEmpty ||
+                                        isAmountTooHigh ||
+                                        isAmountInvalidDecimals ||
+                                        isSubmittingAction ||
+                                        !!withdrawPendingTransaction
+                                    }
+                                    isPending={isSubmittingAction}
+                                    pendingTransaction={withdrawPendingTransaction}
+                                    unitToggle={
+                                        canToggleWithdrawUnit
+                                            ? {
+                                                  otherTokenSymbol: otherUnitTokenSymbol,
+                                                  onClick: handleToggleWithdrawInputUnit,
+                                              }
+                                            : undefined
+                                    }
+                                    onMaxClick={handleMaxClick}
+                                    onSubmit={handleOnWithdraw}
+                                    onPendingTxClick={openPendingTransaction}
+                                />
+                            ),
+                        },
+                        complete: {
+                            isListItem: false,
+                            content: () => (
+                                <YieldFlowCompleteWithdraw
+                                    input={completedInput}
+                                    output={completedOutput}
+                                    vaultId={vault.id}
+                                />
+                            ),
+                        },
+                    }}
+                />
             </Column>
         </Column>
     );

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
@@ -1,21 +1,25 @@
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
-import { YIELD_FLOW_STEPS, type YieldFlowStepId } from '@suite-common/wallet-core';
+import {
+    YIELD_FLOW_STEP_SEQUENCES,
+    type YieldFlowStepId,
+    type YieldFlowType,
+} from '@suite-common/wallet-core';
 import { getApyPercent } from '@suite-common/wallet-utils';
 import type { StepListItemState } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
 export { getYieldApprovalAction, type YieldApprovalAction } from '@suite-common/wallet-core';
 
-interface AmountComparisonParams {
+type AmountComparisonParams = {
     amount?: string;
     threshold?: string;
-}
+};
 
-interface YieldModifyAmountInputParams {
+type YieldModifyAmountInputParams = {
     liveAmount?: string;
     actionAmount?: string | null;
     maxAmount: string;
-}
+};
 
 export const isAmountGreaterThan = ({ amount, threshold }: AmountComparisonParams): boolean =>
     !!amount && !!threshold && new BigNumber(amount).gt(threshold);
@@ -55,13 +59,33 @@ export const getApyBreakdown = (
         .flatMap(([symbol, componentApy]) => [symbol, String(componentApy)])
         .join(',');
 
-export const getStepListItemStates = (
-    currentStep: YieldFlowStepId,
-): Record<YieldFlowStepId, StepListItemState> => {
-    const currentStepIndex = YIELD_FLOW_STEPS.indexOf(currentStep);
+export type YieldFlowStepView = {
+    state: StepListItemState;
+    /**
+     * 1-based position within the flow's step list. Steps that are not list items of
+     * the flow get index 0 — they are never rendered in the StepList.
+     */
+    indicator: { index: number; total: number };
+};
 
-    const getStepState = (stepId: YieldFlowStepId): StepListItemState => {
-        const stepIndex = YIELD_FLOW_STEPS.indexOf(stepId);
+/** `listSteps` are the steps rendered as list items; they default to the flow's sequence without 'complete'. */
+export const getYieldFlowSteps = (
+    flowType: YieldFlowType,
+    currentStep: YieldFlowStepId,
+    listSteps?: readonly YieldFlowStepId[],
+): Record<YieldFlowStepId, YieldFlowStepView> => {
+    // Both annotations widen the per-flow tuples (and the filter's inferred type predicate)
+    // so indexOf below accepts any step id.
+    const sequence: readonly YieldFlowStepId[] = YIELD_FLOW_STEP_SEQUENCES[flowType];
+    const effectiveListSteps: readonly YieldFlowStepId[] =
+        listSteps ?? sequence.filter(stepId => stepId !== 'complete');
+    const currentStepIndex = sequence.indexOf(currentStep);
+
+    const getStepState = (stepIndex: number): StepListItemState => {
+        // Steps outside the flow's sequence are never rendered for it; report them as passed.
+        if (stepIndex === -1) {
+            return 'done';
+        }
 
         if (stepIndex < currentStepIndex) {
             return 'done';
@@ -74,11 +98,17 @@ export const getStepListItemStates = (
         return 'pending';
     };
 
-    const stepStates = {
-        approve: getStepState('approve'),
-        action: getStepState('action'),
-        complete: getStepState('complete'),
-    } satisfies Record<YieldFlowStepId, StepListItemState>;
+    const getStepView = (stepId: YieldFlowStepId): YieldFlowStepView => ({
+        state: getStepState(sequence.indexOf(stepId)),
+        indicator: {
+            index: effectiveListSteps.indexOf(stepId) + 1,
+            total: effectiveListSteps.length,
+        },
+    });
 
-    return stepStates;
+    return {
+        approve: getStepView('approve'),
+        action: getStepView('action'),
+        complete: getStepView('complete'),
+    };
 };

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -67,6 +67,7 @@ export * from './stablecoin-yield/stablecoinYieldReducer';
 export * from './stablecoin-yield/stablecoinYieldSelectors';
 export * from './stablecoin-yield/stablecoinYieldApprovalActionUtils';
 export * from './stablecoin-yield/stablecoinYieldApprovalThunks';
+export * from './stablecoin-yield/stablecoinYieldConstants';
 export * from './stablecoin-yield/stablecoinYieldDepositThunks';
 export * from './stablecoin-yield/stablecoinYieldDeviceUtils';
 export * from './stablecoin-yield/stablecoinYieldTypes';

--- a/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldReducer.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldReducer.test.ts
@@ -1,0 +1,130 @@
+import {
+    type StablecoinYieldState,
+    getStablecoinYieldSessionKey,
+    initialStablecoinYieldState,
+    stablecoinYieldActions,
+    stablecoinYieldReducer,
+} from '../stablecoinYieldReducer';
+import type { YieldFlowType } from '../stablecoinYieldTypes';
+
+const FLOW_KEY = 'account-key:yield-id:0xtoken';
+
+const getSession = (state: StablecoinYieldState, flowType: YieldFlowType) =>
+    state[flowType][getStablecoinYieldSessionKey(FLOW_KEY)];
+
+const initSession = (flowType: YieldFlowType) =>
+    stablecoinYieldReducer(
+        initialStablecoinYieldState,
+        stablecoinYieldActions.initSession({ flowType, flowKey: FLOW_KEY }),
+    );
+
+describe('stablecoinYieldReducer', () => {
+    describe('step machine', () => {
+        it('starts deposit at the approve step', () => {
+            const state = initSession('deposit');
+
+            expect(getSession(state, 'deposit')?.step).toBe('approve');
+        });
+
+        it.each(['withdraw', 'redeem', 'claim'] as const)(
+            'starts %s at the action step',
+            flowType => {
+                const state = initSession(flowType);
+
+                expect(getSession(state, flowType)?.step).toBe('action');
+            },
+        );
+
+        it('moves deposit to the action step when approval completes', () => {
+            const state = stablecoinYieldReducer(
+                initSession('deposit'),
+                stablecoinYieldActions.completeApproval({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    amount: '10',
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('action');
+            expect(getSession(state, 'deposit')?.action.amount).toBe('10');
+        });
+
+        it('moves deposit to the action step when the approval step is skipped', () => {
+            const state = stablecoinYieldReducer(
+                initSession('deposit'),
+                stablecoinYieldActions.skipApprovalStep({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('action');
+        });
+
+        it('keeps deposit on the action step when the approval skip repeats', () => {
+            // The allowance refetch after a confirmed approve tx dispatches skipApprovalStep
+            // again; it must not advance the flow past the action step.
+            const skipAction = stablecoinYieldActions.skipApprovalStep({
+                flowType: 'deposit',
+                flowKey: FLOW_KEY,
+            });
+            const state = stablecoinYieldReducer(
+                stablecoinYieldReducer(initSession('deposit'), skipAction),
+                skipAction,
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('action');
+        });
+
+        it('completes deposit from the action step', () => {
+            const state = stablecoinYieldReducer(
+                stablecoinYieldReducer(
+                    initSession('deposit'),
+                    stablecoinYieldActions.skipApprovalStep({
+                        flowType: 'deposit',
+                        flowKey: FLOW_KEY,
+                    }),
+                ),
+                stablecoinYieldActions.completeAction({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    amount: '10',
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('complete');
+            expect(getSession(state, 'deposit')?.result.completedAmount).toBe('10');
+        });
+
+        it('completes claim from the action step', () => {
+            const state = stablecoinYieldReducer(
+                initSession('claim'),
+                stablecoinYieldActions.completeAction({
+                    flowType: 'claim',
+                    flowKey: FLOW_KEY,
+                    amount: '0',
+                }),
+            );
+
+            expect(getSession(state, 'claim')?.step).toBe('complete');
+        });
+
+        it('returns deposit to the approve step when entering modify mode', () => {
+            const state = stablecoinYieldReducer(
+                stablecoinYieldReducer(
+                    initSession('deposit'),
+                    stablecoinYieldActions.skipApprovalStep({
+                        flowType: 'deposit',
+                        flowKey: FLOW_KEY,
+                    }),
+                ),
+                stablecoinYieldActions.enterModifyMode({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('approve');
+        });
+    });
+});

--- a/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts
@@ -6,6 +6,7 @@ import {
     buildYieldDepositCalldata,
     buildYieldUnsignedTransaction,
     buildYieldWithdrawCalldata,
+    getNextYieldFlowStep,
     splitYieldPendingTransaction,
 } from '../stablecoinYieldUtils';
 
@@ -84,6 +85,29 @@ describe('stablecoinYieldUtils', () => {
                     flowType: 'withdraw',
                 }),
             ).toThrow('Failed to encode withdraw calldata');
+        });
+    });
+
+    describe('getNextYieldFlowStep', () => {
+        it('advances deposit through approve → action → complete', () => {
+            expect(getNextYieldFlowStep('deposit', 'approve')).toBe('action');
+            expect(getNextYieldFlowStep('deposit', 'action')).toBe('complete');
+        });
+
+        it.each(['withdraw', 'redeem', 'claim'] as const)(
+            'advances %s from action to complete',
+            flowType => {
+                expect(getNextYieldFlowStep(flowType, 'action')).toBe('complete');
+            },
+        );
+
+        it('stays on the last step of the flow', () => {
+            expect(getNextYieldFlowStep('deposit', 'complete')).toBe('complete');
+            expect(getNextYieldFlowStep('claim', 'complete')).toBe('complete');
+        });
+
+        it('stays on a step that is not part of the flow', () => {
+            expect(getNextYieldFlowStep('withdraw', 'approve')).toBe('approve');
         });
     });
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
@@ -9,7 +9,8 @@ import {
 } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
-import { STABLECOIN_YIELD_PREFIX, stablecoinYieldActions } from './stablecoinYieldReducer';
+import { STABLECOIN_YIELD_PREFIX } from './stablecoinYieldConstants';
+import { stablecoinYieldActions } from './stablecoinYieldReducer';
 import { selectStablecoinYieldSession } from './stablecoinYieldSelectors';
 import type { YieldFlowResolvedData, YieldPositionFlowType } from './stablecoinYieldTypes';
 import { getAllowanceSpender, getWithdrawRequestAmount } from './stablecoinYieldUtils';

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldConstants.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldConstants.ts
@@ -1,0 +1,10 @@
+import type { YieldFlowStepId, YieldFlowType } from './stablecoinYieldTypes';
+
+export const STABLECOIN_YIELD_PREFIX = '@suite-common/wallet-core/stablecoin-yield';
+
+export const YIELD_FLOW_STEP_SEQUENCES = {
+    deposit: ['approve', 'action', 'complete'],
+    withdraw: ['action', 'complete'],
+    redeem: ['action', 'complete'],
+    claim: ['action', 'complete'],
+} as const satisfies Record<YieldFlowType, readonly YieldFlowStepId[]>;

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.ts
@@ -13,7 +13,8 @@ import TrezorConnect from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
 import { getApprovalRequestAmount, setYieldGenericError } from './stablecoinYieldApprovalThunks';
-import { STABLECOIN_YIELD_PREFIX, stablecoinYieldActions } from './stablecoinYieldReducer';
+import { STABLECOIN_YIELD_PREFIX } from './stablecoinYieldConstants';
+import { stablecoinYieldActions } from './stablecoinYieldReducer';
 import type { YieldFlowResolvedData } from './stablecoinYieldTypes';
 import {
     buildYieldDepositCalldata,

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -9,15 +9,17 @@ import {
 } from '@suite-common/wallet-types';
 import { isSafeObjectKey } from '@trezor/utils';
 
-import type {
-    StablecoinYieldClaimUnsignedTransaction,
-    YieldApproveModalState,
-    YieldFlowCompleteRewardItem,
-    YieldFlowStepId,
-    YieldFlowType,
-    YieldPendingTransactionState,
-    YieldPositionFlowType,
+import {
+    type StablecoinYieldClaimUnsignedTransaction,
+    YIELD_FLOW_STEP_SEQUENCES,
+    type YieldApproveModalState,
+    type YieldFlowCompleteRewardItem,
+    type YieldFlowStepId,
+    type YieldFlowType,
+    type YieldPendingTransactionState,
+    type YieldPositionFlowType,
 } from './stablecoinYieldTypes';
+import { getNextYieldFlowStep } from './stablecoinYieldUtils';
 import { transactionsActions } from '../transactions/transactionsActions';
 
 // Message ids must exist in the desktop `suite/intl` messages — the desktop app renders
@@ -151,8 +153,11 @@ export const initialStablecoinYieldState: StablecoinYieldState = {
     txReview: initialStablecoinYieldTxReviewState,
 };
 
-const createInitialStablecoinYieldSessionState = (): StablecoinYieldSessionState => ({
+const createInitialStablecoinYieldSessionState = (
+    flowType: YieldFlowType,
+): StablecoinYieldSessionState => ({
     ...initialStablecoinYieldSessionState,
+    step: YIELD_FLOW_STEP_SEQUENCES[flowType][0],
     approval: { ...initialStablecoinYieldSessionState.approval },
     action: { ...initialStablecoinYieldSessionState.action },
     result: {
@@ -195,7 +200,7 @@ export const stablecoinYieldSlice = createSlice({
             const sessionKey = getStablecoinYieldSessionKey(flowKey);
 
             if (!state[flowType][sessionKey]) {
-                state[flowType][sessionKey] = createInitialStablecoinYieldSessionState();
+                state[flowType][sessionKey] = createInitialStablecoinYieldSessionState(flowType);
             }
         },
         disposeSession(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
@@ -215,7 +220,7 @@ export const stablecoinYieldSlice = createSlice({
             }
 
             state[flowType][getStablecoinYieldSessionKey(flowKey)] =
-                createInitialStablecoinYieldSessionState();
+                createInitialStablecoinYieldSessionState(flowType);
         },
         setError(
             state,
@@ -330,12 +335,12 @@ export const stablecoinYieldSlice = createSlice({
                 session.action.amount = action.payload.amount;
                 session.action.pendingTransaction = null;
                 session.action.review = null;
-                session.step = 'action';
+                session.step = getNextYieldFlowStep(action.payload.flowType, 'approve');
             });
         },
         skipApprovalStep(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
             withSession(state, action.payload, session => {
-                session.step = 'action';
+                session.step = getNextYieldFlowStep(action.payload.flowType, 'approve');
             });
         },
         revokeSuccess(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
@@ -424,7 +429,7 @@ export const stablecoinYieldSlice = createSlice({
 
                 session.action.pendingTransaction = null;
                 session.action.review = null;
-                session.step = 'complete';
+                session.step = getNextYieldFlowStep(action.payload.flowType, 'action');
             });
         },
         transactionFailed(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -9,9 +9,9 @@ import {
 } from '@suite-common/wallet-types';
 import { isSafeObjectKey } from '@trezor/utils';
 
+import { STABLECOIN_YIELD_PREFIX, YIELD_FLOW_STEP_SEQUENCES } from './stablecoinYieldConstants';
 import {
     type StablecoinYieldClaimUnsignedTransaction,
-    YIELD_FLOW_STEP_SEQUENCES,
     type YieldApproveModalState,
     type YieldFlowCompleteRewardItem,
     type YieldFlowStepId,
@@ -61,8 +61,6 @@ type StablecoinYieldStoreActionReviewDataPayload =
       });
 
 export type YieldAllowanceStatus = 'idle' | 'loading' | 'loaded' | 'error';
-
-export const STABLECOIN_YIELD_PREFIX = '@suite-common/wallet-core/stablecoin-yield';
 
 export type StablecoinYieldTxReviewState = {
     precomposedTx?: PrecomposedTransactionFinal;
@@ -436,18 +434,6 @@ export const stablecoinYieldSlice = createSlice({
             withSession(state, action.payload, session => {
                 session.action.pendingTransaction = null;
                 session.error = 'TR_EARN_YIELD_ERROR_TRANSACTION_FAILED';
-            });
-        },
-        goToStep(
-            state,
-            action: PayloadAction<
-                StablecoinYieldSessionActionPayload & {
-                    step: YieldFlowStepId;
-                }
-            >,
-        ) {
-            withSession(state, action.payload, session => {
-                session.step = action.payload.step;
             });
         },
         storePrecomposedTransaction(

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
@@ -11,13 +11,6 @@ export type YieldPositionFlowType = Exclude<YieldFlowType, 'claim'>;
 export type YieldWithdrawFlowType = Extract<YieldFlowType, 'withdraw' | 'redeem'>;
 export type YieldFlowStepId = (typeof YIELD_FLOW_STEPS)[number];
 
-export const YIELD_FLOW_STEP_SEQUENCES = {
-    deposit: ['approve', 'action', 'complete'],
-    withdraw: ['action', 'complete'],
-    redeem: ['action', 'complete'],
-    claim: ['action', 'complete'],
-} as const satisfies Record<YieldFlowType, readonly YieldFlowStepId[]>;
-
 export type YieldFlowFormValues = {
     amountInput: string;
 };

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
@@ -11,6 +11,13 @@ export type YieldPositionFlowType = Exclude<YieldFlowType, 'claim'>;
 export type YieldWithdrawFlowType = Extract<YieldFlowType, 'withdraw' | 'redeem'>;
 export type YieldFlowStepId = (typeof YIELD_FLOW_STEPS)[number];
 
+export const YIELD_FLOW_STEP_SEQUENCES = {
+    deposit: ['approve', 'action', 'complete'],
+    withdraw: ['action', 'complete'],
+    redeem: ['action', 'complete'],
+    claim: ['action', 'complete'],
+} as const satisfies Record<YieldFlowType, readonly YieldFlowStepId[]>;
+
 export type YieldFlowFormValues = {
     amountInput: string;
 };

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -11,12 +11,14 @@ import {
 } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
-import type {
-    YieldFlowDisplayToken,
-    YieldFlowResolvedData,
-    YieldFlowType,
-    YieldPendingTransactionState,
-    YieldWithdrawFlowType,
+import {
+    YIELD_FLOW_STEP_SEQUENCES,
+    type YieldFlowDisplayToken,
+    type YieldFlowResolvedData,
+    type YieldFlowStepId,
+    type YieldFlowType,
+    type YieldPendingTransactionState,
+    type YieldWithdrawFlowType,
 } from './stablecoinYieldTypes';
 
 type TokenLike = {
@@ -108,6 +110,25 @@ export const getStablecoinYieldFlowKey = ({
 
 export const isYieldWithdrawFlow = (flowType: YieldFlowType): flowType is YieldWithdrawFlowType =>
     flowType === 'withdraw' || flowType === 'redeem';
+
+/**
+ * Returns the step that follows `step` in the flow's step sequence. Stays on `step`
+ * when it is the last one or not part of the flow at all.
+ */
+export const getNextYieldFlowStep = (
+    flowType: YieldFlowType,
+    step: YieldFlowStepId,
+): YieldFlowStepId => {
+    // Widened so indexOf accepts any step id across the per-flow tuples.
+    const sequence: readonly YieldFlowStepId[] = YIELD_FLOW_STEP_SEQUENCES[flowType];
+    const stepIndex = sequence.indexOf(step);
+
+    if (stepIndex === -1) {
+        return step;
+    }
+
+    return sequence[stepIndex + 1] ?? step;
+};
 
 export const getYieldWithdrawInputToken = ({
     flowData,

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -11,14 +11,14 @@ import {
 } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
-import {
-    YIELD_FLOW_STEP_SEQUENCES,
-    type YieldFlowDisplayToken,
-    type YieldFlowResolvedData,
-    type YieldFlowStepId,
-    type YieldFlowType,
-    type YieldPendingTransactionState,
-    type YieldWithdrawFlowType,
+import { YIELD_FLOW_STEP_SEQUENCES } from './stablecoinYieldConstants';
+import type {
+    YieldFlowDisplayToken,
+    YieldFlowResolvedData,
+    YieldFlowStepId,
+    YieldFlowType,
+    YieldPendingTransactionState,
+    YieldWithdrawFlowType,
 } from './stablecoinYieldTypes';
 
 type TokenLike = {

--- a/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
@@ -115,14 +115,6 @@ export const YieldClaimScreen = () => {
     });
 
     useEffect(() => {
-        if (!flowKey || session?.step !== 'approve') {
-            return;
-        }
-
-        dispatch(stablecoinYieldActions.skipApprovalStep({ flowType: 'claim', flowKey }));
-    }, [dispatch, flowKey, session?.step]);
-
-    useEffect(() => {
         if (session?.step === 'complete') {
             navigation.replace(YieldStackRoutes.YieldClaimComplete, route.params);
         }

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -266,14 +266,6 @@ export const YieldWithdrawScreen = () => {
     }, [closePendingBottomSheet, isFocused, isWithdrawPending, openPendingBottomSheet]);
 
     useEffect(() => {
-        if (resolutionStatus !== 'resolved' || !flowKey || session?.step !== 'approve') {
-            return;
-        }
-
-        dispatch(stablecoinYieldActions.skipApprovalStep({ flowType, flowKey }));
-    }, [dispatch, flowKey, flowType, resolutionStatus, session?.step]);
-
-    useEffect(() => {
         if (session?.step === 'complete') {
             navigation.replace(YieldStackRoutes.YieldWithdrawComplete, {
                 ...route.params,


### PR DESCRIPTION
## Description

Makes `YIELD_FLOW_STEP_SEQUENCES` the single source of truth for the yield step machine (F-2.4):

- **State machine:** initial step = first element of the flow's sequence (withdraw/redeem/claim start at `'action'`), transitions derive via `getNextYieldFlowStep`, static `skipApprovalStep` dispatches removed (deposit's runtime skip stays). Transitions are anchored to the completed phase, not the current step — a repeated skip after the allowance refetch must not jump past the deposit (regression-tested). First step-machine unit tests.
- **Step UI:** new `YieldFlowStepList` renders steps by mapping over the sequence; forms supply per-step definitions typed per flow, so adding a step to a sequence is a compile error until every form implements it. Deposit/withdraw/claim migrated 1:1, dead `goToStep` removed, `YieldApproveStep` variant dissolved.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29492

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/yield-declarative-steps/web/](https://dev.suite.sldev.cz/suite-web/refactor/yield-declarative-steps/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/yield-declarative-steps&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/yield-declarative-steps&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/yield-declarative-steps&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-08T13:56:24.490Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T13:54:25.790Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->