### PR TITLE
test(urls): remove LTC_ADDRESS_INFO_URL from expected failing URLs

### DIFF
--- a/packages/urls/tests/e2e/urls.test.ts
+++ b/packages/urls/tests/e2e/urls.test.ts
@@ -14,8 +14,6 @@ const skippedUrls = [
 const expectedFailingUrls = [
     // DATA_URL because it returns 404 on itself (forbidden listing)
     URLS.DATA_URL,
-    // 503 from CI
-    URLS.LTC_ADDRESS_INFO_URL,
     // captcha, returning 403 in ci
     URLS.TREZOR_FORUM_URL,
     URLS.IMAGE_PROXY_API_URL, // returns 'unauthorized'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The URL test was failing for some time on this URL that seems to be accessible now from CI
[Actions](https://github.com/trezor/trezor-suite/actions/workflows/test-urls.yml)
Error:
```
  ● External URLs integration › URLs expected to be failing › HTTP GET request to https://blog.trezor.io/litecoins-new-p2sh-segwit-addresses-843633e3e707 should respond with an unacceptable http code

    thrown: "Got acceptable http code 200. Remove https://blog.trezor.io/litecoins-new-p2sh-segwit-addresses-843633e3e707 from expectedFailingUrls."

      78 |             .filter(url => expectedFailingUrls.includes(url) && !skippedUrls.includes(url))
      79 |             .forEach(url => {
    > 80 |                 it(`HTTP GET request to ${url} should respond with an unacceptable http code`, async () => {
         |                 ^
      81 |                     const { status } = await fetch(url);
      82 |                     const isAcceptable = isAcceptableHttpCode(status);
      83 |                     if (isAcceptable) {

      at it (tests/e2e/urls.test.ts:80:17)
          at Array.forEach (<anonymous>)
      at forEach (tests/e2e/urls.test.ts:79:14)
      at describe (tests/e2e/urls.test.ts:76:5)
      at Object.describe (tests/e2e/urls.test.ts:43:1)
```

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/removes-passing-url/web/](https://dev.suite.sldev.cz/suite-web/removes-passing-url/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is a test file for the @trezor/urls package (packages/urls/tests/e2e/urls.test.ts), not a source file itself. This is a very low-risk change since it's modifying test code rather than production code. However, if the test change reflects underlying URL constant changes, the check-links test would be the most relevant E2E test to validate that all URLs remain functional. The backup fail test has a minor connection through its assertion on HELP_CENTER_RECOVERY_ISSUES_URL.

<details><summary><b>Changed files (1)</b></summary>

- `packages/urls/tests/e2e/urls.test.ts`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — The changed file is a test for the @trezor/urls package. The check-links test validates that all URLs used across the Suite app return HTTP 200, and it relies on URL constants from @trezor/urls. If the urls.test.ts change reflects modifications to URL definitions or additions/removals, the check-links test would catch any broken links in the application.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test explicitly asserts that the backup failed setting link href matches the HELP_CENTER_RECOVERY_ISSUES_URL from @trezor/urls. If the URL constants were modified alongside this test change, this would catch regressions in that specific URL reference.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/urls/tests/e2e/urls.test.ts`

_Updated: 2026-07-09T07:18:24.131Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=removes-passing-url&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=removes-passing-url&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-09T07:29:50.300Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-09T07:22:09.399Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->