### PR TITLE
feat(suite): add WalletConnect entry to account header menu

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
@@ -2,6 +2,7 @@ import { type JSX } from 'react';
 
 import { selectSelectedAccount } from '@suite/account';
 import { Translation } from '@suite/intl';
+import { getNetwork } from '@suite-common/wallet-config';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 import { Dropdown, type DropdownMenuItemProps, type IconName } from '@trezor/components';
 
@@ -44,6 +45,19 @@ export const HeaderDropdown = ({ isDisabled, showSignAndVerify }: HeaderDropdown
                   },
               ]
             : []),
+        {
+            id: 'settings-connected-apps',
+            callback: () => {
+                goToWithAnalytics({
+                    routeName: 'settings-connected-apps',
+                    preserveParams: true,
+                });
+            },
+            title: <Translation id="TR_WALLETCONNECT" />,
+            icon: 'walletConnect' as const,
+            // caipId marks networks with a WalletConnect adapter (see suite-common/walletconnect)
+            isHidden: account ? !getNetwork(account.symbol).caipId : true,
+        },
     ];
 
     const visibleAdditionalActions = additionalActions?.filter(action => !action.isHidden);


### PR DESCRIPTION
## Description

Adds a "WalletConnect" item to the account page's "..." dropdown (next to the existing "Sign & verify" item), which navigates to the WalletConnect tab in Connected apps Settings. The item is shown only for accounts on networks with a WalletConnect adapter, determined by the presence of `caipId` in `networksConfig.ts` (Bitcoin, Ethereum, Polygon PoS, BNB Smart Chain, Arbitrum One, Base, Optimism, Avalanche C-Chain, Solana, Tron, Stellar, Litecoin, Dogecoin).

## Notes for QA

Open an account for one of the supported networks above, click the "..." menu next to Buy/Sell/Receive/Send, and confirm a "WalletConnect" entry appears and navigates to Settings > Connected apps > WalletConnect.

## Related Issue

Resolve #29505

## Screenshots:

<img width="842" height="240" alt="Screenshot 2026-07-07 at 14 06 55" src="https://github.com/user-attachments/assets/aa5e7b69-f792-4462-89a0-3ac902ee0166" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to HeaderDropdown.tsx, a shared layout component in the SuiteLayout page header that is transitively imported by virtually all E2E tests (121 tests). Since this is a broad global component, most tests should be omitted. The recommended strategy focuses on tests that specifically interact with header-level UI elements like the discreet mode toggle, device switcher, global send/receive buttons, and settings navigation — areas most likely to be directly affected by changes to the page header dropdown. The risk is moderate: a rendering or interaction bug in this component could affect many flows, but the blast radius for a typical change is limited to dropdown menu visibility and interaction behavior.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx`

</details>

**Recommended tests (6)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — HeaderDropdown is part of the SuiteLayout page header, and the discreet mode toggle (hideBalanceButton) is likely rendered in or near this dropdown. Changes to the dropdown component could affect the discreet mode toggle's visibility or functionality.
- `suite/e2e/tests/analytics/toggle.test.ts` — This test interacts with the device switcher from the dashboard, which is part of the page header area. The HeaderDropdown may contain or interact with device switching UI elements that this test exercises.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test uses global receive and send buttons from the wallet menu header (@wallet/menu/wallet-global-receive, @wallet/menu/wallet-global-send), which are likely rendered within or adjacent to the HeaderDropdown component in the page header.
- `suite/e2e/tests/settings/general.test.ts` — The HeaderDropdown likely contains navigation items or settings access points. This test navigates through settings and verifies the suite version element, which could be affected by header dropdown changes.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/suite/guide.test.ts` — The guide panel can be opened over existing UI including modals accessed from settings. If the HeaderDropdown contains or gates access to guide-related buttons, changes could affect guide accessibility.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test interacts with the @send/header-dropdown component for toggling options like locktime and OP_RETURN. While this is a different dropdown, if HeaderDropdown.tsx is a shared dropdown pattern, changes could propagate.

</details>

_Updated: 2026-07-07T12:00:08.628Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=issue-29505&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=issue-29505&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-07T12:04:48.675Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |

</details>

_Updated: 2026-07-07T12:02:56.759Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/issue-29505/web/](https://dev.suite.sldev.cz/suite-web/issue-29505/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->