### PR TITLE
`getTransactions` with analyzed transactions

### DIFF
--- a/packages/blockchain-link-types/src/messages.ts
+++ b/packages/blockchain-link-types/src/messages.ts
@@ -46,7 +46,7 @@ export interface GetAccountUtxo {
 
 export interface GetTransaction {
     type: typeof MESSAGES.GET_TRANSACTION;
-    payload: string;
+    payload: { txid: string; descriptor?: string };
 }
 
 export interface GetTransactionHex {

--- a/packages/blockchain-link/src/ui/index.ui.ts
+++ b/packages/blockchain-link/src/ui/index.ui.ts
@@ -64,7 +64,7 @@ const handleClick = (event: MouseEvent) => {
         case 'get-tx': {
             try {
                 blockchain
-                    .getTransaction(getInputValue('get-tx-id'))
+                    .getTransaction({ txid: getInputValue('get-tx-id') })
                     .then(onResponse)
                     .catch(onError);
             } catch (error) {

--- a/packages/blockchain-link/src/workers/blockbook/index.ts
+++ b/packages/blockchain-link/src/workers/blockbook/index.ts
@@ -126,7 +126,7 @@ const getFiatRatesTickersList = async (request: Request<MessageTypes.GetFiatRate
 
 const getTransaction = async (request: Request<MessageTypes.GetTransaction>) => {
     const api = await request.connect();
-    const rawtx = await api.getTransaction(request.payload);
+    const rawtx = await api.getTransaction(request.payload.txid);
     const tx = utils.transformTransaction(rawtx);
 
     return {

--- a/packages/blockchain-link/src/workers/blockbook/index.ts
+++ b/packages/blockchain-link/src/workers/blockbook/index.ts
@@ -126,8 +126,13 @@ const getFiatRatesTickersList = async (request: Request<MessageTypes.GetFiatRate
 
 const getTransaction = async (request: Request<MessageTypes.GetTransaction>) => {
     const api = await request.connect();
-    const rawtx = await api.getTransaction(request.payload.txid);
-    const tx = utils.transformTransaction(rawtx);
+    const { txid, descriptor } = request.payload;
+    const rawtx = await api.getTransaction(txid);
+    const account = descriptor ? request.state.getAccount(descriptor) : undefined;
+    const tx = utils.transformTransaction(
+        rawtx,
+        account?.addresses ?? account?.descriptor ?? descriptor,
+    );
 
     return {
         type: RESPONSES.GET_TRANSACTION,

--- a/packages/blockchain-link/src/workers/blockfrost/index.ts
+++ b/packages/blockchain-link/src/workers/blockfrost/index.ts
@@ -56,8 +56,13 @@ const getAccountBalanceHistory = async (
 
 const getTransaction = async (request: Request<MessageTypes.GetTransaction>) => {
     const api = await request.connect();
-    const txData = await api.getTransaction(request.payload.txid);
-    const tx = transformTransaction({ txData });
+    const { txid, descriptor } = request.payload;
+    const txData = await api.getTransaction(txid);
+    const account = descriptor ? request.state.getAccount(descriptor) : undefined;
+    const tx = transformTransaction(
+        { txData },
+        account?.addresses ?? account?.descriptor ?? descriptor,
+    );
 
     return {
         type: RESPONSES.GET_TRANSACTION,

--- a/packages/blockchain-link/src/workers/blockfrost/index.ts
+++ b/packages/blockchain-link/src/workers/blockfrost/index.ts
@@ -56,7 +56,7 @@ const getAccountBalanceHistory = async (
 
 const getTransaction = async (request: Request<MessageTypes.GetTransaction>) => {
     const api = await request.connect();
-    const txData = await api.getTransaction(request.payload);
+    const txData = await api.getTransaction(request.payload.txid);
     const tx = transformTransaction({ txData });
 
     return {

--- a/packages/blockchain-link/src/workers/electrum/methods/getTransaction.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getTransaction.ts
@@ -6,12 +6,21 @@ import { type Api, getTransactions } from '../utils';
 type Req = MessageTypes.GetTransaction;
 type Res = ResponseTypes.GetTransaction;
 
-const getTransaction: Api<Req, Res> = async ({ client }, { txid }) => {
+const getTransaction: Api<Req, Res> = async ({ client, addressCache }, { txid, descriptor }) => {
     const txs = await getTransactions(client, [{ tx_hash: txid, height: -1 }]);
     // @ts-expect-error: indexing with noUncheckedIndexedAccess
     const tx: (typeof txs)[number] = txs[0];
 
-    return transformTransaction(tx);
+    const addresses = descriptor
+        ? {
+              // It doesn't matter for transformTransaction which receive addrs are used and which are unused
+              used: [],
+              unused: addressCache(descriptor, 'receive').getAllDerived(),
+              change: addressCache(descriptor, 'change').getAllDerived(),
+          }
+        : undefined;
+
+    return transformTransaction(tx, addresses);
 };
 
 export default getTransaction;

--- a/packages/blockchain-link/src/workers/electrum/methods/getTransaction.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getTransaction.ts
@@ -6,8 +6,8 @@ import { type Api, getTransactions } from '../utils';
 type Req = MessageTypes.GetTransaction;
 type Res = ResponseTypes.GetTransaction;
 
-const getTransaction: Api<Req, Res> = async ({ client }, payload) => {
-    const txs = await getTransactions(client, [{ tx_hash: payload, height: -1 }]);
+const getTransaction: Api<Req, Res> = async ({ client }, { txid }) => {
+    const txs = await getTransactions(client, [{ tx_hash: txid, height: -1 }]);
     // @ts-expect-error: indexing with noUncheckedIndexedAccess
     const tx: (typeof txs)[number] = txs[0];
 

--- a/packages/blockchain-link/src/workers/evm-rpc/handlers/getTransaction.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/handlers/getTransaction.ts
@@ -9,7 +9,7 @@ export const getTransaction = async (
     request: Request<MessageTypes.GetTransaction>,
 ): Promise<Responses.GetTransaction> => {
     const client = await request.connect();
-    const hash = toHex(request.payload);
+    const hash = toHex(request.payload.txid);
 
     const [tx, receipt] = await Promise.all([
         client.getTransaction({ hash }),

--- a/packages/blockchain-link/src/workers/ripple/index.ts
+++ b/packages/blockchain-link/src/workers/ripple/index.ts
@@ -175,7 +175,7 @@ const getTransaction = async ({ connect, payload }: Request<MessageTypes.GetTran
     const client = await connect();
     const rawTx = await client.request({
         command: 'tx',
-        transaction: payload,
+        transaction: payload.txid,
         binary: false,
     });
 

--- a/packages/blockchain-link/src/workers/ripple/index.ts
+++ b/packages/blockchain-link/src/workers/ripple/index.ts
@@ -183,6 +183,7 @@ const getTransaction = async ({ connect, payload }: Request<MessageTypes.GetTran
         rawTx.result.hash,
         rawTx.result.tx_json,
         rawTx.result.meta,
+        payload.descriptor,
     );
 
     return {

--- a/packages/blockchain-link/tests/unit/fixtures/getTransaction.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/getTransaction.ts
@@ -138,7 +138,7 @@ export default {
     blockbook: [
         {
             description: 'Successful',
-            params: '28451eff296d05f25cdb08c8bb7956d4f18d0c1e09fe4a1d337f347afdf9a7a1',
+            params: { txid: '28451eff296d05f25cdb08c8bb7956d4f18d0c1e09fe4a1d337f347afdf9a7a1' },
             serverFixtures: [
                 {
                     method: 'getTransaction',
@@ -151,14 +151,14 @@ export default {
         },
         {
             description: 'Not found',
-            params: 'AA',
+            params: { txid: 'AA' },
             error: 'Transaction not found',
         },
     ],
     ripple: [
         {
             description: 'Successful',
-            params: '6390FE5EE3B22239B2CA403C32DAFCA613B7FEEE55473A50CB8602CE0FE3EB3F',
+            params: { txid: '6390FE5EE3B22239B2CA403C32DAFCA613B7FEEE55473A50CB8602CE0FE3EB3F' },
             serverFixtures: [
                 {
                     method: 'tx',
@@ -173,14 +173,14 @@ export default {
         },
         {
             description: 'Not found',
-            params: '6390FE5EE3B22239B2CA403C32DAFCA613B7FEEE55473A50CB8602CE0FE3EB3F',
+            params: { txid: '6390FE5EE3B22239B2CA403C32DAFCA613B7FEEE55473A50CB8602CE0FE3EB3F' },
             error: 'Transaction not found',
         },
     ],
     blockfrost: [
         {
             description: 'Successful',
-            params: '28172ea876c3d1e691284e5179fae2feb3e69d7d41e43f8023dc380115741026',
+            params: { txid: '28172ea876c3d1e691284e5179fae2feb3e69d7d41e43f8023dc380115741026' },
             serverFixtures: [{ method: 'GET_TRANSACTION', response: { data: blockfrostFixture } }],
             response: blockfrostTx,
         },
@@ -200,7 +200,7 @@ export default {
                     },
                 },
             ],
-            params: 'non_existing_tx',
+            params: { txid: 'non_existing_tx' },
             error: 'The requested component has not been found.',
         },
     ],

--- a/packages/connect-common/src/types/api/blockchain/blockchainGetTransactions.ts
+++ b/packages/connect-common/src/types/api/blockchain/blockchainGetTransactions.ts
@@ -4,6 +4,7 @@ import type { CommonParamsWithCoin, Response } from '../../params';
 
 export type BlockchainGetTransactions = CommonParamsWithCoin & {
     txs: string[];
+    descriptor?: string;
 };
 
 export declare function blockchainGetTransactions(

--- a/packages/connect/src/api/blockchainGetTransactions.ts
+++ b/packages/connect/src/api/blockchainGetTransactions.ts
@@ -13,6 +13,7 @@ type Params = {
     txs: string[];
     coinInfo: CoinInfo;
     identity?: string;
+    descriptor?: string;
 };
 
 export default class BlockchainGetTransactions extends AbstractMethod<
@@ -27,6 +28,7 @@ export default class BlockchainGetTransactions extends AbstractMethod<
             { name: 'txs', type: 'array', required: true },
             { name: 'coin', type: 'string', required: true },
             { name: 'identity', type: 'string' },
+            { name: 'descriptor', type: 'string' },
         ]);
 
         const coinInfo = getCoinInfo(payload.coin);
@@ -40,6 +42,7 @@ export default class BlockchainGetTransactions extends AbstractMethod<
             txs: payload.txs,
             coinInfo,
             identity: payload.identity,
+            descriptor: payload.descriptor,
         };
 
         super(message, params);
@@ -60,6 +63,6 @@ export default class BlockchainGetTransactions extends AbstractMethod<
             this.params.identity,
         );
 
-        return backend.getTransactions(this.params.txs);
+        return backend.getTransactions(this.params.txs, this.params.descriptor);
     }
 }

--- a/packages/connect/src/backend/Blockchain.ts
+++ b/packages/connect/src/backend/Blockchain.ts
@@ -182,8 +182,8 @@ export class Blockchain {
         return this.initPromise;
     }
 
-    getTransactions(txs: string[]) {
-        return Promise.all(txs.map(id => this.link.getTransaction(id)));
+    getTransactions(txs: string[], descriptor?: string) {
+        return Promise.all(txs.map(txid => this.link.getTransaction({ txid, descriptor })));
     }
 
     getTransactionHexes(txids: string[]) {

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -625,6 +625,7 @@ export const fetchUtxoTransactionsForAccountThunk = createSingleInstanceThunk(
         const result = await TrezorConnect.blockchainGetTransactions({
             coin: account.symbol,
             txs: account.utxo.map(utxo => utxo.txid),
+            descriptor: account.descriptor,
         });
 
         if (signal.aborted) {


### PR DESCRIPTION
## Description

As part of an effort to fix unknown transactions bug in #29519, `descriptor` param was added to `TrezorConnect.blockchainGetTransactions` call, which will try to get account addresses related to given descriptor (only in case when user was subscribed to it) and analyze the transaction with respect to them.

In case descriptor isn't passed or user wasn't subscribed to it, nothing should chage.

## QA

You can test this on testnet with academic seed (I'll happily provide you passphrase where it is set up):
- connect the device and add passphrase wallet
- go to the first testnet normal account
- **don't use pagination so only the first page is loaded**
- go to send form and open coin selection
- go back to transaction list
  - before fix: **an unknown transaction should appear on the first page of transactions**
  - after fix: **the same transaction should appear, but now correctly identified**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes span the blockchain data pipeline: from blockchain-link worker implementations (blockbook, blockfrost, electrum, evm-rpc, ripple) through connect's Blockchain class and blockchainGetTransactions API to the wallet-core transactionsThunks. This is a cross-cutting change to how transaction data is fetched and processed. The highest risk is in tests that directly display, paginate, or export transaction data. Since both Blockchain.ts and transactionsThunks.ts map to 121+ tests each, they are treated as broad utilities — only tests with direct transaction-fetching behavior are recommended. Tests covering discovery, custom backends, and transaction display across multiple networks (BTC, ETH, ADA, Electrum) should be prioritized.

<details><summary><b>Changed files (12)</b></summary>

- `packages/blockchain-link-types/src/messages.ts`
- `packages/blockchain-link/src/ui/index.ui.ts`
- `packages/blockchain-link/src/workers/blockbook/index.ts`
- `packages/blockchain-link/src/workers/blockfrost/index.ts`
- `packages/blockchain-link/src/workers/electrum/methods/getTransaction.ts`
- `packages/blockchain-link/src/workers/evm-rpc/handlers/getTransaction.ts`
- `packages/blockchain-link/src/workers/ripple/index.ts`
- `packages/blockchain-link/tests/unit/fixtures/getTransaction.ts`
- `packages/connect-common/src/types/api/blockchain/blockchainGetTransactions.ts`
- `packages/connect/src/api/blockchainGetTransactions.ts`
- `packages/connect/src/backend/Blockchain.ts`
- `suite-common/wallet-core/src/transactions/transactionsThunks.ts`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test exercises transaction fetching and display for BTC accounts. The changes to transactionsThunks.ts, Blockchain.ts, and blockbook worker's getTransaction directly affect how transactions are fetched from the backend and rendered. Graph range filtering and transaction search rely on the transaction data pipeline being correct.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test exports transaction history in PDF/CSV/JSON for BTC, LTC, ETH, and ADA. Changes to transactionsThunks.ts, blockchainGetTransactions API, and multiple blockchain-link workers (blockbook, blockfrost, evm-rpc) directly impact how transaction data is fetched and populated for export across all these networks.
- `suite/e2e/tests/wallet/pagination.test.ts` — This test navigates through paginated transaction pages on a legacy BTC account, directly exercising the transaction fetching pipeline. Changes to blockchainGetTransactions, transactionsThunks, and blockbook worker getTransaction handling would break pagination if the response shape or cursor logic changed.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test sends BTC transactions on regtest and verifies pending/confirmed transaction states. The transaction listing, status transitions, and display all flow through transactionsThunks and the blockbook worker, which are directly changed.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — Discovery activates multiple coin networks (BTC, ETH, LTC, ETC, BCH, DOGE, XRP, ZEC) and verifies account balances. Changes to Blockchain.ts and multiple blockchain-link workers affect how account data is fetched during discovery. A regression in the Blockchain class could break discovery for any network.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test checks account balance display after receiving BTC on regtest. The balance is derived from transaction data fetched through the blockbook worker and Blockchain.ts pipeline that was changed.
- `suite/e2e/tests/wallet/cardano.test.ts` — This test opens a Cardano account and verifies account details, send form, and receive flow. Changes to the blockfrost worker (Cardano's backend) could affect account loading and transaction data retrieval.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends for BTC and LTC and verifies discovery completes. Changes to the blockbook worker and Blockchain.ts directly affect how custom backends are connected to and how discovery data is fetched.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test configures custom blockbook backends for BTC/ETH and verifies discovery success/failure with correct/wrong backends. Changes to blockbook worker and Blockchain.ts directly affect custom backend connection and discovery error handling.
- `suite/e2e/tests/settings/electrum.test.ts` — This test configures an Electrum backend for RegTest and verifies discovery completes with correct balances. Changes to the electrum worker's getTransaction method and Blockchain.ts could break Electrum-based discovery.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test labels transaction outputs and exports CSV containing labeled transactions. Changes to transactionsThunks and blockbook worker affect how transaction outputs are fetched and associated with labels.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — ADA staking claim flow involves blockfrost backend for account state. Changes to blockfrost worker could affect how staking account data and balances are fetched.
- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking flow uses blockfrost backend for account discovery and balance display. Changes to blockfrost worker could affect staking account state retrieval.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test sends transactions on regtest with OP_RETURN and locktime. Changes to transactionsThunks affect how pending transactions appear in the transaction list after sending.

</details>

⚠️ **Changes with no test coverage (7)**
- `packages/blockchain-link-types/src/messages.ts`
- `packages/blockchain-link/src/ui/index.ui.ts`
- `packages/blockchain-link/src/workers/evm-rpc/handlers/getTransaction.ts`
- `packages/blockchain-link/src/workers/ripple/index.ts`
- `packages/blockchain-link/tests/unit/fixtures/getTransaction.ts`
- `packages/connect-common/src/types/api/blockchain/blockchainGetTransactions.ts`
- `packages/connect/src/api/blockchainGetTransactions.ts`

_Updated: 2026-07-07T15:57:33.886Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/get-categorized-transactions/web/](https://dev.suite.sldev.cz/suite-web/feat/get-categorized-transactions/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/get-categorized-transactions&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/get-categorized-transactions&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/get-categorized-transactions&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-08T08:41:41.492Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T08:39:07.634Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->