### PR TITLE
Hide token and staking badges in stake, unstake and claim flows

### DIFF
--- a/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
@@ -104,8 +104,10 @@ const AccountsListItemComponent = ({
 
     const isNetworkSupportingTokens = isNetworkWithTokens(account.symbol);
     const shouldShowAccountLabel = !isNetworkSupportingTokens || !isNativeCoinOnly;
-    const shouldShowTokenBadge = accountHasKnownTokensWithBalance && !isNativeCoinOnly;
-    const shouldShowStakingBadge = accountHasStaking && !isNativeCoinOnly;
+    const shouldShowTokenBadge =
+        accountHasKnownTokensWithBalance && !isNativeCoinOnly && !isCryptoBalancePrimary;
+    const shouldShowStakingBadge =
+        accountHasStaking && !isNativeCoinOnly && !isCryptoBalancePrimary;
     const [primaryBalanceTextProps, secondaryBalanceTextProps] = isCryptoBalancePrimary
         ? CRYPTO_PRIMARY_BALANCE_TEXT_PROPS
         : [undefined, undefined];


### PR DESCRIPTION
## Description

The stake, unstake, and claim review screens previously showed the account's token-count badge and the staking badge, together with a combined fiat value that summed the native coin and its tokens. None of that is relevant to the staking flow, which concerns only the native coin. This change hides both badges on those screens so the card shows the native (staked) coin balance with the fiat value of just that coin below it.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29254

## Screenshots:
<img width="1290" height="2394" alt="Simulator Screenshot - iPhone 16 Plus - 2026-07-07 at 20 20 23" src="https://github.com/user-attachments/assets/ba5d99b1-76fb-407c-8a96-3a55beb6c472" />
<img width="1290" height="1102" alt="Simulator Screenshot - iPhone 16 Plus - 2026-07-07 at 20 31 15" src="https://github.com/user-attachments/assets/0ab5dd32-ff9a-4d41-b733-426375e613c1" />
<img width="1290" height="1253" alt="Simulator Screenshot - iPhone 16 Plus - 2026-07-07 at 20 31 33" src="https://github.com/user-attachments/assets/aa15f9d4-1150-47fb-a709-a318abbca3f2" />

