### PR TITLE
fix(trading): do not sign approval again as dex swap tx

### DIFF
--- a/suite-common/trading/src/thunks/exchange/__tests__/confirmApprovalThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/confirmApprovalThunk.test.ts
@@ -167,6 +167,7 @@ describe('confirmApprovalThunk', () => {
                 expect.objectContaining({
                     trade: expect.objectContaining({ fromAddress: refundAddress }),
                 }),
+                expect.anything(),
             );
         });
 
@@ -192,7 +193,34 @@ describe('confirmApprovalThunk', () => {
                 expect.objectContaining({
                     trade: expect.objectContaining({ fromAddress: 'fromAddress' }),
                 }),
+                expect.anything(),
             );
+        });
+
+        it('should not overwrite the quote when aborted mid-request', async () => {
+            const { store, receiveAddress, account, trade, mockProcessResponseData } = getMocks();
+
+            invityAPI.doExchangeTrade = jest.fn().mockResolvedValue({
+                ...trade,
+                status: 'CONFIRM',
+                orderId: 'orderId',
+            } as ExchangeTrade);
+
+            const quoteBefore = getExchangeState(store).selectedQuote;
+
+            const promiseAction = store.dispatch(
+                exchangeThunks.confirmApprovalThunk({
+                    receiveAddress,
+                    account,
+                    trade,
+                    processResponseData: mockProcessResponseData,
+                }),
+            );
+            promiseAction.abort();
+            const response = await promiseAction.unwrap().catch(() => undefined);
+
+            expect(response).toBeUndefined();
+            expect(getExchangeState(store).selectedQuote).toEqual(quoteBefore);
         });
     });
 

--- a/suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts
@@ -121,6 +121,48 @@ describe('sendDexTransactionThunk', () => {
         });
     });
 
+    it('should reject without signing when swap quote still carries the approval calldata', async () => {
+        const approvalCalldata =
+            '0x095ea7b3000000000000000000000000beef047a543e45807105e51a8bbefcc5950fcfba00000000000000000000000000000000000000000000000000000000000f4240';
+        const quote = getQuote();
+        const { store, returnUrl, account } = getMocks({
+            selectedQuote: {
+                ...quote,
+                status: 'CONFIRM',
+                approvalType: 'INFINITE',
+                dexTx: { ...quote.dexTx, data: approvalCalldata },
+            } as TradingExchangeState['selectedQuote'],
+        });
+
+        (tradingThunks.recomposeAndSignTxThunk as unknown as jest.Mock) = jest
+            .fn()
+            .mockImplementation(
+                createThunk('@trading/thunk/recomposeAndSignTx', (_, { fulfillWithValue }) =>
+                    fulfillWithValue({ success: true, payload: { txid: 'txid' } }),
+                ),
+            );
+
+        const result = await store.dispatch(
+            exchangeThunks.sendDexTransactionThunk({
+                account,
+                returnUrl,
+                nextStep: jest.fn(),
+                triggerAnalyticsTradeConfirmation: jest.fn(),
+                processResponseData: jest.fn(),
+                signAndPushSendFormTransaction: jest.fn(),
+            }),
+        );
+
+        expect(result.meta.requestStatus).toEqual('rejected');
+        expect(result.payload).toEqual({
+            type: 'error',
+            error: {
+                id: 'TR_TRADING_CANNOT_SEND_TRANSACTION',
+            },
+        });
+        expect(tradingThunks.recomposeAndSignTxThunk).not.toHaveBeenCalled();
+    });
+
     describe('should return error after recompose and sign transaction', () => {
         it.each([
             ['when payload is undefined', undefined],

--- a/suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts
@@ -4,6 +4,7 @@ import { type CryptoId } from 'invity-api';
 import { createThunk } from '@suite-common/redux-utils';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { type Account } from '@suite-common/wallet-types';
+import { buildApprovalTransactionData } from '@suite-common/wallet-utils';
 
 import { MIN_MAX_QUOTES_OK } from '../../../__fixtures__/exchangeUtils';
 import { accountBtc } from '../../../__fixtures__/utils';
@@ -121,46 +122,99 @@ describe('sendDexTransactionThunk', () => {
         });
     });
 
-    it('should reject without signing when swap quote still carries the approval calldata', async () => {
-        const approvalCalldata =
-            '0x095ea7b3000000000000000000000000beef047a543e45807105e51a8bbefcc5950fcfba00000000000000000000000000000000000000000000000000000000000f4240';
-        const quote = getQuote();
-        const { store, returnUrl, account } = getMocks({
-            selectedQuote: {
-                ...quote,
-                status: 'CONFIRM',
-                approvalType: 'INFINITE',
-                dexTx: { ...quote.dexTx, data: approvalCalldata },
-            } as TradingExchangeState['selectedQuote'],
+    describe('stale dexTx guard', () => {
+        const testSpender = '0x1234567890123456789012345678901234567890';
+        const approveCalldata = buildApprovalTransactionData({
+            spender: testSpender,
+            amount: '1000000',
+        });
+        const revokeCalldata = buildApprovalTransactionData({ spender: testSpender, amount: '0' });
+
+        const mockRecomposeAndSignTxThunk = () => {
+            (tradingThunks.recomposeAndSignTxThunk as unknown as jest.Mock) = jest
+                .fn()
+                .mockImplementation(
+                    createThunk('@trading/thunk/recomposeAndSignTx', (_, { fulfillWithValue }) =>
+                        fulfillWithValue({ success: true, payload: { txid: 'txid' } }),
+                    ),
+                );
+        };
+
+        type QuoteOverrides = { status: string; approvalType: string; dexTx: { data: string } };
+
+        const dispatchSendDexTransactionThunk = (quoteOverrides: QuoteOverrides) => {
+            const quote = getQuote();
+            const { store, returnUrl, account } = getMocks({
+                selectedQuote: {
+                    ...quote,
+                    ...quoteOverrides,
+                    dexTx: { ...quote.dexTx, ...quoteOverrides.dexTx },
+                } as TradingExchangeState['selectedQuote'],
+            });
+
+            return store.dispatch(
+                exchangeThunks.sendDexTransactionThunk({
+                    account,
+                    returnUrl,
+                    nextStep: jest.fn(),
+                    triggerAnalyticsTradeConfirmation: jest.fn(),
+                    processResponseData: jest.fn(),
+                    signAndPushSendFormTransaction: jest.fn(),
+                }),
+            );
+        };
+
+        it.each([
+            [
+                'swap quote carries approval calldata',
+                { status: 'CONFIRM', approvalType: 'INFINITE', dexTx: { data: approveCalldata } },
+            ],
+            [
+                'swap quote carries revoke calldata',
+                { status: 'CONFIRM', approvalType: 'INFINITE', dexTx: { data: revokeCalldata } },
+            ],
+            [
+                'approval quote carries revoke calldata',
+                {
+                    status: 'APPROVAL_REQ',
+                    approvalType: 'MINIMAL',
+                    dexTx: { data: revokeCalldata },
+                },
+            ],
+            [
+                'revoke quote carries approval calldata',
+                { status: 'APPROVAL_REQ', approvalType: 'ZERO', dexTx: { data: approveCalldata } },
+            ],
+        ])('should reject without signing when %s', async (_, quoteOverrides) => {
+            mockRecomposeAndSignTxThunk();
+
+            const result = await dispatchSendDexTransactionThunk(quoteOverrides);
+
+            expect(result.meta.requestStatus).toEqual('rejected');
+            expect(result.payload).toEqual({
+                type: 'error',
+                error: {
+                    id: 'TR_TRADING_CANNOT_SEND_TRANSACTION',
+                },
+            });
+            expect(tradingThunks.recomposeAndSignTxThunk).not.toHaveBeenCalled();
         });
 
-        (tradingThunks.recomposeAndSignTxThunk as unknown as jest.Mock) = jest
-            .fn()
-            .mockImplementation(
-                createThunk('@trading/thunk/recomposeAndSignTx', (_, { fulfillWithValue }) =>
-                    fulfillWithValue({ success: true, payload: { txid: 'txid' } }),
-                ),
+        it('should sign a revoke quote carrying revoke calldata', async () => {
+            mockRecomposeAndSignTxThunk();
+            (confirmExchangeTradeThunk as unknown as jest.Mock).mockImplementation(
+                createThunk('@trading-exchange/thunk/confirmTrade', () => undefined),
             );
 
-        const result = await store.dispatch(
-            exchangeThunks.sendDexTransactionThunk({
-                account,
-                returnUrl,
-                nextStep: jest.fn(),
-                triggerAnalyticsTradeConfirmation: jest.fn(),
-                processResponseData: jest.fn(),
-                signAndPushSendFormTransaction: jest.fn(),
-            }),
-        );
+            const result = await dispatchSendDexTransactionThunk({
+                status: 'APPROVAL_REQ',
+                approvalType: 'ZERO',
+                dexTx: { data: revokeCalldata },
+            });
 
-        expect(result.meta.requestStatus).toEqual('rejected');
-        expect(result.payload).toEqual({
-            type: 'error',
-            error: {
-                id: 'TR_TRADING_CANNOT_SEND_TRANSACTION',
-            },
+            expect(result.meta.requestStatus).toEqual('fulfilled');
+            expect(tradingThunks.recomposeAndSignTxThunk).toHaveBeenCalledTimes(1);
         });
-        expect(tradingThunks.recomposeAndSignTxThunk).not.toHaveBeenCalled();
     });
 
     describe('should return error after recompose and sign transaction', () => {

--- a/suite-common/trading/src/thunks/exchange/confirmApprovalThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/confirmApprovalThunk.ts
@@ -36,7 +36,7 @@ export const confirmApprovalThunk = createThunk(
             extraField,
             processResponseData,
         }: ConfirmApprovalThunkProps,
-        { dispatch, getState },
+        { dispatch, getState, signal },
     ) => {
         const getCoinSymbol = (cryptoId: CryptoId) =>
             selectTradingCoinSymbolByCryptoId(getState(), cryptoId);
@@ -62,13 +62,22 @@ export const confirmApprovalThunk = createThunk(
 
         dispatch(tradingExchangeActions.saveTransactionId(undefined));
 
-        const rawResponse = await invityAPI.doExchangeTrade({
-            trade,
-            receiveAddress,
-            refundAddress,
-            extraField,
-            returnUrl: undefined,
-        });
+        const rawResponse = await invityAPI.doExchangeTrade(
+            {
+                trade,
+                receiveAddress,
+                refundAddress,
+                extraField,
+                returnUrl: undefined,
+            },
+            signal,
+        );
+
+        // The flow was cancelled while the request was in flight — do not
+        // overwrite the store with a response the user no longer wants.
+        if (signal.aborted) {
+            return undefined;
+        }
 
         // invity drops DEX-specific fields on the response — preserve those the review flow needs
         const response = rawResponse && {

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -3,6 +3,7 @@ import { type ExchangeTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
 import { type Account } from '@suite-common/wallet-types';
+import { isEvmApprovalTx } from '@suite-common/wallet-utils';
 
 import { confirmExchangeTradeThunk } from './confirmExchangeTradeThunk';
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
@@ -70,6 +71,21 @@ export const sendDexTransactionThunk = createThunk<
             });
         }
 
+        const isSwapTx =
+            selectedQuote.status === 'CONFIRM' && selectedQuote.approvalType !== 'ZERO';
+
+        // The swap quote must carry the swap calldata. If dexTx still holds the approval
+        // transaction (API has not indexed the confirmed approval yet), signing it would
+        // broadcast the approval a second time instead of the swap.
+        if (isSwapTx && isEvmApprovalTx(selectedQuote.dexTx.data)) {
+            console.error('Failed to send dex transaction - swap quote carries approval calldata');
+
+            return rejectWithValue({
+                type: 'error',
+                error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
+            });
+        }
+
         const tradingFormState = getTradingFormState({
             activeSection: 'exchange',
             providers,
@@ -130,9 +146,6 @@ export const sendDexTransactionThunk = createThunk<
             ...selectedQuote,
             receiveAddress: selectedQuote.receiveAddress, // just for type assurance
         };
-
-        const isSwapTx =
-            selectedQuote.status === 'CONFIRM' && selectedQuote.approvalType !== 'ZERO';
 
         if (isSwapTx) {
             trade.receiveTxHash = txid;

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -3,7 +3,10 @@ import { type ExchangeTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
 import { type Account } from '@suite-common/wallet-types';
-import { isEvmApprovalTx } from '@suite-common/wallet-utils';
+import {
+    getEvmTransactionTextSignature,
+    isEvmApprovalTxByTextSignature,
+} from '@suite-common/wallet-utils';
 
 import { confirmExchangeTradeThunk } from './confirmExchangeTradeThunk';
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
@@ -71,14 +74,24 @@ export const sendDexTransactionThunk = createThunk<
             });
         }
 
-        const isSwapTx =
-            selectedQuote.status === 'CONFIRM' && selectedQuote.approvalType !== 'ZERO';
+        const dexTxPurpose = getEvmTransactionTextSignature(selectedQuote.dexTx.data);
+        const isApprovalTx = isEvmApprovalTxByTextSignature(dexTxPurpose);
+        const isSwapTx = selectedQuote.status === 'CONFIRM' && !isApprovalTx;
 
-        // The swap quote must carry the swap calldata. If dexTx still holds the approval
-        // transaction (API has not indexed the confirmed approval yet), signing it would
-        // broadcast the approval a second time instead of the swap.
-        if (isSwapTx && isEvmApprovalTx(selectedQuote.dexTx.data)) {
-            console.error('Failed to send dex transaction - swap quote carries approval calldata');
+        const expectedApprovalPurpose =
+            selectedQuote.approvalType === 'ZERO' ? 'revoke' : 'approve';
+
+        // The quote must carry calldata matching its step. CONFIRM must never sign
+        // approve/revoke calldata (per the API contract it carries the swap tx), and
+        // the approval step must sign the direction requested by approvalType. A
+        // mismatch means the quote still holds the previous step's transaction (API
+        // has not indexed it yet) — signing it would broadcast that transaction again.
+        const isStaleDexTx =
+            isApprovalTx &&
+            (selectedQuote.status === 'CONFIRM' || dexTxPurpose !== expectedApprovalPurpose);
+
+        if (isStaleDexTx) {
+            console.error('Failed to send dex transaction - dexTx does not match the current step');
 
             return rejectWithValue({
                 type: 'error',

--- a/suite-native/module-trading/src/__tests__/thunks.test.ts
+++ b/suite-native/module-trading/src/__tests__/thunks.test.ts
@@ -209,6 +209,34 @@ describe('thunks', () => {
             expect(result.type).toContain('fulfilled');
         });
 
+        it('should derive the spender from dexTx.to when dexTx is the swap tx (LiFi)', async () => {
+            // LiFi returns the swap dexTx (non-approve calldata); the router that must be
+            // approved is dexTx.to, not encoded in the calldata.
+            const lifiSwapQuote: ExchangeTrade = {
+                ...dexQuoteWithApprovalData,
+                dexTx: {
+                    from: '0x0000000000000000000000000000000000000000',
+                    to: '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+                    data: '0x4630a0d8000000000000000000000000000000000000000000000000000000000000dead',
+                    value: '0x0',
+                },
+            };
+
+            const ethAccount = store
+                .getState()
+                .wallet.accounts.find((account: Account) => account.key === eth1NormalAccount.key);
+
+            const result = await store.dispatch(
+                composeEvmApprovalFeeLevelsThunk({
+                    quote: lifiSwapQuote,
+                    account: ethAccount!,
+                    feeInfo,
+                }),
+            );
+
+            expect(result.type).toContain('fulfilled');
+        });
+
         it('should merge composed approval fees into existing exchange form draft without dropping fields', async () => {
             const formDraftKey = getFormDraftKey('trading-exchange', '');
 

--- a/suite-native/module-trading/src/hooks/exchange/Approval/useApprovalFlow.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/useApprovalFlow.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import type { DexApprovalType, ExchangeTrade } from 'invity-api';
@@ -28,6 +28,8 @@ export const useApprovalFlow = () => {
     const [isConfirming, setIsConfirming] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
+    const inFlightConfirmApprovalRef = useRef<{ abort: (reason?: string) => void } | null>(null);
+
     const confirmApproval = useCallback(
         async (quoteToConfirm: ExchangeTrade) => {
             if (!sendAccount || !receiveAddress || !quoteToConfirm) {
@@ -38,14 +40,17 @@ export const useApprovalFlow = () => {
             setError(null);
 
             try {
-                const response = await dispatch(
+                const promiseAction = dispatch(
                     exchangeThunks.confirmApprovalThunk({
                         trade: quoteToConfirm,
                         receiveAddress,
                         account: sendAccount,
                         processResponseData: () => {},
                     }),
-                ).unwrap();
+                );
+                inFlightConfirmApprovalRef.current = promiseAction;
+
+                const response = await promiseAction.unwrap();
 
                 if (!response) {
                     setError(translate('moduleTrading.confirmApprovalError'));
@@ -55,16 +60,27 @@ export const useApprovalFlow = () => {
 
                 return response;
             } catch (e) {
+                if ((e as Error)?.name === 'AbortError') {
+                    // The flow was cancelled — not an error to surface.
+                    return undefined;
+                }
+
                 console.error('Failed to confirm approval trade', e);
                 setError(translate('moduleTrading.confirmApprovalError'));
 
                 return undefined;
             } finally {
+                inFlightConfirmApprovalRef.current = null;
                 setIsConfirming(false);
             }
         },
         [dispatch, receiveAddress, sendAccount, translate],
     );
+
+    const abortConfirmApproval = useCallback(() => {
+        inFlightConfirmApprovalRef.current?.abort();
+        inFlightConfirmApprovalRef.current = null;
+    }, []);
 
     const isReady = !!sendAccount && !!receiveAddress;
 
@@ -91,6 +107,7 @@ export const useApprovalFlow = () => {
         isConfirming,
         error,
         confirmApproval,
+        abortConfirmApproval,
         onApprovalTypeChange,
     };
 };

--- a/suite-native/module-trading/src/screens/TradingConfirmingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingConfirmingScreen.tsx
@@ -39,6 +39,8 @@ export type TradingConfirmingScreenProps = StackProps<
     RootStackRoutes.TradingConfirming
 >;
 
+export const APPROVAL_STATUS_POLL_INTERVAL_MS = 5000;
+
 export const TradingConfirmingScreen = ({
     route: { params },
     navigation,
@@ -115,22 +117,29 @@ export const TradingConfirmingScreen = ({
             const handleConfirmed = async () => {
                 switch (flowType) {
                     case 'approve': {
-                        const response = await confirmApproval(activeQuote);
+                        let response = await confirmApproval(activeQuote);
 
-                        if (response?.status === 'APPROVAL_PENDING') {
-                            // we know it was confirmed, so we can set the status to CONFIRM even if it came as APPROVAL_PENDING
-                            // that is basically what api does (but it takes time)
-                            // so we need to do it here to avoid the approval screen transition through useExchangeFlow
-                            dispatch(
-                                tradingExchangeActions.saveSelectedQuote({
-                                    ...response,
-                                    status: 'CONFIRM',
-                                }),
-                            );
+                        // The API keeps returning APPROVAL_PENDING (with the approval dexTx)
+                        // until it indexes the confirmed approval. Poll until it returns the
+                        // follow-up status carrying the swap transaction — navigating earlier
+                        // would leave the approval calldata in the quote to be signed again
+                        // as the swap.
+                        while (response?.status === 'APPROVAL_PENDING' && navigation.isFocused()) {
+                            await new Promise(resolve => {
+                                setTimeout(resolve, APPROVAL_STATUS_POLL_INTERVAL_MS);
+                            });
+                            response = await confirmApproval(response);
                         }
 
                         if (!response) {
                             // confirmApproval already sets the error state — stay on this screen.
+                            hasConfirmedRef.current = false;
+
+                            return;
+                        }
+
+                        if (response.status === 'APPROVAL_PENDING') {
+                            // Polling was interrupted by losing focus — allow restart on refocus.
                             hasConfirmedRef.current = false;
 
                             return;

--- a/suite-native/module-trading/src/screens/TradingConfirmingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingConfirmingScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useEffectEvent, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useFocusEffect } from '@react-navigation/native';
+import type { ExchangeTrade } from 'invity-api';
 
 import {
     selectTradingExchangeSelectedQuote,
@@ -9,6 +10,10 @@ import {
     useAllowanceTxTracking,
 } from '@suite-common/trading';
 import { sendFormActions } from '@suite-common/wallet-core';
+import {
+    getEvmTransactionTextSignature,
+    isEvmApprovalTxByTextSignature,
+} from '@suite-common/wallet-utils';
 import { Translation } from '@suite-native/intl';
 import {
     type RootStackParamList,
@@ -25,6 +30,7 @@ import {
     useTransactionDetails,
 } from '@suite-native/transaction-management';
 import { exhaustive } from '@trezor/type-utils';
+import { resolveAfter } from '@trezor/utils';
 
 import { ConfirmationQuoteDebugView } from '../components/exchange/Confirmation/ConfirmationQuoteDebugView';
 import { ExchangeConfirmationHeader } from '../components/exchange/Confirmation/ExchangeConfirmationHeader';
@@ -40,6 +46,60 @@ export type TradingConfirmingScreenProps = StackProps<
 >;
 
 export const APPROVAL_STATUS_POLL_INTERVAL_MS = 5000;
+// Give up after ~5 minutes of polling; the user can leave or refocus to retry.
+export const APPROVAL_STATUS_POLL_MAX_ATTEMPTS = 60;
+
+// Until the API indexes the confirmed approval it keeps returning
+// APPROVAL_PENDING — or CONFIRM still carrying the approval dexTx.
+const isStaleApprovalQuote = (quote: ExchangeTrade) =>
+    !quote.error &&
+    (quote.status === 'APPROVAL_PENDING' ||
+        (quote.status === 'CONFIRM' &&
+            isEvmApprovalTxByTextSignature(getEvmTransactionTextSignature(quote.dexTx?.data))));
+
+// Until the API indexes the confirmed revoke it still sees the old allowance
+// and keeps returning the revoke dexTx instead of the follow-up approval.
+const isStaleRevokeQuote = (quote: ExchangeTrade) =>
+    !quote.error && getEvmTransactionTextSignature(quote.dexTx?.data) === 'revoke';
+
+type PollConfirmApprovalProps = {
+    initialQuote: ExchangeTrade;
+    confirmApproval: (quote: ExchangeTrade) => Promise<ExchangeTrade | undefined>;
+    isStale: (quote: ExchangeTrade) => boolean;
+    signal: AbortSignal;
+};
+
+// Re-requests the trade until the API acknowledges the confirmed on-chain state.
+// Resolves with the settled quote, or undefined when the flow should stay on the
+// confirming screen (request failed, polling aborted, or attempts exhausted).
+const pollConfirmApproval = async ({
+    initialQuote,
+    confirmApproval,
+    isStale,
+    signal,
+}: PollConfirmApprovalProps): Promise<ExchangeTrade | undefined> => {
+    let response = await confirmApproval(initialQuote);
+
+    for (
+        let attempt = 0;
+        response && isStale(response) && attempt < APPROVAL_STATUS_POLL_MAX_ATTEMPTS;
+        attempt += 1
+    ) {
+        try {
+            await resolveAfter(APPROVAL_STATUS_POLL_INTERVAL_MS, signal);
+        } catch {
+            // Aborted by blur, unmount, or flow cancellation.
+            return undefined;
+        }
+        response = await confirmApproval(response);
+    }
+
+    if (!response || isStale(response) || signal.aborted) {
+        return undefined;
+    }
+
+    return response;
+};
 
 export const TradingConfirmingScreen = ({
     route: { params },
@@ -56,9 +116,23 @@ export const TradingConfirmingScreen = ({
         flowType === 'approve' ? 'approval-confirming' : 'revoke-confirming',
     );
 
-    const { confirmApproval } = useApprovalFlow();
+    const { confirmApproval, abortConfirmApproval } = useApprovalFlow();
 
     const hasConfirmedRef = useRef(false);
+    const pollAbortControllerRef = useRef(new AbortController());
+
+    // Recreate the abort controller on focus; abort polling on blur or unmount.
+    useFocusEffect(
+        useCallback(() => {
+            pollAbortControllerRef.current = new AbortController();
+
+            return () => {
+                pollAbortControllerRef.current.abort();
+                abortConfirmApproval();
+                hasConfirmedRef.current = false;
+            };
+        }, [abortConfirmApproval]),
+    );
 
     const {
         status: originalStatus,
@@ -90,10 +164,13 @@ export const TradingConfirmingScreen = ({
 
     const navigateToInitialScreen = useNavigateToInitialScreen();
     const handleRemoveConfirmed = useCallback(() => {
+        // Stop polling first so an in-flight response cannot resurrect the quote.
+        pollAbortControllerRef.current.abort();
+        abortConfirmApproval();
         dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
         reportToAnalytics('cancel');
         navigateToInitialScreen();
-    }, [dispatch, navigateToInitialScreen, reportToAnalytics]);
+    }, [abortConfirmApproval, dispatch, navigateToInitialScreen, reportToAnalytics]);
 
     useNavigationRemoveInterceptorAlert({
         shouldPrevent: !isFailed,
@@ -117,29 +194,19 @@ export const TradingConfirmingScreen = ({
             const handleConfirmed = async () => {
                 switch (flowType) {
                     case 'approve': {
-                        let response = await confirmApproval(activeQuote);
+                        // Poll until the API returns the follow-up quote carrying the swap
+                        // transaction — navigating earlier would leave the approval calldata
+                        // in the quote to be signed again as the swap.
+                        const settledQuote = await pollConfirmApproval({
+                            initialQuote: activeQuote,
+                            confirmApproval,
+                            isStale: isStaleApprovalQuote,
+                            signal: pollAbortControllerRef.current.signal,
+                        });
 
-                        // The API keeps returning APPROVAL_PENDING (with the approval dexTx)
-                        // until it indexes the confirmed approval. Poll until it returns the
-                        // follow-up status carrying the swap transaction — navigating earlier
-                        // would leave the approval calldata in the quote to be signed again
-                        // as the swap.
-                        while (response?.status === 'APPROVAL_PENDING' && navigation.isFocused()) {
-                            await new Promise(resolve => {
-                                setTimeout(resolve, APPROVAL_STATUS_POLL_INTERVAL_MS);
-                            });
-                            response = await confirmApproval(response);
-                        }
-
-                        if (!response) {
-                            // confirmApproval already sets the error state — stay on this screen.
-                            hasConfirmedRef.current = false;
-
-                            return;
-                        }
-
-                        if (response.status === 'APPROVAL_PENDING') {
-                            // Polling was interrupted by losing focus — allow restart on refocus.
+                        if (!settledQuote) {
+                            // Request failed, polling aborted, or attempts exhausted —
+                            // stay on this screen; refocusing restarts the confirmation.
                             hasConfirmedRef.current = false;
 
                             return;
@@ -153,27 +220,44 @@ export const TradingConfirmingScreen = ({
                         break;
                     }
 
-                    case 'revoke-and-approve':
+                    case 'revoke-and-approve': {
                         dispatch(sendFormActions.dispose());
                         // The post-revoke quote carries the revoke transaction's
                         // approvalSendTxHash and approvalType: 'ZERO'. Strip them so the
                         // next confirmApproval call requests a fresh approval rather than
                         // re-using the revoke txid as the approval txid.
-                        if (activeQuote) {
-                            dispatch(
-                                tradingExchangeActions.saveSelectedQuote({
-                                    ...activeQuote,
-                                    approvalSendTxHash: undefined,
-                                    approvalType: undefined,
-                                    status: 'APPROVAL_REQ',
-                                }),
-                            );
+                        const approvalQuote = {
+                            ...activeQuote,
+                            approvalSendTxHash: undefined,
+                            approvalType: 'MINIMAL',
+                            status: 'APPROVAL_REQ',
+                        } satisfies ExchangeTrade;
+                        dispatch(tradingExchangeActions.saveSelectedQuote(approvalQuote));
+
+                        // Same stale window as 'approve': poll until the API indexes the
+                        // confirmed revoke and returns the approval dexTx — navigating with
+                        // the revoke calldata would let it be signed again as the approval.
+                        const settledQuote = await pollConfirmApproval({
+                            initialQuote: approvalQuote,
+                            confirmApproval,
+                            isStale: isStaleRevokeQuote,
+                            signal: pollAbortControllerRef.current.signal,
+                        });
+
+                        if (!settledQuote) {
+                            // Request failed, polling aborted, or attempts exhausted —
+                            // stay on this screen; refocusing restarts the confirmation.
+                            hasConfirmedRef.current = false;
+
+                            return;
                         }
+
                         navigation.popToTop();
                         navigation.push(RootStackRoutes.TradingExchangeApproval, {
                             isRevoked: true,
                         });
                         break;
+                    }
 
                     case 'revoke':
                         dispatch(sendFormActions.dispose());

--- a/suite-native/module-trading/src/screens/__tests__/TradingConfirmingScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingConfirmingScreen.test.tsx
@@ -15,7 +15,10 @@ import {
 } from '@suite-native/transaction-management';
 
 import { createTradingLightStore } from '../../__tests__/tradingTestUtils';
-import { TradingConfirmingScreen } from '../TradingConfirmingScreen';
+import {
+    APPROVAL_STATUS_POLL_INTERVAL_MS,
+    TradingConfirmingScreen,
+} from '../TradingConfirmingScreen';
 
 const mockOpenInBlockchain = jest.fn();
 
@@ -61,6 +64,7 @@ const mockNavigation = {
     setOptions: jest.fn(),
     addListener: mockAddListener,
     canGoBack: jest.fn(() => true),
+    isFocused: jest.fn(() => true),
     getState: jest.fn(() => ({ routes: [{ key: 'root' }, { key: 'confirming' }] })),
 } as any;
 
@@ -189,20 +193,34 @@ describe('TradingConfirmingScreen', () => {
         });
     });
 
-    it('approve: saves quote with CONFIRM status when confirmApproval returns APPROVAL_PENDING', async () => {
+    it('approve: polls confirmApproval while API returns APPROVAL_PENDING and navigates only on CONFIRM', async () => {
+        jest.useFakeTimers();
         mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
-        mockConfirmApproval.mockResolvedValue({ ...testQuote, status: 'APPROVAL_PENDING' });
+        mockConfirmApproval
+            .mockResolvedValueOnce({ ...testQuote, status: 'APPROVAL_PENDING' })
+            .mockResolvedValueOnce({ ...testQuote, status: 'CONFIRM' });
 
         renderScreen({ flowType: 'approve' });
 
         await act(async () => {
-            await Promise.resolve();
+            await jest.advanceTimersByTimeAsync(0);
         });
 
-        expect(selectTradingExchangeSelectedQuote(store.getState())).toEqual(
-            expect.objectContaining({ status: 'CONFIRM' }),
-        );
+        // The swap transaction is not ready yet — no fabricated CONFIRM, no navigation.
+        expect(selectTradingExchangeSelectedQuote(store.getState())?.status).not.toBe('CONFIRM');
+        expect(mockNavigation.popToTop).not.toHaveBeenCalled();
+
+        await act(async () => {
+            await jest.advanceTimersByTimeAsync(APPROVAL_STATUS_POLL_INTERVAL_MS);
+        });
+
+        expect(mockConfirmApproval).toHaveBeenCalledTimes(2);
         expect(mockNavigation.popToTop).toHaveBeenCalled();
+        expect(mockNavigation.push).toHaveBeenCalledWith(RootStackRoutes.TradingExchangePreview, {
+            isApproved: true,
+        });
+
+        jest.useRealTimers();
     });
 
     it('approve: does not navigate when confirmApproval fails', async () => {
@@ -365,7 +383,7 @@ describe('TradingConfirmingScreen', () => {
 
         it('should report continue when on navigation to next screen', async () => {
             mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
-            mockConfirmApproval.mockResolvedValue({ ...testQuote, status: 'APPROVAL_PENDING' });
+            mockConfirmApproval.mockResolvedValue({ ...testQuote, status: 'CONFIRM' });
 
             renderScreen({ flowType: 'approve' });
 

--- a/suite-native/module-trading/src/screens/__tests__/TradingConfirmingScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingConfirmingScreen.test.tsx
@@ -4,6 +4,7 @@ import {
     tradingExchangeActions,
     useAllowanceTxTracking,
 } from '@suite-common/trading';
+import { buildApprovalTransactionData } from '@suite-common/wallet-utils';
 import { getTranslation } from '@suite-native/intl';
 import { type RootStackParamList, RootStackRoutes } from '@suite-native/navigation';
 import { type TestStore, act, renderWithStoreProvider } from '@suite-native/test-utils-store';
@@ -17,8 +18,13 @@ import {
 import { createTradingLightStore } from '../../__tests__/tradingTestUtils';
 import {
     APPROVAL_STATUS_POLL_INTERVAL_MS,
+    APPROVAL_STATUS_POLL_MAX_ATTEMPTS,
     TradingConfirmingScreen,
 } from '../TradingConfirmingScreen';
+
+const testSpender = '0x1234567890123456789012345678901234567890';
+const approveCalldata = buildApprovalTransactionData({ spender: testSpender, amount: '1000000' });
+const revokeCalldata = buildApprovalTransactionData({ spender: testSpender, amount: '0' });
 
 const mockOpenInBlockchain = jest.fn();
 
@@ -34,10 +40,12 @@ jest.mock('@suite-common/device', () => ({
 }));
 
 const mockConfirmApproval = jest.fn().mockResolvedValue({});
+const mockAbortConfirmApproval = jest.fn();
 
 jest.mock('../../hooks/exchange/Approval/useApprovalFlow', () => ({
     useApprovalFlow: () => ({
         confirmApproval: mockConfirmApproval,
+        abortConfirmApproval: mockAbortConfirmApproval,
     }),
 }));
 
@@ -223,6 +231,62 @@ describe('TradingConfirmingScreen', () => {
         jest.useRealTimers();
     });
 
+    it('approve: keeps polling while CONFIRM still carries the approval calldata', async () => {
+        jest.useFakeTimers();
+        mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
+        mockConfirmApproval
+            .mockResolvedValueOnce({
+                ...testQuote,
+                status: 'CONFIRM',
+                dexTx: { data: approveCalldata },
+            })
+            .mockResolvedValueOnce({
+                ...testQuote,
+                status: 'CONFIRM',
+                dexTx: { data: '0xdeadbeef' },
+            });
+
+        renderScreen({ flowType: 'approve' });
+
+        await act(async () => {
+            await jest.advanceTimersByTimeAsync(0);
+        });
+
+        // CONFIRM but still approval calldata — must keep polling, not navigate.
+        expect(mockNavigation.popToTop).not.toHaveBeenCalled();
+
+        await act(async () => {
+            await jest.advanceTimersByTimeAsync(APPROVAL_STATUS_POLL_INTERVAL_MS);
+        });
+
+        expect(mockConfirmApproval).toHaveBeenCalledTimes(2);
+        expect(mockNavigation.push).toHaveBeenCalledWith(RootStackRoutes.TradingExchangePreview, {
+            isApproved: true,
+        });
+
+        jest.useRealTimers();
+    });
+
+    it('approve: stops polling and stays on screen after max attempts', async () => {
+        jest.useFakeTimers();
+        mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
+        mockConfirmApproval.mockResolvedValue({ ...testQuote, status: 'APPROVAL_PENDING' });
+
+        renderScreen({ flowType: 'approve' });
+
+        await act(async () => {
+            await jest.advanceTimersByTimeAsync(
+                APPROVAL_STATUS_POLL_INTERVAL_MS * (APPROVAL_STATUS_POLL_MAX_ATTEMPTS + 1),
+            );
+        });
+
+        // Initial call + one per attempt, then it gives up without navigating.
+        expect(mockConfirmApproval).toHaveBeenCalledTimes(APPROVAL_STATUS_POLL_MAX_ATTEMPTS + 1);
+        expect(mockNavigation.push).not.toHaveBeenCalled();
+
+        jest.useRealTimers();
+    });
+
     it('approve: does not navigate when confirmApproval fails', async () => {
         mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
         mockConfirmApproval.mockResolvedValue(undefined);
@@ -237,7 +301,7 @@ describe('TradingConfirmingScreen', () => {
         expect(mockNavigation.push).not.toHaveBeenCalled();
     });
 
-    it('revoke-and-approve: navigates to TradingExchangeApproval and strips revoke-tx artifacts from selectedQuote', () => {
+    it('revoke-and-approve: navigates to TradingExchangeApproval and strips revoke-tx artifacts from selectedQuote', async () => {
         // Seed selectedQuote with revoke artifacts that the post-revoke confirmExchangeTradeThunk would have written.
         store.dispatch(
             tradingExchangeActions.saveSelectedQuote({
@@ -253,6 +317,17 @@ describe('TradingConfirmingScreen', () => {
 
         renderScreen({ flowType: 'revoke-and-approve' });
 
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mockConfirmApproval).toHaveBeenCalledWith(
+            expect.objectContaining({
+                approvalSendTxHash: undefined,
+                approvalType: 'MINIMAL',
+                status: 'APPROVAL_REQ',
+            }),
+        );
         expect(mockNavigation.popToTop).toHaveBeenCalled();
         expect(mockNavigation.push).toHaveBeenCalledWith(RootStackRoutes.TradingExchangeApproval, {
             isRevoked: true,
@@ -267,10 +342,55 @@ describe('TradingConfirmingScreen', () => {
         const persisted = selectTradingExchangeSelectedQuote(store.getState());
         expect(persisted).toBeDefined();
         expect(persisted?.approvalSendTxHash).toBeUndefined();
-        expect(persisted?.approvalType).toBeUndefined();
+        expect(persisted?.approvalType).toBe('MINIMAL');
         expect(persisted?.status).toBe('APPROVAL_REQ');
 
         dispatchSpy.mockRestore();
+    });
+
+    it('revoke-and-approve: polls confirmApproval while API still returns the revoke dexTx', async () => {
+        jest.useFakeTimers();
+        store.dispatch(
+            tradingExchangeActions.saveSelectedQuote({
+                ...testQuote,
+                approvalType: 'ZERO',
+                approvalSendTxHash: 'revoke-txid',
+                status: 'APPROVAL_PENDING',
+            }),
+        );
+        mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
+        mockConfirmApproval
+            .mockResolvedValueOnce({
+                ...testQuote,
+                status: 'APPROVAL_REQ',
+                dexTx: { data: revokeCalldata },
+            })
+            .mockResolvedValueOnce({
+                ...testQuote,
+                status: 'APPROVAL_REQ',
+                dexTx: { data: approveCalldata },
+            });
+
+        renderScreen({ flowType: 'revoke-and-approve' });
+
+        await act(async () => {
+            await jest.advanceTimersByTimeAsync(0);
+        });
+
+        // The API still returns the revoke dexTx — no navigation yet.
+        expect(mockNavigation.popToTop).not.toHaveBeenCalled();
+
+        await act(async () => {
+            await jest.advanceTimersByTimeAsync(APPROVAL_STATUS_POLL_INTERVAL_MS);
+        });
+
+        expect(mockConfirmApproval).toHaveBeenCalledTimes(2);
+        expect(mockNavigation.popToTop).toHaveBeenCalled();
+        expect(mockNavigation.push).toHaveBeenCalledWith(RootStackRoutes.TradingExchangeApproval, {
+            isRevoked: true,
+        });
+
+        jest.useRealTimers();
     });
 
     it('revoke: pops to top and clears selectedQuote', () => {

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -288,8 +288,10 @@ export const composeEvmApprovalFeeLevelsThunk = createThunk(
                 return rejectWithValue('DEX quote with dexTx data is required');
             }
 
-            const approvalData = Calldata.evm.erc20.approve.decode(dexTx.data);
-            const spender = approvalData?.spender;
+            // 1inch returns an approve() dexTx with the spender encoded in the calldata;
+            // LiFi returns the swap dexTx whose `to` is the router that must be approved
+            // to pull the token. Both identify the same spender.
+            const spender = Calldata.evm.erc20.approve.decode(dexTx.data)?.spender ?? dexTx.to;
             if (!spender) {
                 return rejectWithValue('Could not extract spender from dexTx data');
             }


### PR DESCRIPTION
## Description

After a DEX swap approval confirmed on-chain, `TradingConfirmingScreen` fabricated `status: 'CONFIRM'` on an `APPROVAL_PENDING` response that still carried the approval `dexTx`. The swap step then signed and broadcast the approval calldata a second time, recorded its txid as `receiveTxHash`, and the swap tx was never signed. The revoke-and-approve flow had the same stale window: until the API indexes the confirmed revoke it keeps returning the revoke `dexTx`, so the approval screen would sign approve(0) again.

- `TradingConfirmingScreen` (approve): poll `confirmApproval` until the API returns the follow-up status carrying the swap transaction, instead of faking `CONFIRM`.
- `TradingConfirmingScreen` (revoke-and-approve): poll `confirmApproval` until the API returns the approval `dexTx` instead of the revoke.
- `sendDexTransactionThunk`: reject when the quote's `dexTx` does not match the current step — swap carrying approve/revoke calldata, approval carrying revoke calldata, or revoke carrying approve calldata.

## Notes for QA

On mobile, run a swap requiring approval (e.g. USDC → ETH, 1inch Classic). After the approval confirms, the second device prompt must be the swap tx (recipient = DEX router), not the approval again. Also cover revoke-and-approve (existing allowance too low → revoke, then approve): after the revoke confirms, the next prompt must be the new approval, not approve(0) again. Plain revoke flow unaffected.

## Related Issue

Resolve #29511

## Screenshots:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on DEX exchange thunks (confirmApprovalThunk and sendDexTransactionThunk) in the trading module, plus suite-native mobile trading screens and hooks. The two changed source files map to 121 E2E tests each due to broad transitive imports, but only swap/exchange trading tests actually exercise the DEX approval and transaction sending paths. The suite-native changes (mobile app screens, hooks, thunks) have no E2E test coverage since Playwright tests target the web/desktop Suite only. Unit test files in the changeset provide direct coverage for the thunk logic but are not E2E tests. The recommended strategy focuses on swap trading E2E tests that exercise token approval and DEX transaction flows.

<details><summary><b>Changed files (9)</b></summary>

- `suite-common/trading/src/thunks/exchange/__tests__/confirmApprovalThunk.test.ts`
- `suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts`
- `suite-common/trading/src/thunks/exchange/confirmApprovalThunk.ts`
- `suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts`
- `suite-native/module-trading/src/__tests__/thunks.test.ts`
- `suite-native/module-trading/src/hooks/exchange/Approval/useApprovalFlow.ts`
- `suite-native/module-trading/src/screens/TradingConfirmingScreen.tsx`
- `suite-native/module-trading/src/screens/__tests__/TradingConfirmingScreen.test.tsx`
- `suite-native/module-trading/src/thunks.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test exercises the full swap flow including DEX transaction sending and approval confirmation, which directly uses the changed confirmApprovalThunk and sendDexTransactionThunk. The swap flow with token approval is the primary user-facing path affected by these thunk changes.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Token-to-token swaps (USDT to USDC) are likely to involve DEX exchange paths requiring token approval and DEX transaction sending, directly exercising the changed thunks.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swapping a token (USDT) to a native coin (BTC) involves DEX exchange mechanics including potential token approval flows, directly testing the changed approval and send thunks.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-coins.test.ts` — SOL-to-BTC swap exercises the swap exchange flow end-to-end. While native coin swaps may not require token approval, the sendDexTransactionThunk changes could still affect the transaction sending path.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — ETH-to-BTC swap with custom fee settings exercises the DEX transaction flow with Ethereum-specific fee parameters, which the sendDexTransactionThunk processes.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — BTC-to-ETH swap with custom fees exercises the exchange transaction flow. Changes to sendDexTransactionThunk could affect how transaction info is composed and sent.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swap quote retrieval for a token-to-disabled-network scenario. While it doesn't complete a full DEX transaction, the swap infrastructure that loads quotes shares code paths with the changed exchange thunks.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form input validation and fraction buttons using a remembered wallet. While it doesn't execute a full swap transaction, the swap form infrastructure loads the exchange module containing the changed thunks.
- `suite/e2e/tests/trading/swap-history.test.ts` — Swap history displays completed exchange trades. A regression in the exchange thunks could affect how trade status is tracked, though this test primarily reads historical data rather than executing new swaps.

</details>

⚠️ **Changes with no test coverage (7)**
- `suite-native/module-trading/src/hooks/exchange/Approval/useApprovalFlow.ts`
- `suite-native/module-trading/src/screens/TradingConfirmingScreen.tsx`
- `suite-native/module-trading/src/thunks.ts`
- `suite-native/module-trading/src/screens/__tests__/TradingConfirmingScreen.test.tsx`
- `suite-native/module-trading/src/__tests__/thunks.test.ts`
- `suite-common/trading/src/thunks/exchange/__tests__/confirmApprovalThunk.test.ts`
- `suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts`

_Updated: 2026-07-08T15:27:40.138Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/native/trading-dex-swap-signs-approval-twice/web/](https://dev.suite.sldev.cz/suite-web/fix/native/trading-dex-swap-signs-approval-twice/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/trading-dex-swap-signs-approval-twice&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/trading-dex-swap-signs-approval-twice&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/trading-dex-swap-signs-approval-twice&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-08T15:33:19.972Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T15:31:22.854Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->