### PR TITLE
fix(suite): disable all tracing integrations before analytics enabled

### DIFF
--- a/packages/suite-desktop-core/src/libs/sentry.ts
+++ b/packages/suite-desktop-core/src/libs/sentry.ts
@@ -19,6 +19,7 @@ interface InitSentryParams {
 
 const ELECTRON_MAIN_SENTRY_CONFIG = {
     ...SENTRY_CONFIG,
+    // Important: must be a function to keep default Sentry integrations; an array would mean ONLY those specific integrations.
     integrations: defaults => [
         ...defaults.filter(i => i.name !== 'MainProcessSession'),
         captureConsoleIntegration({ levels: ['error'] }),

--- a/packages/suite-desktop-ui/src/sentry.ts
+++ b/packages/suite-desktop-ui/src/sentry.ts
@@ -1,10 +1,10 @@
 import { type BrowserOptions, init } from '@sentry/electron/renderer';
 
-import { SENTRY_BROWSER_CONFIG } from '@suite/sentry';
+import { SENTRY_BROWSER_CONFIG, getCommonBrowserIntegrations } from '@suite/sentry';
 
 const ELECTRON_RENDERER_SENTRY_CONFIG = {
     ...SENTRY_BROWSER_CONFIG,
-    integrations: defaults => [...defaults, ...SENTRY_BROWSER_CONFIG.integrations],
+    integrations: defaults => [...defaults, ...getCommonBrowserIntegrations()],
 } satisfies BrowserOptions;
 
 export const initSentry = () => {

--- a/packages/suite-desktop-ui/src/sentry.ts
+++ b/packages/suite-desktop-ui/src/sentry.ts
@@ -4,6 +4,7 @@ import { SENTRY_BROWSER_CONFIG, getCommonBrowserIntegrations } from '@suite/sent
 
 const ELECTRON_RENDERER_SENTRY_CONFIG = {
     ...SENTRY_BROWSER_CONFIG,
+    // Important: must be a function to keep default Sentry integrations; an array would mean ONLY those specific integrations.
     integrations: defaults => [...defaults, ...getCommonBrowserIntegrations()],
 } satisfies BrowserOptions;
 

--- a/packages/suite-web/src/sentry.ts
+++ b/packages/suite-web/src/sentry.ts
@@ -1,12 +1,12 @@
 import { type BrowserOptions, init } from '@sentry/browser';
 
-import { SENTRY_BROWSER_CONFIG } from '@suite/sentry';
+import { SENTRY_BROWSER_CONFIG, getCommonBrowserIntegrations } from '@suite/sentry';
 
 const BROWSER_SENTRY_CONFIG: BrowserOptions = {
     ...SENTRY_BROWSER_CONFIG,
     integrations: defaults => [
         ...defaults.filter(i => i.name !== 'BrowserSession'),
-        ...SENTRY_BROWSER_CONFIG.integrations,
+        ...getCommonBrowserIntegrations(),
     ],
 };
 

--- a/packages/suite-web/src/sentry.ts
+++ b/packages/suite-web/src/sentry.ts
@@ -4,6 +4,7 @@ import { SENTRY_BROWSER_CONFIG, getCommonBrowserIntegrations } from '@suite/sent
 
 const BROWSER_SENTRY_CONFIG: BrowserOptions = {
     ...SENTRY_BROWSER_CONFIG,
+    // Important: must be a function to keep default Sentry integrations; an array would mean ONLY those specific integrations.
     integrations: defaults => [
         ...defaults.filter(i => i.name !== 'BrowserSession'),
         ...getCommonBrowserIntegrations(),

--- a/packages/suite/src/utils/suite/sentry.ts
+++ b/packages/suite/src/utils/suite/sentry.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/core';
 
-import { setShouldCaptureBrowserTracing } from '@suite/sentry';
+import { setAnalyticsConfirmedAndEnabled } from '@suite/sentry';
 import { selectAnalyticsInstanceId } from '@suite-common/analytics-redux';
 import { selectSelectedDevice } from '@suite-common/device';
 import { redactDevice, redactDiscovery, selectRedactedActionsLog } from '@suite-common/logger';
@@ -28,7 +28,7 @@ export const captureSentryMessage = Sentry.captureMessage;
 export const allowSentryReport = (value: boolean) => {
     Sentry.setTag(ALLOW_REPORT_TAG, value);
     // synchronize the newly set value to localStorage (`value` may have been also be retrieved from IDB, which effectively synces it)
-    setShouldCaptureBrowserTracing(value);
+    setAnalyticsConfirmedAndEnabled(value);
 };
 
 export const setSentryUser = (instanceId: string) => {

--- a/suite-native/sentry/src/sentry.ts
+++ b/suite-native/sentry/src/sentry.ts
@@ -31,6 +31,7 @@ export const initSentry = () => {
         dsn: 'https://d473f56df60c4974ae3f3ce00547c2a9@o117836.ingest.sentry.io/4504214699245568',
         enableAutoSessionTracking: false,
         environment: isDetoxTestBuild() ? 'test' : getEnv(),
+        // Important: must be a function to keep default Sentry integrations; an array would mean ONLY those specific integrations.
         integrations: defaults => [
             // remove consoleLoggingIntegration, which sends console.errors as logs
             ...defaults.filter(i => i.name !== 'ConsoleLogs'),

--- a/suite/sentry/src/config.ts
+++ b/suite/sentry/src/config.ts
@@ -89,6 +89,7 @@ const beforeBreadcrumb: Options['beforeBreadcrumb'] = breadcrumb => {
 
 const isProd = isCodesignBuild();
 
+// Common Sentry config for all Suite Desktop & Web envs
 export const SENTRY_CONFIG = {
     dsn: 'https://6d91ca6e6a5d4de7b47989455858b5f6@o117836.ingest.sentry.io/5193825',
 
@@ -108,6 +109,7 @@ export const SENTRY_CONFIG = {
     },
 } satisfies Options;
 
+// Common Sentry config for Suite browser-based envs (i.e. Web & Electron Renderer, but not Electron Main)
 export const SENTRY_BROWSER_CONFIG = {
     ...SENTRY_CONFIG,
     profileSessionSampleRate: isProd ? 0.1 : 1,
@@ -115,11 +117,7 @@ export const SENTRY_BROWSER_CONFIG = {
     profileLifecycle: 'trace',
 } satisfies BrowserOptions;
 
-/**
- * Get a list of extra Sentry integrations that should be added on top of the default ones for browser-based envs.
- * Warning: if you set integrations[] as the final config, it erases default integrations → must be a function,
- * as in packages/suite-web/src/sentry.ts or packages/suite-desktop-ui/src/sentry.ts
- */
+// Get Sentry integrations common for Suite browser-based envs, that should be added on top of the default ones.
 export const getCommonBrowserIntegrations = () => {
     const areAnalyticsConfirmedAndEnabled = getAnalyticsConfirmedAndEnabled();
 

--- a/suite/sentry/src/config.ts
+++ b/suite/sentry/src/config.ts
@@ -17,8 +17,8 @@ import { isDevEnv } from '@suite-common/suite-utils';
 import { isCodesignBuild } from '@trezor/env-utils';
 import { redactUserPathFromString } from '@trezor/utils';
 
+import { getAnalyticsConfirmedAndEnabled } from './consent';
 import { ignoreErrors } from './ignoreErrors';
-import { tracesSampler } from './traces';
 
 /**
  * Full user path could be part of reported error in some cases and we want to actively filter username out.
@@ -111,13 +111,31 @@ export const SENTRY_CONFIG = {
 export const SENTRY_BROWSER_CONFIG = {
     ...SENTRY_CONFIG,
     profileSessionSampleRate: isProd ? 0.1 : 1,
-    // In our case, `tracesSampler` is used only to drop traces based on arbitrary condition (similarly to `beforeSend` for error events)
-    tracesSampler,
+    tracesSampleRate: isProd ? 0.1 : 1,
     profileLifecycle: 'trace',
-    integrations: [
-        captureConsoleIntegration({ levels: ['error'] }),
-        browserProfilingIntegration(),
-        browserTracingIntegration(),
-        elementTimingIntegration(),
-    ],
 } satisfies BrowserOptions;
+
+/**
+ * Get a list of extra Sentry integrations that should be added on top of the default ones for browser-based envs.
+ * Warning: if you set integrations[] as the final config, it erases default integrations → must be a function,
+ * as in packages/suite-web/src/sentry.ts or packages/suite-desktop-ui/src/sentry.ts
+ */
+export const getCommonBrowserIntegrations = () => {
+    const areAnalyticsConfirmedAndEnabled = getAnalyticsConfirmedAndEnabled();
+
+    return [
+        captureConsoleIntegration({ levels: ['error'] }),
+        /*
+         Unless explicit analytics consent was persisted from before, don't start with tracing & profiling integrations.
+         This means that after you accept analytics on your first session, tracing & profiling is still off until app is
+         reloaded, but that's an acceptable cost – most important is to make sure nothing gets through rejected consent.
+        */
+        ...(areAnalyticsConfirmedAndEnabled
+            ? [
+                  browserProfilingIntegration(),
+                  browserTracingIntegration(),
+                  elementTimingIntegration(),
+              ]
+            : []),
+    ] satisfies BrowserOptions['integrations'];
+};

--- a/suite/sentry/src/consent.ts
+++ b/suite/sentry/src/consent.ts
@@ -1,10 +1,3 @@
-import type { BrowserOptions } from '@sentry/browser';
-
-import { isCodesignBuild } from '@trezor/env-utils';
-
-const isProd = isCodesignBuild();
-const DEFAULT_TRACES_SAMPLE_RATE = isProd ? 0.1 : 1;
-
 const STORAGE_KEY = 'analytics-confirmed-and-enabled';
 
 /**
@@ -17,20 +10,9 @@ const STORAGE_KEY = 'analytics-confirmed-and-enabled';
  *
  * Known issue: the first fresh app load will not emit trace, that is due to design (need to confirm analytics first).
  */
-export const setShouldCaptureBrowserTracing = (newValue: boolean) => {
+export const setAnalyticsConfirmedAndEnabled = (newValue: boolean) => {
     localStorage.setItem(STORAGE_KEY, String(newValue));
 };
 
-export const getShouldCaptureBrowserTracing = (): boolean =>
+export const getAnalyticsConfirmedAndEnabled = (): boolean =>
     localStorage.getItem(STORAGE_KEY) === 'true';
-
-/**
- * Drop Sentry tracing & profiling when analytics are not explicitly enabled, by dynamically setting the sample rate.
- * As per Sentry docs, that is the recommended way for arbitrary traces filtering.
- */
-export const tracesSampler: NonNullable<BrowserOptions['tracesSampler']> = samplingContext => {
-    const shouldCaptureBrowserTracing = getShouldCaptureBrowserTracing();
-    if (shouldCaptureBrowserTracing !== true) return 0;
-
-    return samplingContext.inheritOrSampleWith(DEFAULT_TRACES_SAMPLE_RATE);
-};

--- a/suite/sentry/src/index.ts
+++ b/suite/sentry/src/index.ts
@@ -1,2 +1,2 @@
-export { SENTRY_CONFIG, SENTRY_BROWSER_CONFIG } from './config';
-export { getShouldCaptureBrowserTracing, setShouldCaptureBrowserTracing } from './traces';
+export { SENTRY_CONFIG, SENTRY_BROWSER_CONFIG, getCommonBrowserIntegrations } from './config';
+export { getAnalyticsConfirmedAndEnabled, setAnalyticsConfirmedAndEnabled } from './consent';


### PR DESCRIPTION
## Description

Different solution for turning off tracing & profiling, because it turns out, that the `tracesSampler` from #29168 doesn't work. Somehow, the filter is reliable on localhost, but on sldev deployments traces pass through rejected consent, which is unacceptable.

→ simpler, more brutish solution that is definitely reliable: just don't load the integrations if there isn't persisted consent.

:information_source: This means traces will never be available on the first session – only after reloading Suite Web or restarting Suite Desktop
The previous solution was meant to drop the "initial page load" trace, but after analytics consent, other traces from that session would be available. Now we're losing slightly more data, but whatever, the privacy comes first, we'll surely have enough data from subsequent sessions :slightly_smiling_face: 

## Notes for QA

Copied from #29168 and updated:

Most important case that no sentry trace is sent before analytics confirmation, and none after rejecting the analytics.
 
On Suite Web you may open devtools → network tab → Fetch/XHR → filter for `sentry.io`.
Before confirmation, only errror events, **nothing else!**

On Suite Desktop Sentry network traffic is not observable in devtools, [only on Sentry dashboard](https://satoshilabs.sentry.io/explore/profiles/?environment=develop&project=5193825&statsPeriod=1h). There you can find your session in traces, if they are enabled. [Example for this branch on Web](https://satoshilabs.sentry.io/insights/summary/profiles/?environment=develop&project=5193825&statsPeriod=1h&transaction=%2Fsuite-web%2Ffix%2Fsentry-tracing-with-analytics-off%2Fweb%2Fstart%2F) 

## Related Issue

Resolve #28998

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are entirely within Sentry error-reporting infrastructure: configuration, consent handling, and platform-specific initialization (web, desktop-core, desktop-ui, native). These are global utilities that map to 121+ tests via static coverage but have no test that directly exercises Sentry behavior. The risk is primarily around app initialization failures (broken Sentry init could crash the app) and analytics consent coupling (Sentry consent is typically tied to analytics opt-in/out). A small set of tests covering app startup, analytics consent toggling, and settings changes provides sufficient confidence. Most E2E tests would only fail if Sentry changes cause a hard crash during initialization.

<details><summary><b>Changed files (8)</b></summary>

- `packages/suite-desktop-core/src/libs/sentry.ts`
- `packages/suite-desktop-ui/src/sentry.ts`
- `packages/suite-web/src/sentry.ts`
- `packages/suite/src/utils/suite/sentry.ts`
- `suite-native/sentry/src/sentry.ts`
- `suite/sentry/src/config.ts`
- `suite/sentry/src/consent.ts`
- `suite/sentry/src/index.ts`

</details>

**Recommended tests (4)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/analytics/toggle.test.ts` — Sentry consent is closely tied to analytics consent. The changed files include suite/sentry/src/consent.ts which likely governs when Sentry error reporting is enabled/disabled based on user analytics preferences. This test exercises enabling/disabling analytics during onboarding and in settings, which is the most direct user-facing flow that would interact with Sentry consent logic.
- `suite/e2e/tests/analytics/events.test.ts` — This test validates that analytics events (including SuiteReady) fire correctly when analytics is enabled/disabled. Since Sentry consent is typically coupled with analytics consent, changes to sentry consent logic could affect the initialization path that also controls analytics event dispatch.
- `suite/e2e/tests/suite/initial-run.test.ts` — Sentry initialization happens during app startup, and sentry config/consent changes could cause crashes or errors during the initial run flow. This test validates that the app loads correctly through onboarding across page reloads, which would catch any initialization-time errors from broken Sentry setup.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — This test toggles the analytics/data usage switch in settings, which is the primary UI for controlling Sentry consent. If the consent module change breaks the toggle behavior, this test would catch it through the analytics toggle assertion.

</details>

⚠️ **Changes with no test coverage (6)**
- `packages/suite-desktop-core/src/libs/sentry.ts`
- `packages/suite-desktop-ui/src/sentry.ts`
- `suite-native/sentry/src/sentry.ts`
- `suite/sentry/src/config.ts`
- `suite/sentry/src/consent.ts`
- `suite/sentry/src/index.ts`

_Updated: 2026-07-08T11:39:55.783Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/sentry-tracing-with-analytics-off/web/](https://dev.suite.sldev.cz/suite-web/fix/sentry-tracing-with-analytics-off/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sentry-tracing-with-analytics-off&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sentry-tracing-with-analytics-off&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/sentry-tracing-with-analytics-off&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-08T11:45:39.079Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T11:43:39.303Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->