### PR TITLE
chore(nix-flake): update electron version to 42

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774709303,
-        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,9 @@
 
         androidEnv = import ./.nix/android.nix { inherit pkgs; };
 
+        # Keep in sync with the electron version pinned in package.json
+        electron = pkgs.electron_42;
+
         commonBuildInputs = [
           pkgs.bash
           pkgs.jq
@@ -49,7 +52,7 @@
           (pkgs.yarn.override { nodejs = null; })
           pkgs.python3
           pkgs.python3Packages.pip
-          pkgs.electron_39
+          electron
           pkgs.pkg-config
           pkgs.pixman # build dependencies for node-canvas
           pkgs.cairo # build dependencies for node-canvas
@@ -90,10 +93,10 @@
           export PLAYWRIGHT_BROWSERS_PATH="${pkgs.playwright-driver.browsers}"
         ''
         + pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
-          export ELECTRON_OVERRIDE_DIST_PATH="${pkgs.electron_39}/Applications/"
+          export ELECTRON_OVERRIDE_DIST_PATH="${electron}/Applications/"
         ''
         + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
-          export ELECTRON_OVERRIDE_DIST_PATH="${pkgs.electron_39}/bin/"
+          export ELECTRON_OVERRIDE_DIST_PATH="${electron}/bin/"
           export npm_config_build_from_source=true
         '';
 


### PR DESCRIPTION
## Description

Updates Electron in the Nix dev shell to v42, matching the 42.5.0 pin in package.json resolutions. The Electron package is now defined once as a let binding in flake.nix, so future bumps are a one-line change. Also updates flake.lock accordingly.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-07-08T11:15:07.929Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=nix-flake-bump-electron&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=nix-flake-bump-electron&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-08T11:21:20.024Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T11:18:42.366Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/nix-flake-bump-electron/web/](https://dev.suite.sldev.cz/suite-web/nix-flake-bump-electron/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->