### PR TITLE
chore(suite-native): annotate send form reducer state params

### DIFF
--- a/suite-native/transaction-management/src/sendFormSlice.ts
+++ b/suite-native/transaction-management/src/sendFormSlice.ts
@@ -33,11 +33,11 @@ export const sendFormSlice = createSliceWithExtraDeps({
     name: 'send',
     initialState: sendFormInitialState,
     reducers: {
-        clearFeeLevels: state => {
+        clearFeeLevels: (state: NativeSendState) => {
             state.feeLevels = {};
         },
         storeFeeLevels: (
-            state,
+            state: NativeSendState,
             { payload }: PayloadAction<{ feeLevels: GeneralPrecomposedLevels }>,
         ) => {
             state.feeLevels = payload.feeLevels;


### PR DESCRIPTION
## Description

Annotates the `send` reducer state params in `suite-native/transaction-management` with the explicit `NativeSendState` type. Without it, TypeScript inlined the fully expanded state into every case reducer signature, bloating the emitted `sendFormSlice.d.ts` to ~40k lines. Type-only change, no runtime impact. Same pattern as #29502.

## Notes for QA

No QA. Type-only change.


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/transaction-management/add-annotations&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->