### PR TITLE
fix(suite-native): stablecoin-yield redeem fee guard and cold-start resolution alert

### DIFF
--- a/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts
+++ b/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts
@@ -241,7 +241,8 @@ export const useResolvedYieldFlowData = ({
     displayError = true,
     yieldId,
 }: YieldFlowProps) => {
-    const { data: yieldOpportunities } = useAllYieldOpportunities();
+    const { data: yieldOpportunities, isFetching: isFetchingYieldOpportunities } =
+        useAllYieldOpportunities();
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
@@ -268,6 +269,7 @@ export const useResolvedYieldFlowData = ({
     useEffect(() => {
         if (
             !displayError ||
+            isFetchingYieldOpportunities ||
             resolvedFlowData.resolutionStatus === 'resolved' ||
             hasDisplayedAlertRef.current
         ) {
@@ -283,7 +285,14 @@ export const useResolvedYieldFlowData = ({
             primaryButtonTitle: translate('generic.buttons.close'),
             onPressPrimaryButton: handleGoBack,
         });
-    }, [displayError, handleGoBack, resolvedFlowData.resolutionStatus, showAlert, translate]);
+    }, [
+        displayError,
+        handleGoBack,
+        isFetchingYieldOpportunities,
+        resolvedFlowData.resolutionStatus,
+        showAlert,
+        translate,
+    ]);
 
     return resolvedFlowData;
 };

--- a/suite-native/module-earn/src/utils/deviceTransactionUtils.ts
+++ b/suite-native/module-earn/src/utils/deviceTransactionUtils.ts
@@ -1,6 +1,6 @@
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { type Account, AddressDisplayOptions } from '@suite-common/wallet-types';
-import { getAccountIdentity } from '@suite-common/wallet-utils';
+import { getAccountIdentity, getMevProtectedTxData } from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
 
 type SignYieldTransactionOnDeviceParams = {
@@ -32,11 +32,16 @@ export const signYieldTransactionOnDevice = ({
 type PushYieldTransactionParams = {
     tx: string;
     account: Account;
+    isMevProtectionEnabled: boolean;
 };
 
-export const pushYieldTransaction = ({ tx, account }: PushYieldTransactionParams) =>
+export const pushYieldTransaction = ({
+    tx,
+    account,
+    isMevProtectionEnabled,
+}: PushYieldTransactionParams) =>
     TrezorConnect.pushTransaction({
-        tx,
+        tx: getMevProtectedTxData(account.symbol, tx, isMevProtectionEnabled),
         coin: account.symbol,
         identity: getAccountIdentity(account),
     });

--- a/suite-native/module-earn/src/wrappedNativeTokenThunks.test.ts
+++ b/suite-native/module-earn/src/wrappedNativeTokenThunks.test.ts
@@ -46,7 +46,9 @@ const pushTransactionMock = TrezorConnect.pushTransaction as jest.Mock;
 
 const buildStore = (storeAccount: Account) =>
     configureMockStore({
-        preloadedState: { wallet: { accounts: [storeAccount] } },
+        preloadedState: {
+            wallet: { accounts: [storeAccount], settings: { mevProtection: false } },
+        },
     });
 
 const getTrackedTokenUpdates = (store: ReturnType<typeof buildStore>) =>

--- a/suite-native/module-earn/src/wrappedNativeTokenThunks.ts
+++ b/suite-native/module-earn/src/wrappedNativeTokenThunks.ts
@@ -1,11 +1,13 @@
 import { selectSelectedDevice } from '@suite-common/device';
 import { buildStablecoinYieldTransactionReview } from '@suite-common/earn-stablecoin';
+import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import { createThunk } from '@suite-common/redux-utils';
 import {
     type WrappedNativeFlowType,
     type YieldFlowDisplayToken,
     isWrappedNativeFlowSupported,
     selectAddressDisplayType,
+    selectIsMevProtectionEnabled,
     synchronizeSentTransactionThunk,
     trackWrappedNativeTokenThunk,
 } from '@suite-common/wallet-core';
@@ -134,10 +136,13 @@ export const pushWrappedNativeTokenThunk = createThunk<
     { rejectValue: WrappedNativeTokenPushError }
 >(
     `${WRAPPED_NATIVE_TOKEN_THUNK_PREFIX}/push`,
-    async ({ account, flowType, signedTransaction }, { dispatch, rejectWithValue }) => {
+    async ({ account, flowType, signedTransaction }, { dispatch, getState, rejectWithValue }) => {
         const pushResponse = await pushYieldTransaction({
             tx: signedTransaction.serializedTx,
             account,
+            isMevProtectionEnabled:
+                selectIsMevProtectionEnabled(getState()) &&
+                selectIsMevProtectionFeatureEnabled(getState()),
         });
 
         if (!pushResponse.success) {

--- a/suite-native/module-earn/src/yieldClaimThunks.test.ts
+++ b/suite-native/module-earn/src/yieldClaimThunks.test.ts
@@ -40,6 +40,7 @@ jest.mock('@suite-common/wallet-core', () => ({
         type: 'test/synchronizeSentTransactionThunk',
         payload: params,
     })),
+    selectIsMevProtectionEnabled: () => false,
 }));
 
 const STATIC_SESSION_ID: StaticSessionId = '1stTestnetAddress@device_id:0';
@@ -184,7 +185,7 @@ describe('pushYieldClaimReviewThunk', () => {
 
         expect(result).toEqual({ ok: true, txid: '0xpushedtxid' });
         expect(pushTransactionMock).toHaveBeenCalledWith({
-            tx: '0xsignedtx',
+            tx: { hex: '0xsignedtx', disableAlternativeRPC: true },
             coin: account.symbol,
             identity: account.deviceState,
         });

--- a/suite-native/module-earn/src/yieldClaimThunks.ts
+++ b/suite-native/module-earn/src/yieldClaimThunks.ts
@@ -1,11 +1,13 @@
 import { selectSelectedDevice } from '@suite-common/device';
 import { buildClaimTransactionReview } from '@suite-common/earn-stablecoin';
+import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import { createThunk } from '@suite-common/redux-utils';
 import {
     formDraftActions,
     isYieldTxReviewForFlow,
     selectAddressDisplayType,
     selectDeepCopyOfFormDraft,
+    selectIsMevProtectionEnabled,
     selectStablecoinYieldSession,
     selectStablecoinYieldTxReview,
     stablecoinYieldActions,
@@ -208,6 +210,9 @@ export const pushYieldClaimReviewThunk = createThunk<
         const pushResponse = await pushYieldTransaction({
             tx: serializedTx.tx,
             account,
+            isMevProtectionEnabled:
+                selectIsMevProtectionEnabled(getState()) &&
+                selectIsMevProtectionFeatureEnabled(getState()),
         });
 
         dispatch(stablecoinYieldActions.discardTransaction());

--- a/suite-native/module-earn/src/yieldTransactionThunks.test.ts
+++ b/suite-native/module-earn/src/yieldTransactionThunks.test.ts
@@ -50,6 +50,7 @@ jest.mock('@suite-common/wallet-core', () => ({
         type: 'test/synchronizeSentTransactionThunk',
         payload: params,
     })),
+    selectIsMevProtectionEnabled: () => false,
 }));
 
 const STATIC_SESSION_ID: StaticSessionId = '1stTestnetAddress@device_id:0';
@@ -220,7 +221,7 @@ describe('pushYieldActionReviewThunk', () => {
 
         expect(result).toEqual({ ok: true, txid: '0xpushedtxid' });
         expect(pushTransactionMock).toHaveBeenCalledWith({
-            tx: '0xsignedtx',
+            tx: { hex: '0xsignedtx', disableAlternativeRPC: true },
             coin: account.symbol,
             identity: account.deviceState,
         });

--- a/suite-native/module-earn/src/yieldTransactionThunks.ts
+++ b/suite-native/module-earn/src/yieldTransactionThunks.ts
@@ -7,6 +7,7 @@ import {
     type YieldPositionFlowType,
     isStablecoinYieldSupported,
     isYieldTxReviewForFlow,
+    isYieldWithdrawFlow,
     selectAddressDisplayType,
     selectStablecoinYieldSession,
     selectStablecoinYieldTxReview,
@@ -67,7 +68,7 @@ export const signYieldActionReviewThunk = createThunk<
             });
         }
 
-        if (flowType === 'withdraw' && !selectedFee) {
+        if (isYieldWithdrawFlow(flowType) && !selectedFee) {
             return rejectWithValue({
                 error: 'sign-transaction-failed',
                 message: 'Fee information is missing for the transaction.',

--- a/suite-native/module-earn/src/yieldTransactionThunks.ts
+++ b/suite-native/module-earn/src/yieldTransactionThunks.ts
@@ -1,5 +1,6 @@
 import { selectSelectedDevice } from '@suite-common/device';
 import { buildStablecoinYieldTransactionReview } from '@suite-common/earn-stablecoin';
+import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import { createThunk } from '@suite-common/redux-utils';
 import {
     type YieldFlowDisplayToken,
@@ -9,6 +10,7 @@ import {
     isYieldTxReviewForFlow,
     isYieldWithdrawFlow,
     selectAddressDisplayType,
+    selectIsMevProtectionEnabled,
     selectStablecoinYieldSession,
     selectStablecoinYieldTxReview,
     stablecoinYieldActions,
@@ -194,6 +196,9 @@ export const pushYieldActionReviewThunk = createThunk<
         const pushResponse = await pushYieldTransaction({
             tx: serializedTx.tx,
             account: flowData.account,
+            isMevProtectionEnabled:
+                selectIsMevProtectionEnabled(getState()) &&
+                selectIsMevProtectionFeatureEnabled(getState()),
         });
 
         dispatch(stablecoinYieldActions.discardTransaction());


### PR DESCRIPTION
## Description

- do not show yield not available for a sec
- apply MEV protection

## Notes for QA

- **Redeem:** open a vault position, choose Redeem (shares), pick a fee, confirm the fee in review matches the device and the broadcast. Regular Withdraw/Deposit unchanged.
- **Loading race:** cold-start the app and open a yield screen directly (deep link/notification) before visiting the Earn list — it should wait for opportunities to load, not flash "Yield not available" and bounce back. A genuinely unavailable vault should still alert after loading.
- **MEV:** with MEV protection ON and OFF, run a deposit / withdraw / redeem / claim and confirm each broadcasts and confirms successfully in both states.

Resolve #31627


## Screenshots:

N/A — no visual changes.

