### PR TITLE
feat(suite): Add tracking for contact support

### DIFF
--- a/packages/suite/src/components/guide/SupportConsentPopover.tsx
+++ b/packages/suite/src/components/guide/SupportConsentPopover.tsx
@@ -1,7 +1,10 @@
 import { type ReactNode, useState } from 'react';
 
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
+import { events } from '@suite-common/analytics';
 import { selectIsAnalyticsEnabled } from '@suite-common/analytics-redux';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectSupportChatUrl } from '@suite-common/support';
 import { Button, Card, Checkbox, Column, Paragraph, Popover, variables } from '@trezor/components';
 import { zIndices } from '@trezor/theme';
@@ -19,6 +22,15 @@ export const SupportConsentPopover = ({ children }: SupportConsentPopoverProps) 
     const isAnalyticsEnabled = useSelector(selectIsAnalyticsEnabled);
     const [isSystemInfoShared, setIsSystemInfoShared] = useState(isAnalyticsEnabled);
     const supportChatUrl = useSelector(state => selectSupportChatUrl(state, isSystemInfoShared));
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
+
+    const handleOpenSupportChat = () => {
+        analytics.report({
+            type: events.guideSupportChatOpenedEvent.name,
+            payload: { systemInfoShared: isSystemInfoShared, platform: 'desktop' },
+        });
+        window.open(supportChatUrl, '_blank');
+    };
 
     return (
         <Popover
@@ -51,7 +63,7 @@ export const SupportConsentPopover = ({ children }: SupportConsentPopoverProps) 
                         </Column>
                         <Button
                             iconRight="arrowLineUpRight"
-                            onClick={() => window.open(supportChatUrl, '_blank')}
+                            onClick={handleOpenSupportChat}
                             width="100%"
                         >
                             <Translation id="TR_GUIDE_SUPPORT_CONSENT_BUTTON" />

--- a/suite-common/analytics/src/constants.ts
+++ b/suite-common/analytics/src/constants.ts
@@ -32,4 +32,5 @@ export enum EventType {
     OnboardingStepViewed = 'onboarding/step-viewed',
     OnboardingFeedbackBannerClicked = 'onboarding/feedback-banner',
     PromoNoDeviceEshopCta = 'promo/no-device-eshop-cta',
+    GuideSupportChatOpened = 'guide/support-chat-opened',
 }

--- a/suite-common/analytics/src/events/guideSupportChatOpenedEvent.ts
+++ b/suite-common/analytics/src/events/guideSupportChatOpenedEvent.ts
@@ -1,0 +1,28 @@
+import { EventType } from '../constants';
+import type { AnalyticsPlatform, AttributeDef, EventDef } from '../eventDefinition';
+
+type Attributes = {
+    systemInfoShared: AttributeDef<boolean>;
+    platform: AttributeDef<AnalyticsPlatform>;
+};
+
+export const guideSupportChatOpenedEvent: EventDef<Attributes, EventType.GuideSupportChatOpened> = {
+    name: EventType.GuideSupportChatOpened,
+    descriptionTrigger:
+        'Fired when a user opens the support chat from the support consent prompt. Emitted by both desktop (guide) and mobile (settings FAQ contact support).',
+    description:
+        'Measures how often users reach out to support and whether they opt in to sharing system information.',
+    changelog: [{ version: '26.7.1', notes: 'added' }],
+
+    attributes: {
+        systemInfoShared: {
+            changelog: [{ version: '26.7.1', notes: 'added' }],
+            description:
+                '`true` if the user kept the "share system info" toggle checked, `false` if unchecked.',
+        },
+        platform: {
+            changelog: [{ version: '26.7.1', notes: 'added' }],
+            description: '`desktop` or `mobile`, identifying which app emitted the event.',
+        },
+    },
+};

--- a/suite-common/analytics/src/events/index.ts
+++ b/suite-common/analytics/src/events/index.ts
@@ -32,3 +32,4 @@ export {
     promoNoDeviceEshopCtaEvent,
     type NoDeviceEshopCtaOrigin,
 } from './promoNoDeviceEshopCtaEvent';
+export { guideSupportChatOpenedEvent } from './guideSupportChatOpenedEvent';

--- a/suite-native/module-settings/src/components/ContactSupportAlertAppendix.tsx
+++ b/suite-native/module-settings/src/components/ContactSupportAlertAppendix.tsx
@@ -16,6 +16,7 @@ const checkboxRowStyle = prepareNativeStyle(utils => ({
 
 export type ContactSupportAlertAppendixRef = {
     getSupportChatUrl: () => string;
+    getIsSystemInfoShared: () => boolean;
 };
 
 export const ContactSupportAlertAppendix = forwardRef<ContactSupportAlertAppendixRef>((_, ref) => {
@@ -29,7 +30,17 @@ export const ContactSupportAlertAppendix = forwardRef<ContactSupportAlertAppendi
     const supportChatUrlRef = useRef(supportChatUrl);
     supportChatUrlRef.current = supportChatUrl;
 
-    useImperativeHandle(ref, () => ({ getSupportChatUrl: () => supportChatUrlRef.current }), []);
+    const isCheckedRef = useRef(isChecked);
+    isCheckedRef.current = isChecked;
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            getSupportChatUrl: () => supportChatUrlRef.current,
+            getIsSystemInfoShared: () => isCheckedRef.current,
+        }),
+        [],
+    );
 
     return (
         <VStack spacing="sp12">

--- a/suite-native/module-settings/src/components/useContactSupportAlert.tsx
+++ b/suite-native/module-settings/src/components/useContactSupportAlert.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useRef } from 'react';
 
+import { events } from '@suite-common/analytics';
+import { useServices } from '@suite-common/dependency-injection';
 import { useAlert } from '@suite-native/alerts';
+import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Translation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
 
@@ -13,6 +16,7 @@ export const useContactSupportAlert = () => {
     const appendixRef = useRef<ContactSupportAlertAppendixRef>(null);
     const { showAlert } = useAlert();
     const openLink = useOpenLink();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     const showContactSupportAlert = useCallback(() => {
         showAlert({
@@ -26,13 +30,20 @@ export const useContactSupportAlert = () => {
             onPressPrimaryButton: async () => {
                 if (appendixRef.current) {
                     // We need to access the URL via a ref to ensure it's always up to date, even if the value changes while the alert is already displayed.
+                    analytics.report({
+                        type: events.guideSupportChatOpenedEvent.name,
+                        payload: {
+                            systemInfoShared: appendixRef.current.getIsSystemInfoShared(),
+                            platform: 'mobile',
+                        },
+                    });
                     await openLink(appendixRef.current.getSupportChatUrl());
                 }
             },
             secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
             testID: '@contact-support-alert',
         });
-    }, [showAlert, openLink]);
+    }, [showAlert, openLink, analytics]);
 
     return { showContactSupportAlert };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- send analytics event when user contact trezor support, see screenshot below

## Notes for QA

- toggle **analytics console logging** in settings –> debug to validate events
- it's mobile AND desktop feature

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28851

## Screenshots:

desktop:
<img width="393" height="845" alt="Screenshot 2026-07-08 at 9 52 37" src="https://github.com/user-attachments/assets/15e56def-fde2-46cc-92a2-8779ec638d4f" />

mobile:
@PeKne could you test it please? 🙏 

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set adds a new analytics event (guideSupportChatOpenedEvent) and modifies the guide SupportConsentPopover component, along with suite-native contact support components. The highest risk is in the guide/support feedback flow where SupportConsentPopover is used — three guide-related tests directly exercise this path. The analytics constants and events index changes have moderate risk for existing analytics tests. The suite-native changes have no E2E test coverage as they target the mobile app which uses a separate test infrastructure.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/components/guide/SupportConsentPopover.tsx`
- `suite-common/analytics/src/constants.ts`
- `suite-common/analytics/src/events/guideSupportChatOpenedEvent.ts`
- `suite-common/analytics/src/events/index.ts`
- `suite-native/module-settings/src/components/ContactSupportAlertAppendix.tsx`
- `suite-native/module-settings/src/components/useContactSupportAlert.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/general/suite-guide.test.ts` — This test directly exercises the Suite Guide panel, including opening it, submitting bug reports, and searching articles. The SupportConsentPopover component is part of the guide/support feedback flow, so changes to it could affect the bug report submission or support interaction behavior tested here.
- `suite/e2e/tests/suite/bug-report-form.test.ts` — This test directly tests the guide panel's Support and Feedback section and bug report form submission. The SupportConsentPopover is a consent/interaction component within the guide support flow, which is exactly what this test exercises.
- `suite/e2e/tests/suite/guide.test.ts` — This test covers opening/closing the guide panel, submitting feedback, searching articles, and accessing bug report forms — all directly related to the guide support flow where SupportConsentPopover lives. Changes to the consent popover could affect the feedback submission or guide interaction UX.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — The analytics constants and events index were changed. This test comprehensively validates analytics event types and payloads (SuiteReady, DeviceConnect, etc.). While the new guideSupportChatOpenedEvent isn't tested here, changes to the events index could affect event registration or constants used by other events.
- `suite/e2e/tests/analytics/toggle.test.ts` — This test validates analytics event dispatching, enable/disable toggling, and specific event payloads. Changes to the analytics constants and events index module could affect event type resolution or event registration that this test validates.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/analytics/src/events/guideSupportChatOpenedEvent.ts`
- `suite-native/module-settings/src/components/ContactSupportAlertAppendix.tsx`
- `suite-native/module-settings/src/components/useContactSupportAlert.tsx`

_Updated: 2026-07-08T08:29:01.889Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/track-contact-support/web/](https://dev.suite.sldev.cz/suite-web/track-contact-support/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=track-contact-support&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=track-contact-support&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=track-contact-support&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-08T08:34:25.708Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T08:32:13.841Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->