### PR TITLE
chore(sentry-native): cleanup undefined from DAC sentry reports

### DIFF
--- a/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
+++ b/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
@@ -68,10 +68,10 @@ export const useDeviceAuthenticityCheck = () => {
                     scope.setLevel(sentryLevel);
                     scope.setTag('deviceAuthenticityResult', result);
                     scope.setTag('deviceAuthenticityError', error);
-
-                    const exceptionForSentry = new Error(
-                        `Device authenticity ${result}!\n${JSON.stringify(payload)}`,
-                    );
+                    if (payload) {
+                        scope.setExtra('errorDetails', payload);
+                    }
+                    const exceptionForSentry = new Error(`Device authenticity ${result}!`);
                     exceptionForSentry.name = 'reportCheckFail'; // Custom issue title
                     captureSentryException(exceptionForSentry, scope);
                 });


### PR DESCRIPTION
## Description

Just a small cleanup not to send `undefined` in Sentry issue title, [example here](https://satoshilabs.sentry.io/issues/6851824120/events/?project=4504214699245568)
```
reportCheckFail
Device authenticity failed! undefined
```

Rather send the payload to extras – btw that's the whole DAC payload we're talking about, for example if MCU check fails but Optiga and Tropic passes, this "payload" is the whole result with Optiga,Tropic,MCU.
It's just for context when one check fails, how are the other checks doing. So it doesn't have to be in the title to distinguish the Sentry issues – that would actually be quite messy (too many distinct issues for one failure).
Extras will be fine.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/dac-sentry-undefined&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->