### PR TITLE
feat(suite): redesign transaction list filter dropdown

### DIFF
--- a/packages/components/src/components/ComponentWithSubIcon/ComponentWithSubIcon.stories.tsx
+++ b/packages/components/src/components/ComponentWithSubIcon/ComponentWithSubIcon.stories.tsx
@@ -65,3 +65,45 @@ export const ComponentWithSubIcon: StoryObj<ComponentWithSubIconProps> = {
         ...getFramePropsStory(allowedComponentWithSubIconFrameProps).argTypes,
     },
 };
+
+export const ComponentWithSubContent: StoryObj<ComponentWithSubIconProps> = {
+    args: {
+        subContent: '2',
+        intent: 'brand',
+        children: (
+            <IconButton
+                icon={generatedIcons.FunnelSimpleIcon}
+                size="large"
+                intent="neutral"
+                priority="secondary"
+                tooltip={{ content: 'Filters' }}
+            />
+        ),
+        iconOffset: 4,
+        ...getFramePropsStory(allowedComponentWithSubIconFrameProps).args,
+    },
+    argTypes: {
+        subContent: {
+            control: {
+                type: 'text',
+            },
+        },
+        intent: {
+            options: componentWithSubIconIntents,
+            control: {
+                type: 'select',
+            },
+        },
+        iconOffset: {
+            control: {
+                type: 'number',
+            },
+        },
+        icon: {
+            options: ['none', ...Object.keys(generatedIcons)],
+            mapping: { none: undefined, ...generatedIcons },
+            control: { type: 'select' },
+        },
+        ...getFramePropsStory(allowedComponentWithSubIconFrameProps).argTypes,
+    },
+};

--- a/packages/components/src/components/ComponentWithSubIcon/ComponentWithSubIcon.tsx
+++ b/packages/components/src/components/ComponentWithSubIcon/ComponentWithSubIcon.tsx
@@ -10,7 +10,11 @@ import {
     pickAndPrepareFrameProps,
 } from '../../utils/frameProps';
 import { Box } from '../Box/Box';
+import { Row } from '../Flex/Flex';
 import { Icon, type IconComponent } from '../Icon/Icon';
+import { Text } from '../typography/Text/Text';
+
+const SUB_CONTENT_SIZE = 14;
 
 export const allowedComponentWithSubIconFrameProps = ['margin'] as const satisfies FramePropsKeys[];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedComponentWithSubIconFrameProps)[number]>;
@@ -19,6 +23,7 @@ export type ComponentWithSubIconProps = AllowedFrameProps & {
     icon?: IconComponent;
     iconSize?: number;
     children: ReactNode;
+    subContent?: ReactNode;
     iconPadding?: SpacingValuesNew;
     iconOffset?: SpacingValuesNew;
     intent?: ComponentWithSubIconIntent;
@@ -29,23 +34,42 @@ export const ComponentWithSubIcon = ({
     iconSize = 8,
     icon,
     children,
+    subContent,
     iconPadding = 2,
     iconOffset = 4,
     ...rest
 }: ComponentWithSubIconProps) => {
     const frameProps = pickAndPrepareFrameProps(rest, allowedComponentWithSubIconFrameProps, false);
+    const hasSubIcon = icon !== undefined || subContent !== undefined;
 
     return (
         <Box width="fit-content" position={{ type: 'relative' }} {...frameProps}>
             {children}
-            {icon && (
+            {hasSubIcon && (
                 <Box
                     position={{ type: 'absolute', top: iconOffset * -1, right: iconOffset * -1 }}
                     backgroundColor={mapIntentToBackgroundColor(intent)}
                     borderRadius={borders.radii.full}
-                    padding={iconPadding}
+                    padding={icon !== undefined ? iconPadding : undefined}
                 >
-                    <Icon as={icon} size={iconSize} color={mapIntentToIconColor(intent)} />
+                    {icon !== undefined ? (
+                        <Icon as={icon} size={iconSize} color={mapIntentToIconColor(intent)} />
+                    ) : (
+                        <Row
+                            justifyContent="center"
+                            height={SUB_CONTENT_SIZE}
+                            minWidth={SUB_CONTENT_SIZE}
+                            padding={{ horizontal: 4 }}
+                        >
+                            <Text
+                                typographyStyle="body-xs"
+                                color={mapIntentToIconColor(intent)}
+                                textWrap="nowrap"
+                            >
+                                {subContent}
+                            </Text>
+                        </Row>
+                    )}
                 </Box>
             )}
         </Box>

--- a/packages/components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/components/src/components/Dropdown/Dropdown.tsx
@@ -20,6 +20,8 @@ export type DropdownProps = Omit<MenuProps, 'onClose'> &
         iconSize?: ButtonSize;
         isLoading?: boolean;
         icon?: IconComponent;
+        intent?: IconButtonProps['intent'];
+        priority?: IconButtonProps['priority'];
         tooltip?: IconButtonProps['tooltip'];
         'data-testid'?: string;
     };
@@ -41,6 +43,8 @@ export const Dropdown = forwardRef(
             isLoading,
             placement,
             icon = DotsThreeIcon,
+            intent = 'neutral',
+            priority = 'secondary',
             'data-testid': dataTest,
             minWidth,
             maxWidth,
@@ -78,8 +82,8 @@ export const Dropdown = forwardRef(
                 }
             >
                 <IconButton
-                    intent="neutral"
-                    priority="secondary"
+                    intent={intent}
+                    priority={priority}
                     icon={icon}
                     size={iconSize}
                     tabIndex={-1}

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { type ReactNode } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { selectFlags, setFlag } from '@suite/flags';
@@ -9,31 +9,55 @@ import {
     toggleHideSuspiciousTransactions,
 } from '@suite-common/wallet-core';
 import {
+    Badge,
     Box,
     Button,
     Column,
+    ComponentWithSubIcon,
+    Divider,
     Dropdown,
-    type DropdownRef,
     Paragraph,
     Radio,
     Row,
     Text,
+    TextButton,
     Tooltip,
 } from '@trezor/components';
 import { FunnelSimpleIcon } from '@trezor/icons';
-import { spacings, zIndices } from '@trezor/theme';
+import { zIndices } from '@trezor/theme';
 
-const options = [
+type FilterValue = boolean | string;
+
+type FilterOption = {
+    value: FilterValue;
+    label: ReactNode;
+    description?: ReactNode;
+    isDefault?: boolean;
+};
+
+type FilterSection = {
+    key: string;
+    title: ReactNode;
+    options: readonly FilterOption[];
+    value: FilterValue;
+    onChange: (value: FilterValue) => void;
+};
+
+const suspiciousTransactionsOptions: readonly FilterOption[] = [
     {
-        id: 0,
-        label: <Translation id="TR_SHOW_SUSPICIOUS_TRANSACTIONS" />,
+        value: false,
+        label: <Translation id="TR_SHOW_ALL" />,
+        isDefault: true,
     },
     {
-        id: 1,
-        label: <Translation id="TR_HIDE_SUSPICIOUS_TRANSACTIONS" />,
+        value: true,
+        label: <Translation id="TR_HIDE_SUSPICIOUS" />,
         description: <Translation id="TR_HIDE_SUSPICIOUS_TRANSACTIONS_DESCRIPTION" />,
     },
-] as const;
+];
+
+const getSectionDefaultValue = (section: FilterSection) =>
+    section.options.find(option => option.isDefault)?.value;
 
 export const FilterAction = () => {
     const { suspiciousTransactionsTooltipClosed } = useSelector(selectFlags);
@@ -48,12 +72,32 @@ export const FilterAction = () => {
     };
     const dataTest = '@wallet/accounts/hide-scam-transactions';
 
-    const dropdownRef = useRef<DropdownRef>(undefined);
-
-    const handleToggleSuspiciousTransactionsRequest = (requestedHidden: boolean) => {
-        if (requestedHidden === suspiciousTransactionsHidden) return;
-        dropdownRef.current?.close();
+    const handleToggleSuspiciousTransactionsRequest = (requestedHidden: FilterValue) => {
+        if (requestedHidden === Boolean(suspiciousTransactionsHidden)) return;
         dispatch(toggleHideSuspiciousTransactions());
+    };
+
+    const filterSections: FilterSection[] = [
+        {
+            key: 'suspiciousTransactions',
+            title: <Translation id="TR_SUSPICIOUS_TRANSACTIONS" />,
+            options: suspiciousTransactionsOptions,
+            value: Boolean(suspiciousTransactionsHidden),
+            onChange: handleToggleSuspiciousTransactionsRequest,
+        },
+    ];
+
+    const activeFilterCount = filterSections.filter(
+        section => section.value !== getSectionDefaultValue(section),
+    ).length;
+
+    const handleClearAll = () => {
+        filterSections.forEach(section => {
+            const defaultValue = getSectionDefaultValue(section);
+            if (defaultValue !== undefined && section.value !== defaultValue) {
+                section.onChange(defaultValue);
+            }
+        });
     };
 
     return (
@@ -63,7 +107,7 @@ export const FilterAction = () => {
             placement="bottom-end"
             zIndex={zIndices.popover}
             content={
-                <Row gap={spacings.sm} padding={spacings.xs}>
+                <Row gap={12} padding={8}>
                     <Box maxWidth={290}>
                         <Paragraph>
                             <Translation id="TR_HIDE_SCAM_TRANSACTIONS_TOOLTIP" />
@@ -81,55 +125,89 @@ export const FilterAction = () => {
                 </Row>
             }
         >
-            <Dropdown
-                icon={FunnelSimpleIcon}
-                ref={dropdownRef}
-                placement={{ position: 'bottom', alignment: 'end' }}
-                isDisabled={false}
-                tooltip={{ content: <Translation id="TR_FILTER" />, placement: 'left' }}
-                content={
-                    <Column maxWidth={250} padding={spacings.xxs} gap={spacings.md}>
-                        {options.map(option => (
-                            <Radio
-                                key={option.id}
-                                isChecked={
-                                    Boolean(suspiciousTransactionsHidden) === Boolean(option.id)
-                                }
-                                onChange={() => {
-                                    handleToggleSuspiciousTransactionsRequest(Boolean(option.id));
-                                }}
-                                data-testid={dataTest}
-                                verticalAlignment="center"
-                            >
-                                <Column>
+            <ComponentWithSubIcon
+                intent="brand"
+                subContent={activeFilterCount > 0 ? activeFilterCount : undefined}
+            >
+                <Dropdown
+                    icon={FunnelSimpleIcon}
+                    intent={activeFilterCount > 0 ? 'brand' : 'neutral'}
+                    placement={{ position: 'bottom', alignment: 'end' }}
+                    isDisabled={false}
+                    tooltip={{ content: <Translation id="TR_FILTERS" />, placement: 'left' }}
+                    content={
+                        <Column width={250} padding={4} gap={16}>
+                            <Row justifyContent="space-between" gap={16}>
+                                <Text typographyStyle="body-md-strong">
+                                    <Translation id="TR_FILTERS" />
+                                </Text>
+                                <TextButton
+                                    size="small"
+                                    isDisabled={activeFilterCount === 0}
+                                    onClick={handleClearAll}
+                                    data-testid={`${dataTest}/clear-all`}
+                                >
+                                    <Translation id="TR_CLEAR_ALL" />
+                                </TextButton>
+                            </Row>
+                            <Divider margin={{ vertical: 0 }} />
+                            {filterSections.map(section => (
+                                <Column key={section.key} gap={16}>
                                     <Text
-                                        typographyStyle="body-sm-strong"
-                                        intent={
-                                            Boolean(suspiciousTransactionsHidden) ===
-                                            Boolean(option.id)
-                                                ? 'brand'
-                                                : 'neutral'
-                                        }
+                                        typographyStyle="body-xs"
+                                        intent="neutral"
+                                        priority="secondary"
                                     >
-                                        {option.label}
+                                        {section.title}
                                     </Text>
-                                    {'description' in option && option.description && (
-                                        <Paragraph
-                                            typographyStyle="body-xs"
-                                            intent="neutral"
-                                            priority="secondary"
-                                            textWrap="pretty"
-                                        >
-                                            {option.description}
-                                        </Paragraph>
-                                    )}
+                                    {section.options.map(option => {
+                                        const isChecked = section.value === option.value;
+
+                                        return (
+                                            <Radio
+                                                key={String(option.value)}
+                                                isChecked={isChecked}
+                                                onChange={() => {
+                                                    section.onChange(option.value);
+                                                }}
+                                                data-testid={dataTest}
+                                                verticalAlignment="center"
+                                            >
+                                                <Column>
+                                                    <Row gap={8}>
+                                                        <Text
+                                                            typographyStyle="body-sm-strong"
+                                                            intent={isChecked ? 'brand' : 'neutral'}
+                                                        >
+                                                            {option.label}
+                                                        </Text>
+                                                        {option.isDefault && (
+                                                            <Badge size="small">
+                                                                <Translation id="TR_DEFAULT" />
+                                                            </Badge>
+                                                        )}
+                                                    </Row>
+                                                    {option.description && (
+                                                        <Paragraph
+                                                            typographyStyle="body-xs"
+                                                            intent="neutral"
+                                                            priority="secondary"
+                                                            textWrap="pretty"
+                                                        >
+                                                            {option.description}
+                                                        </Paragraph>
+                                                    )}
+                                                </Column>
+                                            </Radio>
+                                        );
+                                    })}
                                 </Column>
-                            </Radio>
-                        ))}
-                    </Column>
-                }
-                data-testid={`${dataTest}/dropdown`}
-            />
+                            ))}
+                        </Column>
+                    }
+                    data-testid={`${dataTest}/dropdown`}
+                />
+            </ComponentWithSubIcon>
         </Tooltip>
     );
 };

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -111,21 +111,29 @@ export const messages = defineMessages({
         description: 'Used as a variable for device name',
         id: 'TR_ANY_TREZOR',
     },
-    TR_FILTER: {
-        defaultMessage: 'Filter',
-        id: 'TR_FILTER',
+    TR_FILTERS: {
+        defaultMessage: 'Filters',
+        id: 'TR_FILTERS',
+    },
+    TR_SUSPICIOUS_TRANSACTIONS: {
+        defaultMessage: 'Suspicious transactions',
+        id: 'TR_SUSPICIOUS_TRANSACTIONS',
+    },
+    TR_SHOW_ALL: {
+        defaultMessage: 'Show all',
+        id: 'TR_SHOW_ALL',
+    },
+    TR_HIDE_SUSPICIOUS: {
+        defaultMessage: 'Hide suspicious',
+        id: 'TR_HIDE_SUSPICIOUS',
+    },
+    TR_DEFAULT: {
+        defaultMessage: 'Default',
+        id: 'TR_DEFAULT',
     },
     TR_HIDE_SCAM_TRANSACTIONS_TOOLTIP: {
         defaultMessage: 'Hide suspicious transactions for a cleaner view.',
         id: 'TR_HIDE_SCAM_TRANSACTIONS_TOOLTIP',
-    },
-    TR_SHOW_SUSPICIOUS_TRANSACTIONS: {
-        defaultMessage: 'Show suspicious transactions',
-        id: 'TR_SHOW_SUSPICIOUS_TRANSACTIONS',
-    },
-    TR_HIDE_SUSPICIOUS_TRANSACTIONS: {
-        defaultMessage: 'Hide suspicious transactions',
-        id: 'TR_HIDE_SUSPICIOUS_TRANSACTIONS',
     },
     TR_HIDE_SUSPICIOUS_TRANSACTIONS_DESCRIPTION: {
         defaultMessage: 'Crypto moves fast. Our filters may not always be 100% up to date.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Redesigns the transaction list filter dropdown to match the new design:

- "Filters" header with a "Clear all" button that resets filters to default
- "Suspicious transactions" section with "Show all" (with Default badge) and "Hide suspicious" options
- Funnel icon switches to brand intent and shows an active filter count badge when a filter is active
- Dropdown stays open when selecting an option

Component changes: `ComponentWithSubIcon` newly supports text `subContent` (used for the count badge, added to Storybook) and `Dropdown` accepts `intent`/`priority` for its icon button.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28644

## Screenshots:

<img width="392" height="309" alt="image" src="https://github.com/user-attachments/assets/af27ccba-8438-478e-8f67-aaf22ea7de82" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies two broadly-shared UI components (ComponentWithSubIcon, Dropdown), a transaction list filter action component (FilterAction.tsx), a Storybook file, and the intl messages file. The highest risk is in FilterAction.tsx which directly affects the transaction list view — tests exercising transaction listing, searching, filtering, pagination, and export are most critical. The Dropdown.tsx change is a widely-used component but only tests that specifically interact with dropdown menus (wallet extra menu, settings selectors) have concrete regression risk. ComponentWithSubIcon and messages.ts are too broadly consumed to target specific tests without evidence of behavioral changes.

<details><summary><b>Changed files (5)</b></summary>

- `packages/components/src/components/ComponentWithSubIcon/ComponentWithSubIcon.stories.tsx`
- `packages/components/src/components/ComponentWithSubIcon/ComponentWithSubIcon.tsx`
- `packages/components/src/components/Dropdown/Dropdown.tsx`
- `packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — FilterAction.tsx is a direct component in the transaction list view. This test exercises the account transaction overview, including searching and filtering transactions, which directly exercises the TransactionListActions area where FilterAction lives.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test extensively interacts with the transaction list UI (pending/confirmed groups, transaction items, transaction details), which renders through the TransactionList component tree where FilterAction.tsx resides. Changes to the Dropdown component used by FilterAction could affect transaction list rendering.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — Export transactions functionality is triggered from the transaction list view where FilterAction.tsx lives. The export action likely shares the TransactionListActions area, and the Dropdown component may be used for the export format selection.
- `suite/e2e/tests/wallet/pagination.test.ts` — Pagination test navigates through paginated transaction lists on a Bitcoin legacy account. The transaction list view renders TransactionListActions including FilterAction.tsx, so changes there could affect layout or rendering of the transaction page.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — This test uses the wallet extra dropdown menu (walletExtraDropDown) to access Sign & Verify, which directly exercises the Dropdown component. A bug in Dropdown could prevent the menu from opening.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — Similar to the BTC sign-and-verify test, this uses the wallet extra dropdown menu to navigate to Sign & Verify for Ethereum, directly exercising the Dropdown component.
- `suite/e2e/tests/settings/general.test.ts` — The settings general test exercises dropdown-based selectors (fiat currency, language, theme) which likely use the Dropdown component. Changes to Dropdown could affect these select interactions.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/components/src/components/ComponentWithSubIcon/ComponentWithSubIcon.stories.tsx`
- `suite/intl/src/messages.ts`

_Updated: 2026-07-10T14:49:47.131Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/transaction-filters-dropdown&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/transaction-filters-dropdown&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T14:53:05.497Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T14:53:34.448Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/transaction-filters-dropdown/web/](https://dev.suite.sldev.cz/suite-web/feat/transaction-filters-dropdown/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->