### PR TITLE
fix(suite): enforce selectAccount requireOnDeviceVerification

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectSelectAccount/ConnectSelectAccount.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectSelectAccount/ConnectSelectAccount.tsx
@@ -62,7 +62,14 @@ export const ConnectSelectAccount = () => {
         manualPhase,
         manualAccountIndex,
     } = popupCall;
-    const { selectionType, minCount, maxCount, accountTypeTabs, addressSelection } = options;
+    const {
+        selectionType,
+        minCount,
+        maxCount,
+        accountTypeTabs,
+        addressSelection,
+        requireOnDeviceVerification,
+    } = options;
     // 'manual' is a two-phase flow: pick an account (drill-in, no export), then pick one of its
     // used addresses (the actual export). Every other mode has a single, flat account-index list.
     const isManualAccountPickPhase = addressSelection === 'manual' && manualPhase !== 'address';
@@ -90,12 +97,15 @@ export const ConnectSelectAccount = () => {
     // Selection stays live: it's pure Redux state and touches no device.
     const isDiscovering = pageCandidates.some(c => c.loading);
 
-    // Verification is always available but optional (mirrors ConnectAddressConfirmation) — connecting
-    // only requires a valid selection.
+    // When requireOnDeviceVerification is set (the default), every selected candidate must be
+    // confirmed on the device before it can be exported; otherwise verification stays optional
+    // (mirrors ConnectAddressConfirmation).
+    const allSelectedVerified = selectedCandidates.every(c => c.validated === 'valid');
     const canConfirm =
         selectedCount >= minCount &&
         (maxCount === undefined || selectedCount <= maxCount) &&
-        !isVerifying;
+        !isVerifying &&
+        (!requireOnDeviceVerification || allSelectedVerified);
 
     const toggle = (target: SelectAccountCandidate) => {
         const isTarget = (c: SelectAccountCandidate) =>

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -899,20 +899,30 @@ export const connectPopupResolveSelectAccountThunk = createThunk<void, { confirm
             return;
         }
 
+        const selectedCandidates = call.candidates.filter(c => c.selected && (c.address || c.xpub));
+
+        // Safety net for the confirm gate in ConnectSelectAccount: when the app requires on-device
+        // verification, never export a selection that hasn't been fully verified, even if this thunk
+        // is somehow reached with an unverified candidate.
+        if (
+            call.options.requireOnDeviceVerification &&
+            !selectedCandidates.every(c => c.validated === 'valid')
+        ) {
+            return;
+        }
+
         // Always an array, even for a 'single' selection — mirrors eth_requestAccounts. `address`
         // and `xpub` are mutually exclusive per candidate (see SelectAccountCandidate).
-        const payload = call.candidates
-            .filter(c => c.selected && (c.address || c.xpub))
-            .map(c => ({
-                symbol: c.symbol,
-                path: c.path,
-                address: c.address,
-                xpub: c.xpub,
-                // undefined for custom (non-built-in) account-type tabs — no real AccountType to report
-                accountType: call.options.accountTypeTabs.find(tab => tab.key === c.accountTypeKey)
-                    ?.accountType,
-                mac: c.mac,
-            }));
+        const payload = selectedCandidates.map(c => ({
+            symbol: c.symbol,
+            path: c.path,
+            address: c.address,
+            xpub: c.xpub,
+            // undefined for custom (non-built-in) account-type tabs — no real AccountType to report
+            accountType: call.options.accountTypeTabs.find(tab => tab.key === c.accountTypeKey)
+                ?.accountType,
+            mac: c.mac,
+        }));
 
         // Export: deliver the selection to the 3rd-party app and flip the picker into its `exported`
         // phase, then unblock the methodHook. Do NOT finishCall — keep the modal open so the user can

--- a/suite/e2e/tests/trezor-connect/selectAccount.test.ts
+++ b/suite/e2e/tests/trezor-connect/selectAccount.test.ts
@@ -100,6 +100,50 @@ test.describe('TrezorConnect.selectAccount', { tag: ['@T3T1', '@T3W1', '@desktop
         await connectSelectAccountModal.closeButton.click();
     });
 
+    // Characterization test documenting that `requireOnDeviceVerification` is currently a dead
+    // option: even when the app explicitly requires on-device verification, the picker exposes no
+    // blocking gate — selecting an account is enough to confirm and export, without ever verifying
+    // it on the device. This locks in the present (broken) behaviour so the follow-up fix that wires
+    // the option to an actual gate has a red test to flip.
+    test('requireOnDeviceVerification is not enforced (dead option)', async ({
+        connectPermissionsModal,
+        connectSelectAccountModal,
+    }) => {
+        const res = TrezorConnect.selectAccount({
+            coin: 'eth',
+            selectionType: 'single',
+            requireOnDeviceVerification: true,
+        });
+
+        await connectPermissionsModal.confirmButton.click();
+
+        await expect(connectSelectAccountModal.account(0)).toBeVisible();
+
+        // Selection count is the only gate: disabled with nothing selected, enabled the moment an
+        // account is picked — regardless of verification state.
+        await expect(connectSelectAccountModal.confirmButton).toBeDisabled();
+        await connectSelectAccountModal.checkbox(0).click();
+
+        // Account is selected but never verified on the device...
+        await expect(connectSelectAccountModal.verifiedBadge(0)).not.toBeVisible();
+        // ...yet confirm is enabled despite requireOnDeviceVerification: true — no blocking gate.
+        await expect(connectSelectAccountModal.confirmButton).toBeEnabled();
+
+        await connectSelectAccountModal.confirmButton.click();
+
+        const response = await res;
+        // Export succeeds with an unverified address — the option had no effect.
+        expect(response.success).toBe(true);
+        if (!response.success) return;
+
+        expect(response.payload).toHaveLength(1);
+        const [account] = response.payload;
+        if (!account) return;
+        expect(account.address).toMatch(/^0x[0-9a-fA-F]{40}$/);
+
+        await connectSelectAccountModal.closeButton.click();
+    });
+
     test('cancelling returns a Method_Cancel error', async ({
         connectPermissionsModal,
         connectSelectAccountModal,

--- a/suite/e2e/tests/trezor-connect/selectAccount.test.ts
+++ b/suite/e2e/tests/trezor-connect/selectAccount.test.ts
@@ -100,12 +100,12 @@ test.describe('TrezorConnect.selectAccount', { tag: ['@T3T1', '@T3W1', '@desktop
         await connectSelectAccountModal.closeButton.click();
     });
 
-    // Characterization test documenting that `requireOnDeviceVerification` is currently a dead
-    // option: even when the app explicitly requires on-device verification, the picker exposes no
-    // blocking gate — selecting an account is enough to confirm and export, without ever verifying
-    // it on the device. This locks in the present (broken) behaviour so the follow-up fix that wires
-    // the option to an actual gate has a red test to flip.
-    test('requireOnDeviceVerification is not enforced (dead option)', async ({
+    // With requireOnDeviceVerification set (the default), the picker must not let the user export a
+    // selection until it has been confirmed on the device: selecting alone keeps confirm disabled,
+    // and only verifying the address unlocks it.
+    test('requireOnDeviceVerification blocks confirm until the address is verified', async ({
+        page,
+        device,
         connectPermissionsModal,
         connectSelectAccountModal,
     }) => {
@@ -119,20 +119,22 @@ test.describe('TrezorConnect.selectAccount', { tag: ['@T3T1', '@T3W1', '@desktop
 
         await expect(connectSelectAccountModal.account(0)).toBeVisible();
 
-        // Selection count is the only gate: disabled with nothing selected, enabled the moment an
-        // account is picked — regardless of verification state.
-        await expect(connectSelectAccountModal.confirmButton).toBeDisabled();
+        // Selecting an account is not enough — confirm stays disabled while it is unverified.
         await connectSelectAccountModal.checkbox(0).click();
+        await expect(connectSelectAccountModal.verifiedBadge(0)).toBeHidden();
+        await expect(connectSelectAccountModal.confirmButton).toBeDisabled();
 
-        // Account is selected but never verified on the device...
-        await expect(connectSelectAccountModal.verifiedBadge(0)).not.toBeVisible();
-        // ...yet confirm is enabled despite requireOnDeviceVerification: true — no blocking gate.
+        // Verify the selected address on the device; only then does confirm unlock.
+        await connectSelectAccountModal.verifyButton(0).click();
+        // TODO: 'verifying' is set right after clicking; give the device call time to start.
+        await page.waitForTimeout(1000);
+        await device.pressYes();
+        await expect(connectSelectAccountModal.verifiedBadge(0)).toBeVisible();
         await expect(connectSelectAccountModal.confirmButton).toBeEnabled();
 
         await connectSelectAccountModal.confirmButton.click();
 
         const response = await res;
-        // Export succeeds with an unverified address — the option had no effect.
         expect(response.success).toBe(true);
         if (!response.success) return;
 


### PR DESCRIPTION
## Description

Follow-up to #28831 (`selectAccount` method), targeting its feature branch.

While reviewing #28831 we found that `requireOnDeviceVerification` was effectively a dead option. The schema documents it as defaulting to `true` and the value is plumbed all the way into the picker options (`buildOptions` → `SelectAccountOptions.requireOnDeviceVerification`), but nothing ever read it:

- the confirm gate (`ConnectSelectAccount.tsx`) computed `canConfirm` from the selection count and `!isVerifying` only — never from each candidate's `validated` state;
- the resolve thunk (`connectPopupResolveSelectAccountThunk`) exported whatever was `selected`, without checking verification.

So an app that explicitly required on-device verification got the exact same behaviour as one passing `requireOnDeviceVerification: false`: a selected address could be exported without ever being confirmed on the device.

## Approach

Two commits, so the behavioural change is visible as a red→green test flip:

1. **`test`** — a Playwright characterization test that locks in the original (broken) behaviour: with an explicit `requireOnDeviceVerification: true`, confirm was enabled the moment an account was selected, no verified badge appeared, and export still succeeded. This is the "prove it's a dead option" step (it was green against the parent branch, documenting the bug).
2. **`fix`** — wire the option to a real gate and flip the test:
   - `canConfirm` now additionally requires every selected candidate to be `validated === 'valid'` whenever `requireOnDeviceVerification` is set (the default);
   - a matching safety net in `connectPopupResolveSelectAccountThunk` refuses to deliver an unverified selection even if the thunk is reached directly;
   - when the app opts out (`requireOnDeviceVerification: false`), verification stays optional, mirroring `ConnectAddressConfirmation`.

The verify action is available on every exportable row (`SelectAccountRow` renders it for any candidate carrying an `address`/`xpub`, i.e. both the address and the xpub/full-account flows), so the gate is always satisfiable.

## Related

- Base branch / parent feature: #28831

## Notes for QA

Behavioural change in the `selectAccount` picker:

- With `requireOnDeviceVerification` omitted or `true`: selecting an account/address is no longer enough to Connect — the Connect button stays disabled until each selected entry is verified on the device (tap Verify → confirm on Trezor → the button unlocks). Applies to both the individual-address/EVM flow and the UTXO xpub/full-account flow.
- With `requireOnDeviceVerification: false`: unchanged — verification stays optional and Connect is enabled as soon as a valid selection is made.

Covered by the e2e suite (`@desktopOnly`, `@T3T1`/`@T3W1`).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/select-account-verification-gate&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/select-account-verification-gate&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/select-account-verification-gate&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This changeset modifies the ConnectSelectAccount modal component, the connectPopupThunks (which orchestrates all TrezorConnect popup interactions including permissions, account selection, and lifecycle management), and the selectAccount E2E test itself. The highest risk is in the selectAccount flow which is directly tested. Medium risk exists across all TrezorConnect popup flows (permissions, address export, webextension) since connectPopupThunks is the shared orchestration layer. The two source files map to 129 tests each via static analysis, but this is because they are broadly imported — only TrezorConnect-specific tests have concrete code paths through these components.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectSelectAccount/ConnectSelectAccount.tsx`
- `suite-common/connect-popup/src/connectPopupThunks.ts`
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — This test was directly modified in the changeset and is the primary E2E test for the ConnectSelectAccount component and the selectAccount flow in connectPopupThunks. It exercises multi/single selection, on-device verification, cancellation, privacy (no xpub/publicKey exposure), and modal lifecycle — all of which are directly affected by changes to ConnectSelectAccount.tsx and connectPopupThunks.ts.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — getAccountInfo uses the same select-account modal component (ConnectSelectAccount) and connectPopupThunks flow to let the user pick an account type and account before returning account info. Changes to the account selection modal or thunk logic would directly break this flow.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trezor-connect/permissions.test.ts` — This test exercises the TrezorConnect permissions flow managed by connectPopupThunks (granting, remembering, and revoking permissions). Changes to connectPopupThunks.ts could affect how permissions are dispatched, stored, or revoked.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test covers the full TrezorConnect popup web flow including permissions granting, address confirmation, cancellation, and popup lifecycle — all orchestrated via connectPopupThunks. Changes to thunk logic could affect popup behavior, permission handling, or cancellation flows.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Similar to connectPopupWeb, this test covers the webextension variant of the TrezorConnect popup flow. connectPopupThunks handles the permission and popup lifecycle logic that this test validates, including grant, cancel, and force-close scenarios.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — getAddress tests the connect permissions modal and address confirmation flow, both of which are orchestrated by connectPopupThunks. The verified/error badge behavior and bundle export rely on the thunk dispatching correct actions.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Silent mode interacts with connectPopupThunks for permission management (remember checkbox, silent mode checkbox, connected apps settings). Changes to the thunk's permission handling could break silent mode toggling or focus suppression logic.

</details>

<details><summary>🟢 <b>Low priority (4)</b></summary>

- `suite/e2e/tests/trezor-connect/error.test.ts` — This test validates TrezorConnect error display when an invalid path is provided. The error modal rendering path goes through connectPopupThunks, and changes there could affect how errors are surfaced.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — This test uses the connect permissions modal flow managed by connectPopupThunks. While the sign message modal itself is separate from ConnectSelectAccount, the permissions confirmation step could be affected by thunk changes.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This test exercises the connect permissions modal confirmation flow before transaction signing, which is handled by connectPopupThunks. Changes to the thunk could affect the permissions step.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Similar to ethereumSignTransaction, this test goes through the connect permissions modal managed by connectPopupThunks before signing a Bitcoin transaction.

</details>

_Updated: 2026-07-10T16:26:05.363Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/select-account-verification-gate/web/](https://dev.suite.sldev.cz/suite-web/mroz22/select-account-verification-gate/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T16:29:30.514Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T16:29:29.306Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->