### PR TITLE
chore(trading): annotate reducer state params

### DIFF
--- a/suite-common/trading/src/reducers/buyReducer.ts
+++ b/suite-common/trading/src/reducers/buyReducer.ts
@@ -53,47 +53,56 @@ const tradingBuySlice = createSlice({
     name: TRADING_BUY_PREFIX,
     initialState: buyInitialState,
     reducers: {
-        saveBuyInfo(state, action: PayloadAction<BuyInfo>) {
+        saveBuyInfo(state: TradingBuyState, action: PayloadAction<BuyInfo>) {
             state.buyInfo = action.payload;
         },
-        setIsFromRedirect(state, action: PayloadAction<boolean>) {
+        setIsFromRedirect(state: TradingBuyState, action: PayloadAction<boolean>) {
             state.isFromRedirect = action.payload;
         },
-        saveQuoteRequest(state, action: PayloadAction<BuyTradeQuoteRequest>) {
+        saveQuoteRequest(state: TradingBuyState, action: PayloadAction<BuyTradeQuoteRequest>) {
             state.quotesRequest = action.payload;
         },
-        saveTransactionId(state, action: PayloadAction<string | undefined>) {
+        saveTransactionId(state: TradingBuyState, action: PayloadAction<string | undefined>) {
             state.transactionId = action.payload;
         },
-        saveQuotes(state, action: PayloadAction<BuyTrade[]>) {
+        saveQuotes(state: TradingBuyState, action: PayloadAction<BuyTrade[]>) {
             state.quotes = action.payload;
         },
-        saveSelectedQuote(state, action: PayloadAction<BuyTrade | undefined>) {
+        saveSelectedQuote(state: TradingBuyState, action: PayloadAction<BuyTrade | undefined>) {
             state.selectedQuote = action.payload;
         },
-        clearQuotes(state) {
+        clearQuotes(state: TradingBuyState) {
             state.quotes = [];
             state.selectedQuote = undefined;
         },
-        setIsLoading(state, action: PayloadAction<boolean>) {
+        setIsLoading(state: TradingBuyState, action: PayloadAction<boolean>) {
             state.isLoading = action.payload;
         },
-        setAmountLimits(state, action: PayloadAction<TradingAmountLimitProps | undefined>) {
+        setAmountLimits(
+            state: TradingBuyState,
+            action: PayloadAction<TradingAmountLimitProps | undefined>,
+        ) {
             state.amountLimits = action.payload;
         },
-        setTradingAccountKey(state, action: PayloadAction<AccountKey | undefined>) {
+        setTradingAccountKey(
+            state: TradingBuyState,
+            action: PayloadAction<AccountKey | undefined>,
+        ) {
             state.tradingAccountKey = action.payload;
         },
-        setReceiveAccountKey(state, action: PayloadAction<AccountKey | undefined>) {
+        setReceiveAccountKey(
+            state: TradingBuyState,
+            action: PayloadAction<AccountKey | undefined>,
+        ) {
             state.receiveAccountKey = action.payload;
         },
-        setReceiveAddress(state, action: PayloadAction<string | undefined>) {
+        setReceiveAddress(state: TradingBuyState, action: PayloadAction<string | undefined>) {
             state.receiveAddress = action.payload;
         },
-        setLastErrorMessage(state, action: PayloadAction<string | undefined>) {
+        setLastErrorMessage(state: TradingBuyState, action: PayloadAction<string | undefined>) {
             state.lastErrorMessage = action.payload;
         },
-        clearQuotesAndParams(state) {
+        clearQuotesAndParams(state: TradingBuyState) {
             state.quotes = [];
             state.quotesRequest = undefined;
             state.selectedQuote = undefined;

--- a/suite-common/trading/src/reducers/exchangeReducer.ts
+++ b/suite-common/trading/src/reducers/exchangeReducer.ts
@@ -57,61 +57,79 @@ const tradingExchangeSlice = createSlice({
     name: TRADING_EXCHANGE_PREFIX,
     initialState: exchangeInitialState,
     reducers: {
-        saveExchangeInfo(state, action: PayloadAction<ExchangeInfo>) {
+        saveExchangeInfo(state: TradingExchangeState, action: PayloadAction<ExchangeInfo>) {
             state.exchangeInfo = action.payload;
         },
-        saveTransactionId(state, action: PayloadAction<string | undefined>) {
+        saveTransactionId(state: TradingExchangeState, action: PayloadAction<string | undefined>) {
             state.transactionId = action.payload;
         },
-        saveQuoteRequest(state, action: PayloadAction<ExchangeTradeQuoteRequest>) {
+        saveQuoteRequest(
+            state: TradingExchangeState,
+            action: PayloadAction<ExchangeTradeQuoteRequest>,
+        ) {
             state.quotesRequest = action.payload;
         },
-        saveQuotes(state, action: PayloadAction<ExchangeTrade[]>) {
+        saveQuotes(state: TradingExchangeState, action: PayloadAction<ExchangeTrade[]>) {
             state.quotes = action.payload;
         },
-        clearQuotes(state) {
+        clearQuotes(state: TradingExchangeState) {
             state.quotes = [];
             state.selectedQuote = undefined;
         },
-        setTradingAccountKey(state, action: PayloadAction<AccountKey | undefined>) {
+        setTradingAccountKey(
+            state: TradingExchangeState,
+            action: PayloadAction<AccountKey | undefined>,
+        ) {
             state.tradingAccountKey = action.payload;
         },
-        setReceiveAccountKey(state, action: PayloadAction<AccountKey | undefined>) {
+        setReceiveAccountKey(
+            state: TradingExchangeState,
+            action: PayloadAction<AccountKey | undefined>,
+        ) {
             state.receiveAccountKey = action.payload;
         },
-        setReceiveAddress(state, action: PayloadAction<string | undefined>) {
+        setReceiveAddress(state: TradingExchangeState, action: PayloadAction<string | undefined>) {
             state.receiveAddress = action.payload;
         },
-        setExtraField(state, action: PayloadAction<string | undefined>) {
+        setExtraField(state: TradingExchangeState, action: PayloadAction<string | undefined>) {
             state.extraField = action.payload;
         },
-        saveSelectedQuote(state, action: PayloadAction<ExchangeTrade | undefined>) {
+        saveSelectedQuote(
+            state: TradingExchangeState,
+            action: PayloadAction<ExchangeTrade | undefined>,
+        ) {
             state.selectedQuote = action.payload;
         },
-        setSelectedQuoteSwapSlippage(state, action: PayloadAction<string>) {
+        setSelectedQuoteSwapSlippage(state: TradingExchangeState, action: PayloadAction<string>) {
             if (state.selectedQuote?.isDex) {
                 state.selectedQuote.swapSlippage = action.payload;
             }
         },
-        setIsFromRedirect(state, action: PayloadAction<boolean>) {
+        setIsFromRedirect(state: TradingExchangeState, action: PayloadAction<boolean>) {
             state.isFromRedirect = action.payload;
         },
-        setIsLoading(state, action: PayloadAction<boolean>) {
+        setIsLoading(state: TradingExchangeState, action: PayloadAction<boolean>) {
             state.isLoading = action.payload;
         },
         setDexQuoteApprovalPrefetchLoadingQuoteId(
-            state,
+            state: TradingExchangeState,
             action: PayloadAction<string | undefined>,
         ) {
             state.dexQuoteApprovalPrefetchLoadingQuoteId = action.payload;
         },
-        setAmountLimits(state, action: PayloadAction<TradingExchangeAmountLimitProps | undefined>) {
+        setAmountLimits(
+            state: TradingExchangeState,
+            action: PayloadAction<TradingExchangeAmountLimitProps | undefined>,
+        ) {
             state.amountLimits = action.payload;
         },
-        setFormStep(state, action: PayloadAction<TradingExchangeStepType>) {
+        setFormStep(state: TradingExchangeState, action: PayloadAction<TradingExchangeStepType>) {
             state.formStep = action.payload;
         },
-        setLastErrorMessage(state, action: PayloadAction<string | undefined>) {
+        setLastErrorMessage(
+            state: TradingExchangeState,
+            action: PayloadAction<string | undefined>,
+        ) {
             state.lastErrorMessage = action.payload;
         },
     },

--- a/suite-common/trading/src/reducers/sellReducer.ts
+++ b/suite-common/trading/src/reducers/sellReducer.ts
@@ -55,44 +55,56 @@ const tradingSellSlice = createSlice({
     name: TRADING_SELL_PREFIX,
     initialState: sellInitialState,
     reducers: {
-        saveSellInfo(state, action: PayloadAction<SellInfo>) {
+        saveSellInfo(state: TradingSellState, action: PayloadAction<SellInfo>) {
             state.sellInfo = action.payload;
         },
-        saveTransactionId(state, action: PayloadAction<string | undefined>) {
+        saveTransactionId(state: TradingSellState, action: PayloadAction<string | undefined>) {
             state.transactionId = action.payload;
         },
-        saveQuoteRequest(state, action: PayloadAction<SellFiatTradeQuoteRequest>) {
+        saveQuoteRequest(
+            state: TradingSellState,
+            action: PayloadAction<SellFiatTradeQuoteRequest>,
+        ) {
             state.quotesRequest = action.payload;
         },
-        saveQuotes(state, action: PayloadAction<SellFiatTrade[]>) {
+        saveQuotes(state: TradingSellState, action: PayloadAction<SellFiatTrade[]>) {
             state.quotes = action.payload;
         },
-        clearQuotes(state) {
+        clearQuotes(state: TradingSellState) {
             state.quotes = [];
             state.selectedQuote = undefined;
         },
-        saveSelectedQuote(state, action: PayloadAction<SellFiatTrade | undefined>) {
+        saveSelectedQuote(
+            state: TradingSellState,
+            action: PayloadAction<SellFiatTrade | undefined>,
+        ) {
             state.selectedQuote = action.payload;
         },
-        setIsFromRedirect(state, action: PayloadAction<boolean>) {
+        setIsFromRedirect(state: TradingSellState, action: PayloadAction<boolean>) {
             state.isFromRedirect = action.payload;
         },
-        setTradingAccountKey(state, action: PayloadAction<AccountKey | undefined>) {
+        setTradingAccountKey(
+            state: TradingSellState,
+            action: PayloadAction<AccountKey | undefined>,
+        ) {
             state.tradingAccountKey = action.payload;
         },
-        setIsLoading(state, action: PayloadAction<boolean>) {
+        setIsLoading(state: TradingSellState, action: PayloadAction<boolean>) {
             state.isLoading = action.payload;
         },
-        setAmountLimits(state, action: PayloadAction<TradingAmountLimitProps | undefined>) {
+        setAmountLimits(
+            state: TradingSellState,
+            action: PayloadAction<TradingAmountLimitProps | undefined>,
+        ) {
             state.amountLimits = action.payload;
         },
-        setFormStep(state, action: PayloadAction<TradingSellStepType>) {
+        setFormStep(state: TradingSellState, action: PayloadAction<TradingSellStepType>) {
             state.formStep = action.payload;
         },
-        setLastErrorMessage(state, action: PayloadAction<string | undefined>) {
+        setLastErrorMessage(state: TradingSellState, action: PayloadAction<string | undefined>) {
             state.lastErrorMessage = action.payload;
         },
-        clearQuotesAndParams(state) {
+        clearQuotesAndParams(state: TradingSellState) {
             state.quotes = [];
             state.quotesRequest = undefined;
             state.selectedQuote = undefined;

--- a/suite-common/trading/src/reducers/tradingCommonReducer.ts
+++ b/suite-common/trading/src/reducers/tradingCommonReducer.ts
@@ -111,26 +111,35 @@ const tradingCommonSlice = createSlice({
     name: TRADING_PREFIX,
     initialState,
     reducers: {
-        addTradeableAssetToFavourites: (state, { payload }: PayloadAction<CryptoId>) => {
+        addTradeableAssetToFavourites: (
+            state: TradingState,
+            { payload }: PayloadAction<CryptoId>,
+        ) => {
             if (!state.favouriteAssets) {
                 state.favouriteAssets = {};
             }
             state.favouriteAssets[payload] = true;
         },
-        removeTradeableAssetFromFavourites: (state, { payload }: PayloadAction<CryptoId>) => {
+        removeTradeableAssetFromFavourites: (
+            state: TradingState,
+            { payload }: PayloadAction<CryptoId>,
+        ) => {
             if (state.favouriteAssets) {
                 delete state.favouriteAssets[payload];
             }
         },
-        saveInfo(state, action: PayloadAction<InfoResponse>) {
+        saveInfo(state: TradingState, action: PayloadAction<InfoResponse>) {
             state.info.coins = action.payload.coins;
             state.info.platforms = action.payload.platforms;
         },
-        saveComposedTransactionInfo(state, action: PayloadAction<TradingComposedTransactionInfo>) {
+        saveComposedTransactionInfo(
+            state: TradingState,
+            action: PayloadAction<TradingComposedTransactionInfo>,
+        ) {
             state.composedTransactionInfo = action.payload;
         },
 
-        saveTrade(state, action: PayloadAction<TradingTransaction>) {
+        saveTrade(state: TradingState, action: PayloadAction<TradingTransaction>) {
             if (action.payload.key) {
                 const trades = state.trades.filter(t => t.key !== action.payload.key);
                 trades.push(action.payload);
@@ -138,24 +147,24 @@ const tradingCommonSlice = createSlice({
                 state.trades = trades;
             }
         },
-        setModalCryptoCurrency(state, action: PayloadAction<CryptoId | undefined>) {
+        setModalCryptoCurrency(state: TradingState, action: PayloadAction<CryptoId | undefined>) {
             state.modalCryptoId = action.payload;
         },
-        setModalAccountKey(state, action: PayloadAction<AccountKey | undefined>) {
+        setModalAccountKey(state: TradingState, action: PayloadAction<AccountKey | undefined>) {
             state.modalAccountKey = action.payload;
         },
         setLoading(
-            state,
+            state: TradingState,
             action: PayloadAction<{ isLoading: boolean; lastLoadedTimestamp?: number }>,
         ) {
             state.isLoading = action.payload.isLoading;
             state.lastLoadedTimestamp = action.payload.lastLoadedTimestamp ?? 0;
         },
-        setTradingActiveSection(state, action: PayloadAction<TradingType>) {
+        setTradingActiveSection(state: TradingState, action: PayloadAction<TradingType>) {
             state.activeSection = action.payload;
         },
         setTradingFromPrefilledAccount(
-            state,
+            state: TradingState,
             action: PayloadAction<{
                 cryptoId: CryptoId | undefined;
                 key: AccountKey | undefined;
@@ -164,22 +173,22 @@ const tradingCommonSlice = createSlice({
             state.prefilledFromAccount.cryptoId = action.payload.cryptoId;
             state.prefilledFromAccount.key = action.payload.key;
         },
-        setVerifiedAddress(state, action: PayloadAction<TradingVerifiedAddress>) {
+        setVerifiedAddress(state: TradingState, action: PayloadAction<TradingVerifiedAddress>) {
             state.verifiedAddress = action.payload;
         },
         setCurrentProviderMetadata: (
-            state,
+            state: TradingState,
             { payload }: PayloadAction<ProviderMetadata | undefined>,
         ) => {
             state.currentProviderMetadata = payload;
         },
-        stopRefetchQuotes: state => {
+        stopRefetchQuotes: (state: TradingState) => {
             state.quoteRefetchingState.status = 'stopped';
             state.quoteRefetchingState.remainingRefetches = REFETCH_QUOTES_MAX_COUNT;
             state.quoteRefetchingState.lastFetchTimestamp = undefined;
         },
         setRefetchQuotesTimestamp: (
-            state,
+            state: TradingState,
             { payload }: PayloadAction<QuoteRefetchingState['lastFetchTimestamp']>,
         ) => {
             state.quoteRefetchingState.remainingRefetches -= 1;

--- a/suite-native/trading-state/src/reducers/buySlice.ts
+++ b/suite-native/trading-state/src/reducers/buySlice.ts
@@ -1,5 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+import { type TradingBuyState } from '@suite-common/trading';
 import { tradingInitialState } from '@suite-native/trading-consts';
 
 export const TRADING_BUY = 'tradingBuy';
@@ -8,7 +9,7 @@ const buySlice = createSlice({
     name: TRADING_BUY,
     initialState: tradingInitialState.buy,
     reducers: {
-        clearState: state => {
+        clearState: (state: TradingBuyState) => {
             state.tradingAccountKey = undefined;
             state.receiveAccountKey = undefined;
             state.receiveAddress = undefined;
@@ -18,22 +19,22 @@ const buySlice = createSlice({
             state.amountLimits = undefined;
             state.lastErrorMessage = undefined;
         },
-        clearQuotesAndQuotesRequest: state => {
+        clearQuotesAndQuotesRequest: (state: TradingBuyState) => {
             state.quotesRequest = undefined;
             state.quotes = [];
         },
-        assetChanged: state => {
+        assetChanged: (state: TradingBuyState) => {
             state.tradingAccountKey = undefined;
             state.receiveAccountKey = undefined;
             state.receiveAddress = undefined;
             state.amountLimits = undefined;
             state.quotesRequest = undefined;
         },
-        assetTokenChanged: state => {
+        assetTokenChanged: (state: TradingBuyState) => {
             state.amountLimits = undefined;
             state.quotesRequest = undefined;
         },
-        fiatCurrencyChanged: state => {
+        fiatCurrencyChanged: (state: TradingBuyState) => {
             state.amountLimits = undefined;
             state.quotesRequest = undefined;
         },

--- a/suite-native/trading-state/src/reducers/exchangeSlice.ts
+++ b/suite-native/trading-state/src/reducers/exchangeSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+import { type TradingExchangeState } from '@suite-common/trading';
 import { tradingInitialState } from '@suite-native/trading-consts';
 
 export const TRADING_EXCHANGE = 'tradingExchange';
@@ -8,7 +9,7 @@ const exchangeSlice = createSlice({
     name: TRADING_EXCHANGE,
     initialState: tradingInitialState.exchange,
     reducers: {
-        clearState: state => {
+        clearState: (state: TradingExchangeState) => {
             state.tradingAccountKey = undefined;
             state.receiveAccountKey = undefined;
             state.receiveAddress = undefined;
@@ -18,21 +19,21 @@ const exchangeSlice = createSlice({
             state.amountLimits = undefined;
             state.lastErrorMessage = undefined;
         },
-        clearQuotesAndQuotesRequest: state => {
+        clearQuotesAndQuotesRequest: (state: TradingExchangeState) => {
             state.quotesRequest = undefined;
             state.quotes = [];
         },
-        sendAssetChanged: state => {
+        sendAssetChanged: (state: TradingExchangeState) => {
             state.amountLimits = undefined;
             state.quotesRequest = undefined;
         },
-        receiveAssetChanged: state => {
+        receiveAssetChanged: (state: TradingExchangeState) => {
             state.amountLimits = undefined;
             state.quotesRequest = undefined;
             state.receiveAccountKey = undefined;
             state.receiveAddress = undefined;
         },
-        receiveTokenChanged: state => {
+        receiveTokenChanged: (state: TradingExchangeState) => {
             state.amountLimits = undefined;
             state.quotesRequest = undefined;
         },

--- a/suite-native/trading-state/src/reducers/residenceSlice.ts
+++ b/suite-native/trading-state/src/reducers/residenceSlice.ts
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 import { type TradingCountryCode } from '@suite-common/trading';
 import { tradingInitialState } from '@suite-native/trading-consts';
+import { type TradingResidenceState } from '@suite-native/trading-types';
 
 export const TRADING_RESIDENCE = 'tradingResidence';
 
@@ -14,11 +15,14 @@ const residenceSlice = createSlice({
     name: TRADING_RESIDENCE,
     initialState: tradingInitialState.residence,
     reducers: {
-        setResidenceCountry(state, action: { payload: SetResidenceCountryPayload }) {
+        setResidenceCountry(
+            state: TradingResidenceState,
+            action: { payload: SetResidenceCountryPayload },
+        ) {
             state.country = action.payload.country;
             state.countrySubdivision = action.payload.countrySubdivision;
         },
-        setOnboardingVisited(state) {
+        setOnboardingVisited(state: TradingResidenceState) {
             state.wasOnboardingVisited = true;
         },
     },

--- a/suite-native/trading-state/src/reducers/sellSlice.ts
+++ b/suite-native/trading-state/src/reducers/sellSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+import { type TradingSellState } from '@suite-common/trading';
 import { tradingInitialState } from '@suite-native/trading-consts';
 
 export const TRADING_SELL = 'tradingSell';
@@ -8,7 +9,7 @@ const sellSlice = createSlice({
     name: TRADING_SELL,
     initialState: tradingInitialState.sell,
     reducers: {
-        clearState: state => {
+        clearState: (state: TradingSellState) => {
             state.tradingAccountKey = undefined;
             state.quotesRequest = undefined;
             state.quotes = [];
@@ -16,15 +17,15 @@ const sellSlice = createSlice({
             state.amountLimits = undefined;
             state.lastErrorMessage = undefined;
         },
-        clearQuotesAndQuotesRequest: state => {
+        clearQuotesAndQuotesRequest: (state: TradingSellState) => {
             state.quotesRequest = undefined;
             state.quotes = [];
         },
-        sendAssetChanged: state => {
+        sendAssetChanged: (state: TradingSellState) => {
             state.amountLimits = undefined;
             state.quotesRequest = undefined;
         },
-        fiatCurrencyChanged: state => {
+        fiatCurrencyChanged: (state: TradingSellState) => {
             state.amountLimits = undefined;
             state.quotesRequest = undefined;
         },

--- a/suite-native/trading-state/src/reducers/tradingSlice.ts
+++ b/suite-native/trading-state/src/reducers/tradingSlice.ts
@@ -7,7 +7,7 @@ import {
     prepareTradingReducer,
 } from '@suite-common/trading';
 import { tradingInitialState } from '@suite-native/trading-consts';
-import type { ProviderConfirmationStatus } from '@suite-native/trading-types';
+import type { ProviderConfirmationStatus, TradingState } from '@suite-native/trading-types';
 
 import { TRADING_BUY, buyActions, buyReducer } from './buySlice';
 import { TRADING_EXCHANGE, exchangeActions, exchangeReducer } from './exchangeSlice';
@@ -46,30 +46,36 @@ export const tradingSlice = createSliceWithExtraDeps({
     name: 'trading',
     initialState: tradingInitialState,
     reducers: {
-        setTradingEnvironment: (state, { payload }: PayloadAction<InvityServerEnvironment>) => {
+        setTradingEnvironment: (
+            state: TradingState,
+            { payload }: PayloadAction<InvityServerEnvironment>,
+        ) => {
             state.tradingEnvironment = payload;
             state.tradeOrderIdToBeOpened = undefined;
             buyReducer(state.buy, buyActions.clearState());
             exchangeReducer(state.exchange, exchangeActions.clearState());
             sellReducer(state.sell, sellActions.clearState());
         },
-        setTradeOrderIdToBeOpened: (state, { payload }: PayloadAction<string>) => {
+        setTradeOrderIdToBeOpened: (state: TradingState, { payload }: PayloadAction<string>) => {
             state.tradeOrderIdToBeOpened = payload;
         },
-        clearTradeOrderIdToBeOpened: state => {
+        clearTradeOrderIdToBeOpened: (state: TradingState) => {
             state.tradeOrderIdToBeOpened = undefined;
         },
-        setIsAmountInputActive: (state, { payload }: PayloadAction<boolean>) => {
+        setIsAmountInputActive: (state: TradingState, { payload }: PayloadAction<boolean>) => {
             state.isAmountInputActive = payload;
         },
-        setActiveTradingType: (state, { payload }: PayloadAction<TradingTypeWithConcierge>) => {
+        setActiveTradingType: (
+            state: TradingState,
+            { payload }: PayloadAction<TradingTypeWithConcierge>,
+        ) => {
             state.activeTradingType = payload;
         },
-        clearActiveTradingType: state => {
+        clearActiveTradingType: (state: TradingState) => {
             state.activeTradingType = undefined;
         },
         setProviderConfirmationStatus: (
-            state,
+            state: TradingState,
             { payload: newStatus }: PayloadAction<ProviderConfirmationStatus>,
         ) => {
             const currentStatus = state.providerConfirmationStatus;
@@ -83,7 +89,7 @@ export const tradingSlice = createSliceWithExtraDeps({
                 state.providerConfirmationStatus = newStatus;
             }
         },
-        clearSelectedAccounts: state => {
+        clearSelectedAccounts: (state: TradingState) => {
             state.buy.tradingAccountKey = undefined;
             state.buy.receiveAccountKey = undefined;
             state.buy.receiveAddress = undefined;


### PR DESCRIPTION
## Description

Adds explicit `state` type annotations to all trading createSlice reducers (`suite-common/trading` and `suite-native/trading-state`). Without the annotation, declaration emit inlines the fully expanded state type into every case reducer signature, bloating the generated `.d.ts` files (e.g. `tradingSlice.d.ts`: 20 732 → 28 lines, `exchangeSlice.d.ts`: 1 829 → 10). Type-only change, no runtime behavior affected.

## Notes for QA

No functional change; nothing to test manually.

## Related Issue

Resolve

## Screenshots:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/trading/anotate-reducers&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/trading/anotate-reducers&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/trading/anotate-reducers&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-07T10:39:19.574Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-07T10:36:42.846Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/trading/anotate-reducers/web/](https://dev.suite.sldev.cz/suite-web/chore/trading/anotate-reducers/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->