### PR TITLE
Limit tron claim

### DIFF
--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -54,6 +54,8 @@ export interface TronStakingInfo {
     votes: TronVote[];
     /** Unclaimed voting reward, in Sun. */
     unclaimedReward: string;
+    /** Unix timestamp in seconds of the last voting-reward withdrawal, or 0 if never withdrawn. */
+    latestWithdrawTime: number;
     /** TRX delegated to other accounts for the ENERGY resource, in Sun. */
     delegatedBalanceEnergy: string;
     /** TRX delegated to other accounts for the BANDWIDTH resource, in Sun. */

--- a/packages/suite/src/components/earn/staking/tron/claim/TronClaimAmount.tsx
+++ b/packages/suite/src/components/earn/staking/tron/claim/TronClaimAmount.tsx
@@ -10,8 +10,9 @@ import { useTronStakeContext } from '../TronStakeContext';
 import { TronStakeInfoRow } from '../TronStakeInfoRow';
 
 export const TronClaimAmount = () => {
-    const { account } = useTronStakeContext();
-    const reward = getTronStakingRewards(account);
+    const { account, form } = useTronStakeContext();
+    const snapshotAmount = form.methods.watch('amount');
+    const reward = snapshotAmount || getTronStakingRewards(account);
 
     return (
         <Card paddingType="none">

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx
@@ -1,11 +1,24 @@
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { type Account } from '@suite-common/wallet-types';
-import { getTronStakingRewards } from '@suite-common/wallet-utils';
-import { Box, Button, Card, Column, Row, Text } from '@trezor/components';
+import {
+    getTronRewardClaimCooldownEndsAt,
+    getTronStakingRewards,
+    isTronRewardClaimOnCooldown,
+} from '@suite-common/wallet-utils';
+import {
+    Box,
+    Button,
+    Card,
+    Column,
+    Row,
+    TOOLTIP_DELAY_NONE,
+    Text,
+    Tooltip,
+} from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
-import { BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
+import { BaseCurrencyValue, CountdownTimer, FormattedCryptoAmount } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
 
 interface TronVotingRewardsCardProps {
@@ -14,7 +27,10 @@ interface TronVotingRewardsCardProps {
 
 export const TronVotingRewardsCard = ({ account }: TronVotingRewardsCardProps) => {
     const dispatch = useDispatch();
+
     const rewards = getTronStakingRewards(account);
+    const isClaimOnCooldown = isTronRewardClaimOnCooldown(account);
+    const claimCooldownEndsAt = getTronRewardClaimCooldownEndsAt(account);
 
     if (new BigNumber(rewards).lte(0)) {
         return null;
@@ -52,9 +68,32 @@ export const TronVotingRewardsCard = ({ account }: TronVotingRewardsCardProps) =
                                 />
                             </Text>
                         </Column>
-                        <Button intent="neutral" priority="secondary" onClick={goToClaim}>
-                            <Translation id="TR_STAKE_CLAIM" />
-                        </Button>
+                        <Tooltip
+                            isActive={isClaimOnCooldown}
+                            tooltipMaxWidth={220}
+                            content={
+                                claimCooldownEndsAt !== null && (
+                                    <CountdownTimer
+                                        deadline={claimCooldownEndsAt * 1000}
+                                        message="TR_EARN_TRON_CLAIM_COOLDOWN"
+                                        minUnit="minute"
+                                        unitDisplay="narrow"
+                                    />
+                                )
+                            }
+                            placement="top"
+                            cursor="not-allowed"
+                            delayShow={TOOLTIP_DELAY_NONE}
+                        >
+                            <Button
+                                intent="neutral"
+                                priority="secondary"
+                                onClick={goToClaim}
+                                isDisabled={isClaimOnCooldown}
+                            >
+                                <Translation id="TR_STAKE_CLAIM" />
+                            </Button>
+                        </Tooltip>
                     </Row>
                 </Row>
             </Box>

--- a/suite-common/wallet-utils/src/__tests__/tronStakingUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/tronStakingUtils.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@trezor/blockchain-link-types';
 
 import {
+    TRON_REWARD_CLAIM_COOLDOWN_SECONDS,
     calculateTronFreezeSuggestion,
     getResourceGain,
     getTronAccountTotalStakingBalance,
@@ -14,6 +15,7 @@ import {
     getTronCryptoBalanceWithStaking,
     getTronPendingUnstakeBalance,
     getTronResources,
+    getTronRewardClaimCooldownEndsAt,
     getTronStakingInfo,
     getTronStakingRewards,
     getTronTotalVotingPower,
@@ -21,6 +23,7 @@ import {
     getTronVotes,
     getTronWithdrawableBalance,
     isSupportedTronStakingNetworkSymbol,
+    isTronRewardClaimOnCooldown,
     isTronStakingActive,
 } from '../tronStakingUtils';
 
@@ -36,6 +39,7 @@ const buildStakingInfo = (overrides: Partial<TronStakingInfo> = {}): TronStaking
     availableVotingPower: '0',
     votes: [],
     unclaimedReward: '0',
+    latestWithdrawTime: 0,
     delegatedBalanceEnergy: '0',
     delegatedBalanceBandwidth: '0',
     ...overrides,
@@ -188,6 +192,60 @@ describe('getTronStakingRewards', () => {
             stakingInfo: buildStakingInfo({ unclaimedReward: String(2 * TRX) }),
         });
         expect(getTronStakingRewards(account)).toBe('2');
+    });
+});
+
+describe('Tron reward claim cooldown', () => {
+    beforeEach(() => {
+        jest.spyOn(Date, 'now').mockReturnValue(NOW_SECONDS * 1000);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe('getTronRewardClaimCooldownEndsAt', () => {
+        it('returns null when there is no stakingInfo', () => {
+            expect(getTronRewardClaimCooldownEndsAt(buildTronAccount())).toBe(null);
+        });
+
+        it('returns null when rewards were never withdrawn', () => {
+            const account = buildTronAccount({
+                stakingInfo: buildStakingInfo({ latestWithdrawTime: 0 }),
+            });
+            expect(getTronRewardClaimCooldownEndsAt(account)).toBe(null);
+        });
+
+        it('adds the 24h cooldown to the last withdrawal time', () => {
+            const account = buildTronAccount({
+                stakingInfo: buildStakingInfo({ latestWithdrawTime: NOW_SECONDS }),
+            });
+            expect(getTronRewardClaimCooldownEndsAt(account)).toBe(
+                NOW_SECONDS + TRON_REWARD_CLAIM_COOLDOWN_SECONDS,
+            );
+        });
+    });
+
+    describe('isTronRewardClaimOnCooldown', () => {
+        it('returns false when rewards were never withdrawn', () => {
+            expect(isTronRewardClaimOnCooldown(buildTronAccount())).toBe(false);
+        });
+
+        it('returns true within 24h of the last withdrawal', () => {
+            const account = buildTronAccount({
+                stakingInfo: buildStakingInfo({ latestWithdrawTime: NOW_SECONDS - 100 }),
+            });
+            expect(isTronRewardClaimOnCooldown(account)).toBe(true);
+        });
+
+        it('returns false once the 24h cooldown has passed', () => {
+            const account = buildTronAccount({
+                stakingInfo: buildStakingInfo({
+                    latestWithdrawTime: NOW_SECONDS - TRON_REWARD_CLAIM_COOLDOWN_SECONDS - 1,
+                }),
+            });
+            expect(isTronRewardClaimOnCooldown(account)).toBe(false);
+        });
     });
 });
 

--- a/suite-common/wallet-utils/src/tronStakingUtils.ts
+++ b/suite-common/wallet-utils/src/tronStakingUtils.ts
@@ -67,6 +67,22 @@ export const getTronStakingRewards = (account: Account): string => {
     return sunToTrx(stakingInfo.unclaimedReward, account.symbol);
 };
 
+export const TRON_REWARD_CLAIM_COOLDOWN_SECONDS = 24 * 60 * 60;
+
+export const getTronRewardClaimCooldownEndsAt = (account: Account): number | null => {
+    const stakingInfo = getTronStakingInfo(account);
+    if (!stakingInfo?.latestWithdrawTime) return null;
+
+    return stakingInfo.latestWithdrawTime + TRON_REWARD_CLAIM_COOLDOWN_SECONDS;
+};
+
+export const isTronRewardClaimOnCooldown = (account: Account): boolean => {
+    const cooldownEndsAt = getTronRewardClaimCooldownEndsAt(account);
+    if (cooldownEndsAt === null) return false;
+
+    return Date.now() / 1000 < cooldownEndsAt;
+};
+
 const sumUnstakingBatchesSun = (
     account: Account,
     predicate: (batch: TronUnstakingBatch) => boolean,

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10793,6 +10793,10 @@ export const messages = defineMessages({
         id: 'TR_EARN_TRON_VOTING_REWARDS',
         defaultMessage: 'Voting rewards',
     },
+    TR_EARN_TRON_CLAIM_COOLDOWN: {
+        id: 'TR_EARN_TRON_CLAIM_COOLDOWN',
+        defaultMessage: 'Rewards can be claimed again in {value}.',
+    },
     TR_EARN_TRON_WITHDRAW_READY: {
         id: 'TR_EARN_TRON_WITHDRAW_READY',
         defaultMessage: '{amount} unstaked & ready to be withdrawn',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Disable "Claim" button if claim is on a cooldown
- Show claimable amount during the pending tx (it got reset to 0 as soon as tx was successful but blockbook was still pending)

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29401

## Screenshots:
<img width="656" height="293" alt="image" src="https://github.com/user-attachments/assets/8f5b8cab-934b-47cf-b5b3-db7482ff578f" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on TRX (Tron) staking functionality: TronClaimAmount component, TronVotingRewardsCard component, tronStakingUtils, and related translation keys in messages.ts. There are no E2E tests in the candidate suite that directly cover Tron staking flows (the /earn/tron/* routes are listed in check-links but not functionally tested). The blockbook-api.ts change is a type-level change unlikely to cause UI regressions. The primary risk is that translation key changes in messages.ts could affect other staking flows that share keys, but this is low probability. Most changes are untested at the E2E level.

<details><summary><b>Changed files (6)</b></summary>

- `packages/blockchain-link-types/src/blockbook-api.ts`
- `packages/suite/src/components/earn/staking/tron/claim/TronClaimAmount.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx`
- `suite-common/wallet-utils/src/__tests__/tronStakingUtils.test.ts`
- `suite-common/wallet-utils/src/tronStakingUtils.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — The TronClaimAmount component and TronVotingRewardsCard changes relate to staking claim/rewards UI. While this test covers ADA staking claims specifically, it exercises the staking claim flow pattern (claim rewards button, reward amounts, fee display, toast notifications) that shares UI infrastructure with TRX staking. Changes to messages.ts translation keys used in staking claim flows could affect this test.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — Staking flow shares translation keys from messages.ts. The TronVotingRewardsCard and staking utilities changes could indicate broader staking infrastructure changes that might affect shared staking UI patterns, though ADA staking is a separate code path.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Unstaking flow uses shared staking translation keys from messages.ts. Changes to staking-related translations could affect unstake modal headers and status messages used across all staking networks.

</details>

⚠️ **Changes with no test coverage (5)**
- `packages/blockchain-link-types/src/blockbook-api.ts`
- `packages/suite/src/components/earn/staking/tron/claim/TronClaimAmount.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx`
- `suite-common/wallet-utils/src/__tests__/tronStakingUtils.test.ts`
- `suite-common/wallet-utils/src/tronStakingUtils.ts`

_Updated: 2026-07-07T14:20:20.369Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/limit-tron-claim&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/limit-tron-claim&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/limit-tron-claim&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-07T14:26:25.327Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-07T14:23:44.811Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->