### PR TITLE
Feat/tron claim fw check

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useState } from 'react';
-
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
 import { useTranslation } from '@suite/intl';
@@ -22,9 +20,8 @@ import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { Card, Column, Icon, Row, Table } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
-import { selectIsConnectionModalOpen } from 'src/actions/device/deviceSelectors';
-import { setConnectionModal, setConnectionMode } from 'src/actions/device/deviceSlice';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useFirmwareUpgradeModal } from 'src/hooks/suite/useFirmwareUpgradeModal';
 import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 import { useMessageSystemYield } from 'src/hooks/suite/useMessageSystemYield';
 
@@ -50,46 +47,10 @@ export const EarnYieldAccountOpportunity = ({
     const { CryptoAmountFormatter } = useFormatters();
     const { translationString } = useTranslation();
     const { isBelowMobile } = useLayoutSize();
-    const [isFirmwareModalOpen, setIsFirmwareModalOpen] = useState(false);
-    const [isAwaitingConnectionForFwUpdate, setIsAwaitingConnectionForFwUpdate] = useState(false);
     const selectedDevice = useSelector(selectSelectedDevice);
-    const isConnectionModalOpen = useSelector(selectIsConnectionModalOpen);
     const isFirmwareOutdated = !isStablecoinYieldSupported(selectedDevice);
-
-    useEffect(() => {
-        if (isAwaitingConnectionForFwUpdate && !isConnectionModalOpen) {
-            setIsAwaitingConnectionForFwUpdate(false);
-            if (selectedDevice?.connected) {
-                setIsFirmwareModalOpen(false);
-                dispatch(goto({ routeName: 'firmware-index', params: { cancelable: true } }));
-            }
-        }
-    }, [
-        isAwaitingConnectionForFwUpdate,
-        isConnectionModalOpen,
-        selectedDevice?.connected,
-        dispatch,
-    ]);
-
-    const handleFirmwareModalClose = () => {
-        setIsFirmwareModalOpen(false);
-        setIsAwaitingConnectionForFwUpdate(false);
-    };
-
-    const handleFirmwareUpdate = () => {
-        if (!selectedDevice?.connected) {
-            if (selectedDevice?.descriptor?.apiType === 'bluetooth') {
-                dispatch(setConnectionMode('bluetooth'));
-            }
-            setIsAwaitingConnectionForFwUpdate(true);
-            dispatch(setConnectionModal(true));
-
-            return;
-        }
-
-        setIsFirmwareModalOpen(false);
-        dispatch(goto({ routeName: 'firmware-index', params: { cancelable: true } }));
-    };
+    const { isFirmwareModalOpen, openFirmwareModal, closeFirmwareModal, updateFirmware } =
+        useFirmwareUpgradeModal();
 
     const vaultContractAddress = getYieldVaultContractAddress(opportunity.vault);
     const depositMessageSystem = useMessageSystemYield('deposit', { vaultContractAddress });
@@ -187,7 +148,7 @@ export const EarnYieldAccountOpportunity = ({
                     vaultId: opportunity.vault.id,
                 },
             });
-            setIsFirmwareModalOpen(true);
+            openFirmwareModal();
 
             return;
         }
@@ -233,7 +194,7 @@ export const EarnYieldAccountOpportunity = ({
                     vaultId: opportunity.vault.id,
                 },
             });
-            setIsFirmwareModalOpen(true);
+            openFirmwareModal();
 
             return;
         }
@@ -276,7 +237,7 @@ export const EarnYieldAccountOpportunity = ({
                     vaultId: opportunity.vault.id,
                 },
             });
-            setIsFirmwareModalOpen(true);
+            openFirmwareModal();
 
             return;
         }
@@ -312,8 +273,8 @@ export const EarnYieldAccountOpportunity = ({
 
     const firmwareModal = isFirmwareModalOpen && (
         <FirmwareUpgradeNeededModal
-            onClose={handleFirmwareModalClose}
-            onUpdate={handleFirmwareUpdate}
+            onClose={closeFirmwareModal}
+            onUpdate={updateFirmware}
             featureName={translationString('TR_EARN_STABLECOIN_YIELD_TITLE')}
         />
     );

--- a/packages/suite/src/components/earn/staking/tron/claim/TronClaimSubmitButton.tsx
+++ b/packages/suite/src/components/earn/staking/tron/claim/TronClaimSubmitButton.tsx
@@ -1,35 +1,60 @@
 import { useDevice } from '@suite/device';
-import { Translation } from '@suite/intl';
+import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
+import { Translation, useTranslation } from '@suite/intl';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
-import { getTronStakingRewards } from '@suite-common/wallet-utils';
+import { getTronStakingRewards, isTronClaimSupported } from '@suite-common/wallet-utils';
 import { Button } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
+import { useFirmwareUpgradeModal } from 'src/hooks/suite/useFirmwareUpgradeModal';
 
 import { useTronStakeContext } from '../TronStakeContext';
 
 export const TronClaimSubmitButton = () => {
     const { device, isLocked } = useDevice();
+    const { translationString } = useTranslation();
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
     const { account, actions } = useTronStakeContext();
     const { isSubmitting, pendingTxid, submitAction } = actions;
+    const { isFirmwareModalOpen, openFirmwareModal, closeFirmwareModal, updateFirmware } =
+        useFirmwareUpgradeModal();
 
     const hasReward = new BigNumber(getTronStakingRewards(account)).gt(0);
     const isDeviceLocked = !!device?.connected && !!device?.available && isLocked();
+    const isClaimFirmwareOutdated = !isTronClaimSupported(device);
 
     const isDisabled = !hasReward || isSubmitting || isDeviceLocked || !!pendingTxid;
     const isLoading = isSubmitting || isDiscoveryRunning;
 
+    const handleClick = () => {
+        if (isClaimFirmwareOutdated) {
+            openFirmwareModal();
+
+            return;
+        }
+
+        submitAction();
+    };
+
     return (
-        <Button
-            size="large"
-            width="100%"
-            onClick={submitAction}
-            isDisabled={isDisabled}
-            isLoading={isLoading}
-        >
-            <Translation id="TR_CONTINUE" />
-        </Button>
+        <>
+            {isFirmwareModalOpen && (
+                <FirmwareUpgradeNeededModal
+                    onClose={closeFirmwareModal}
+                    onUpdate={updateFirmware}
+                    featureName={translationString('TR_EARN_TRON_CLAIM_TITLE')}
+                />
+            )}
+            <Button
+                size="large"
+                width="100%"
+                onClick={handleClick}
+                isDisabled={isDisabled}
+                isLoading={isLoading}
+            >
+                <Translation id="TR_CONTINUE" />
+            </Button>
+        </>
     );
 };

--- a/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
@@ -1,11 +1,10 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
 import { Translation, useTranslation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { type YieldAccountRewards } from '@suite-common/earn-stablecoin-api';
 import { Context } from '@suite-common/message-system';
@@ -18,11 +17,11 @@ import {
 import { type Account } from '@suite-common/wallet-types';
 import { Banner, Button, Card, Column, Text } from '@trezor/components';
 
-import { selectIsConnectionModalOpen } from 'src/actions/device/deviceSelectors';
 import { setConnectionModal, setConnectionMode } from 'src/actions/device/deviceSlice';
 import { claimMerklRewardsThunk } from 'src/actions/wallet/stablecoin-yield';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useFirmwareUpgradeModal } from 'src/hooks/suite/useFirmwareUpgradeModal';
 import { useMessageSystemYield } from 'src/hooks/suite/useMessageSystemYield';
 
 import { YieldRewardsList } from './YieldRewardsList';
@@ -43,10 +42,9 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
     const { translationString } = useTranslation();
     const flowKey = account.key;
     const { isDisabled, content, variant } = useMessageSystemYield('claim');
-    const [isFirmwareModalOpen, setIsFirmwareModalOpen] = useState(false);
-    const [isAwaitingConnectionForFwUpdate, setIsAwaitingConnectionForFwUpdate] = useState(false);
+    const { isFirmwareModalOpen, openFirmwareModal, closeFirmwareModal, updateFirmware } =
+        useFirmwareUpgradeModal();
 
-    const isConnectionModalOpen = useSelector(selectIsConnectionModalOpen);
     const yieldTxReview = useSelector(selectStablecoinYieldTxReview);
     const claimSession = useSelector(state =>
         selectStablecoinYieldSession(state, 'claim', flowKey),
@@ -71,16 +69,6 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
         };
     }, [dispatch, flowKey]);
 
-    useEffect(() => {
-        if (isAwaitingConnectionForFwUpdate && !isConnectionModalOpen) {
-            setIsAwaitingConnectionForFwUpdate(false);
-            if (device?.connected) {
-                setIsFirmwareModalOpen(false);
-                dispatch(goto({ routeName: 'firmware-index', params: { cancelable: true } }));
-            }
-        }
-    }, [isAwaitingConnectionForFwUpdate, isConnectionModalOpen, device?.connected, dispatch]);
-
     useYieldPendingTransactionTracking({
         account,
         flowType: 'claim',
@@ -92,7 +80,7 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
         if (!accountRewards) return;
 
         if (isClaimFirmwareOutdated) {
-            setIsFirmwareModalOpen(true);
+            openFirmwareModal();
 
             return;
         }
@@ -123,26 +111,6 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
         } catch {
             // cancelled or rejected — isClaiming resets via Redux (discardTransaction in finally)
         }
-    };
-
-    const handleFirmwareModalClose = () => {
-        setIsFirmwareModalOpen(false);
-        setIsAwaitingConnectionForFwUpdate(false);
-    };
-
-    const handleFirmwareUpdate = () => {
-        if (!device?.connected) {
-            if (device?.descriptor?.apiType === 'bluetooth') {
-                dispatch(setConnectionMode('bluetooth'));
-            }
-            setIsAwaitingConnectionForFwUpdate(true);
-            dispatch(setConnectionModal(true));
-
-            return;
-        }
-
-        setIsFirmwareModalOpen(false);
-        dispatch(goto({ routeName: 'firmware-index', params: { cancelable: true } }));
     };
 
     const handleTxClick = useCallback(
@@ -184,8 +152,8 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
         <Column width="100%" alignItems="center">
             {isFirmwareModalOpen && (
                 <FirmwareUpgradeNeededModal
-                    onClose={handleFirmwareModalClose}
-                    onUpdate={handleFirmwareUpdate}
+                    onClose={closeFirmwareModal}
+                    onUpdate={updateFirmware}
                     featureName={translationString('TR_EARN_STABLECOIN_YIELD_TITLE')}
                 />
             )}

--- a/packages/suite/src/hooks/suite/useFirmwareUpgradeModal.ts
+++ b/packages/suite/src/hooks/suite/useFirmwareUpgradeModal.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+import { goto } from '@suite/router';
+import { selectSelectedDevice } from '@suite-common/device';
+
+import { selectIsConnectionModalOpen } from 'src/actions/device/deviceSelectors';
+import { setConnectionModal, setConnectionMode } from 'src/actions/device/deviceSlice';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+export const useFirmwareUpgradeModal = () => {
+    const dispatch = useDispatch();
+    const device = useSelector(selectSelectedDevice);
+    const isConnectionModalOpen = useSelector(selectIsConnectionModalOpen);
+    const [isFirmwareModalOpen, setIsFirmwareModalOpen] = useState(false);
+    const [isAwaitingConnectionForFwUpdate, setIsAwaitingConnectionForFwUpdate] = useState(false);
+
+    useEffect(() => {
+        if (isAwaitingConnectionForFwUpdate && !isConnectionModalOpen) {
+            setIsAwaitingConnectionForFwUpdate(false);
+            if (device?.connected) {
+                setIsFirmwareModalOpen(false);
+                dispatch(goto({ routeName: 'firmware-index', params: { cancelable: true } }));
+            }
+        }
+    }, [isAwaitingConnectionForFwUpdate, isConnectionModalOpen, device?.connected, dispatch]);
+
+    const openFirmwareModal = () => setIsFirmwareModalOpen(true);
+
+    const closeFirmwareModal = () => {
+        setIsFirmwareModalOpen(false);
+        setIsAwaitingConnectionForFwUpdate(false);
+    };
+
+    const updateFirmware = () => {
+        if (!device?.connected) {
+            if (device?.descriptor?.apiType === 'bluetooth') {
+                dispatch(setConnectionMode('bluetooth'));
+            }
+            setIsAwaitingConnectionForFwUpdate(true);
+            dispatch(setConnectionModal(true));
+
+            return;
+        }
+
+        setIsFirmwareModalOpen(false);
+        dispatch(goto({ routeName: 'firmware-index', params: { cancelable: true } }));
+    };
+
+    return { isFirmwareModalOpen, openFirmwareModal, closeFirmwareModal, updateFirmware };
+};

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx
@@ -1,9 +1,12 @@
-import { Translation } from '@suite/intl';
+import { useDevice } from '@suite/device';
+import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
+import { Translation, useTranslation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { type Account } from '@suite-common/wallet-types';
 import {
     getTronRewardClaimCooldownEndsAt,
     getTronStakingRewards,
+    isTronClaimSupported,
     isTronRewardClaimOnCooldown,
 } from '@suite-common/wallet-utils';
 import {
@@ -20,6 +23,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { BaseCurrencyValue, CountdownTimer, FormattedCryptoAmount } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
+import { useFirmwareUpgradeModal } from 'src/hooks/suite/useFirmwareUpgradeModal';
 
 interface TronVotingRewardsCardProps {
     account: Account;
@@ -27,16 +31,27 @@ interface TronVotingRewardsCardProps {
 
 export const TronVotingRewardsCard = ({ account }: TronVotingRewardsCardProps) => {
     const dispatch = useDispatch();
+    const { device } = useDevice();
+    const { translationString } = useTranslation();
+    const { isFirmwareModalOpen, openFirmwareModal, closeFirmwareModal, updateFirmware } =
+        useFirmwareUpgradeModal();
 
     const rewards = getTronStakingRewards(account);
     const isClaimOnCooldown = isTronRewardClaimOnCooldown(account);
     const claimCooldownEndsAt = getTronRewardClaimCooldownEndsAt(account);
+    const isClaimFirmwareOutdated = !isTronClaimSupported(device);
 
     if (new BigNumber(rewards).lte(0)) {
         return null;
     }
 
-    const goToClaim = () =>
+    const goToClaim = () => {
+        if (isClaimFirmwareOutdated) {
+            openFirmwareModal();
+
+            return;
+        }
+
         dispatch(
             goto({
                 routeName: 'earn-tron-claim',
@@ -47,56 +62,73 @@ export const TronVotingRewardsCard = ({ account }: TronVotingRewardsCardProps) =
                 },
             }),
         );
+    };
 
     return (
-        <Card paddingType="none">
-            <Box padding={{ vertical: 12, horizontal: 20 }}>
-                <Row justifyContent="space-between" alignItems="center">
-                    <Text typographyStyle="body-sm-strong">
-                        <Translation id="TR_EARN_TRON_VOTING_REWARDS" />
-                    </Text>
-                    <Row gap={16} alignItems="center">
-                        <Column gap={2} alignItems="flex-end">
-                            <Text typographyStyle="body-md-strong">
-                                <FormattedCryptoAmount value={rewards} symbol={account.symbol} />
-                            </Text>
-                            <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
-                                <BaseCurrencyValue
-                                    amount={rewards}
-                                    symbol={account.symbol}
-                                    showApproximationIndicator
-                                />
-                            </Text>
-                        </Column>
-                        <Tooltip
-                            isActive={isClaimOnCooldown}
-                            tooltipMaxWidth={220}
-                            content={
-                                claimCooldownEndsAt !== null && (
-                                    <CountdownTimer
-                                        deadline={claimCooldownEndsAt * 1000}
-                                        message="TR_EARN_TRON_CLAIM_COOLDOWN"
-                                        minUnit="minute"
-                                        unitDisplay="narrow"
+        <>
+            {isFirmwareModalOpen && (
+                <FirmwareUpgradeNeededModal
+                    onClose={closeFirmwareModal}
+                    onUpdate={updateFirmware}
+                    featureName={translationString('TR_EARN_TRON_CLAIM_TITLE')}
+                />
+            )}
+            <Card paddingType="none">
+                <Box padding={{ vertical: 12, horizontal: 20 }}>
+                    <Row justifyContent="space-between" alignItems="center">
+                        <Text typographyStyle="body-sm-strong">
+                            <Translation id="TR_EARN_TRON_VOTING_REWARDS" />
+                        </Text>
+                        <Row gap={16} alignItems="center">
+                            <Column gap={2} alignItems="flex-end">
+                                <Text typographyStyle="body-md-strong">
+                                    <FormattedCryptoAmount
+                                        value={rewards}
+                                        symbol={account.symbol}
                                     />
-                                )
-                            }
-                            placement="top"
-                            cursor="not-allowed"
-                            delayShow={TOOLTIP_DELAY_NONE}
-                        >
-                            <Button
-                                intent="neutral"
-                                priority="secondary"
-                                onClick={goToClaim}
-                                isDisabled={isClaimOnCooldown}
+                                </Text>
+                                <Text
+                                    typographyStyle="body-sm"
+                                    intent="neutral"
+                                    priority="secondary"
+                                >
+                                    <BaseCurrencyValue
+                                        amount={rewards}
+                                        symbol={account.symbol}
+                                        showApproximationIndicator
+                                    />
+                                </Text>
+                            </Column>
+                            <Tooltip
+                                isActive={isClaimOnCooldown}
+                                tooltipMaxWidth={220}
+                                content={
+                                    claimCooldownEndsAt !== null && (
+                                        <CountdownTimer
+                                            deadline={claimCooldownEndsAt * 1000}
+                                            message="TR_EARN_TRON_CLAIM_COOLDOWN"
+                                            minUnit="minute"
+                                            unitDisplay="narrow"
+                                        />
+                                    )
+                                }
+                                placement="top"
+                                cursor="not-allowed"
+                                delayShow={TOOLTIP_DELAY_NONE}
                             >
-                                <Translation id="TR_STAKE_CLAIM" />
-                            </Button>
-                        </Tooltip>
+                                <Button
+                                    intent="neutral"
+                                    priority="secondary"
+                                    onClick={goToClaim}
+                                    isDisabled={isClaimOnCooldown}
+                                >
+                                    <Translation id="TR_STAKE_CLAIM" />
+                                </Button>
+                            </Tooltip>
+                        </Row>
                     </Row>
-                </Row>
-            </Box>
-        </Card>
+                </Box>
+            </Card>
+        </>
     );
 };

--- a/suite-common/wallet-utils/src/__tests__/tronStakingUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/tronStakingUtils.test.ts
@@ -1,3 +1,5 @@
+import { type TrezorDevice } from '@suite-common/suite-types';
+import { testMocks } from '@suite-common/test-utils';
 import { type Account, type GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
 import {
     type TronAccountExtraData,
@@ -5,6 +7,7 @@ import {
     type TronUnstakingBatch,
     type TronVote,
 } from '@trezor/blockchain-link-types';
+import { type Features } from '@trezor/connect';
 
 import {
     TRON_REWARD_CLAIM_COOLDOWN_SECONDS,
@@ -23,6 +26,7 @@ import {
     getTronVotes,
     getTronWithdrawableBalance,
     isSupportedTronStakingNetworkSymbol,
+    isTronClaimSupported,
     isTronRewardClaimOnCooldown,
     isTronStakingActive,
 } from '../tronStakingUtils';
@@ -456,5 +460,31 @@ describe(calculateTronFreezeSuggestion.name, () => {
 
     it('no resources data — no suggestion', () => {
         expect(calculateTronFreezeSuggestion(makeTrc20Tx(), undefined)).toBeNull();
+    });
+});
+
+const createDevice = (features: Partial<Features>): TrezorDevice =>
+    ({
+        features: testMocks.getDeviceFeatures(features),
+    }) as unknown as TrezorDevice;
+
+const createDeviceWithFirmware = ([major, minor, patch]: [number, number, number]): TrezorDevice =>
+    createDevice({ major_version: major, minor_version: minor, patch_version: patch });
+
+describe(isTronClaimSupported.name, () => {
+    it('returns false when no device is selected', () => {
+        expect(isTronClaimSupported(undefined)).toBe(false);
+    });
+
+    it('returns false when device has no features', () => {
+        const deviceWithoutFeatures = {} as unknown as TrezorDevice;
+
+        expect(isTronClaimSupported(deviceWithoutFeatures)).toBe(false);
+    });
+
+    it('requires firmware 2.12.2', () => {
+        expect(isTronClaimSupported(createDeviceWithFirmware([2, 12, 1]))).toBe(false);
+        expect(isTronClaimSupported(createDeviceWithFirmware([2, 12, 2]))).toBe(true);
+        expect(isTronClaimSupported(createDeviceWithFirmware([2, 13, 0]))).toBe(true);
     });
 });

--- a/suite-common/wallet-utils/src/tronStakingUtils.ts
+++ b/suite-common/wallet-utils/src/tronStakingUtils.ts
@@ -1,3 +1,4 @@
+import { type TrezorDevice } from '@suite-common/suite-types';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { TRON_STAKING_CONTRACT_TYPES } from '@suite-common/wallet-constants';
 import {
@@ -14,7 +15,8 @@ import {
     type TronUnstakingBatch,
     type TronVote,
 } from '@trezor/blockchain-link-types';
-import { BigNumber, isArrayMember } from '@trezor/utils';
+import { getFirmwareVersionArray } from '@trezor/device-utils';
+import { BigNumber, isArrayMember, versionUtils } from '@trezor/utils';
 
 import { asAmountSubunit } from './AmountTypes';
 import { subunitsToUnits } from './amountUtils';
@@ -24,6 +26,16 @@ export function isSupportedTronStakingNetworkSymbol(
 ): symbol is SupportedTronNetworkSymbols {
     return isArrayMember(symbol, supportedTronNetworkSymbols);
 }
+
+export const isTronClaimSupported = (device: TrezorDevice | undefined): boolean => {
+    const firmware = getFirmwareVersionArray(device);
+
+    if (firmware === null) {
+        return false;
+    }
+
+    return versionUtils.isNewerOrEqual(firmware, [2, 12, 2]);
+};
 
 export const isTronStakingTx = (transaction: WalletAccountTransaction) =>
     TRON_STAKING_CONTRACT_TYPES.some(type => type === transaction.tronSpecific?.contractType);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Create shared `useFirmwareUpgradeModal` hook
- Use it in TRON Claim flow to prompt fw update when fw < 2.12.2
- Reuse in stablecoin yield

## Notes for QA

Please also check stablecoin yield fw boundaries to make sure I didn't break anything.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29560

## Screenshots:
<img width="666" height="308" alt="image" src="https://github.com/user-attachments/assets/e23500d5-e0da-4cb6-9cff-8404dae12889" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily affects Tron staking utilities, yield/earn dashboard components, and claim submission UI. The highest risk is in the yield claim flow (YieldClaim.tsx) which is directly exercised by ETH unstake tests. The EarnYieldAccountOpportunity.tsx maps to 121 tests via broad static coverage but only staking-related tests actually render this component. Tron-specific changes (TronClaimSubmitButton, TronVotingRewardsCard, tronStakingUtils) have no E2E test coverage. The useFirmwareUpgradeModal hook change is also uncovered but is a narrow modal hook unlikely to cause broad regressions.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx`
- `packages/suite/src/components/earn/staking/tron/claim/TronClaimSubmitButton.tsx`
- `packages/suite/src/components/earn/yield/claim/YieldClaim.tsx`
- `packages/suite/src/hooks/suite/useFirmwareUpgradeModal.ts`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx`
- `suite-common/wallet-utils/src/__tests__/tronStakingUtils.test.ts`
- `suite-common/wallet-utils/src/tronStakingUtils.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test exercises the ETH unstaking and claiming flow, which directly relates to the YieldClaim.tsx component change. The claim flow (confirming claim on device, seeing claim card, verifying amounts) exercises the yield claim UI path that was modified.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test covers the ETH staking dashboard including staking empty card vs dashboard card visibility and progress indicators. Changes to EarnYieldAccountOpportunity.tsx (the dashboard yield opportunity component) could affect how staking opportunities are displayed on the dashboard.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test verifies the staking dashboard showing staked amounts, rewards, and action buttons. Changes to EarnYieldAccountOpportunity.tsx could affect how existing staking positions are displayed on the dashboard before initiating stake-more.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates the ETH staking form including balance display and amount validation. The EarnYieldAccountOpportunity component is part of the staking dashboard that leads into this form flow.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — While this is ADA-specific rather than yield-based, the claim rewards flow shares conceptual UI patterns with the YieldClaim component. Changes to claim submission logic could have been refactored in shared ways.

</details>

⚠️ **Changes with no test coverage (5)**
- `packages/suite/src/components/earn/staking/tron/claim/TronClaimSubmitButton.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx`
- `suite-common/wallet-utils/src/tronStakingUtils.ts`
- `suite-common/wallet-utils/src/__tests__/tronStakingUtils.test.ts`
- `packages/suite/src/hooks/suite/useFirmwareUpgradeModal.ts`

_Updated: 2026-07-08T12:38:56.844Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-claim-fw-check&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-claim-fw-check&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-claim-fw-check&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-08T12:45:15.419Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T12:42:11.027Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-claim-fw-check/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-claim-fw-check/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->