### PR TITLE
fix(trading): do not show dust warning when max spendable amount is unknown

### DIFF
--- a/suite-common/wallet-core/src/fees/__tests__/feesThunks.test.ts
+++ b/suite-common/wallet-core/src/fees/__tests__/feesThunks.test.ts
@@ -1,0 +1,58 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { type FeeInfo } from '@suite-common/wallet-types';
+
+import {
+    blockchainInitialState,
+    prepareBlockchainReducer,
+} from '../../blockchain/blockchainReducer';
+import { DEFAULT_FEE_INFO } from '../feesConstants';
+import { feesReducer } from '../feesReducer';
+import { updateFeeInfoThunk } from '../feesThunks';
+
+const blockchainReducer = prepareBlockchainReducer(extraDependenciesCommonMock);
+
+const tronFeeInfo: FeeInfo = {
+    blockHeight: 100,
+    blockTime: 3,
+    minFee: 0,
+    maxFee: 0,
+    minPriorityFee: 0,
+    levels: [{ label: 'normal', feePerUnit: '1000', blocks: -1 }],
+};
+
+const initStore = (feeInfo?: FeeInfo) =>
+    configureMockStore({
+        reducer: combineReducers({
+            wallet: combineReducers({
+                fees: feesReducer,
+                blockchain: blockchainReducer,
+            }),
+        }),
+        preloadedState: {
+            wallet: {
+                fees: feeInfo ? { trx: { status: 'preloaded', data: feeInfo } } : {},
+                blockchain: blockchainInitialState,
+            },
+        },
+    });
+
+describe(updateFeeInfoThunk.name, () => {
+    it('fulfills with existing data for tron instead of fetching', async () => {
+        const store = initStore(tronFeeInfo);
+        const response = await store.dispatch(updateFeeInfoThunk({ networkSymbol: 'trx' }));
+
+        expect(response.meta.requestStatus).toBe('fulfilled');
+        expect(response.payload).toEqual(tronFeeInfo);
+        expect(store.getState().wallet.fees.trx).toEqual({ status: 'loaded', data: tronFeeInfo });
+    });
+
+    it('fulfills with default fee info for tron when no data is stored', async () => {
+        const store = initStore();
+        const response = await store.dispatch(updateFeeInfoThunk({ networkSymbol: 'trx' }));
+
+        expect(response.meta.requestStatus).toBe('fulfilled');
+        expect(response.payload).toEqual({ ...DEFAULT_FEE_INFO, blockHeight: 0 });
+    });
+});

--- a/suite-common/wallet-core/src/fees/feesConstants.ts
+++ b/suite-common/wallet-core/src/fees/feesConstants.ts
@@ -1,4 +1,15 @@
+import { type FeeInfo } from '@suite-common/wallet-types';
+
 export const FEES_UPDATE_INTERVAL_MILLISECONDS = 60_000; // interval to refetch estimated fees from backend
 export const FEE_UPDATE_DELAY_MILLISECONDS = 1_000; // artificial delay before updating fees after user input
 
 export const EVM_FEE_RATE_DECIMALS = 4;
+
+export const DEFAULT_FEE_INFO: FeeInfo = {
+    blockHeight: 0,
+    blockTime: 10,
+    minFee: 1,
+    maxFee: 100,
+    minPriorityFee: 0,
+    levels: [{ label: 'normal', feePerUnit: '1', blocks: 0 }],
+};

--- a/suite-common/wallet-core/src/fees/feesReducer.ts
+++ b/suite-common/wallet-core/src/fees/feesReducer.ts
@@ -17,15 +17,6 @@ import { updateFeeInfoThunk } from './feesThunks';
 
 export type FeesRootState = { wallet: { fees: FeesState } };
 
-export const DEFAULT_FEE_INFO: FeeInfo = {
-    blockHeight: 0,
-    blockTime: 10,
-    minFee: 1,
-    maxFee: 100,
-    minPriorityFee: 0,
-    levels: [{ label: 'normal', feePerUnit: '1', blocks: 0 }],
-};
-
 export const feesInitialState: FeesState = {};
 
 export const feesReducer = createReducer<FeesState>(feesInitialState, builder => {

--- a/suite-common/wallet-core/src/fees/feesThunks.ts
+++ b/suite-common/wallet-core/src/fees/feesThunks.ts
@@ -1,11 +1,12 @@
 import { selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import { type NetworkSymbol, getNetwork, networksCollection } from '@suite-common/wallet-config';
-import { type FeeInfo } from '@suite-common/wallet-types';
+import { type FeeInfo, type FeesState } from '@suite-common/wallet-types';
 import TrezorConnect from '@trezor/connect';
 import { isNotUndefined, resolveAfter, typedObjectFromEntries } from '@trezor/utils';
 
 import { FEES_MODULE_PREFIX, feesActions } from './feesActions';
+import { DEFAULT_FEE_INFO } from './feesConstants';
 import { getNewFeeInfo, sortLevels } from './feesUtils';
 import { selectNetworkBlockchainInfo } from '../blockchain/blockchainReducer';
 import { selectEnabledNetworks } from '../settings/walletSettingsReducer';
@@ -81,6 +82,19 @@ export const updateFeeInfoThunk = createThunk<
         const network = getNetwork(networkSymbol);
         const { symbol } = network;
         const blockchainInfo = selectNetworkBlockchainInfo(getState(), symbol);
+
+        // Tron fees are derived per transaction from bandwidth/energy, there is no
+        // network-level fee estimate to fetch. Keep the current (preloaded) data.
+        if (network.networkType === 'tron') {
+            const currentFeeInfo = (getState() as { wallet: { fees: FeesState } }).wallet.fees[
+                symbol
+            ]?.data;
+
+            return fulfillWithValue(
+                currentFeeInfo ?? { ...DEFAULT_FEE_INFO, blockHeight: blockchainInfo.blockHeight },
+            );
+        }
+
         const device = selectSelectedDevice(getState());
 
         const [newFeeInfo] = await Promise.all([

--- a/suite-common/wallet-core/src/fees/feesUtils.ts
+++ b/suite-common/wallet-core/src/fees/feesUtils.ts
@@ -43,10 +43,6 @@ export const getNewFeeInfo = async ({
 }: GetNewFeeInfoProps): Promise<BlockchainEstimatedFeeLevel | undefined> => {
     const { symbol } = network;
 
-    if (network.networkType === 'tron') {
-        return;
-    }
-
     if (network.networkType === 'ethereum') {
         const result = await TrezorConnect.blockchainEstimateFee({
             coin: symbol,

--- a/suite-native/module-trading/src/utils/general/__tests__/validationSchemes.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/validationSchemes.test.ts
@@ -243,16 +243,16 @@ describe('validationSchemes', () => {
                 );
             });
 
-            it('shows lower than dust limit when maxSpendableAmount is undefined', async () => {
+            it('passes when maxSpendableAmount is undefined and value is within balance', async () => {
                 const context = createContext({
                     sendSymbol: 'btc',
-                    balance: '0.00000001',
+                    balance: '100',
                     maxSpendableAmount: undefined,
                 });
 
-                await expect(
-                    validate(sendCryptoAmountValidationSchema, 0.00000001, context),
-                ).rejects.toThrow(getTranslation('moduleTrading.validators.dustLimit'));
+                await expect(validate(sendCryptoAmountValidationSchema, 50, context)).resolves.toBe(
+                    50,
+                );
             });
         });
     });

--- a/suite-native/module-trading/src/utils/general/validationSchemes.ts
+++ b/suite-native/module-trading/src/utils/general/validationSchemes.ts
@@ -139,14 +139,13 @@ export const sendCryptoAmountValidationSchema = yup
             });
         }
 
+        // undefined means the max amount is unknown (still loading or its calculation
+        // failed), there is nothing to validate against
         if (maxSpendableAmount === undefined) {
-            return testContext.createError({
-                type: 'dust-limit',
-                message: translate('moduleTrading.validators.dustLimit'),
-            });
+            return true;
         }
 
-        if (maxSpendableAmount && convertedValue > parseFloat(maxSpendableAmount)) {
+        if (convertedValue > parseFloat(maxSpendableAmount)) {
             return testContext.createError({
                 type: 'network-reserve',
                 message: translate('moduleTrading.validators.networkReserve', {


### PR DESCRIPTION
## Description

Fixes a false "Amount is lower than the dust limit" error in the trading (swap/sell) form, seen consistently for TRX.

- `feesThunks`: root cause. Tron has no estimateFee-based fee levels, so `updateFeeInfoThunk` rejected on every `trx`/`ttrx` call. Callers unwrapping it (mobile trading max-amount calculation, web exchange form) failed, leaving `maxSpendableAmount` undefined. Now fulfills with the current preloaded fee info; rejection now means only a failed fetch.
- `validationSchemes`: an undefined `maxSpendableAmount` (still loading or calculation failed) was mapped to the dust-limit validation error, flagging any amount. Skip the max check when the value is unknown.

## Notes for QA

On mobile, open a TRX swap/sell and enter a valid amount — no "Amount is lower than the dust limit" error should appear. Verify dust validation still triggers for genuinely tiny amounts on other coins.

## Related Issue

Resolve #29500

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes primarily affect the fee infrastructure (feesThunks, feesReducer, feesUtils, feesConstants) which is a broadly imported module (121 tests). However, the actual user-facing impact is concentrated in send forms, trading flows, and staking where fee data is fetched, computed, and displayed. The validation schemes change in suite-native is mobile-only and has no E2E test coverage. The recommended strategy focuses on tests that explicitly exercise fee calculation, custom fee settings, and fee display on device prompts — these are the most likely to catch regressions from fee infrastructure changes.

<details><summary><b>Changed files (7)</b></summary>

- `suite-common/wallet-core/src/fees/__tests__/feesThunks.test.ts`
- `suite-common/wallet-core/src/fees/feesConstants.ts`
- `suite-common/wallet-core/src/fees/feesReducer.ts`
- `suite-common/wallet-core/src/fees/feesThunks.ts`
- `suite-common/wallet-core/src/fees/feesUtils.ts`
- `suite-native/module-trading/src/utils/general/__tests__/validationSchemes.test.ts`
- `suite-native/module-trading/src/utils/general/validationSchemes.ts`

</details>

**Recommended tests (16)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — This test sets custom Ethereum fees (gas limit, max fee per gas, max priority fee per gas) and verifies fee calculations on both UI and device display. Changes to feesThunks, feesReducer, feesUtils, and feesConstants directly affect how fee data is fetched, stored, and computed for Ethereum transactions.
- `suite/e2e/tests/wallet/send-base.test.ts` — This test exercises custom Ethereum fee settings (gas limit, max fee per gas, max priority fee per gas) on the Base EVM L2 network, verifies calculated maximum fee, and checks fee info on the device display. Fee infrastructure changes directly impact this flow.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test sends Bitcoin transactions on regtest including locktime and OP_RETURN outputs, which requires fee calculation. Changes to fee infrastructure could affect transaction composition and fee display in the send form.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test specifically validates custom Ethereum fee parameters (gas limit, max fee per gas, max priority fee per gas) during a swap, verifies fee calculation correctness, and checks fee info on the device. Directly exercises the fee computation pipeline.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test sets a custom Bitcoin fee rate for swap transactions and verifies the fee rate and total amount on the device prompt. Changes to fee fetching/computation directly affect Bitcoin fee rate handling.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/wallet/send-sol.test.ts` — This test sends max SOL amount and verifies fee calculations (maxFee, total sent). While Solana fees work differently from EVM, changes to the generic fee infrastructure in feesReducer/feesThunks could affect how Solana fees are fetched and displayed.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test sends DOGE and verifies fee display on the device prompt. Fee calculation changes could affect the total and fee amounts shown for DOGE transactions.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test sends LTC with max amount using broadcast mode, which depends on fee calculation for determining the max sendable amount. Changes to fee computation could affect the transaction composition.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test verifies Bitcoin fee calculation in the sell flow and checks that fee amounts are non-zero on the device prompt. Fee infrastructure changes could affect sell transaction fee display.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test sets custom Ethereum gas fees during a sell flow and verifies crypto amount on the device prompt. Custom fee handling directly relies on fee infrastructure.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test verifies fee display (maxFee, maxFeeFiat) during SOL sell flow and checks fee amounts on the device prompt. Fee infrastructure changes could affect Solana fee fetching and display.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test uses custom fee rate for Bitcoin sell transactions and max button calculations that subtract fees. Fee computation changes directly affect max amount calculation and custom fee input behavior.
- `suite/e2e/tests/staking/staking-form.test.ts` — The staking form validates amounts and uses Max button which subtracts a withdrawal buffer. While not directly setting custom fees, the staking transaction composition relies on fee data from the fee infrastructure.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test verifies Solana fee display during a swap and checks fee on the device prompt. The fee value comes from the fee infrastructure being changed.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This swap test verifies fee amounts on device prompt (fee > 0). While fee display depends on fee infrastructure, the assertions are less specific than the dedicated fee tests.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — This test checks that the ERC-20 token sell transaction fee is greater than 0 on the device prompt. It indirectly depends on fee infrastructure but with weak assertions on fee correctness.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/wallet-core/src/fees/__tests__/feesThunks.test.ts`
- `suite-native/module-trading/src/utils/general/__tests__/validationSchemes.test.ts`
- `suite-native/module-trading/src/utils/general/validationSchemes.ts`

_Updated: 2026-07-08T15:07:12.873Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trx-swap-dust-warning&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trx-swap-dust-warning&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trx-swap-dust-warning&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-08T15:12:43.946Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T15:09:52.437Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/trx-swap-dust-warning/web/](https://dev.suite.sldev.cz/suite-web/fix/trx-swap-dust-warning/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->