### PR TITLE
fix(blockchain-link): handle uncaught exception in Electrum client

### DIFF
--- a/packages/blockchain-link/src/workers/electrum/client/batching.ts
+++ b/packages/blockchain-link/src/workers/electrum/client/batching.ts
@@ -26,9 +26,9 @@ export class BatchingJsonRpcClient extends JsonRpcClient {
         this.maxQueueLength = options?.maxQueueLength || MAX_QUEUE_LENGTH;
     }
 
-    protected send(message: string) {
+    protected send(id: number, message: string) {
         if (this.batchingDisabled) {
-            super.send(message);
+            super.send(id, message);
 
             return;
         }
@@ -42,7 +42,7 @@ export class BatchingJsonRpcClient extends JsonRpcClient {
                 // @ts-expect-error: indexing with noUncheckedIndexedAccess
                 const first: string = q[0];
                 const content = q.length > 1 ? `[${q.join(',')}]` : first;
-                super.send(content);
+                super.send(id, content);
             }
         }, this.timeoutMs);
     }

--- a/packages/blockchain-link/src/workers/electrum/client/json-rpc.ts
+++ b/packages/blockchain-link/src/workers/electrum/client/json-rpc.ts
@@ -1,7 +1,5 @@
 import { EventEmitter } from 'events';
 
-import { throwError } from '@trezor/utils';
-
 import type { ISocket } from '../sockets/interface';
 
 type Callback = (error: any, result?: any) => void;
@@ -15,7 +13,7 @@ export class JsonRpcClient {
     private id = 0;
     private buffer = '';
     private emitter = new EventEmitter();
-    protected callbacks: CallbackMessageQueue = {};
+    private callbacks: CallbackMessageQueue = {};
     protected socket?: ISocket;
     protected debug = false;
 
@@ -56,7 +54,7 @@ export class JsonRpcClient {
                 if (err) reject(err);
                 else resolve(result);
             };
-            this.send(request);
+            this.send(id, request);
         });
     }
 
@@ -68,26 +66,31 @@ export class JsonRpcClient {
         this.emitter.off(event, listener);
     }
 
-    protected send(message: string) {
-        const socket = this.socket || throwError('Connection not established');
-        this.log('SENDING:', message);
-        socket.send(`${message}\n`);
+    protected send(id: number, message: string) {
+        if (this.socket) {
+            this.log('SENDING:', message);
+            this.socket.send(`${message}\n`);
+        } else {
+            this.processCallback(id, new Error('Connection not established'));
+        }
     }
 
     protected response(response: any) {
         const { id, method, params, result, error } = response;
-        if (!id) {
-            // Notification
-            this.emitter.emit(method, params);
+        if (id) {
+            this.processCallback(id, error, result);
         } else {
-            // Response
-            const callback = this.callbacks[id];
-            if (callback) {
-                delete this.callbacks[id];
-                callback(error, result);
-            } else {
-                this.log(`Can't get callback for ${id}`);
-            }
+            this.emitter.emit(method, params);
+        }
+    }
+
+    private processCallback(id: number, error: any, result?: any) {
+        const callback = this.callbacks[id];
+        if (callback) {
+            delete this.callbacks[id];
+            callback(error, result);
+        } else {
+            this.log(`Can't get callback for ${id}`);
         }
     }
 


### PR DESCRIPTION
## Description

When connecting to an Electrum backend behind nginx, the proxy itself accepts the TCP connection instantly (triggering the `connect` event), and then fails if the backend is down. And since the connection seems established, the `ElectrumClient` tries to request `server.version` which leads to an uncaught exception that crashes the mobile app.

## Related Issue

Resolve #27651

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect the Electrum client's JSON-RPC communication layer (batching and message serialization), which is a specialized subsystem used only when connecting to Electrum backends. The only E2E test that directly exercises Electrum backend functionality is the electrum.test.ts settings test, which configures a custom Electrum server and verifies account discovery through it. No other E2E tests interact with Electrum backends, so the test surface is narrow but the risk within that surface is high — any protocol-level regression would completely break Electrum connectivity.

<details><summary><b>Changed files (2)</b></summary>

- `packages/blockchain-link/src/workers/electrum/client/batching.ts`
- `packages/blockchain-link/src/workers/electrum/client/json-rpc.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/settings/electrum.test.ts` — This test directly exercises the Electrum backend integration by configuring a custom Electrum server for RegTest and verifying that discovery completes successfully. The changed files (batching.ts and json-rpc.ts) are core Electrum client communication modules that handle JSON-RPC message formatting and request batching — any regression here would break Electrum connectivity, which this test validates end-to-end.

</details>

_Updated: 2026-07-08T15:26:18.748Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/blockchain-link/send-error-handling&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/blockchain-link/send-error-handling&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-08T15:32:30.743Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-08T15:29:51.456Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/blockchain-link/send-error-handling/web/](https://dev.suite.sldev.cz/suite-web/fix/blockchain-link/send-error-handling/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->