### PR TITLE
fix(wallet-config): guard network lookups against unknown/removed symbols

### DIFF
--- a/suite-common/wallet-config/src/__tests__/utils.test.ts
+++ b/suite-common/wallet-config/src/__tests__/utils.test.ts
@@ -3,6 +3,7 @@ import { type NetworkSymbol } from '../types';
 import {
     filterNetworksByName,
     getMainnets,
+    getNetworkFeatures,
     getNetworksWithMevProtection,
     getNetworksWithNativeTokenReserve,
     getTestnets,
@@ -146,5 +147,18 @@ describe(getNetworksWithNativeTokenReserve.name, () => {
         expect(getNetworksWithNativeTokenReserve()).toEqual(
             'Base, Optimism, Robinhood Chain, Solana',
         );
+    });
+});
+
+describe(getNetworkFeatures.name, () => {
+    it('returns the configured features for a known symbol', () => {
+        expect(getNetworkFeatures('eth')).toBe(networks.eth.features);
+    });
+
+    // A persisted transaction can carry a symbol the config lookup does not recognize (observed
+    // in production, Sentry TREZOR-SUITE-1MX4); callers immediately call `.includes()`, so an
+    // empty-array fallback prevents a crash.
+    it('returns an empty array for an unknown symbol', () => {
+        expect(getNetworkFeatures('unknown' as NetworkSymbol)).toEqual([]);
     });
 });

--- a/suite-common/wallet-config/src/__tests__/utils.test.ts
+++ b/suite-common/wallet-config/src/__tests__/utils.test.ts
@@ -2,6 +2,7 @@ import { networks } from '../networksConfig';
 import { type NetworkSymbol } from '../types';
 import {
     filterNetworksByName,
+    getCoingeckoId,
     getMainnets,
     getNetworkFeatures,
     getNetworksWithMevProtection,
@@ -160,5 +161,17 @@ describe(getNetworkFeatures.name, () => {
     // empty-array fallback prevents a crash.
     it('returns an empty array for an unknown symbol', () => {
         expect(getNetworkFeatures('unknown' as NetworkSymbol)).toEqual([]);
+    });
+});
+
+describe(getCoingeckoId.name, () => {
+    it('returns the configured CoinGecko id for a known symbol', () => {
+        expect(getCoingeckoId('eth')).toBe(networks.eth.coingeckoId);
+    });
+
+    // Same crash class as getNetworkFeatures: an unknown symbol must not throw on the missing
+    // network object (coingeckoId is already optional, so undefined is an expected value).
+    it('returns undefined for an unknown symbol', () => {
+        expect(getCoingeckoId('unknown' as NetworkSymbol)).toBeUndefined();
     });
 });

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -107,7 +107,7 @@ export const isAccountBasedNetwork = (symbol: NetworkSymbol) => {
 
 // Takes into account just network features, not features for specific accountTypes.
 export const getNetworkFeatures = (symbol: NetworkSymbol): NetworkFeature[] =>
-    networks[symbol]?.features;
+    networks[symbol]?.features ?? [];
 
 export const getCoingeckoId = (symbol: NetworkSymbol) => networks[symbol].coingeckoId;
 

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -109,7 +109,7 @@ export const isAccountBasedNetwork = (symbol: NetworkSymbol) => {
 export const getNetworkFeatures = (symbol: NetworkSymbol): NetworkFeature[] =>
     networks[symbol]?.features ?? [];
 
-export const getCoingeckoId = (symbol: NetworkSymbol) => networks[symbol].coingeckoId;
+export const getCoingeckoId = (symbol: NetworkSymbol) => networks[symbol]?.coingeckoId;
 
 export const isNetworkSymbol = (symbol: NetworkSymbolExtended): symbol is NetworkSymbol =>
     Object.hasOwn(networks, symbol);


### PR DESCRIPTION
## Description

Production crash, Sentry [TREZOR-SUITE-1MX4](https://satoshilabs.sentry.io/issues/7561580249/): `TypeError: Cannot read properties of undefined (reading 'includes')` in `isPhishingTransaction` while rendering the account transaction list — 23 events / 8 users between 2026-06-19 and 2026-07-05, Suite Web and Desktop 26.6.1.

What the Sentry events establish:

- The crash frame maps to `getNetworkFeatures(transaction.symbol)` + `.includes('coin-definitions')` in `phishing.ts`. The only other `.includes()` on that path operates on `txsMarkedAsNotScam`, which cannot be `undefined` (`selectAccountTransactionsMarkedAsNotScam` has a stable empty-array fallback), so the failing lookup is `networks[symbol]`.
- The transaction already sits in the redux store when it crashes, i.e. `WalletAccountTransaction.symbol` being typed `NetworkSymbol` is a compile-time guarantee only — at runtime the store held a value the config lookup does not recognize.
- The events do not reveal the offending symbol value: they occurred on ordinary mainnet accounts (`btc`, `ltc`, `eth`, `sol` routes; notably all 8 users on Windows). A removed/renamed network surviving in persisted state and a malformed persisted transaction record are both plausible origins; neither is confirmed. Either way, these helpers must tolerate the input.

Two lookup helpers in `wallet-config` did not survive it:

- **`getNetworkFeatures`** declared `NetworkFeature[]` but returned `networks[symbol]?.features`, i.e. `undefined` for an unknown symbol. All ~20 callers immediately call `.includes()` on the result — this is the crashing helper. Fixed with an empty-array fallback so the declared type holds.
- **`getCoingeckoId`** had the identical latent defect two lines below: `networks[symbol].coingeckoId` with no optional chaining, throwing `Cannot read properties of undefined (reading 'coingeckoId')` for the same class of input (no production occurrences in the last 90 days — this one is preventive). Added the missing `?.`. The `coingeckoId` field is already declared optional, so the inferred return type stays `string | undefined` and every caller already handles the undefined case (`fetchTokenDefinitions` throws, `AssetLogo` guards with `isNetworkSymbol`).

Both fixes align these helpers with the sibling `getNetworkType`, which already returns `undefined` for unknown symbols and whose callers expect it.

### Impact when it fires

The throw is synchronous inside `useSelector` (`TransactionItem.tsx` → `selectIsPhishingTransaction` → `isPhishingTransaction`), so it happens during React render, not inside an async thunk. Suite has a single top-level `ErrorBoundary` (`Main.tsx`) wrapping the whole router and every view, with no per-route or per-view boundary below it. The render throw is therefore not contained to the offending transaction row: React unwinds the entire tree under that boundary and replaces the whole app UI with the full-screen `<Error>` fallback (and reports the error to Sentry). For the user this is effectively a dead app — the only recovery is a reload, and because the offending transaction stays in persisted state, reopening the same account re-triggers the crash.

### Scope note

This makes the lookups total; it does not answer *why* the store contained a symbol missing from the config — the Sentry events don't carry the value and there is no reproduction. If the crash class recurs, the next diagnostic step is capturing the offending symbol value (a network symbol is not confidential), which these guards no longer mask as a render crash.

## Related

First commit is a rebase of the existing Sentry fix `fd15952`; second commit extends the same guard to `getCoingeckoId`.

## Notes for QA

Low blast radius — pure defensive guards in two pure functions, no behaviour change for any known network symbol (added unit tests assert the known-symbol path is unchanged). The only behaviour change is for a symbol absent from the config: `getNetworkFeatures` now returns `[]` instead of throwing, `getCoingeckoId` returns `undefined` instead of throwing. Not reproducible manually (requires a persisted transaction whose symbol misses the config lookup); the Sentry crash in the transaction list should stop. No dedicated QA needed beyond confirming normal account/transaction-list rendering is unaffected.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change modifies `suite-common/wallet-config/src/utils.ts`, a broadly-used utility module (mapped to 129 tests), along with its unit test file. Since utils.ts is a global dependency, the risk is distributed but shallow — most E2E tests only transitively import it. The recommended strategy focuses on tests that most directly exercise network/coin configuration, discovery, and account type resolution, where wallet-config utils are most likely to have a concrete impact. The unit test file change has no E2E coverage (as expected for a unit test). Running the unit tests themselves (via the test runner, not E2E) is the primary validation path.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-config/src/__tests__/utils.test.ts`
- `suite-common/wallet-config/src/utils.ts`

</details>

**Recommended tests (6)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — This test directly exercises network/coin activation, configuration, and custom backend setup — all of which rely on wallet-config utilities to resolve network symbols, types, and backend configurations. Changes to utils.ts could affect how networks are identified, enabled, or configured.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test imports BackendType and NetworkSymbol from @suite-common/wallet-config and configures custom backends per coin. The wallet-config utils likely provide helper functions for resolving network properties used in this flow.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coins (BTC, ETH, LTC, ETC, BCH, DOGE, XRP, ZEC) and verifies discovery completes for all of them. wallet-config utils are used to resolve network symbols and configurations during discovery, making this a good integration check.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds various account types (normal, taproot, segwit, legacy) for multiple coins and verifies analytics events contain correct symbols and paths. The wallet-config utils likely provide getNetwork or similar functions used to resolve account type metadata.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-history.test.ts` — This test explicitly uses getNetwork from @suite-common/wallet-config to resolve network names for display in trade history. A change to utils.ts could affect network name resolution in the trade detail sidebar assertions.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test enables networks and verifies asset contents in grid/table views. Network activation and asset display depend on wallet-config utilities for resolving coin metadata, though the dependency is somewhat indirect.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-config/src/__tests__/utils.test.ts`

_Updated: 2026-07-10T16:06:07.426Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/wallet-config-unknown-symbol-guards/web/](https://dev.suite.sldev.cz/suite-web/mroz22/wallet-config-unknown-symbol-guards/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/wallet-config-unknown-symbol-guards&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/wallet-config-unknown-symbol-guards&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/wallet-config-unknown-symbol-guards&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-21T14:33:47.775Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect.ethereumSignMessage > TrezorConnect.ethereumSignMessage | 🤖 auto |
| TrezorConnect > Error screen | 🤖 auto |
| TrezorConnect.signTransaction > TrezorConnect.signTransaction | 🤖 auto |
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-21T14:33:55.107Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

