### PR TITLE
feat(suite-native): show representative asset icons in coin enabling list

### DIFF
--- a/suite-native/coin-enabling/package.json
+++ b/suite-native/coin-enabling/package.json
@@ -31,6 +31,7 @@
         "react": "19.2.3",
         "react-native": "0.85.3",
         "react-native-reanimated": "4.3.1",
+        "react-native-svg": "15.15.5",
         "react-redux": "9.3.0"
     }
 }

--- a/suite-native/coin-enabling/src/components/CryptoIconSet.tsx
+++ b/suite-native/coin-enabling/src/components/CryptoIconSet.tsx
@@ -1,0 +1,84 @@
+import {
+    type NetworkSymbol,
+    getNetwork,
+    getRepresentativeAssets,
+} from '@suite-common/wallet-config';
+import { Box, Text } from '@suite-native/atoms';
+import { CryptoIcon } from '@suite-native/icons';
+import { Translation } from '@suite-native/intl';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+export type CryptoIconSetProps = {
+    symbol: NetworkSymbol;
+};
+
+const ICON_SIZE = 20;
+const RING_WIDTH = 2;
+const ICONS_OVERLAP = 8;
+
+const bubbleStyle = prepareNativeStyle<{ isFirst: boolean; zIndex: number }>(
+    (utils, { isFirst, zIndex }) => ({
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: ICON_SIZE + RING_WIDTH * 2,
+        height: ICON_SIZE + RING_WIDTH * 2,
+        marginLeft: isFirst ? 0 : -ICONS_OVERLAP,
+        borderRadius: utils.borders.radii.round,
+        backgroundColor: utils.colors.surfaceFillRaised,
+        zIndex,
+    }),
+);
+
+const countStyle = prepareNativeStyle(utils => ({
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: ICON_SIZE + RING_WIDTH * 2,
+    marginLeft: -ICONS_OVERLAP + utils.spacings.sp2,
+    paddingHorizontal: utils.spacings.sp4,
+    borderRadius: utils.borders.radii.round,
+    backgroundColor: utils.colors.elementFillNeutralSofter,
+    zIndex: 0,
+}));
+
+export const CryptoIconSet = ({ symbol }: CryptoIconSetProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    const assets = getRepresentativeAssets(symbol);
+
+    if (assets.length === 0) {
+        return null;
+    }
+
+    const showCount = assets.length > 1;
+
+    // Native coins have no contract – render their icon via the settlement layer symbol
+    // (e.g. Base/Arbitrum... → ETH), falling back to the network symbol itself.
+    const nativeCoinSymbol = getNetwork(symbol).settlementLayer ?? symbol;
+
+    return (
+        <Box flexDirection="row" alignItems="center">
+            {assets.map((asset, index) => (
+                <Box
+                    key={asset.contract ?? asset.symbol}
+                    style={applyStyle(bubbleStyle, {
+                        isFirst: index === 0,
+                        zIndex: assets.length - index,
+                    })}
+                >
+                    <CryptoIcon
+                        symbol={asset.contract ? symbol : nativeCoinSymbol}
+                        contractAddress={asset.contract}
+                        size={ICON_SIZE}
+                    />
+                </Box>
+            ))}
+            {showCount && (
+                <Box style={applyStyle(countStyle)}>
+                    <Text variant="body-xs" color="contentSecondary">
+                        <Translation id="moduleSettings.coinEnabling.labels.more" />
+                    </Text>
+                </Box>
+            )}
+        </Box>
+    );
+};

--- a/suite-native/coin-enabling/src/components/MainnetNetworkListItemContent.tsx
+++ b/suite-native/coin-enabling/src/components/MainnetNetworkListItemContent.tsx
@@ -1,0 +1,62 @@
+import { type ReactNode } from 'react';
+
+import { type Network } from '@suite-common/wallet-config';
+import { Box, Divider, HStack, Text, VStack } from '@suite-native/atoms';
+import { NetworkIcon } from '@suite-native/icons';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+import { CryptoIconSet } from './CryptoIconSet';
+import { NetworkBackendsButton } from './NetworkBackendsButton';
+import { RepresentativeAssetsConnectorSvg } from './RepresentativeAssetsConnectorSvg';
+
+type NetworkListItemContentProps = {
+    network: Network;
+    accessory: ReactNode;
+};
+
+const dividerStyle = prepareNativeStyle(utils => ({
+    marginRight: -utils.spacings.sp16,
+}));
+
+export const MainnetNetworkListItemContent = ({
+    network,
+    accessory,
+}: NetworkListItemContentProps) => {
+    const { applyStyle } = useNativeStyles();
+    const { name: networkName, symbol } = network;
+
+    return (
+        <HStack spacing="sp8">
+            <Box>
+                <VStack justifyContent="flex-start" flex={1}>
+                    <NetworkIcon symbol={symbol} size="extraLarge" />
+
+                    <Box paddingLeft="sp12">
+                        <RepresentativeAssetsConnectorSvg />
+                    </Box>
+                </VStack>
+            </Box>
+            <VStack flex={1} spacing="sp8">
+                <VStack justifyContent="flex-start" spacing="sp16">
+                    <HStack
+                        spacing="sp12"
+                        justifyContent="space-between"
+                        alignItems="center"
+                        flex={1}
+                    >
+                        <Text variant="body-sm-strong" numberOfLines={1}>
+                            {networkName}
+                        </Text>
+                        {accessory}
+                    </HStack>
+                    <Divider style={applyStyle(dividerStyle)} />
+                </VStack>
+
+                <HStack spacing="sp12" justifyContent="space-between" alignItems="center">
+                    <CryptoIconSet symbol={symbol} />
+                    <NetworkBackendsButton symbol={symbol} />
+                </HStack>
+            </VStack>
+        </HStack>
+    );
+};

--- a/suite-native/coin-enabling/src/components/NetworkListItem.tsx
+++ b/suite-native/coin-enabling/src/components/NetworkListItem.tsx
@@ -1,13 +1,12 @@
 import { type ReactNode } from 'react';
-import { type AccessibilityRole, View } from 'react-native';
+import { type AccessibilityRole } from 'react-native';
 
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
-import { Card, HStack, PressableOpacity, Text, VStack } from '@suite-native/atoms';
-import { NetworkIcon } from '@suite-native/icons';
-import { Translation } from '@suite-native/intl';
+import { Box, Card, PressableOpacity } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
-import { NetworkBackendsButton } from './NetworkBackendsButton';
+import { MainnetNetworkListItemContent } from './MainnetNetworkListItemContent';
+import { TestnetNetworkListItemContent } from './TestnetNetworkListItemContent';
 
 type NetworkListItemProps = {
     symbol: NetworkSymbol;
@@ -18,15 +17,13 @@ type NetworkListItemProps = {
 };
 
 const wrapperStyle = prepareNativeStyle(utils => ({
-    paddingVertical: 6,
-    paddingHorizontal: 14,
+    paddingVertical: utils.spacings.sp12,
+    paddingLeft: utils.spacings.sp12,
+    paddingRight: utils.spacings.sp16,
+
     gap: utils.spacings.sp12,
     alignItems: 'center',
     flex: 1,
-}));
-
-const iconWrapperStyle = prepareNativeStyle(utils => ({
-    paddingVertical: utils.spacings.sp8,
 }));
 
 export const NetworkListItem = ({
@@ -38,9 +35,8 @@ export const NetworkListItem = ({
 }: NetworkListItemProps) => {
     const { applyStyle } = useNativeStyles();
 
-    const { name, features } = getNetwork(symbol);
-    const isTokensFeatureSupported = features.includes('tokens');
-    const isStakingFeatureSupported = features.includes('staking');
+    const network = getNetwork(symbol);
+    const { testnet: isTestnet } = network;
 
     return (
         <Card noPadding>
@@ -49,36 +45,13 @@ export const NetworkListItem = ({
                 accessibilityRole={accessibilityRole}
                 testID={testID}
             >
-                <HStack style={applyStyle(wrapperStyle)}>
-                    <View style={applyStyle(iconWrapperStyle)}>
-                        <NetworkIcon symbol={symbol} size={32} />
-                    </View>
-                    <HStack
-                        flex={1}
-                        spacing="sp12"
-                        justifyContent="space-between"
-                        alignItems="center"
-                    >
-                        <VStack spacing={0}>
-                            <Text variant="body-sm-strong">{name}</Text>
-                            {isTokensFeatureSupported && (
-                                <Text variant="body-sm" color="contentSecondary">
-                                    <Translation
-                                        id={
-                                            isStakingFeatureSupported
-                                                ? 'moduleSettings.coinEnabling.labels.tokensAndStaking'
-                                                : 'moduleSettings.coinEnabling.labels.tokens'
-                                        }
-                                    />
-                                </Text>
-                            )}
-                        </VStack>
-                        <HStack spacing="sp16" alignItems="center">
-                            <NetworkBackendsButton symbol={symbol} />
-                            {accessory}
-                        </HStack>
-                    </HStack>
-                </HStack>
+                <Box style={applyStyle(wrapperStyle)} justifyContent="flex-start">
+                    {isTestnet ? (
+                        <TestnetNetworkListItemContent network={network} accessory={accessory} />
+                    ) : (
+                        <MainnetNetworkListItemContent network={network} accessory={accessory} />
+                    )}
+                </Box>
             </PressableOpacity>
         </Card>
     );

--- a/suite-native/coin-enabling/src/components/RepresentativeAssetsConnectorSvg.tsx
+++ b/suite-native/coin-enabling/src/components/RepresentativeAssetsConnectorSvg.tsx
@@ -1,0 +1,19 @@
+import Svg, { Path, type SvgProps } from 'react-native-svg';
+
+import { useNativeStyles } from '@trezor/styles-native';
+
+export const RepresentativeAssetsConnectorSvg = (props: SvgProps) => {
+    const { utils } = useNativeStyles();
+
+    return (
+        <Svg width={16} height={32} viewBox="0 0 17 33" fill="none" {...props}>
+            <Path
+                d="M0.5 0.5V22.5C0.5 28.0228 4.97715 32.5 10.5 32.5H16.5"
+                stroke={utils.colors.borderNeutral}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeDasharray={[2, 4]}
+            />
+        </Svg>
+    );
+};

--- a/suite-native/coin-enabling/src/components/TestnetNetworkListItemContent.tsx
+++ b/suite-native/coin-enabling/src/components/TestnetNetworkListItemContent.tsx
@@ -1,0 +1,32 @@
+import { type ReactNode } from 'react';
+
+import { type Network } from '@suite-common/wallet-config';
+import { HStack, Text } from '@suite-native/atoms';
+import { NetworkIcon } from '@suite-native/icons';
+
+import { NetworkBackendsButton } from './NetworkBackendsButton';
+
+type NetworkListItemContentProps = {
+    network: Network;
+    accessory: ReactNode;
+};
+
+export const TestnetNetworkListItemContent = ({
+    network,
+    accessory,
+}: NetworkListItemContentProps) => {
+    const { symbol, name: networkName } = network;
+
+    return (
+        <HStack spacing="sp12" alignItems="center">
+            <NetworkIcon symbol={symbol} size={24} />
+            <HStack flex={1} spacing="sp12" justifyContent="space-between" alignItems="center">
+                <Text variant="body-sm-strong">{networkName}</Text>
+                <HStack spacing="sp16" alignItems="center">
+                    <NetworkBackendsButton symbol={symbol} />
+                    {accessory}
+                </HStack>
+            </HStack>
+        </HStack>
+    );
+};

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1337,6 +1337,7 @@ export const messages = {
                 testnets: 'Testnet networks',
                 tokens: 'Including tokens',
                 tokensAndStaking: 'Including tokens & staking',
+                more: '+more',
             },
             toasts: {
                 coinEnabled: 'Connect your Trezor to load {coin}',

--- a/yarn.lock
+++ b/yarn.lock
@@ -12186,6 +12186,7 @@ __metadata:
     react: "npm:19.2.3"
     react-native: "npm:0.85.3"
     react-native-reanimated: "npm:4.3.1"
+    react-native-svg: "npm:15.15.5"
     react-redux: "npm:9.3.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

Redesigns the coin-enabling `NetworkListItem` card on mobile to show an
overlapping set of representative asset icons per network.

## Notes for QA

Open the coin-enabling / network selection settings screen on the mobile
app. Each network row should show its icon, name, an overlapping row of
representative asset icons.

## Related Issue

Resolve #29016

## Screenshots:

https://github.com/user-attachments/assets/d7fa6048-6e3c-4ac5-94dd-230335ad2cce


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All changed files are under `suite-native/coin-enabling/` (a React Native mobile component package) and `suite-native/intl/src/messages.ts`. The E2E test suite covers the desktop/web Trezor Suite application, not the native mobile app. The `messages.ts` file is a shared intl module that could theoretically affect web Suite translations, but none of the 119 candidate E2E tests have static coverage mapping to it, and the changes are in the native-specific coin-enabling package. The components changed (CryptoIconSet, NetworkListItem, MainnetNetworkListItemContent, TestnetNetworkListItemContent, RepresentativeAssetsConnectorSvg) are mobile-only UI components with no equivalent usage in the web/desktop E2E test paths. No E2E tests are recommended for this change set as the risk to web/desktop functionality is negligible.

<details><summary><b>Changed files (7)</b></summary>

- `suite-native/coin-enabling/package.json`
- `suite-native/coin-enabling/src/components/CryptoIconSet.tsx`
- `suite-native/coin-enabling/src/components/MainnetNetworkListItemContent.tsx`
- `suite-native/coin-enabling/src/components/NetworkListItem.tsx`
- `suite-native/coin-enabling/src/components/RepresentativeAssetsConnectorSvg.tsx`
- `suite-native/coin-enabling/src/components/TestnetNetworkListItemContent.tsx`
- `suite-native/intl/src/messages.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (7)**
- `suite-native/coin-enabling/package.json`
- `suite-native/coin-enabling/src/components/CryptoIconSet.tsx`
- `suite-native/coin-enabling/src/components/MainnetNetworkListItemContent.tsx`
- `suite-native/coin-enabling/src/components/NetworkListItem.tsx`
- `suite-native/coin-enabling/src/components/RepresentativeAssetsConnectorSvg.tsx`
- `suite-native/coin-enabling/src/components/TestnetNetworkListItemContent.tsx`
- `suite-native/intl/src/messages.ts`

_Updated: 2026-07-10T12:11:38.833Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native-coin-enabling-representative-assets/web/](https://dev.suite.sldev.cz/suite-web/feat/native-coin-enabling-representative-assets/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native-coin-enabling-representative-assets&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native-coin-enabling-representative-assets&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native-coin-enabling-representative-assets&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T12:15:33.087Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T12:15:36.162Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->