### PR TITLE
fix(suite): Fix TS7 onboarding fast passing tutorial issue

### DIFF
--- a/packages/suite/src/views/onboarding/steps/DeviceTutorialStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceTutorialStep.tsx
@@ -21,6 +21,11 @@ export const DeviceTutorialStep = () => {
         dispatch(beginOnboardingTutorial());
     }, [dispatch]);
 
+    // Cancelling before the `showDeviceTutorial` call reaches the device (and registers in Connect
+    // core) is a no-op, leaving the device stuck showing the tutorial. Wait for the device to report
+    // it is waiting for interaction before allowing Skip.
+    const isDeviceReady = !!device?.buttonRequests.length;
+
     const handleSkipClick = () =>
         TrezorConnect.cancel({ reason: intl.formatMessage(messages.TR_CANCELLED) });
 
@@ -38,6 +43,8 @@ export const DeviceTutorialStep = () => {
                     intent="neutral"
                     priority="secondary"
                     onClick={handleSkipClick}
+                    isDisabled={!isDeviceReady}
+                    isLoading={!isDeviceReady}
                 >
                     <Translation id="TR_SKIP" />
                 </OnboardingCard.Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adds loading and disabled state for `skip (tutorial)` when device is not ready
- when you click to `skip` too early you will stuck (typically when we test onboarding)


## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

first seconds:
<img width="1105" height="647" alt="Screenshot 2026-07-08 at 17 34 33" src="https://github.com/user-attachments/assets/372a2dd1-1eee-487f-b79d-cbdd3705b0fa" />

later:
<img width="1088" height="643" alt="Screenshot 2026-07-08 at 17 34 54" src="https://github.com/user-attachments/assets/c3d71097-846c-45fb-bc07-3913db34ed73" />



<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to DeviceTutorialStep.tsx, which is the tutorial step component shown during device onboarding (primarily for T3T1 devices). While this file is statically imported by 121 tests (since nearly all tests complete onboarding), the actual risk is concentrated in tests that directly interact with the tutorial step or exercise the onboarding step sequence. The T3T1 create wallet test is highest priority as it explicitly interacts with the tutorial step. Other onboarding flow tests are medium priority due to potential step sequencing impacts. Most of the 121 mapped tests merely pass through onboarding via completeOnboarding() which likely handles the tutorial step generically, so they are omitted.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/onboarding/steps/DeviceTutorialStep.tsx`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — DeviceTutorialStep.tsx is the tutorial step component in onboarding. The T3T1 create wallet test explicitly calls onboardingPage.tutorial (skip tutorial step), which directly exercises the DeviceTutorialStep component. Any breakage here would be caught by this test.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — The T2T1 create wallet onboarding flow passes through multiple onboarding steps. While the tutorial step may be model-specific (T3T1), the DeviceTutorialStep component could still be rendered or conditionally skipped during T2T1 onboarding, making this a plausible regression path.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — This test navigates through the full T2T1 onboarding recovery flow including firmware and multiple steps. Changes to the DeviceTutorialStep could affect step sequencing or rendering in the onboarding wizard even if the tutorial step is skipped for T2T1.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test validates firmware readiness during onboarding. The DeviceTutorialStep is part of the onboarding step sequence, and changes could affect step ordering or the transition logic between firmware check and subsequent steps.
- `suite/e2e/tests/suite/initial-run.test.ts` — This test validates the full initial run/onboarding persistence flow including page reloads at various onboarding stages. Changes to DeviceTutorialStep could affect the onboarding step progression and what's shown after reloads.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — This test navigates through onboarding including completing it fully. While analytics consent is a different step, the DeviceTutorialStep is part of the onboarding wizard and changes could affect step navigation flow.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test exercises the onboarding wizard through wallet creation steps. The DeviceTutorialStep is part of the step sequence and changes could theoretically affect step transitions, though the test focuses on entropy check errors.

</details>

_Updated: 2026-07-08T15:15:51.273Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-ts7-onboarding-fast-passing-tutorial-issue/web/](https://dev.suite.sldev.cz/suite-web/fix-ts7-onboarding-fast-passing-tutorial-issue/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-ts7-onboarding-fast-passing-tutorial-issue&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-ts7-onboarding-fast-passing-tutorial-issue&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-08T15:21:29.076Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T15:19:30.243Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->