### PR TITLE
fix(trading): fix gasless swap amount validation

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
@@ -40,6 +40,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
     values,
     methods,
     setShowReserveBanner,
+    shouldSuppressComposeErrors,
 }: TradingUseComposeTransactionProps<T>): TradingUseComposeTransactionReturnProps => {
     const dispatch = useDispatch();
     const accounts = useSelector(selectAccounts);
@@ -193,11 +194,18 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
 
         if (!composed) return;
 
-        if (composed.type === 'error' && isTranslationKey(composed.errorMessage?.id)) {
-            setError(TRADING_FORM_OUTPUT_AMOUNT, {
-                type: COMPOSE_ERROR_TYPES.COMPOSE,
-                message: translationString(composed.errorMessage.id, composed.errorMessage.values),
-            });
+        if (composed.type === 'error') {
+            if (shouldSuppressComposeErrors) {
+                clearErrors(TRADING_FORM_OUTPUT_AMOUNT);
+            } else if (isTranslationKey(composed.errorMessage?.id)) {
+                setError(TRADING_FORM_OUTPUT_AMOUNT, {
+                    type: COMPOSE_ERROR_TYPES.COMPOSE,
+                    message: translationString(
+                        composed.errorMessage.id,
+                        composed.errorMessage.values,
+                    ),
+                });
+            }
         }
 
         if (composed.type === 'final' || composed.type === 'nonfinal') {
@@ -237,6 +245,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
         setError,
         setValue,
         translationString,
+        shouldSuppressComposeErrors,
     ]);
 
     return {

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -20,6 +20,7 @@ import {
     cryptoIdToNetwork,
     exchangeThunks,
     getDexEstimationData,
+    hasEip712SignDataType,
     isSendingEvmNativeToken,
     selectTradingComposedTransactionInfo,
     selectTradingExchangeAmountLimits,
@@ -191,6 +192,7 @@ export const useTradingExchangeForm = (): TradingExchangeFormContextProps => {
         values,
         methods,
         setShowReserveBanner,
+        shouldSuppressComposeErrors: hasEip712SignDataType(selectedQuote),
     });
 
     const isFormLoading = isInitialDataLoading || formState.isSubmitting || isLoading;

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -344,6 +344,7 @@ export interface TradingUseComposeTransactionProps<T extends TradingSellExchange
     methods: UseFormReturn<T>;
     values: T;
     setShowReserveBanner: (showReserveBanner: boolean) => void;
+    shouldSuppressComposeErrors?: boolean;
 }
 
 export interface TradingUseComposeTransactionStateProps {

--- a/suite-common/trading/src/utils/exchange/__tests__/exchangeUtils.test.ts
+++ b/suite-common/trading/src/utils/exchange/__tests__/exchangeUtils.test.ts
@@ -412,11 +412,11 @@ describe('getDisplayComposedLevels', () => {
         expect(getDisplayComposedLevels(quote, composedLevels)).toBe(composedLevels);
     });
 
-    it('should zero the fee on final and nonfinal levels, leaving error levels untouched', () => {
+    it('should zero the fee on all levels, replacing error levels with a zero-fee nonfinal level', () => {
         expect(getDisplayComposedLevels(gaslessQuote, composedLevels)).toEqual({
             normal: { type: 'final', fee: '0' },
             high: { type: 'nonfinal', fee: '0' },
-            custom: { type: 'error', error: 'NOT_ENOUGH_FUNDS' },
+            custom: { type: 'nonfinal', fee: '0' },
         });
     });
 });

--- a/suite-common/trading/src/utils/exchange/exchangeUtils.ts
+++ b/suite-common/trading/src/utils/exchange/exchangeUtils.ts
@@ -143,7 +143,7 @@ export const getDisplayComposedLevels = <T extends GeneralPrecomposedLevels>(
         return Object.fromEntries(
             Object.entries(composedLevels).map(([label, level]) => [
                 label,
-                level.type === 'error' ? level : { ...level, fee: '0' },
+                level.type === 'error' ? { type: 'nonfinal', fee: '0' } : { ...level, fee: '0' },
             ]),
         ) as T;
     }


### PR DESCRIPTION
## Description

- Treat gasless EIP-712 swap quotes as zero-fee when deriving the amount validation fee.
- Pass the selected exchange quote into swap amount validation for both crypto and fiat inputs.
- Prevent 1inch Fusion swaps from entering an invalid amount state when native balance is 0.
- Add regression coverage for regular, gasless, and nonfinal trading fee levels.

## Notes for QA

- In Wallet > Trade > Swap with provider 1INCH FUSION and approval already prepared, set native balance to 0 and verify Network fee stays 0 and Swap Amount shows no validation error.
- In Wallet > Trade > Swap with a regular non-gasless quote, change the amount and verify amount validation still reflects the composed network fee.

## Related Issue

Resolve #28961

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes center on trading/swap infrastructure: the exchange form hook, compose transaction hook, trading form types, and exchange utility functions. The highest risk is in swap flows that compose transactions and display fees, since both the compose hook and exchange form hook are modified. The exchange utility file maps to 131 tests but is a broad dependency — only trading-specific tests that actually exercise exchange logic are recommended. The unit test file for exchangeUtils has no E2E coverage mapping but validates the utility directly. The type file (tradingForm.ts) affects all trading forms but is unlikely to cause runtime regressions unless type shapes changed in ways that affect runtime behavior.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts`
- `packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts`
- `packages/suite/src/types/trading/tradingForm.ts`
- `suite-common/trading/src/utils/exchange/__tests__/exchangeUtils.test.ts`
- `suite-common/trading/src/utils/exchange/exchangeUtils.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-coins.test.ts` — This test exercises the full swap flow (SOL→BTC) including compose transaction, quote confirmation, device prompt verification, and transaction status polling. It directly uses useTradingExchangeForm and useTradingComposeTransaction through the swap form, and verifies composedTransactionInfo in Redux state — making it highly sensitive to changes in exchange form hooks and compose transaction logic.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test specifically validates custom fee handling during swap (BTC→ETH), checks composedTransactionInfo Redux state is non-empty after selecting best offer, and verifies fee calculations on device prompt. It directly exercises the compose transaction hook with custom fee inputs and the exchange form hook.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test validates Ethereum custom fee parameters (gas limit, max fee per gas, max priority fee per gas) during a swap flow and explicitly asserts composedTransactionInfo is non-empty. Changes to useTradingComposeTransaction or the exchange form hook could break fee composition and display.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test validates swap form input behavior including asset selection, crypto amount filling, fraction buttons, max balance, fee calculation, provider selection, and validation errors. It exercises the exchange form hook's input handling and compose transaction logic for fee computation.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests cross-chain swap (SOL→USDC) including form filling, quote confirmation, device prompt, and transaction detail verification. It exercises the exchange form and compose transaction hooks for a token-receiving swap scenario.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Tests DEX swap flow (ETH→USDC via LI.FI) with different transaction composition path than CEX swaps, including gas buffer calculation and multi-step device confirmation. Changes to compose transaction logic could affect DEX-specific gas handling.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping a Solana token (USDT) to Bitcoin, exercising the exchange form hook for token-to-coin scenarios and compose transaction for SPL token sends.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests SPL token-to-token swap (USDT→USDC on Solana), a distinct code path in the exchange form hook for token pair swaps where both assets are tokens on the same chain.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation (decimal limits, insufficient funds, percentage buttons, max button, custom fees) which uses useTradingComposeTransaction for fee calculation and amount validation. Changes to compose transaction logic could break sell form validation.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests the full sell flow for Solana including form filling, fee display, device confirmation, and transaction status tracking. Uses useTradingComposeTransaction for composing the sell transaction.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swap form with a disabled buy-asset network. While it uses the exchange form hook, it primarily validates UI display of provider info rather than transaction composition, so risk from these changes is lower.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation to buy/sell/swap forms and verifies correct cryptocurrency is preselected. While it imports the exchange form hook, it only validates form opening behavior, not transaction composition or exchange utilities.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/trading/src/utils/exchange/__tests__/exchangeUtils.test.ts`

_Updated: 2026-07-14T10:20:29.765Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/28961-1inch-fusion-gasless-validation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/28961-1inch-fusion-gasless-validation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/28961-1inch-fusion-gasless-validation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-14T10:23:21.895Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-14T10:22:38.762Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/28961-1inch-fusion-gasless-validation/web/](https://dev.suite.sldev.cz/suite-web/fix/28961-1inch-fusion-gasless-validation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->