### PR TITLE
test(assets): add e2e test for activating assets modal and user inter actions

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ActivateAssetsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ActivateAssetsModal.tsx
@@ -161,7 +161,11 @@ export const ActivateAssetsModal = ({ onCancel }: ActivateAssetsModalProps) => {
                                 icon={InfoIcon}
                                 title={<Translation id="TR_DASHBOARD_MODAL_ACTIVATE_ASSETS_NOTE" />}
                                 rightContent={
-                                    <Banner.Button size="small" onClick={handleBannerClose}>
+                                    <Banner.Button
+                                        size="small"
+                                        onClick={handleBannerClose}
+                                        data-testid="@modal/activate-assets/got-it"
+                                    >
                                         <Translation id="TR_GOT_IT" />
                                     </Banner.Button>
                                 }

--- a/suite/e2e/support/pageObjects/assetsSection.ts
+++ b/suite/e2e/support/pageObjects/assetsSection.ts
@@ -12,8 +12,13 @@ export class AssetsSection {
         this.page.getByTestId(`@dashboard/asset/${symbol}/buy-button`);
     readonly enableMoreCoins: Locator;
     readonly activateAssetsModalSaveButton: Locator;
+    readonly activateAssetsModalNoteGotItButton: Locator;
     readonly activateAssetsModalNetworkButton = (symbol: NetworkSymbol) =>
         this.page.getByTestId(`@settings/wallet/network/${symbol}`);
+    readonly assetName = (symbol: NetworkSymbol) =>
+        this.page
+            .getByTestId(`@dashboard/asset-item/${symbol}`)
+            .getByTestId('@dashboard/asset/name');
     readonly assetCard = (symbol: NetworkSymbol) =>
         this.page.getByTestId(`@dashboard/asset-card/${symbol}`);
     readonly assetRow = (symbol: NetworkSymbol) =>
@@ -30,6 +35,9 @@ export class AssetsSection {
         this.gridIcon = this.page.getByTestId('@dashboard/assets/grid-icon');
         this.enableMoreCoins = this.page.getByTestId('@dashboard/assets/enable-more-coins');
         this.activateAssetsModalSaveButton = this.page.getByTestId('@modal/activate-assets/save');
+        this.activateAssetsModalNoteGotItButton = this.page.getByTestId(
+            '@modal/activate-assets/got-it',
+        );
         this.bottomInfo = this.page.getByTestId('@dashboard/asset/bottom-info');
         this.assetExchangeRate = this.page.getByTestId('@dashboard/asset/exchange-rate');
         this.assetWeekChange = this.page.getByTestId('@dashboard/asset/week-change');

--- a/suite/e2e/tests/onboarding/get-started-modal.test.ts
+++ b/suite/e2e/tests/onboarding/get-started-modal.test.ts
@@ -1,0 +1,34 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
+
+import { expect, test } from '../../support/fixtures';
+
+const networks: NetworkSymbol[] = ['btc', 'eth', 'pol', 'bsc', 'arb'];
+
+test.describe('Onboarding', { tag: ['@T3W1', '@T3T1'] }, () => {
+    test.beforeEach(async ({ onboardingPage }) => {
+        await onboardingPage.completeOnboarding();
+    });
+
+    test('Verify get started modal works and loads coins', async ({
+        dashboardPage,
+        assetsSection,
+        page,
+    }) => {
+        await expect(dashboardPage.discoveryEmptyHeader).toHaveTranslation(
+            'TR_YOUR_WALLET_IS_READY_WHAT',
+        );
+        await dashboardPage.discoveryEmptyPrimaryButton.click();
+
+        await expect(page.modalHeader).toHaveTranslation(
+            'TR_DASHBOARD_MODAL_ACTIVATE_ASSETS_TITLE',
+        );
+        await assetsSection.activateAssetsModalNoteGotItButton.click();
+
+        await assetsSection.enableNetworkViaActivateAssetsModal(networks);
+        await page.discoveryShouldFinish();
+        for (const coin of networks) {
+            await expect(assetsSection.assetName(coin)).toBeVisible();
+        }
+        await expect(dashboardPage.discoveryEmptyHeader).toBeHidden();
+    });
+});


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

add e2e test for activating assets modal and user interactions
## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/get-started-modal-test/web/](https://dev.suite.sldev.cz/suite-web/get-started-modal-test/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=get-started-modal-test&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=get-started-modal-test&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-17T12:43:54.164Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-17T12:43:23.961Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->