### PR TITLE
fix(suite-native-29359): simplify trade failure copy

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -3547,9 +3547,9 @@ export const messages = {
                     buyDescription:
                         "Your transaction failed or was rejected. Your payment method hasn't been charged.",
                     sellDescription:
-                        'The transaction didn’t go through. We’re looking into it, but your funds are safe in your account.',
+                        'The transaction didn’t go through. Your funds are safe in your account.',
                     swapDescription:
-                        'The transaction didn’t go through. We’re looking into it, but your funds are safe in your account.',
+                        'The transaction didn’t go through. Your funds are safe in your account.',
                 },
                 waitingAlert: {
                     title: 'Waiting for your payment ...',


### PR DESCRIPTION
## Description
- Removed the extra "We’re looking into it".

## Notes for QA

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/29359

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/29359-trade-failure-copy&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->