### PR TITLE
feat(suite-native-28186): remove receive address from trade form mobile

### DIFF
--- a/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountPicker.test.tsx
@@ -19,7 +19,6 @@ import { BuyReceiveAccountPicker } from '../BuyReceiveAccountPicker';
 
 const mockNavigate = jest.fn();
 const btcAccountName1 = 'BTC Account #1';
-const btcAddressAddress = 'USED1';
 
 jest.mock('@react-navigation/native', () => ({
     ...jest.requireActual('@react-navigation/native'),
@@ -84,7 +83,7 @@ describe('BuyReceiveAccountPicker', () => {
         expect(getByText(getTranslation('moduleTrading.notSelected'))).toBeTruthy();
     });
 
-    it('should display selected account name and address', () => {
+    it('should display selected account name', () => {
         setSelectedAsset(btcAsset);
         const { getByText } = renderPicker(
             tradingStateWithReceiveAccount({
@@ -94,7 +93,6 @@ describe('BuyReceiveAccountPicker', () => {
         );
 
         expect(getByText(btcAccountName1)).toBeTruthy();
-        expect(getByText(btcAddressAddress)).toBeTruthy();
     });
 
     it('should call navigate with correct params on press', () => {

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountPicker.test.tsx
@@ -21,7 +21,6 @@ import { ExchangeReceiveAccountPicker } from '../ExchangeReceiveAccountPicker';
 
 const mockNavigate = jest.fn();
 const btcAccountName1 = 'BTC Account #1';
-const btcAddressAddress = 'USED1';
 
 jest.mock('@react-navigation/native', () => ({
     ...jest.requireActual('@react-navigation/native'),
@@ -91,7 +90,7 @@ describe('ExchangeReceiveAccountPicker', () => {
         expect(getByText(getTranslation('moduleTrading.notSelected'))).toBeTruthy();
     });
 
-    it('should display selected account name and address', () => {
+    it('should display selected account name', () => {
         setSelectedAsset(btcAsset);
         const { getByText } = renderPicker(
             exchangeStateWithReceiveAccount({
@@ -101,7 +100,6 @@ describe('ExchangeReceiveAccountPicker', () => {
         );
 
         expect(getByText(btcAccountName1)).toBeTruthy();
-        expect(getByText(btcAddressAddress)).toBeTruthy();
     });
 
     it('should call navigate with correct params on press', () => {

--- a/suite-native/module-trading/src/components/general/ReceiveAccount/ReceiveAccountPicker.tsx
+++ b/suite-native/module-trading/src/components/general/ReceiveAccount/ReceiveAccountPicker.tsx
@@ -7,7 +7,6 @@ import { type TradingType } from '@suite-common/trading';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectAccountLabel } from '@suite-native/accounts';
 import { Text, VStack } from '@suite-native/atoms';
-import { AddressFormatter } from '@suite-native/formatters';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { type CombinedLabelingState } from '@suite-native/labeling';
 import {
@@ -20,8 +19,6 @@ import {
 import { OverviewRow } from '@suite-native/trading-atoms';
 import { type ReceiveAccount } from '@suite-native/trading-types';
 import { type Color } from '@trezor/theme';
-
-import { getReceiveAccountAddressText } from '../../../utils/general/receiveAccountUtils';
 
 export type ReceiveAccountPickerProps = {
     symbol: NetworkSymbol | undefined;
@@ -40,7 +37,6 @@ type RightTextProps = {
 
 type ReceiveAccountPickerRightProps = {
     accountLabel: string | undefined;
-    addressText: string | undefined;
     testID?: string;
 };
 
@@ -63,11 +59,7 @@ const RightText = ({ color, variant = 'body-sm', testID, children }: RightTextPr
     </Text>
 );
 
-const ReceiveAccountPickerRight = ({
-    accountLabel,
-    addressText,
-    testID,
-}: ReceiveAccountPickerRightProps) => {
+const ReceiveAccountPickerRight = ({ accountLabel, testID }: ReceiveAccountPickerRightProps) => {
     if (accountLabel == null) {
         return (
             <RightText
@@ -79,33 +71,13 @@ const ReceiveAccountPickerRight = ({
         );
     }
 
-    if (!addressText) {
-        return (
-            <RightText
-                color="contentPrimary"
-                testID={testID ? `${testID}/selected-account` : undefined}
-            >
-                {accountLabel}
-            </RightText>
-        );
-    }
-
     return (
-        <>
-            <RightText
-                color="contentPrimary"
-                testID={testID ? `${testID}/selected-account` : undefined}
-            >
-                {accountLabel}
-            </RightText>
-            <AddressFormatter
-                value={addressText}
-                format="short"
-                color="contentSecondary"
-                variant="body-sm"
-                textAlign="right"
-            />
-        </>
+        <RightText
+            color="contentPrimary"
+            testID={testID ? `${testID}/selected-account` : undefined}
+        >
+            {accountLabel}
+        </RightText>
     );
 };
 
@@ -135,8 +107,6 @@ export const ReceiveAccountPicker = ({
     const openAccountPicker = () =>
         navigation.navigate(RootStackRoutes.ReceiveAccounts, { symbol, tradingType });
 
-    const addressText = getReceiveAccountAddressText(receiveAccount) ?? '';
-
     return (
         <OverviewRow
             title={translate('moduleTrading.tradingScreen.receiveAccount')}
@@ -145,11 +115,7 @@ export const ReceiveAccountPicker = ({
             noBottomBorder={noBottomBorder}
         >
             <VStack spacing={0} paddingLeft="sp20">
-                <ReceiveAccountPickerRight
-                    accountLabel={accountLabel}
-                    addressText={addressText}
-                    testID={testID}
-                />
+                <ReceiveAccountPickerRight accountLabel={accountLabel} testID={testID} />
             </VStack>
         </OverviewRow>
     );

--- a/suite-native/module-trading/src/components/general/ReceiveAccount/__tests__/ReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/general/ReceiveAccount/__tests__/ReceiveAccountPicker.test.tsx
@@ -110,7 +110,7 @@ describe('ReceiveAccountPicker', () => {
         expect(getByText('BTC Account #1')).toBeTruthy();
     });
 
-    it('should display account name and address', () => {
+    it('should display account name when address is selected', () => {
         const { getByText } = renderReceiveAccountPicker({
             receiveAccount: {
                 account: btc1NormalAccount,
@@ -119,7 +119,6 @@ describe('ReceiveAccountPicker', () => {
         });
 
         expect(getByText('BTC Account #1')).toBeTruthy();
-        expect(getByText('USED1')).toBeTruthy();
     });
 
     describe('with testID specified', () => {


### PR DESCRIPTION
## Description 
- Remove receive address rendering from the mobile trading receive-account picker.

## Notes for QA
- Verify the buy and exchange receive-account pickers show only the account name when an account is selected.

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/28186

## Screenshots:
<img width="320" alt="simulator_screenshot_2EA7F28A-CEAF-4BC8-B71D-AEB1C159EF3A" src="https://github.com/user-attachments/assets/2af56ef6-676b-41f4-879c-570b9045c1ef" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/28186-remove-receive-address-from-the-trade-form-mobile&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->