### PR TITLE
chore: enable strict ESLint TSQ linter

### DIFF
--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -11,6 +11,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@tanstack/eslint-plugin-query": "5.101.0",
         "eslint": "^9.39.4",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jest": "^29.15.3",

--- a/packages/eslint/src/index.mjs
+++ b/packages/eslint/src/index.mjs
@@ -8,6 +8,7 @@ import { javascriptNodejsConfig } from './javascriptNodejsConfig.mjs';
 import { jestConfig } from './jestConfig.mjs';
 import { localRulesConfig } from './localRulesConfig.mjs';
 import { reactConfig } from './reactConfig.mjs';
+import { reactQueryConfig } from './reactQueryConfig.mjs';
 import { restrictedImportsPatterns, typescriptConfig } from './typescriptConfig.mjs';
 /**
  * @typedef {import('eslint').Linter.Config} Config
@@ -51,6 +52,7 @@ export const eslint = [
     },
 
     ...reactConfig,
+    ...reactQueryConfig,
     ...javascriptConfig,
     ...javascriptNodejsConfig,
     ...typescriptConfig,

--- a/packages/eslint/src/reactQueryConfig.mjs
+++ b/packages/eslint/src/reactQueryConfig.mjs
@@ -1,0 +1,11 @@
+import pluginQuery from '@tanstack/eslint-plugin-query';
+/**
+ * @typedef {import('eslint').Linter.Config} Config
+ */
+
+/** @type {Config[]} */
+export const reactQueryConfig = [
+    // TanStack Query — enforces Query best practices (only fires on files using the Query API).
+    // `flat/recommended-strict` extends `flat/recommended` with the more aggressive opinionated rules.
+    ...pluginQuery.configs['flat/recommended-strict'],
+];

--- a/packages/suite/src/hooks/suite/useProxyImage.ts
+++ b/packages/suite/src/hooks/suite/useProxyImage.ts
@@ -11,6 +11,7 @@ import { IMAGE_PROXY_API_AUTH_BEARER, IMAGE_PROXY_API_URL } from '@trezor/urls';
  */
 export const useProxyImage = (src?: string) => {
     const abortControllersRef = useRef(new Map<string, AbortController>());
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- cache identity is src; abortControllersRef is a mutable ref used only for abort bookkeeping and must not be part of the key
     const proxyImageQuery = useQuery({
         enabled: Boolean(src),
         queryKey: desktopQueryKeys.proxyImage(src),

--- a/packages/suite/src/hooks/wallet/trading/useTradingStellarActivateToken.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingStellarActivateToken.ts
@@ -18,6 +18,7 @@ export const useTradingStellarActivateToken = ({
 }: UseTradingStellarActivateTokenProps) => {
     const [isModalOpen, setIsModalOpen] = useState(false);
 
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- cache identity is account.symbol + account.key; the queryFn passes the full account to getStellarInactiveTokens, but the extra fields aren't part of the key
     const { data: inactiveTokens, refetch } = useQuery({
         enabled: account?.symbol === 'xlm',
         queryKey: desktopQueryKeys.inactiveTokens(account?.symbol ?? 'xlm', account?.key),

--- a/packages/suite/src/hooks/wallet/useEvmNonceInfo.ts
+++ b/packages/suite/src/hooks/wallet/useEvmNonceInfo.ts
@@ -44,6 +44,7 @@ export const useEvmNonceInfo = (
     );
     const isEnabled = enabled && account !== undefined;
 
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- cache identity is symbol + descriptor + misc.nonce; tryGetAccountIdentity(account) only reads stable identity fields that don't widen the key
     const { data, isLoading } = useQuery({
         // account.misc.nonce is included so a delayed store update (e.g. fetchAndUpdateAccountThunk
         // dispatches the tx-list update, then updates account.misc.nonce only after an `await` a few

--- a/packages/suite/src/views/wallet/tokens/inactive-tokens/InactiveTokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/inactive-tokens/InactiveTokensTable.tsx
@@ -45,9 +45,10 @@ export const InactiveTokensTable = ({ selectedAccount, searchQuery }: InactiveTo
         data: allInactiveTokens,
         isLoading,
         isError,
+        // eslint-disable-next-line @tanstack/query/exhaustive-deps -- cache identity is account.symbol + account.key; the queryFn passes the full account to getStellarInactiveTokens and uses dispatch only for an error toast — neither the extra account fields nor the stable dispatch belong in the key
     } = useQuery({
         enabled: account.symbol === 'xlm',
-        queryKey: desktopQueryKeys.inactiveTokens(account.symbol),
+        queryKey: desktopQueryKeys.inactiveTokens(account.symbol, account.key),
         queryFn: () => {
             try {
                 return getStellarInactiveTokens(account);

--- a/scripts/list-outdated-dependencies/wallet-dependencies.txt
+++ b/scripts/list-outdated-dependencies/wallet-dependencies.txt
@@ -56,5 +56,6 @@ yup
 viem
 @tanstack/react-query-devtools
 @tanstack/react-query
+@tanstack/eslint-plugin-query
 orval
 up-fetch

--- a/suite-common/earn-stablecoin-api/src/hooks/useGetVaultByAddress.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/useGetVaultByAddress.ts
@@ -20,7 +20,7 @@ export function useGetVaultByAddress({ enabled, outputToken }: GetVaultByAddress
                 },
             });
 
-            return items?.[0];
+            return items?.[0] ?? null;
         },
     });
 }

--- a/suite-common/earn-staking-api/src/staking/hooks/useSolanaRewardsHistory.ts
+++ b/suite-common/earn-staking-api/src/staking/hooks/useSolanaRewardsHistory.ts
@@ -75,6 +75,7 @@ export function useSolanaRewardsHistory(
     account: Account,
     { limit, offset }: UseSolanaRewardsProps,
 ) {
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- cache identity is account.descriptor (+ offset/limit); the queryFn only additionally reads account.misc/symbol to derive staleness & telemetry flags, which intentionally must not widen the key
     return useQuery({
         enabled: account.symbol === 'sol',
         queryKey: commonQueryKeys.solanaRewards(account.descriptor, offset, limit),

--- a/suite-common/logger/src/hooks/useCommonApplicationLogs.ts
+++ b/suite-common/logger/src/hooks/useCommonApplicationLogs.ts
@@ -28,6 +28,7 @@ export const useCommonApplicationLogs = (hideSensitiveInfo: boolean) => {
 
     // Enhance devices info with telemetry data (battery temp, etc.)
     const devicePaths = new Set(redactedApplicationInfo.devices.map(d => d.path));
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- cache identity is the set of device paths (already spread into the key); the queryFn reads the full device objects only to enrich them with telemetry
     const { data: devicesWithTelemetry, isLoading } = useQuery({
         queryKey: ['device-telemetry', ...devicePaths],
         queryFn: async ({ signal }) => {

--- a/suite-common/trading/src/queries/useFetchOtc.ts
+++ b/suite-common/trading/src/queries/useFetchOtc.ts
@@ -8,7 +8,7 @@ import { type TradingCountryCode, type TradingOTC } from '../types';
 const FALLBACK_API_KEY = getWeakRandomId(20);
 
 export const getOtcProvidersByCountry = (
-    data: TradingOTC | undefined,
+    data: TradingOTC | null | undefined,
     country: TradingCountryCode,
 ) =>
     returnStableArrayIfEmpty(data?.links?.filter(link => link.allowedCountries?.includes(country)));
@@ -21,7 +21,7 @@ export const useFetchOtc = () =>
                 invityAPI.createInvityAPIKey(FALLBACK_API_KEY);
             }
 
-            return await invityAPI.getOTCData();
+            return (await invityAPI.getOTCData()) ?? null;
         },
         staleTime: 1000 * 6,
     });

--- a/suite-common/tx-simulation/src/hooks/useNetworkTxSimulation.ts
+++ b/suite-common/tx-simulation/src/hooks/useNetworkTxSimulation.ts
@@ -68,6 +68,7 @@ export function useNetworkTxSimulation(
     input: UseTxSimulationParams,
     { onSuccess }: UseTxSimulationProps = {},
 ) {
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- cache identity is input.params; onSuccess is a side-effect callback and input.method is derived from the same params — neither belongs in the key
     return useQuery({
         enabled: Boolean(input),
         queryKey: commonQueryKeys.networkTxSimulation(input?.params),

--- a/suite-common/wallet-core/src/fiat-rates/useMissingRateTickersQuery.ts
+++ b/suite-common/wallet-core/src/fiat-rates/useMissingRateTickersQuery.ts
@@ -17,6 +17,7 @@ export const useMissingRateTickersQuery = ({
 }: UseMissingRateTickersQueryProps) => {
     const dispatch = useDispatch();
 
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- dispatch from useDispatch() is referentially stable and is not part of the query identity (missingRateTickers + baseCurrencyCode)
     return useQuery({
         queryKey: commonQueryKeys.missingRateTickers(missingRateTickers, baseCurrencyCode),
         queryFn: () =>

--- a/suite-native/module-earn/src/hooks/useApproximateInstantUnstakeAmount.ts
+++ b/suite-native/module-earn/src/hooks/useApproximateInstantUnstakeAmount.ts
@@ -22,6 +22,7 @@ export const useApproximateInstantUnstakeAmount = (accountKey: AccountKey, amoun
         descriptor && symbol && isSupportedEthStakingNetworkSymbol(symbol) && isAmountValid,
     );
 
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- isAmountValid is derived from amount, which is already part of the key
     const { data: approximatedAmount } = useQuery<string | null>({
         enabled: isQueryEnabled,
         queryKey: ['approximate-instant-unstake-amount', descriptor, symbol, amount],

--- a/yarn.lock
+++ b/yarn.lock
@@ -15707,6 +15707,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/eslint-plugin-query@npm:5.101.0":
+  version: 5.101.0
+  resolution: "@tanstack/eslint-plugin-query@npm:5.101.0"
+  dependencies:
+    "@typescript-eslint/utils": "npm:^8.58.1"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ^5.4.0 || ^6.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/f0b4abc774631c5ead7c33b139cb3f28782c2690f273ead4792a02c3733bdf4c4b14556aaf221bf1017116de2310302096ae8b9ff1667edcb2e801ddc86b6e36
+  languageName: node
+  linkType: hard
+
 "@tanstack/query-core@npm:5.101.2":
   version: 5.101.2
   resolution: "@tanstack/query-core@npm:5.101.2"
@@ -16440,6 +16455,7 @@ __metadata:
   resolution: "@trezor/eslint@workspace:packages/eslint"
   dependencies:
     "@eslint/js": "npm:^9.39.4"
+    "@tanstack/eslint-plugin-query": "npm:5.101.0"
     eslint: "npm:^9.39.4"
     eslint-plugin-import: "npm:^2.32.0"
     eslint-plugin-jest: "npm:^29.15.3"
@@ -18607,6 +18623,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/project-service@npm:8.62.0":
+  version: 8.62.0
+  resolution: "@typescript-eslint/project-service@npm:8.62.0"
+  dependencies:
+    "@typescript-eslint/tsconfig-utils": "npm:^8.62.0"
+    "@typescript-eslint/types": "npm:^8.62.0"
+    debug: "npm:^4.4.3"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/e296f3aaaf7b4fc56e6410420a98a995f59bf45187445c9ad94d76de557a47071558869414c8ec179dfefce4f65ef8c15fcda7db653ed8fb95ff25b8119f9bb1
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/scope-manager@npm:8.62.0":
   version: 8.62.0
   resolution: "@typescript-eslint/scope-manager@npm:8.62.0"
@@ -18617,7 +18646,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/tsconfig-utils@npm:8.62.0, @typescript-eslint/tsconfig-utils@npm:^8.62.0":
+"@typescript-eslint/scope-manager@npm:8.62.0":
+  version: 8.62.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.62.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.62.0"
+    "@typescript-eslint/visitor-keys": "npm:8.62.0"
+  checksum: 10/6477062eb056986c9f94b35761c0b67bb9995798ba94c5d2bcb01932e525604715ce62e816468b2c80a8f05daa33b3339ea40646a31f733ea9840cee1dd3e82d
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/tsconfig-utils@npm:8.60.0":
+  version: 8.60.0
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.60.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/578f486df8eb2d2ec3939afc37102b89521d531d409d76e30a8ac3e9f48a3ae410e19e40c2aba3810f28391925a35ed391204ff786cc230542de82817efafda0
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/tsconfig-utils@npm:8.62.0, @typescript-eslint/tsconfig-utils@npm:^8.60.0, @typescript-eslint/tsconfig-utils@npm:^8.62.0":
   version: 8.62.0
   resolution: "@typescript-eslint/tsconfig-utils@npm:8.62.0"
   peerDependencies:
@@ -18642,7 +18690,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.62.0, @typescript-eslint/types@npm:^8.62.0":
+"@typescript-eslint/types@npm:8.60.0":
+  version: 8.60.0
+  resolution: "@typescript-eslint/types@npm:8.60.0"
+  checksum: 10/8c6967503b3a370af10fea7bfec9adc7a4152e0e8aaa72ee790f105f08721683f6e8829acf610de82bfcdeb56bdf07f6795ccec394edbdac222fd3a1d76fe9cd
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.62.0, @typescript-eslint/types@npm:^8.60.0, @typescript-eslint/types@npm:^8.62.0":
   version: 8.62.0
   resolution: "@typescript-eslint/types@npm:8.62.0"
   checksum: 10/459f5834dedbb73fc80c8eb92de693faef0f0f341d3b4d65426dbf43640f98a50104f6e15108808aed2c3c66d518db15a648c72c40831f498d36bfb62be564cb
@@ -18668,7 +18723,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.62.0, @typescript-eslint/utils@npm:^8.0.0":
+"@typescript-eslint/typescript-estree@npm:8.62.0":
+  version: 8.62.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.62.0"
+  dependencies:
+    "@typescript-eslint/project-service": "npm:8.62.0"
+    "@typescript-eslint/tsconfig-utils": "npm:8.62.0"
+    "@typescript-eslint/types": "npm:8.62.0"
+    "@typescript-eslint/visitor-keys": "npm:8.62.0"
+    debug: "npm:^4.4.3"
+    minimatch: "npm:^10.2.2"
+    semver: "npm:^7.7.3"
+    tinyglobby: "npm:^0.2.15"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/c3ae8e13671957e4a1c4acfc861b40e1545a9d32fe9d5cc851992186314f5a1dbe780cecc8f16b8448a1350f4c11648572352b5d04b77bb62e8dac3e6f3a2e04
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:8.60.0":
+  version: 8.60.0
+  resolution: "@typescript-eslint/utils@npm:8.60.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.9.1"
+    "@typescript-eslint/scope-manager": "npm:8.62.0"
+    "@typescript-eslint/types": "npm:8.62.0"
+    "@typescript-eslint/typescript-estree": "npm:8.62.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/95fed9feb823106f09b517637b0cf00e39fdc3537d05023f84710f23d00457898d8f1c68a69115d624a686411136b5cfdd7b84b657d6b51aea410cf2eb7fde7a
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:^8.0.0, @typescript-eslint/utils@npm:^8.58.1":
   version: 8.62.0
   resolution: "@typescript-eslint/utils@npm:8.62.0"
   dependencies:
@@ -18680,6 +18769,26 @@ __metadata:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
   checksum: 10/95fed9feb823106f09b517637b0cf00e39fdc3537d05023f84710f23d00457898d8f1c68a69115d624a686411136b5cfdd7b84b657d6b51aea410cf2eb7fde7a
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.62.0":
+  version: 8.62.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.62.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.62.0"
+    eslint-visitor-keys: "npm:^5.0.0"
+  checksum: 10/63d66db628befb1d160c02f3fe3b00b7c7ffc47a477335591affde2108e913a72d4a327bdd15d91f5784c3c3624e9b347e9351754390a61ca182bb7e1788d350
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.62.0":
+  version: 8.62.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.62.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.62.0"
+    eslint-visitor-keys: "npm:^5.0.0"
+  checksum: 10/63d66db628befb1d160c02f3fe3b00b7c7ffc47a477335591affde2108e913a72d4a327bdd15d91f5784c3c3624e9b347e9351754390a61ca182bb7e1788d350
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18623,19 +18623,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/project-service@npm:8.62.0":
-  version: 8.62.0
-  resolution: "@typescript-eslint/project-service@npm:8.62.0"
-  dependencies:
-    "@typescript-eslint/tsconfig-utils": "npm:^8.62.0"
-    "@typescript-eslint/types": "npm:^8.62.0"
-    debug: "npm:^4.4.3"
-  peerDependencies:
-    typescript: ">=4.8.4 <6.1.0"
-  checksum: 10/e296f3aaaf7b4fc56e6410420a98a995f59bf45187445c9ad94d76de557a47071558869414c8ec179dfefce4f65ef8c15fcda7db653ed8fb95ff25b8119f9bb1
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/scope-manager@npm:8.62.0":
   version: 8.62.0
   resolution: "@typescript-eslint/scope-manager@npm:8.62.0"
@@ -18646,26 +18633,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.62.0":
-  version: 8.62.0
-  resolution: "@typescript-eslint/scope-manager@npm:8.62.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.62.0"
-    "@typescript-eslint/visitor-keys": "npm:8.62.0"
-  checksum: 10/6477062eb056986c9f94b35761c0b67bb9995798ba94c5d2bcb01932e525604715ce62e816468b2c80a8f05daa33b3339ea40646a31f733ea9840cee1dd3e82d
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/tsconfig-utils@npm:8.60.0":
-  version: 8.60.0
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.60.0"
-  peerDependencies:
-    typescript: ">=4.8.4 <6.1.0"
-  checksum: 10/578f486df8eb2d2ec3939afc37102b89521d531d409d76e30a8ac3e9f48a3ae410e19e40c2aba3810f28391925a35ed391204ff786cc230542de82817efafda0
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/tsconfig-utils@npm:8.62.0, @typescript-eslint/tsconfig-utils@npm:^8.60.0, @typescript-eslint/tsconfig-utils@npm:^8.62.0":
+"@typescript-eslint/tsconfig-utils@npm:8.62.0, @typescript-eslint/tsconfig-utils@npm:^8.62.0":
   version: 8.62.0
   resolution: "@typescript-eslint/tsconfig-utils@npm:8.62.0"
   peerDependencies:
@@ -18690,14 +18658,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.60.0":
-  version: 8.60.0
-  resolution: "@typescript-eslint/types@npm:8.60.0"
-  checksum: 10/8c6967503b3a370af10fea7bfec9adc7a4152e0e8aaa72ee790f105f08721683f6e8829acf610de82bfcdeb56bdf07f6795ccec394edbdac222fd3a1d76fe9cd
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/types@npm:8.62.0, @typescript-eslint/types@npm:^8.60.0, @typescript-eslint/types@npm:^8.62.0":
+"@typescript-eslint/types@npm:8.62.0, @typescript-eslint/types@npm:^8.62.0":
   version: 8.62.0
   resolution: "@typescript-eslint/types@npm:8.62.0"
   checksum: 10/459f5834dedbb73fc80c8eb92de693faef0f0f341d3b4d65426dbf43640f98a50104f6e15108808aed2c3c66d518db15a648c72c40831f498d36bfb62be564cb
@@ -18723,41 +18684,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.62.0":
-  version: 8.62.0
-  resolution: "@typescript-eslint/typescript-estree@npm:8.62.0"
-  dependencies:
-    "@typescript-eslint/project-service": "npm:8.62.0"
-    "@typescript-eslint/tsconfig-utils": "npm:8.62.0"
-    "@typescript-eslint/types": "npm:8.62.0"
-    "@typescript-eslint/visitor-keys": "npm:8.62.0"
-    debug: "npm:^4.4.3"
-    minimatch: "npm:^10.2.2"
-    semver: "npm:^7.7.3"
-    tinyglobby: "npm:^0.2.15"
-    ts-api-utils: "npm:^2.5.0"
-  peerDependencies:
-    typescript: ">=4.8.4 <6.1.0"
-  checksum: 10/c3ae8e13671957e4a1c4acfc861b40e1545a9d32fe9d5cc851992186314f5a1dbe780cecc8f16b8448a1350f4c11648572352b5d04b77bb62e8dac3e6f3a2e04
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/utils@npm:8.60.0":
-  version: 8.60.0
-  resolution: "@typescript-eslint/utils@npm:8.60.0"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.9.1"
-    "@typescript-eslint/scope-manager": "npm:8.62.0"
-    "@typescript-eslint/types": "npm:8.62.0"
-    "@typescript-eslint/typescript-estree": "npm:8.62.0"
-  peerDependencies:
-    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-    typescript: ">=4.8.4 <6.1.0"
-  checksum: 10/95fed9feb823106f09b517637b0cf00e39fdc3537d05023f84710f23d00457898d8f1c68a69115d624a686411136b5cfdd7b84b657d6b51aea410cf2eb7fde7a
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/utils@npm:^8.0.0, @typescript-eslint/utils@npm:^8.58.1":
+"@typescript-eslint/utils@npm:8.62.0, @typescript-eslint/utils@npm:^8.0.0, @typescript-eslint/utils@npm:^8.58.1":
   version: 8.62.0
   resolution: "@typescript-eslint/utils@npm:8.62.0"
   dependencies:
@@ -18769,26 +18696,6 @@ __metadata:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
   checksum: 10/95fed9feb823106f09b517637b0cf00e39fdc3537d05023f84710f23d00457898d8f1c68a69115d624a686411136b5cfdd7b84b657d6b51aea410cf2eb7fde7a
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/visitor-keys@npm:8.62.0":
-  version: 8.62.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.62.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.62.0"
-    eslint-visitor-keys: "npm:^5.0.0"
-  checksum: 10/63d66db628befb1d160c02f3fe3b00b7c7ffc47a477335591affde2108e913a72d4a327bdd15d91f5784c3c3624e9b347e9351754390a61ca182bb7e1788d350
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/visitor-keys@npm:8.62.0":
-  version: 8.62.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.62.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.62.0"
-    eslint-visitor-keys: "npm:^5.0.0"
-  checksum: 10/63d66db628befb1d160c02f3fe3b00b7c7ffc47a477335591affde2108e913a72d4a327bdd15d91f5784c3c3624e9b347e9351754390a61ca182bb7e1788d350
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adjusted configuration as well as implementation where checks were not passing. 

You can read more about these here: https://tanstack.com/query/latest/docs/eslint/eslint-plugin-query

## Notes for QA

No regression

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29097

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/tsq-eslint-rules/web/](https://dev.suite.sldev.cz/suite-web/chore/tsq-eslint-rules/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily consists of modifications to React hooks and a view component across several domains: Solana staking rewards, application logging, trading/OTC, token display, EVM nonce handling, fiat rates, and tx simulation. Most changed files (useProxyImage, useEvmNonceInfo, useCommonApplicationLogs, useNetworkTxSimulation, useMissingRateTickersQuery) are broad global utilities imported by 131+ tests, so only tests with specific functional overlap should be run. The highest-risk change is useSolanaRewardsHistory.ts which directly affects Solana staking rewards display. The InactiveTokensTable.tsx change is narrowly scoped to token views. Two files have no test coverage: the eslint package.json (config-only) and the native-only useApproximateInstantUnstakeAmount hook.

<details><summary><b>Changed files (12)</b></summary>

- `packages/eslint/package.json`
- `packages/suite/src/hooks/suite/useProxyImage.ts`
- `packages/suite/src/hooks/wallet/trading/useTradingStellarActivateToken.ts`
- `packages/suite/src/hooks/wallet/useEvmNonceInfo.ts`
- `packages/suite/src/views/wallet/tokens/inactive-tokens/InactiveTokensTable.tsx`
- `suite-common/earn-stablecoin-api/src/hooks/useGetVaultByAddress.ts`
- `suite-common/earn-staking-api/src/staking/hooks/useSolanaRewardsHistory.ts`
- `suite-common/logger/src/hooks/useCommonApplicationLogs.ts`
- `suite-common/trading/src/queries/useFetchOtc.ts`
- `suite-common/tx-simulation/src/hooks/useNetworkTxSimulation.ts`
- `suite-common/wallet-core/src/fiat-rates/useMissingRateTickersQuery.ts`
- `suite-native/module-earn/src/hooks/useApproximateInstantUnstakeAmount.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/staking/sol/rewards.test.ts` — This test directly exercises Solana staking rewards display, which is the primary consumer of the changed useSolanaRewardsHistory.ts hook. It verifies rewards fetching, cache expiration, and individual reward entry rendering — all behaviors that would break if the hook changes.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/settings/application-log.test.ts` — This test directly verifies application log viewing and export functionality. The changed useCommonApplicationLogs.ts hook feeds the log content displayed in the application log modal, so changes could affect log content or rendering.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Tests the full Solana staking flow which uses the staking API layer. Changes to useSolanaRewardsHistory could affect the staking dashboard state display (rewards showing 0) and progress indicators after staking.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Tests stake-more flow on Solana where the staking dashboard shows existing rewards. Changes to useSolanaRewardsHistory could affect how rewards are displayed on the dashboard before and after staking additional SOL.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Tests SOL unstaking and claiming flow. The staking dashboard displays rewards which depend on useSolanaRewardsHistory. The test verifies the dashboard returns to empty state after claiming.
- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates to token-level pages (TrueUSD, USDC on Ethereum) and opens trading forms from them. The changed InactiveTokensTable.tsx component is directly involved in token display views, and useTradingStellarActivateToken.ts is part of the trading flow.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — Tests ETH staking form validation and input behavior. While it shares the staking API layer with changed files, the changed useSolanaRewardsHistory hook is Solana-specific and unlikely to directly affect ETH staking form validation.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/eslint/package.json`
- `suite-native/module-earn/src/hooks/useApproximateInstantUnstakeAmount.ts`

_Updated: 2026-07-17T11:32:18.556Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/tsq-eslint-rules&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/tsq-eslint-rules&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/tsq-eslint-rules&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-17T11:35:19.756Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-17T11:34:36.526Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->