### PR TITLE
Mobile - Account Settings

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsConstants.ts
+++ b/suite-common/wallet-core/src/accounts/accountsConstants.ts
@@ -2,9 +2,9 @@ import { type AccountType, type NetworkType } from '@suite-common/wallet-config'
 
 export const ACCOUNTS_MODULE_PREFIX = '@common/wallet-core/accounts';
 
-export const formattedAccountTypeMap: Partial<
-    Record<NetworkType, Partial<Record<AccountType, string>>>
-> = {
+type AccountTypeMap = Partial<Record<NetworkType, Partial<Record<AccountType, string>>>>;
+
+export const formattedAccountTypeMap: AccountTypeMap = {
     bitcoin: {
         normal: 'SegWit',
         taproot: 'Taproot',
@@ -21,5 +21,37 @@ export const formattedAccountTypeMap: Partial<
     },
     solana: {
         ledger: 'Ledger',
+    },
+};
+
+export const formattedAccountTypeWithDefaultMap: AccountTypeMap = {
+    bitcoin: {
+        normal: 'SegWit',
+        taproot: 'Taproot',
+        segwit: 'Legacy SegWit',
+        legacy: 'Legacy',
+    },
+    cardano: {
+        normal: 'Default',
+        legacy: 'Legacy',
+        ledger: 'Ledger',
+    },
+    ethereum: {
+        normal: 'Default',
+        legacy: 'Legacy',
+        ledger: 'Ledger',
+    },
+    solana: {
+        normal: 'Default',
+        ledger: 'Ledger',
+    },
+    ripple: {
+        normal: 'Default',
+    },
+    stellar: {
+        normal: 'Default',
+    },
+    tron: {
+        normal: 'Default',
     },
 };

--- a/suite-common/wallet-core/src/accounts/accountsSelectors.ts
+++ b/suite-common/wallet-core/src/accounts/accountsSelectors.ts
@@ -12,7 +12,7 @@ import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import { isCardanoStakingActive, isTestnet, isUtxoBased } from '@suite-common/wallet-utils';
 import { type DeviceState, type StaticSessionId } from '@trezor/connect';
 
-import { formattedAccountTypeMap } from './accountsConstants';
+import { formattedAccountTypeMap, formattedAccountTypeWithDefaultMap } from './accountsConstants';
 import { type AccountsRootState } from './accountsReducer';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<
@@ -236,6 +236,17 @@ export const selectFormattedAccountType = createMemoizedSelector([selectAccountB
 
     return formattedType ?? null;
 });
+
+export const selectFormattedAccountTypeWithDefault = createMemoizedSelector(
+    [selectAccountByKey],
+    account => {
+        if (!account) return null;
+        const { networkType, accountType } = account;
+        const formattedType = formattedAccountTypeWithDefaultMap[networkType]?.[accountType];
+
+        return formattedType ?? null;
+    },
+);
 
 export const selectIsAccountUtxoBased = createMemoizedSelector([selectAccountByKey], account =>
     account ? isUtxoBased(account) : false,

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1902,6 +1902,7 @@ export const messages = {
         accountSettingsScreen: {
             coin: 'Coin',
             accountType: 'Account type',
+            derivationPath: 'Derivation path',
             xpubBottomSheet: {
                 xpub: {
                     title: 'Public key (XPUB)',

--- a/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsScreenHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsScreenHeader.tsx
@@ -1,5 +1,7 @@
 import { useSelector } from 'react-redux';
 
+import { useNavigation } from '@react-navigation/native';
+
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import {
@@ -7,12 +9,24 @@ import {
     type NativeAccountsRootState,
     selectAccountFiatBalance,
 } from '@suite-native/accounts';
-import { HStack, VStack } from '@suite-native/atoms';
+import { HStack, IconButton, VStack } from '@suite-native/atoms';
 import { BaseCurrencyAmountFormatter } from '@suite-native/formatters';
 import { CryptoIcon } from '@suite-native/icons';
-import { ScreenHeader } from '@suite-native/navigation';
+import {
+    type AccountsStackParamList,
+    type RootStackParamList,
+    RootStackRoutes,
+    ScreenHeader,
+    type StackToStackCompositeNavigationProps,
+} from '@suite-native/navigation';
 
 import { type AccountAssetsFlow } from './types';
+
+type AccountDetailNavigationProps = StackToStackCompositeNavigationProps<
+    AccountsStackParamList,
+    RootStackRoutes.AccountDetail,
+    RootStackParamList
+>;
 
 type Props = { accountKey: AccountKey; flowType?: AccountAssetsFlow };
 
@@ -48,9 +62,29 @@ const AccountAssetsScreenHeaderContent = ({ accountKey }: Omit<Props, 'flowType'
     );
 };
 
-export const AccountAssetsScreenHeader = ({ accountKey, flowType }: Props) => (
-    <ScreenHeader
-        customContent={<AccountAssetsScreenHeaderContent accountKey={accountKey} />}
-        closeActionType={flowType === 'send' ? 'back' : 'close'}
-    />
-);
+export const AccountAssetsScreenHeader = ({ accountKey, flowType }: Props) => {
+    const navigation = useNavigation<AccountDetailNavigationProps>();
+
+    const handleSettingsNavigation = () => {
+        navigation.navigate(RootStackRoutes.AccountSettings, {
+            accountKey,
+        });
+    };
+
+    return (
+        <ScreenHeader
+            customContent={<AccountAssetsScreenHeaderContent accountKey={accountKey} />}
+            closeActionType={flowType === 'send' ? 'back' : 'close'}
+            rightIcon={
+                <IconButton
+                    intent="neutral"
+                    priority="secondary"
+                    size="medium"
+                    iconName="gear"
+                    onPress={handleSettingsNavigation}
+                    testID="@account-assets/settings-button"
+                />
+            }
+        />
+    );
+};

--- a/suite-native/module-accounts-management/src/components/AccountDetailScreenHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailScreenHeader.tsx
@@ -2,8 +2,9 @@ import { type RouteProp, useNavigation, useRoute } from '@react-navigation/nativ
 
 import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
+import { isStakingSymbol } from '@suite-common/wallet-utils';
 import { AccountLabel } from '@suite-native/accounts';
-import { HStack, IconButton, Text, VStack } from '@suite-native/atoms';
+import { HStack, IconButton, Text, VStack, useBottomSheetModal } from '@suite-native/atoms';
 import { CryptoIconWithNetwork } from '@suite-native/icons';
 import {
     type AccountsStackParamList,
@@ -13,6 +14,9 @@ import {
     type StackToStackCompositeNavigationProps,
     useNavigateToInitialScreen,
 } from '@suite-native/navigation';
+import { isNetworkWithTokens } from '@suite-native/tokens';
+
+import { TokenSettingsBottomSheet } from './TokenSettingsBottomSheet';
 
 type AccountDetailScreenHeaderProps = {
     account: Account;
@@ -49,27 +53,37 @@ export const AccountDetailScreenHeader = ({ account }: AccountDetailScreenHeader
     const route = useRoute<RouteProp<RootStackParamList, RootStackRoutes.AccountDetail>>();
     const { closeActionType } = route.params;
 
+    const { bottomSheetRef, openModal } = useBottomSheetModal();
+
     const handleSettingsNavigation = () => {
-        navigation.navigate(RootStackRoutes.AccountSettings, {
-            accountKey: account.key,
-        });
+        if (isNetworkWithTokens(account.symbol) || isStakingSymbol(account.symbol)) {
+            openModal();
+        } else {
+            navigation.navigate(RootStackRoutes.AccountSettings, {
+                accountKey: account.key,
+            });
+        }
     };
 
     return (
-        <ScreenHeader
-            customContent={<AccountDetailScreenHeaderContent account={account} />}
-            rightIcon={
-                <IconButton
-                    intent="neutral"
-                    priority="secondary"
-                    size="medium"
-                    iconName="gear"
-                    onPress={handleSettingsNavigation}
-                    testID="@account-detail/settings-button"
-                />
-            }
-            closeActionType={closeActionType}
-            closeAction={navigateToInitialScreen}
-        />
+        <>
+            <ScreenHeader
+                customContent={<AccountDetailScreenHeaderContent account={account} />}
+                rightIcon={
+                    <IconButton
+                        intent="neutral"
+                        priority="secondary"
+                        size="medium"
+                        iconName="gear"
+                        onPress={handleSettingsNavigation}
+                        testID="@account-detail/settings-button"
+                    />
+                }
+                closeActionType={closeActionType}
+                closeAction={navigateToInitialScreen}
+            />
+
+            <TokenSettingsBottomSheet ref={bottomSheetRef} accountKey={account.key} />
+        </>
     );
 };

--- a/suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx
+++ b/suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx
@@ -10,7 +10,7 @@ import {
     TokenManagementAction,
     tokenDefinitionsActions,
 } from '@suite-common/token-definitions';
-import { getNetwork } from '@suite-common/wallet-config';
+import { getDisplaySymbol, getNetwork } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type TokensRootState,
@@ -18,7 +18,7 @@ import {
     selectAccountHiddenTokens,
     selectAccountNetworkSymbol,
 } from '@suite-common/wallet-core';
-import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
+import { type AccountKey, type TokenAddress, toTokenSymbol } from '@suite-common/wallet-types';
 import {
     BottomSheetModal,
     Box,
@@ -31,6 +31,7 @@ import {
 } from '@suite-native/atoms';
 import {
     AddressFormatter,
+    CoinToFiatAmountFormatter,
     TokenAmountFormatter,
     TokenToFiatAmountFormatter,
 } from '@suite-native/formatters';
@@ -77,7 +78,7 @@ const DetailRow = ({ label, children }: DetailRowProps) => {
 
 type TokenSettingsBottomSheetProps = {
     accountKey: AccountKey;
-    tokenContract: TokenAddress;
+    tokenContract?: TokenAddress;
 };
 
 export const TokenSettingsBottomSheet = forwardRef(
@@ -104,16 +105,20 @@ export const TokenSettingsBottomSheet = forwardRef(
             selectIsUnrecognizedToken(state, accountKey, tokenContract),
         );
 
-        if (!token || !account || !symbol) return null;
+        if (!account || !symbol) return null;
 
-        const balance = token.balance ?? '0';
+        const displaySymbol = getDisplaySymbol(account.symbol);
+
+        const balance = token?.balance ?? account.balance;
         const networkName = getNetwork(symbol).name;
 
         const isHidden = hiddenTokens.some(
-            t => t.contract.toLowerCase() === tokenContract.toLowerCase(),
+            t => t.contract.toLowerCase() === tokenContract?.toLowerCase(),
         );
 
         const handleToggleHide = () => {
+            if (!tokenContract) return;
+
             dispatch(
                 tokenDefinitionsActions.setTokenStatus({
                     symbol,
@@ -125,24 +130,30 @@ export const TokenSettingsBottomSheet = forwardRef(
         };
 
         return (
-            <BottomSheetModal ref={ref} title={token.name ?? tokenContract} isCloseDisplayed>
+            <BottomSheetModal ref={ref} title={token?.name ?? displaySymbol} isCloseDisplayed>
                 <VStack spacing="sp16" paddingBottom="sp16">
                     <Card style={applyStyle(cardStyle)}>
                         <VStack>
-                            <DetailRow
-                                label={
-                                    <Translation id="moduleAccountManagement.tokenSettings.contractAddress" />
-                                }
-                            >
-                                <Box flex={1} alignItems="flex-end" marginLeft="sp8">
-                                    <AddressFormatter
-                                        value={tokenContract}
-                                        variant="body-sm"
-                                        format="long"
-                                    />
-                                </Box>
-                            </DetailRow>
-                            <CardDivider />
+                            {tokenContract && (
+                                <>
+                                    <DetailRow
+                                        label={
+                                            <Translation id="moduleAccountManagement.tokenSettings.contractAddress" />
+                                        }
+                                    >
+                                        <Box flex={1} alignItems="flex-end" marginLeft="sp8">
+                                            <AddressFormatter
+                                                value={tokenContract}
+                                                variant="body-sm"
+                                                format="long"
+                                            />
+                                        </Box>
+                                    </DetailRow>
+
+                                    <CardDivider />
+                                </>
+                            )}
+
                             <DetailRow
                                 label={
                                     <Translation id="moduleAccountManagement.tokenSettings.network" />
@@ -162,31 +173,48 @@ export const TokenSettingsBottomSheet = forwardRef(
                                 <VStack spacing={0} alignItems="flex-end">
                                     <TokenAmountFormatter
                                         value={balance}
-                                        tokenSymbol={token.symbol}
+                                        tokenSymbol={token?.symbol ?? toTokenSymbol(account.symbol)}
                                         variant="body-sm"
                                         color="contentPrimary"
                                     />
+
                                     {!isUnrecognized && (
-                                        <TokenToFiatAmountFormatter
-                                            symbol={symbol}
-                                            value={balance}
-                                            contract={tokenContract}
-                                            variant="body-sm"
-                                            color="contentSecondary"
-                                        />
+                                        <>
+                                            {tokenContract ? (
+                                                <TokenToFiatAmountFormatter
+                                                    symbol={symbol}
+                                                    value={balance}
+                                                    contract={tokenContract}
+                                                    variant="body-sm"
+                                                    color="contentSecondary"
+                                                />
+                                            ) : (
+                                                <CoinToFiatAmountFormatter
+                                                    accountKey={accountKey}
+                                                    value={balance}
+                                                    variant="body-sm"
+                                                    color="contentSecondary"
+                                                />
+                                            )}
+                                        </>
                                     )}
                                 </VStack>
                             </DetailRow>
                         </VStack>
                     </Card>
-                    <TouchableSwitchRow
-                        icon="eyeSlash"
-                        accessibilityLabel="Hide token"
-                        text={<Translation id="moduleAccountManagement.tokenSettings.hideToken" />}
-                        isChecked={isHidden}
-                        onChange={handleToggleHide}
-                        testID="@token-detail/hide-token-switch"
-                    />
+
+                    {!!tokenContract && (
+                        <TouchableSwitchRow
+                            icon="eyeSlash"
+                            accessibilityLabel="Hide token"
+                            text={
+                                <Translation id="moduleAccountManagement.tokenSettings.hideToken" />
+                            }
+                            isChecked={isHidden}
+                            onChange={handleToggleHide}
+                            testID="@token-detail/hide-token-switch"
+                        />
+                    )}
                 </VStack>
             </BottomSheetModal>
         );

--- a/suite-native/module-accounts-management/src/screens/AccountSettingsScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountSettingsScreen.tsx
@@ -8,7 +8,7 @@ import { type NetworkSymbol, networks } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     selectAccountByKey,
-    selectFormattedAccountType,
+    selectFormattedAccountTypeWithDefault,
     selectIsAccountUtxoBased,
 } from '@suite-common/wallet-core';
 import { AccountLabel } from '@suite-native/accounts';
@@ -28,13 +28,12 @@ import { AccountRenameButton } from '../components/AccountRenameButton';
 import { AccountSettingsRemoveCoinButton } from '../components/AccountSettingsRemoveCoinButton';
 import { AccountSettingsShowXpubButton } from '../components/AccountSettingsShowXpubButton';
 
-const AccountDetailSettingsRow = ({
-    title,
-    children,
-}: {
+interface AccountDetailSettingsRowProps {
     title: ReactNode;
     children: ReactNode;
-}) => (
+}
+
+const AccountDetailSettingsRow = ({ title, children }: AccountDetailSettingsRowProps) => (
     <Box
         paddingVertical="sp8"
         flexDirection="row"
@@ -67,7 +66,7 @@ export const AccountSettingsScreen = ({
     );
 
     const formattedAccountType = useSelector((state: AccountsRootState) =>
-        selectFormattedAccountType(state, accountKey),
+        selectFormattedAccountTypeWithDefault(state, accountKey),
     );
 
     const isUtxoBasedAccount = useSelector((state: AccountsRootState) =>
@@ -102,6 +101,7 @@ export const AccountSettingsScreen = ({
                             >
                                 <CryptoNameWithIcon symbol={account.symbol} />
                             </AccountDetailSettingsRow>
+
                             {!!formattedAccountType && (
                                 <AccountDetailSettingsRow
                                     title={
@@ -109,6 +109,16 @@ export const AccountSettingsScreen = ({
                                     }
                                 >
                                     <Text variant="body-sm">{formattedAccountType}</Text>
+                                </AccountDetailSettingsRow>
+                            )}
+
+                            {account.path && (
+                                <AccountDetailSettingsRow
+                                    title={
+                                        <Translation id="moduleAccountManagement.accountSettingsScreen.derivationPath" />
+                                    }
+                                >
+                                    <Text variant="body-sm">{account.path}</Text>
                                 </AccountDetailSettingsRow>
                             )}
                         </VStack>


### PR DESCRIPTION
## Description

This PR introduces the following changes:
- moves account settings to account detail
- adds bottom sheet settings modal to native coin detail
- adds account type and derivation path to account settings

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27973

## Screenshots:


<table>
<tr>
<td>
<img width="100%" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 13 21 37" src="https://github.com/user-attachments/assets/66272814-6e92-4ebc-af9f-647fbbce9bd6" />
</td>
<td>
<img width="100%" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 13 11 50" src="https://github.com/user-attachments/assets/63ee53a3-1cad-49ea-b009-1852723e3958" />
</td>
</tr>
<tr>
<td>
<img width="100%" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 13 16 53" src="https://github.com/user-attachments/assets/b5a05450-3107-4a36-adec-c7f9568b1a70" />
</td>
<td>
<img width="100%" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 13 12 15" src="https://github.com/user-attachments/assets/b14685f9-fb1c-4ce6-9ffb-7ff95bd4e6b5" />
</td>
</tr>
</table>

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native/account-settings/web/](https://dev.suite.sldev.cz/suite-web/feat/native/account-settings/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/account-settings&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/account-settings&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/account-settings&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-07T12:12:03.396Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |

</details>

_Updated: 2026-07-07T12:08:57.373Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily touches two areas: (1) shared wallet-core account constants and selectors used broadly across Suite, and (2) suite-native mobile components (account management screens, token settings, intl messages) that have zero E2E test coverage in the Playwright suite. The wallet-core changes map to 121 tests each, indicating they are deeply shared infrastructure — but since these are constants and selectors, only tests that directly exercise account listing, filtering, discovery, or type management are meaningfully at risk. The suite-native changes are mobile-only React Native components with no corresponding web E2E tests. A small, targeted set of account-focused tests provides the best confidence without over-testing.

<details><summary><b>Changed files (7)</b></summary>

- `suite-common/wallet-core/src/accounts/accountsConstants.ts`
- `suite-common/wallet-core/src/accounts/accountsSelectors.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsScreenHeader.tsx`
- `suite-native/module-accounts-management/src/components/AccountDetailScreenHeader.tsx`
- `suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx`
- `suite-native/module-accounts-management/src/screens/AccountSettingsScreen.tsx`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — This test exercises account discovery across multiple networks and checks account balances via accountsSelectors. Changes to accountsConstants or accountsSelectors could affect how accounts are discovered, stored, or queried, potentially breaking the discovery status checks and account visibility assertions.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds different account types (normal, taproot, segwit, legacy) and verifies account counts per type group. Changes to accountsSelectors (which likely provides selectors for counting/filtering accounts by type) and accountsConstants could directly affect account type grouping and counting logic.
- `suite/e2e/tests/wallet/account-search.test.ts` — Account search and filtering depends on account selectors to retrieve and filter the account list. Changes to accountsSelectors could affect which accounts are visible/hidden during search operations.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/wallet/general-discovery.test.ts` — Wallet discovery test verifies account balances after discovery, which relies on accounts being correctly stored and selected. Changes to the accounts module could subtly affect balance retrieval.
- `suite/e2e/tests/dashboard/assets.test.ts` — The assets dashboard test enables networks and verifies asset contents are correctly displayed. Account selectors are used to determine which accounts/assets to show. Changes to accountsSelectors or constants could affect the asset list rendering.

</details>

⚠️ **Changes with no test coverage (5)**
- `suite-native/intl/src/messages.ts`
- `suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsScreenHeader.tsx`
- `suite-native/module-accounts-management/src/components/AccountDetailScreenHeader.tsx`
- `suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx`
- `suite-native/module-accounts-management/src/screens/AccountSettingsScreen.tsx`

_Updated: 2026-07-07T12:06:01.348Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->