### PR TITLE
fix(suite): Show onboarding feedback (only) after each onboarding

### DIFF
--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -135,7 +135,11 @@ const goToSuite = () => (dispatch: Dispatch, getState: GetState, extra: ExtraDep
     // ensure navigation to 'suite-index'. Particularly, setting PIN leaves ButtonRequest_Success hanging for a moment.
     dispatch(closeModal());
 
-    dispatch(initialRunCompleted());
+    // A non-empty onboarding path means the user went through a create or recovery flow, i.e. set up
+    // a device from scratch. Pairing an already set up device leaves the path empty.
+    const isFreshDeviceSetup = getState().onboarding.path.length > 0;
+
+    dispatch(initialRunCompleted({ isFreshDeviceSetup }));
     dispatch(resetOnboarding());
     dispatch(closeModalApp(true));
 

--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -228,7 +228,7 @@ describe('Storage actions', () => {
         const f = global.fetch;
         global.fetch = mockFetch({ TR_ID: 'Message' });
         await store.dispatch(storageActions.saveSuiteSettings());
-        await store.dispatch(initialRunCompleted());
+        await store.dispatch(initialRunCompleted({ isFreshDeviceSetup: true }));
         store.dispatch(await preloadStore());
 
         expect(store.getState().flags.initialRun).toEqual(false);

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -355,7 +355,16 @@ export const extraDependencies: ExtraDependenciesStatic = {
             return state;
         },
         storageLoadFlags: (state: FlagsState, { payload }: StorageLoadAction) =>
-            payload.suiteSettings?.flags ? { ...state, ...payload.suiteSettings.flags } : state,
+            payload.suiteSettings?.flags
+                ? {
+                      ...state,
+                      ...payload.suiteSettings.flags,
+                      // The onboarding feedback banner is session-only: it is enabled when onboarding
+                      // is completed and must not survive an app restart. Reset it on every load so a
+                      // returning user only sees it again after completing onboarding once more.
+                      showOnboardingFeedbackBanner: false,
+                  }
+                : state,
         storageLoadSuiteSettings: (state: SuiteSettingsState, { payload }: StorageLoadAction) => {
             if (!payload.suiteSettings?.settings) return state;
 

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx
@@ -11,8 +11,10 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOverallStatus';
 
 import { BannerCarousel, type CarouselBanner } from './BannerCarousel';
+import { DashboardPromoBannerSkeleton } from './DashboardPromoBannerSkeleton';
 import { type DashboardBannerType, isDashboardBannerType } from './dashboardBannerTypes';
 import { DASHBOARD_BANNERS } from './dashboardBanners';
+import { selectShouldShowOnboardingFeedbackBanner } from '../OnboardingFeedbackBanner/onboardingFeedbackBannerSelectors';
 import { bannerAnimationConfig } from '../banner-animations';
 
 const isCarouselBannerKey = (key: string): key is DashboardBannerType => isDashboardBannerType(key);
@@ -24,6 +26,7 @@ export const DashboardPromoBanner = () => {
     const isDiscoveryEmpty = discoveryStatus?.type === 'discovery-empty';
     const flags = useSelector(selectFlags);
     const selectedDevice = useSelector(selectSelectedDevice);
+    const isOnboardingFeedbackBannerShown = useSelector(selectShouldShowOnboardingFeedbackBanner);
 
     const allPromoBanners = useSelector(state =>
         selectFeaturesConfig(state, Feature.banners.dashboard.promo),
@@ -98,11 +101,30 @@ export const DashboardPromoBanner = () => {
         render: handlers => DASHBOARD_BANNERS[bannerType].render(handlers),
     }));
 
-    const shouldRender = !isDiscoveryEmpty && carouselBanners.length > 0;
+    const isDiscoveryLoading = discoveryStatus?.status === 'loading';
+    const hasEligibleBanner = carouselBanners.length > 0;
+
+    // While assets are loading we don't yet know whether the onboarding feedback banner will take
+    // over the slot, so we reserve it with a skeleton instead of committing to a promo banner. This
+    // prevents a flash where e.g. the TS7 banner briefly shows and is replaced by the onboarding
+    // feedback banner once the discovery finishes.
+    const shouldRenderSkeleton = !isDiscoveryEmpty && hasEligibleBanner && isDiscoveryLoading;
+
+    // The onboarding feedback banner takes precedence over the promo banner.
+    const shouldRenderBanner =
+        !isDiscoveryEmpty &&
+        !isOnboardingFeedbackBannerShown &&
+        hasEligibleBanner &&
+        !isDiscoveryLoading;
 
     return (
         <AnimatePresence>
-            {shouldRender && (
+            {shouldRenderSkeleton && (
+                <motion.div key="dashboard-promo-banner-skeleton" {...bannerAnimationConfig}>
+                    <DashboardPromoBannerSkeleton />
+                </motion.div>
+            )}
+            {shouldRenderBanner && (
                 <motion.div key="dashboard-promo-banner" {...bannerAnimationConfig}>
                     <BannerCarousel
                         banners={carouselBanners}

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBannerSkeleton.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBannerSkeleton.tsx
@@ -1,0 +1,22 @@
+import { selectShouldAnimateLoadingSkeleton } from '@suite/ui-animations';
+import { Box, Skeleton } from '@trezor/components';
+import { borders } from '@trezor/theme';
+
+import { useSelector } from 'src/hooks/suite';
+import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
+
+export const DashboardPromoBannerSkeleton = () => {
+    const shouldAnimate = useSelector(selectShouldAnimateLoadingSkeleton);
+    const isVerticalLayout = useIsContentBelowBreakpoint();
+
+    return (
+        <Box data-testid="@dashboard/promo-banner/skeleton">
+            <Skeleton
+                width="100%"
+                height={isVerticalLayout ? 320 : 213}
+                borderRadius={borders.radii.sm}
+                animate={shouldAnimate}
+            />
+        </Box>
+    );
+};

--- a/packages/suite/src/views/dashboard/OnboardingFeedbackBanner/OnboardingFeedbackBanner.tsx
+++ b/packages/suite/src/views/dashboard/OnboardingFeedbackBanner/OnboardingFeedbackBanner.tsx
@@ -5,19 +5,18 @@ import { ThemeProvider, useTheme } from 'styled-components';
 
 import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useExternalLink } from '@suite/external-links';
-import { selectIsOnboardingFeedbackBannerShown, setFlag } from '@suite/flags';
+import { setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
-import { selectAllAccountsToList } from '@suite-common/wallet-core';
 import { Box, Button, Column, Image, Paragraph, Row, intermediaryTheme } from '@trezor/components';
 import { borders } from '@trezor/theme';
 import { DASHBOARD_ONBOARDING_FEEDBACK_URL } from '@trezor/urls';
 
 import { useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
 import { ContentFlex, useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
-import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOverallStatus';
 
+import { selectShouldShowOnboardingFeedbackBanner } from './onboardingFeedbackBannerSelectors';
 import { CloseButton } from '../DashboardPromoBanner/CommonPromoBannerComponents';
 import { bannerAnimationConfig } from '../banner-animations';
 
@@ -90,13 +89,7 @@ export const OnboardingFeedbackBanner = () => {
     const { isBelowLaptop, isBelowDesktop } = useLayoutSize();
     const isVerticalLayout = useIsContentBelowBreakpoint();
 
-    const isBannerShown = useSelector(selectIsOnboardingFeedbackBannerShown);
-    const accounts = useSelector(selectAllAccountsToList);
-    const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
-
-    const isDeviceEmpty = accounts.every(account => account.empty);
-
-    const isEligible = isBannerShown && isDeviceEmpty && discoveryStatus?.status !== 'loading';
+    const isEligible = useSelector(selectShouldShowOnboardingFeedbackBanner);
 
     const clearBanner = () => {
         dispatch(setFlag({ key: 'showOnboardingFeedbackBanner', value: false }));

--- a/packages/suite/src/views/dashboard/OnboardingFeedbackBanner/onboardingFeedbackBannerSelectors.ts
+++ b/packages/suite/src/views/dashboard/OnboardingFeedbackBanner/onboardingFeedbackBannerSelectors.ts
@@ -1,0 +1,18 @@
+import { selectIsOnboardingFeedbackBannerShown } from '@suite/flags';
+import { selectAllAccountsToList } from '@suite-common/wallet-core';
+
+import { type AppState } from 'src/types/suite';
+import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOverallStatus';
+
+// The onboarding feedback banner is shown after onboarding is completed, as long as the device
+// has no funds yet. It takes precedence over the dashboard promo banner, so the promo banner is
+// hidden while this one is eligible.
+export const selectShouldShowOnboardingFeedbackBanner = (state: AppState) => {
+    const isBannerShown = selectIsOnboardingFeedbackBannerShown(state);
+    const accounts = selectAllAccountsToList(state);
+    const discoveryStatus = selectDiscoveryOverallStatus(state);
+
+    const isDeviceEmpty = accounts.every(account => account.empty);
+
+    return isBannerShown && isDeviceEmpty && discoveryStatus?.status !== 'loading';
+};

--- a/suite/flags/src/__tests__/flagsThunks.test.ts
+++ b/suite/flags/src/__tests__/flagsThunks.test.ts
@@ -15,25 +15,31 @@ const initStore = (flags?: Partial<FlagsState>) =>
 describe('initialRunCompleted', () => {
     it('should set initialRun to false when initialRun is true', async () => {
         const store = initStore();
-        await store.dispatch(initialRunCompleted());
+        await store.dispatch(initialRunCompleted({ isFreshDeviceSetup: true }));
         expect(store.getState().flags.initialRun).toBe(false);
     });
 
     it('should set initialRun to false when initialRun is already false', async () => {
         const store = initStore({ initialRun: false });
-        await store.dispatch(initialRunCompleted());
+        await store.dispatch(initialRunCompleted({ isFreshDeviceSetup: false }));
         expect(store.getState().flags.initialRun).toBe(false);
     });
 
-    it('should make a freshly onboarded user eligible for the onboarding feedback banner', async () => {
+    it('should make a freshly set up device eligible for the onboarding feedback banner', async () => {
         const store = initStore({ showOnboardingFeedbackBanner: false });
-        await store.dispatch(initialRunCompleted());
+        await store.dispatch(initialRunCompleted({ isFreshDeviceSetup: true }));
         expect(store.getState().flags.showOnboardingFeedbackBanner).toBe(true);
     });
 
-    it('should re-enable the onboarding feedback banner when a returning user completes onboarding again', async () => {
+    it('should re-enable the onboarding feedback banner when a returning user sets up a device again', async () => {
         const store = initStore({ initialRun: false, showOnboardingFeedbackBanner: false });
-        await store.dispatch(initialRunCompleted());
+        await store.dispatch(initialRunCompleted({ isFreshDeviceSetup: true }));
         expect(store.getState().flags.showOnboardingFeedbackBanner).toBe(true);
+    });
+
+    it('should not enable the onboarding feedback banner when only pairing an already set up device', async () => {
+        const store = initStore({ showOnboardingFeedbackBanner: false });
+        await store.dispatch(initialRunCompleted({ isFreshDeviceSetup: false }));
+        expect(store.getState().flags.showOnboardingFeedbackBanner).toBe(false);
     });
 });

--- a/suite/flags/src/__tests__/flagsThunks.test.ts
+++ b/suite/flags/src/__tests__/flagsThunks.test.ts
@@ -31,9 +31,9 @@ describe('initialRunCompleted', () => {
         expect(store.getState().flags.showOnboardingFeedbackBanner).toBe(true);
     });
 
-    it('should not show the onboarding feedback banner for a returning user (initialRun already false)', async () => {
+    it('should re-enable the onboarding feedback banner when a returning user completes onboarding again', async () => {
         const store = initStore({ initialRun: false, showOnboardingFeedbackBanner: false });
         await store.dispatch(initialRunCompleted());
-        expect(store.getState().flags.showOnboardingFeedbackBanner).toBe(false);
+        expect(store.getState().flags.showOnboardingFeedbackBanner).toBe(true);
     });
 });

--- a/suite/flags/src/flagsThunks.ts
+++ b/suite/flags/src/flagsThunks.ts
@@ -1,14 +1,14 @@
 import { createThunk } from '@suite-common/redux-utils';
 
 import { FLAGS_MODULE_PREFIX } from './flagsConstants';
-import { selectIsInitialRun, setFlag } from './flagsSlice';
+import { setFlag } from './flagsSlice';
 
 export const initialRunCompleted = createThunk(
     `${FLAGS_MODULE_PREFIX}/initialRunCompleted`,
-    (_, { dispatch, getState }) => {
-        if (selectIsInitialRun(getState())) {
-            dispatch(setFlag({ key: 'initialRun', value: false }));
-            dispatch(setFlag({ key: 'showOnboardingFeedbackBanner', value: true }));
-        }
+    (_, { dispatch }) => {
+        dispatch(setFlag({ key: 'initialRun', value: false }));
+        // Re-enable the onboarding feedback banner on every onboarding completion, so a user
+        // going through onboarding again (e.g. a newly set up device) sees the banner again.
+        dispatch(setFlag({ key: 'showOnboardingFeedbackBanner', value: true }));
     },
 );

--- a/suite/flags/src/flagsThunks.ts
+++ b/suite/flags/src/flagsThunks.ts
@@ -3,12 +3,22 @@ import { createThunk } from '@suite-common/redux-utils';
 import { FLAGS_MODULE_PREFIX } from './flagsConstants';
 import { setFlag } from './flagsSlice';
 
+type InitialRunCompletedParams = {
+    // Whether the user has just set up a device from scratch (create or recovery), as opposed to
+    // only pairing an already set up device with a fresh Suite.
+    isFreshDeviceSetup: boolean;
+};
+
 export const initialRunCompleted = createThunk(
     `${FLAGS_MODULE_PREFIX}/initialRunCompleted`,
-    (_, { dispatch }) => {
+    ({ isFreshDeviceSetup }: InitialRunCompletedParams, { dispatch }) => {
         dispatch(setFlag({ key: 'initialRun', value: false }));
-        // Re-enable the onboarding feedback banner on every onboarding completion, so a user
-        // going through onboarding again (e.g. a newly set up device) sees the banner again.
-        dispatch(setFlag({ key: 'showOnboardingFeedbackBanner', value: true }));
+
+        // Only offer the feedback banner to users arriving from a fresh device setup. Pairing an
+        // already set up device (e.g. on a new Suite installation) must not enable it. The banner is
+        // session-only, so completing onboarding again later re-enables it for that session.
+        if (isFreshDeviceSetup) {
+            dispatch(setFlag({ key: 'showOnboardingFeedbackBanner', value: true }));
+        }
     },
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- we never show two banners (dashboard promo banner and feedback banner) at once
- dashboard promo banner is shown only directly after user onboarding
- if user set another device in the same suite app, banner is shown again
- should not be visible when we have onboarded trezor but suite app is clean



## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve 

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set touches onboarding actions, dashboard banner components (DashboardPromoBanner and OnboardingFeedbackBanner), feature flags thunks, extra dependencies, and storage action tests. The highest risk is in the onboarding flow (onboardingActions.ts changes could break initial setup) and the dashboard promo banner (direct UI component changes). The OnboardingFeedbackBanner and its selectors are new/changed dashboard components with no direct E2E coverage. Testing should focus on onboarding flows, the promo banner analytics test, and dashboard rendering to catch regressions.

<details><summary><b>Changed files (9)</b></summary>

- `packages/suite/src/actions/onboarding/onboardingActions.ts`
- `packages/suite/src/actions/suite/__tests__/storageActions.test.ts`
- `packages/suite/src/support/extraDependencies.ts`
- `packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx`
- `packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBannerSkeleton.tsx`
- `packages/suite/src/views/dashboard/OnboardingFeedbackBanner/OnboardingFeedbackBanner.tsx`
- `packages/suite/src/views/dashboard/OnboardingFeedbackBanner/onboardingFeedbackBannerSelectors.ts`
- `suite/flags/src/__tests__/flagsThunks.test.ts`
- `suite/flags/src/flagsThunks.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — Directly tests the DashboardPromoBanner component which was changed. The test clicks promo banners on the dashboard and verifies analytics events, so changes to DashboardPromoBanner.tsx could break banner rendering or click behavior.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — Directly exercises the onboarding flow which is affected by onboardingActions.ts changes. Tests analytics consent during onboarding and completing onboarding, which are core behaviors of the changed action file.
- `suite/e2e/tests/suite/initial-run.test.ts` — Tests the initial run/onboarding persistence flow — analytics consent persisting across reloads and onboarding completion state. Changes to onboardingActions.ts and flagsThunks.ts (which likely manages feature flags/initial-run state) could break this critical flow.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/onboarding/firmware-check.test.ts` — Tests firmware readiness detection during onboarding which involves onboardingActions flow. Changes to onboardingActions.ts could affect the firmware check step progression.
- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — Tests wallet creation during onboarding on T2T1, exercising the full onboarding flow including analytics consent and wallet setup steps that depend on onboardingActions.ts.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — Tests wallet creation onboarding on T3T1 device, exercising the full create wallet flow that depends on onboardingActions.ts for step management.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — Tests wallet creation onboarding on T3W1 device. Changes to onboardingActions.ts could affect the onboarding step transitions and completion logic.
- `suite/e2e/tests/dashboard/assets.test.ts` — Tests dashboard functionality including asset views. The DashboardPromoBanner and OnboardingFeedbackBanner are dashboard components; changes could affect dashboard rendering or layout.
- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — Tests authenticity check during onboarding, which uses onboardingActions for flow management. Changes to onboarding actions could break step progression through the authenticity check.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/suite/db-migration.test.ts` — Tests database migration which involves extraDependencies.ts for storage/state management. The change to extraDependencies.ts and storageActions could affect how settings are persisted and migrated across versions.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — Tests locale migration across Suite versions, which may be affected by changes to extraDependencies.ts if storage/persistence logic was modified.

</details>

⚠️ **Changes with no test coverage (6)**
- `packages/suite/src/actions/suite/__tests__/storageActions.test.ts`
- `packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBannerSkeleton.tsx`
- `packages/suite/src/views/dashboard/OnboardingFeedbackBanner/OnboardingFeedbackBanner.tsx`
- `packages/suite/src/views/dashboard/OnboardingFeedbackBanner/onboardingFeedbackBannerSelectors.ts`
- `suite/flags/src/__tests__/flagsThunks.test.ts`
- `suite/flags/src/flagsThunks.ts`

_Updated: 2026-07-08T13:33:07.216Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/show-onboarding-feedback-only-after-onboarding/web/](https://dev.suite.sldev.cz/suite-web/show-onboarding-feedback-only-after-onboarding/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=show-onboarding-feedback-only-after-onboarding&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=show-onboarding-feedback-only-after-onboarding&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-08T13:38:29.583Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T13:36:24.926Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->