### PR TITLE
fix(suite): make sure other flows also use new nonces' logic 

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -149,7 +149,10 @@ export const claimMerklRewardsThunk = createThunk(
             });
 
             const nonceTask = dispatch(
-                ethereumGetCurrentNonceThunk({ selectedAccount: account }),
+                ethereumGetCurrentNonceThunk({
+                    selectedAccount: account,
+                    fetchConfirmedNonce: true,
+                }),
             ).unwrap();
 
             const [estimatedFee, { nonce }] = await Promise.all([estimatedFeeTask, nonceTask]);

--- a/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts
@@ -63,7 +63,9 @@ export const composeYieldWithdrawTransaction = async ({
         flowType,
     });
 
-    const nonceTask = dispatch(ethereumGetCurrentNonceThunk({ selectedAccount: account })).unwrap();
+    const nonceTask = dispatch(
+        ethereumGetCurrentNonceThunk({ selectedAccount: account, fetchConfirmedNonce: true }),
+    ).unwrap();
 
     const estimatedFeeTask = TrezorConnect.blockchainEstimateFee({
         coin: account.symbol,

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -130,6 +130,7 @@ export const signTransaction =
             ethereumGetCurrentNonceThunk({
                 selectedAccount: account,
                 rbfParams: formValues.rbfParams,
+                fetchConfirmedNonce: true,
             }),
         ).unwrap();
 

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -450,6 +450,9 @@ interface ResolveEthereumNonceParams {
     selectedAccount: AccountWithNetworkType<'ethereum'>;
     rbfParams?: RbfTransactionParams;
     accountTransactions: WalletAccountTransaction[];
+    // Required (yet optional for types to match) on purpose: every caller must consciously decide whether to pay for
+    // the authoritative mined-only backend nonce (outgoing txs) or skip it (RBF / display-only).
+    // Silently omitting it is exactly how the staking/WalletConnect/earn flows ended up stale.
     fetchConfirmedNonce?: boolean;
 }
 
@@ -516,6 +519,7 @@ export const resolveEthereumNonce = async ({
 interface EthereumGetCurrentNonceThunkParams {
     selectedAccount: AccountWithNetworkType<'ethereum'>;
     rbfParams?: RbfTransactionParams;
+    // See ResolveEthereumNonceParams: temporarily required so no caller can silently fall back to the stale nonce.
     fetchConfirmedNonce?: boolean;
 }
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.ts
@@ -125,7 +125,12 @@ export const composeYieldDepositTransactionThunk = createThunk<
         });
 
         const [{ nonce }, estimatedFee] = await Promise.all([
-            dispatch(ethereumGetCurrentNonceThunk({ selectedAccount: account })).unwrap(),
+            dispatch(
+                ethereumGetCurrentNonceThunk({
+                    selectedAccount: account,
+                    fetchConfirmedNonce: true,
+                }),
+            ).unwrap(),
             TrezorConnect.blockchainEstimateFee({
                 coin: account.symbol,
                 identity: getAccountIdentity(account),

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -373,8 +373,11 @@ export const addFakePendingEvmTxThunk = createThunk(
             return;
         }
 
+        // Display-only fake pending tx (rendered after the real tx was already pushed): a confirmed-
+        // nonce backend round-trip here is unwarranted, and any transient mismatch self-corrects once
+        // the backend picks up the real tx.
         const { nonce } = await dispatch(
-            ethereumGetCurrentNonceThunk({ selectedAccount: account }),
+            ethereumGetCurrentNonceThunk({ selectedAccount: account, fetchConfirmedNonce: false }),
         ).unwrap();
 
         const blockHeight = selectBlockchainHeightBySymbol(getState(), account.symbol);

--- a/suite-common/wallet-core/tests/send/ethereumGetCurrentNonceThunk.test.ts
+++ b/suite-common/wallet-core/tests/send/ethereumGetCurrentNonceThunk.test.ts
@@ -33,7 +33,12 @@ describe(ethereumGetCurrentNonceThunk.name, () => {
         const store = storeWithTxs([evmTx(13, { confirmed: false })]);
 
         const result = await store
-            .dispatch(ethereumGetCurrentNonceThunk({ selectedAccount: accountWithNonce(6) }))
+            .dispatch(
+                ethereumGetCurrentNonceThunk({
+                    selectedAccount: accountWithNonce(6),
+                    fetchConfirmedNonce: false,
+                }),
+            )
             .unwrap();
 
         expect(result).toEqual({ nonce: '6', confirmedNonce: '6' });
@@ -43,9 +48,37 @@ describe(ethereumGetCurrentNonceThunk.name, () => {
         const store = storeWithTxs([]);
 
         const result = await store
-            .dispatch(ethereumGetCurrentNonceThunk({ selectedAccount: accountWithNonce(0) }))
+            .dispatch(
+                ethereumGetCurrentNonceThunk({
+                    selectedAccount: accountWithNonce(0),
+                    fetchConfirmedNonce: false,
+                }),
+            )
             .unwrap();
 
         expect(result).toEqual({ nonce: '0', confirmedNonce: '0' });
+    });
+
+    it('fetches the authoritative confirmed nonce from the backend when opted in', async () => {
+        const getAccountInfo = jest.spyOn(TrezorConnect, 'getAccountInfo').mockResolvedValue({
+            success: true,
+            payload: { misc: { nonce: '10', confirmedNonce: '9' } },
+        } as any);
+        // Stale local account nonce (3) must be overridden by the backend confirmed nonce (9).
+        const store = storeWithTxs([]);
+
+        const result = await store
+            .dispatch(
+                ethereumGetCurrentNonceThunk({
+                    selectedAccount: accountWithNonce(3),
+                    fetchConfirmedNonce: true,
+                }),
+            )
+            .unwrap();
+
+        expect(getAccountInfo).toHaveBeenCalledWith(
+            expect.objectContaining({ confirmedNonce: true }),
+        );
+        expect(result).toEqual({ nonce: '9', confirmedNonce: '9' });
     });
 });

--- a/suite-common/wallet-core/tests/send/resolveEthereumNonce.test.ts
+++ b/suite-common/wallet-core/tests/send/resolveEthereumNonce.test.ts
@@ -27,6 +27,7 @@ describe('resolveEthereumNonce', () => {
             selectedAccount: ethAccount,
             rbfParams: rbf(7),
             accountTransactions: [],
+            fetchConfirmedNonce: false,
         });
 
         expect(result).toEqual({ nonce: '7', confirmedNonce: '7' });
@@ -37,6 +38,7 @@ describe('resolveEthereumNonce', () => {
         const result = await resolveEthereumNonce({
             selectedAccount: accountWithNonce(0),
             accountTransactions: [],
+            fetchConfirmedNonce: false,
         });
 
         expect(result).toEqual({ nonce: '0', confirmedNonce: '0' });
@@ -46,6 +48,7 @@ describe('resolveEthereumNonce', () => {
         const result = await resolveEthereumNonce({
             selectedAccount: accountWithNonce(5),
             accountTransactions: [],
+            fetchConfirmedNonce: false,
         });
 
         expect(result).toEqual({ nonce: '5', confirmedNonce: '5' });
@@ -59,6 +62,7 @@ describe('resolveEthereumNonce', () => {
                 evmTx(6, { confirmed: false }),
                 evmTx(7, { confirmed: false }),
             ],
+            fetchConfirmedNonce: false,
         });
 
         expect(result).toEqual({ nonce: '8', confirmedNonce: '5' });
@@ -68,6 +72,7 @@ describe('resolveEthereumNonce', () => {
         const result = await resolveEthereumNonce({
             selectedAccount: accountWithNonce(6),
             accountTransactions: [evmTx(13, { confirmed: false })],
+            fetchConfirmedNonce: false,
         });
 
         expect(result).toEqual({ nonce: '6', confirmedNonce: '6' });
@@ -77,6 +82,7 @@ describe('resolveEthereumNonce', () => {
         const result = await resolveEthereumNonce({
             selectedAccount: accountWithNonce(3),
             accountTransactions: [evmTx(99, { confirmed: false, type: 'recv' })],
+            fetchConfirmedNonce: false,
         });
 
         expect(result).toEqual({ nonce: '3', confirmedNonce: '3' });

--- a/suite-common/walletconnect/src/adapters/ethereum.ts
+++ b/suite-common/walletconnect/src/adapters/ethereum.ts
@@ -171,7 +171,10 @@ const ethereumRequestThunk = createThunk<
                 transaction.value = '0x0';
             }
             const { nonce } = await dispatch(
-                ethereumGetCurrentNonceThunk({ selectedAccount: account }),
+                ethereumGetCurrentNonceThunk({
+                    selectedAccount: account,
+                    fetchConfirmedNonce: true,
+                }),
             ).unwrap();
             const nonceHex = sanitizeHex(parseInt(nonce).toString(16));
             const payload = {

--- a/suite-native/staking/src/stakeFormEthereumNativeThunks.ts
+++ b/suite-native/staking/src/stakeFormEthereumNativeThunks.ts
@@ -200,7 +200,10 @@ export const signEthereumStakingTransactionNativeThunk = createThunk<
                 const device = selectSelectedDevice(getState());
 
                 const { nonce } = await dispatch(
-                    ethereumGetCurrentNonceThunk({ selectedAccount: account }),
+                    ethereumGetCurrentNonceThunk({
+                        selectedAccount: account,
+                        fetchConfirmedNonce: true,
+                    }),
                 ).unwrap();
 
                 const tx = transformTx(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When https://github.com/trezor/trezor-suite/pull/28816 was introduced the flag to fetch confirmed backend nonce was set to  false by default which resulted in inconsistent nonces produced across the app. 

This PR adds the flag for both desktop and native initiators of transactions 

## Notes for QA

We'd need to make sure that these flows are producing a correct nonce
- send flow
- earn deposit/withdraw/claim
- staking deposit/claim
- wc triggered tx

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29631

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes focus on Ethereum/EVM transaction handling: nonce resolution (sendFormEthereumThunks, new unit tests for nonce), ETH staking actions, stablecoin yield operations, transaction broadcasting (transactionsThunks), and the WalletConnect Ethereum adapter. The highest risk is in ETH staking and sending flows since stakeFormEthereumActions.ts and sendFormEthereumThunks.ts are directly exercised by those E2E tests. The stablecoin yield files and native staking thunks have no E2E coverage. Despite 121 tests being statically mapped to the changed files, most are unrelated (the files are broadly imported); only tests that exercise Ethereum transaction composition, staking, or WalletConnect are meaningfully affected.

<details><summary><b>Changed files (10)</b></summary>

- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts`
- `packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts`
- `suite-common/wallet-core/src/send/sendFormEthereumThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.ts`
- `suite-common/wallet-core/src/transactions/transactionsThunks.ts`
- `suite-common/wallet-core/tests/send/ethereumGetCurrentNonceThunk.test.ts`
- `suite-common/wallet-core/tests/send/resolveEthereumNonce.test.ts`
- `suite-common/walletconnect/src/adapters/ethereum.ts`
- `suite-native/staking/src/stakeFormEthereumNativeThunks.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Directly exercises ETH staking flow which uses stakeFormEthereumActions.ts and sendFormEthereumThunks.ts for composing and signing staking transactions. Changes to nonce resolution and transaction composition in these files could break the staking confirmation and broadcast flow.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Tests staking additional ETH which relies on stakeFormEthereumActions.ts for transaction composition and sendFormEthereumThunks.ts for Ethereum transaction signing. Nonce handling changes directly affect whether sequential staking transactions succeed.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Tests ETH unstaking and claiming flow which uses stakeFormEthereumActions.ts for composing unstake/claim transactions and sendFormEthereumThunks.ts for signing. Changes to nonce resolution could cause transaction failures in the multi-step unstake→claim flow.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Directly tests sending ETH with custom gas parameters, exercising sendFormEthereumThunks.ts for transaction composition and signing. Changes to Ethereum nonce resolution and transaction thunks could break the send confirmation flow.
- `suite/e2e/tests/wallet/send-base.test.ts` — Tests sending on Base (EVM L2) network with custom Ethereum fees, directly exercising sendFormEthereumThunks.ts for EVM transaction composition and transactionsThunks.ts for broadcast. Nonce resolution changes affect all EVM chains.
- `suite/e2e/tests/staking/staking-form.test.ts` — Tests ETH staking form validation including amount calculations, fraction buttons, and max staking. Uses stakeFormEthereumActions.ts for form composition logic. Changes to transaction composition could affect form validation and amount calculations.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — Tests WalletConnect proposal approval/rejection flow which uses the walletconnect ethereum adapter (ethereum.ts). Changes to the ethereum adapter could affect how WalletConnect sessions are handled.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests selling ETH with custom gas fees, which exercises sendFormEthereumThunks.ts for Ethereum transaction composition. Changes to nonce resolution could affect the sell transaction confirmation flow.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling ERC-20 tokens (USDC) which uses sendFormEthereumThunks.ts for EVM token transaction composition. Nonce resolution changes could affect token transfer signing.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Tests DEX swap via LI.FI on Ethereum, exercising sendFormEthereumThunks.ts for composing DEX contract interaction transactions. Gas limit adjustments and nonce handling directly affect DEX swap execution.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests custom Ethereum fee settings during swap (gas limit, max fee per gas, max priority fee per gas), directly exercising sendFormEthereumThunks.ts fee calculation logic.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Tests Ethereum transaction signing via TrezorConnect which may use the walletconnect ethereum adapter and sendFormEthereumThunks for transaction preparation. Changes to nonce handling could affect the signing flow.

</details>

⚠️ **Changes with no test coverage (6)**
- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.ts`
- `suite-common/wallet-core/tests/send/ethereumGetCurrentNonceThunk.test.ts`
- `suite-common/wallet-core/tests/send/resolveEthereumNonce.test.ts`
- `suite-native/staking/src/stakeFormEthereumNativeThunks.ts`

_Updated: 2026-07-09T22:41:18.171Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/evm-nonce&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/evm-nonce&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/evm-nonce&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-09T22:44:50.883Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-09T22:44:37.803Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/evm-nonce/web/](https://dev.suite.sldev.cz/suite-web/fix/evm-nonce/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->