### PR TITLE
refactor(connect): share selectAccount addressSelection union type

### DIFF
--- a/packages/connect-common/src/types/api/selectAccount.ts
+++ b/packages/connect-common/src/types/api/selectAccount.ts
@@ -42,6 +42,16 @@ export const SelectionType = Type.Union([
     MultiSelectBounds,
 ]);
 
+// UTXO-only sharing flow (see the `addressSelection` field on SelectAccount for the full
+// semantics). 'fullAccount' shares the whole account as an xpub; 'firstFresh' | 'manual' export
+// only an individual address.
+export type AddressSelection = Static<typeof AddressSelection>;
+export const AddressSelection = Type.Union([
+    Type.Literal('fullAccount'),
+    Type.Literal('firstFresh'),
+    Type.Literal('manual'),
+]);
+
 export type SelectAccount = Static<typeof SelectAccount>;
 export const SelectAccount = Type.Object({
     // Network to select an account for, e.g. 'eth' | 'btc' | 'ada'.
@@ -59,13 +69,7 @@ export const SelectAccount = Type.Object({
     // - 'firstFresh' | 'manual': only the individual address(es) the user picks are exported —
     //   'firstFresh' auto-selects the next unused receive address, 'manual' lets the user pick a
     //   used one. The xpub is never exported here; requires the narrower `read_address` instead.
-    addressSelection: Type.Optional(
-        Type.Union([
-            Type.Literal('fullAccount'),
-            Type.Literal('firstFresh'),
-            Type.Literal('manual'),
-        ]),
-    ),
+    addressSelection: Type.Optional(AddressSelection),
     // Require the selected address(es) to be confirmed on the device. Default true.
     requireOnDeviceVerification: Type.Optional(Type.Boolean()),
 });

--- a/packages/connect/src/api/selectAccount.ts
+++ b/packages/connect/src/api/selectAccount.ts
@@ -1,6 +1,9 @@
 import { type CoinInfo, type PermissionRequest } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
-import { SelectAccount as SelectAccountSchema } from '@trezor/connect-common/src/types/api/selectAccount';
+import {
+    type AddressSelection,
+    SelectAccount as SelectAccountSchema,
+} from '@trezor/connect-common/src/types/api/selectAccount';
 import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage, MethodReturnType } from '../core/AbstractMethod';
@@ -11,7 +14,7 @@ import { getLabel } from '../utils/pathUtils';
 
 type Params = {
     coinInfo: CoinInfo;
-    addressSelection?: 'fullAccount' | 'firstFresh' | 'manual';
+    addressSelection?: AddressSelection;
 };
 
 export default class SelectAccount extends AbstractMethod<'selectAccount', Params> {

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -2,6 +2,7 @@ import { type AccountType, type NetworkSymbol, getNetwork } from '@suite-common/
 import { type AccountKey, type TxSimulationAction } from '@suite-common/wallet-types';
 import { type CallMethodKeys, type PermissionRequest } from '@trezor/connect';
 import { type SerializedError } from '@trezor/connect-common/src/constants/errors';
+import { type AddressSelection } from '@trezor/connect-common/src/types/api/selectAccount';
 
 // UTXO coins have accounts with many addresses (mirrors `isUtxoBased` in
 // wallet-utils/accountUtils, which operates on an already-loaded `Account` instead of a symbol) —
@@ -128,7 +129,7 @@ export type SelectAccountOptions = {
     mode: 'xpub' | 'address';
     // Normalized: 'fullAccount' when the coin is UTXO-based and the param was omitted or explicit;
     // undefined only for account-based networks, where `addressSelection` is ignored entirely.
-    addressSelection?: 'fullAccount' | 'firstFresh' | 'manual';
+    addressSelection?: AddressSelection;
     requireOnDeviceVerification: boolean;
     minCount: number;
     maxCount?: number;


### PR DESCRIPTION
The `addressSelection` union `'fullAccount' | 'firstFresh' | 'manual'` was declared verbatim in three places: the connect-common `SelectAccount` schema (source of truth, inline in the object), the connect `selectAccount` method params, and the connect-popup `SelectAccountOptions`.

This extracts it into a named `AddressSelection` export in the connect-common schema — mirroring the existing `AccountType` and `SelectionType` exports in the same file — and reuses the derived type from the two consumers. Adding a future variant now happens in one place instead of three. No runtime behaviour change; the connect-popup field keeps its "normalized" comment since it plays a slightly different role there (same value set).

Based on top of the `connect-select-account-method` branch, which introduces the `selectAccount` method this cleans up.

## Notes for QA

No QA needed — pure type-level refactor. The union is byte-identical to what was there before (same three string literals, same optionality); it only moves where the type is declared. No effect on the wire schema, validation, or runtime.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mvarmuza/select-account-share-address-selection-type&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mvarmuza/select-account-share-address-selection-type&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mvarmuza/select-account-share-address-selection-type&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect the TrezorConnect selectAccount API (types and implementation) and the connect popup types used for communication between TrezorConnect and Suite. The selectAccount API is directly exercised by the getAccountInfo test, making it critical. The connectPopupTypes file maps to 121 tests but is a broad shared dependency — only TrezorConnect-specific tests that directly interact with the connect popup flow are recommended. The risk is moderate: type changes may cause compile-time issues but runtime behavior changes would primarily affect TrezorConnect popup interactions and account selection flows.

<details><summary><b>Changed files (3)</b></summary>

- `packages/connect-common/src/types/api/selectAccount.ts`
- `packages/connect/src/api/selectAccount.ts`
- `suite-common/connect-popup/src/connectPopupTypes.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — This test directly exercises TrezorConnect.getAccountInfo which uses the selectAccount API. The test verifies account selection modal behavior (selecting account type p2wpkh and a specific account), which is the exact functionality defined in packages/connect/src/api/selectAccount.ts and its types in packages/connect-common/src/types/api/selectAccount.ts.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trezor-connect/permissions.test.ts` — This test exercises the TrezorConnect permissions flow and connected apps management, which shares the connectPopupTypes infrastructure. Changes to connect popup types could affect how permissions are granted, remembered, and revoked for TrezorConnect API calls.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test covers the TrezorConnect popup flow for getAddress including permissions granting, cancellation, and popup lifecycle. The connectPopupTypes changes could affect how the popup communicates with the host app, and the selectAccount types may be transitively involved in account resolution within the popup.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Similar to the web popup test, this exercises TrezorConnect popup flows from a webextension context. Changes to connectPopupTypes directly affect the communication protocol between the extension and the Suite popup.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — This test verifies silent mode behavior in the connect popup permissions flow, directly using connectPopup Redux state (connectPopup.permissions). Changes to connectPopupTypes could affect the permissions data structure and silent mode checkbox behavior.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/error.test.ts` — This test exercises TrezorConnect error handling in suite-desktop core mode. While it doesn't directly test selectAccount, changes to connectPopupTypes could affect how errors are propagated through the connect popup infrastructure.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This test exercises TrezorConnect.getAddress with permissions modal and address confirmation. While it doesn't use selectAccount directly, it shares the connect popup type infrastructure that was modified.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/connect-common/src/types/api/selectAccount.ts`
- `packages/connect/src/api/selectAccount.ts`

_Updated: 2026-07-09T05:12:13.501Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mvarmuza/select-account-share-address-selection-type/web/](https://dev.suite.sldev.cz/suite-web/mvarmuza/select-account-share-address-selection-type/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-09T05:18:19.428Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->