### PR TITLE
fix(suite): remove rewards epoch tooltip and rename heading to Rewards history

### DIFF
--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/Rewards/RewardsList.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/Rewards/RewardsList.tsx
@@ -3,8 +3,7 @@ import React, { useRef } from 'react';
 import { Translation } from '@suite/intl';
 import { type SolanaRewardsHistory } from '@suite-common/earn-staking-api/src/staking';
 import { formatNetworkAmount, isTestnet } from '@suite-common/wallet-utils';
-import { SOLANA_EPOCH_DAYS } from '@trezor/coins-solana/constants';
-import { Card, Column, Grid, IconCircle, Row, Text, Tooltip } from '@trezor/components';
+import { Card, Column, Grid, IconCircle, Row, Text } from '@trezor/components';
 
 import { DashboardSection } from 'src/components/dashboard';
 import { BaseCurrencyValue, FormattedCryptoAmount, FormattedDate } from 'src/components/suite';
@@ -92,25 +91,12 @@ export const RewardsList = ({ account, rewardsQueryResult, pagination }: Rewards
                                             >
                                                 <TransactionTargetLayout
                                                     addressLabel={
-                                                        <Tooltip
-                                                            maxWidth={250}
-                                                            content={
-                                                                <Translation
-                                                                    id="TR_STAKE_REWARDS_TOOLTIP"
-                                                                    values={{
-                                                                        count: SOLANA_EPOCH_DAYS,
-                                                                    }}
-                                                                />
-                                                            }
-                                                            hasIcon
-                                                        >
-                                                            <span data-testid={`${TEST_ID}/epoch`}>
-                                                                <Translation
-                                                                    id="TR_STAKE_REWARDS_BADGE"
-                                                                    values={{ count: reward.epoch }}
-                                                                />
-                                                            </span>
-                                                        </Tooltip>
+                                                        <span data-testid={`${TEST_ID}/epoch`}>
+                                                            <Translation
+                                                                id="TR_STAKE_REWARDS_BADGE"
+                                                                values={{ count: reward.epoch }}
+                                                            />
+                                                        </span>
                                                     }
                                                     amount={
                                                         reward?.amount && (

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2533,7 +2533,7 @@ export const messages = {
             solRewardsWarning:
                 'Your recent rewards are securely on the blockchain and may take more time to appear in Trezor Suite.',
             rewardsList: {
-                title: 'Total rewards',
+                title: 'Rewards history',
                 itemLabel: 'Reward',
                 epoch: 'Epoch number {epoch}',
                 empty: {

--- a/suite-native/intl/translations/en-US.json
+++ b/suite-native/intl/translations/en-US.json
@@ -1277,7 +1277,7 @@
     "earn.stakingManagementScreen.outsideStakingBanner.title": "You're staking outside of Trezor Suite.",
     "earn.stakingManagementScreen.outsideStakingBanner.description": "{amount} {symbol} (≈ {fiat}) is currently staked elsewhere.",
     "earn.stakingManagementScreen.solRewardsWarning": "Your recent rewards are securely on the blockchain and may take more time to appear in Trezor Suite.",
-    "earn.stakingManagementScreen.rewardsList.title": "Total rewards",
+    "earn.stakingManagementScreen.rewardsList.title": "Rewards history",
     "earn.stakingManagementScreen.rewardsList.itemLabel": "Reward",
     "earn.stakingManagementScreen.rewardsList.epoch": "Epoch number {epoch}",
     "earn.stakingManagementScreen.rewardsList.empty.title": "No rewards",

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -6072,7 +6072,7 @@ export const messages = defineMessages({
     },
     TR_REWARDS: {
         id: 'TR_REWARDS',
-        defaultMessage: 'Total rewards',
+        defaultMessage: 'Rewards history',
     },
     TR_ALL_TRANSACTIONS: {
         id: 'TR_ALL_TRANSACTIONS',
@@ -10459,11 +10459,6 @@ export const messages = defineMessages({
     TR_STAKE_REWARDS_BADGE: {
         id: 'TR_STAKE_REWARDS_BADGE',
         defaultMessage: 'Epoch number {count}',
-    },
-    TR_STAKE_REWARDS_TOOLTIP: {
-        id: 'TR_STAKE_REWARDS_TOOLTIP',
-        defaultMessage:
-            'An epoch in Solana is approximately {count, plural, one {# day} other {# days}} long.',
     },
     TR_EARN_REWARDS_ARE_EMPTY: {
         id: 'TR_EARN_REWARDS_ARE_EMPTY',


### PR DESCRIPTION
## Description

- Removes the epoch info tooltip shown on every Solana staking rewards item on desktop (per issue discussion, the tooltip is dropped entirely instead of being introduced on mobile). The `TR_STAKE_REWARDS_TOOLTIP` message had no other usages and is removed as well.
- Renames the rewards list heading from "Total rewards" to "Rewards history" on both desktop (`TR_REWARDS`) and mobile (`earn.stakingManagementScreen.rewardsList.title`).

## Notes for QA

- Desktop: open a Solana account with staking rewards (Staking dashboard → rewards section). Each reward item shows "Epoch number N" without an info icon/tooltip, and the section heading reads "Rewards history".
- Mobile: staking management screen for a Solana account — rewards list heading reads "Rewards history".

## Related Issue

Resolve #29303

## Screenshots:

<img width="792" height="414" alt="Screenshot 2026-07-08 at 13 21 33" src="https://github.com/user-attachments/assets/d2ff90d8-291d-4aaf-8230-42c2a436a76b" />



<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The primary risk is in the Solana staking rewards list component (RewardsList.tsx), which directly affects the SOL staking dashboard. The intl/messages changes (both suite and suite-native) are broad translation key files that map to many tests but are unlikely to cause targeted regressions unless specific translation keys used by the RewardsList were modified. The highest-priority test is the SOL rewards test which directly exercises the changed component. Other SOL staking tests are medium priority as they render the same dashboard view. ETH/ADA staking tests and the staking form test are omitted because RewardsList.tsx is specific to the Solana staking dashboard and would not affect those code paths.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/views/wallet/staking/components/SolStakingDashboard/Rewards/RewardsList.tsx`
- `suite-native/intl/src/messages.ts`
- `suite-native/intl/translations/en-US.json`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/staking/sol/rewards.test.ts` — This test directly exercises the Solana staking rewards display, including the reward list with pagination support. The changed file RewardsList.tsx is the component rendering individual reward entries, which this test explicitly validates by checking 'Individual rewards in the reward list match the mocked reward data'.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test covers the full Solana staking flow including the staking dashboard. While RewardsList.tsx is not the primary focus, the staking dashboard view renders components from the SolStakingDashboard directory and any breaking change in RewardsList could affect the overall dashboard rendering.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — This test verifies the Solana staking dashboard view including staked amounts and rewards display. The RewardsList component is part of the same SolStakingDashboard view hierarchy, so a rendering error could propagate and affect this test's dashboard assertions.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — This test validates the Solana staking dashboard state throughout the unstake/claim lifecycle. The dashboard renders the SolStakingDashboard component tree that includes RewardsList, and changes there could break the overall staking tab rendering.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-native/intl/src/messages.ts`
- `suite-native/intl/translations/en-US.json`

_Updated: 2026-07-07T15:52:14.014Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sol-rewards-tooltip-heading&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sol-rewards-tooltip-heading&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/sol-rewards-tooltip-heading&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-07T15:57:16.211Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-07T15:56:16.466Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/sol-rewards-tooltip-heading/web/](https://dev.suite.sldev.cz/suite-web/fix/sol-rewards-tooltip-heading/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->