### PR TITLE
fix(dom-utils): await clipboard write so its rejection is handled

### DIFF
--- a/packages/dom-utils/src/copyToClipboard.ts
+++ b/packages/dom-utils/src/copyToClipboard.ts
@@ -1,9 +1,9 @@
 /**
  * Returns string if there is an error, otherwise returns true
  */
-export const copyToClipboard = (value: string) => {
+export const copyToClipboard = async (value: string) => {
     try {
-        navigator.clipboard.writeText(value);
+        await navigator.clipboard.writeText(value);
 
         return true;
     } catch (error) {

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -102,8 +102,8 @@ export const ConfirmValueModal = ({
     // Do not show Add address label button if there is device interaction needed and device is not connected.
     const shouldShowAddressLabelAction = suiteSyncInteraction === null || !!device?.connected;
 
-    const copy = () => {
-        const result = copyToClipboard(value);
+    const copy = async () => {
+        const result = await copyToClipboard(value);
 
         if (account) {
             analytics.report({

--- a/packages/suite/src/components/suite/modals/ReduxModal/CopyAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/CopyAddressModal.tsx
@@ -32,12 +32,12 @@ export const CopyAddressModal = ({ address, onCancel, addressType }: CopyAddress
 
     const dispatch = useDispatch();
 
-    const onCopyAddress = () => {
+    const onCopyAddress = async () => {
         if (checked) {
             dispatch(setFlag({ key: 'showCopyAddressModal', value: false }));
         }
 
-        const result = copyToClipboard(address);
+        const result = await copyToClipboard(address);
         if (typeof result !== 'string') {
             dispatch(notificationsActions.addToast({ type: 'copy-to-clipboard' }));
         }

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalBottomContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalBottomContent.tsx
@@ -143,8 +143,8 @@ export const TransactionReviewModalBottomContent = ({
         }
     };
 
-    const handleCopy = () => {
-        const result = copyToClipboard(serializedTx!.tx);
+    const handleCopy = async () => {
+        const result = await copyToClipboard(serializedTx!.tx);
 
         if (typeof result !== 'string') {
             dispatch(notificationsActions.addToast({ type: 'copy-to-clipboard' }));

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailProviderInfo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailProviderInfo.tsx
@@ -32,8 +32,8 @@ export const TradingDetailProviderInfo = ({
 }: TradingDetailProviderInfoProps) => {
     const dispatch = useDispatch();
 
-    const copyOrderId = () => {
-        const result = copyToClipboard(orderId || '');
+    const copyOrderId = async () => {
+        const result = await copyToClipboard(orderId || '');
         if (typeof result !== 'string') {
             dispatch(notificationsActions.addToast({ type: 'copy-to-clipboard' }));
         }

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactionId.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactionId.tsx
@@ -11,8 +11,8 @@ interface TradingTransactionIdProps {
 
 export const TradingTransactionId = ({ transactionId }: TradingTransactionIdProps) => {
     const dispatch = useDispatch();
-    const copy = () => {
-        const result = copyToClipboard(transactionId);
+    const copy = async () => {
+        const result = await copyToClipboard(transactionId);
         if (typeof result !== 'string') {
             dispatch(notificationsActions.addToast({ type: 'copy-to-clipboard' }));
         }

--- a/suite/address/src/copyAddressActions.ts
+++ b/suite/address/src/copyAddressActions.ts
@@ -16,8 +16,8 @@ export const showCopyAddressModal =
         );
     };
 
-export const copyAddressToClipboard = (address: string) => (dispatch: Dispatch) => {
-    const result = copyToClipboard(address);
+export const copyAddressToClipboard = (address: string) => async (dispatch: Dispatch) => {
+    const result = await copyToClipboard(address);
 
     const isSuccess = result === true;
 

--- a/suite/sign-verify/src/useCopySignedMessage.ts
+++ b/suite/sign-verify/src/useCopySignedMessage.ts
@@ -43,10 +43,10 @@ export const useCopySignedMessage = <T extends SignedMessageData>(
         );
     };
 
-    const copy = () => {
+    const copy = async () => {
         const formatted = formatMessage();
 
-        const result = copyToClipboard(formatted);
+        const result = await copyToClipboard(formatted);
 
         if (typeof result !== 'string') {
             dispatch(notificationsActions.addToast({ type: 'copy-to-clipboard' }));


### PR DESCRIPTION
## Description

### Problem

`copyToClipboard` wrapped `navigator.clipboard.writeText` in a synchronous `try/catch`, but `writeText` returns a promise. A rejected clipboard write (e.g. Chrome's "Must be handling a user gesture to use custom clipboard" on the receive page, or a denied clipboard permission) therefore escaped as an **unhandled promise rejection** and was reported to Sentry instead of being handled.

### Fix

Make `copyToClipboard` `async` and `await` the write, so the existing `try/catch` actually catches the rejection and returns it to the caller. Every call site that consumes the return value now `await`s it — including `copyAddressToClipboard`, whose `result === true` check had silently become a `Promise === true` comparison once the helper turned async.

Sentry: https://satoshilabs.sentry.io/issues/7589994551/ (TREZOR-SUITE-1N6H)

### Notes for QA

Blast radius: every "copy to clipboard" action in Suite — receive address, xpub, signed message, transaction id, trading order/provider id, and the confirm-value / copy-address modals.

Please verify:
- Copying any of the above still works and still shows the "copied to clipboard" success toast.
- A denied/failed clipboard write no longer leaves the flow in a broken state and no longer produces an unhandled rejection (previously flooding Sentry).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is concentrated around copy-to-clipboard behavior in address display, signed-message output and trading detail UIs, plus two trading-specific detail components. The highest-confidence regression test is the receive flow, which directly asserts clipboard copying across multiple coins. Medium-confidence tests extend coverage to Cardano/global receive, signed-message copy hooks, and trading history provider/transaction-ID rendering. No changed file is entirely without inferred coverage.

<details><summary><b>Changed files (8)</b></summary>

- `packages/dom-utils/src/copyToClipboard.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/CopyAddressModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalBottomContent.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailProviderInfo.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingTransactionId.tsx`
- `suite/address/src/copyAddressActions.ts`
- `suite/sign-verify/src/useCopySignedMessage.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — This test directly exercises the copy-to-clipboard flow for BTC, ETH, SOL and TRX receive addresses, including the copy button, clipboard content and confirmation toast. It is the strongest end-to-end coverage for the changed copy utility, CopyAddressModal, ConfirmValueModal and copy-address actions.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — The test reveals and copies a Cardano receive address after on-device confirmation, so it hits the copy-address modal/action path for a coin with distinct address formatting. It provides coin-specific coverage beyond the generic receive test.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — Tests the global receive flow where a new ETH account is selected and its address is revealed and copied. This exercises the copy-address flow from a different entry point (global menu) than the account-level receive test.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — Covers Ethereum message signing and verifies the signature output field. The changed useCopySignedMessage hook is expected to be used in this flow, so the test validates that signing/copy UI still renders and functions correctly.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Covers Bitcoin message signing in standard and Electrum formats and checks the signature field. Like the ETH variant, this flow likely uses the changed signed-message copy hook, making it a good regression check.
- `suite/e2e/tests/trading/swap-history.test.ts` — Statically mapped to both changed trading detail files. It exercises provider name display and order/transaction ID rendering in the trading history list and detail views, covering TradingDetailProviderInfo and TradingTransactionId behavior.

</details>

_Updated: 2026-08-04T09:50:42.057Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/clipboard-await-unhandled-rejection&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/clipboard-await-unhandled-rejection&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T09:51:30.671Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T09:51:00.918Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/clipboard-await-unhandled-rejection/web/](https://dev.suite.sldev.cz/suite-web/mroz22/clipboard-await-unhandled-rejection/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->
