### PR TITLE
feat(suite): add APY and APR labels to yield tooltip

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
@@ -31,54 +31,97 @@ const getYieldSourceDescriptionId = (
     }
 };
 
+// The compounded native yield is quoted as APY; incentive rewards are simple, non-compounded APR.
+const getRateTranslationId = (yieldSource: RewardDtoV2['yieldSource']): TranslationKey | null => {
+    switch (yieldSource) {
+        case 'lending':
+            return 'TR_EARN_YIELD_RATE_APY';
+        case 'protocol_incentive':
+        case 'campaign_incentive':
+            return 'TR_EARN_YIELD_RATE_APR';
+        default:
+            return null;
+    }
+};
+
+const isAprReward = (reward: RewardDtoV2): boolean => {
+    const ratePercent = getApyPercent(reward.rate);
+
+    return (
+        getRateTranslationId(reward.yieldSource) === 'TR_EARN_YIELD_RATE_APR' &&
+        ratePercent !== null &&
+        ratePercent > 0
+    );
+};
+
 export const EarnYieldApyBreakdown = ({
     rewards,
     networkSymbol,
     underlyingToken,
-}: EarnYieldApyBreakdownProps) => (
-    <Column gap={16} padding={{ vertical: 10, horizontal: 8 }}>
-        {sortRewardsByUnderlyingToken(rewards, underlyingToken).map((reward, index) => {
-            const ratePercent = getApyPercent(reward.rate);
-            const hasRatePercent = ratePercent !== null && ratePercent > 0;
-            const descriptionId = getYieldSourceDescriptionId(reward.yieldSource);
+}: EarnYieldApyBreakdownProps) => {
+    const sortedRewards = sortRewardsByUnderlyingToken(rewards, underlyingToken);
+    // Only mention APR in the footer when a row actually shows an APR rate.
+    const footerId = sortedRewards.some(isAprReward)
+        ? 'TR_EARN_YIELD_APY_APR_TOOLTIP_FOOTER'
+        : 'TR_EARN_YIELD_APY_TOOLTIP_FOOTER';
 
-            return (
-                <Row key={index} gap={8} alignItems="center">
-                    <AssetLogo
-                        placeholder={reward.token.symbol || reward.token.name || 'token'}
-                        symbol={networkSymbol}
-                        contractAddress={reward.token.address}
-                        showNetworkIcon
-                        size={20}
-                        isBordered={false}
-                    />
-                    <Column flex="1">
-                        <Text typographyStyle="body-sm">{reward.token.symbol}</Text>
-                        {descriptionId && (
-                            <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
-                                <Translation id={descriptionId} />
-                            </Text>
-                        )}
-                    </Column>
-                    <Text
-                        typographyStyle="body-sm"
-                        intent={hasRatePercent ? 'brand' : 'neutral'}
-                        priority={hasRatePercent ? 'primary' : 'secondary'}
-                    >
-                        {hasRatePercent ? (
-                            <>+{ratePercent}%</>
-                        ) : (
-                            <Translation id="TR_EARN_APY_N_A" />
-                        )}
-                    </Text>
-                </Row>
-            );
-        })}
-        <Row gap={4} alignItems="center" margin={{ top: 4 }}>
-            <Icon name="chartLine" size={14} intent="neutral" priority="secondary" />
-            <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
-                <Translation id="TR_EARN_YIELD_APY_TOOLTIP_FOOTER" />
-            </Text>
-        </Row>
-    </Column>
-);
+    return (
+        <Column gap={16} padding={{ vertical: 10, horizontal: 8 }}>
+            {sortedRewards.map((reward, index) => {
+                const ratePercent = getApyPercent(reward.rate);
+                const hasRatePercent = ratePercent !== null && ratePercent > 0;
+                const descriptionId = getYieldSourceDescriptionId(reward.yieldSource);
+                const rateTranslationId = getRateTranslationId(reward.yieldSource);
+
+                let rateNode;
+                if (!hasRatePercent) {
+                    rateNode = <Translation id="TR_EARN_APY_N_A" />;
+                } else if (rateTranslationId) {
+                    rateNode = (
+                        <Translation id={rateTranslationId} values={{ rate: ratePercent }} />
+                    );
+                } else {
+                    rateNode = <>+{ratePercent}%</>;
+                }
+
+                return (
+                    <Row key={index} gap={8} alignItems="center">
+                        <AssetLogo
+                            placeholder={reward.token.symbol || reward.token.name || 'token'}
+                            symbol={networkSymbol}
+                            contractAddress={reward.token.address}
+                            showNetworkIcon
+                            size={20}
+                            isBordered={false}
+                        />
+                        <Column flex="1">
+                            <Text typographyStyle="body-sm">{reward.token.symbol}</Text>
+                            {descriptionId && (
+                                <Text
+                                    typographyStyle="body-sm"
+                                    intent="neutral"
+                                    priority="secondary"
+                                >
+                                    <Translation id={descriptionId} />
+                                </Text>
+                            )}
+                        </Column>
+                        <Text
+                            typographyStyle="body-sm"
+                            intent={hasRatePercent ? 'brand' : 'neutral'}
+                            priority={hasRatePercent ? 'primary' : 'secondary'}
+                        >
+                            {rateNode}
+                        </Text>
+                    </Row>
+                );
+            })}
+            <Row gap={4} alignItems="center" margin={{ top: 4 }}>
+                <Icon name="chartLine" size={14} intent="neutral" priority="secondary" />
+                <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                    <Translation id={footerId} />
+                </Text>
+            </Row>
+        </Column>
+    );
+};

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10058,6 +10058,18 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_APY_TOOLTIP_FOOTER',
         defaultMessage: 'APY can change over time',
     },
+    TR_EARN_YIELD_APY_APR_TOOLTIP_FOOTER: {
+        id: 'TR_EARN_YIELD_APY_APR_TOOLTIP_FOOTER',
+        defaultMessage: 'APY and APR rates can change over time',
+    },
+    TR_EARN_YIELD_RATE_APY: {
+        id: 'TR_EARN_YIELD_RATE_APY',
+        defaultMessage: '+{rate}% APY',
+    },
+    TR_EARN_YIELD_RATE_APR: {
+        id: 'TR_EARN_YIELD_RATE_APR',
+        defaultMessage: '+{rate}% APR',
+    },
     TR_EARN_STAKING_APY_TOOLTIP: {
         id: 'TR_EARN_STAKING_APY_TOOLTIP',
         defaultMessage: 'Annual percentage yield (APY)',


### PR DESCRIPTION
## Description

As the Table column was renamed to Rate, we should add APY and APR to the tooltip

- **Native yield** (`lending` source — compounded) now shows the rate as `+3.06% APY`.
- **Incentive campaigns** (`protocol_incentive` / `campaign_incentive` — simple, non-compounded) now show `+0.5% APR`.
- The footer says **"APY and APR rates can change over time"** only when a row actually shows an APR rate; otherwise it keeps the original **"APY can change over time"**.

Unknown/other reward sources fall back to the plain `+X%` (no suffix), and the `N/A` case is unchanged.

## Notes for QA

- Open the APY tooltip on a yield vault (e.g. USDC): the native-yield row reads `+X% APY`
- With an incentive present, the footer reads "APY and APR rates can change over time"; with native yield only, it reads "APY can change over time".
- Rows with no/zero rate still show `N/A`.

## Related Issue

Resolve #29586

## Screenshots:

<img width="561" height="243" alt="Screenshot 2026-07-08 at 16 03 03" src="https://github.com/user-attachments/assets/cff80ddc-58a1-46c1-907e-f8b1c82ba043" />
<img width="563" height="356" alt="Screenshot 2026-07-08 at 16 02 58" src="https://github.com/user-attachments/assets/a3059322-cfed-4c0f-a26f-c3536356340a" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes involve the EarnYieldApyBreakdown component (earn/dashboard/yield UI) and the global messages.ts translation file. The primary risk is in the staking/earn dashboard views where APY breakdown information is displayed. ETH staking tests are highest priority since yield-based staking with APY breakdown is most relevant to ETH. SOL staking tests are medium priority as they also use the earn dashboard. messages.ts is a global file touching all translations, but without static mapping data and given the co-change with a yield-specific component, staking tests are the most targeted coverage. ADA staking is lower priority as it uses delegation-based staking rather than yield.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — EarnYieldApyBreakdown is a component in the earn/dashboard/yield path. ETH initial staking tests exercise the staking dashboard UI including staking cards, amounts, and progress indicators which are part of the earn dashboard yield flow where this component would render.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test exercises the ETH staking dashboard showing staked amounts, rewards, pending/unstaking sections, and progress indicators — all part of the earn dashboard yield UI where EarnYieldApyBreakdown likely renders APY breakdown information.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Tests the ETH staking dashboard view with staked, rewards, pending, and unstaking amounts displayed. The earn yield dashboard components including APY breakdown are part of this staking dashboard view.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — Tests the ETH staking form and balance display within the staking section. While focused on form validation, it navigates through the staking dashboard where yield APY breakdown may be visible, and uses translation keys from messages.ts.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL initial staking test exercises the staking dashboard empty and active states. The earn yield dashboard components may render APY breakdown for SOL staking as well, and translation keys from messages.ts are used throughout.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Tests the SOL staking dashboard display including staked amounts and rewards. The yield APY breakdown component could be part of the rewards display on the staking dashboard.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Tests SOL staking dashboard with existing staked amounts and the stake-more flow. The earn dashboard yield components including APY breakdown may render on this staking view.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Tests the SOL staking dashboard and unstaking flow. The yield APY breakdown component is part of the earn dashboard that displays staking information visible during these flows.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — ADA staking tests exercise the staking section UI. While ADA staking uses a different mechanism (Cardano delegation vs yield), the earn dashboard yield component and shared translation keys could still affect this flow.
- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking flow uses the earn/staking UI section. Translation key changes in messages.ts could affect labels visible during the ADA staking flow (e.g., TR_EARN_* keys).

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx`

_Updated: 2026-07-08T13:55:10.795Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/29586-yield-tooltip-apy-apr&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/29586-yield-tooltip-apy-apr&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-08T14:01:24.599Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T13:59:17.982Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/29586-yield-tooltip-apy-apr/web/](https://dev.suite.sldev.cz/suite-web/feat/29586-yield-tooltip-apy-apr/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->