### PR TITLE
feat(suite): suggest closest valid amounts when Solana unstake can't split

### DIFF
--- a/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeForm.tsx
+++ b/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeForm.tsx
@@ -1,15 +1,16 @@
 import { FormProvider } from 'react-hook-form';
 
 import { Translation } from '@suite/intl';
-import { getDisplaySymbol } from '@suite-common/wallet-config';
-import { getStakingDataForNetwork } from '@suite-common/wallet-utils';
-import { Banner, Card, Column, InfoItem, Tooltip } from '@trezor/components';
+import { getDisplaySymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getSolanaUnstakeAmountBounds, getStakingDataForNetwork } from '@suite-common/wallet-utils';
+import { Banner, Card, Column, InfoItem, Link, Tooltip } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
+import { getStakingHelpCenterLink } from 'src/components/earn/utils/getStakingHelpCenterLink';
 import { SolanaStakingLimitBanner } from 'src/components/suite/modals/ReduxModal/UserContextModal/SolanaStakingLimitBanner';
 import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useWithdrawalFormContext } from 'src/hooks/earn/useWithdrawalForm';
-import { CRYPTO_INPUT, FIAT_INPUT } from 'src/types/earn/earnFormFields';
+import { CRYPTO_INPUT, FIAT_INPUT, OUTPUT_AMOUNT } from 'src/types/earn/earnFormFields';
 import { ApproximateInstantEthAmount } from 'src/views/wallet/staking/components/EthStakingDashboard/ApproximateInstantEthAmount';
 
 import { UnstakeInputs } from './UnstakeInputs';
@@ -26,6 +27,8 @@ export const UnstakeForm = () => {
         feeInfo,
         composedLevels,
         methods,
+        onCryptoAmountChange,
+        getValues,
     } = useWithdrawalFormContext();
 
     const { symbol, networkType } = account;
@@ -40,6 +43,15 @@ export const UnstakeForm = () => {
 
     const inputError = errors[CRYPTO_INPUT] || errors[FIAT_INPUT] || errors?.outputs?.[0]?.amount;
     const showError = inputError && !['required', 'min'].includes(inputError.type);
+
+    const unstakeAmountBounds =
+        inputError?.type === 'solanaUnstakeAmount'
+            ? getSolanaUnstakeAmountBounds(account, getValues(OUTPUT_AMOUNT) ?? '')
+            : null;
+
+    const renderClickableUnstakeAmount = (amount: string) => (
+        <Link onClick={() => onCryptoAmountChange(amount)}>{amount}</Link>
+    );
     const shouldShowInstantWithdrawalEthAmount =
         approximatedInstantEthAmount && BigNumber(approximatedInstantEthAmount).gt(0);
 
@@ -79,7 +91,46 @@ export const UnstakeForm = () => {
                             <Column gap={20}>
                                 <UnstakeInputs />
                                 {showError && (
-                                    <Banner intent="critical" description={inputError?.message} />
+                                    <Banner
+                                        intent="critical"
+                                        description={
+                                            unstakeAmountBounds ? (
+                                                <Translation
+                                                    id={
+                                                        unstakeAmountBounds.closestLower
+                                                            ? 'TR_STAKE_SOL_INVALID_UNSTAKE_AMOUNT'
+                                                            : 'TR_STAKE_SOL_INVALID_UNSTAKE_AMOUNT_HIGHER_ONLY'
+                                                    }
+                                                    values={{
+                                                        symbol: getNetworkDisplaySymbol(
+                                                            account.symbol,
+                                                        ),
+                                                        higher: renderClickableUnstakeAmount(
+                                                            unstakeAmountBounds.closestHigher,
+                                                        ),
+                                                        lower: unstakeAmountBounds.closestLower
+                                                            ? renderClickableUnstakeAmount(
+                                                                  unstakeAmountBounds.closestLower,
+                                                              )
+                                                            : undefined,
+                                                    }}
+                                                />
+                                            ) : (
+                                                inputError?.message
+                                            )
+                                        }
+                                        rightContent={
+                                            inputError?.type === 'solanaUnstakeAmount' ? (
+                                                <Banner.Button
+                                                    href={getStakingHelpCenterLink(
+                                                        account.networkType,
+                                                    )}
+                                                >
+                                                    <Translation id="TR_STAKE_FIND_OUT_MORE" />
+                                                </Banner.Button>
+                                            ) : undefined
+                                        }
+                                    />
                                 )}
                             </Column>
                         </>

--- a/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeInputs.tsx
+++ b/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeInputs.tsx
@@ -18,6 +18,7 @@ import {
     validateDecimals,
     validateFiatLimits,
     validateMin,
+    validateSolanaUnstakeAmount,
 } from 'src/utils/suite/validation';
 
 export const UnstakeInputs = () => {
@@ -83,6 +84,7 @@ export const UnstakeInputs = () => {
                 amountLimits,
                 formatter: CryptoAmountFormatter,
             }),
+            solanaUnstakeAmount: validateSolanaUnstakeAmount(translationString, { account }),
         },
     };
 

--- a/packages/suite/src/utils/suite/validation.ts
+++ b/packages/suite/src/utils/suite/validation.ts
@@ -1,10 +1,15 @@
 import { type TranslationFunction } from '@suite/intl';
 import { type Formatter, type Formatters } from '@suite-common/formatters';
-import { getDisplaySymbol, isNetworkSymbol } from '@suite-common/wallet-config';
+import {
+    getDisplaySymbol,
+    getNetworkDisplaySymbol,
+    isNetworkSymbol,
+} from '@suite-common/wallet-config';
 import { type Account, asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import {
     fromBaseCurrencyToCryptoUnit,
     getAmountValidationResult,
+    getSolanaUnstakeAmountBounds,
     isAmountWithinNetworkReserve,
     isDecimalsValid,
     isInteger,
@@ -127,6 +132,32 @@ export const validateCryptoLimits =
                 });
             }
         }
+    };
+
+interface ValidateSolanaUnstakeAmountOptions {
+    account: Account;
+}
+
+export const validateSolanaUnstakeAmount =
+    (translationString: TranslationFunction, { account }: ValidateSolanaUnstakeAmountOptions) =>
+    (value: string) => {
+        if (!value) return;
+
+        const bounds = getSolanaUnstakeAmountBounds(account, value);
+        if (!bounds) return;
+
+        const symbol = getNetworkDisplaySymbol(account.symbol);
+
+        return bounds.closestLower
+            ? translationString('TR_STAKE_SOL_INVALID_UNSTAKE_AMOUNT', {
+                  lower: bounds.closestLower,
+                  higher: bounds.closestHigher,
+                  symbol,
+              })
+            : translationString('TR_STAKE_SOL_INVALID_UNSTAKE_AMOUNT_HIGHER_ONLY', {
+                  higher: bounds.closestHigher,
+                  symbol,
+              });
     };
 
 interface ValidateFiatLimitsOptions {

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
@@ -82,21 +82,23 @@ export const SolStakingDashboard = ({ selectedAccount }: SolStakingDashboardProp
         selectSolExternalStakingAccountsTotalStaked(state, account.key),
     );
 
+    const externalStakingProviderCard = hasExternalStakingAccounts ? (
+        <ExternalStakingProviderCard
+            symbol={account.symbol}
+            totalStaked={externalStakingTotalStaked}
+        />
+    ) : null;
+
     return (
         <StakingDashboard
             selectedAccount={selectedAccount}
             dashboard={
                 <Column alignItems="normal" gap={spacings.xxxxl}>
-                    {hasExternalStakingAccounts && (
-                        <ExternalStakingProviderCard
-                            symbol={account.symbol}
-                            totalStaked={externalStakingTotalStaked}
-                        />
-                    )}
                     {isStakingActive ? (
                         <>
                             <DashboardSection>
                                 <Column alignItems="normal" gap={spacings.sm}>
+                                    {externalStakingProviderCard}
                                     {isDiscoveryRunning && <DiscoveryWarning />}
                                     {shouldShowWarning && <StakingRewardsWarning />}
 
@@ -130,9 +132,10 @@ export const SolStakingDashboard = ({ selectedAccount }: SolStakingDashboardProp
                             />
                         </>
                     ) : (
-                        <>
+                        <Column alignItems="normal" gap={spacings.sm}>
+                            {externalStakingProviderCard}
                             <EmptyStakingCard />
-                        </>
+                        </Column>
                     )}
                 </Column>
             }

--- a/suite-common/wallet-utils/src/__tests__/solanaStakingUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/solanaStakingUtils.test.ts
@@ -1,0 +1,124 @@
+import { type Account } from '@suite-common/wallet-types';
+import { type SolanaStakingAccount } from '@trezor/blockchain-link-types';
+import { StakeState } from '@trezor/coins-solana/constants';
+
+import { getSolanaUnstakeAmountBounds } from '../solanaStakingUtils';
+
+const SOL = 1_000_000_000;
+
+const buildStakingAccount = (
+    overrides: Partial<SolanaStakingAccount> = {},
+): SolanaStakingAccount => ({
+    status: StakeState.Active,
+    stake: `${SOL}`,
+    rentExemptReserve: '2282880',
+    ...overrides,
+});
+
+const buildSolanaAccount = (solStakingAccounts: SolanaStakingAccount[]): Account =>
+    ({
+        symbol: 'sol',
+        networkType: 'solana',
+        formattedBalance: '0',
+        misc: { solStakingAccounts },
+    }) as unknown as Account;
+
+const buildNonSolanaAccount = (): Account =>
+    ({
+        symbol: 'eth',
+        networkType: 'ethereum',
+        formattedBalance: '0',
+        misc: {},
+    }) as unknown as Account;
+
+describe('getSolanaUnstakeAmountBounds', () => {
+    it('returns null for non-Solana accounts', () => {
+        expect(getSolanaUnstakeAmountBounds(buildNonSolanaAccount(), '1')).toBeNull();
+    });
+
+    it('returns null for zero, negative or invalid amounts', () => {
+        const account = buildSolanaAccount([buildStakingAccount({ stake: `${3.12 * SOL}` })]);
+
+        expect(getSolanaUnstakeAmountBounds(account, '0')).toBeNull();
+        expect(getSolanaUnstakeAmountBounds(account, '-1')).toBeNull();
+        expect(getSolanaUnstakeAmountBounds(account, 'abc')).toBeNull();
+    });
+
+    it('returns null when there are no active staking accounts', () => {
+        const account = buildSolanaAccount([
+            buildStakingAccount({ status: StakeState.Deactivating }),
+        ]);
+
+        expect(getSolanaUnstakeAmountBounds(account, '0.5')).toBeNull();
+    });
+
+    it('returns null when the requested amount covers the whole active stake', () => {
+        const account = buildSolanaAccount([buildStakingAccount({ stake: `${1.42 * SOL}` })]);
+
+        expect(getSolanaUnstakeAmountBounds(account, '1.42')).toBeNull();
+        expect(getSolanaUnstakeAmountBounds(account, '2')).toBeNull();
+    });
+
+    it('returns null when both split legs stay above the minimum delegation', () => {
+        const account = buildSolanaAccount([buildStakingAccount({ stake: `${3.12 * SOL}` })]);
+
+        expect(getSolanaUnstakeAmountBounds(account, '1')).toBeNull();
+        expect(getSolanaUnstakeAmountBounds(account, '1.5')).toBeNull();
+        expect(getSolanaUnstakeAmountBounds(account, '2.12')).toBeNull();
+    });
+
+    it('suggests only the full amount when the account is too small to split', () => {
+        const account = buildSolanaAccount([buildStakingAccount({ stake: `${1.42 * SOL}` })]);
+
+        expect(getSolanaUnstakeAmountBounds(account, '1')).toEqual({ closestHigher: '1.42' });
+        expect(getSolanaUnstakeAmountBounds(account, '0.5')).toEqual({ closestHigher: '1.42' });
+    });
+
+    it('suggests bounds around the invalid gap of a splittable account', () => {
+        const account = buildSolanaAccount([buildStakingAccount({ stake: `${3.12 * SOL}` })]);
+
+        expect(getSolanaUnstakeAmountBounds(account, '2.5')).toEqual({
+            closestLower: '2.12',
+            closestHigher: '3.12',
+        });
+        expect(getSolanaUnstakeAmountBounds(account, '0.42')).toEqual({ closestHigher: '1' });
+    });
+
+    it('consumes smaller accounts whole before splitting the next one', () => {
+        const account = buildSolanaAccount([
+            buildStakingAccount({ stake: `${2 * SOL}` }),
+            buildStakingAccount({ stake: `${1.42 * SOL}` }),
+        ]);
+
+        expect(getSolanaUnstakeAmountBounds(account, '1.42')).toBeNull();
+        expect(getSolanaUnstakeAmountBounds(account, '2')).toEqual({
+            closestLower: '1.42',
+            closestHigher: '2.42',
+        });
+        expect(getSolanaUnstakeAmountBounds(account, '3')).toEqual({
+            closestLower: '2.42',
+            closestHigher: '3.42',
+        });
+    });
+
+    it('ignores accounts without stake and non-active accounts', () => {
+        const account = buildSolanaAccount([
+            buildStakingAccount({ stake: undefined }),
+            buildStakingAccount({ stake: `${5 * SOL}`, status: StakeState.Deactivating }),
+            buildStakingAccount({ stake: `${3.12 * SOL}` }),
+        ]);
+
+        expect(getSolanaUnstakeAmountBounds(account, '2.5')).toEqual({
+            closestLower: '2.12',
+            closestHigher: '3.12',
+        });
+    });
+
+    it('returns null when the runtime switches to the capped DESC selection', () => {
+        const account = buildSolanaAccount(
+            Array.from({ length: 16 }, () => buildStakingAccount({ stake: `${2 * SOL}` })),
+        );
+
+        expect(getSolanaUnstakeAmountBounds(account, '1.5')).toBeNull();
+    });
+});

--- a/suite-common/wallet-utils/src/solanaStakingUtils.ts
+++ b/suite-common/wallet-utils/src/solanaStakingUtils.ts
@@ -2,6 +2,8 @@ import { type NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-con
 import { type Account } from '@suite-common/wallet-types';
 import { type SolanaStakingAccount } from '@trezor/blockchain-link-types';
 import {
+    MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT,
+    MIN_STAKE_DELEGATION,
     SOLANA_EPOCH_DAYS,
     StakeState,
     supportedSolanaNetworkSymbols,
@@ -9,7 +11,7 @@ import {
 import type { SupportedSolanaNetworkSymbols } from '@trezor/coins-solana/types';
 import { BigNumber, isArrayMember } from '@trezor/utils';
 
-import { formatNetworkAmount } from './amountUtils';
+import { formatNetworkAmount, networkAmountToSmallestUnit } from './amountUtils';
 
 export function isSupportedSolStakingNetworkSymbol(
     symbol: NetworkSymbol,
@@ -108,6 +110,73 @@ export const getSolStakingAccountTotalBalanceByStatus = (account: Account, statu
     const stakingBalance = calculateTotalSolStakingBalance(selectedStakingAccounts) ?? '0';
 
     return formatNetworkAmount(stakingBalance, account.symbol);
+};
+
+export type SolanaUnstakeAmountBounds = {
+    closestLower?: string;
+    closestHigher: string;
+};
+
+// Mirrors the stake account selection of `unstake` in @trezor/coins-solana/runtime/staking.ts:
+// accounts are consumed whole in ASC order and the requested remainder is split off the next one,
+// which is only possible when both split legs stay above MIN_STAKE_DELEGATION.
+export const getSolanaUnstakeAmountBounds = (
+    account: Account,
+    requestedAmount: string,
+): SolanaUnstakeAmountBounds | null => {
+    if (account.networkType !== 'solana') return null;
+
+    const requested = new BigNumber(networkAmountToSmallestUnit(requestedAmount, account.symbol));
+    if (!requested.isFinite() || requested.lte(0)) return null;
+
+    const activeAccounts = getSolanaStakingAccountsByStatus(account, StakeState.Active);
+    // With this many accounts the runtime consumes them DESC and caps the transaction size;
+    // SolanaStakingLimitBanner covers that case.
+    if (!activeAccounts.length || activeAccounts.length >= MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT) {
+        return null;
+    }
+
+    const stakes = activeAccounts
+        .map(({ stake }) => new BigNumber(stake ?? '0'))
+        .filter(stake => stake.gt(0))
+        .sort((a, b) => a.comparedTo(b) ?? 0);
+
+    const totalStake = stakes.reduce((acc, stake) => acc.plus(stake), new BigNumber(0));
+    if (requested.gte(totalStake)) return null;
+
+    const minDelegation = new BigNumber(MIN_STAKE_DELEGATION.toString());
+
+    let remaining = requested;
+    let consumedStake = new BigNumber(0);
+    for (const stake of stakes) {
+        if (stake.lte(remaining)) {
+            remaining = remaining.minus(stake);
+            consumedStake = consumedStake.plus(stake);
+            continue;
+        }
+
+        const isSplitAccountValid = remaining.gte(minDelegation);
+        const isSplitRemainderValid = stake.minus(remaining).gte(minDelegation);
+        if (remaining.isZero() || (isSplitAccountValid && isSplitRemainderValid)) return null;
+
+        const canSplit = stake.gte(minDelegation.times(2));
+        const closestLower = isSplitAccountValid
+            ? consumedStake.plus(canSplit ? stake.minus(minDelegation) : 0)
+            : consumedStake;
+        const closestHigher =
+            !isSplitAccountValid && canSplit
+                ? consumedStake.plus(minDelegation)
+                : consumedStake.plus(stake);
+
+        return {
+            ...(closestLower.gt(0)
+                ? { closestLower: formatNetworkAmount(closestLower.toString(), account.symbol) }
+                : {}),
+            closestHigher: formatNetworkAmount(closestHigher.toString(), account.symbol),
+        };
+    }
+
+    return null;
 };
 
 type StakeStateType = (typeof StakeState)[keyof typeof StakeState];

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11465,6 +11465,20 @@ export const messages = defineMessages({
         defaultMessage:
             'Unstaking is limited to {limit} accounts per transaction. You can unstake up to {amount} {symbol}. Repeat to unstake more.',
     },
+    TR_STAKE_SOL_INVALID_UNSTAKE_AMOUNT: {
+        id: 'TR_STAKE_SOL_INVALID_UNSTAKE_AMOUNT',
+        defaultMessage:
+            "Due to recent Solana blockchain changes, this amount can't be unstaked. Try {higher} {symbol} or more, or {lower} {symbol} or less.",
+    },
+    TR_STAKE_SOL_INVALID_UNSTAKE_AMOUNT_HIGHER_ONLY: {
+        id: 'TR_STAKE_SOL_INVALID_UNSTAKE_AMOUNT_HIGHER_ONLY',
+        defaultMessage:
+            "Due to recent Solana blockchain changes, this amount can't be unstaked. Try {higher} {symbol} or more.",
+    },
+    TR_STAKE_FIND_OUT_MORE: {
+        id: 'TR_STAKE_FIND_OUT_MORE',
+        defaultMessage: 'Find out more',
+    },
     TR_STAKE_CAN_CLAIM_FROM_ACCOUNTS: {
         id: 'TR_STAKE_CAN_CLAIM_FROM_ACCOUNTS',
         defaultMessage:


### PR DESCRIPTION
Inform user about closest valid amounts when unstaking solana. 

When unstaking on Solana, the requested amount can be composed from multiple stake accounts. However, any touched stake account that remains delegated after a split must keep at least the minimum delegation amount, currently 1 SOL. This means the last partially used stake account must have enough balance to cover both the requested remaining amount and the 1 SOL that has to stay staked.

Will be better targeted in next releases, for example 10%, 20% buttons do not really make sense.

## Notes for QA

- Solana account with one active stake account of e.g. 3.12 SOL:
  - unstake 2.5 → error suggests 3.12 or more / 2.12 or less, submit blocked, no fee estimate is composed;
  - unstake 0.42 → error suggests 1 SOL or more;
  - unstake 1–2.12, or Max → composes and signs normally, device amount matches the input.
- Click a suggested amount in the banner → the input fills with it and the error clears.
- Stake account below 2 SOL: any partial amount suggests the full amount only.
- Fiat input entry triggers the same validation via the converted crypto value.
- ETH/ADA/TRX unstake forms are unaffected.
- Solana staking dashboard: the min-amount / “staking outside” / rewards-warning banners now sit closer together.

## Related Issue

Resolve #29314

## Screenshots:

It takes user to https://trezor.io/guides/sending-receiving-staking-funds/staking-assets-in-trezor-suite/staking-solana-in-trezor-suite?utm_medium=web

The banner will be removed asap by message system
<img width="1130" height="877" alt="Screenshot 2026-07-08 at 14 02 17" src="https://github.com/user-attachments/assets/f921d8de-0a24-43b8-9fcb-cbf40eaddff6" />
<img width="1032" height="793" alt="Screenshot 2026-07-08 at 14 02 04" src="https://github.com/user-attachments/assets/ad1cfb1b-72e7-4e97-bae9-5a92b097254b" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies Solana staking utilities, the unstake modal form components (UnstakeForm/UnstakeInputs), the SOL staking dashboard view, validation utilities, and i18n messages. The highest risk is in the SOL staking flows where both the dashboard rendering and underlying utility calculations changed simultaneously. ETH and ADA unstaking flows share the unstake modal components and should also be verified. The validation.ts and messages.ts changes map broadly to 121+ tests but are only meaningfully exercised by staking/form-related tests. The unit test file (solanaStakingUtils.test.ts) has no E2E coverage mapping but provides its own coverage.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeForm.tsx`
- `packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeInputs.tsx`
- `packages/suite/src/utils/suite/validation.ts`
- `packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx`
- `suite-common/wallet-utils/src/__tests__/solanaStakingUtils.test.ts`
- `suite-common/wallet-utils/src/solanaStakingUtils.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/staking/sol/unstake.test.ts` — Directly exercises the SOL unstaking flow which is affected by changes to UnstakeForm.tsx, UnstakeInputs.tsx, SolStakingDashboard.tsx, and solanaStakingUtils.ts. The test verifies unstaking amounts, dashboard display, claim flow, and balance updates — all areas touched by these changes.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Tests the SOL staking dashboard empty state and initial staking flow, directly rendering SolStakingDashboard.tsx. Changes to solanaStakingUtils.ts affect how staked/pending amounts are calculated and displayed, which this test asserts on.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Tests SOL staking dashboard amounts (staked, unstaking, rewards) and reward updates after epoch advancement. Directly exercises SolStakingDashboard.tsx and relies on solanaStakingUtils.ts for computing displayed balances.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Tests staking more SOL from an already-staked account, verifying dashboard amounts and pending transitions. Directly uses SolStakingDashboard.tsx and solanaStakingUtils.ts for amount calculations.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Directly exercises the ETH unstaking modal flow (UnstakeForm.tsx, UnstakeInputs.tsx) including filling the unstake form, reviewing amounts, and confirming on device. Changes to validation.ts could affect form input validation.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — Tests staking form validation (minimum amounts, decimals, insufficient funds, percentage buttons). While focused on staking rather than unstaking, it shares validation logic from validation.ts and form infrastructure with the unstake components.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Tests the ETH staking dashboard and staking flow. While the unstake modal components are not directly exercised, the staking dashboard shares infrastructure and the test verifies that unstake-to-claim is disabled after initial stake, touching related UI state.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Tests the ETH staking dashboard with existing stakes, verifying staked/pending/rewards amounts. While primarily about staking more, it shares the staking dashboard component structure and verifies unstake button state.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Tests the ADA unstaking flow which uses UnstakeForm.tsx and UnstakeInputs.tsx for the unstake modal. While ADA uses a different staking dashboard than SOL, the unstake modal components are shared.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/wallet-utils/src/__tests__/solanaStakingUtils.test.ts`
- `suite/intl/src/messages.ts`

_Updated: 2026-07-08T11:59:28.152Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/sol-unstake-amount-bounds/web/](https://dev.suite.sldev.cz/suite-web/feat/sol-unstake-amount-bounds/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/sol-unstake-amount-bounds&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/sol-unstake-amount-bounds&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/sol-unstake-amount-bounds&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-08T12:04:48.396Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T11:37:48.409Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

