### PR TITLE
feat(e2e): add stablecoin yield deposit test

### DIFF
--- a/packages/product-components/src/components/PendingTransactionInfo/PendingTransactionInfo.tsx
+++ b/packages/product-components/src/components/PendingTransactionInfo/PendingTransactionInfo.tsx
@@ -26,6 +26,7 @@ export const PendingTransactionInfo = ({
             <Column flex="1">
                 <Row width="100%" justifyContent="space-between" alignItems="center" gap={8}>
                     <Paragraph
+                        data-testid="@pending-transaction/title"
                         typographyStyle="body-md"
                         intent="neutral"
                         priority="secondary"

--- a/packages/suite/src/components/dashboard/DashboardSection.tsx
+++ b/packages/suite/src/components/dashboard/DashboardSection.tsx
@@ -60,7 +60,12 @@ export const DashboardSection = forwardRef(
                                 >
                                     {heading && (
                                         <H3>
-                                            <Row as="span">{heading}</Row>
+                                            <Row
+                                                data-testid="@dashboard/dashboard-section/heading"
+                                                as="span"
+                                            >
+                                                {heading}
+                                            </Row>
                                         </H3>
                                     )}
 

--- a/packages/suite/src/components/earn/dashboard/common/EarnAccountCellDetails.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnAccountCellDetails.tsx
@@ -53,10 +53,16 @@ export const EarnAccountCellDetails = ({
                 intent="neutral"
                 priority="primary"
                 typographyStyle="body-sm"
+                data-testid="@earn/dashboard/account-label"
             />
 
             {subtitle ? (
-                <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                <Text
+                    data-testid="@earn/dashboard/subtitle"
+                    typographyStyle="body-sm"
+                    intent="neutral"
+                    priority="secondary"
+                >
                     {subtitle}
                 </Text>
             ) : (

--- a/packages/suite/src/components/earn/dashboard/common/EarnRewardsAmount.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnRewardsAmount.tsx
@@ -12,6 +12,7 @@ type EarnRewardsAmountProps = {
     intent?: TextProps['intent'];
     priority?: TextProps['priority'];
     isDisabled?: TextProps['isDisabled'];
+    'data-testid'?: string;
 };
 
 export const EarnRewardsAmount = ({
@@ -21,6 +22,7 @@ export const EarnRewardsAmount = ({
     intent,
     priority,
     isDisabled,
+    'data-testid': dataTestId,
 }: EarnRewardsAmountProps) => {
     const { CryptoAmountFormatter } = useFormatters();
 
@@ -32,7 +34,7 @@ export const EarnRewardsAmount = ({
         );
 
     return (
-        <H4 intent={intent} priority={priority} isDisabled={isDisabled}>
+        <H4 data-testid={dataTestId} intent={intent} priority={priority} isDisabled={isDisabled}>
             <HiddenPlaceholder>
                 <CryptoAmountFormatter
                     value={rewards}

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -342,7 +342,10 @@ export const EarnYieldAccountOpportunity = ({
         return (
             <>
                 {firmwareModal}
-                <Card paddingType="small">
+                <Card
+                    paddingType="small"
+                    data-testid={`@earn/dashboard/row/${opportunity.vault.id}`}
+                >
                     <Column gap={12} width="100%">
                         <Row justifyContent="space-between" alignItems="flex-start">
                             {accountCell}
@@ -408,7 +411,7 @@ export const EarnYieldAccountOpportunity = ({
     return (
         <>
             {firmwareModal}
-            <Table.Row>
+            <Table.Row data-testid={`@earn/dashboard/row/${opportunity.vault.id}`}>
                 <Table.Cell>{accountCell}</Table.Cell>
 
                 <Table.Cell>{apyCell}</Table.Cell>

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldActionButtons.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldActionButtons.tsx
@@ -38,6 +38,7 @@ export const EarnYieldActionButtons = ({
             <>
                 <Tooltip content={depositMessageContent}>
                     <Button
+                        data-testid="@earn/dashboard/deposit-more-button"
                         size="small"
                         isDisabled={isDepositMoreDisabled}
                         iconLeft={isDepositDisabled ? InfoIcon : undefined}
@@ -48,6 +49,7 @@ export const EarnYieldActionButtons = ({
                 </Tooltip>
                 <Tooltip content={withdrawMessageContent}>
                     <Button
+                        data-testid="@earn/dashboard/withdraw-button"
                         size="small"
                         intent="brand"
                         priority="secondary"
@@ -64,6 +66,7 @@ export const EarnYieldActionButtons = ({
         {!hasDepositedBalance && hasAdditionalDepositAmount && (
             <Tooltip content={depositMessageContent}>
                 <Button
+                    data-testid="@earn/dashboard/deposit-now-button"
                     size="small"
                     isDisabled={isDepositNowDisabled}
                     iconLeft={isDepositDisabled ? InfoIcon : undefined}
@@ -75,7 +78,13 @@ export const EarnYieldActionButtons = ({
         )}
 
         {!hasDepositedBalance && !hasAdditionalDepositAmount && (
-            <Button size="small" intent="neutral" priority="secondary" onClick={onBuy}>
+            <Button
+                data-testid="@earn/dashboard/buy-button"
+                size="small"
+                intent="neutral"
+                priority="secondary"
+                onClick={onBuy}
+            >
                 <Translation id="TR_BUY" />
             </Button>
         )}

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
@@ -96,13 +96,19 @@ export const EarnYieldApyBreakdown = ({
                             isBordered={false}
                         />
                         <Column flex="1">
-                            <Text typographyStyle="body-sm">{reward.token.symbol}</Text>
+                            <Text
+                                data-testid="@earn/dashboard/apy-breakdown/symbol"
+                                typographyStyle="body-sm"
+                            >
+                                {reward.token.symbol}
+                            </Text>
                             {descriptionId && (
                                 <Text
                                     typographyStyle="body-sm"
                                     intent="neutral"
                                     priority="secondary"
                                     isInverse
+                                    data-testid="@earn/dashboard/apy-breakdown/description"
                                 >
                                     <Translation id={descriptionId} />
                                 </Text>
@@ -113,6 +119,7 @@ export const EarnYieldApyBreakdown = ({
                             intent={hasRatePercent ? 'brand' : 'neutral'}
                             priority={hasRatePercent ? 'primary' : 'secondary'}
                             isInverse
+                            data-testid="@earn/dashboard/apy-breakdown/rate-percent"
                         >
                             {rateNode}
                         </Text>
@@ -127,7 +134,13 @@ export const EarnYieldApyBreakdown = ({
                     priority="secondary"
                     isInverse
                 />
-                <Text typographyStyle="body-sm" intent="neutral" priority="secondary" isInverse>
+                <Text
+                    data-testid="@earn/dashboard/apy-breakdown/footer"
+                    typographyStyle="body-sm"
+                    intent="neutral"
+                    priority="secondary"
+                    isInverse
+                >
                     <Translation id={footerId} />
                 </Text>
             </Row>

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx
@@ -87,7 +87,11 @@ export const EarnYieldApyTooltip = ({
             maxWidth={600}
             placement="top"
         >
-            <Abbr onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+            <Abbr
+                data-testid="@earn/dashboard/apy-percentage"
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+            >
                 {children ?? <ApyValue apy={apyPercentage} />}
             </Abbr>
         </Tooltip>

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldPotentialRewards.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldPotentialRewards.tsx
@@ -38,7 +38,13 @@ export const EarnYieldPotentialRewards = ({
 
     return (
         <Column>
-            <EarnRewardsAmount symbol={symbol} rewards={rewards} apy={apy} intent="brand" />
+            <EarnRewardsAmount
+                data-testid="@earn/dashboard/potential-rewards/amount"
+                symbol={symbol}
+                rewards={rewards}
+                apy={apy}
+                intent="brand"
+            />
 
             <Paragraph typographyStyle="body-sm" intent="neutral" priority="secondary">
                 <HiddenPlaceholder>

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
@@ -144,7 +144,7 @@ export const EarnYieldTable = () => {
     };
 
     return (
-        <Column gap={16}>
+        <Column data-testid="@earn/dashboard" gap={16}>
             <ContextMessage context={Context.getEarnDashboard('yield')} />
 
             <OutlineHighlight shouldHighlight={shouldHighlight}>

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldYearlyRewards.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldYearlyRewards.tsx
@@ -23,7 +23,12 @@ export const EarnYieldYearlyRewards = ({
     displaySymbol,
 }: EarnYieldYearlyRewardsProps) => (
     <Column>
-        <EarnRewardsAmount symbol={symbol} rewards={rewards} apy={apy} />
+        <EarnRewardsAmount
+            data-testid="@earn/dashboard/yearly-rewards/amount"
+            symbol={symbol}
+            rewards={rewards}
+            apy={apy}
+        />
 
         {hasDisplayableDepositedAmount && (
             <Paragraph typographyStyle="body-sm" intent="neutral" priority="secondary">

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/YieldEarnInANutshellModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/YieldEarnInANutshellModal.tsx
@@ -65,6 +65,7 @@ export const YieldEarnInANutshellModal = ({
     const processes: EarnInANutshellProcess[] = [
         {
             processType: 'deposit',
+            'data-testid': '@modal/earn-in-a-nutshell/deposit-process',
             heading: <Translation id="TR_EARN_DEPOSITING_PROCESS" />,
             badge: <Translation id="TR_TX_FEE_COUNT" values={{ count: 2 }} />,
             content: (
@@ -79,6 +80,7 @@ export const YieldEarnInANutshellModal = ({
         },
         {
             processType: 'withdraw',
+            'data-testid': '@modal/earn-in-a-nutshell/withdraw-process',
             heading: <Translation id="TR_EARN_WITHDRAWING_PROCESS" />,
             badge: <Translation id="TR_TX_FEE_COUNT" values={{ count: 1 }} />,
             content: <YieldWithdrawingInfo depositSymbol={depositSymbol} />,
@@ -87,6 +89,7 @@ export const YieldEarnInANutshellModal = ({
             ? [
                   {
                       processType: 'claim' as const,
+                      'data-testid': '@modal/earn-in-a-nutshell/claim-process',
                       heading: <Translation id="TR_EARN_CLAIMING_PROCESS" />,
                       badge: <Translation id="TR_TX_FEE_COUNT" values={{ count: 1 }} />,
                       content: <YieldClaimingInfo rewardsSymbols={rewardsSymbols} />,

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnInANutshellModalLayout.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnInANutshellModalLayout.tsx
@@ -20,6 +20,7 @@ export const EarnInANutshellModalLayout = ({
     children,
 }: EarnInANutshellModalLayoutProps) => (
     <Modal
+        data-testid="@modal/earn-in-a-nutshell"
         heading={heading}
         width={400}
         onCancel={onCancel}

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnInANutshellProcesses.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnInANutshellProcesses.tsx
@@ -5,6 +5,7 @@ import { Badge, CollapsibleBox, Column, Row, Text } from '@trezor/components';
 
 export type EarnInANutshellProcess = {
     processType?: YieldFlowType;
+    'data-testid'?: string;
     heading: ReactNode;
     badge?: ReactNode;
     content: ReactNode;
@@ -20,9 +21,10 @@ export const EarnInANutshellProcesses = ({
     onItemToggle,
 }: EarnInANutshellProcessesProps) => (
     <Column gap={20}>
-        {items.map(({ processType, heading, badge, content }, index) => (
+        {items.map(({ processType, 'data-testid': dataTestId, heading, badge, content }, index) => (
             <CollapsibleBox
                 key={index}
+                data-testid={dataTestId}
                 heading={
                     <Row gap={8}>
                         <Text intent="neutral" priority="secondary">

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/components/EarnProviderConsentModalLayout.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/components/EarnProviderConsentModalLayout.tsx
@@ -43,6 +43,7 @@ export const EarnProviderConsentModalLayout = ({
 
     return (
         <Modal
+            data-testid="@modal/earn-provider-consent"
             heading={heading}
             description={description}
             onCancel={onCancel}

--- a/packages/suite/src/components/earn/yield/common/ApprovedAmountValue.tsx
+++ b/packages/suite/src/components/earn/yield/common/ApprovedAmountValue.tsx
@@ -34,5 +34,11 @@ export const ApprovedAmountValue = ({
         );
     }
 
-    return <FormattedCryptoAmount value={amount} symbol={token.symbol} />;
+    return (
+        <FormattedCryptoAmount
+            value={amount}
+            symbol={token.symbol}
+            data-testid="@yield/approve/approved-amount"
+        />
+    );
 };

--- a/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
@@ -80,6 +80,7 @@ export const YieldActionStep = ({
             <Button
                 size="large"
                 width="100%"
+                data-testid={`@yield/form/${flowType}-button`}
                 onClick={onSubmit}
                 isDisabled={isDisabled}
                 isLoading={isPending}

--- a/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
@@ -93,6 +93,7 @@ export const YieldAmountCard = ({
                 </Row>
                 <NumberInput
                     name="amountInput"
+                    data-testid="@yield/form/amount-input"
                     locale={locale}
                     control={control}
                     rules={rules}

--- a/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
@@ -98,6 +98,7 @@ export const YieldApproveStep = ({
             <Button
                 size="large"
                 width="100%"
+                data-testid="@yield/form/approve-button"
                 onClick={onApprovalSubmit}
                 isDisabled={isDisabled || !!pendingApproveTransaction || !onApprovalSubmit}
                 isLoading={isLoading}

--- a/packages/suite/src/components/earn/yield/common/YieldFlowComplete.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowComplete.tsx
@@ -78,7 +78,9 @@ export const YieldFlowComplete = ({
             <IconCircle icon={CheckIcon} intent="brand" size={isBelowMobile ? 64 : 96} />
 
             <Column gap={4}>
-                <Text typographyStyle="headline-md">{heading}</Text>
+                <Text typographyStyle="headline-md" data-testid="@yield/flow-complete/heading">
+                    {heading}
+                </Text>
 
                 <Text intent="neutral" priority="secondary">
                     {description}
@@ -97,7 +99,11 @@ export const YieldFlowComplete = ({
                         </Text>
                         <Row alignItems="center" gap={8}>
                             <Icon as={CheckCircleFilledIcon} intent="brand" />
-                            <Text typographyStyle="body-md" intent="brand">
+                            <Text
+                                data-testid="@yield/flow-complete/status"
+                                typographyStyle="body-md"
+                                intent="brand"
+                            >
                                 <Translation id="TR_EARN_YIELD_COMPLETED" />
                             </Text>
                         </Row>

--- a/packages/suite/src/components/earn/yield/common/YieldFlowTransferRow.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowTransferRow.tsx
@@ -33,6 +33,7 @@ export const YieldFlowTransferRow = ({
                     contractAddress: input.token.contractAddress ?? null,
                 }}
                 amount={input.amount}
+                data-testid="@yield/flow-complete/transfer/input"
             />
         </Column>
     );
@@ -48,13 +49,18 @@ export const YieldFlowTransferRow = ({
                     contractAddress: output.token.contractAddress ?? null,
                 }}
                 amount={output.amount}
+                data-testid="@yield/flow-complete/transfer/output"
             />
         </Column>
     );
 
     if (isBelowTablet) {
         return (
-            <Column gap={12} padding={{ vertical: 16, horizontal: 20 }}>
+            <Column
+                gap={12}
+                padding={{ vertical: 16, horizontal: 20 }}
+                data-testid="@yield/flow-complete/transfer"
+            >
                 {inputColumn}
                 <Icon as={ArrowDownIcon} size={20} intent="neutral" priority="secondary" />
                 {outputColumn}
@@ -67,6 +73,7 @@ export const YieldFlowTransferRow = ({
             justifyContent="space-between"
             alignItems="center"
             padding={{ vertical: 16, horizontal: 20 }}
+            data-testid="@yield/flow-complete/transfer"
         >
             {inputColumn}
             <Icon as={ArrowRightIcon} size={20} intent="neutral" priority="secondary" />

--- a/packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx
@@ -14,9 +14,14 @@ type YieldTokenValueToken = {
 type YieldTokenValueProps = {
     token: YieldTokenValueToken;
     amount: string;
+    'data-testid'?: string;
 };
 
-export const YieldTokenValue = ({ token, amount }: YieldTokenValueProps) => {
+export const YieldTokenValue = ({
+    token,
+    amount,
+    'data-testid': dataTestId,
+}: YieldTokenValueProps) => {
     const roundedAmount = new BigNumber(amount).decimalPlaces(2, BigNumber.ROUND_DOWN).toFixed();
 
     return (
@@ -30,7 +35,11 @@ export const YieldTokenValue = ({ token, amount }: YieldTokenValueProps) => {
                 isBordered={false}
             />
             <Text typographyStyle="body-md-strong">
-                <FormattedCryptoAmount value={roundedAmount} symbol={token.symbol} />
+                <FormattedCryptoAmount
+                    value={roundedAmount}
+                    symbol={token.symbol}
+                    data-testid={dataTestId}
+                />
             </Text>
         </Row>
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx
@@ -92,6 +92,7 @@ export const ApproveModal = (props: ApproveModalProps) => {
                 bottomContent={
                     <>
                         <Modal.Button
+                            data-testid="@modal/approve/continue-button"
                             isLoading={isLoading || isConfirmInProgress}
                             isDisabled={!device?.connected || !canSubmit || isConfirmInProgress}
                             onClick={() => handleClick(confirmAndSend)}

--- a/suite/account/src/labels/AccountLabel.tsx
+++ b/suite/account/src/labels/AccountLabel.tsx
@@ -16,6 +16,7 @@ type AccountLabelProps = {
     isDisabled?: TextProps['isDisabled'];
     typographyStyle?: TypographyStyle;
     rowProps?: Omit<FlexProps, 'children'>;
+    'data-testid'?: string;
 };
 
 export const AccountLabel = ({
@@ -27,6 +28,7 @@ export const AccountLabel = ({
     priority,
     isDisabled,
     rowProps,
+    'data-testid': dataTestId,
 }: AccountLabelProps) => {
     const { label } = useAccountLabel({ account });
 
@@ -35,6 +37,7 @@ export const AccountLabel = ({
     return (
         <Row gap={12} overflow="hidden" maxWidth="100%" {...rowProps}>
             <Text
+                data-testid={dataTestId}
                 intent={intent}
                 priority={priority}
                 isDisabled={isDisabled}

--- a/suite/e2e/support/fixtures.ts
+++ b/suite/e2e/support/fixtures.ts
@@ -9,6 +9,7 @@ import { MetadataMock } from './mocks/metadataMock';
 import { PassthruTradingMock } from './mocks/passthruTradingMock';
 import { SolanaStakingMock } from './mocks/solanaStakingMock';
 import { TradingMock } from './mocks/tradingMock';
+import { YieldMock } from './mocks/yieldMock';
 import { AnalyticsSection } from './pageObjects/analyticsSection';
 import { AssetsSection } from './pageObjects/assetsSection';
 import { ConnectPermissionsModal } from './pageObjects/connectPermissionsModal';
@@ -25,7 +26,12 @@ import { StakingSection } from './pageObjects/staking/stakingSection';
 import { FeeSection } from './pageObjects/trading/feeSection';
 import { TradingPage } from './pageObjects/trading/tradingPage';
 import { TrezorInput } from './pageObjects/trezorInput';
+import { TxSimulationModal } from './pageObjects/txSimulationModal';
 import { WalletPage } from './pageObjects/walletPage';
+import { YieldConsentModal } from './pageObjects/yield/yieldConsentModal';
+import { YieldFlowSection } from './pageObjects/yield/yieldFlowSection';
+import { YieldNutshellModal } from './pageObjects/yield/yieldNutshellModal';
+import { YieldSection } from './pageObjects/yield/yieldSection';
 import { suiteBaseTest } from './testExtends/suiteBaseFixture';
 import { TradingStoreFixture } from './tradingStore';
 
@@ -55,6 +61,12 @@ type Fixtures = {
     connectPermissionsModal: ConnectPermissionsModal;
     connectSelectAccountModal: ConnectSelectAccountModal;
     stakingSection: StakingSection;
+    yieldSection: YieldSection;
+    yieldFlowSection: YieldFlowSection;
+    yieldNutshellModal: YieldNutshellModal;
+    yieldConsentModal: YieldConsentModal;
+    yieldMock: YieldMock;
+    txSimulationModal: TxSimulationModal;
     paginationControl: PaginationControl;
     evoluClient: EvoluClient;
 };
@@ -143,6 +155,26 @@ const test = suiteBaseTest.extend<Fixtures>({
     },
     stakingSection: async ({ page }, use) => {
         await use(new StakingSection(page));
+    },
+    yieldSection: async ({ page }, use) => {
+        await use(new YieldSection(page));
+    },
+    yieldFlowSection: async ({ page }, use) => {
+        await use(new YieldFlowSection(page));
+    },
+    yieldNutshellModal: async ({ page }, use) => {
+        await use(new YieldNutshellModal(page));
+    },
+    yieldConsentModal: async ({ page }, use) => {
+        await use(new YieldConsentModal(page));
+    },
+    yieldMock: async ({ page }, use) => {
+        const yieldMock = new YieldMock(page);
+        await use(yieldMock);
+        await yieldMock.stop();
+    },
+    txSimulationModal: async ({ page }, use) => {
+        await use(new TxSimulationModal(page));
     },
     paginationControl: async ({ page }, use) => {
         await use(new PaginationControl(page));

--- a/suite/e2e/support/mocks/blockBookMock.ts
+++ b/suite/e2e/support/mocks/blockBookMock.ts
@@ -109,4 +109,51 @@ export class BlockbookMock {
 
         this.mockServer.setFixtures(updatedFixtures);
     }
+
+    @step()
+    updateCurrentFiatRate(usdRate: number) {
+        const currentFixtures = this.mockServer.getFixtures();
+        const updatedFixtures = currentFixtures.map(fixture => {
+            if (fixture.method !== 'getCurrentFiatRates') {
+                return fixture;
+            }
+
+            return {
+                method: 'getCurrentFiatRates',
+                default: true,
+                response: {
+                    data: {
+                        ts: 1752167345,
+                        rates: {
+                            usd: usdRate,
+                        },
+                    },
+                },
+            };
+        });
+
+        this.mockServer.setFixtures(updatedFixtures);
+    }
+
+    // Updates the `rpcCall` fixture used by ERC-20 allowance checks. `rawAmount` is the
+    // token allowance in subunits (e.g. '10000000' for 10 USDC with 6 decimals), returned
+    // ABI-encoded as a uint256.
+    @step()
+    updateAllowance(rawAmount: string) {
+        const hexValue = BigInt(rawAmount).toString(16).padStart(64, '0');
+        const currentFixtures = this.mockServer.getFixtures();
+        const updatedFixtures = currentFixtures.map(fixture => {
+            if (fixture.method !== 'rpcCall') {
+                return fixture;
+            }
+
+            return {
+                method: 'rpcCall',
+                default: true,
+                response: { data: { data: `0x${hexValue}` } },
+            };
+        });
+
+        this.mockServer.setFixtures(updatedFixtures);
+    }
 }

--- a/suite/e2e/support/mocks/eth-endpoints.ts
+++ b/suite/e2e/support/mocks/eth-endpoints.ts
@@ -26,7 +26,28 @@ export const ETH_MOCKED_ACCOUNT = {
         },
     ],
     nonce: '1',
-    tokens: [],
+    tokens: [
+        {
+            type: 'ERC20',
+            standard: 'ERC20',
+            name: 'Tether USD',
+            contract: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+            symbol: 'USDT',
+            decimals: 6,
+            balance: '1000000000',
+            transfers: 1,
+        },
+        {
+            type: 'ERC20',
+            standard: 'ERC20',
+            name: 'USD Coin',
+            contract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            symbol: 'USDC',
+            decimals: 6,
+            balance: '1000000000',
+            transfers: 1,
+        },
+    ],
     addressAliases: {},
 };
 
@@ -67,14 +88,29 @@ export const fixtures = [
     {
         method: 'estimateFee',
         default: true,
-        response: {
-            data: [
-                {
-                    feePerTx: '25293986739000',
-                    feePerUnit: '1204475559',
-                    feeLimit: '21000',
-                },
-            ],
+        response: ({ params }: any) => {
+            // deposit(assets, receiver) === 0x6e553f65
+            if (params?.specific?.data?.startsWith('0x6e553f65')) {
+                return {
+                    data: [
+                        {
+                            feePerTx: '108402800310000',
+                            feePerUnit: '1204475559',
+                            feeLimit: '90000',
+                        },
+                    ],
+                };
+            }
+
+            return {
+                data: [
+                    {
+                        feePerTx: '25293986739000',
+                        feePerUnit: '1204475559',
+                        feeLimit: '21000',
+                    },
+                ],
+            };
         },
     },
     {
@@ -82,6 +118,16 @@ export const fixtures = [
         default: true,
         response: {
             data: { result: '0x1b4e7dfff573a40ae04daafa67798ee5984345a2bde5e5387d77493a6029690c' },
+        },
+    },
+    {
+        method: 'rpcCall',
+        default: true,
+        response: {
+            data: {
+                // ABI-encoded uint256(0) — allowance = 0
+                data: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            },
         },
     },
     {
@@ -103,7 +149,7 @@ export const fixtures = [
             data: {
                 ts: 1752167345,
                 rates: {
-                    usd: 0.5,
+                    usd: 1,
                 },
             },
         },

--- a/suite/e2e/support/mocks/yieldMock.ts
+++ b/suite/e2e/support/mocks/yieldMock.ts
@@ -1,0 +1,285 @@
+import type { Page } from '@playwright/test';
+
+import { step } from '../common';
+
+export const YIELD_VAULTS = {
+    usdcPrime: {
+        id: 'steakusdc-prime-eth',
+        name: 'Trezor Steakhouse USDC Prime',
+        apy: '~4.26%',
+        yearlyReward: '0 USDC',
+        potentialReward: '42.6 USDC',
+        apyBreakdown: {
+            apyPercent: '4.26',
+            symbols: ['USDC', 'MORPHO'],
+            rates: ['+3.76% APY', '+0.5% APR'],
+        },
+    },
+    usdtPrime: {
+        id: 'steakusdt-prime-eth',
+        name: 'Trezor Steakhouse USDT Prime',
+        apy: '~6.4%',
+        yearlyReward: '0 USDT',
+        potentialReward: '64 USDT',
+    },
+} as const;
+
+const YIELD_API_PATTERN = /\/yieldxyz\/v2\/yields/;
+const YIELD_DETAIL_API_PATTERN = /\/yieldxyz\/v2\/yields\/(?<vaultId>[^/?]+)/;
+const MERKL_API_PATTERN = /\/merkl\/v1\/users\/rewards/;
+const BLOCKAID_API_PATTERN = /\/evm\/json-rpc\/scan/;
+
+const USDC_CONTRACT = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+// Trezor Steakhouse USDC Prime Vault
+const YIELD_USDC_VAULT_ADDRESS = '0xde6c23E561F3e55846207EC45A91b777e0F7C889';
+const USDC_VAULT = YIELD_USDC_VAULT_ADDRESS.toLowerCase();
+const BLOCKAID_BENIGN_RESPONSE = {
+    validation: {
+        status: 'Success',
+        result_type: 'Benign',
+        classification: '',
+        reason: '',
+        description: '',
+        features: [],
+    },
+    simulation: {
+        status: 'Success',
+        assets_diffs: {},
+        exposures: {},
+        total_usd_diff: {},
+        address_details: {},
+
+        account_summary: {
+            assets_diffs: [
+                {
+                    asset_type: 'ERC20',
+                    asset: {
+                        type: 'ERC20',
+                        address: USDC_CONTRACT,
+                        decimals: 6,
+                        name: 'USD Coin',
+                        symbol: 'USDC',
+                    },
+                    in: [],
+                    out: [
+                        {
+                            raw_value: '0x989680',
+                            value: '10.0',
+                            usd_price: '9.996549999999999159',
+                            summary: 'Sending 10 USDC',
+                        },
+                    ],
+                },
+                {
+                    asset_type: 'ERC20',
+                    asset: {
+                        type: 'ERC20',
+                        address: USDC_VAULT,
+                        decimals: 18,
+                        name: YIELD_VAULTS.usdcPrime.name,
+                        symbol: 'trSHUSDCp',
+                    },
+                    in: [
+                        {
+                            raw_value: '0x8a01083041395266',
+                            value: '9.944238455556494216',
+                            usd_price: '9.996535861217905605',
+                            summary: 'Receiving 9.944 trSHUSDCp',
+                        },
+                    ],
+                    out: [],
+                },
+            ],
+            exposures: [],
+            total_usd_diff: {
+                in: '9.996535861217905605',
+                out: '9.996549999999999159',
+                total: '-0.000014138782093553',
+            },
+            total_usd_exposure: {},
+            traces: [],
+        },
+        block: 'latest',
+        addressbook_messages: [],
+        error: null,
+    },
+};
+
+const YIELD_VAULTS_RESPONSE = {
+    items: [
+        {
+            id: YIELD_VAULTS.usdcPrime.id,
+            providerId: 'morpho',
+            network: 'ethereum',
+            chainId: 1,
+            token: {
+                symbol: 'USDC',
+                name: 'USD Coin',
+                decimals: 6,
+                network: 'ethereum',
+                address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            },
+            outputToken: {
+                symbol: 'trSHUSDCp',
+                name: YIELD_VAULTS.usdcPrime.name,
+                decimals: 18,
+                network: 'ethereum',
+                address: '0xde6c23e561f3e55846207ec45a91b777e0f7c889',
+            },
+            inputTokens: [
+                {
+                    symbol: 'USDC',
+                    name: 'USD Coin',
+                    decimals: 6,
+                    network: 'ethereum',
+                    address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                },
+            ],
+            rewardRate: {
+                total: 0.0426,
+                rateType: 'APY',
+                components: [
+                    {
+                        rate: 0.0376,
+                        rateType: 'APY',
+                        yieldSource: 'lending',
+                        token: {
+                            symbol: 'USDC',
+                            name: 'USD Coin',
+                            decimals: 6,
+                            network: 'ethereum',
+                            address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                        },
+                    },
+                    {
+                        rate: 0.005,
+                        rateType: 'APY',
+                        yieldSource: 'protocol_incentive',
+                        token: {
+                            symbol: 'MORPHO',
+                            name: 'Morpho Token',
+                            decimals: 18,
+                            network: 'ethereum',
+                            address: '0x9994e35db50125e0df82e4c2dde62496ce330999',
+                        },
+                    },
+                ],
+            },
+            status: {
+                enter: true,
+                exit: true,
+            },
+            // Share price so 10 USDC converts to ~9.944 trSHUSDCp shares (matches the deposit
+            // simulation in yielddepositusdc.har): shares = amount / price.
+            state: {
+                pricePerShareState: {
+                    price: '1.005606287729678',
+                    shareToken: {
+                        symbol: 'trSHUSDCp',
+                        name: YIELD_VAULTS.usdcPrime.name,
+                        decimals: 18,
+                        network: 'ethereum',
+                        address: '0xde6c23e561f3e55846207ec45a91b777e0f7c889',
+                    },
+                    quoteToken: {
+                        symbol: 'USDC',
+                        name: 'USD Coin',
+                        decimals: 6,
+                        network: 'ethereum',
+                        address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                    },
+                },
+            },
+            metadata: {
+                name: YIELD_VAULTS.usdcPrime.name,
+                description: 'Earn yield on USDC via Morpho.',
+                underMaintenance: false,
+                deprecated: false,
+            },
+        },
+        {
+            id: YIELD_VAULTS.usdtPrime.id,
+            providerId: 'morpho',
+            network: 'ethereum',
+            chainId: 1,
+            token: {
+                symbol: 'USDT',
+                name: 'Tether USD',
+                decimals: 6,
+                network: 'ethereum',
+                address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+            },
+            outputToken: {
+                symbol: 'steakUSDT',
+                name: YIELD_VAULTS.usdtPrime.name,
+                decimals: 6,
+                network: 'ethereum',
+                address: '0xbeed7a9ef40bb1f4928b8b5a1b8ae35db4bc0c5a',
+            },
+            inputTokens: [
+                {
+                    symbol: 'USDT',
+                    name: 'Tether USD',
+                    decimals: 6,
+                    network: 'ethereum',
+                    address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+                },
+            ],
+            rewardRate: {
+                total: 0.064,
+                rateType: 'APY',
+                components: [],
+            },
+            status: {
+                enter: true,
+                exit: true,
+            },
+            metadata: {
+                name: YIELD_VAULTS.usdtPrime.name,
+                description: 'Earn yield on USDT via Morpho.',
+                underMaintenance: false,
+                deprecated: false,
+            },
+        },
+    ],
+    total: 2,
+    offset: 0,
+    limit: 100,
+};
+
+export class YieldMock {
+    constructor(private readonly page: Page) {}
+
+    @step()
+    async start() {
+        await this.page.route(YIELD_API_PATTERN, route =>
+            route.fulfill({ json: YIELD_VAULTS_RESPONSE }),
+        );
+        // Registered after the list route so it wins for `/yields/:vaultId` URLs, which the list
+        // pattern would otherwise match too.
+        await this.page.route(YIELD_DETAIL_API_PATTERN, route => {
+            // match(YIELD_DETAIL_API_PATTERN)? is guaranteed to have match thanks to page.route and
+            // the a capture group vaultId will have value. Either a string or empty string
+            const vaultId = route.request().url().match(YIELD_DETAIL_API_PATTERN)?.groups?.vaultId;
+            const vault = YIELD_VAULTS_RESPONSE.items.find(item => item.id === vaultId);
+
+            return vault ? route.fulfill({ json: vault }) : route.continue();
+        });
+        await this.page.route(MERKL_API_PATTERN, route => route.fulfill({ json: [] }));
+    }
+
+    @step()
+    async mockUsdcDeposit() {
+        await this.page.route(BLOCKAID_API_PATTERN, route =>
+            route.fulfill({ json: BLOCKAID_BENIGN_RESPONSE }),
+        );
+    }
+
+    @step()
+    async stop() {
+        await this.page.unroute(BLOCKAID_API_PATTERN);
+        await this.page.unroute(MERKL_API_PATTERN);
+        await this.page.unroute(YIELD_DETAIL_API_PATTERN);
+        await this.page.unroute(YIELD_API_PATTERN);
+    }
+}

--- a/suite/e2e/support/pageObjects/txSimulationModal.ts
+++ b/suite/e2e/support/pageObjects/txSimulationModal.ts
@@ -1,0 +1,29 @@
+import { type Locator, type Page } from '@playwright/test';
+
+export class TxSimulationModal {
+    readonly maxFeeAmount: Locator;
+    readonly maxFeeFiat: Locator;
+    readonly confirmButton: Locator;
+
+    constructor(private readonly page: Page) {
+        this.maxFeeAmount = this.page.getByTestId('@trading/quote/maximum-fee-amount-with-symbol');
+        this.maxFeeFiat = this.page.getByTestId('@trading/quote/maximum-fee-fiat-amount');
+        this.confirmButton = this.page.getByTestId('@tx-simulation-modal/confirm-button');
+    }
+
+    sentAsset(index: number): Locator {
+        return this.page.getByTestId(`@sign-message-modal/tx-simulation-out-${index}`);
+    }
+
+    sentAssetFiat(index: number): Locator {
+        return this.page.getByTestId(`@sign-message-modal/tx-simulation-out-${index}/fiat`);
+    }
+
+    receivedAsset(index: number): Locator {
+        return this.page.getByTestId(`@sign-message-modal/tx-simulation-in-${index}`);
+    }
+
+    receivedAssetFiat(index: number): Locator {
+        return this.page.getByTestId(`@sign-message-modal/tx-simulation-in-${index}/fiat`);
+    }
+}

--- a/suite/e2e/support/pageObjects/yield/yieldConsentModal.ts
+++ b/suite/e2e/support/pageObjects/yield/yieldConsentModal.ts
@@ -1,0 +1,17 @@
+import { type Locator, type Page } from '@playwright/test';
+
+export class YieldConsentModal {
+    readonly modalContainer: Locator;
+    readonly heading: Locator;
+    readonly acknowledgeCheckbox: Locator;
+    readonly confirmButton: Locator;
+
+    constructor(private readonly page: Page) {
+        this.modalContainer = this.page.getByTestId('@modal/earn-provider-consent');
+        this.heading = this.modalContainer.getByTestId('@modal/header');
+        this.acknowledgeCheckbox = this.modalContainer.getByTestId(
+            '@staking/provider-acknowledge-checkbox',
+        );
+        this.confirmButton = this.modalContainer.getByTestId('@modal/staking/confirm-button');
+    }
+}

--- a/suite/e2e/support/pageObjects/yield/yieldFlowSection.ts
+++ b/suite/e2e/support/pageObjects/yield/yieldFlowSection.ts
@@ -1,0 +1,43 @@
+import { type Locator, type Page } from '@playwright/test';
+
+export class YieldFlowSection {
+    // Approve step
+    readonly approvedAmount: Locator;
+    readonly amountInput: Locator;
+    readonly approveButton: Locator;
+    // Continue button of the shared allowance approve modal opened by the approve step
+    readonly approveModalContinueButton: Locator;
+    readonly pendingTransactionLabel: Locator;
+    readonly approvedToast: Locator;
+    readonly approvedToastAmount: Locator;
+    // Deposit step
+    readonly depositButton: Locator;
+    readonly depositedToast: Locator;
+    // Flow-complete screen
+    readonly flowCompleteHeading: Locator;
+    readonly flowCompleteStatus: Locator;
+    readonly flowCompleteApy: Locator;
+    readonly flowCompleteTransferInputAmount: Locator;
+    readonly flowCompleteTransferOutputAmount: Locator;
+
+    constructor(private readonly page: Page) {
+        this.approvedAmount = this.page.getByTestId('@yield/approve/approved-amount-with-symbol');
+        this.amountInput = this.page.getByTestId('@yield/form/amount-input');
+        this.approveButton = this.page.getByTestId('@yield/form/approve-button');
+        this.approveModalContinueButton = this.page.getByTestId('@modal/approve/continue-button');
+        this.pendingTransactionLabel = this.page.getByTestId('@pending-transaction/title');
+        this.approvedToast = this.page.getByTestId('@toast/tx-approved');
+        this.approvedToastAmount = this.page.getByTestId('@toast/tx-approved/amount');
+        this.depositButton = this.page.getByTestId('@yield/form/deposit-button');
+        this.depositedToast = this.page.getByTestId('@toast/tx-yield-deposit');
+        this.flowCompleteHeading = this.page.getByTestId('@yield/flow-complete/heading');
+        this.flowCompleteStatus = this.page.getByTestId('@yield/flow-complete/status');
+        this.flowCompleteApy = this.page.getByTestId('@earn/dashboard/apy-percentage');
+        this.flowCompleteTransferInputAmount = this.page.getByTestId(
+            '@yield/flow-complete/transfer/input-with-symbol',
+        );
+        this.flowCompleteTransferOutputAmount = this.page.getByTestId(
+            '@yield/flow-complete/transfer/output-with-symbol',
+        );
+    }
+}

--- a/suite/e2e/support/pageObjects/yield/yieldNutshellModal.ts
+++ b/suite/e2e/support/pageObjects/yield/yieldNutshellModal.ts
@@ -1,0 +1,27 @@
+import { type Locator, type Page } from '@playwright/test';
+
+export class YieldNutshellModal {
+    readonly modalContainer: Locator;
+    readonly heading: Locator;
+    readonly depositProcess: Locator;
+    readonly withdrawProcess: Locator;
+    readonly claimProcess: Locator;
+    readonly continueButton: Locator;
+    readonly depositApyValue: Locator;
+
+    constructor(private readonly page: Page) {
+        this.modalContainer = this.page.getByTestId('@modal/earn-in-a-nutshell');
+        this.heading = this.modalContainer.getByTestId('@modal/header');
+        this.depositProcess = this.modalContainer.getByTestId(
+            '@modal/earn-in-a-nutshell/deposit-process',
+        );
+        this.withdrawProcess = this.modalContainer.getByTestId(
+            '@modal/earn-in-a-nutshell/withdraw-process',
+        );
+        this.claimProcess = this.modalContainer.getByTestId(
+            '@modal/earn-in-a-nutshell/claim-process',
+        );
+        this.continueButton = this.modalContainer.getByTestId('@modal/staking/continue-button');
+        this.depositApyValue = this.depositProcess.getByTestId('@earn/dashboard/apy-percentage');
+    }
+}

--- a/suite/e2e/support/pageObjects/yield/yieldSection.ts
+++ b/suite/e2e/support/pageObjects/yield/yieldSection.ts
@@ -1,0 +1,63 @@
+import { type Locator, type Page } from '@playwright/test';
+
+import { step } from '../../common';
+
+export class YieldSection {
+    readonly earnMenuButton: Locator;
+    readonly dashboardContainer: Locator;
+    readonly yieldTitle: Locator;
+    readonly apyBreakdownSymbols: Locator;
+    readonly apyBreakdownDescriptions: Locator;
+    readonly apyBreakdownRates: Locator;
+    readonly apyBreakdownFooter: Locator;
+
+    constructor(private readonly page: Page) {
+        this.earnMenuButton = this.page.getByTestId('@suite/menu/suite-earn');
+        this.dashboardContainer = this.page.getByTestId('@earn/dashboard');
+        this.yieldTitle = this.dashboardContainer.getByTestId(
+            '@dashboard/dashboard-section/heading',
+        );
+        this.apyBreakdownSymbols = this.page.getByTestId('@earn/dashboard/apy-breakdown/symbol');
+        this.apyBreakdownDescriptions = this.page.getByTestId(
+            '@earn/dashboard/apy-breakdown/description',
+        );
+        this.apyBreakdownRates = this.page.getByTestId(
+            '@earn/dashboard/apy-breakdown/rate-percent',
+        );
+        this.apyBreakdownFooter = this.page.getByTestId('@earn/dashboard/apy-breakdown/footer');
+    }
+
+    row(vaultId: string): Locator {
+        return this.dashboardContainer.getByTestId(`@earn/dashboard/row/${vaultId}`);
+    }
+
+    accountLabel(vaultId: string): Locator {
+        return this.row(vaultId).getByTestId('@earn/dashboard/account-label');
+    }
+
+    vaultSubtitle(vaultId: string): Locator {
+        return this.row(vaultId).getByTestId('@earn/dashboard/subtitle');
+    }
+
+    apyPercentage(vaultId: string): Locator {
+        return this.row(vaultId).getByTestId('@earn/dashboard/apy-percentage');
+    }
+
+    yearlyRewardAmount(vaultId: string): Locator {
+        return this.row(vaultId).getByTestId('@earn/dashboard/yearly-rewards/amount');
+    }
+
+    potentialRewardAmount(vaultId: string): Locator {
+        return this.row(vaultId).getByTestId('@earn/dashboard/potential-rewards/amount');
+    }
+
+    @step()
+    async hoverApyPercentage(vaultId: string) {
+        await this.apyPercentage(vaultId).hover();
+    }
+
+    @step()
+    async clickDepositNow(vaultId: string) {
+        await this.row(vaultId).getByTestId('@earn/dashboard/deposit-now-button').click();
+    }
+}

--- a/suite/e2e/tests/staking/ada/stake.test.ts
+++ b/suite/e2e/tests/staking/ada/stake.test.ts
@@ -63,6 +63,7 @@ test.describe('Staking - Cardano', { tag: ['@T3W1', '@T3T1'] }, () => {
             walletPage,
             feeSection,
             stakingSection,
+            yieldNutshellModal,
             blockbookMock,
         }) => {
             const stakingAccountItemInLeftSection = walletPage.accountButton({
@@ -88,7 +89,7 @@ test.describe('Staking - Cardano', { tag: ['@T3W1', '@T3T1'] }, () => {
             await test.step('Initiate staking flow', async () => {
                 await stakingSection.startStakingButton.click();
                 await expect(page.modalHeader).toHaveTranslation('TR_EARN_STAKING_IN_A_NUTSHELL');
-                await expect(page.modal).toContainTranslation(
+                await expect(yieldNutshellModal.modalContainer).toContainTranslation(
                     'TR_EARN_YOUR_FUNDS_STAY_ACCESSIBLE',
                     {
                         values: { networkDisplaySymbol: 'ADA' },

--- a/suite/e2e/tests/staking/staking-form.test.ts
+++ b/suite/e2e/tests/staking/staking-form.test.ts
@@ -20,6 +20,7 @@ test.describe('ETH staking form', { tag: ['@T3W1', '@T3T1'] }, () => {
         await onboardingPage.completeOnboarding();
         await settingsPage.navigateTo('coins');
         await blockbookMock.start('eth');
+        blockbookMock.updateCurrentFiatRate(0.5);
 
         await settingsPage.changeNetworks({
             enableNetworks: [

--- a/suite/e2e/tests/yield/deposit.test.ts
+++ b/suite/e2e/tests/yield/deposit.test.ts
@@ -1,0 +1,236 @@
+import ETH_BASE_TX from '../../fixtures/staking/eth-base-tx.json';
+import ETH_STAKE_CONFIRMED_TX from '../../fixtures/staking/eth-stake-confirmed-tx.json';
+import { expect, test } from '../../support/fixtures';
+import { YIELD_VAULTS } from '../../support/mocks/yieldMock';
+
+const { usdcPrime, usdtPrime } = YIELD_VAULTS;
+const YIELD_USDC_VAULT_DISPLAY_NAME = ['Trezor Steakhouse', '\n', 'USDC Prime Vault'];
+const EXPECT_YIELD_DASHBOARD_ROWS = [usdcPrime, usdtPrime];
+const APPROVE_MAX_FEE = '0.00003161748342375 ETH';
+const DEPOSIT_MAX_FEE = '0.00010840280031 ETH';
+
+test.describe('stablecoin yield', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+    test.use({
+        deviceSetup: {
+            mnemonic: 'access juice claim special truth ugly swarm rabbit hair man error bar',
+        },
+    });
+
+    test.beforeEach(async ({ onboardingPage, settingsPage, blockbookMock, yieldMock }) => {
+        await onboardingPage.completeOnboarding();
+        await blockbookMock.start('eth');
+        await yieldMock.start();
+        await settingsPage.changeNetworks({
+            enableNetworks: [
+                { symbol: 'eth', backend: { type: 'blockbook', url: blockbookMock.url } },
+            ],
+        });
+    });
+
+    test('User can deposit USDC into a yield vault', async ({
+        page,
+        walletPage,
+        yieldSection,
+        yieldFlowSection,
+        yieldNutshellModal,
+        yieldConsentModal,
+        txSimulationModal,
+        devicePrompt,
+        device,
+        blockbookMock,
+        yieldMock,
+    }) => {
+        await test.step('Check yield dashboard', async () => {
+            await yieldSection.earnMenuButton.click();
+
+            const ethAccountName = await walletPage
+                .accountLabel({ symbol: 'eth', type: 'normal', atIndex: 0 })
+                .textContent();
+
+            await expect(yieldSection.yieldTitle).toHaveTranslation('TR_EARN_DEFI_YIELD_TITLE');
+
+            for (const expectedRow of EXPECT_YIELD_DASHBOARD_ROWS) {
+                await expect(yieldSection.accountLabel(expectedRow.id)).toHaveText(ethAccountName!);
+                await expect(yieldSection.vaultSubtitle(expectedRow.id)).toHaveText(
+                    expectedRow.name,
+                );
+                await expect(yieldSection.apyPercentage(expectedRow.id)).toHaveText(
+                    expectedRow.apy,
+                );
+                await expect(yieldSection.yearlyRewardAmount(expectedRow.id)).toHaveText(
+                    expectedRow.yearlyReward,
+                );
+                await expect(yieldSection.potentialRewardAmount(expectedRow.id)).toHaveText(
+                    expectedRow.potentialReward,
+                );
+            }
+        });
+
+        await test.step('Check APY breakdown tooltip', async () => {
+            await yieldSection.hoverApyPercentage(usdcPrime.id);
+
+            const { symbols, rates } = usdcPrime.apyBreakdown;
+            await expect(yieldSection.apyBreakdownSymbols).toHaveText([...symbols]);
+            await expect(yieldSection.apyBreakdownRates).toHaveText([...rates]);
+            await expect(yieldSection.apyBreakdownDescriptions).toHaveTranslation([
+                'TR_EARN_YIELD_APY_SOURCE_LENDING_INTEREST',
+                'TR_EARN_YIELD_APY_SOURCE_PROTOCOL_INCENTIVE',
+            ]);
+            await expect(yieldSection.apyBreakdownFooter).toHaveTranslation(
+                'TR_EARN_YIELD_APY_APR_TOOLTIP_FOOTER',
+            );
+        });
+
+        await yieldSection.clickDepositNow(usdcPrime.id);
+
+        await test.step('Check earn-in-a-nutshell modal', async () => {
+            await expect(yieldNutshellModal.heading).toHaveTranslation(
+                'TR_EARN_DEFI_YIELD_IN_A_NUTSHELL',
+            );
+            await expect(yieldNutshellModal.withdrawProcess).toBeVisible();
+            await expect(yieldNutshellModal.claimProcess).toBeVisible();
+
+            await yieldNutshellModal.depositProcess.click();
+            await expect(yieldNutshellModal.depositApyValue).toHaveTranslation(
+                'TR_EARN_APY_APPROX',
+                { values: { apyPercent: usdcPrime.apyBreakdown.apyPercent } },
+            );
+            await yieldNutshellModal.continueButton.click();
+        });
+
+        await test.step('Check consent modal', async () => {
+            await expect(yieldConsentModal.heading).toHaveTranslation('TR_EARN_DEPOSIT_TOKEN', {
+                values: { symbol: 'USDC' },
+            });
+            await yieldConsentModal.acknowledgeCheckbox.click();
+            await yieldConsentModal.confirmButton.click();
+        });
+
+        await test.step('Approve USDC spending', async () => {
+            await page.clock.install();
+            await yieldMock.mockUsdcDeposit();
+            await yieldFlowSection.amountInput.fill('10');
+            await yieldFlowSection.approveButton.click();
+            await yieldFlowSection.approveModalContinueButton.click();
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Token approval' },
+                    body: [['Review details to', '\n', 'approve token', '\n', 'spending.']],
+                    actions: { right_button: 'Continue' },
+                },
+            });
+            await devicePrompt.waitForPromptAndClick();
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Token approval' },
+                    body: [YIELD_USDC_VAULT_DISPLAY_NAME],
+                    actions: { right_button: 'Continue' },
+                },
+                T3T1: {
+                    header: { title: 'Approve to' },
+                },
+            });
+            await device.pressYes();
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Token approval' },
+                    body: [['Amount allowance'], ['10 USDC'], ['Chain'], ['Ethereum']],
+                    actions: { right_button: 'Continue' },
+                },
+                T3T1: {
+                    header: { title: 'Approve' },
+                },
+            });
+            await device.pressYes();
+            await expect(devicePrompt.cryptoAmountWithSymbolOf('fee')).toHaveText(APPROVE_MAX_FEE);
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Token approval' },
+                    body: [['Maximum fee'], device.wrapText(APPROVE_MAX_FEE, { isAmount: true })],
+                    actions: { right_button: 'Hold to sign' },
+                },
+                T3T1: {
+                    header: { title: 'Summary' },
+                },
+            });
+            await devicePrompt.waitForFinalPromptAndConfirm();
+            blockbookMock.updateAccountState({
+                txs: 2,
+                transactions: [ETH_STAKE_CONFIRMED_TX, ETH_BASE_TX],
+            });
+            blockbookMock.updateAllowance('10000000'); // 10 USDC
+            await devicePrompt.sendButton.click();
+            await expect(yieldFlowSection.approvedToast).toBeVisible();
+            await expect(yieldFlowSection.approvedToastAmount).toHaveText('10USDC');
+            await expect(yieldFlowSection.pendingTransactionLabel).toHaveTranslation(
+                'TR_EXCHANGE_APPROVAL_FORM_CONFIRMING_APPROVAL',
+            );
+            await page.clock.fastForward('01:00');
+        });
+
+        await test.step('Deposit USDC', async () => {
+            await expect(yieldFlowSection.approvedAmount).toHaveText('10 USDC');
+            await yieldFlowSection.depositButton.click();
+            await expect(txSimulationModal.sentAsset(0)).toHaveText('Sending 10 USDC');
+            await expect(txSimulationModal.sentAssetFiat(0)).toHaveText('-$10.00');
+            await expect(txSimulationModal.receivedAsset(0)).toHaveText(
+                'Receiving 9.944 trSHUSDCp',
+            );
+            await expect(txSimulationModal.receivedAssetFiat(0)).toHaveText('+$10.00');
+            await expect(txSimulationModal.maxFeeAmount).toHaveText('0.000108403 ETH');
+            await expect(txSimulationModal.maxFeeFiat).toHaveText('≈ $0.00');
+            await txSimulationModal.confirmButton.click();
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Deposit' },
+                    body: [['Review details to', '\n', 'deposit to vault.']],
+                    actions: { right_button: 'Confirm' },
+                },
+            });
+            await devicePrompt.waitForPromptAndClick();
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Deposit' },
+                    body: [YIELD_USDC_VAULT_DISPLAY_NAME],
+                    actions: { right_button: 'Continue' },
+                },
+                T3T1: {
+                    body: [['Deposit to'], YIELD_USDC_VAULT_DISPLAY_NAME],
+                },
+            });
+            await device.pressYes();
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Deposit' },
+                    body: [['Deposit amount'], ['10 USDC'], ['Chain'], ['Ethereum']],
+                    actions: { right_button: 'Continue' },
+                },
+            });
+            await device.pressYes();
+            await expect(devicePrompt.cryptoAmountWithSymbolOf('fee')).toHaveText(DEPOSIT_MAX_FEE);
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Deposit' },
+                    body: [['Maximum fee'], device.wrapText(DEPOSIT_MAX_FEE, { isAmount: true })],
+                    actions: { right_button: 'Hold to sign' },
+                },
+            });
+            await devicePrompt.waitForFinalPromptAndConfirm();
+            await devicePrompt.sendButton.click();
+            await expect(yieldFlowSection.depositedToast).toBeVisible();
+            await expect(yieldFlowSection.flowCompleteHeading).toHaveTranslation(
+                'TR_EARN_YIELD_DEPOSIT_COMPLETE',
+            );
+            await expect(yieldFlowSection.flowCompleteStatus).toHaveTranslation(
+                'TR_EARN_YIELD_COMPLETED',
+            );
+            await expect(yieldFlowSection.flowCompleteApy).toHaveText(usdcPrime.apy);
+            await expect(yieldFlowSection.flowCompleteTransferInputAmount).toHaveText('10 USDC');
+            await expect(yieldFlowSection.flowCompleteTransferOutputAmount).toHaveText(
+                '9.94 trSHUSDCp',
+            );
+        });
+    });
+});

--- a/suite/tx-simulation/src/common/components/TxSimulationAssetRow.tsx
+++ b/suite/tx-simulation/src/common/components/TxSimulationAssetRow.tsx
@@ -32,7 +32,7 @@ export function TxSimulationAssetRow({
                 {children}
             </Text>
             {fiatAmount && (
-                <Text intent="neutral" priority="secondary">
+                <Text intent="neutral" priority="secondary" data-testid={`${dataTestId}/fiat`}>
                     {fiatAmount.prefix}
                     <BaseCurrencyAmountFormatter
                         value={asBaseCurrencyAmount(new BigNumber(fiatAmount.value))}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds an e2e test for the stablecoin yield deposit flow (nutshell → consent → approve → deposit → completion), with supporting mocks, page objects, and fixtures. Product changes are limited to adding data-testid props to earn/yield components.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-yield&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-yield&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-22T12:03:24.295Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| TrezorConnect > Error screen | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-22T12:03:32.597Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-yield/web/](https://dev.suite.sldev.cz/suite-web/test-yield/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->