### PR TITLE
fix(suite-native): display information about reward tokens

### DIFF
--- a/suite-common/earn-stablecoin-api/src/utils/sortRewardsByUnderlyingToken.ts
+++ b/suite-common/earn-stablecoin-api/src/utils/sortRewardsByUnderlyingToken.ts
@@ -27,3 +27,14 @@ export const sortRewardsByUnderlyingToken = (
 
         return b.rate - a.rate;
     });
+
+export const getBonusRewardToken = (
+    rewards: RewardDtoV2[],
+    underlyingToken: TokenDtoV2 | undefined,
+) => {
+    if (!underlyingToken) {
+        return null;
+    }
+
+    return rewards.find(reward => !isSameToken(reward.token, underlyingToken))?.token ?? null;
+};

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2806,6 +2806,10 @@ export const messages = {
                     title: 'Deposit {tokenSymbol} to receive {vaultTokenSymbol}',
                     description: 'This is your vault position.',
                 },
+                fourth: {
+                    title: 'You will also earn {bonusRewardTokenName} tokens as rewards.',
+                    description: 'These must be claimed separately.',
+                },
             },
             timelineCardTitle: 'Deposit timeline',
             timelineBottomSheetTitle: 'Deposit timeline',

--- a/suite-native/intl/translations/en-US.json
+++ b/suite-native/intl/translations/en-US.json
@@ -1413,6 +1413,8 @@
     "earn.howYieldWorksScreen.benefits.second.description": "Most rewards compound automatically—some must be claimed manually.",
     "earn.howYieldWorksScreen.benefits.third.title": "Deposit {tokenSymbol} to receive {vaultTokenSymbol}",
     "earn.howYieldWorksScreen.benefits.third.description": "This is your vault position.",
+    "earn.howYieldWorksScreen.benefits.fourth.title": "You will also earn {bonusRewardTokenName} tokens as rewards.",
+    "earn.howYieldWorksScreen.benefits.fourth.description": "These must be claimed separately.",
     "earn.howYieldWorksScreen.timelineCardTitle": "Deposit timeline",
     "earn.howYieldWorksScreen.timelineBottomSheetTitle": "Deposit timeline",
     "earn.howYieldWorksScreen.depositTimelineTitle": "Deposit",

--- a/suite-native/module-earn/src/components/YieldDepositInfoBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/YieldDepositInfoBottomSheet.tsx
@@ -15,6 +15,7 @@ import { createHowYieldWorksPreset } from '../presets/HowEarnWorks/yieldPresets'
 
 type YieldDepositInfoBottomSheetProps = {
     apy: number | null;
+    bonusRewardTokenName?: string | null;
     onClose: () => void;
     ref: BottomSheetModalRef;
     tokenSymbol: string;
@@ -23,6 +24,7 @@ type YieldDepositInfoBottomSheetProps = {
 
 export const YieldDepositInfoBottomSheet = ({
     apy,
+    bonusRewardTokenName,
     onClose,
     ref,
     tokenSymbol,
@@ -30,6 +32,7 @@ export const YieldDepositInfoBottomSheet = ({
 }: YieldDepositInfoBottomSheetProps) => {
     const { benefitItems, timelineSections } = createHowYieldWorksPreset({
         apy,
+        bonusRewardTokenName,
         tokenSymbol,
         vaultTokenSymbol,
     });

--- a/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts
+++ b/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts
@@ -3,7 +3,11 @@ import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { type YieldDtoV2, useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
+import {
+    type YieldDtoV2,
+    getBonusRewardToken,
+    useAllYieldOpportunities,
+} from '@suite-common/earn-stablecoin-api';
 import { getNetworkByYieldXyzId } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
@@ -30,6 +34,7 @@ export type YieldFlowResolutionStatus =
 type UnresolvedYieldFlowData = {
     account: Account | null;
     apy: number | null;
+    bonusRewardTokenName: string | null;
     flowKey: string | null;
     providerName: string | null;
     receiptToken: YieldFlowDisplayToken | null;
@@ -46,6 +51,7 @@ type UnresolvedYieldFlowData = {
 type YieldFlowDataResolved = {
     account: Account;
     apy: number | null;
+    bonusRewardTokenName: string | null;
     flowKey: string;
     providerName: string;
     receiptToken: YieldFlowDisplayToken;
@@ -78,6 +84,7 @@ type YieldFlowProps = { displayError?: boolean } & YieldFlowParams;
 const defaultFlowData: ResolvedYieldFlowData = {
     account: null,
     apy: null,
+    bonusRewardTokenName: null,
     flowKey: null,
     providerName: null,
     receiptToken: null,
@@ -136,8 +143,10 @@ export const resolveYieldFlowData = ({
     const providerName = capitalizeFirstLetter(vault.providerId);
     const vaultTokenName = vault.outputToken?.name;
     const vaultTokenSymbol = vault.outputToken.symbol;
+    const bonusRewardToken = getBonusRewardToken(vault.rewardRate.components, vault.token);
     const resolvedVaultData = {
         apy,
+        bonusRewardTokenName: bonusRewardToken?.name ?? null,
         providerName,
         tokenSymbol: toTokenSymbol(vault.token.symbol.toUpperCase()),
         vault,

--- a/suite-native/module-earn/src/presets/HowEarnWorks/yieldPresets.tsx
+++ b/suite-native/module-earn/src/presets/HowEarnWorks/yieldPresets.tsx
@@ -6,12 +6,14 @@ type CreateHowYieldWorksPresetProps = {
     tokenSymbol: string;
     vaultTokenSymbol: string;
     apy: number | null;
+    bonusRewardTokenName?: string | null;
 };
 
 export const createHowYieldWorksPreset = ({
     tokenSymbol,
     vaultTokenSymbol,
     apy,
+    bonusRewardTokenName,
 }: CreateHowYieldWorksPresetProps): HowEarnWorksScreenPreset => ({
     benefitItems: [
         {
@@ -42,6 +44,23 @@ export const createHowYieldWorksPreset = ({
             ),
             description: <Translation id="earn.howYieldWorksScreen.benefits.third.description" />,
         },
+        ...(bonusRewardTokenName
+            ? [
+                  {
+                      id: 'yield-benefit-bonus-reward',
+                      icon: 'coin' as const,
+                      title: (
+                          <Translation
+                              id="earn.howYieldWorksScreen.benefits.fourth.title"
+                              values={{ bonusRewardTokenName }}
+                          />
+                      ),
+                      description: (
+                          <Translation id="earn.howYieldWorksScreen.benefits.fourth.description" />
+                      ),
+                  },
+              ]
+            : []),
     ],
     timelineSections: [
         {

--- a/suite-native/module-earn/src/screens/HowYieldWorksScreen.tsx
+++ b/suite-native/module-earn/src/screens/HowYieldWorksScreen.tsx
@@ -21,9 +21,8 @@ type NavigationProps = StackNavigationProps<YieldStackParamList, YieldStackRoute
 export const HowYieldWorksScreen = () => {
     const navigation = useNavigation<NavigationProps>();
     const route = useRoute<RouteProp<YieldStackParamList, YieldStackRoutes.HowYieldWorks>>();
-    const { apy, tokenSymbol, vaultTokenSymbol, resolutionStatus } = useResolvedYieldFlowData(
-        route.params,
-    );
+    const { apy, tokenSymbol, vaultTokenSymbol, bonusRewardTokenName, resolutionStatus } =
+        useResolvedYieldFlowData(route.params);
 
     const handleNavigateToYieldConsents = () => {
         navigation.navigate(YieldStackRoutes.YieldConsents, route.params);
@@ -37,6 +36,7 @@ export const HowYieldWorksScreen = () => {
         tokenSymbol,
         vaultTokenSymbol,
         apy,
+        bonusRewardTokenName,
     });
 
     return (

--- a/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
@@ -66,6 +66,7 @@ export const YieldDepositApprovalScreen = () => {
         account,
         flowData,
         apy,
+        bonusRewardTokenName,
         flowKey,
         token,
         tokenSymbol,
@@ -345,6 +346,7 @@ export const YieldDepositApprovalScreen = () => {
             <YieldDepositInfoBottomSheet
                 ref={infoBottomSheetRef}
                 apy={apy}
+                bonusRewardTokenName={bonusRewardTokenName}
                 onClose={handleCloseInfoBottomSheet}
                 tokenSymbol={tokenSymbol}
                 vaultTokenSymbol={vaultTokenSymbol}

--- a/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
@@ -67,6 +67,7 @@ export const YieldDepositScreen = () => {
     const {
         account,
         apy,
+        bonusRewardTokenName,
         flowData,
         flowKey,
         token,
@@ -349,6 +350,7 @@ export const YieldDepositScreen = () => {
             <YieldDepositInfoBottomSheet
                 ref={infoBottomSheetRef}
                 apy={apy}
+                bonusRewardTokenName={bonusRewardTokenName}
                 onClose={handleCloseInfoBottomSheet}
                 tokenSymbol={tokenSymbol}
                 vaultTokenSymbol={vaultTokenSymbol}

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -106,6 +106,7 @@ export const YieldWithdrawScreen = () => {
     const {
         account,
         apy,
+        bonusRewardTokenName,
         flowData,
         flowKey,
         resolutionStatus,
@@ -589,6 +590,7 @@ export const YieldWithdrawScreen = () => {
             <YieldDepositInfoBottomSheet
                 ref={infoBottomSheetRef}
                 apy={apy}
+                bonusRewardTokenName={bonusRewardTokenName}
                 onClose={handleCloseInfoBottomSheet}
                 tokenSymbol={underlyingTokenSymbol}
                 vaultTokenSymbol={resolvedVaultTokenSymbol}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Checking contract address in the context of the vault to determine if there are additional rewards and then append the message. 

## Notes for QA

During deposit steps you'll see a one more row with information about rewards. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29530

## Screenshots:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-07-08 at 09 51 13" src="https://github.com/user-attachments/assets/b6ecf3b8-91a2-4b6f-b635-95ba2e556015" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All 10 changed files are under `suite-native/` (mobile/React Native app) or `suite-common/earn-stablecoin-api/` — none of them are part of the Suite web/desktop codebase that the 123 candidate E2E tests exercise. The E2E test suite covers `suite/e2e/tests/` which tests the web and Electron desktop app. The changed screens (YieldDepositScreen, YieldWithdrawScreen, HowYieldWorksScreen, etc.), hooks, components, and native intl files have no corresponding web E2E test coverage. No candidate test exercises any of the changed code paths, so no tests are recommended. The risk of web/desktop regression from these mobile-only changes is negligible.

<details><summary><b>Changed files (10)</b></summary>

- `suite-common/earn-stablecoin-api/src/utils/sortRewardsByUnderlyingToken.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/intl/translations/en-US.json`
- `suite-native/module-earn/src/components/YieldDepositInfoBottomSheet.tsx`
- `suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts`
- `suite-native/module-earn/src/presets/HowEarnWorks/yieldPresets.tsx`
- `suite-native/module-earn/src/screens/HowYieldWorksScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (10)**
- `suite-common/earn-stablecoin-api/src/utils/sortRewardsByUnderlyingToken.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/intl/translations/en-US.json`
- `suite-native/module-earn/src/components/YieldDepositInfoBottomSheet.tsx`
- `suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts`
- `suite-native/module-earn/src/presets/HowEarnWorks/yieldPresets.tsx`
- `suite-native/module-earn/src/screens/HowYieldWorksScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx`

_Updated: 2026-07-08T08:27:35.245Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-rewards-copy-native&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-rewards-copy-native&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/yield-rewards-copy-native&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-08T08:33:53.097Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T08:31:25.335Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-rewards-copy-native/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-rewards-copy-native/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->