### PR TITLE
fix(suite-native): display BCH addresses without prefix

### DIFF
--- a/suite-native/formatters/src/components/AddressFormatter.tsx
+++ b/suite-native/formatters/src/components/AddressFormatter.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import {
     type AddressFormat,
     AddressFormatter as CommonAddressFormatter,
+    clearAddressPrefix,
 } from '@suite-common/formatters';
 import { selectAddressDisplayType } from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
@@ -18,7 +19,11 @@ export const AddressFormatter = ({ value, format, ...textProps }: AddressFormatt
 
     return (
         <Text {...textProps}>
-            <CommonAddressFormatter value={value} format={format} isChunked={isChunked} />
+            <CommonAddressFormatter
+                value={clearAddressPrefix(value)}
+                format={format}
+                isChunked={isChunked}
+            />
         </Text>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As simple as that. Similar to the desktop PR: https://github.com/trezor/trezor-suite/pull/28732

## Notes for QA

Check displaying of BCH addresses without suffix 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28352

## Screenshots:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-07-07 at 13 38 33" src="https://github.com/user-attachments/assets/7d6aaba2-fb7a-4427-ad09-cd7b173a3308" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/bch-prefix-native&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->