### PR TITLE
fix(suite-native): remove redundant search input ref assertion

### DIFF
--- a/suite-native/atoms/src/Input/BottomSheetSearchInput.tsx
+++ b/suite-native/atoms/src/Input/BottomSheetSearchInput.tsx
@@ -1,4 +1,4 @@
-import { type Ref, forwardRef } from 'react';
+import { forwardRef } from 'react';
 import { type TextInput } from 'react-native';
 
 import { SearchInput, type SearchInputProps } from './SearchInput';
@@ -13,4 +13,4 @@ export type BottomSheetSearchInputRef = TextInput | null;
 export const BottomSheetSearchInput = forwardRef<
     BottomSheetSearchInputRef,
     BottomSheetSearchInputProps
->((props, ref) => <SearchInput ref={ref as Ref<TextInput>} {...props} isBottomSheetInput />);
+>((props, ref) => <SearchInput ref={ref} {...props} isBottomSheetInput />);


### PR DESCRIPTION
## Description

Removes an unnecessary `Ref<TextInput>` assertion from `BottomSheetSearchInput` and drops the now-unused `Ref` import.

This fixes the `@typescript-eslint/no-unnecessary-type-assertion` lint failure in `@suite-native/atoms` after the rule was enabled repo-wide.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/fix-atoms-search-input-lint&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->