### PR TITLE
fix(workflow): consolidate web and desktop E2E release jobs in orches…

### DIFF
--- a/.github/workflows/test-suite-release-e2e-report-orchestration.yml
+++ b/.github/workflows/test-suite-release-e2e-report-orchestration.yml
@@ -14,14 +14,8 @@ jobs:
     uses: ./.github/workflows/test-suite-manual-release.yml
     secrets: inherit
 
-  call-test-suite-desktop-e2e-release:
-    uses: ./.github/workflows/test-suite-desktop-e2e-release.yml
-    secrets: inherit
-    with:
-      publish_results_to_github: true
-
-  call-test-suite-web-e2e-release:
-    uses: ./.github/workflows/test-suite-web-e2e-release.yml
+  call-test-suite-web-desktop-e2e-release:
+    uses: ./.github/workflows/test-suite-web-desktop-e2e-release.yml
     secrets: inherit
     with:
       publish_results_to_github: true


### PR DESCRIPTION
## Description
fix release orchestration test runs after merging web and desktop runs in https://github.com/trezor/trezor-suite/pull/28292

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-report-orchestration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-report-orchestration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-09T09:43:55.158Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-09T09:42:17.344Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-report-orchestration/web/](https://dev.suite.sldev.cz/suite-web/fix-report-orchestration/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->