### PR TITLE
feat(trading): poll trade api watch endpoint after native approval/revoke

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -16,12 +16,10 @@ import {
     TRADING_FORM_PROVIDER_SELECT,
     type TradingExchangeAmountLimitProps,
     type TradingExchangeFormProps,
-    type TradingExchangeType,
     type TradingTransactionExchange,
     cryptoIdToNetwork,
     exchangeThunks,
     getDexEstimationData,
-    invityAPI,
     isSendingEvmNativeToken,
     selectTradingComposedTransactionInfo,
     selectTradingExchangeAmountLimits,
@@ -40,7 +38,6 @@ import {
 import { getNetwork, isAccountBasedNetwork } from '@suite-common/wallet-config';
 import {
     ETHEREUM_ADJUST_GAS_LIMIT,
-    fetchAndUpdateAccountThunk,
     selectAccountByKey,
     updateFeeInfoThunk,
 } from '@suite-common/wallet-core';
@@ -339,39 +336,6 @@ export const useTradingExchangeForm = (): TradingExchangeFormContextProps => {
         ).unwrap();
     };
 
-    const watchApproval = async ({ refreshCount }: { refreshCount: number }) => {
-        if (!selectedQuote) return;
-
-        const response = await invityAPI.watchTrade<TradingExchangeType>(
-            selectedQuote,
-            'exchange',
-            refreshCount,
-        );
-
-        if (!response.status || response.status === selectedQuote.status) {
-            return;
-        }
-
-        const updatedSelectedQuote = {
-            ...selectedQuote,
-            status: response.status,
-            error: response.error,
-            approvalType: undefined,
-        };
-
-        if (!updatedSelectedQuote.dexTx || !updatedSelectedQuote.receiveAddress) {
-            return;
-        }
-
-        const newTrade = await confirmApproval({
-            trade: updatedSelectedQuote,
-            receiveAddress: updatedSelectedQuote.receiveAddress,
-        });
-
-        dispatch(tradingExchangeActions.saveSelectedQuote(newTrade));
-        await dispatch(fetchAndUpdateAccountThunk({ accountKey: account.key }));
-    };
-
     const approveTransaction = async (exchangeTrade: ExchangeTrade) => {
         if (!receiveAddress) return false;
 
@@ -569,7 +533,6 @@ export const useTradingExchangeForm = (): TradingExchangeFormContextProps => {
         approveTransaction,
         revokeApproval,
         confirmApproval,
-        watchApproval,
         refreshQuotes,
         isScheduledQuotesRefresh,
         resetSelectedOffer,

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -238,7 +238,6 @@ export interface TradingExchangeFormContextProps
         trade?: ExchangeTrade;
         receiveAddress: string;
     }) => Promise<ExchangeTrade | undefined>;
-    watchApproval: ({ refreshCount }: { refreshCount: number }) => Promise<void>;
     refreshQuotes: () => Promise<void>;
     isScheduledQuotesRefresh: boolean;
     resetSelectedOffer: () => void;

--- a/suite-common/trading/src/hooks/useTradingExchangeWatchApproval.ts
+++ b/suite-common/trading/src/hooks/useTradingExchangeWatchApproval.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { type Account } from '@suite-common/wallet-types';
+
+import { useSelector } from './useSelector';
+import { selectTradingExchangeSelectedQuote } from '../selectors/tradingSelectors';
+import { exchangeThunks } from '../thunks/exchange';
+
+const POLLING_TIME = 5000;
+
+export type UseTradingExchangeWatchApprovalProps = {
+    account: Account | undefined;
+    isEnabled: boolean;
+};
+
+export const useTradingExchangeWatchApproval = ({
+    account,
+    isEnabled,
+}: UseTradingExchangeWatchApprovalProps) => {
+    const dispatch = useDispatch();
+    const status = useSelector(state => selectTradingExchangeSelectedQuote(state)?.status);
+
+    useEffect(() => {
+        if (!isEnabled || !account || status !== 'APPROVAL_PENDING') {
+            return;
+        }
+
+        let refreshCount = 1;
+        const intervalId = setInterval(() => {
+            dispatch(exchangeThunks.watchExchangeApprovalThunk({ account, refreshCount }));
+            refreshCount += 1;
+        }, POLLING_TIME);
+
+        return () => clearInterval(intervalId);
+    }, [account, status, isEnabled, dispatch]);
+};

--- a/suite-common/trading/src/index.ts
+++ b/suite-common/trading/src/index.ts
@@ -12,6 +12,7 @@ export * from './hooks/useProviderMetadataChangeEffect';
 export * from './hooks/useTradingFiatValues';
 export * from './hooks/useExchangeFiatDeviation';
 export * from './hooks/useApprovalStep';
+export * from './hooks/useTradingExchangeWatchApproval';
 export * from './hooks/useTradingRefetchScheduler';
 export {
     type TransactionStatus,

--- a/suite-common/trading/src/thunks/exchange/index.ts
+++ b/suite-common/trading/src/thunks/exchange/index.ts
@@ -7,6 +7,7 @@ import { selectExchangeQuoteThunk } from './selectExchangeQuoteThunk';
 import { sendDexTransactionThunk } from './sendDexTransactionThunk';
 import { sendTransactionThunk } from './sendTransactionThunk';
 import { signDataAndConfirmThunk } from './signDataAndConfirmThunk';
+import { watchExchangeApprovalThunk } from './watchExchangeApprovalThunk';
 
 export const exchangeThunks = {
     loadInfoThunk: loadExchangeInfoThunk,
@@ -18,4 +19,5 @@ export const exchangeThunks = {
     signDataAndConfirmThunk,
     sendDexTransactionThunk,
     sendTransactionThunk,
+    watchExchangeApprovalThunk,
 };

--- a/suite-common/trading/src/thunks/exchange/watchExchangeApprovalThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/watchExchangeApprovalThunk.ts
@@ -1,0 +1,47 @@
+import { createThunk } from '@suite-common/redux-utils';
+import { type Account } from '@suite-common/wallet-types';
+
+import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
+import { invityAPI } from '../../invityAPI';
+import { tradingExchangeActions } from '../../reducers/exchangeReducer';
+import { selectTradingExchangeSelectedQuote } from '../../selectors/tradingSelectors';
+
+export type WatchExchangeApprovalThunkProps = {
+    account: Account;
+    refreshCount: number;
+};
+
+// Read-only watch poll: saves the quote only when the backend advances its status.
+export const watchExchangeApprovalThunk = createThunk(
+    `${TRADING_EXCHANGE_THUNK_PREFIX}/watchExchangeApproval`,
+    async ({ account, refreshCount }: WatchExchangeApprovalThunkProps, { dispatch, getState }) => {
+        const selectedQuote = selectTradingExchangeSelectedQuote(getState());
+
+        if (!selectedQuote) {
+            return undefined;
+        }
+
+        invityAPI.createInvityAPIKey(account.descriptor);
+
+        const response = await invityAPI.watchTrade<'exchange'>(
+            selectedQuote,
+            'exchange',
+            refreshCount,
+        );
+
+        if (!response.status || response.status === selectedQuote.status) {
+            return undefined;
+        }
+
+        const updatedQuote = {
+            ...selectedQuote,
+            status: response.status,
+            error: response.error,
+            approvalType: undefined,
+        };
+
+        dispatch(tradingExchangeActions.saveSelectedQuote(updatedQuote));
+
+        return updatedQuote;
+    },
+);

--- a/suite-native/module-trading/src/screens/TradingConfirmingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingConfirmingScreen.tsx
@@ -1,12 +1,11 @@
 import { useCallback, useEffect, useEffectEvent, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { useFocusEffect } from '@react-navigation/native';
-
 import {
     selectTradingExchangeSelectedQuote,
     tradingExchangeActions,
     useAllowanceTxTracking,
+    useTradingExchangeWatchApproval,
 } from '@suite-common/trading';
 import { sendFormActions } from '@suite-common/wallet-core';
 import { Translation } from '@suite-native/intl';
@@ -24,7 +23,6 @@ import {
     useNavigationRemoveInterceptorAlert,
     useTransactionDetails,
 } from '@suite-native/transaction-management';
-import { exhaustive } from '@trezor/type-utils';
 
 import { ConfirmationQuoteDebugView } from '../components/exchange/Confirmation/ConfirmationQuoteDebugView';
 import { ExchangeConfirmationHeader } from '../components/exchange/Confirmation/ExchangeConfirmationHeader';
@@ -32,7 +30,6 @@ import { ExchangeConfirmationInfo } from '../components/exchange/Confirmation/Ex
 import { ExchangeConfirmationTitle } from '../components/exchange/Confirmation/ExchangeConfirmationTitle';
 import { ExploreInBlockchainButton } from '../components/exchange/Confirmation/ExploreInBlockchainButton';
 import { TradingDeviceConnectionGuard } from '../components/general/TradingDeviceConnectionGuard';
-import { useApprovalFlow } from '../hooks/exchange/Approval/useApprovalFlow';
 
 export type TradingConfirmingScreenProps = StackProps<
     RootStackParamList,
@@ -54,9 +51,7 @@ export const TradingConfirmingScreen = ({
         flowType === 'approve' ? 'approval-confirming' : 'revoke-confirming',
     );
 
-    const { confirmApproval } = useApprovalFlow();
-
-    const hasConfirmedRef = useRef(false);
+    const hasNavigatedRef = useRef(false);
 
     const {
         status: originalStatus,
@@ -84,7 +79,11 @@ export const TradingConfirmingScreen = ({
         txid: approvalTxid,
     });
 
-    const { isConfirmed, isFailed, isPending } = status;
+    const { isConfirmed, isFailed: isTxFailed } = status;
+
+    const isFailed = isTxFailed || activeQuote?.status === 'ERROR';
+
+    const isPending = !isFailed && activeQuote?.status === 'APPROVAL_PENDING';
 
     const navigateToInitialScreen = useNavigateToInitialScreen();
     const handleRemoveConfirmed = useCallback(() => {
@@ -106,92 +105,53 @@ export const TradingConfirmingScreen = ({
         },
     });
 
-    useFocusEffect(
-        useCallback(() => {
-            if (!isConfirmed || !activeQuote || hasConfirmedRef.current) return;
+    useTradingExchangeWatchApproval({
+        account: sendAccount,
+        isEnabled: isConfirmed && flowType !== 'revoke',
+    });
 
-            hasConfirmedRef.current = true;
+    useEffect(() => {
+        if (!activeQuote || hasNavigatedRef.current || !isConfirmed) {
+            return;
+        }
 
-            const handleConfirmed = async () => {
-                switch (flowType) {
-                    case 'approve': {
-                        const response = await confirmApproval(activeQuote);
+        if (flowType === 'revoke') {
+            hasNavigatedRef.current = true;
+            dispatch(sendFormActions.dispose());
+            dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
+            navigation.popToTop();
+            reportToAnalytics('continue');
 
-                        if (response?.status === 'APPROVAL_PENDING') {
-                            // we know it was confirmed, so we can set the status to CONFIRM even if it came as APPROVAL_PENDING
-                            // that is basically what api does (but it takes time)
-                            // so we need to do it here to avoid the approval screen transition through useExchangeFlow
-                            dispatch(
-                                tradingExchangeActions.saveSelectedQuote({
-                                    ...response,
-                                    status: 'CONFIRM',
-                                }),
-                            );
-                        }
+            return;
+        }
 
-                        if (!response) {
-                            // confirmApproval already sets the error state — stay on this screen.
-                            hasConfirmedRef.current = false;
+        if (activeQuote.status === 'CONFIRM') {
+            hasNavigatedRef.current = true;
+            dispatch(sendFormActions.dispose());
+            navigation.popToTop();
+            navigation.push(RootStackRoutes.TradingExchangePreview, { isApproved: true });
+            reportToAnalytics('continue');
 
-                            return;
-                        }
+            return;
+        }
 
-                        dispatch(sendFormActions.dispose());
-                        navigation.popToTop();
-                        navigation.push(RootStackRoutes.TradingExchangePreview, {
-                            isApproved: true,
-                        });
-                        break;
-                    }
-
-                    case 'revoke-and-approve':
-                        dispatch(sendFormActions.dispose());
-                        // The post-revoke quote carries the revoke transaction's
-                        // approvalSendTxHash and approvalType: 'ZERO'. Strip them so the
-                        // next confirmApproval call requests a fresh approval rather than
-                        // re-using the revoke txid as the approval txid.
-                        if (activeQuote) {
-                            dispatch(
-                                tradingExchangeActions.saveSelectedQuote({
-                                    ...activeQuote,
-                                    approvalSendTxHash: undefined,
-                                    approvalType: undefined,
-                                    status: 'APPROVAL_REQ',
-                                }),
-                            );
-                        }
-                        navigation.popToTop();
-                        navigation.push(RootStackRoutes.TradingExchangeApproval, {
-                            isRevoked: true,
-                        });
-                        break;
-
-                    case 'revoke':
-                        dispatch(sendFormActions.dispose());
-                        dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
-                        navigation.popToTop();
-                        break;
-
-                    default:
-                        exhaustive(flowType);
-                }
-
-                reportToAnalytics('continue');
-            };
-
-            void handleConfirmed().catch(() => {
-                hasConfirmedRef.current = false;
+        if (activeQuote.status === 'APPROVAL_REQ') {
+            hasNavigatedRef.current = true;
+            dispatch(sendFormActions.dispose());
+            dispatch(
+                tradingExchangeActions.saveSelectedQuote({
+                    ...activeQuote,
+                    approvalSendTxHash: undefined,
+                    approvalType: undefined,
+                }),
+            );
+            navigation.popToTop();
+            navigation.push(RootStackRoutes.TradingExchangeApproval, {
+                isRevoked: flowType === 'revoke-and-approve',
             });
-        }, [
-            isConfirmed,
-            activeQuote,
-            flowType,
-            confirmApproval,
-            dispatch,
-            navigation,
-            reportToAnalytics,
-        ]),
-    );
+            reportToAnalytics('continue');
+        }
+    }, [activeQuote, flowType, isConfirmed, dispatch, navigation, reportToAnalytics]);
 
     return (
         <TradingDeviceConnectionGuard>

--- a/suite-native/module-trading/src/screens/__tests__/TradingConfirmingScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingConfirmingScreen.test.tsx
@@ -30,14 +30,6 @@ jest.mock('@suite-common/device', () => ({
     selectIsDeviceConnected: () => true,
 }));
 
-const mockConfirmApproval = jest.fn().mockResolvedValue({});
-
-jest.mock('../../hooks/exchange/Approval/useApprovalFlow', () => ({
-    useApprovalFlow: () => ({
-        confirmApproval: mockConfirmApproval,
-    }),
-}));
-
 const mockUseTransactionDetails = useTransactionDetails as jest.Mock;
 const mockUseNavigationRemoveInterceptorAlert = jest.mocked(useNavigationRemoveInterceptorAlert);
 
@@ -124,7 +116,6 @@ describe('TradingConfirmingScreen', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-        mockConfirmApproval.mockResolvedValue({});
         store = createTradingLightStore({ tradeType: 'exchange' });
         store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
         mockUseAllowanceTxTracking.mockReturnValue({
@@ -174,13 +165,18 @@ describe('TradingConfirmingScreen', () => {
         expect(mockNavigation.push).not.toHaveBeenCalled();
     });
 
-    it('approve: navigates to TradingExchangePreview after confirmApproval succeeds', async () => {
+    it('approve: navigates to TradingExchangePreview when the quote status becomes CONFIRM', () => {
         mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
 
         renderScreen({ flowType: 'approve' });
 
-        await act(async () => {
-            await Promise.resolve(); // flush confirmApproval promise
+        expect(mockNavigation.push).not.toHaveBeenCalled();
+
+        // Simulate the backend advancing the status (what the watch poll saves).
+        act(() => {
+            store.dispatch(
+                tradingExchangeActions.saveSelectedQuote({ ...testQuote, status: 'CONFIRM' }),
+            );
         });
 
         expect(mockNavigation.popToTop).toHaveBeenCalled();
@@ -189,31 +185,13 @@ describe('TradingConfirmingScreen', () => {
         });
     });
 
-    it('approve: saves quote with CONFIRM status when confirmApproval returns APPROVAL_PENDING', async () => {
+    it('approve: does not navigate while status stays APPROVAL_PENDING', () => {
         mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
-        mockConfirmApproval.mockResolvedValue({ ...testQuote, status: 'APPROVAL_PENDING' });
-
-        renderScreen({ flowType: 'approve' });
-
-        await act(async () => {
-            await Promise.resolve();
-        });
-
-        expect(selectTradingExchangeSelectedQuote(store.getState())).toEqual(
-            expect.objectContaining({ status: 'CONFIRM' }),
+        store.dispatch(
+            tradingExchangeActions.saveSelectedQuote({ ...testQuote, status: 'APPROVAL_PENDING' }),
         );
-        expect(mockNavigation.popToTop).toHaveBeenCalled();
-    });
-
-    it('approve: does not navigate when confirmApproval fails', async () => {
-        mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
-        mockConfirmApproval.mockResolvedValue(undefined);
 
         renderScreen({ flowType: 'approve' });
-
-        await act(async () => {
-            await Promise.resolve();
-        });
 
         expect(mockNavigation.popToTop).not.toHaveBeenCalled();
         expect(mockNavigation.push).not.toHaveBeenCalled();
@@ -231,28 +209,31 @@ describe('TradingConfirmingScreen', () => {
         );
         mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
 
-        const dispatchSpy = jest.spyOn(store, 'dispatch');
-
         renderScreen({ flowType: 'revoke-and-approve' });
+
+        expect(mockNavigation.push).not.toHaveBeenCalled();
+
+        // Simulate the backend reporting the follow-up approval is required.
+        act(() => {
+            store.dispatch(
+                tradingExchangeActions.saveSelectedQuote({
+                    ...testQuote,
+                    approvalType: 'ZERO',
+                    approvalSendTxHash: 'revoke-txid',
+                    status: 'APPROVAL_REQ',
+                }),
+            );
+        });
 
         expect(mockNavigation.popToTop).toHaveBeenCalled();
         expect(mockNavigation.push).toHaveBeenCalledWith(RootStackRoutes.TradingExchangeApproval, {
             isRevoked: true,
         });
-        const dispatchedActions = dispatchSpy.mock.calls.map(([action]) => action);
-        // savePreselectedQuote action no longer exists; assert against the action-type string.
-        expect(
-            dispatchedActions.find(
-                (action: any) => action?.type === '@trading-exchange/savePreselectedQuote',
-            ),
-        ).toBeUndefined();
         const persisted = selectTradingExchangeSelectedQuote(store.getState());
         expect(persisted).toBeDefined();
         expect(persisted?.approvalSendTxHash).toBeUndefined();
         expect(persisted?.approvalType).toBeUndefined();
         expect(persisted?.status).toBe('APPROVAL_REQ');
-
-        dispatchSpy.mockRestore();
     });
 
     it('revoke: pops to top and clears selectedQuote', () => {
@@ -327,6 +308,18 @@ describe('TradingConfirmingScreen', () => {
         );
     });
 
+    it('surfaces a backend error status and allows leaving without confirmation', () => {
+        mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
+        store.dispatch(tradingExchangeActions.saveSelectedQuote({ ...testQuote, status: 'ERROR' }));
+
+        renderScreen({ flowType: 'approve' });
+
+        expect(mockUseNavigationRemoveInterceptorAlert).toHaveBeenCalledWith(
+            expect.objectContaining({ shouldPrevent: false }),
+        );
+        expect(mockNavigation.push).not.toHaveBeenCalled();
+    });
+
     describe('analytics', () => {
         it('should report approval-confirming visit ', () => {
             renderScreen();
@@ -363,14 +356,15 @@ describe('TradingConfirmingScreen', () => {
             expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);
         });
 
-        it('should report continue when on navigation to next screen', async () => {
+        it('should report continue when on navigation to next screen', () => {
             mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
-            mockConfirmApproval.mockResolvedValue({ ...testQuote, status: 'APPROVAL_PENDING' });
 
             renderScreen({ flowType: 'approve' });
 
-            await act(async () => {
-                await Promise.resolve();
+            act(() => {
+                store.dispatch(
+                    tradingExchangeActions.saveSelectedQuote({ ...testQuote, status: 'CONFIRM' }),
+                );
             });
 
             expect(mockAnalyticsReport).toHaveBeenCalledWith('approval-confirming', 'continue');


### PR DESCRIPTION
## Description

Native exchange approval/revoke confirming flow. Replaces the force-`CONFIRM` hack: previously, once the approval/revoke tx confirmed on-chain the screen called `confirmApproval` once and locally overwrote `APPROVAL_PENDING` -> `CONFIRM`, guessing the backend had caught up. Now it polls the read-only trade api watch endpoint (`watchExchangeApprovalThunk` via `useTradingExchangeWatchApproval`, every 5s) after on-chain confirmation and navigates on the backend-reported quote status: `CONFIRM` -> swap preview, `APPROVAL_REQ` -> approval screen.

Also removes the orphaned desktop `watchApproval` hook/form code (dead on `develop`; superseded by desktop `useApprovalStep`).

## Notes for QA

Native DEX swap. Approve a token then confirm the swap; and the revoke-then-approve path. Verify the confirming screen advances to the correct next step only after the backend confirms (no premature navigation), and that a plain revoke still finishes as before.

## Related Issue

Resolve #29511

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on the trading/exchange (swap) functionality: the exchange form hook, exchange thunks, approval watching logic, form types, and the trading module index. The highest risk is in the swap execution flow — particularly DEX swaps that require token approval watching (watchExchangeApprovalThunk). The recommended strategy prioritizes all swap E2E tests that exercise the full exchange flow (coin-to-token, token-to-coin, token-to-token, coin-to-coin, DEX), with medium priority for swap fee, input validation, and history tests. The native mobile changes (TradingConfirmingScreen) and its unit test have no E2E coverage in this suite.

<details><summary><b>Changed files (8)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts`
- `packages/suite/src/types/trading/tradingForm.ts`
- `suite-common/trading/src/hooks/useTradingExchangeWatchApproval.ts`
- `suite-common/trading/src/index.ts`
- `suite-common/trading/src/thunks/exchange/index.ts`
- `suite-common/trading/src/thunks/exchange/watchExchangeApprovalThunk.ts`
- `suite-native/module-trading/src/screens/TradingConfirmingScreen.tsx`
- `suite-native/module-trading/src/screens/__tests__/TradingConfirmingScreen.test.tsx`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test exercises the swap/exchange flow end-to-end including confirmation and transaction sending. The changed files modify the exchange form hook (useTradingExchangeForm), exchange thunks, and the approval watching logic — all directly involved in the swap confirmation and execution pipeline.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Swap coins (SOL→BTC) test covers the full exchange flow including quote selection, confirmation, device signing, and transaction status polling. The exchange thunks and form hook changes directly affect this swap execution path, including the approval watching mechanism for swap completion.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — DEX swaps through LI.FI are the most likely path to exercise the approval watching logic (watchExchangeApprovalThunk) since DEX trades often require token approval transactions before the actual swap. This test covers the full DEX exchange flow including confirmation and status transitions.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Token-to-coin swaps (USDT→BTC) test the exchange form and confirmation flow. Token swaps may trigger the approval watching mechanism since ERC-20/SPL token swaps often require prior approval, making this a direct test of the watchExchangeApprovalThunk changes.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Token-to-token swaps (USDT→USDC) directly exercise the exchange form hook and exchange thunks. These swaps are most likely to require token approval steps, directly testing the watchExchangeApprovalThunk flow.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test verifies Bitcoin swap fee calculation and device confirmation during exchange. While it focuses on fee details, it still exercises the exchange form hook and thunks to get to the confirmation step.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Ethereum swap fee test exercises the exchange form with custom gas parameters. Changes to the exchange form hook could affect how fees are composed and displayed in the swap confirmation flow.
- `suite/e2e/tests/trading/swap-history.test.ts` — Swap history displays past exchange trades and their statuses. Changes to the exchange thunks index (which re-exports exchange-related functionality) could affect how trade status data is stored and displayed in history.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Swap input validation tests exercise the swap form filling and quote fetching. The useTradingExchangeForm hook changes could affect form state management, validation, and how inputs interact with the exchange flow.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test verifies swap form behavior when the buy asset's network is disabled. Changes to the exchange form hook could affect how the form handles cross-network asset selection and quote display.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — Navigation test verifies routing to swap/buy/sell forms. While it doesn't deeply exercise the exchange logic, changes to the trading module index and form types could theoretically break the swap form initialization when navigated to.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-native/module-trading/src/screens/TradingConfirmingScreen.tsx`
- `suite-native/module-trading/src/screens/__tests__/TradingConfirmingScreen.test.tsx`

_Updated: 2026-07-09T13:05:32.065Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-unused-watch-approval&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-unused-watch-approval&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/remove-unused-watch-approval&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-09T13:13:26.318Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-09T13:14:59.134Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/remove-unused-watch-approval/web/](https://dev.suite.sldev.cz/suite-web/chore/remove-unused-watch-approval/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->