### PR TITLE
fix(suite): solana rewards item alignment

### DIFF
--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/Rewards/RewardsList.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/Rewards/RewardsList.tsx
@@ -10,6 +10,7 @@ import { BaseCurrencyValue, FormattedCryptoAmount, FormattedDate } from 'src/com
 import { Pagination } from 'src/components/wallet';
 import { TransactionTargetLayout } from 'src/components/wallet/TransactionItem/TransactionTargetLayout';
 import { type UsePagination } from 'src/hooks/general/usePagination';
+import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 import { type Account } from 'src/types/wallet';
 import SkeletonTransactionItem from 'src/views/wallet/transactions/TransactionList/SkeletonTransactionItem';
 
@@ -25,6 +26,7 @@ interface RewardsListProps {
 
 export const RewardsList = ({ account, rewardsQueryResult, pagination }: RewardsListProps) => {
     const sectionRef = useRef<HTMLDivElement>(null);
+    const { isBelowTablet } = useLayoutSize();
     const isSolanaMainnet = !isTestnet(account.symbol);
 
     const onPageSelected = (page: number) => {
@@ -76,6 +78,7 @@ export const RewardsList = ({ account, rewardsQueryResult, pagination }: Rewards
                                         year="numeric"
                                     />
                                 </Text>
+
                                 <Card paddingType="none">
                                     <Row gap={32} padding={{ vertical: 16, horizontal: 24 }}>
                                         <IconCircle name="piggyBank" intent="neutral" size={40} />
@@ -84,7 +87,11 @@ export const RewardsList = ({ account, rewardsQueryResult, pagination }: Rewards
                                                 <Translation id="TR_REWARD" />
                                             </Text>
                                             <Grid
-                                                columns="1fr max-content minmax(110px, max-content)"
+                                                columns={
+                                                    isBelowTablet
+                                                        ? '1fr max-content'
+                                                        : '1fr max-content minmax(110px, max-content)'
+                                                }
                                                 rowGap={6}
                                                 columnGap={24}
                                                 flex="1"


### PR DESCRIPTION
## Description

Fix broken alignment of the Solana rewards item crypto/fiat amount.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29317

## Screenshots:

<img width="100%" alt="Screenshot 2026-07-08 at 14 19 51" src="https://github.com/user-attachments/assets/ae3137f9-b5cb-4236-8dc1-6a75fc1f6b58" />

<img width="100%" alt="Screenshot 2026-07-08 at 14 20 05" src="https://github.com/user-attachments/assets/241a4f98-8685-4672-a9d9-9ad5c6f44b72" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to the Solana staking RewardsList component. The highest risk is to the SOL rewards test which directly validates reward list display and pagination. Other SOL staking tests have medium risk since they render the same dashboard where RewardsList lives. ETH, ADA, and analytics staking tests are omitted because they use entirely different staking dashboard components and would not render the Solana-specific RewardsList.tsx, despite the broad static mapping.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/staking/components/SolStakingDashboard/Rewards/RewardsList.tsx`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/staking/sol/rewards.test.ts` — This test directly exercises the Solana staking rewards display, including reward list rendering with pagination. The changed file (RewardsList.tsx) is the exact component responsible for displaying individual reward entries in the Solana staking dashboard, which this test explicitly validates.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/sol/unstake.test.ts` — This test covers the full Solana staking dashboard lifecycle including viewing staked amounts and claim flows. While it doesn't directly test reward list rendering, it navigates through the Solana staking dashboard where the RewardsList component is rendered, so a breaking change could cause failures.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — This test views the Solana staking dashboard with staked amounts and rewards display. It interacts with the SolStakingDashboard where RewardsList is a child component, so a render-breaking change could affect this test.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test navigates through the Solana staking dashboard flow. Although it starts from an empty staking state, the RewardsList component may still be rendered (possibly empty) as part of the dashboard, so a crash in RewardsList could affect this test.

</details>

_Updated: 2026-07-08T12:24:00.792Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/solana-rewards-layout&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/solana-rewards-layout&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-08T12:29:27.980Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T12:27:27.227Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/solana-rewards-layout/web/](https://dev.suite.sldev.cz/suite-web/fix/solana-rewards-layout/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->