### PR TITLE
fix(suite-native): remove last no-op step of completed deposit

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2765,7 +2765,6 @@ export const messages = {
             approvalStepTitle: 'Select amount & approve',
             modalTitle: 'Deposit',
             depositTransactionStepTitle: 'Deposit transaction',
-            depositCompleteStepTitle: 'Deposit complete',
             depositPendingTitle: 'Confirming deposit',
             amountToDeposit: 'Amount to deposit',
             depositMax: 'Deposit max',

--- a/suite-native/module-earn/src/components/YieldDepositStepCard.tsx
+++ b/suite-native/module-earn/src/components/YieldDepositStepCard.tsx
@@ -38,13 +38,9 @@ const steps = [
         id: 'deposit',
         label: <Translation id="earn.yieldDepositFlowScreen.depositTransactionStepTitle" />,
     },
-    {
-        id: 'complete',
-        label: <Translation id="earn.yieldDepositFlowScreen.depositCompleteStepTitle" />,
-    },
 ] as const satisfies EarnModalStep[];
 
-type YieldDepositStepIndex = 0 | 1 | 2;
+type YieldDepositStepIndex = 0 | 1;
 
 type YieldDepositStepCardProps = {
     currentStepIndex: YieldDepositStepIndex;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As GH issue suggest, removing the last no-op step for earn deposit flow.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29522

## Screenshots:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-07-07 at 16 29 06" src="https://github.com/user-attachments/assets/ee847297-e132-4924-8f66-e6406017f952" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/rm-earn-native-deposit-step&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->