### PR TITLE
feat(suite): show time estimate for pending staking transactions

### DIFF
--- a/packages/product-components/src/components/PendingTransactionInfo/PendingTransactionInfo.stories.tsx
+++ b/packages/product-components/src/components/PendingTransactionInfo/PendingTransactionInfo.stories.tsx
@@ -1,3 +1,5 @@
+import { IntlProvider } from 'react-intl';
+
 import { type Meta, type StoryObj } from '@storybook/react';
 import { action } from 'storybook/actions';
 
@@ -7,11 +9,19 @@ type StoryArgs = {
     title: string;
     txidLabel: string;
     txidComponent: string;
+    timeEstimateSeconds?: number;
     hasLink: boolean;
 };
 
 const meta: Meta<StoryArgs> = {
     title: 'PendingTransactionInfo',
+    decorators: [
+        (Story: React.FC) => (
+            <IntlProvider locale="en">
+                <Story />
+            </IntlProvider>
+        ),
+    ],
     component: PendingTransactionInfoComponent,
 };
 
@@ -22,10 +32,12 @@ export const PendingTransactionInfo: StoryObj<StoryArgs> = {
         title: 'Confirming approval...',
         txidLabel: 'Transaction ID',
         txidComponent: '0x1234...5678',
+        timeEstimateSeconds: 30,
         hasLink: true,
     },
     argTypes: {
         hasLink: { control: 'boolean' },
+        timeEstimateSeconds: { control: 'number' },
     },
     render: ({ hasLink, ...args }) => (
         <PendingTransactionInfoComponent

--- a/packages/product-components/src/components/PendingTransactionInfo/PendingTransactionInfo.tsx
+++ b/packages/product-components/src/components/PendingTransactionInfo/PendingTransactionInfo.tsx
@@ -2,10 +2,13 @@ import { type ReactNode } from 'react';
 
 import { Column, Link, Paragraph, Row, Spinner } from '@trezor/components';
 
+import { PendingTransactionTimeEstimate } from './PendingTransactionTimeEstimate';
+
 export type PendingTransactionInfoProps = {
     title: ReactNode;
     txidLabel: ReactNode;
     txidComponent: ReactNode;
+    timeEstimateSeconds?: number;
     onTxClick?: () => void;
 };
 
@@ -13,21 +16,28 @@ export const PendingTransactionInfo = ({
     title,
     txidLabel,
     txidComponent,
+    timeEstimateSeconds,
     onTxClick,
 }: PendingTransactionInfoProps) => (
     <Column width="100%" alignItems="flex-start">
-        <Row alignItems="flex-start" gap={12}>
+        <Row width="100%" alignItems="flex-start" gap={12}>
             <Spinner size={20} margin={{ top: 4 }} />
 
-            <Column>
-                <Paragraph
-                    typographyStyle="body-md"
-                    intent="neutral"
-                    priority="secondary"
-                    align="start"
-                >
-                    {title}
-                </Paragraph>
+            <Column flex="1">
+                <Row width="100%" justifyContent="space-between" alignItems="center" gap={8}>
+                    <Paragraph
+                        typographyStyle="body-md"
+                        intent="neutral"
+                        priority="secondary"
+                        align="start"
+                    >
+                        {title}
+                    </Paragraph>
+
+                    {timeEstimateSeconds !== undefined && (
+                        <PendingTransactionTimeEstimate seconds={timeEstimateSeconds} />
+                    )}
+                </Row>
 
                 <Row gap={4} flexWrap="wrap" alignItems="center">
                     <Paragraph

--- a/packages/product-components/src/components/PendingTransactionInfo/PendingTransactionTimeEstimate.tsx
+++ b/packages/product-components/src/components/PendingTransactionInfo/PendingTransactionTimeEstimate.tsx
@@ -1,0 +1,35 @@
+import { FormattedNumber } from 'react-intl';
+
+import { Icon, Paragraph, Row } from '@trezor/components';
+
+/**
+ * Rough default estimate of how long a just-broadcast transaction stays pending,
+ * covering block inclusion, backend indexing, and the pending-transaction polling interval.
+ */
+export const PENDING_TRANSACTION_TIME_ESTIMATE_SECONDS = 30;
+
+export type PendingTransactionTimeEstimateProps = {
+    seconds: number;
+};
+
+export const PendingTransactionTimeEstimate = ({
+    seconds,
+}: PendingTransactionTimeEstimateProps) => {
+    const isInMinutes = seconds >= 60;
+
+    return (
+        <Row gap={4} alignItems="center">
+            <Icon name="clock" size={16} intent="neutral" priority="secondary" />
+
+            <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
+                ~
+                <FormattedNumber
+                    value={isInMinutes ? Math.round(seconds / 60) : seconds}
+                    style="unit"
+                    unit={isInMinutes ? 'minute' : 'second'}
+                    unitDisplay="narrow"
+                />
+            </Paragraph>
+        </Row>
+    );
+};

--- a/packages/product-components/src/components/PendingTransactionInfo/PendingTransactionTimeEstimate.tsx
+++ b/packages/product-components/src/components/PendingTransactionInfo/PendingTransactionTimeEstimate.tsx
@@ -1,6 +1,7 @@
 import { FormattedNumber } from 'react-intl';
 
-import { Icon, Paragraph, Row } from '@trezor/components';
+import { Note } from '@trezor/components';
+import { ClockIcon } from '@trezor/icons';
 
 /**
  * Rough default estimate of how long a just-broadcast transaction stays pending,
@@ -18,18 +19,14 @@ export const PendingTransactionTimeEstimate = ({
     const isInMinutes = seconds >= 60;
 
     return (
-        <Row gap={4} alignItems="center">
-            <Icon name="clock" size={16} intent="neutral" priority="secondary" />
-
-            <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
-                ~
-                <FormattedNumber
-                    value={isInMinutes ? Math.round(seconds / 60) : seconds}
-                    style="unit"
-                    unit={isInMinutes ? 'minute' : 'second'}
-                    unitDisplay="narrow"
-                />
-            </Paragraph>
-        </Row>
+        <Note icon={ClockIcon}>
+            ~
+            <FormattedNumber
+                value={isInMinutes ? Math.round(seconds / 60) : seconds}
+                style="unit"
+                unit={isInMinutes ? 'minute' : 'second'}
+                unitDisplay="narrow"
+            />
+        </Note>
     );
 };

--- a/packages/product-components/src/index.ts
+++ b/packages/product-components/src/index.ts
@@ -61,3 +61,8 @@ export {
     PendingTransactionInfo,
     type PendingTransactionInfoProps,
 } from './components/PendingTransactionInfo/PendingTransactionInfo';
+export {
+    PENDING_TRANSACTION_TIME_ESTIMATE_SECONDS,
+    PendingTransactionTimeEstimate,
+    type PendingTransactionTimeEstimateProps,
+} from './components/PendingTransactionInfo/PendingTransactionTimeEstimate';

--- a/packages/suite/src/components/earn/staking/tron/TronStakePendingTransaction.tsx
+++ b/packages/suite/src/components/earn/staking/tron/TronStakePendingTransaction.tsx
@@ -3,7 +3,10 @@ import { type ReactNode } from 'react';
 import { Address } from '@suite/address';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { PendingTransactionInfo } from '@trezor/product-components';
+import {
+    PENDING_TRANSACTION_TIME_ESTIMATE_SECONDS,
+    PendingTransactionInfo,
+} from '@trezor/product-components';
 
 import { useDispatch } from 'src/hooks/suite';
 
@@ -35,6 +38,7 @@ export const TronStakePendingTransaction = ({ title }: TronStakePendingTransacti
                     typographyStyle="body-md"
                 />
             }
+            timeEstimateSeconds={PENDING_TRANSACTION_TIME_ESTIMATE_SECONDS}
             onTxClick={() =>
                 dispatch(
                     openModal({

--- a/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
@@ -2,7 +2,10 @@ import { Address } from '@suite/address';
 import type { TranslationKey } from '@suite/intl';
 import { Translation } from '@suite/intl';
 import type { YieldPendingTransactionState } from '@suite-common/wallet-core';
-import { PendingTransactionInfo } from '@trezor/product-components';
+import {
+    PENDING_TRANSACTION_TIME_ESTIMATE_SECONDS,
+    PendingTransactionInfo,
+} from '@trezor/product-components';
 
 type YieldPendingTransactionProps = {
     pendingTransaction: YieldPendingTransactionState;
@@ -41,6 +44,7 @@ export const YieldPendingTransaction = ({
                 typographyStyle="body-md"
             />
         }
+        timeEstimateSeconds={PENDING_TRANSACTION_TIME_ESTIMATE_SECONDS}
         onTxClick={() => onTxClick(pendingTransaction.txid)}
     />
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Show an estimated confirmation time (~30s) on the pending transaction info row for Tron staking and stablecoin Yield flows. Added as a reusable `timeEstimateSeconds` prop on `PendingTransactionInfo`.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #29355

## Screenshots:

<img width="631" height="589" alt="image" src="https://github.com/user-attachments/assets/c7d81a99-f3e8-4e36-9652-4c3b1f58f18b" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes modify the PendingTransactionInfo component (shared UI for displaying pending transaction status with time estimates) and its consumers: TronStakePendingTransaction and YieldPendingTransaction. These components are used in the staking/earn flows to show pending transaction states. Despite mapping to 129 tests via transitive imports, the actual rendering impact is confined to staking pending transaction UI. The highest risk is in ETH staking tests that explicitly assert on pending transaction text, confirming status, and speed-up buttons. SOL staking tests are medium risk as they verify similar pending state transitions. No Tron staking E2E tests exist in the suite, leaving TronStakePendingTransaction uncovered.

<details><summary><b>Changed files (6)</b></summary>

- `packages/product-components/src/components/PendingTransactionInfo/PendingTransactionInfo.stories.tsx`
- `packages/product-components/src/components/PendingTransactionInfo/PendingTransactionInfo.tsx`
- `packages/product-components/src/components/PendingTransactionInfo/PendingTransactionTimeEstimate.tsx`
- `packages/product-components/src/index.ts`
- `packages/suite/src/components/earn/staking/tron/TronStakePendingTransaction.tsx`
- `packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — YieldPendingTransaction.tsx is directly used in the ETH staking yield flow. This test exercises the full ETH staking lifecycle including pending transaction display with confirming status and speed-up option, which is exactly the UI rendered by the changed PendingTransactionInfo and YieldPendingTransaction components.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test verifies pending staking transaction display (TR_TX_CONFIRMING status, speed-up button) and transition to confirmed status after ETH stake-more, directly exercising the YieldPendingTransaction and PendingTransactionInfo components for the yield/staking pending state UI.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test checks pending unstaking transaction display with speed-up option and status transitions (confirming → confirmed), which renders through YieldPendingTransaction and PendingTransactionInfo components. A regression in these components would break the pending transaction UI assertions.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL staking shows pending staking state with progress indicators after staking. While SOL pending display may differ from ETH yield, the PendingTransactionInfo component could be shared or have similar rendering paths worth verifying.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — SOL stake-more test verifies pending staking amounts and progress indicators during the addingToPool phase. The PendingTransactionInfo component changes could affect how pending state is rendered for Solana staking.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstake test verifies pending/unstaking state transitions and claim flow. PendingTransactionInfo changes could affect the display of pending unstaking transactions.
- `suite/e2e/tests/staking/staking-form.test.ts` — The staking form test opens the ETH staking interface where pending transaction components may be rendered. While the test focuses on form validation, any rendering crash in the staking UI from PendingTransactionInfo changes could cause failures.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/product-components/src/components/PendingTransactionInfo/PendingTransactionInfo.stories.tsx`
- `packages/product-components/src/components/PendingTransactionInfo/PendingTransactionTimeEstimate.tsx`
- `packages/product-components/src/index.ts`
- `packages/suite/src/components/earn/staking/tron/TronStakePendingTransaction.tsx`

_Updated: 2026-07-10T14:58:27.834Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/pending-transaction-time-estimate&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/pending-transaction-time-estimate&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T15:02:19.830Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T15:02:15.655Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/pending-transaction-time-estimate/web/](https://dev.suite.sldev.cz/suite-web/feat/pending-transaction-time-estimate/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->