### PR TITLE
fix(suite): show passphrase error instead of generic message in stablecoin yield flows

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -33,6 +33,8 @@ import {
 import { getAccountIdentity, getMevProtectedTxData } from '@suite-common/wallet-utils';
 import TrezorConnect, { type StaticSessionId } from '@trezor/connect';
 
+import { getYieldErrorTranslationKey } from './signingHelpers';
+
 type ClaimMerklReward = YieldAccountsRewards[number]['rewards'][number];
 
 interface GetEstimatedClaimFeeParams {
@@ -220,7 +222,13 @@ export const claimMerklRewardsThunk = createThunk(
 
                 if (!signingResponse.success) {
                     dispatch(closeModal());
-                    throw new Error(signingResponse.error.message);
+
+                    const { code } = signingResponse.error;
+                    if (code === 'Failure_ActionCancelled' || code === 'Method_Cancel') {
+                        return null;
+                    }
+
+                    throw new Error(signingResponse.error.message, { cause: code });
                 }
 
                 dispatch(
@@ -306,6 +314,13 @@ export const claimMerklRewardsThunk = createThunk(
                     errorMessage: 'submit-failed',
                 },
             });
+            dispatch(
+                stablecoinYieldActions.setError({
+                    flowType: 'claim',
+                    flowKey,
+                    error: getYieldErrorTranslationKey(error),
+                }),
+            );
         } finally {
             dispatch(stablecoinYieldActions.finishSubmittingAction({ flowType: 'claim', flowKey }));
         }

--- a/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
@@ -18,6 +18,13 @@ import TrezorConnect from '@trezor/connect';
 
 import type { AppState, Dispatch } from 'src/types/suite';
 
+export const getYieldErrorTranslationKey = (error: unknown) =>
+    error instanceof Error &&
+    (error.cause === 'Device_InvalidState' || // incorrect passphrase submitted
+        error.cause === 'Method_Interrupted') // passphrase modal closed
+        ? 'TR_EARN_YIELD_ERROR_PASSPHRASE_INCORRECT'
+        : 'TR_EARN_YIELD_ERROR_GENERIC';
+
 export type SendYieldTransactionParams = {
     account: Account;
     amount: string;
@@ -89,7 +96,7 @@ export const sendYieldTransaction = async ({
                 return;
             }
 
-            throw new Error(`${code}: ${signingResponse.error.message}`);
+            throw new Error(`${code}: ${signingResponse.error.message}`, { cause: code });
         }
 
         dispatch(

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
@@ -12,7 +12,7 @@ import {
     stablecoinYieldActions,
 } from '@suite-common/wallet-core';
 
-import { sendYieldTransaction } from './signingHelpers';
+import { getYieldErrorTranslationKey, sendYieldTransaction } from './signingHelpers';
 
 type SubmitYieldDepositPayload = {
     flowKey: string;
@@ -151,7 +151,13 @@ export const submitYieldDepositThunk = createThunk(
                     errorMessage: 'submit-failed',
                 },
             });
-            setYieldGenericError({ dispatch, flowType, flowKey });
+            dispatch(
+                stablecoinYieldActions.setError({
+                    flowType,
+                    flowKey,
+                    error: getYieldErrorTranslationKey(error),
+                }),
+            );
         } finally {
             dispatch(stablecoinYieldActions.finishSubmittingAction({ flowType, flowKey }));
         }

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
@@ -7,12 +7,11 @@ import {
     STABLECOIN_YIELD_PREFIX,
     type YieldFlowResolvedData,
     type YieldWithdrawFlowType,
-    setYieldGenericError,
     stablecoinYieldActions,
 } from '@suite-common/wallet-core';
 
 import { composeYieldWithdrawTransaction } from './composeYieldWithdrawTransaction';
-import { sendYieldTransaction } from './signingHelpers';
+import { getYieldErrorTranslationKey, sendYieldTransaction } from './signingHelpers';
 
 type SubmitYieldWithdrawPayload = {
     flowKey: string;
@@ -135,7 +134,13 @@ export const submitYieldWithdrawThunk = createThunk(
                     errorMessage: 'submit-failed',
                 },
             });
-            setYieldGenericError({ dispatch, flowType, flowKey });
+            dispatch(
+                stablecoinYieldActions.setError({
+                    flowType,
+                    flowKey,
+                    error: getYieldErrorTranslationKey(error),
+                }),
+            );
         } finally {
             dispatch(stablecoinYieldActions.finishSubmittingAction({ flowType, flowKey }));
         }

--- a/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
@@ -30,6 +30,7 @@ import { useMerklRewards } from './hooks';
 import { YieldDisabledBanner } from '../common/YieldDisabledBanner';
 import { YieldFlowCompleteClaim } from '../common/YieldFlowCompleteClaim';
 import { YieldPendingTransaction } from '../common/YieldPendingTransaction';
+import { useEnsureYieldDeviceSession } from '../hooks/useEnsureYieldDeviceSession';
 import { useYieldPendingTransactionTracking } from '../hooks/useYieldPendingTransactionTracking';
 
 type YieldClaimProps = {
@@ -58,6 +59,7 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
     const isDeviceConnected = !!device?.connected && device.available;
     const isClaimFirmwareOutdated = !isStablecoinYieldSupported(device, 'claim');
 
+    const ensureDeviceSession = useEnsureYieldDeviceSession({ flowType: 'claim', flowKey });
     const { merklRewardsQuery, missingRateTickersQuery } = useMerklRewards(account);
     const accountRewards: YieldAccountRewards | undefined =
         merklRewardsQuery.data?.accountsRewards[0];
@@ -117,6 +119,12 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
                 rewardCount: rewards.length,
             },
         });
+
+        const isSessionReady = await ensureDeviceSession();
+
+        if (!isSessionReady) {
+            return;
+        }
 
         try {
             await dispatch(claimMerklRewardsThunk({ account, flowKey, rewards })).unwrap();

--- a/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
@@ -225,6 +225,13 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
                                 />
                             )}
 
+                        {claimSession.error && (
+                            <Banner
+                                intent="warning"
+                                description={<Translation id={claimSession.error} />}
+                            />
+                        )}
+
                         <Button
                             size="large"
                             width="100%"

--- a/packages/suite/src/components/earn/yield/hooks/useEnsureYieldDeviceSession.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useEnsureYieldDeviceSession.ts
@@ -1,0 +1,65 @@
+import { useCallback } from 'react';
+
+import { useDevice } from '@suite/device';
+import { type YieldFlowType, stablecoinYieldActions } from '@suite-common/wallet-core';
+import TrezorConnect from '@trezor/connect';
+
+import { getYieldErrorTranslationKey } from 'src/actions/wallet/stablecoin-yield/signingHelpers';
+import { useDispatch } from 'src/hooks/suite';
+
+type UseEnsureYieldDeviceSessionParams = {
+    flowType: YieldFlowType;
+    flowKey: string;
+};
+
+export const useEnsureYieldDeviceSession = ({
+    flowType,
+    flowKey,
+}: UseEnsureYieldDeviceSessionParams) => {
+    const dispatch = useDispatch();
+    const { device } = useDevice();
+
+    return useCallback(async (): Promise<boolean> => {
+        if (!device?.state?.staticSessionId) {
+            dispatch(
+                stablecoinYieldActions.setError({
+                    flowType,
+                    flowKey,
+                    error: 'TR_EARN_YIELD_ERROR_GENERIC',
+                }),
+            );
+
+            return false;
+        }
+
+        const response = await TrezorConnect.getDeviceState({
+            device: {
+                path: device.path,
+                instance: device.instance,
+                state: { staticSessionId: device.state.staticSessionId },
+                useEmptyPassphrase: device.useEmptyPassphrase,
+            },
+        });
+
+        if (response.success) {
+            return true;
+        }
+
+        const { code } = response.error;
+        if (code === 'Failure_ActionCancelled' || code === 'Method_Cancel') {
+            return false;
+        }
+
+        dispatch(
+            stablecoinYieldActions.setError({
+                flowType,
+                flowKey,
+                error: getYieldErrorTranslationKey(
+                    new Error(response.error.message, { cause: code }),
+                ),
+            }),
+        );
+
+        return false;
+    }, [device, dispatch, flowType, flowKey]);
+};

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -563,7 +563,7 @@ export const useYieldFlow = ({
         actionAmount: session.action.amount,
         completedAmount: session.result.completedAmount,
         completedReceiptAmount: session.result.completedReceiptAmount,
-        errorMessage: session.error as TranslationKey | undefined,
+        errorMessage: session.error ?? undefined,
         approveModalState: session.approval.modalState,
         pendingTransaction: session.action.pendingTransaction,
         allowanceAmount,

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -37,6 +37,7 @@ import {
 } from 'src/actions/wallet/stablecoin-yield';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
+import { useEnsureYieldDeviceSession } from './useEnsureYieldDeviceSession';
 import { useResolvedYieldFlowData } from './useResolvedYieldFlowData';
 import { useYieldPendingTransactionTracking } from './useYieldPendingTransactionTracking';
 import {
@@ -145,6 +146,7 @@ export const useYieldFlow = ({
         receiptToken,
     });
 
+    const ensureDeviceSession = useEnsureYieldDeviceSession({ flowType, flowKey });
     const session = useSelector(state => selectStablecoinYieldSession(state, flowType, flowKey));
     const sessionRef = useCurrentRef(session);
 
@@ -350,7 +352,7 @@ export const useYieldFlow = ({
 
     const isDeviceConnected = !!device?.connected && !!device?.available;
 
-    const submitApprove = useCallback(() => {
+    const submitApprove = useCallback(async () => {
         if (flowType !== 'deposit') {
             return;
         }
@@ -375,7 +377,13 @@ export const useYieldFlow = ({
 
         const amount = methodsRef.current.getValues('amountInput');
 
-        void dispatch(
+        const isSessionReady = await ensureDeviceSession();
+
+        if (!isSessionReady) {
+            return;
+        }
+
+        await dispatch(
             submitYieldApproveThunk({
                 flowKey,
                 flowType,
@@ -392,11 +400,12 @@ export const useYieldFlow = ({
         token,
         vault,
         methodsRef,
+        ensureDeviceSession,
         isDeviceConnected,
         openDeviceConnectionModal,
     ]);
 
-    const revokeAllowance = useCallback(() => {
+    const revokeAllowance = useCallback(async () => {
         if (!isDeviceConnected) {
             openDeviceConnectionModal();
 
@@ -417,16 +426,21 @@ export const useYieldFlow = ({
 
         const amount = session.approval.allowanceAmount || '0';
 
-        void dispatch(
+        const isSessionReady = await ensureDeviceSession();
+
+        if (!isSessionReady) {
+            return;
+        }
+
+        await dispatch(
             submitYieldRevokeThunk({
                 flowKey,
                 flowType,
                 flowData: { account, vault, token, receiptToken },
                 amount,
             }),
-        ).then(() => {
-            methodsRef.current.reset({ amountInput: '' });
-        });
+        );
+        methodsRef.current.reset({ amountInput: '' });
     }, [
         account,
         flowKey,
@@ -437,6 +451,7 @@ export const useYieldFlow = ({
         vault,
         methodsRef,
         session.approval.allowanceAmount,
+        ensureDeviceSession,
         isDeviceConnected,
         openDeviceConnectionModal,
     ]);
@@ -451,17 +466,17 @@ export const useYieldFlow = ({
         tokenContractAddress: token?.contractAddress,
     });
 
-    const submitApprovalAction = useCallback(() => {
+    const submitApprovalAction = useCallback(async () => {
         if (approvalAction === 'revoke') {
-            revokeAllowance();
+            await revokeAllowance();
 
             return;
         }
 
-        submitApprove();
+        await submitApprove();
     }, [approvalAction, revokeAllowance, submitApprove]);
 
-    const submitAction = useCallback(() => {
+    const submitAction = useCallback(async () => {
         if (!isDeviceConnected) {
             openDeviceConnectionModal();
 
@@ -482,8 +497,14 @@ export const useYieldFlow = ({
 
         const amount = methodsRef.current.getValues('amountInput');
 
+        const isSessionReady = await ensureDeviceSession();
+
+        if (!isSessionReady) {
+            return;
+        }
+
         if (isYieldWithdrawFlow(flowType)) {
-            void dispatch(
+            await dispatch(
                 submitYieldWithdrawThunk({
                     flowKey,
                     flowData: { account, vault, token, receiptToken },
@@ -495,7 +516,7 @@ export const useYieldFlow = ({
             return;
         }
 
-        void dispatch(
+        await dispatch(
             submitYieldDepositThunk({
                 flowKey,
                 flowData: { account, vault, token, receiptToken },
@@ -511,6 +532,7 @@ export const useYieldFlow = ({
         token,
         vault,
         methodsRef,
+        ensureDeviceSession,
         isDeviceConnected,
         openDeviceConnectionModal,
     ]);

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -20,7 +20,12 @@ import type {
 } from './stablecoinYieldTypes';
 import { transactionsActions } from '../transactions/transactionsActions';
 
-type StablecoinYieldTranslationKey = string;
+// Message ids must exist in the desktop `suite/intl` messages — the desktop app renders
+// `session.error` directly via `<Translation>`.
+type StablecoinYieldTranslationKey =
+    | 'TR_EARN_YIELD_ERROR_GENERIC'
+    | 'TR_EARN_YIELD_ERROR_PASSPHRASE_INCORRECT'
+    | 'TR_EARN_YIELD_ERROR_TRANSACTION_FAILED';
 
 type StablecoinYieldSerializedTx = {
     tx: string;

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10183,6 +10183,10 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_ERROR_GENERIC',
         defaultMessage: 'Something went wrong. Try again.',
     },
+    TR_EARN_YIELD_ERROR_PASSPHRASE_INCORRECT: {
+        id: 'TR_EARN_YIELD_ERROR_PASSPHRASE_INCORRECT',
+        defaultMessage: 'Passphrase is incorrect. Try again.',
+    },
     TR_EARN_YIELD_LOAD_ERROR_TITLE: {
         id: 'TR_EARN_YIELD_LOAD_ERROR_TITLE',
         defaultMessage: 'Unable to load yield opportunities',


### PR DESCRIPTION
## Description

Entering a wrong passphrase during stablecoin yield deposit/withdraw/claim showed the generic "Something went wrong. Try again." Sign errors now carry the Connect error code and show "Passphrase is incorrect. Try again." in the error banner instead. Claim also newly shows the error banner (previously it failed silently).

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29336

## Screenshots:

<img width="573" height="416" alt="image" src="https://github.com/user-attachments/assets/ccdbe673-c8aa-4502-96f0-548e6718600b" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on the stablecoin yield feature — deposit, withdraw, and claim thunks, signing helpers, UI components (YieldClaim), hooks (useYieldFlow, useEnsureYieldDeviceSession), and the stablecoinYieldReducer. There are no E2E tests that directly exercise the stablecoin yield flows (deposit/withdraw/claim for yield products). The existing staking E2E tests cover native ETH/ADA/SOL staking via Everstake, which shares some infrastructure but is a distinct feature. The messages.ts change is extremely broad but without knowing which specific keys changed, its impact is hard to assess. The primary risk is that these changes are largely uncovered by existing E2E tests, and the recommended tests provide only indirect coverage through shared staking/earn infrastructure.

<details><summary><b>Changed files (9)</b></summary>

- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts`
- `packages/suite/src/components/earn/yield/claim/YieldClaim.tsx`
- `packages/suite/src/components/earn/yield/hooks/useEnsureYieldDeviceSession.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test exercises ETH staking flows including deposit transactions and Everstake interactions. The changed files include submitYieldDepositThunk.ts and signingHelpers.ts which handle yield deposit signing — while this test targets native ETH staking rather than stablecoin yield, both share the earn/staking infrastructure, EVM transaction signing patterns, and the stablecoinYieldReducer may affect shared state.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test covers ETH unstaking and claiming flows. The changed submitYieldWithdrawThunk.ts and claimMerklRewardsThunk.ts handle yield withdrawal and claiming respectively. While this test targets native ETH staking, the claim flow and withdraw flow share similar transaction signing infrastructure and the reducer changes could affect shared staking state.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the initial ETH staking flow including the staking form, Everstake confirmation, and transaction signing. The changed signingHelpers.ts and submitYieldDepositThunk.ts share EVM transaction signing patterns with the staking infrastructure, and the stablecoinYieldReducer changes could impact shared earn/staking state management.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates the staking form UI including amount validation, percentage buttons, and crypto/fiat conversion for ETH. The YieldClaim.tsx component and useYieldFlow.ts hook are part of the earn/yield UI layer, and changes to the yield flow hooks or claim component could affect shared form infrastructure or earn route rendering.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test covers all application routes including /earn/yield/deposit, /earn/yield/withdraw, and /earn/yield/claim which directly correspond to the changed yield components (YieldClaim.tsx, useYieldFlow.ts). If these components crash on render, the link checker would detect broken pages at those routes.

</details>

⚠️ **Changes with no test coverage (9)**
- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts`
- `packages/suite/src/components/earn/yield/claim/YieldClaim.tsx`
- `packages/suite/src/components/earn/yield/hooks/useEnsureYieldDeviceSession.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`
- `suite/intl/src/messages.ts`

_Updated: 2026-07-08T11:53:39.055Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/desktop-yield-passphrase-error/web/](https://dev.suite.sldev.cz/suite-web/fix/desktop-yield-passphrase-error/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/desktop-yield-passphrase-error&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/desktop-yield-passphrase-error&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/desktop-yield-passphrase-error&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-08T11:57:29.736Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T11:57:14.200Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->