### PR TITLE
Open how-staking-works for Solana with no active stake

### DIFF
--- a/suite-native/module-earn/src/utils/__tests__/navigateByAccountState.test.ts
+++ b/suite-native/module-earn/src/utils/__tests__/navigateByAccountState.test.ts
@@ -68,25 +68,26 @@ describe('navigateByAccountState', () => {
         });
     });
 
-    it('navigates to StakingManagement when a Solana account has a balance but no stake', () => {
+    it('navigates to HowStakeWorksScreen when a Solana account has a balance but no stake', () => {
         const account = createMockAccount({ symbol: 'sol' });
         mockGetAccountTotalStakingBalance.mockReturnValue('0');
 
         navigateByAccountState(account, mockNavigate);
 
-        // Solana onboards through its dashboard, not the stake form.
-        expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.StakingManagement, {
+        expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.HowStakeWorksScreen, {
+            symbol: 'sol',
             accountKey: account.key,
         });
     });
 
-    it('navigates to StakingManagement when a Solana account has insufficient balance and no stake', () => {
-        const account = createMockAccount({ symbol: 'sol', availableBalance: '100' });
+    it('navigates to HowStakeWorksScreen when a Solana account has a zero balance and no stake', () => {
+        const account = createMockAccount({ symbol: 'sol', availableBalance: '0' });
         mockGetAccountTotalStakingBalance.mockReturnValue(null);
 
         navigateByAccountState(account, mockNavigate);
 
-        expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.StakingManagement, {
+        expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.HowStakeWorksScreen, {
+            symbol: 'sol',
             accountKey: account.key,
         });
     });

--- a/suite-native/module-earn/src/utils/navigateByAccountState.ts
+++ b/suite-native/module-earn/src/utils/navigateByAccountState.ts
@@ -23,8 +23,17 @@ export const navigateByAccountState = (account: Account, navigate: StakingNaviga
     const stakedBalance = getAccountTotalStakingBalance(account);
     const hasStakedBalance = !!stakedBalance && stakedBalance !== '0';
 
-    if (isSupportedSolStakingNetworkSymbol(account.symbol) || hasStakedBalance) {
+    if (hasStakedBalance) {
         navigate(resolveStakingTargetRoute(account.symbol), {
+            accountKey: account.key,
+        });
+
+        return;
+    }
+
+    if (isSupportedSolStakingNetworkSymbol(account.symbol)) {
+        navigate(RootStackRoutes.HowStakeWorksScreen, {
+            symbol: account.symbol,
             accountKey: account.key,
         });
 


### PR DESCRIPTION
## Description

Solana accounts without an active stake now open the "How SOL staking works" screen instead of the "Your Stake" overview, matching the intended onboarding flow - from there, "Continue" opens the staking amount form. Accounts with an existing staked balance still open the overview unchanged.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29252
