### PR TITLE
perf(suite-native): refactor re-renders on a transaction detail page

### DIFF
--- a/suite-native/module-transactions/package.json
+++ b/suite-native/module-transactions/package.json
@@ -15,7 +15,6 @@
         "@react-navigation/native": "7.1.28",
         "@react-navigation/native-stack": "7.12.0",
         "@suite-common/dependency-injection": "workspace:*",
-        "@suite-common/discreet-mode": "workspace:*",
         "@suite-common/formatters": "workspace:*",
         "@suite-common/token-definitions": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",

--- a/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
+++ b/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
@@ -4,8 +4,6 @@ import { useSelector } from 'react-redux';
 import { useNavigation, usePreventRemove } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { redactNumericalSubstring, useDiscreetMode } from '@suite-common/discreet-mode';
-import { useFormatters } from '@suite-common/formatters';
 import {
     type AccountsRootState,
     createTargets,
@@ -27,6 +25,7 @@ import { useTransactionDetails } from '@suite-native/transaction-management';
 import {
     InstantStakeBanner,
     TransactionName,
+    UnstakeTransactionDetailTitle,
     getUnstakeTxAmount,
     useFetchMissingTransactionFiatRates,
 } from '@suite-native/transactions';
@@ -40,8 +39,6 @@ export const TransactionDetailScreen = ({
     const { askForRating } = useInAppRating();
     const navigation = useNavigation();
     const { analytics } = useServices(selectNativeAnalyticsDep);
-    const { CryptoAmountFormatter: cryptoAmountFormatter } = useFormatters();
-    const { isDiscreetMode } = useDiscreetMode();
     const { txid, accountKey, tokenContract, closeActionType = 'back', source } = route.params;
 
     const { transaction, isPending, tokenTransfer, openInBlockchain } = useTransactionDetails({
@@ -77,16 +74,6 @@ export const TransactionDetailScreen = ({
 
     const unstakeAmount = getUnstakeTxAmount(transaction);
     const isUnstakeTransaction = unstakeAmount !== undefined;
-    const formattedUnstakeAmount = isUnstakeTransaction
-        ? cryptoAmountFormatter.format(unstakeAmount, {
-              symbol: transaction.symbol,
-              isBalance: false,
-              isEllipsisAppended: false,
-          })
-        : '';
-    const displayedUnstakeAmount = isDiscreetMode
-        ? redactNumericalSubstring(formattedUnstakeAmount)
-        : formattedUnstakeAmount;
 
     const handleOpenBlockchain = () => {
         analytics.report({
@@ -104,34 +91,35 @@ export const TransactionDetailScreen = ({
                     closeActionType={closeActionType}
                     customContent={
                         <HStack spacing="sp8" alignItems="center" justifyContent="center">
-                            {!isUnstakeTransaction && (
-                                <CryptoIconWithNetwork
+                            {isUnstakeTransaction ? (
+                                <UnstakeTransactionDetailTitle
+                                    unstakeAmount={unstakeAmount}
                                     symbol={transaction.symbol}
-                                    contractAddress={tokenTransfer?.contract}
+                                    variant="body-md-strong"
                                 />
+                            ) : (
+                                <>
+                                    <CryptoIconWithNetwork
+                                        symbol={transaction.symbol}
+                                        contractAddress={tokenTransfer?.contract}
+                                    />
+                                    <Text variant="body-md-strong">
+                                        <Translation
+                                            id="transactions.detail.header"
+                                            values={{
+                                                transactionType: () => (
+                                                    <TransactionName
+                                                        key={transaction.txid}
+                                                        transaction={transaction}
+                                                        isPending={isPending}
+                                                        variant="body-md-strong"
+                                                    />
+                                                ),
+                                            }}
+                                        />
+                                    </Text>
+                                </>
                             )}
-                            <Text variant="body-md-strong">
-                                {isUnstakeTransaction ? (
-                                    <Translation
-                                        id="transactions.detail.unstakeHeader"
-                                        values={{ amount: displayedUnstakeAmount }}
-                                    />
-                                ) : (
-                                    <Translation
-                                        id="transactions.detail.header"
-                                        values={{
-                                            transactionType: () => (
-                                                <TransactionName
-                                                    key={transaction.txid}
-                                                    transaction={transaction}
-                                                    isPending={isPending}
-                                                    variant="body-md-strong"
-                                                />
-                                            ),
-                                        }}
-                                    />
-                                )}
-                            </Text>
                         </HStack>
                     }
                 />

--- a/suite-native/module-transactions/tsconfig.json
+++ b/suite-native/module-transactions/tsconfig.json
@@ -6,9 +6,6 @@
             "path": "../../suite-common/dependency-injection"
         },
         {
-            "path": "../../suite-common/discreet-mode"
-        },
-        {
             "path": "../../suite-common/formatters"
         },
         {

--- a/suite-native/transactions/src/components/TransactionName.tsx
+++ b/suite-native/transactions/src/components/TransactionName.tsx
@@ -10,6 +10,7 @@ import { exhaustive } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { getUnstakeTxAmount } from '../utils';
+import { UnstakeTransactionDetailTitle } from './UnstakeTransactionDetailTitle';
 
 type TransactionNameProps = {
     transaction: WalletAccountTransaction;
@@ -187,22 +188,12 @@ export const TransactionName = ({ transaction, isPending, variant }: Transaction
     const unstakeAmount = getUnstakeTxAmount(transaction);
 
     if (unstakeAmount !== undefined && !isPending) {
-        const formattedUnstakeAmount = cryptoAmountFormatter.format(unstakeAmount, {
-            symbol: transaction.symbol,
-            isBalance: false,
-            isEllipsisAppended: false,
-        });
-        const displayedUnstakeAmount = isDiscreetMode
-            ? redactNumericalSubstring(formattedUnstakeAmount)
-            : formattedUnstakeAmount;
-
         return (
-            <Text variant={variant}>
-                <Translation
-                    id="transactions.detail.unstakeHeader"
-                    values={{ amount: displayedUnstakeAmount }}
-                />
-            </Text>
+            <UnstakeTransactionDetailTitle
+                unstakeAmount={unstakeAmount}
+                symbol={transaction.symbol}
+                variant={variant}
+            />
         );
     }
 

--- a/suite-native/transactions/src/components/UnstakeTransactionDetailTitle.tsx
+++ b/suite-native/transactions/src/components/UnstakeTransactionDetailTitle.tsx
@@ -1,0 +1,39 @@
+import { redactNumericalSubstring, useDiscreetMode } from '@suite-common/discreet-mode';
+import { useFormatters } from '@suite-common/formatters';
+import { type WalletAccountTransaction } from '@suite-common/wallet-types';
+import { Text } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import { type NativeTypographyStyle } from '@trezor/theme';
+
+type UnstakeTransactionDetailTitleProps = {
+    unstakeAmount: string;
+    symbol: WalletAccountTransaction['symbol'];
+    variant?: NativeTypographyStyle;
+};
+
+export const UnstakeTransactionDetailTitle = ({
+    unstakeAmount,
+    symbol,
+    variant,
+}: UnstakeTransactionDetailTitleProps) => {
+    const { CryptoAmountFormatter: cryptoAmountFormatter } = useFormatters();
+    const { isDiscreetMode } = useDiscreetMode();
+
+    const formattedUnstakeAmount = cryptoAmountFormatter.format(unstakeAmount, {
+        symbol,
+        isBalance: false,
+        isEllipsisAppended: false,
+    });
+    const displayedUnstakeAmount = isDiscreetMode
+        ? redactNumericalSubstring(formattedUnstakeAmount)
+        : formattedUnstakeAmount;
+
+    return (
+        <Text variant={variant}>
+            <Translation
+                id="transactions.detail.unstakeHeader"
+                values={{ amount: displayedUnstakeAmount }}
+            />
+        </Text>
+    );
+};

--- a/suite-native/transactions/src/index.ts
+++ b/suite-native/transactions/src/index.ts
@@ -2,6 +2,7 @@ export * from './components/InstantStakeBanner';
 export * from './components/TransactionList';
 export * from './components/TransactionIcon';
 export * from './components/TransactionName';
+export * from './components/UnstakeTransactionDetailTitle';
 export * from './components/TransactionOutputLabel';
 export * from './components/TransactionOutputLabelEditable';
 export * from './components/TokenTransferListItem';

--- a/yarn.lock
+++ b/yarn.lock
@@ -13744,7 +13744,6 @@ __metadata:
     "@react-navigation/native": "npm:7.1.28"
     "@react-navigation/native-stack": "npm:7.12.0"
     "@suite-common/dependency-injection": "workspace:*"
-    "@suite-common/discreet-mode": "workspace:*"
     "@suite-common/formatters": "workspace:*"
     "@suite-common/token-definitions": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Optimizes re-renders

## Notes for QA

No visual changes, slightly better performance. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28589

## Screenshots:

### Befrore

https://github.com/user-attachments/assets/2c69641b-4621-4227-8865-2658c4b6fe1a

### After

https://github.com/user-attachments/assets/dbe700b6-d746-4b12-988e-611de72574e1




<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=perf/discreet-mode-native&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=perf/discreet-mode-native&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=perf/discreet-mode-native&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All changed files are under the `suite-native/` directory, which is the React Native mobile app codebase (TransactionDetailScreen, TransactionName, UnstakeTransactionDetailTitle components). The E2E test suite available covers only the desktop/web Trezor Suite application (Playwright-based tests running against Electron or web builds). None of the 115 candidate E2E tests exercise React Native mobile screens or components. There is no static coverage mapping and no inferable connection between these native mobile transaction UI changes and any of the available web/desktop E2E tests. No tests should be run from this suite for these changes; mobile-specific tests (if they exist) would be needed instead.

<details><summary><b>Changed files (6)</b></summary>

- `suite-native/module-transactions/package.json`
- `suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx`
- `suite-native/module-transactions/tsconfig.json`
- `suite-native/transactions/src/components/TransactionName.tsx`
- `suite-native/transactions/src/components/UnstakeTransactionDetailTitle.tsx`
- `suite-native/transactions/src/index.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (6)**
- `suite-native/module-transactions/package.json`
- `suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx`
- `suite-native/module-transactions/tsconfig.json`
- `suite-native/transactions/src/components/TransactionName.tsx`
- `suite-native/transactions/src/components/UnstakeTransactionDetailTitle.tsx`
- `suite-native/transactions/src/index.ts`

_Updated: 2026-07-10T14:44:08.143Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/perf/discreet-mode-native/web/](https://dev.suite.sldev.cz/suite-web/perf/discreet-mode-native/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T14:47:00.920Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T14:46:52.066Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->