### PR TITLE
refactor(utils): extract RgbColor and RgbaColor template-literal types

### DIFF
--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -1,6 +1,3 @@
-export type CSSColor =
-    | `#${string}`
-    | `rgb(${number}, ${number}, ${number})`
-    | `rgba(${number}, ${number}, ${number}, ${number})`
-    | 'transparent'
-    | 'currentColor';
+import { type RgbColor, type RgbaColor } from '@trezor/utils';
+
+export type CSSColor = `#${string}` | RgbColor | RgbaColor | 'transparent' | 'currentColor';

--- a/packages/utils/src/hexToRgba.ts
+++ b/packages/utils/src/hexToRgba.ts
@@ -1,7 +1,7 @@
-export function hexToRgba(
-    hex: string,
-    alpha?: number,
-): `rgba(${number}, ${number}, ${number}, ${number})` | `rgb(${number}, ${number}, ${number})` {
+export type RgbColor = `rgb(${number}, ${number}, ${number})`;
+export type RgbaColor = `rgba(${number}, ${number}, ${number}, ${number})`;
+
+export function hexToRgba(hex: string, alpha?: number): RgbaColor | RgbColor {
     const norm = hex.replace('#', '');
     const r = parseInt(norm.slice(0, 2), 16);
     const g = parseInt(norm.slice(2, 4), 16);

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -33,7 +33,7 @@ export * from './getWeakRandomId';
 export * from './getWeakRandomInt';
 export * from './getWeakRandomNumberInRange';
 export * from './getWeakRandomUUID';
-export { hexToRgba } from './hexToRgba';
+export { type RgbColor, type RgbaColor, hexToRgba } from './hexToRgba';
 export { hexToRgbaArray } from './hexToRgbaArray';
 export * from './isArrayMember';
 export * from './isFullPath';

--- a/suite-native/trading-atoms/src/hooks/useAnimatedBorderStyle.ts
+++ b/suite-native/trading-atoms/src/hooks/useAnimatedBorderStyle.ts
@@ -7,6 +7,7 @@ import {
 } from 'react-native-reanimated';
 
 import { useNativeStyles } from '@trezor/styles-native';
+import { type RgbaColor } from '@trezor/utils';
 
 export const useAnimatedBorderStyle = (isAmountInputActive: boolean) => {
     const { utils } = useNativeStyles();
@@ -17,7 +18,7 @@ export const useAnimatedBorderStyle = (isAmountInputActive: boolean) => {
             progress.value,
             [0, 1],
             [utils.colors.surfaceFillRaised, utils.colors.elementBorderFieldFocused],
-        ) as `rgba(${number}, ${number}, ${number}, ${number})`,
+        ) as RgbaColor,
         borderWidth: interpolate(progress.value, [0, 1], [0, utils.borders.widths.large]),
         borderRadius: utils.borders.radii.r16,
     }));


### PR DESCRIPTION
## Summary

Follow-up to #28979, resolving [this review comment](https://github.com/trezor/trezor-suite/pull/28979#discussion_r3550091203): extract the `rgb(...)`/`rgba(...)` template-literal types as named types and use them everywhere.

## What this PR does

- Adds `RgbColor` and `RgbaColor` type exports to `@trezor/utils` (defined next to `hexToRgba`, which now uses them as its return type).
- `@trezor/theme`'s `CSSColor` union reuses the named types instead of spelling out identical inline members (`theme` already depends on `utils`; the types live in `utils` because the dependency direction rules out the reverse).
- `suite-native/trading-atoms` `useAnimatedBorderStyle` replaces its hand-written `as `rgba(...)`` cast with `as RgbaColor`.

All replacements are type-identical, so there is no behavioral or type-level change — a repo-wide grep confirms no other hand-written occurrences of these template-literal types remain.

Stacked on #28979 — merge that one first (GitHub will retarget this PR to `develop` automatically once the base branch is merged and deleted).

## Notes for QA

No QA needed — type-only refactor with no runtime effect.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies low-level utility and type files: a theme types definition, a hexToRgba color conversion utility, the utils barrel export, and a React Native trading hook. The hexToRgba utility maps to 38+ tests via static coverage, but it is a deeply transitive dependency unlikely to cause E2E-visible regressions unless the function signature or output format changes. The theme types change is most likely to surface in the autodetect test which directly asserts theme colors. The suite-native hook is mobile-only and has no web E2E coverage. Overall risk is low — these are foundational utility/type changes that are best validated by unit tests rather than E2E tests.

<details><summary><b>Changed files (4)</b></summary>

- `packages/theme/src/types.ts`
- `packages/utils/src/hexToRgba.ts`
- `packages/utils/src/index.ts`
- `suite-native/trading-atoms/src/hooks/useAnimatedBorderStyle.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/settings/autodetect.test.ts` — This test directly asserts CSS color values from the theme (colorVariants standard and dark definitions) and background colors. Changes to packages/theme/src/types.ts could alter theme type definitions that affect how colors are resolved, potentially causing color assertion mismatches.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/utils/src/index.ts`
- `suite-native/trading-atoms/src/hooks/useAnimatedBorderStyle.ts`

_Updated: 2026-07-09T15:05:17.106Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/rgb-color-types/web/](https://dev.suite.sldev.cz/suite-web/mroz22/rgb-color-types/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/rgb-color-types&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/rgb-color-types&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/rgb-color-types&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-09T15:08:43.930Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-09T15:08:38.409Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->