### PR TITLE
Use dedicated Everstake source for mobile staking

### DIFF
--- a/coins/coins-solana/src/runtime/staking.ts
+++ b/coins/coins-solana/src/runtime/staking.ts
@@ -414,6 +414,7 @@ export const prepareStakeSolTx = async ({
     connection,
     validator,
     estimatedFee,
+    source = WALLET_SDK_SOURCE,
 }: PrepareStakeSolTxParams): Promise<PrepareStakeSolTxResponse> => {
     try {
         const lamports = toLamports(amount);
@@ -423,7 +424,7 @@ export const prepareStakeSolTx = async ({
             validator,
             sender: from,
             lamports: BigInt(lamports),
-            source: WALLET_SDK_SOURCE,
+            source,
             params,
         });
 
@@ -455,6 +456,7 @@ export const prepareUnstakeSolTx = async ({
     amount,
     connection,
     estimatedFee,
+    source = WALLET_SDK_SOURCE,
 }: PrepareStakeSolTxParams): Promise<PrepareStakeSolTxResponse> => {
     try {
         const lamports = toLamports(amount);
@@ -463,7 +465,7 @@ export const prepareUnstakeSolTx = async ({
             connection,
             sender: from,
             lamports: BigInt(lamports),
-            source: WALLET_SDK_SOURCE,
+            source,
             params,
         });
         const txShim = createTransactionShim(tx.unstakeTx);

--- a/coins/coins-solana/src/types/staking.ts
+++ b/coins/coins-solana/src/types/staking.ts
@@ -48,6 +48,8 @@ export interface PrepareStakeSolTxParams {
     connection: Connection;
     validator: Address;
     estimatedFee?: Fee;
+    // Everstake Wallet SDK source, identifies the integrating app for TVL attribution.
+    source?: string;
 }
 
 export type PrepareClaimSolTxParams = Omit<PrepareStakeSolTxParams, 'amount' | 'validator'>;

--- a/suite-common/staking/src/actions/solanaStakeFormActions.ts
+++ b/suite-common/staking/src/actions/solanaStakeFormActions.ts
@@ -136,6 +136,7 @@ type PrepareSolanaStakeTxDataParams = {
     blockchainUrl: string;
     userAgent: string;
     estimatedFee?: Fee;
+    source?: string;
 };
 
 // Builds stake/unstake/claim tx via Solana runtime; `userAgent` differs for Suite vs Lite.
@@ -147,6 +148,7 @@ export const prepareSolanaStakeTxData = async ({
     blockchainUrl,
     userAgent,
     estimatedFee,
+    source,
 }: PrepareSolanaStakeTxDataParams): Promise<PrepareStakeSolTxResponse | undefined> => {
     const {
         selectSolanaConnection,
@@ -160,11 +162,11 @@ export const prepareSolanaStakeTxData = async ({
     const validator = selectSolanaValidator(symbol);
 
     if (stakeType === 'stake') {
-        return prepareStakeSolTx({ from, amount, connection, validator, estimatedFee });
+        return prepareStakeSolTx({ from, amount, connection, validator, estimatedFee, source });
     }
 
     if (stakeType === 'unstake') {
-        return prepareUnstakeSolTx({ from, amount, connection, validator, estimatedFee });
+        return prepareUnstakeSolTx({ from, amount, connection, validator, estimatedFee, source });
     }
 
     if (stakeType === 'claim') {
@@ -179,6 +181,7 @@ type ComposeSolanaStakingTransactionParams = {
     composeContext: ComposeActionContext;
     blockchainUrl: string;
     userAgent: string;
+    source?: string;
 };
 
 // Solana stake compose: build tx, estimate fee, rebuild with fee and solanaTxMeta (not send-form).
@@ -187,6 +190,7 @@ export const composeSolanaStakingTransaction = async ({
     composeContext,
     blockchainUrl,
     userAgent,
+    source,
 }: ComposeSolanaStakingTransactionParams): Promise<PrecomposedLevels | undefined> => {
     const { account, feeInfo } = composeContext;
     const amount = formValues.outputs[0]?.amount;
@@ -205,6 +209,7 @@ export const composeSolanaStakingTransaction = async ({
         stakeType,
         blockchainUrl,
         userAgent,
+        source,
     });
 
     const estimatedFee = await estimateSolanaStakeFee(account.symbol, txData);
@@ -229,6 +234,7 @@ export const composeSolanaStakingTransaction = async ({
             stakeType,
             blockchainUrl,
             userAgent,
+            source,
             estimatedFee: estimatedFee.payload,
         });
 

--- a/suite-common/staking/src/utils/ethereumStaking.ts
+++ b/suite-common/staking/src/utils/ethereumStaking.ts
@@ -50,9 +50,6 @@ import {
     type StakeTxBaseArgs,
 } from '../types';
 
-const STAKE_SOURCE = new BigNumber(WALLET_SDK_SOURCE);
-const STAKE_SOURCE_BIGINT = BigInt(WALLET_SDK_SOURCE);
-
 const encodeCalldata = <D extends string>(
     label: string,
     result: { isValid: boolean; data: D | null },
@@ -70,23 +67,27 @@ const verifyCalldata = (label: string, result: { isValid: boolean; issues: Verif
     }
 };
 
-export const buildStakeData = () => {
+export const buildStakeData = (source: string = WALLET_SDK_SOURCE) => {
     const data = encodeCalldata(
         'stake',
-        Calldata.evm.everstake.stake.encode({ source: STAKE_SOURCE }),
+        Calldata.evm.everstake.stake.encode({ source: new BigNumber(source) }),
     );
-    verifyCalldata('stake', Verifier.evm.everstake.stake(data, { source: STAKE_SOURCE_BIGINT }));
+    verifyCalldata('stake', Verifier.evm.everstake.stake(data, { source: BigInt(source) }));
 
     return data;
 };
 
-export const buildUnstakeData = (amountWei: string, interchanges: number) => {
+export const buildUnstakeData = (
+    amountWei: string,
+    interchanges: number,
+    source: string = WALLET_SDK_SOURCE,
+) => {
     const data = encodeCalldata(
         'unstake',
         Calldata.evm.everstake.unstake.encode({
             value: new BigNumber(amountWei),
             allowedInterchangeNum: new BigNumber(interchanges),
-            source: STAKE_SOURCE,
+            source: new BigNumber(source),
         }),
     );
     verifyCalldata(
@@ -94,7 +95,7 @@ export const buildUnstakeData = (amountWei: string, interchanges: number) => {
         Verifier.evm.everstake.unstake(data, {
             value: BigInt(amountWei),
             allowedInterchangeNum: interchanges,
-            source: STAKE_SOURCE_BIGINT,
+            source: BigInt(source),
         }),
     );
 
@@ -115,19 +116,22 @@ export const buildClaimWithdrawRequestData = () => {
 export const verifyEthereumStakingCalldata = ({
     stakeType,
     calldata,
+    source = WALLET_SDK_SOURCE,
 }: {
     stakeType: StakeType;
     calldata: string;
+    source?: string;
 }): { isValid: boolean; issues: VerifyIssue[] } => {
     const data = calldata as `0x${string}`;
+    const sourceBigInt = BigInt(source);
 
     if (stakeType === 'stake') {
-        return Verifier.evm.everstake.stake(data, { source: STAKE_SOURCE_BIGINT });
+        return Verifier.evm.everstake.stake(data, { source: sourceBigInt });
     }
     if (stakeType === 'unstake') {
         return Verifier.evm.everstake.unstake(
             data,
-            { value: 0n, allowedInterchangeNum: 0, source: STAKE_SOURCE_BIGINT },
+            { value: 0n, allowedInterchangeNum: 0, source: sourceBigInt },
             ['source'],
         );
     }
@@ -737,7 +741,8 @@ export const simulateUnstake = async ({
     amount,
     from,
     symbol,
-}: StakeTxBaseArgs & { amount: string }) => {
+    source = WALLET_SDK_SOURCE,
+}: StakeTxBaseArgs & { amount: string; source?: string }) => {
     if (!isSupportedEthStakingNetworkSymbol(symbol)) return null;
     if (!amount || !from || !symbol) return null;
 
@@ -746,7 +751,7 @@ export const simulateUnstake = async ({
     const { addressContractPool } = ethAddresses;
 
     const amountWei = fromEther(amount).toWei();
-    const data = buildUnstakeData(amountWei, UNSTAKE_INTERCHANGES);
+    const data = buildUnstakeData(amountWei, UNSTAKE_INTERCHANGES, source);
 
     const transactionData = await TrezorConnect.blockchainEvmRpcCall({
         coin: symbol,

--- a/suite-common/wallet-constants/src/stakingConstants.ts
+++ b/suite-common/wallet-constants/src/stakingConstants.ts
@@ -3,3 +3,5 @@
 // It is a constant which allows the SDK to define which app calls its functions.
 // Each app which integrates the SDK has its own source, e.g. source for Trezor Suite is '1'.
 export const WALLET_SDK_SOURCE = '1';
+
+export const WALLET_SDK_SOURCE_MOBILE = '111';

--- a/suite-native/module-earn/src/hooks/useApproximateInstantUnstakeAmount.ts
+++ b/suite-native/module-earn/src/hooks/useApproximateInstantUnstakeAmount.ts
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { useQuery } from '@suite-common/react-query';
 import { simulateUnstake } from '@suite-common/staking';
+import { WALLET_SDK_SOURCE_MOBILE } from '@suite-common/wallet-constants';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { isSupportedEthStakingNetworkSymbol } from '@suite-common/wallet-utils';
@@ -38,7 +39,12 @@ export const useApproximateInstantUnstakeAmount = (accountKey: AccountKey, amoun
                     return null;
                 }
 
-                const result = await simulateUnstake({ amount, from: descriptor, symbol });
+                const result = await simulateUnstake({
+                    amount,
+                    from: descriptor,
+                    symbol,
+                    source: WALLET_SDK_SOURCE_MOBILE,
+                });
 
                 if (signal.aborted || !result || !new BigNumber(result).gt(0)) {
                     return null;

--- a/suite-native/module-earn/src/hooks/useEarnForm.ts
+++ b/suite-native/module-earn/src/hooks/useEarnForm.ts
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { buildStakeData, getEthereumStakingAddressByType } from '@suite-common/staking';
 import { getNetwork } from '@suite-common/wallet-config';
+import { WALLET_SDK_SOURCE_MOBILE } from '@suite-common/wallet-constants';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
@@ -50,7 +51,7 @@ export const useEarnForm = (accountKey: AccountKey) => {
         return buildEarnComposeFormState(
             getEthereumStakingAddressByType(account.symbol, 'stake'),
             amountValue,
-            buildStakeData(),
+            buildStakeData(WALLET_SDK_SOURCE_MOBILE),
         );
     }, [account, isValid, amountValue]);
 

--- a/suite-native/module-earn/src/hooks/useUnstakeForm.ts
+++ b/suite-native/module-earn/src/hooks/useUnstakeForm.ts
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { buildUnstakeData, getEthereumStakingAddressByType } from '@suite-common/staking';
 import { getNetwork } from '@suite-common/wallet-config';
-import { UNSTAKE_INTERCHANGES } from '@suite-common/wallet-constants';
+import { UNSTAKE_INTERCHANGES, WALLET_SDK_SOURCE_MOBILE } from '@suite-common/wallet-constants';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import {
@@ -77,7 +77,7 @@ export const useUnstakeForm = (accountKey: AccountKey) => {
         return buildEarnComposeFormState(
             getEthereumStakingAddressByType(account.symbol, 'unstake'),
             '0',
-            buildUnstakeData(amountWei, UNSTAKE_INTERCHANGES),
+            buildUnstakeData(amountWei, UNSTAKE_INTERCHANGES, WALLET_SDK_SOURCE_MOBILE),
         );
     }, [account, isValid, amountValue]);
 

--- a/suite-native/staking/src/__tests__/stakeFormEthereumNativeThunks.test.ts
+++ b/suite-native/staking/src/__tests__/stakeFormEthereumNativeThunks.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@suite-common/staking';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
-import { UNSTAKE_INTERCHANGES } from '@suite-common/wallet-constants';
+import { UNSTAKE_INTERCHANGES, WALLET_SDK_SOURCE_MOBILE } from '@suite-common/wallet-constants';
 import { prepareSendFormReducer } from '@suite-common/wallet-core';
 import {
     type Account,
@@ -86,8 +86,13 @@ const buildPrecomposedTransaction = (
     }) as PrecomposedTransactionFinal;
 
 const buildCalldataForKind = (kind: StakeNativeType): string => {
-    if (kind === 'stake') return buildStakeData();
-    if (kind === 'unstake') return buildUnstakeData('1500000000000000000', UNSTAKE_INTERCHANGES);
+    if (kind === 'stake') return buildStakeData(WALLET_SDK_SOURCE_MOBILE);
+    if (kind === 'unstake')
+        return buildUnstakeData(
+            '1500000000000000000',
+            UNSTAKE_INTERCHANGES,
+            WALLET_SDK_SOURCE_MOBILE,
+        );
 
     return buildClaimWithdrawRequestData();
 };
@@ -195,7 +200,7 @@ describe('signEthereumStakingTransactionNativeThunk', () => {
         expect(signCall.transaction.to).toBe(POOL_ADDRESS);
         // 1.5 ETH = 1.5 * 10^18 wei = 1500000000000000000 = 0x14d1120d7b160000
         expect(signCall.transaction.value).toBe('0x14d1120d7b160000');
-        expect(signCall.transaction.data).toBe(buildStakeData());
+        expect(signCall.transaction.data).toBe(buildStakeData(WALLET_SDK_SOURCE_MOBILE));
     });
 
     it('passes value=0 and unstake calldata for an unstake variant', async () => {
@@ -221,7 +226,7 @@ describe('signEthereumStakingTransactionNativeThunk', () => {
         expect(signCall.transaction.to).toBe(POOL_ADDRESS);
         expect(signCall.transaction.value).toBe('0x0');
         expect(signCall.transaction.data).toBe(
-            buildUnstakeData('1500000000000000000', UNSTAKE_INTERCHANGES),
+            buildUnstakeData('1500000000000000000', UNSTAKE_INTERCHANGES, WALLET_SDK_SOURCE_MOBILE),
         );
     });
 

--- a/suite-native/staking/src/__tests__/stakeNativeThunks.test.ts
+++ b/suite-native/staking/src/__tests__/stakeNativeThunks.test.ts
@@ -4,6 +4,7 @@ import { messageSystemInitialState } from '@suite-common/message-system';
 import { buildStakeData } from '@suite-common/staking';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { WALLET_SDK_SOURCE_MOBILE } from '@suite-common/wallet-constants';
 import { prepareSendFormReducer } from '@suite-common/wallet-core';
 import {
     type Account,
@@ -185,7 +186,7 @@ const buildEthStakeFormDraft = (): FormState =>
             },
         ],
         options: ['transactionData'],
-        transactionData: buildStakeData(),
+        transactionData: buildStakeData(WALLET_SDK_SOURCE_MOBILE),
         isCoinControlEnabled: false,
         hasCoinControlBeenOpened: false,
         selectedUtxos: [],

--- a/suite-native/staking/src/stakeFormEthereumNativeThunks.ts
+++ b/suite-native/staking/src/stakeFormEthereumNativeThunks.ts
@@ -2,6 +2,7 @@ import { selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import { transformTx, verifyEthereumStakingCalldata } from '@suite-common/staking';
 import { getNetwork } from '@suite-common/wallet-config';
+import { WALLET_SDK_SOURCE_MOBILE } from '@suite-common/wallet-constants';
 import {
     ethereumGetCurrentNonceThunk,
     selectAccountByKey,
@@ -126,6 +127,7 @@ const prepareEthereumStakingContext = (
     const calldataCheck = verifyEthereumStakingCalldata({
         stakeType,
         calldata: variant.calldata,
+        source: WALLET_SDK_SOURCE_MOBILE,
     });
     if (!calldataCheck.isValid) {
         return failed(

--- a/suite-native/staking/src/stakeFormSolanaNativeThunks.ts
+++ b/suite-native/staking/src/stakeFormSolanaNativeThunks.ts
@@ -2,6 +2,7 @@ import { selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import { composeSolanaStakingTransaction, prepareSolanaStakeTxData } from '@suite-common/staking';
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { WALLET_SDK_SOURCE_MOBILE } from '@suite-common/wallet-constants';
 import {
     selectAccountByKey,
     selectAddressDisplayType,
@@ -144,6 +145,7 @@ export const composeSolanaStakingTransactionFeeLevelsNativeThunk = createThunk<
             },
             blockchainUrl,
             userAgent: getSolanaUserAgent(),
+            source: WALLET_SDK_SOURCE_MOBILE,
         });
     },
 );
@@ -208,6 +210,7 @@ export const signSolanaStakingTransactionNativeThunk = createThunk<
                 stakeType,
                 blockchainUrl,
                 userAgent: getSolanaUserAgent(),
+                source: WALLET_SDK_SOURCE_MOBILE,
                 estimatedFee,
             });
 


### PR DESCRIPTION
## Description

Trezor Suite mobile previously shared the Everstake SDK source `1` with desktop Suite for both Solana and Ethereum staking, so stakes made from mobile could not be distinguished in Everstake's TVL data. This change gives mobile a dedicated source `111`, threaded through the Solana flow and the Ethereum flow (contract calldata and its on-device verification), so mobile staking is attributed separately. Desktop Suite continues to use source `1` unchanged.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29319