### PR TITLE
fix(suite-native): use medium size of connection info icon button

### DIFF
--- a/suite-native/module-settings/src/components/ConnectionInfoButton.tsx
+++ b/suite-native/module-settings/src/components/ConnectionInfoButton.tsx
@@ -45,9 +45,10 @@ export const ConnectionInfoButton = ({ network }: ConnectionInfoButtonProps) => 
     return (
         <>
             <IconButton
+                iconName="info"
                 intent="neutral"
                 priority="secondary"
-                iconName="info"
+                size="medium"
                 onPress={openBottomSheet}
             />
             <BottomSheetModal


### PR DESCRIPTION
## Screenshots:

| Before | After |
| --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/94174d58-f9db-4351-a6a1-d1a5e7c1ee4f" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/e6d98200-9a2a-40a3-bb2b-59d39b58f0a5" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/network-backends-connection-info-button&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->