### PR TITLE
fix(connect-explorer): keep method name casing in browser tab title

### DIFF
--- a/packages/connect-explorer-theme/src/components/head.tsx
+++ b/packages/connect-explorer-theme/src/components/head.tsx
@@ -8,7 +8,7 @@ import { useMounted } from 'nextra/hooks';
 
 import { useConfig } from '../contexts/useConfig';
 
-export function Head(): ReactElement {
+export function Head({ title }: { title?: string } = {}): ReactElement {
     const config = useConfig();
     const { resolvedTheme } = useTheme();
     const mounted = useMounted();
@@ -26,7 +26,7 @@ export function Head(): ReactElement {
     return (
         <>
             <NextSeo
-                title={config.title}
+                title={title ?? config.title}
                 description={frontMatter.description}
                 canonical={frontMatter.canonical}
                 openGraph={frontMatter.openGraph}

--- a/packages/connect-explorer-theme/src/index.tsx
+++ b/packages/connect-explorer-theme/src/index.tsx
@@ -138,6 +138,13 @@ const InnerLayout = ({
         [pageMap, locale, defaultLocale, fsPath],
     );
 
+    // Nextra derives the document title from the filename and title-cases it at build time
+    // (e.g. `selectAccount` → `SelectAccount`), which is independent of the sidebar titles fixed
+    // by `patchedNormalizePages`. Method names must stay in their original casing, so for method
+    // pages reuse the already-corrected title from `activePath`.
+    const documentTitle =
+        activePath[0]?.route === '/methods' ? activePath[activePath.length - 1]?.title : undefined;
+
     const themeContext = { ...activeThemeContext, ...frontMatter };
     const hideSidebar =
         !themeContext.sidebar || themeContext.layout === 'raw' || activeType === 'page';
@@ -172,7 +179,7 @@ const InnerLayout = ({
                     __html: `document.documentElement.setAttribute('dir','${direction}')`,
                 }}
             />
-            <Head />
+            <Head title={documentTitle} />
             <Banner />
             {themeContext.navbar && (
                 <Navbar flatDirectories={flatDirectories} items={topLevelNavbarItems} />


### PR DESCRIPTION
## Description

In the Connect Explorer, the browser tab title for a method page title-cases the method name (e.g. `selectAccount` shows as `SelectAccount – Trezor Connect Explorer`), even though the method name should stay in its original camelCase — it is an API method identifier, not prose.

The mismatch comes from two independent title sources:

- The **sidebar** title is fixed at runtime by `patchedNormalizePages`, which forces method sub-items to keep their original name.
- The **document `<title>`** comes from Nextra's `pageOpts.title`, which Nextra derives at build time via `pageTitleFromFilename` → `title("selectAccount")` = `"SelectAccount"`. Method pages have no frontmatter `title` and no `#` H1 heading (they start at `##`), so this fallback always applies.

This fix reuses the already-corrected title from `activePath` for the document title on method pages, so the tab matches the sidebar. Non-method pages keep `config.title` unchanged, so there is no regression for pages that rely on a frontmatter or H1-derived title.

The change is general — it fixes the tab title for every method page (not just `selectAccount`).

## Screenshot 

before 

<img width="252" height="74" alt="image" src="https://github.com/user-attachments/assets/c7330e08-d5b5-4904-8a20-0bf4bcc85011" />

after 

<img width="217" height="50" alt="image" src="https://github.com/user-attachments/assets/37328a78-8bf8-445b-b695-7904d5adcd5b" />


## Notes for QA

- Blast radius: Connect Explorer only (`@trezor/connect-explorer-theme`); no runtime impact on Suite or Connect itself.
- What to check: open any method page (e.g. `/methods/common/getAccountInfo/`, `/methods/common/selectAccount/`) and confirm the browser tab title keeps the method name in its original casing (`getAccountInfo – Trezor Connect Explorer`) and matches the sidebar entry. Verify non-method pages (Guides/Details/Deeplink) still show their normal titles.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are isolated to the connect-explorer-theme package, which provides theming/layout for the Connect Explorer application. This is a narrow, UI-presentation-focused change with low overall risk. The only E2E tests that directly interact with the Connect Explorer application are the connectPopupWeb and connectPopupWebextension tests. No static coverage mapping exists for these files, so recommendations are inferred from the LLM analysis of test entry points and source hints.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect-explorer-theme/src/components/head.tsx`
- `packages/connect-explorer-theme/src/index.tsx`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — The connect-explorer-theme package provides the UI theme/layout for the Connect Explorer application. The connectPopupWeb test directly uses the Connect Explorer (http://localhost:8088/methods/bitcoin/getAddress/) as its entry point, so changes to the explorer's theme components (head.tsx, index.tsx) could affect rendering or functionality of the explorer pages used in this test.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test uses the Connect Explorer webextension build which depends on the connect-explorer-theme for its UI rendering. Changes to head.tsx (HTML head/meta elements) or index.tsx (theme entry point) could affect how the explorer extension pages render and function.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/connect-explorer-theme/src/components/head.tsx`
- `packages/connect-explorer-theme/src/index.tsx`

_Updated: 2026-07-08T14:28:48.802Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-explorer-method-tab-title&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-explorer-method-tab-title&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-08T14:34:51.515Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T14:32:35.457Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-explorer-method-tab-title/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-explorer-method-tab-title/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->