### PR TITLE
test(suite): fixes coverage map building in workflow

### DIFF
--- a/.github/workflows/test-suite-web-desktop-e2e-nightly.yml
+++ b/.github/workflows/test-suite-web-desktop-e2e-nightly.yml
@@ -152,14 +152,14 @@ jobs:
         with:
           pattern: coverage-map-group-*
           merge-multiple: true
-          path: coverage-map/
+          path: packages/e2e-utils/coverage-map/
 
       - name: Build coverage map index
         run: |
-          yarn tsx packages/e2e-utils/src/testCoverage/buildCoverageMap.ts \
+          yarn workspace @trezor/e2e-utils build-coverage-map \
             --input coverage-map \
             --output coverage-map/index.json
 
       - name: Upload coverage map to S3
         run: |
-          aws s3api put-object --bucket dev.suite.sldev.cz --key coverage/e2e/index.json --body coverage-map/index.json --content-type application/json --cache-control "no-cache, max-age=0"
+          aws s3api put-object --bucket dev.suite.sldev.cz --key coverage/e2e/index.json --body packages/e2e-utils/coverage-map/index.json --content-type application/json --cache-control "no-cache, max-age=0"

--- a/packages/e2e-utils/package.json
+++ b/packages/e2e-utils/package.json
@@ -10,6 +10,7 @@
         "type-check": "yarn g:tsc --build",
         "test-health": "tsx ./src/quarantineBot/index.ts",
         "select-tests": "tsx ./src/testCoverage/selectTestsByChangedFiles.ts",
+        "build-coverage-map": "tsx ./src/testCoverage/buildCoverageMap.ts",
         "seed-tests": "CURRENTS_PROJECT_ID=iBEsWE yarn pwc --config ./src/quarantineBot/seed/playwright.config.ts",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "analyze-tests": "tsx ./src/llmTestAnalyzer/index.ts",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes coverage map building. It is now executed in same manner as rest of our test CI jobs and should not fail on missing tsx `Usage Error: Couldn't find a script named "tsx".`

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-nightly-coverage-building&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-nightly-coverage-building&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-09T07:58:18.061Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-09T07:55:52.285Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-nightly-coverage-building/web/](https://dev.suite.sldev.cz/suite-web/fix-nightly-coverage-building/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->