### PR TITLE
fix(suite-desktop): displaying of nonces for rest of flows

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -200,7 +200,8 @@ export const claimMerklRewardsThunk = createThunk(
             dispatch(
                 stablecoinYieldActions.storePrecomposedTransaction({
                     precomposedTx: precomposedTransaction,
-                    precomposedForm: formState,
+                    // Surface the resolved nonce (decimal) so the review modal shows it like Send.
+                    precomposedForm: { ...formState, ethereumNonce: nonce },
                     availableRewards,
                     accountKey: account.key,
                 }),

--- a/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
@@ -68,7 +68,12 @@ export const sendYieldTransaction = async ({
     dispatch(
         stablecoinYieldActions.storePrecomposedTransaction({
             precomposedTx: precomposedTransaction,
-            precomposedForm: formState,
+            // transactionForSigning.nonce is hex; store a decimal string so the review modal shows
+            // it like the Send flow.
+            precomposedForm: {
+                ...formState,
+                ethereumNonce: parseInt(transactionForSigning.nonce, 16).toString(),
+            },
             accountKey: account.key,
         }),
     );

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -19,7 +19,7 @@ import {
     MIN_ETH_FOR_WITHDRAWALS,
     UNSTAKE_INTERCHANGES,
 } from '@suite-common/wallet-constants';
-import { selectAddressDisplayType } from '@suite-common/wallet-core';
+import { selectAddressDisplayType, stakeActions } from '@suite-common/wallet-core';
 import { ethereumGetCurrentNonceThunk } from '@suite-common/wallet-core/src/send/sendFormEthereumThunks';
 import {
     AddressDisplayOptions,
@@ -133,6 +133,10 @@ export const signTransaction =
                 fetchConfirmedNonce: true,
             }),
         ).unwrap();
+
+        // Store the signed-with nonce (decimal) so the review modal can display it, mirroring the
+        // Send flow. Set before ethereumSignTransaction fires the device button-request below.
+        dispatch(stakeActions.setResolvedEthereumNonce(nonce));
 
         const identity = getAccountIdentity(account);
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewEthereumNotes.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewEthereumNotes.tsx
@@ -1,5 +1,10 @@
 import { Translation } from '@suite/intl';
-import { selectResolvedEthereumNonce } from '@suite-common/wallet-core';
+import {
+    selectResolvedEthereumNonce,
+    selectStablecoinYieldTxReview,
+    selectStake,
+    selectTronStakeTxReview,
+} from '@suite-common/wallet-core';
 import { type GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { getFee, hasEip1559MaxPriorityFee, isEip1559 } from '@suite-common/wallet-utils';
 import { Note } from '@trezor/components';
@@ -15,21 +20,30 @@ type TransactionReviewEthereumNotesProps = {
     tx: GeneralPrecomposedTransactionFinal;
 };
 
-const selectPrecomposedFormEthereumNonce = (state: AppState) =>
-    state.wallet.send.precomposedForm?.ethereumNonce;
+// The nonce shown must come from the flow whose transaction is actually under review. This mirrors
+// getReviewSource() in TransactionReviewModal.tsx and keys off each flow's own precomposedTx, so a
+// nonce resolved for one flow can never leak into another's review (each flow only sets its own
+// state). Every flow resolves the exact signed-with nonce before the device button-request fires,
+// so it's normally set by the time this modal renders; the Note simply doesn't render until then.
+const selectReviewEthereumNonce = (state: AppState) => {
+    if (selectTronStakeTxReview(state).precomposedTx) return undefined; // TRON has no EVM nonce
+    const yieldTxReview = selectStablecoinYieldTxReview(state);
+    if (yieldTxReview.precomposedTx) return yieldTxReview.precomposedForm?.ethereumNonce;
+    if (state.wallet.send?.precomposedTx) {
+        // Send stores the resolved nonce; WalletConnect fills precomposedForm instead.
+        return (
+            selectResolvedEthereumNonce(state) ?? state.wallet.send.precomposedForm?.ethereumNonce
+        );
+    }
+
+    return selectStake(state).resolvedEthereumNonce; // staking (getReviewSource default branch)
+};
 
 export const TransactionReviewEthereumNotes = ({
     account,
     tx,
 }: TransactionReviewEthereumNotesProps) => {
-    const precomposedFormEthereumNonce = useSelector(selectPrecomposedFormEthereumNonce);
-    // signEthereumSendFormTransactionThunk stores the exact signed-with nonce before the device
-    // button-request fires, so it's normally already set by the time this modal renders. Until
-    // then, fall back to the nonce captured at compose time (a custom override, if any) instead of
-    // re-resolving it independently — this modal only displays the nonce, it never signs with it,
-    // and the Note below simply doesn't render until one of the two is available.
-    const storedEthereumNonce = useSelector(selectResolvedEthereumNonce);
-    const ethereumNonce = storedEthereumNonce ?? precomposedFormEthereumNonce;
+    const ethereumNonce = useSelector(selectReviewEthereumNonce);
 
     const fee = getFee(account.networkType, tx);
 

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -43,7 +43,11 @@ const _storePrecomposedTransaction = ({
             options: ['ethereumNonce', 'transactionData'],
             selectedFee: 'custom',
             transactionData: typedPayload.transaction.data?.replace(/^0x/, ''),
-            ethereumNonce: typedPayload.transaction.nonce,
+            // The signing payload carries the nonce in hex; show it as a decimal string in the
+            // review modal to match the Send flow (otherwise it renders e.g. "0x5").
+            ethereumNonce: typedPayload.transaction.nonce
+                ? parseInt(typedPayload.transaction.nonce, 16).toString()
+                : typedPayload.transaction.nonce,
         },
         precomposedTransaction: {
             ...txSigningPrecomposed,

--- a/suite-common/wallet-core/src/stake/stakeActions.ts
+++ b/suite-common/wallet-core/src/stake/stakeActions.ts
@@ -40,11 +40,19 @@ const requestPushTransaction = createAction(
     }),
 );
 
+const setResolvedEthereumNonce = createAction(
+    `${STAKE_MODULE_PREFIX}/setResolvedEthereumNonce`,
+    (payload: string) => ({
+        payload,
+    }),
+);
+
 const dispose = createAction(`${STAKE_MODULE_PREFIX}/dispose`);
 
 export const stakeActions = {
     requestSignTransaction,
     requestPushTransaction,
     setVotingDelegationOption,
+    setResolvedEthereumNonce,
     dispose,
 };

--- a/suite-common/wallet-core/src/stake/stakeReducer.ts
+++ b/suite-common/wallet-core/src/stake/stakeReducer.ts
@@ -15,6 +15,9 @@ export const stakeInitialState: StakeState = {
 export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState, builder => {
     builder
         .addCase(stakeActions.requestSignTransaction, (state, action) => {
+            // Reset the resolved nonce on every (re)start; it's re-set by setResolvedEthereumNonce
+            // once signing resolves it. Clearing it here also covers cancel (falsy payload).
+            delete state.resolvedEthereumNonce;
             if (action.payload) {
                 state.precomposedTx = {
                     ...action.payload.transactionInfo,
@@ -30,6 +33,9 @@ export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState,
                 delete state.precomposedForm;
             }
         })
+        .addCase(stakeActions.setResolvedEthereumNonce, (state, action) => {
+            state.resolvedEthereumNonce = action.payload;
+        })
         .addCase(stakeActions.requestPushTransaction, (state, action) => {
             if (action.payload) {
                 state.serializedTx = action.payload;
@@ -44,6 +50,7 @@ export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState,
             delete state.precomposedTx;
             delete state.precomposedForm;
             delete state.serializedTx;
+            delete state.resolvedEthereumNonce;
         })
         .addDefaultCase((state, action) => {
             state.data = stakeDataSlice.reducer(state.data, action);

--- a/suite-common/wallet-core/src/stake/stakeReducerTypes.ts
+++ b/suite-common/wallet-core/src/stake/stakeReducerTypes.ts
@@ -8,6 +8,7 @@ export interface StakeState {
     precomposedTx?: PrecomposedTransactionFinal;
     precomposedForm?: StakeFormState;
     serializedTx?: SerializedTx; // payload for TrezorConnect.pushTransaction
+    resolvedEthereumNonce?: string; // EVM nonce resolved at signing time, shown in the review modal
     votingDelegation: VotingDelegationOption;
     data: StakeDataState;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Builds on top of previous PR to easier access correctness of issued nonces for rest of the available transaction confirmation flows. 

## Notes for QA

Should be tested together with https://github.com/trezor/trezor-suite/pull/29632 to assert that correct nonces are displayed

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29634

## Screenshots:

<img width="706" height="834" alt="Screenshot 2026-07-09 at 17 25 28" src="https://github.com/user-attachments/assets/c0b79054-64c5-4da3-b991-6d254576b844" />
<img width="714" height="782" alt="Screenshot 2026-07-09 at 17 25 47" src="https://github.com/user-attachments/assets/f7bfd16a-146e-4e7a-863a-faa6a7bdf5d9" />
<img width="706" height="629" alt="Screenshot 2026-07-09 at 17 26 03" src="https://github.com/user-attachments/assets/1c697714-7c87-4065-aad9-ace19c423e91" />
<img width="733" height="616" alt="Screenshot 2026-07-09 at 17 26 35" src="https://github.com/user-attachments/assets/3849c205-ea3c-4984-9e83-4bc3dcbede02" />
<img width="727" height="775" alt="Screenshot 2026-07-09 at 17 27 41" src="https://github.com/user-attachments/assets/d77abf02-346b-415e-907f-51b52d295d3b" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/nonce-preview&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/nonce-preview&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/nonce-preview&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes focus on ETH staking logic (stakeFormEthereumActions, stakeActions, stakeReducer, stakeReducerTypes), stablecoin yield claiming (claimMerklRewardsThunk, signingHelpers), the Ethereum transaction review UI (TransactionReviewEthereumNotes), and the connect-popup ethereumSignTransaction hook. All changed files map to 129 tests via broad static coverage, so only tests that directly exercise staking, ETH transaction review, or Ethereum signing flows are recommended. The highest risk is in the ETH staking tests since multiple core files (actions, reducer, types) were modified simultaneously. Secondary risk exists in any ETH send/swap/sell flow that displays the TransactionReviewEthereumNotes component.

<details><summary><b>Changed files (8)</b></summary>

- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts`
- `packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewEthereumNotes.tsx`
- `suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts`
- `suite-common/wallet-core/src/stake/stakeActions.ts`
- `suite-common/wallet-core/src/stake/stakeReducer.ts`
- `suite-common/wallet-core/src/stake/stakeReducerTypes.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Directly exercises ETH staking form actions (stakeFormEthereumActions.ts), stake reducer/actions, and the TransactionReviewModal flow including EthereumNotes. Changes to stakeActions, stakeReducer, and stakeFormEthereumActions would directly impact the initial stake flow.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Tests the stake-more flow for ETH which directly uses stakeFormEthereumActions, stakeActions, and stakeReducer for composing and confirming additional staking transactions. The TransactionReviewEthereumNotes component is shown during the device confirmation step.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Tests ETH unstaking and claiming flows which rely on stakeFormEthereumActions for transaction composition, stakeReducer for state management, and the TransactionReview modal. The claim flow may also touch claimMerklRewardsThunk/signingHelpers for Merkl reward claims.
- `suite/e2e/tests/staking/staking-form.test.ts` — Directly tests the ETH staking form UI including amount validation, percentage buttons, max amount calculation, and input switching — all driven by stakeFormEthereumActions. Changes to form action logic or reducer types would directly affect validation behavior.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Directly exercises the ethereumSignTransaction connect-popup method hook which is one of the changed files. Changes to the hook's logic would directly impact this test's transaction signing and confirmation flow.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — Tests Ethereum send form with custom gas fees and transaction review on the device. The TransactionReviewEthereumNotes component is rendered during ETH transaction review, and the ethereumSignTransaction hook processes the signing.
- `suite/e2e/tests/wallet/send-base.test.ts` — Tests sending on Base (EVM L2) network with custom Ethereum fees and transaction review. The TransactionReviewEthereumNotes component renders during EVM transaction reviews, and ethereumSignTransaction hook handles the signing flow.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Tests DEX swap on ETH with transaction review showing gas limit, max fee, and priority fee — all rendered through TransactionReviewEthereumNotes. The ethereumSignTransaction hook processes the DEX swap signing.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Directly tests Ethereum fee display (gas limit, max fee per gas, max priority fee per gas) during swap confirmation, which is rendered by TransactionReviewEthereumNotes. Changes to this component could break fee display.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests selling ETH with custom gas fee settings and transaction confirmation on the device. TransactionReviewEthereumNotes renders the fee details, and ethereumSignTransaction handles signing.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token (USDC) on Ethereum. The transaction review modal with EthereumNotes is shown during the confirmation, and ethereumSignTransaction handles the signing.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Tests the TrezorConnect popup web flow which processes permissions and address confirmations. While primarily testing getAddress, the connect-popup infrastructure includes the ethereumSignTransaction hook that was changed.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/stake/stakeReducerTypes.ts`

_Updated: 2026-07-10T07:56:19.313Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/nonce-preview/web/](https://dev.suite.sldev.cz/suite-web/fix/nonce-preview/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T07:59:19.751Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T07:58:46.051Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->