### PR TITLE
fix(connect): connect ESM build for publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ public
 !packages/analytics-docs/public/
 coverage
 tmp
+*.tgz
 
 
 ## React Native section ##

--- a/coins/coins-cardano/package.json
+++ b/coins/coins-cardano/package.json
@@ -12,24 +12,24 @@
         ".": "./src/index.ts"
     },
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             "./constants": {
-                "types": "./lib/constants/index.d.mts",
-                "default": "./lib/constants/index.mjs"
+                "types": "./lib/constants/index.d.ts",
+                "default": "./lib/constants/index.js"
             },
             "./runtime": {
-                "types": "./lib/runtime/index.d.mts",
-                "default": "./lib/runtime/index.mjs"
+                "types": "./lib/runtime/index.d.ts",
+                "default": "./lib/runtime/index.js"
             },
             "./types": {
-                "types": "./lib/types/index.d.mts",
-                "default": "./lib/types/index.mjs"
+                "types": "./lib/types/index.d.ts",
+                "default": "./lib/types/index.js"
             },
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             }
         }
     },

--- a/coins/coins-solana/package.json
+++ b/coins/coins-solana/package.json
@@ -12,24 +12,24 @@
         ".": "./src/index.ts"
     },
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             "./constants": {
-                "types": "./lib/constants/index.d.mts",
-                "default": "./lib/constants/index.mjs"
+                "types": "./lib/constants/index.d.ts",
+                "default": "./lib/constants/index.js"
             },
             "./runtime": {
-                "types": "./lib/runtime/index.d.mts",
-                "default": "./lib/runtime/index.mjs"
+                "types": "./lib/runtime/index.d.ts",
+                "default": "./lib/runtime/index.js"
             },
             "./types": {
-                "types": "./lib/types/index.d.mts",
-                "default": "./lib/types/index.mjs"
+                "types": "./lib/types/index.d.ts",
+                "default": "./lib/types/index.js"
             },
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             }
         }
     },

--- a/coins/coins-stellar/package.json
+++ b/coins/coins-stellar/package.json
@@ -12,24 +12,24 @@
         ".": "./src/index.ts"
     },
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             "./constants": {
-                "types": "./lib/constants/index.d.mts",
-                "default": "./lib/constants/index.mjs"
+                "types": "./lib/constants/index.d.ts",
+                "default": "./lib/constants/index.js"
             },
             "./runtime": {
-                "types": "./lib/runtime/index.d.mts",
-                "default": "./lib/runtime/index.mjs"
+                "types": "./lib/runtime/index.d.ts",
+                "default": "./lib/runtime/index.js"
             },
             "./types": {
-                "types": "./lib/types/index.d.mts",
-                "default": "./lib/types/index.mjs"
+                "types": "./lib/types/index.d.ts",
+                "default": "./lib/types/index.js"
             },
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             }
         }
     },

--- a/coins/coins-xrpl/package.json
+++ b/coins/coins-xrpl/package.json
@@ -12,24 +12,24 @@
         ".": "./src/index.ts"
     },
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             "./constants": {
-                "types": "./lib/constants/index.d.mts",
-                "default": "./lib/constants/index.mjs"
+                "types": "./lib/constants/index.d.ts",
+                "default": "./lib/constants/index.js"
             },
             "./runtime": {
-                "types": "./lib/runtime/index.d.mts",
-                "default": "./lib/runtime/index.mjs"
+                "types": "./lib/runtime/index.d.ts",
+                "default": "./lib/runtime/index.js"
             },
             "./types": {
-                "types": "./lib/types/index.d.mts",
-                "default": "./lib/types/index.mjs"
+                "types": "./lib/types/index.d.ts",
+                "default": "./lib/types/index.js"
             },
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             }
         }
     },

--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -6,17 +6,17 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             },
             "./lib/*": "./lib/*",
             "./lib/constants": {
-                "types": "./lib/constants/index.d.mts",
-                "default": "./lib/constants/index.mjs"
+                "types": "./lib/constants/index.d.ts",
+                "default": "./lib/constants/index.js"
             }
         }
     },

--- a/packages/blockchain-link-utils/package.json
+++ b/packages/blockchain-link-utils/package.json
@@ -6,12 +6,12 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             },
             "./lib/*": "./lib/*"
         }

--- a/packages/blockchain-link/README.md
+++ b/packages/blockchain-link/README.md
@@ -21,7 +21,7 @@ And use it.
 
 ```javascript
 import { BlockchainLink } from '@trezor/blockchain-link';
-import Blockbook from '@trezor/blockchain-link/lib/workers/blockbook/index.mjs';
+import Blockbook from '@trezor/blockchain-link/lib/workers/blockbook/index.js';
 
 const link = new BlockchainLink({
     name: 'Name used in logs.',
@@ -43,7 +43,7 @@ Each `src/workers/*/index` file can be used in WebWorker thread.
 Built from source using webpack `worker-loader`:
 
 ```
-import BlockbookWorker from 'worker-loader?filename=workers/blockbook-worker.[hash].js!@trezor/blockchain-link/lib/workers/blockbook/index.mjs';
+import BlockbookWorker from 'worker-loader?filename=workers/blockbook-worker.[hash].js!@trezor/blockchain-link/lib/workers/blockbook/index.js';
 ```
 
 ## Development

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -33,21 +33,21 @@
         "socks-proxy-agent": "@trezor/blockchain-link/src/utils/socks-proxy-agent.ts"
     },
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             },
             "./lib/*": "./lib/*"
         },
         "browser": {
-            "socks-proxy-agent": "./lib/utils/socks-proxy-agent.mjs"
+            "socks-proxy-agent": "./lib/utils/socks-proxy-agent.js"
         },
         "react-native": {
             "__comment__": "Hotfix for issue where RN metro bundler resolve relatives paths wrong",
-            "socks-proxy-agent": "@trezor/blockchain-link/lib/utils/socks-proxy-agent.mjs"
+            "socks-proxy-agent": "@trezor/blockchain-link/lib/utils/socks-proxy-agent.js"
         }
     },
     "scripts": {

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -23,29 +23,29 @@
         "CHANGELOG.md"
     ],
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             },
             "./lib/*": "./lib/*",
             "./lib/constants": {
-                "types": "./lib/constants/index.d.mts",
-                "default": "./lib/constants/index.mjs"
+                "types": "./lib/constants/index.d.ts",
+                "default": "./lib/constants/index.js"
             },
             "./lib/data": {
-                "types": "./lib/data/index.d.mts",
-                "default": "./lib/data/index.mjs"
+                "types": "./lib/data/index.d.ts",
+                "default": "./lib/data/index.js"
             },
             "./lib/events": {
-                "types": "./lib/events/index.d.mts",
-                "default": "./lib/events/index.mjs"
+                "types": "./lib/events/index.d.ts",
+                "default": "./lib/events/index.js"
             },
             "./lib/types": {
-                "types": "./lib/types/index.d.mts",
-                "default": "./lib/types/index.mjs"
+                "types": "./lib/types/index.d.ts",
+                "default": "./lib/types/index.js"
             }
         }
     },

--- a/packages/connect-data/package.json
+++ b/packages/connect-data/package.json
@@ -25,12 +25,12 @@
         "CHANGELOG.md"
     ],
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             },
             "./lib/*": "./lib/*",
             "./files/*": "./files/*"

--- a/packages/connect-mobile/package.json
+++ b/packages/connect-mobile/package.json
@@ -6,12 +6,12 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             }
         }
     },

--- a/packages/connect-plugin-ethereum/package.json
+++ b/packages/connect-plugin-ethereum/package.json
@@ -20,12 +20,12 @@
     ],
     "sideEffects": false,
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             }
         }
     },

--- a/packages/connect-plugin-stellar/package.json
+++ b/packages/connect-plugin-stellar/package.json
@@ -21,12 +21,12 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             }
         }
     },

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -21,12 +21,12 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             },
             "./lib/impl/*": "./lib/impl/*"
         }

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -22,12 +22,12 @@
     ],
     "main": "src/index.ts",
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             }
         }
     },

--- a/packages/connect/e2e/test-connect-local.sh
+++ b/packages/connect/e2e/test-connect-local.sh
@@ -39,7 +39,7 @@ cat > package.json << EOF
   "version": "1.0.0",
   "description": "Test local @trezor/connect packages",
   "type": "module",
-  "main": "index.mjs",
+  "main": "index.js",
   "dependencies": {
     "@trezor/connect": "${CONNECT_PATH}",
     "@trezor/connect-web": "${CONNECT_WEB_PATH}",
@@ -55,7 +55,7 @@ npm install
 
 cat package.json
 
-cat > index.mjs << 'EOF'
+cat > index.js << 'EOF'
 import assert from 'node:assert';
 import TrezorConnect from '@trezor/connect';
 import TrezorConnectWeb from '@trezor/connect-web';
@@ -113,12 +113,12 @@ echo "=== Type-checking consumer (tsc --noEmit) ==="
 ./node_modules/.bin/tsc --noEmit --project tsconfig.json
 
 echo ""
-echo "=== Testing ESM with tsx (yarn tsx index.mjs) ==="
-yarn tsx index.mjs
+echo "=== Testing ESM with tsx (yarn tsx index.js) ==="
+yarn tsx index.js
 
 echo ""
-echo "=== Testing ESM with node (node index.mjs) ==="
-node index.mjs
+echo "=== Testing ESM with node (node index.js) ==="
+node index.js
 
 echo ""
 echo "All tests passed!"

--- a/packages/connect/e2e/test-npm-install.sh
+++ b/packages/connect/e2e/test-npm-install.sh
@@ -20,5 +20,5 @@ npm install @trezor/connect-web@"$1" --save
 cat package.json
 
 # ESM smoke: @trezor/connect and its entire closure are ESM-only since v10, must work via import.
-printf "import TrezorConnect from '@trezor/connect';\nimport TrezorConnectWeb from '@trezor/connect-web';\nimport { cloneObject } from '@trezor/utils';\nconsole.log('typeof TrezorConnect: '+typeof TrezorConnect);\nconsole.log('typeof TrezorConnectWeb: '+typeof TrezorConnectWeb);\nconsole.log('typeof cloneObject: '+typeof cloneObject);" >./index.mjs
-node index.mjs
+printf "import TrezorConnect from '@trezor/connect';\nimport TrezorConnectWeb from '@trezor/connect-web';\nimport { cloneObject } from '@trezor/utils';\nconsole.log('typeof TrezorConnect: '+typeof TrezorConnect);\nconsole.log('typeof TrezorConnectWeb: '+typeof TrezorConnectWeb);\nconsole.log('typeof cloneObject: '+typeof cloneObject);" >./index.js
+node index.js

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -33,30 +33,30 @@
         "./src/workers/workers": "./src/workers/workers.native.ts"
     },
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             },
             "./lib/*": "./lib/*"
         },
         "browser": {
-            "./lib/index.mjs": "./lib/index.browser.mjs",
-            "./lib/utils/assets.mjs": "./lib/utils/assets.browser.mjs",
-            "./lib/workers/workers.mjs": "./lib/workers/workers.browser.mjs",
+            "./lib/index.js": "./lib/index.browser.js",
+            "./lib/utils/assets.js": "./lib/utils/assets.browser.js",
+            "./lib/workers/workers.js": "./lib/workers/workers.browser.js",
             "./lib/data/*": "./lib/data/*",
-            "./lib/exports.mjs": "./lib/exports.mjs",
+            "./lib/exports.js": "./lib/exports.js",
             "./lib/impl/*": "./lib/impl/*",
             "./lib/utils/*": "./lib/utils/*"
         },
         "react-native": {
-            "./lib/index.mjs": "./lib/index.mjs",
-            "./lib/utils/assets.mjs": "./lib/utils/assets.native.mjs",
-            "./lib/workers/workers.mjs": "./lib/workers/workers.native.mjs",
+            "./lib/index.js": "./lib/index.js",
+            "./lib/utils/assets.js": "./lib/utils/assets.native.js",
+            "./lib/workers/workers.js": "./lib/workers/workers.native.js",
             "./lib/data/*": "./lib/data/*",
-            "./lib/exports.mjs": "./lib/exports.mjs",
+            "./lib/exports.js": "./lib/exports.js",
             "./lib/impl/*": "./lib/impl/*",
             "./lib/utils/*": "./lib/utils/*"
         }

--- a/packages/crypto-utils/package.json
+++ b/packages/crypto-utils/package.json
@@ -24,12 +24,12 @@
         "CHANGELOG.md"
     ],
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             },
             "./lib/*": "./lib/*"
         }

--- a/packages/device-authenticity/package.json
+++ b/packages/device-authenticity/package.json
@@ -15,12 +15,12 @@
     },
     "sideEffects": false,
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             }
         }
     },

--- a/packages/device-utils/package.json
+++ b/packages/device-utils/package.json
@@ -6,12 +6,12 @@
     "sideEffects": false,
     "main": "src/index",
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             }
         }
     },

--- a/packages/env-utils/package.json
+++ b/packages/env-utils/package.json
@@ -14,12 +14,12 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             }
         }
     },

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -13,17 +13,17 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             },
             "./lib/*": "./lib/*",
             "./lib/definitions": {
-                "types": "./lib/definitions/index.d.mts",
-                "default": "./lib/definitions/index.mjs"
+                "types": "./lib/definitions/index.d.ts",
+                "default": "./lib/definitions/index.js"
             },
             "./lib/definitions/*": "./lib/definitions/*"
         }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -13,25 +13,25 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             },
             "./lib/*": "./lib/*",
             "./lib/protocol-thp": {
-                "types": "./lib/protocol-thp/index.d.mts",
-                "default": "./lib/protocol-thp/index.mjs"
+                "types": "./lib/protocol-thp/index.d.ts",
+                "default": "./lib/protocol-thp/index.js"
             },
             "./lib/protocol-thp/messages": {
-                "types": "./lib/protocol-thp/messages/index.d.mts",
-                "default": "./lib/protocol-thp/messages/index.mjs"
+                "types": "./lib/protocol-thp/messages/index.d.ts",
+                "default": "./lib/protocol-thp/messages/index.js"
             },
             "./lib/protocol-tpn": {
-                "types": "./lib/protocol-tpn/index.d.mts",
-                "default": "./lib/protocol-tpn/index.mjs"
+                "types": "./lib/protocol-tpn/index.d.ts",
+                "default": "./lib/protocol-tpn/index.js"
             }
         }
     },

--- a/packages/requirements/src/requirements/package-json/__tests__/requirePublishConfig.test.ts
+++ b/packages/requirements/src/requirements/package-json/__tests__/requirePublishConfig.test.ts
@@ -12,10 +12,10 @@ const validPublicPackageJson = {
     main: 'src/index.ts',
     type: 'module',
     publishConfig: {
-        main: './lib/index.mjs',
-        types: './lib/index.d.mts',
+        main: './lib/index.js',
+        types: './lib/index.d.ts',
         exports: {
-            '.': { types: './lib/index.d.mts', default: './lib/index.mjs' },
+            '.': { types: './lib/index.d.ts', default: './lib/index.js' },
             './lib/*': './lib/*',
         },
     },
@@ -56,7 +56,7 @@ describe(requirePublishConfig.name, () => {
         it('applies to packages with publishConfig but no exports', () => {
             writeFileSync(
                 join(workspaceDir, 'package.json'),
-                JSON.stringify({ publishConfig: { main: './lib/index.mjs' } }),
+                JSON.stringify({ publishConfig: { main: './lib/index.js' } }),
             );
 
             expect(requirePublishConfig.applies?.(context)).toBe(true);
@@ -117,7 +117,7 @@ describe(requirePublishConfig.name, () => {
                 ...validPublicPackageJson,
                 publishConfig: {
                     ...validPublicPackageJson.publishConfig,
-                    main: './lib/index.js',
+                    main: './lib/index.mjs',
                 },
             };
             writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
@@ -125,7 +125,7 @@ describe(requirePublishConfig.name, () => {
             const errors = await requirePublishConfig.verify(context);
 
             expect(errors).toContain(
-                '@trezor/example: Invalid "publishConfig.main": expected "./lib/index.mjs", got "./lib/index.js"',
+                '@trezor/example: Invalid "publishConfig.main": expected "./lib/index.js", got "./lib/index.mjs"',
             );
         });
 
@@ -149,7 +149,7 @@ describe(requirePublishConfig.name, () => {
                 ...validPublicPackageJson,
                 publishConfig: {
                     ...validPublicPackageJson.publishConfig,
-                    types: './lib/index.d.ts',
+                    types: './lib/index.d.mts',
                 },
             };
             writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
@@ -157,7 +157,7 @@ describe(requirePublishConfig.name, () => {
             const errors = await requirePublishConfig.verify(context);
 
             expect(errors).toContain(
-                '@trezor/example: Invalid "publishConfig.types": expected "./lib/index.d.mts", got "./lib/index.d.ts"',
+                '@trezor/example: Invalid "publishConfig.types": expected "./lib/index.d.ts", got "./lib/index.d.mts"',
             );
         });
 
@@ -230,8 +230,8 @@ describe(requirePublishConfig.name, () => {
             const pkg = {
                 ...validPublicPackageJson,
                 publishConfig: {
-                    main: './lib/index.mjs',
-                    types: './lib/index.d.mts',
+                    main: './lib/index.js',
+                    types: './lib/index.d.ts',
                 },
             };
             writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
@@ -264,7 +264,7 @@ describe(requirePublishConfig.name, () => {
                 publishConfig: {
                     ...validPublicPackageJson.publishConfig,
                     exports: {
-                        '.': { types: './lib/index.d.ts', default: './lib/index.js' },
+                        '.': { types: './lib/index.d.mts', default: './lib/index.mjs' },
                         './lib/*': './lib/*',
                     },
                 },
@@ -302,8 +302,8 @@ describe(requirePublishConfig.name, () => {
                     exports: {
                         ...validPublicPackageJson.publishConfig.exports,
                         './lib/events': {
-                            types: './lib/events/index.d.mts',
-                            default: './lib/events/index.mjs',
+                            types: './lib/events/index.d.ts',
+                            default: './lib/events/index.js',
                         },
                     },
                 },
@@ -337,8 +337,8 @@ describe(requirePublishConfig.name, () => {
                     ...validPublicPackageJson.publishConfig,
                     exports: {
                         '.': {
-                            default: './lib/index.mjs',
-                            types: './lib/index.d.mts',
+                            default: './lib/index.js',
+                            types: './lib/index.d.ts',
                         },
                         './lib/*': './lib/*',
                     },
@@ -359,8 +359,8 @@ describe(requirePublishConfig.name, () => {
                     exports: {
                         ...validPublicPackageJson.publishConfig.exports,
                         './lib/events': {
-                            default: './lib/events/index.mjs',
-                            types: './lib/events/index.d.mts',
+                            default: './lib/events/index.js',
+                            types: './lib/events/index.d.ts',
                         },
                     },
                 },

--- a/packages/requirements/src/requirements/package-json/requirePublishConfig.ts
+++ b/packages/requirements/src/requirements/package-json/requirePublishConfig.ts
@@ -29,7 +29,7 @@ type PackageJson = {
 
 const getExpectedExport = (exportKey: string): ExportValue | null => {
     if (exportKey === '.') {
-        return { types: './lib/index.d.mts', default: './lib/index.mjs' };
+        return { types: './lib/index.d.ts', default: './lib/index.js' };
     }
 
     const match = LIB_EXPORT_KEY_PATTERN.exec(exportKey);
@@ -47,7 +47,7 @@ const getExpectedExport = (exportKey: string): ExportValue | null => {
 
     const basePath = exportKey.slice(0, -1);
 
-    // ESM imports already include the .mjs extension, so the wildcard is a passthrough.
+    // ESM imports already include the .js extension, so the wildcard is a passthrough.
     return `${basePath}*`;
 };
 
@@ -65,8 +65,8 @@ const validatePublicPackage = (packageJson: PackageJson): ReadonlyArray<string> 
         errors.push('"files" must include "lib/"');
     }
 
-    const expectedMain = './lib/index.mjs';
-    const expectedTypes = './lib/index.d.mts';
+    const expectedMain = './lib/index.js';
+    const expectedTypes = './lib/index.d.ts';
 
     if (!publishConfig?.main) {
         errors.push('Missing "publishConfig.main" field');

--- a/packages/schema-utils/package.json
+++ b/packages/schema-utils/package.json
@@ -6,12 +6,12 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             },
             "./lib/custom-types/*": "./lib/custom-types/*"
         }

--- a/packages/transport-common/package.json
+++ b/packages/transport-common/package.json
@@ -18,21 +18,21 @@
     "sideEffects": false,
     "type": "module",
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             },
             "./lib/*": "./lib/*",
             "./lib/thp": {
-                "types": "./lib/thp/index.d.mts",
-                "default": "./lib/thp/index.mjs"
+                "types": "./lib/thp/index.d.ts",
+                "default": "./lib/thp/index.js"
             },
             "./lib/types": {
-                "types": "./lib/types/index.d.mts",
-                "default": "./lib/types/index.mjs"
+                "types": "./lib/types/index.d.ts",
+                "default": "./lib/types/index.js"
             }
         }
     },

--- a/packages/transport-web/package.json
+++ b/packages/transport-web/package.json
@@ -19,12 +19,12 @@
     "sideEffects": false,
     "type": "module",
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             },
             "./lib/*": "./lib/*"
         }

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -27,23 +27,23 @@
         "./src/transports/udp": "./src/transports/udp.native.ts"
     },
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             },
             "./lib/*": "./lib/*"
         },
         "browser": {
-            "./lib/pinger/ping": "./lib/pinger/ping.browser.mjs",
-            "./lib/transports/nodeusb": "./lib/transports/nodeusb.browser.mjs",
-            "./lib/transports/udp": "./lib/transports/udp.browser.mjs"
+            "./lib/pinger/ping": "./lib/pinger/ping.browser.js",
+            "./lib/transports/nodeusb": "./lib/transports/nodeusb.browser.js",
+            "./lib/transports/udp": "./lib/transports/udp.browser.js"
         },
         "react-native": {
-            "./lib/transports/nodeusb": "./lib/transports/nodeusb.native.mjs",
-            "./lib/transports/udp": "./lib/transports/udp.native.mjs"
+            "./lib/transports/nodeusb": "./lib/transports/nodeusb.native.js",
+            "./lib/transports/udp": "./lib/transports/udp.native.js"
         }
     },
     "files": [

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -14,12 +14,12 @@
     "sideEffects": false,
     "main": "src/index",
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             }
         }
     },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,12 +16,12 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             },
             "./lib/*": "./lib/*"
         }

--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -26,17 +26,17 @@
         "CHANGELOG.md"
     ],
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             },
             "./lib/*": "./lib/*",
             "./lib/compose": {
-                "types": "./lib/compose/index.d.mts",
-                "default": "./lib/compose/index.mjs"
+                "types": "./lib/compose/index.d.ts",
+                "default": "./lib/compose/index.js"
             }
         }
     },

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -23,20 +23,20 @@
         "ws": "@trezor/websocket-client/src/ws.native.ts"
     },
     "publishConfig": {
-        "main": "./lib/index.mjs",
-        "types": "./lib/index.d.mts",
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "types": "./lib/index.d.mts",
-                "default": "./lib/index.mjs"
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
             }
         },
         "browser": {
-            "ws": "./lib/ws.browser.mjs"
+            "ws": "./lib/ws.browser.js"
         },
         "react-native": {
             "__comment__": "Hotfix for issue where RN metro bundler resolve relatives paths wrong",
-            "ws": "@trezor/websocket-client/lib/ws.native.mjs"
+            "ws": "@trezor/websocket-client/lib/ws.native.js"
         }
     },
     "files": [

--- a/scripts/inline-devdep-types.mjs
+++ b/scripts/inline-devdep-types.mjs
@@ -9,15 +9,7 @@
 
 import { resolve, dirname, relative, join } from 'path';
 import { fileURLToPath } from 'url';
-import {
-    existsSync,
-    readFileSync,
-    writeFileSync,
-    readdirSync,
-    statSync,
-    rmSync,
-    renameSync,
-} from 'fs';
+import { existsSync, readFileSync, writeFileSync, readdirSync, statSync, rmSync } from 'fs';
 
 import { rollup } from 'rollup';
 import dts from 'rollup-plugin-dts';
@@ -135,7 +127,7 @@ function vendorBaseName(pkg) {
     return `_vendor_${pkg.replace('@trezor/', '').replace(/-/g, '_')}`;
 }
 
-async function buildVendorForPackage(pkg, prodClosure, leakSet, libAbs, ext) {
+async function buildVendorForPackage(pkg, prodClosure, leakSet, libAbs) {
     const baseName = vendorBaseName(pkg);
     const entryPath = resolve(libAbs, `${baseName}-entry.d.ts`);
     writeFileSync(entryPath, `export * from '${pkg}';\n`);
@@ -158,12 +150,8 @@ async function buildVendorForPackage(pkg, prodClosure, leakSet, libAbs, ext) {
                 warn(warning);
             },
         });
-        const tmpOut = resolve(libAbs, `${baseName}.d.ts`);
-        await bundle.write({ file: tmpOut, format: 'es' });
+        await bundle.write({ file: resolve(libAbs, `${baseName}.d.ts`), format: 'es' });
         await bundle.close();
-        if (ext !== '.d.ts') {
-            renameSync(tmpOut, resolve(libAbs, `${baseName}${ext}`));
-        }
     } finally {
         rmSync(entryPath, { force: true });
     }
@@ -185,9 +173,9 @@ function rewriteFile(file, leakSet, libAbs) {
     if (rewritten !== original) writeFileSync(file, rewritten);
 }
 
-// In ESM mode (.d.mts), TypeScript with NodeNext/Node16 module resolution requires
+// In ESM mode (.d.ts), TypeScript with NodeNext/Node16 module resolution requires
 // explicit file extensions in relative imports. tsc emits extensionless imports
-// (`from './foo'`); we resolve each to the right `.mjs` extension (file or directory).
+// (`from './foo'`); we resolve each to the right `.js` extension (file or directory).
 function addEsmExtensions(file) {
     const original = readFileSync(file, 'utf8');
     const fileDir = dirname(file);
@@ -195,14 +183,14 @@ function addEsmExtensions(file) {
     const rewritten = original.replace(
         /((?:from|import)\s*\(?\s*['"])(\.\.?(?:\/[^'"]*)?)(['"])/g,
         (full, pre, spec, post) => {
-            if (/\.(mjs|cjs|js|json)$/.test(spec)) return full;
+            if (/\.(js|json)$/.test(spec)) return full;
             const absPath = resolve(fileDir, spec);
-            if (existsSync(`${absPath}.d.mts`)) {
-                return `${pre}${spec}.mjs${post}`;
+            if (existsSync(`${absPath}.d.ts`)) {
+                return `${pre}${spec}.js${post}`;
             }
-            if (existsSync(`${absPath}/index.d.mts`)) {
+            if (existsSync(`${absPath}/index.d.ts`)) {
                 const sep = spec.endsWith('/') ? '' : '/';
-                return `${pre}${spec}${sep}index.mjs${post}`;
+                return `${pre}${spec}${sep}index.js${post}`;
             }
             return full;
         },
@@ -218,9 +206,7 @@ async function main() {
         process.exit(1);
     }
 
-    // Detect output extension by sampling lib/index.d.{ts,mts}.
-    const ext = existsSync(resolve(libAbs, 'index.d.mts')) ? '.d.mts' : '.d.ts';
-    const dtsFiles = walkDts(libAbs, ext);
+    const dtsFiles = walkDts(libAbs, '.d.ts');
 
     const prodClosure = readProdClosure(process.cwd());
     const initialLeaks = scanLeaks(dtsFiles, prodClosure);
@@ -235,19 +221,17 @@ async function main() {
     for (const pkg of leakSet) console.log(`  - ${pkg}`);
 
     for (const pkg of leakSet) {
-        await buildVendorForPackage(pkg, prodClosure, leakSet, libAbs, ext);
+        await buildVendorForPackage(pkg, prodClosure, leakSet, libAbs);
     }
 
     // Rewrite imports in the package's own .d.ts files AND in the just-built vendor
     // files (they may import each other when leak packages cross-reference).
-    const allFiles = walkDts(libAbs, ext);
+    const allFiles = walkDts(libAbs, '.d.ts');
     for (const file of allFiles) rewriteFile(file, leakSet, libAbs);
 
-    // Add explicit `.mjs` extensions to relative imports in ESM declaration files.
+    // Add explicit `.js` extensions to relative imports in ESM declaration files.
     // tsc emits extensionless imports; ESM (NodeNext/Node16) resolution requires them.
-    if (ext === '.d.mts') {
-        for (const file of allFiles) addEsmExtensions(file);
-    }
+    for (const file of allFiles) addEsmExtensions(file);
 }
 
 main().catch(err => {

--- a/scripts/publish/babel-plugin-add-js-extension.js
+++ b/scripts/publish/babel-plugin-add-js-extension.js
@@ -3,7 +3,6 @@ import path from 'node:path';
 
 // Match relative imports without extension: "./x", "../x", "./x/y"
 const isRelativeImport = src => src.startsWith('.') && !path.extname(src);
-const isRelativeJsImport = src => src.startsWith('.') && path.extname(src) === '.js';
 
 // Match @trezor package imports to lib without extension: "@trezor/utils/lib/bigNumber"
 const trezorLibPattern = /^@trezor\/[^/]+\/lib\/[^.]+$/;
@@ -21,9 +20,9 @@ const externalJsonImports = [];
  * This way we can keep our codebase with moduleResolution: bundler (imports without extensions).
  *
  * For Node.js ESM compatibility:
- * - File imports: ./utils/helper → ./utils/helper.mjs
- * - Directory imports: ./constants → ./constants/index.mjs
- * - @trezor package imports: @trezor/utils/lib/bigNumber → @trezor/utils/lib/bigNumber.mjs
+ * - File imports: ./utils/helper → ./utils/helper.js
+ * - Directory imports: ./constants → ./constants/index.js
+ * - @trezor package imports: @trezor/utils/lib/bigNumber → @trezor/utils/lib/bigNumber.js
  * - External CJS subpaths: some-package/subpath → some-package/subpath.js
  */
 const addEsmExtensionPlugin = ({ types }) => {
@@ -63,9 +62,9 @@ const addEsmExtensionPlugin = ({ types }) => {
             // e.g., @trezor/protocol/lib/protocol-tpn -> @trezor/protocol/lib/protocol-tpn/index.js
             // e.g., @trezor/protocol/lib/bigNumber -> @trezor/protocol/lib/bigNumber.js
             if (isDirectory) {
-                nodePath.node.source = types.stringLiteral(src + '/index.mjs');
+                nodePath.node.source = types.stringLiteral(src + '/index.js');
             } else {
-                nodePath.node.source = types.stringLiteral(src + '.mjs');
+                nodePath.node.source = types.stringLiteral(src + '.js');
             }
 
             return;
@@ -86,21 +85,12 @@ const addEsmExtensionPlugin = ({ types }) => {
                 fs.existsSync(resolvedPath) && fs.statSync(resolvedPath).isDirectory();
 
             if (isDirectory) {
-                nodePath.node.source = types.stringLiteral(src + '/index.mjs');
+                nodePath.node.source = types.stringLiteral(src + '/index.js');
             } else {
-                nodePath.node.source = types.stringLiteral(src + '.mjs');
+                nodePath.node.source = types.stringLiteral(src + '.js');
             }
 
             return;
-        }
-
-        if (isRelativeJsImport(src)) {
-            const currentFileDir = path.dirname(state.filename);
-            const resolvedPath = path.resolve(currentFileDir, src);
-
-            if (fs.existsSync(resolvedPath)) {
-                nodePath.node.source = types.stringLiteral(src.replace(/\.js$/, '.mjs'));
-            }
         }
     };
 

--- a/scripts/publish/babel-plugin-sanitize-internal-imports.js
+++ b/scripts/publish/babel-plugin-sanitize-internal-imports.js
@@ -14,7 +14,7 @@ const sanitizeInternalImports = (src, moduleType) => {
 
 const sanitizeDynamicImport = src =>
     // Manually replace .ts extensions with .js (for dynamic imports)
-    src.replace(/\.ts(['"`]|$)/g, '.mjs$1');
+    src.replace(/\.ts(['"`]|$)/g, '.js$1');
 /**
  * Babel plugin to sanitize non-index internal imports, from src to the built lib folder.
  * e.g. @trezor/utils/src/bufferUtils → @trezor/utils/lib/bufferUtils

--- a/scripts/publish/babel.config.ts.json
+++ b/scripts/publish/babel.config.ts.json
@@ -1,0 +1,9 @@
+{
+    "presets": [],
+    "plugins": ["./babel-plugin-add-js-extension.js"],
+    "parserOpts": {
+        "plugins": [["typescript", { "dts": true }]]
+    },
+    "comments": true,
+    "sourceMaps": false
+}

--- a/scripts/publish/replace-imports.sh
+++ b/scripts/publish/replace-imports.sh
@@ -38,8 +38,3 @@ else
     # Linux command with -i and -E for in-place editing without backup (GNU sed syntax) and extended regex.
     find "$1" -name "*.d.ts" -type f -exec sed -i "s|@trezor/\([^/]*\)/src|@trezor/\1/lib|g" {} +
 fi
-
-# Rename all ESM js files to mjs.
-find "$1" -name "*.js" -type f -exec sh -c 'mv "$0" "${0%.js}.mjs"' {} \;
-# Rename declaration files to .d.mts so TypeScript treats them as ESM, matching the .mjs runtime files.
-find "$1" -name "*.d.ts" -type f -exec sh -c 'mv "$0" "${0%.d.ts}.d.mts"' {} \;

--- a/scripts/publish/replace-imports.sh
+++ b/scripts/publish/replace-imports.sh
@@ -18,10 +18,13 @@ if [ "$#" -ne 1 ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BABEL_CONFIG="$SCRIPT_DIR/babel.config.json"
 
 # Transform .js files using Babel
-yarn run -T babel "$1" --out-dir "$1" --extensions ".js" --config-file "$BABEL_CONFIG"
+yarn run -T babel "$1" --out-dir "$1" --extensions ".js" --config-file "$SCRIPT_DIR/babel.config.json"
+
+# Transform .d.ts files using Babel.
+# TODO maybe it'd be better to get rid of babel-plugin-sanitize-internal-imports.js and use only the regex to unify it? Then we can unify the babel configs too.
+yarn run -T babel "$1" --out-dir "$1" --extensions ".ts" --keep-file-extension --config-file "$SCRIPT_DIR/babel.config.ts.json"
 
 # Determine the operating system
 OS="$(uname)"

--- a/skills/publish-config/SKILL.md
+++ b/skills/publish-config/SKILL.md
@@ -15,8 +15,8 @@ Applies to any package with `publishConfig`.
 2. **`files`** — must include `"lib/"`.
 3. **`publishConfig.main`** and **`publishConfig.types`** — both required.
 4. **`publishConfig.exports["."].default`** and **`publishConfig.exports["."].types`** — must export the same files as in Rule 3.
-5. **Wildcard exports** — (`./lib/*`) must be a passthrough string (`"./lib/*"`) — an object would double the `.mjs` extension.
-6. **Explicit (non-wildcard) exports** — not shape-checked (intentional overrides). Typically used to route a directory import to its `index.mjs`, e.g. `"./lib/protocol-thp": { "types": "./lib/protocol-thp/index.d.mts", "default": "./lib/protocol-thp/index.mjs" }` — without this, the wildcard would resolve to `protocol-thp.mjs` instead of `protocol-thp/index.mjs`.
+5. **Wildcard exports** — (`./lib/*`) must be a passthrough string (`"./lib/*"`) — an object would double the `.js` extension.
+6. **Explicit (non-wildcard) exports** — not shape-checked (intentional overrides). Typically used to route a directory import to its `index.js`, e.g. `"./lib/protocol-thp": { "types": "./lib/protocol-thp/index.d.ts", "default": "./lib/protocol-thp/index.js" }` — without this, the wildcard would resolve to `protocol-thp.js` instead of `protocol-thp/index.js`.
 7. **Key order** — `"types"` must come before `"default"` in every condition object (recursive). TypeScript evaluates conditions in declaration order.
 8. **`type`** — must declare top-level `"type": "module"`. Do not duplicate it under `publishConfig.type` — `publishConfig` would only shadow the top level with the same value at publish time, so we keep a single source of truth.
 
@@ -29,13 +29,13 @@ Applies to any package with `publishConfig`.
     "type": "module", // Rule 8
     "files": ["lib/", "CHANGELOG.md"], // Rule 2
     "publishConfig": {
-        "main": "./lib/index.mjs", // Rule 3
-        "types": "./lib/index.d.mts", // Rule 3
+        "main": "./lib/index.js", // Rule 3
+        "types": "./lib/index.d.ts", // Rule 3
         "exports": {
             ".": {
                 // Rule 4: exact shape required
-                "types": "./lib/index.d.mts", // Rule 7: "types" before "default"
-                "default": "./lib/index.mjs",
+                "types": "./lib/index.d.ts", // Rule 7: "types" before "default"
+                "default": "./lib/index.js",
             },
             // Rule 5: ESM wildcard — passthrough string
             "./lib/*": "./lib/*",


### PR DESCRIPTION
## Description

Final touches on proper ESM standards to make Connect v10 libs publishable. Follow up on #28173

- Do not rename `.js` and `.ts` files to `.mjs` and `.mts`, because all published libs are already type: module
- Pass all `.d.ts` files through babel to add the `.js` extensions on local imports, like it's already done with `.js` files
  - Otherwise typescript is broken. It doesn't give any errors – in fact it resolves all `@trezor` types as `any` so everything passes 😱 
  - This bug was found out in https://github.com/trezor/trezor-suite-sync/pull/134
  because that project has tsconfig: `module: NodeNext, moduleResolution: nodenext`

### Details

Q: why wasn't the bug  "all typescript as any" present at v9 releases with dual package CJS and ESM?
A: because if you install for example `@trezor/device-authenticity@1.1.1` and use the ESM package, typescript doesn't find ESM types but will still successfully fall back to the CJS types, even when ESM .js files are used in runtime. That's what I verified in trezor-suite-sync..

## Notes for QA

Releasing connect npm libs:
- should work, all CI should pass
- it should be possible to import the new Connect libs with working typescript in a project with tsconfig: `module: NodeNext, moduleResolution: nodenext`

### What I tested locally

Building locally and manually "installing" into https://github.com/trezor/trezor-suite-sync/pull/134

```
yarn workspace @trezor/crypto-utils build:lib && yarn workspace @trezor/crypto-utils pack
yarn workspace @trezor/device-authenticity build:lib && yarn workspace @trezor/device-authenticity pack
yarn workspace @trezor/protobuf build:lib && yarn workspace @trezor/protobuf pack
yarn workspace @trezor/schema-utils build:lib && yarn workspace @trezor/schema-utils pack
yarn workspace @trezor/type-utils build:lib && yarn workspace @trezor/type-utils pack
yarn workspace @trezor/utils build:lib && yarn workspace @trezor/utils pack
```

Then in `trezor-suite-sync` repo:
```
rm -r ./node_modules/@trezor/crypto-utils/*
rm -r ./node_modules/@trezor/device-authenticity/*
rm -r ./node_modules/@trezor/protobuf/*
rm -r ./node_modules/@trezor/schema-utils/*
rm -r ./node_modules/@trezor/type-utils/*
rm -r ./node_modules/@trezor/utils/*

tar -xzf /my-path/trezor-suite/packages/crypto-utils/package.tgz -C /my-path/trezor-suite-sync/node_modules/@trezor/crypto-utils --strip-components=1 package/
tar -xzf /my-path/trezor-suite/packages/device-authenticity/package.tgz -C /my-path/trezor-suite-sync/node_modules/@trezor/device-authenticity --strip-components=1 package/
tar -xzf /my-path/trezor-suite/packages/protobuf/package.tgz -C /my-path/trezor-suite-sync/node_modules/@trezor/protobuf --strip-components=1 package/
tar -xzf /my-path/trezor-suite/packages/schema-utils/package.tgz -C /my-path/trezor-suite-sync/node_modules/@trezor/schema-utils --strip-components=1 package/
tar -xzf /my-path/trezor-suite/packages/type-utils/package.tgz -C /my-path/trezor-suite-sync/node_modules/@trezor/type-utils --strip-components=1 package/
tar -xzf /my-path/trezor-suite/packages/utils/package.tgz -C /my-path/trezor-suite-sync/node_modules/@trezor/utils --strip-components=1 package/
```

Then deliberately breaking some typescript [here](https://github.com/trezor/trezor-suite-sync/blob/23fc39f6c0ca27c9444353a3505c09ae1936200e/src/quotaManager/storage/endpoints/register/createStorageRegisterOperation.ts#L113)

And running `yarn type-check` to get errors.
(with `@10.0.0-alpha.1` it fails to emit any errors at all)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/finish-connect-ESM&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/finish-connect-ESM&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/finish-connect-ESM&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-14T09:24:46.019Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-14T09:23:36.139Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/finish-connect-ESM/web/](https://dev.suite.sldev.cz/suite-web/refactor/finish-connect-ESM/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files consist almost entirely of package.json files across many packages (coins, blockchain-link, connect, transport, utils, etc.) and a few publish/build scripts (babel plugins, babel config) plus a requirements lint rule and its test. These are infrastructure-level changes — likely version bumps, dependency updates, or publishConfig adjustments — that do not modify any runtime application code, UI components, or business logic. No static test coverage mapping exists for any of these files, and the LLM analysis of the 145 E2E tests reveals no test that directly exercises package.json contents, babel publish plugins, or the requirePublishConfig lint rule. Since no functional application code was changed, the risk of user-facing regression is negligible, and no E2E tests are recommended.

<details><summary><b>Changed files (34)</b></summary>

- `coins/coins-cardano/package.json`
- `coins/coins-solana/package.json`
- `coins/coins-stellar/package.json`
- `coins/coins-xrpl/package.json`
- `packages/blockchain-link-types/package.json`
- `packages/blockchain-link-utils/package.json`
- `packages/blockchain-link/package.json`
- `packages/connect-common/package.json`
- `packages/connect-data/package.json`
- `packages/connect-mobile/package.json`
- `packages/connect-plugin-ethereum/package.json`
- `packages/connect-plugin-stellar/package.json`
- `packages/connect-web/package.json`
- `packages/connect-webextension/package.json`
- `packages/connect/package.json`
- `packages/crypto-utils/package.json`
- `packages/device-authenticity/package.json`
- `packages/device-utils/package.json`
- `packages/env-utils/package.json`
- `packages/protobuf/package.json`
- `packages/protocol/package.json`
- `packages/requirements/src/requirements/package-json/__tests__/requirePublishConfig.test.ts`
- `packages/requirements/src/requirements/package-json/requirePublishConfig.ts`
- `packages/schema-utils/package.json`
- `packages/transport-common/package.json`
- `packages/transport-web/package.json`
- `packages/transport/package.json`
- `packages/type-utils/package.json`
- `packages/utils/package.json`
- `packages/utxo-lib/package.json`
- `packages/websocket-client/package.json`
- `scripts/publish/babel-plugin-add-js-extension.js`
- `scripts/publish/babel-plugin-sanitize-internal-imports.js`
- `scripts/publish/babel.config.ts.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (34)**
- `coins/coins-cardano/package.json`
- `coins/coins-solana/package.json`
- `coins/coins-stellar/package.json`
- `coins/coins-xrpl/package.json`
- `packages/blockchain-link-types/package.json`
- `packages/blockchain-link-utils/package.json`
- `packages/blockchain-link/package.json`
- `packages/connect-common/package.json`
- `packages/connect-data/package.json`
- `packages/connect-mobile/package.json`
- `packages/connect-plugin-ethereum/package.json`
- `packages/connect-plugin-stellar/package.json`
- `packages/connect-web/package.json`
- `packages/connect-webextension/package.json`
- `packages/connect/package.json`
- `packages/crypto-utils/package.json`
- `packages/device-authenticity/package.json`
- `packages/device-utils/package.json`
- `packages/env-utils/package.json`
- `packages/protobuf/package.json`
- `packages/protocol/package.json`
- `packages/requirements/src/requirements/package-json/__tests__/requirePublishConfig.test.ts`
- `packages/requirements/src/requirements/package-json/requirePublishConfig.ts`
- `packages/schema-utils/package.json`
- `packages/transport-common/package.json`
- `packages/transport-web/package.json`
- `packages/transport/package.json`
- `packages/type-utils/package.json`
- `packages/utils/package.json`
- `packages/utxo-lib/package.json`
- `packages/websocket-client/package.json`
- `scripts/publish/babel-plugin-add-js-extension.js`
- `scripts/publish/babel-plugin-sanitize-internal-imports.js`
- `scripts/publish/babel.config.ts.json`

_Updated: 2026-07-14T09:20:43.384Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->