### PR TITLE
fix(suite): keep selectAccount manual-address selections across pages

### DIFF
--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -655,8 +655,17 @@ export const connectPopupLoadSelectAccountPageThunk = createThunk<void, { page: 
                     };
                 });
 
+                // Keep candidates from other tabs AND from other pages of this tab, so selections
+                // made on previously-loaded pages survive pagination (mirrors loadAccountIndexPage).
+                // Filtering by tab alone would drop every prior page, since in the manual address
+                // phase all rows share the single active tab.
                 const otherCandidates = current.candidates.filter(
-                    c => c.accountTypeKey !== activeTab.key,
+                    c =>
+                        !(
+                            c.accountTypeKey === activeTab.key &&
+                            c.accountIndex >= startIndex &&
+                            c.accountIndex < startIndex + SELECT_ACCOUNT_PAGE_SIZE
+                        ),
                 );
                 dispatch(
                     connectPopupActions.updateSelectAccount({


### PR DESCRIPTION
## Description

Follow-up to #28831 (`selectAccount`), targeting its feature branch. Fixes a selection-loss bug found while reviewing the latest revision of #28831.

In the UTXO `addressSelection: 'manual'` flow, the address phase paginates an account's previously-used addresses (5 per page). Each page is merged back into the candidate list by `paintPage`, which kept only candidates from *other* account-type tabs:

```ts
const otherCandidates = current.candidates.filter(c => c.accountTypeKey !== activeTab.key);
dispatch(updateSelectAccount({ candidates: [...otherCandidates, ...rows], ... }));
```

But in the address phase every row belongs to the single active tab, so `otherCandidates` is always empty and the dispatch replaces the whole candidate list with just the current page's rows — discarding the `selected` (and `validated`) state of every previously-loaded page. The sibling loader `loadAccountIndexPage` does this correctly by excluding only the current page's index range for the active tab; the two paths were inconsistent.

### Repro

`selectAccount({ coin: 'btc', addressSelection: 'manual', selectionType: 'multi' })`, on an account with more than 5 used addresses:

1. Drill into the account (manual address phase, page 0 lists addresses #0–#4).
2. Select an address on page 0 — the counter shows 1.
3. Page forward to page 1.
4. The page-0 selection is gone: it disappears from the counter and, on Connect, from the exported payload. It stays lost even when paging back to page 0.

### Fix

Mirror `loadAccountIndexPage` — exclude only the current page's index range of the active tab, keeping candidates from other pages (and other tabs):

```ts
const otherCandidates = current.candidates.filter(
    c => !(c.accountTypeKey === activeTab.key &&
           c.accountIndex >= startIndex &&
           c.accountIndex < startIndex + SELECT_ACCOUNT_PAGE_SIZE),
);
```

## Related

- Base branch / parent feature: #28831
- Sibling fix into the same feature branch: #29515 (`requireOnDeviceVerification` enforcement)

## Notes for QA

Only affects the `selectAccount` picker's UTXO `addressSelection: 'manual'` two-phase flow, and only when the chosen account has more than 5 used addresses (so pagination appears). Before: selecting an address on one page and paging to another silently dropped the earlier selection. After: selections accumulate across pages and are all exported on Connect. Other selectAccount modes (account-index list, xpub full-account, firstFresh) were already correct and are unchanged.

No automated test is included: `@suite-common/connect-popup` has no unit-test setup (adding jest config for one thunk test is out of scope), and an e2e for this path needs an account with 6+ used addresses — that belongs with the broader manual/xpub/cardano e2e coverage gap noted separately in the #28831 review. The fix is a one-line filter change that brings `loadManualAddressPage` in line with the already-correct `loadAccountIndexPage`.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/select-account-manual-pagination&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/select-account-manual-pagination&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/select-account-manual-pagination&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to connectPopupThunks.ts, which is a broadly imported module (121 tests map to it statically). This file likely manages the thunk logic for showing/hiding connect popups, handling device connection prompts, session management modals, and THP pairing flows. The highest risk areas are tests that directly exercise device connection/disconnection prompts, session management, and bridge interactions. Most of the 121 statically mapped tests only transitively import this module and are unlikely to be affected unless the change alters fundamental popup/modal dispatch behavior. The recommended strategy focuses on the 3 high-priority tests covering core connection flows and 3-4 medium/low tests covering reconnection and popup edge cases.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/connect-popup/src/connectPopupThunks.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/suite/initial-run.test.ts` — connectPopupThunks handles the connect popup flow during device connection, which is central to the initial run/onboarding process. This test explicitly validates THP pairing code flow, device connection prompts, and analytics consent persistence across reloads — all of which involve the connect popup infrastructure.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test directly exercises Bridge session management, session stealing/reclaiming, and device connection status changes ('Use Here' vs 'Connected'). connectPopupThunks likely governs the popup/modal logic for session conflicts and reconnection flows, making this a primary test for the change.
- `suite/e2e/tests/suite/bridge.test.ts` — This test navigates to the Bridge page, exercises WebUSB selection, and verifies the connect device prompt (@connect-device-prompt) is displayed. connectPopupThunks directly relates to the connect popup flow and device connection prompts that this test validates.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/without-device.test.ts` — This test validates the connection modal (@suite/connection-modal) appearing when the device is disconnected during a send flow. connectPopupThunks likely manages the logic for showing this reconnection modal, making this test relevant to verify correct popup behavior on device disconnect.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — This test covers the analytics consent dialog during onboarding and THP pairing code flow, which involves connect popup thunks for handling device connection prompts during the onboarding path.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test validates device disconnect/reconnect behavior with passphrase wallets, including re-prompting for passphrase confirmation after reconnection. The connect popup thunks may govern how the reconnection flow and passphrase re-confirmation modals are triggered.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — WalletConnect pairing and proposal flows involve connect popup interactions for approving/rejecting connections. Changes to connectPopupThunks could affect how these connection proposals are presented and handled.

</details>

_Updated: 2026-07-09T06:35:18.903Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-09T06:42:16.607Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-09T06:38:37.598Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/select-account-manual-pagination/web/](https://dev.suite.sldev.cz/suite-web/mroz22/select-account-manual-pagination/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->