### PR TITLE
Fix unknown tx when using coin selection

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
@@ -13,6 +13,7 @@ import {
     createAccountKey,
 } from '@suite-common/wallet-types';
 import {
+    fetchTransactionForAccount,
     findChainedTransactions,
     getPendingEvmNonceStatus,
     isPending,
@@ -21,6 +22,7 @@ import {
     isTransactionCancellable,
 } from '@suite-common/wallet-utils';
 import { Modal } from '@trezor/components';
+import { useAsyncMemo } from '@trezor/react-utils';
 
 import { useSelector } from 'src/hooks/suite';
 import { useEvmNonceInfo } from 'src/hooks/wallet/useEvmNonceInfo';
@@ -45,6 +47,7 @@ type TxDetailModalProps = {
     deviceState: Account['deviceState'];
     flow: 'detail' | 'bump-fee' | 'cancel-transaction';
     onCancel: () => void;
+    allowFetchFallback?: boolean;
 };
 
 export const TxDetailModal = ({
@@ -54,6 +57,7 @@ export const TxDetailModal = ({
     deviceState,
     flow,
     onCancel,
+    allowFetchFallback,
 }: TxDetailModalProps) => {
     const [section, setSection] = useState<TxDetailModalProps['flow']>(flow);
     const [tab, setTab] = useState<TabID | undefined>(undefined);
@@ -63,9 +67,24 @@ export const TxDetailModal = ({
         networkSymbol: symbol,
         deviceStaticSessionId: deviceState,
     });
-    const originalTx = useSelector(state =>
+
+    const account = useSelector(state => selectAccountByKey(state, accountKey));
+
+    // Try to get the transaction from redux
+    const reducerTx = useSelector(state =>
         selectTransactionByAccountKeyAndTxid(state, accountKey, txid),
     );
+
+    // If it's not there, fetch the transaction from backend
+    const fetchedTx = useAsyncMemo(
+        () =>
+            !reducerTx && account && allowFetchFallback
+                ? fetchTransactionForAccount(txid, account)
+                : Promise.resolve(undefined),
+        [account, reducerTx, txid, allowFetchFallback],
+    );
+
+    const originalTx = reducerTx ?? fetchedTx;
 
     // Filter out internal transfers that are instant staking transactions
     const filteredInternalTransfers = useMemo(() => {
@@ -87,7 +106,6 @@ export const TxDetailModal = ({
         };
     }, [originalTx, filteredInternalTransfers]);
 
-    const account = useSelector(state => selectAccountByKey(state, accountKey));
     const selectedAccount = useSelector(selectWalletSelectedAccount);
     const nonceAccount = account?.networkType === 'ethereum' ? account : undefined;
     const { nonceInfo: fetchedNonceInfo } = useEvmNonceInfo(nonceAccount);

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -7,8 +7,11 @@ import { Translation } from '@suite/intl';
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import { filterAndCategorizeUtxos } from '@suite-common/transaction-search';
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
-import { fetchUtxoTransactionsForAccountThunk } from '@suite-common/wallet-core';
-import { convertAmountUnitsToSubunits, formatNetworkAmount } from '@suite-common/wallet-utils';
+import {
+    convertAmountUnitsToSubunits,
+    fetchUtxoTransactionsForAccount,
+    formatNetworkAmount,
+} from '@suite-common/wallet-utils';
 import {
     Banner,
     Card,
@@ -22,11 +25,12 @@ import {
     Text,
 } from '@trezor/components';
 import { CaretUpIcon, InfoIcon, ShieldCheckIcon, ShieldWarningIcon } from '@trezor/icons';
+import { useAsyncMemo } from '@trezor/react-utils';
 import { spacings, spacingsPx } from '@trezor/theme';
 
 import { FormattedCryptoAmount } from 'src/components/suite';
 import { Pagination } from 'src/components/wallet';
-import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useSelector } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { selectAccountLabelsForSearch } from 'src/selectors/suite/selectAccountLabelsForSearch';
@@ -69,7 +73,6 @@ export const CoinControl = ({ close }: CoinControlProps) => {
     } = useSendFormContext();
     const { outputLabels } = useSelector(state => selectAccountLabelsForSearch(state, account));
     const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
-    const dispatch = useDispatch();
 
     const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
 
@@ -143,17 +146,7 @@ export const CoinControl = ({ close }: CoinControlProps) => {
     const hasEligibleUtxos = spendableUtxos.length + lowAnonymityUtxos.length > 0;
 
     // fetch all transactions so that we can show a transaction timestamp for each UTXO
-    useEffect(() => {
-        const promise = dispatch(
-            fetchUtxoTransactionsForAccountThunk({
-                accountKey: account.key,
-            }),
-        );
-
-        return () => {
-            promise.abort();
-        };
-    }, [account, dispatch]);
+    const utxoTxs = useAsyncMemo(() => fetchUtxoTransactionsForAccount(account), [account]);
 
     const missingToInputValues = {
         amount: <FormattedCryptoAmount value={formattedMissing} symbol={account.symbol} />,
@@ -225,6 +218,7 @@ export const CoinControl = ({ close }: CoinControlProps) => {
                         icon={ShieldCheckIcon}
                         iconIntent="brand"
                         utxos={spendableUtxosOnPage}
+                        utxoTxs={utxoTxs}
                     />
                 )}
                 {!!lowAnonymityUtxosOnPage.length && (
@@ -240,6 +234,7 @@ export const CoinControl = ({ close }: CoinControlProps) => {
                         icon={ShieldWarningIcon}
                         iconIntent="warning"
                         utxos={lowAnonymityUtxosOnPage}
+                        utxoTxs={utxoTxs}
                     />
                 )}
                 {!hasEligibleUtxos && (
@@ -255,6 +250,7 @@ export const CoinControl = ({ close }: CoinControlProps) => {
                         icon={InfoIcon}
                         iconIntent="neutral"
                         utxos={dustUtxosOnPage}
+                        utxoTxs={utxoTxs}
                     />
                 )}
                 {showPagination && (

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
@@ -129,6 +129,7 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
                     symbol: transaction.symbol,
                     deviceState: transaction.deviceState,
                     flow: 'detail',
+                    allowFetchFallback: true,
                 }),
             );
         }

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelectionList.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelectionList.tsx
@@ -3,6 +3,7 @@ import { type ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { selectAccountTransactions } from '@suite-common/wallet-core';
+import type { WalletAccountTransaction } from '@suite-common/wallet-types';
 import {
     Column,
     IconCircle,
@@ -32,6 +33,7 @@ interface UtxoSelectionListProps {
     icon: IconComponent;
     iconIntent?: IconCircleIntent;
     utxos: AccountUtxo[];
+    utxoTxs?: { [txid: string]: WalletAccountTransaction };
     withHeader: boolean;
 }
 
@@ -41,6 +43,7 @@ export const UtxoSelectionList = ({
     icon,
     iconIntent = 'neutral',
     utxos,
+    utxoTxs = {},
     withHeader,
 }: UtxoSelectionListProps) => {
     const { account } = useSendFormContext();
@@ -71,9 +74,11 @@ export const UtxoSelectionList = ({
                 {utxos.map(utxo => (
                     <UtxoSelection
                         key={`${utxo.txid}-${utxo.vout}`}
-                        transaction={accountTransactions.find(
-                            transaction => transaction.txid === utxo.txid,
-                        )}
+                        transaction={
+                            accountTransactions.find(
+                                transaction => transaction.txid === utxo.txid,
+                            ) ?? utxoTxs[utxo.txid]
+                        }
                         utxo={utxo}
                     />
                 ))}

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -66,6 +66,7 @@ export type UserContextPayload =
           descriptor: Account['descriptor'];
           symbol: Account['symbol'];
           deviceState: Account['deviceState'];
+          allowFetchFallback?: boolean;
           flow: 'detail' | 'bump-fee' | 'cancel-transaction';
       }
     | {

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -606,50 +606,6 @@ export const fetchTransactionsPageThunk = createThunk(
     },
 );
 
-type FetchUtxoTransactionsForAccountThunkParams = {
-    accountKey: AccountKey;
-};
-
-export const fetchUtxoTransactionsForAccountThunk = createSingleInstanceThunk(
-    `${TRANSACTIONS_MODULE_PREFIX}/fetchUtxoTransactionsForAccountThunk`,
-    async (
-        { accountKey }: FetchUtxoTransactionsForAccountThunkParams,
-        { dispatch, getState, signal },
-    ) => {
-        const account = selectAccountByKey(getState(), accountKey);
-        if (!account) {
-            throw new Error(`Account not found: ${accountKey}`);
-        }
-
-        if (account.utxo === undefined || account.utxo.length === 0) {
-            return selectAccountTransactions(getState(), accountKey);
-        }
-
-        const result = await TrezorConnect.blockchainGetTransactions({
-            coin: account.symbol,
-            txs: account.utxo.map(utxo => utxo.txid),
-            descriptor: account.descriptor,
-        });
-
-        if (signal.aborted) {
-            throw new Error('Aborted');
-        }
-
-        if (!result.success) {
-            throw new Error(result.error.message);
-        }
-
-        dispatch(
-            transactionsActions.addTransaction({
-                transactions: result.payload,
-                account,
-            }),
-        );
-
-        return selectAccountTransactions(getState(), accountKey);
-    },
-);
-
 /**
  * @param noLoading - disable loading indicator, it's not used directly in this thunk, but it's used in reducer
  */

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -20,7 +20,7 @@ import {
     asBaseCurrencyAmount,
 } from '@suite-common/wallet-types';
 import type { BaseCurrencyCode, TokenStandard } from '@trezor/blockchain-link-types';
-import {
+import TrezorConnect, {
     type AccountAddress,
     type AccountTransaction,
     type InternalTransfer,
@@ -28,7 +28,13 @@ import {
     type TokenTransfer,
 } from '@trezor/connect';
 import { type Branded } from '@trezor/type-utils';
-import { BigNumber, arrayPartition, isNotNullOrUndefined, typedObjectKeys } from '@trezor/utils';
+import {
+    BigNumber,
+    arrayPartition,
+    isNotNullOrUndefined,
+    typedObjectKeys,
+    unique,
+} from '@trezor/utils';
 
 import { convertAmountSubunitsToUnits, formatNetworkAmount } from './amountUtils';
 import { isCardanoStakingTx } from './cardanoStakingUtils';
@@ -1110,3 +1116,25 @@ export const getTxValidityTimeoutInMs = (networkType?: NetworkType) => {
 
     return 0;
 };
+
+const fetchAccountTransactions = async (account: Account, txids: string[]) => {
+    if (!txids.length) return [];
+
+    const response = await TrezorConnect.blockchainGetTransactions({
+        coin: account.symbol,
+        txs: unique(txids),
+        descriptor: account.descriptor,
+    });
+
+    if (!response.success) return [];
+
+    return response.payload.map(tx => enhanceTransaction(tx, account));
+};
+
+export const fetchUtxoTransactionsForAccount = (account: Account) =>
+    fetchAccountTransactions(account, account.utxo?.map(({ txid }) => txid) ?? []).then(txs =>
+        Object.fromEntries(txs.map(tx => [tx.txid, tx])),
+    );
+
+export const fetchTransactionForAccount = (txid: string, account: Account) =>
+    fetchAccountTransactions(account, [txid]).then(([tx]) => tx);

--- a/suite-native/module-send/src/components/CoinControl/UtxoCard.tsx
+++ b/suite-native/module-send/src/components/CoinControl/UtxoCard.tsx
@@ -12,7 +12,7 @@ import {
     selectFiatRatesByFiatRateKey,
     selectTransactionBlockTimeById,
 } from '@suite-common/wallet-core';
-import { type AccountKey } from '@suite-common/wallet-types';
+import { type AccountKey, type WalletAccountTransaction } from '@suite-common/wallet-types';
 import { getFiatRateKey } from '@suite-common/wallet-utils';
 import {
     Card,
@@ -45,6 +45,7 @@ const cardStyle = prepareNativeStyle(utils => ({
 
 export type Props = {
     utxo: Utxo;
+    utxoTx?: WalletAccountTransaction;
     deviceStaticSessionId: StaticSessionId;
     onToggle: (utxo: Utxo) => void;
     accountKey: AccountKey;
@@ -60,6 +61,7 @@ type TransactionDetailNavigation = StackToStackCompositeNavigationProps<
 
 export const UtxoCard = ({
     utxo,
+    utxoTx,
     onToggle,
     deviceStaticSessionId,
     accountKey,
@@ -70,9 +72,13 @@ export const UtxoCard = ({
     const { applyStyle } = useNativeStyles();
     const navigation = useNavigation<TransactionDetailNavigation>();
 
-    const transactionBlockTime = useSelector((state: TransactionsRootState) =>
+    const stateTransactionBlockTime = useSelector((state: TransactionsRootState) =>
         selectTransactionBlockTimeById(state, accountKey, utxo.txid),
     );
+
+    const transactionBlockTime = utxoTx?.blockTime
+        ? utxoTx.blockTime * 1000
+        : stateTransactionBlockTime;
 
     const fiatCurrencyCode = useSelector(selectBaseCurrency);
     const fiatRateKey = getFiatRateKey(symbol, fiatCurrencyCode);

--- a/suite-native/module-send/src/components/CoinControl/UtxoCard.tsx
+++ b/suite-native/module-send/src/components/CoinControl/UtxoCard.tsx
@@ -93,6 +93,7 @@ export const UtxoCard = ({
             params: {
                 txid: utxo.txid,
                 accountKey,
+                allowFetchFallback: true,
             },
         });
     };

--- a/suite-native/module-send/src/components/CoinControl/UtxoList.tsx
+++ b/suite-native/module-send/src/components/CoinControl/UtxoList.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { FlashList } from '@shopify/flash-list';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type AccountKey } from '@suite-common/wallet-types';
+import type { AccountKey, WalletAccountTransaction } from '@suite-common/wallet-types';
 import { isSameUtxo } from '@suite-common/wallet-utils';
 import { Box } from '@suite-native/atoms';
 import { type Utxo } from '@trezor/blockchain-link-types';
@@ -22,6 +22,7 @@ type UtxoListProps = {
     deviceStaticSessionId: StaticSessionId;
     accountKey: AccountKey;
     utxos: Utxo[];
+    utxoTxs?: { [txid: string]: WalletAccountTransaction };
     selectedUtxos: Utxo[];
     onUtxoToggle: (utxo: Utxo) => void;
     symbol: NetworkSymbol;
@@ -31,6 +32,7 @@ export const UtxoList = ({
     deviceStaticSessionId,
     accountKey,
     utxos,
+    utxoTxs = {},
     selectedUtxos,
     onUtxoToggle,
     symbol,
@@ -49,11 +51,12 @@ export const UtxoList = ({
                 onToggle={onUtxoToggle}
                 accountKey={accountKey}
                 utxo={item}
+                utxoTx={utxoTxs[item.txid]}
                 symbol={symbol}
                 deviceStaticSessionId={deviceStaticSessionId}
             />
         ),
-        [accountKey, onUtxoToggle, symbol, isSelected, deviceStaticSessionId],
+        [accountKey, onUtxoToggle, symbol, isSelected, deviceStaticSessionId, utxoTxs],
     );
 
     const rowSeparator = useCallback(() => <Box style={applyStyle(spacerStyle)} />, [applyStyle]);

--- a/suite-native/module-send/src/screens/SendUtxoScreen.tsx
+++ b/suite-native/module-send/src/screens/SendUtxoScreen.tsx
@@ -1,16 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { type TextInput } from 'react-native';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
 import { useFilteredUtxos } from '@suite-common/transaction-search';
-import {
-    type AccountsRootState,
-    fetchUtxoTransactionsForAccountThunk,
-    selectAccountByKey,
-} from '@suite-common/wallet-core';
-import { isSameUtxo } from '@suite-common/wallet-utils';
+import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
+import { fetchUtxoTransactionsForAccount, isSameUtxo } from '@suite-common/wallet-utils';
 import { SearchInput, SearchInputWithCancel, Text, VStack } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 import {
@@ -20,6 +16,7 @@ import {
     type StackProps,
 } from '@suite-native/navigation';
 import { type Utxo } from '@trezor/blockchain-link-types';
+import { useAsyncMemo } from '@trezor/react-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { SendUtxoScreenFooter } from '../components/CoinControl/SendUtxoScreenFooter';
@@ -31,7 +28,6 @@ export const SendUtxoScreen = ({
     route: { params },
 }: StackProps<SendStackParamList, SendStackRoutes.SendUtxo>) => {
     const { accountKey, amount } = params;
-    const dispatch = useDispatch();
 
     const { translate } = useTranslate();
     const navigation = useNavigation();
@@ -48,18 +44,11 @@ export const SendUtxoScreen = ({
     );
     const filteredUtxos = useFilteredUtxos(account?.utxo ?? [], searchQuery);
 
-    // we need to fetch all transactions for the account to have the additional UTXOs data available
-    useEffect(() => {
-        const promise = dispatch(
-            fetchUtxoTransactionsForAccountThunk({
-                accountKey,
-            }),
-        );
-
-        return () => {
-            promise.abort();
-        };
-    }, [accountKey, dispatch]);
+    // fetch transactions referenced by UTXOs so we can show additional UTXO data (e.g., timestamp)
+    const utxoTxs = useAsyncMemo(
+        () => (account ? fetchUtxoTransactionsForAccount(account) : Promise.resolve(undefined)),
+        [account],
+    );
 
     const handleUtxoSelect = (utxo: Utxo) => {
         const exists = tempSelectedUtxos.some(selected => isSameUtxo(selected, utxo));
@@ -131,6 +120,7 @@ export const SendUtxoScreen = ({
                     <UtxoList
                         deviceStaticSessionId={account.deviceState}
                         utxos={filteredUtxos}
+                        utxoTxs={utxoTxs}
                         selectedUtxos={tempSelectedUtxos}
                         onUtxoToggle={handleUtxoSelect}
                         accountKey={accountKey}

--- a/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
+++ b/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
@@ -42,12 +42,20 @@ export const TransactionDetailScreen = ({
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const { CryptoAmountFormatter: cryptoAmountFormatter } = useFormatters();
     const { isDiscreetMode } = useDiscreetMode();
-    const { txid, accountKey, tokenContract, closeActionType = 'back', source } = route.params;
+    const {
+        txid,
+        accountKey,
+        tokenContract,
+        closeActionType = 'back',
+        source,
+        allowFetchFallback,
+    } = route.params;
 
     const { transaction, isPending, tokenTransfer, openInBlockchain } = useTransactionDetails({
         accountKey,
         txid,
         tokenContract,
+        allowFetchFallback,
     });
 
     usePreventRemove(source === 'send', ({ data }) => {

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -544,6 +544,7 @@ export type TransactionDetailStackParamList = {
         closeActionType?: CloseActionType;
         tokenContract?: TokenAddress;
         source?: 'send';
+        allowFetchFallback?: boolean;
     };
     [TransactionDetailStackRoutes.TransactionDetailOverview]: {
         txid: string;

--- a/suite-native/transaction-management/src/hooks/__tests__/useTransactionDetails.test.ts
+++ b/suite-native/transaction-management/src/hooks/__tests__/useTransactionDetails.test.ts
@@ -43,6 +43,7 @@ const buildPreloadedState = (
     transactions: WalletAccountTransaction[] = [confirmedTransaction],
 ) => ({
     wallet: {
+        accounts: [],
         transactions: {
             transactions: { [ACCOUNT_KEY]: transactions },
             fetchStatusDetail: {},

--- a/suite-native/transaction-management/src/hooks/useTransactionDetails.ts
+++ b/suite-native/transaction-management/src/hooks/useTransactionDetails.ts
@@ -2,36 +2,56 @@ import { useSelector } from 'react-redux';
 
 import { getExplorerUrl } from '@suite-common/wallet-config';
 import {
+    type AccountsRootState,
     type ExplorerState,
     type TransactionsRootState,
+    selectAccountByKey,
     selectExplorer,
     selectIsTransactionPending,
     selectTransactionByAccountKeyAndTxid,
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
+import { fetchTransactionForAccount } from '@suite-common/wallet-utils';
 import { useOpenLink } from '@suite-native/link';
 import { type WalletAccountTransaction } from '@suite-native/tokens';
+import { useAsyncMemo } from '@trezor/react-utils';
 
 type UseTransactionDetailsParams = {
     accountKey: AccountKey | null;
     txid: string | null;
     tokenContract?: string;
+    allowFetchFallback?: boolean;
 };
 
 export const useTransactionDetails = ({
     accountKey,
     txid,
     tokenContract,
+    allowFetchFallback,
 }: UseTransactionDetailsParams) => {
     const openLink = useOpenLink();
 
-    const transaction = useSelector((state: TransactionsRootState) =>
+    // Try to get the transaction from redux
+    const reducerTx = useSelector((state: TransactionsRootState) =>
         accountKey && txid
-            ? (selectTransactionByAccountKeyAndTxid(state, accountKey, txid) as
-                  | WalletAccountTransaction
-                  | undefined)
+            ? selectTransactionByAccountKeyAndTxid(state, accountKey, txid)
             : undefined,
     );
+
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+
+    // If it's not there, fetch the transaction from backend
+    const fetchedTx = useAsyncMemo(
+        () =>
+            !reducerTx && account && txid && allowFetchFallback
+                ? fetchTransactionForAccount(txid, account)
+                : Promise.resolve(undefined),
+        [account, reducerTx, txid, allowFetchFallback],
+    );
+
+    const transaction = (fetchedTx ?? reducerTx) as WalletAccountTransaction | null | undefined;
 
     const blockchainExplorer = useSelector((state: ExplorerState) =>
         selectExplorer(state, transaction?.symbol),


### PR DESCRIPTION
## Description

When using coin selection on utxo-based coins, unknown tx is sometimes shown in transaction history. This (together with #29542) should fix it.

## Explanation

In #20479, an optimization was introduced. In coin selection, transaction data (mostly timestamp) are needed for every utxo, and instead of fetching all the transaction history, only the txs related to utxos were fetched and stored to redux. There are two issues with this approach:

1. transactions fetched by `blockchainGetTransactions` method are not analyzed with respect to the specific account, meaning that they are missing `send`/`receive`/`self` classification, targets to be displayed etc. (fixed in #29542)
2. usual `page`/`perPage` parameters are missing in this case, meaning that the transaction is placed to more or less unspecified position in transaction history

As a result of this, whenever utxo transaction is fetched and stored which wasn't already in the reducer, it's shown in transaction history as unknown and at a wrong position forever.

<img width="480" height="300" alt="Snímek obrazovky z 2026-07-06 21-25-06" src="https://github.com/user-attachments/assets/a13a7936-a501-4d90-9642-59da1b6b45ef" />

## Mitigation

With this fix, utxo transactions are still fetched, but propagated to appropriate components instead of stored into reducers, which allows to show their details without polluting transaction history.

Pros:
- No unknown txs in transaction history
- No wrong ordering of transactions in reducers

Cons:
- Transactions are not cached until they're needed again (wasn't implemented up to now anyway)

## PR Anatomy

1. implementing `useAsyncMemo` hook which is later used (separate PR #29595)
2. fetching utxo-related transaction and passing them down the coin-selection-related components instead of storing them into transaction reducer
   - this should fix incorrect ordering of transactions
   - for both desktop and native Suite
3. in transaction details modal/screen, fetch the transaction to display in case it's not already in the reducer
   - without this, it's not possible to open transaction details from utxo list 
   - for both desktop and native Suite
   - `allowFetchFallback` was added and used only in case transaction detail is opened from utxo list, so the blast radius is as small as possible

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes span two main areas: (1) Bitcoin send form CoinControl/UTXO selection components and (2) transaction processing utilities (transactionsThunks, transactionUtils, TxDetailModal). Several files are suite-native only and have no web E2E coverage. The modal.ts type change could affect any modal but is likely a non-breaking type refinement. The testing strategy focuses on tests that directly exercise transaction display, send form with coin control, and transaction detail modals — avoiding the 129-test blast radius of the broadly-shared utility files.

<details><summary><b>Changed files (14)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx`
- `packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx`
- `packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx`
- `packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelectionList.tsx`
- `suite-common/suite-types/src/modal.ts`
- `suite-common/wallet-core/src/transactions/transactionsThunks.ts`
- `suite-common/wallet-utils/src/transactionUtils.ts`
- `suite-native/module-send/src/components/CoinControl/UtxoCard.tsx`
- `suite-native/module-send/src/components/CoinControl/UtxoList.tsx`
- `suite-native/module-send/src/screens/SendUtxoScreen.tsx`
- `suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx`
- `suite-native/navigation/src/navigators.ts`
- `suite-native/transaction-management/src/hooks/__tests__/useTransactionDetails.test.ts`
- `suite-native/transaction-management/src/hooks/useTransactionDetails.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test directly exercises transaction display, pending/confirmed status transitions, and transaction detail modals — all areas touched by changes to transactionsThunks.ts, transactionUtils.ts, and TxDetailModal.tsx. It verifies txid display in the transaction detail modal and transaction list rendering.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test exercises the Bitcoin send form with multiple outputs, OP_RETURN, and coin control components (CoinControl.tsx, UtxoSelection.tsx, UtxoSelectionList.tsx). It also verifies pending transaction display after sending, directly touching the changed send and transaction code paths.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly exercises transaction list rendering, filtering, and searching on a BTC account. Changes to transactionUtils.ts and transactionsThunks.ts could affect how transactions are fetched, processed, and displayed in the transaction overview.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — Transaction export (PDF/CSV/JSON) depends on transactionUtils.ts for transaction data processing. Changes to transaction utility functions could affect the data structure or formatting used during export.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test uses the send form for DOGE which includes CoinControl components. It also verifies device prompt transaction details and error handling on sign, exercising the send flow that includes the changed CoinControl/UtxoSelection components.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test sends LTC with a MimbleWimble peg-out output using the send form's broadcast mode. The CoinControl components are part of the Bitcoin-like send form rendered for LTC, and changes there could affect the send flow.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — CSV import populates the BTC send form with multiple outputs. The CoinControl components are rendered as part of the Bitcoin send form, and changes to UtxoSelection/UtxoSelectionList could affect form rendering.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test labels transaction outputs and exports transactions with labels to CSV. It exercises transaction detail display and output labeling, which depend on transactionUtils.ts for transaction processing and potentially TxDetailModal for viewing transaction details.
- `suite/e2e/tests/wallet/pagination.test.ts` — This test navigates paginated transaction lists on a BTC account. Changes to transactionsThunks.ts could affect how transaction pages are fetched, and transactionUtils.ts changes could affect how transaction addresses are displayed.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test sends regtest BTC and verifies balance updates, which triggers transaction processing via transactionsThunks.ts. While the test focuses on balance display, the underlying transaction fetching and processing is exercised.

</details>

⚠️ **Changes with no test coverage (8)**
- `suite-common/suite-types/src/modal.ts`
- `suite-native/module-send/src/components/CoinControl/UtxoCard.tsx`
- `suite-native/module-send/src/components/CoinControl/UtxoList.tsx`
- `suite-native/module-send/src/screens/SendUtxoScreen.tsx`
- `suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx`
- `suite-native/navigation/src/navigators.ts`
- `suite-native/transaction-management/src/hooks/__tests__/useTransactionDetails.test.ts`
- `suite-native/transaction-management/src/hooks/useTransactionDetails.ts`

_Updated: 2026-07-10T15:11:37.825Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/coin-selection-unknown-tx/web/](https://dev.suite.sldev.cz/suite-web/fix/coin-selection-unknown-tx/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/coin-selection-unknown-tx&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/coin-selection-unknown-tx&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/coin-selection-unknown-tx&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T15:15:07.436Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T15:15:13.047Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->