### PR TITLE
fix(suite-native): use transaction historic fiat rate only if available

### DIFF
--- a/suite-native/transactions/src/components/TransactionTarget.tsx
+++ b/suite-native/transactions/src/components/TransactionTarget.tsx
@@ -73,13 +73,12 @@ export const TransactionListItemValues = ({
                         value={amount}
                         symbol={transaction.symbol}
                         historicRate={historicRate}
-                        useHistoricRate
+                        useHistoricRate={!!historicRate}
                         isForcedDiscreetMode={isPhishingTransaction}
                         style={applyStyle(failedTxStyle, { isFailedTx })}
                     />
                 </Box>
             )}
-
             <CryptoAmountFormatter
                 value={amount}
                 symbol={transaction.symbol}


### PR DESCRIPTION
## Description

Blockbook returns `blockTime` even though a transaction is still unconfirmed while Electrum backend doesn't. Missing `blockTime` means no historic fiat rate is available and that leads to the fiat value skeleton to be shown.

## Screenshots:

| Before | After |
| --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/4b047b45-13d1-4d0e-98be-382a8b8534b3" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/72d6400f-5a75-4a0c-a103-fa51567517c3" /> |


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/transaction-fiat-amount&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->