### PR TITLE
fix(suite-desktop): guard debounced winBounds store against destroyed window

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -97,7 +97,9 @@ const createMainWindow = ({ winBounds, cspNonce, store }: CreateMainWindowParams
     mainWindow.webContents.setUserAgent(`Trezor Suite ${app.getVersion()}`);
 
     const debouncedStoreWinBounds = debounce(() => {
-        if (!mainWindow) return;
+        // The trailing debounced call can fire after the window was destroyed within the debounce
+        // window; getBounds() on a destroyed BrowserWindow throws "Object has been destroyed".
+        if (!isMainWindowUsable(mainWindow)) return;
         const winBound = mainWindow.getBounds();
         Store.getStore().setWinBounds(winBound);
         logger.debug('app', 'new winBounds saved');


### PR DESCRIPTION
## Description

The trailing 500ms debounced resize/move/maximize handler in `createMainWindow` captures the `mainWindow` const, so its `if (!mainWindow) return` guard is dead code — `mainWindow` is never null. When the window is destroyed within the debounce window, the callback still runs `mainWindow.getBounds()` on a destroyed `BrowserWindow`, which throws "Object has been destroyed".

This replaces the ineffective null check with the existing `isMainWindowUsable()` helper (`!!mainWindow && !mainWindow.isDestroyed()`), matching how the rest of `app.ts` guards native window calls.

Sentry: https://satoshilabs.sentry.io/issues/7063775260/ (TREZOR-SUITE-1A1C)

## Notes for QA

Low blast radius: single desktop-only guard, no behaviour change on the happy path. The saved window bounds still persist exactly as before. To exercise the fixed path, resize/move the window and immediately quit/close it (within ~500ms) so the debounced save fires after the window is gone — this previously produced the "Object has been destroyed" crash and should now be silently skipped. No functional regression expected in normal window resize/move/maximize persistence.

## Related Issue

Fixes Sentry issue TREZOR-SUITE-1A1C

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to packages/suite-desktop-core/src/app.ts affects the Electron main process entry point, which controls app initialization, bridge lifecycle, IPC handlers, window management, and the TrezorConnect WebSocket bridge. The highest risk is to tests that directly exercise desktop app launching and bridge management (spawn-bridge tests). Medium risk applies to all TrezorConnect desktop-mode tests that depend on the WebSocket bridge exposed by app.ts. No static coverage mapping exists, so all recommendations are inferred from the LLM analysis of test behaviors and source hints.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite-desktop-core/src/app.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test directly exercises the Electron app launch lifecycle including daemon mode, bridge spawning, and app initialization — all of which are orchestrated by the suite-desktop-core app.ts entry point. Changes to app.ts could break daemon mode launching, bridge lifecycle management, or window initialization.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test validates the core Electron app startup flow: bridge spawning on launch, bridge persistence across renderer reload, bridge stopping on app close, and device reconnection after bridge restart. The app.ts file is the main process entry point that manages all of these lifecycle behaviors.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/trezor-connect/error.test.ts` — This test initializes TrezorConnect with coreMode 'suite-desktop' after onboarding in the Electron app. Changes to app.ts could affect the WebSocket bridge (exposeConnectWs) that enables TrezorConnect communication in desktop mode.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Uses TrezorConnect.init with coreMode 'suite-desktop' and exposeConnectWs, which depends on the desktop core app.ts setting up the WebSocket bridge correctly for connect integration.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Relies on suite-desktop coreMode with exposeConnectWs WebSocket bridge setup in the Electron main process, which is managed by app.ts.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Uses TrezorConnect.init with coreMode 'suite-desktop' connecting to localhost:8080, relying on the desktop core app entry point to expose the connect WebSocket.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Exercises TrezorConnect in suite-desktop coreMode with multiple address export flows, all dependent on the WebSocket bridge infrastructure set up by app.ts.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests TrezorConnect permission management in suite-desktop coreMode, which requires the Electron main process (app.ts) to properly initialize the connect WebSocket bridge.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Uses TrezorConnect.signTransaction with coreMode 'suite-desktop', depending on the desktop core app.ts to set up the connect integration properly.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests silent mode which intercepts app/focus IPC events and uses TrezorConnect in suite-desktop coreMode. The app.ts file manages IPC handlers and the connect WebSocket bridge, both directly relevant to this test's assertions.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — Tests offline mode behavior in the desktop Electron app, including offline banner display and graceful discovery failure. The app.ts entry point controls how the desktop app handles network state and offline conditions.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/settings/forget-device.test.ts` — The Bluetooth state mocking and device forget flow in the desktop app may be affected by changes to app.ts if IPC handlers or device management lifecycle are modified. The test uses page.mockDeviceBluetoothState which interacts with desktop-specific APIs.

</details>

_Updated: 2026-07-07T12:23:40.601Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-winbounds-destroyed-window&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-winbounds-destroyed-window&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-07T12:28:00.785Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |

</details>

_Updated: 2026-07-07T12:27:10.135Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-winbounds-destroyed-window/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-winbounds-destroyed-window/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->