### PR TITLE
fix(suite-desktop): improve transaction cancelation reliability 

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransaction.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransaction.tsx
@@ -1,9 +1,6 @@
 import { Translation } from '@suite/intl';
 import { selectShouldAnimateLoadingSkeleton } from '@suite/ui-animations';
-import {
-    type SelectedAccountLoaded,
-    type WalletAccountTransaction,
-} from '@suite-common/wallet-types';
+import { type Account, type WalletAccountTransaction } from '@suite-common/wallet-types';
 import { Column, Divider, InfoItem, Row, Skeleton, Text } from '@trezor/components';
 import { FeeRate } from '@trezor/product-components';
 
@@ -18,13 +15,13 @@ import { useCancelTransactionData } from './useCancelTransactionData';
 
 type CancelTransactionProps = {
     tx: WalletAccountTransaction;
-    selectedAccount: SelectedAccountLoaded;
+    account: Account;
 };
 
-export const CancelTransaction = ({ tx, selectedAccount }: CancelTransactionProps) => {
+export const CancelTransaction = ({ tx, account }: CancelTransactionProps) => {
     const { isComposing } = useCancelTxContext();
     const shouldAnimate = useSelector(selectShouldAnimateLoadingSkeleton);
-    const data = useCancelTransactionData({ tx, selectedAccount });
+    const data = useCancelTransactionData({ tx, account });
 
     if (!data) {
         if (!isComposing) return null;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx
@@ -12,7 +12,6 @@ import {
     type ChainedTransactions,
     type FormState,
     type PrecomposedTransactionFinalCancelRbf,
-    type SelectedAccountLoaded,
     type WalletAccountTransactionWithRequiredRbfParams,
 } from '@suite-common/wallet-types';
 import { type PendingEvmNonceStatus } from '@suite-common/wallet-utils';
@@ -39,7 +38,7 @@ type CancelTransactionModalProps = {
     onBackClick: () => void;
     onShowChained: () => void;
     chainedTxs?: ChainedTransactions;
-    selectedAccount: SelectedAccountLoaded;
+    account: Account;
     nonceStatus?: PendingEvmNonceStatus;
     nextNonce?: number;
 };
@@ -50,11 +49,10 @@ export const CancelTransactionModal = ({
     onBackClick,
     onShowChained,
     chainedTxs,
-    selectedAccount,
+    account,
     nonceStatus,
     nextNonce,
 }: CancelTransactionModalProps) => {
-    const { account } = selectedAccount;
     const dispatch = useDispatch();
 
     const {
@@ -123,10 +121,7 @@ export const CancelTransactionModal = ({
                         </Modal.Button>
                     ) : (
                         <>
-                            <CancelTransactionButton
-                                account={selectedAccount.account}
-                                onSuccess={onCancel}
-                            />
+                            <CancelTransactionButton account={account} onSuccess={onCancel} />
                             {error !== null ? (
                                 // This shall never happen, error like this always signal big in the code,
                                 // this is here just to make easier to detect and fix
@@ -154,7 +149,7 @@ export const CancelTransactionModal = ({
                     />
                 ) : (
                     <Column gap={16}>
-                        <CancelTransaction tx={tx} selectedAccount={selectedAccount} />
+                        <CancelTransaction tx={tx} account={account} />
                         <AffectedTransactions showChained={onShowChained} chainedTxs={chainedTxs} />
                     </Column>
                 )}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/useCancelTransactionData.ts
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/useCancelTransactionData.ts
@@ -1,8 +1,5 @@
 import { type TranslationKey } from '@suite/intl';
-import {
-    type SelectedAccountLoaded,
-    type WalletAccountTransaction,
-} from '@suite-common/wallet-types';
+import { type Account, type WalletAccountTransaction } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
@@ -18,20 +15,19 @@ type UseCancelTransactionDataResult = {
     noticeId: TranslationKey;
     topRow: CancelTxRow;
     bottomRow: CancelTxRow;
-    networkType: SelectedAccountLoaded['account']['networkType'];
+    networkType: Account['networkType'];
     symbol: WalletAccountTransaction['symbol'];
 } | null;
 
 type UseCancelTransactionDataParams = {
     tx: WalletAccountTransaction;
-    selectedAccount: SelectedAccountLoaded;
+    account: Account;
 };
 
 export const useCancelTransactionData = ({
     tx,
-    selectedAccount,
+    account,
 }: UseCancelTransactionDataParams): UseCancelTransactionDataResult => {
-    const { account } = selectedAccount;
     const { networkType } = account;
     const { composedCancelTx } = useCancelTxContext();
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/DetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/DetailModal.tsx
@@ -57,16 +57,18 @@ export const DetailModal = ({
             onCancel={onCancel}
             heading={<Translation id="TR_TRANSACTION_DETAILS" />}
             bottomContent={
-                canReplaceTransaction ? (
+                canReplaceTransaction || canCancelTransaction ? (
                     <>
-                        <Modal.Button
-                            iconLeft={GaugeIcon}
-                            intent="neutral"
-                            priority="secondary"
-                            onClick={onChangeFeeClick}
-                        >
-                            <Translation id="TR_BUMP_FEE" />
-                        </Modal.Button>
+                        {canReplaceTransaction && (
+                            <Modal.Button
+                                iconLeft="gauge"
+                                intent="neutral"
+                                priority="secondary"
+                                onClick={onChangeFeeClick}
+                            >
+                                <Translation id="TR_BUMP_FEE" />
+                            </Modal.Button>
+                        )}
                         {canCancelTransaction && (
                             <Modal.Button
                                 iconLeft={XIcon}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/DetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/DetailModal.tsx
@@ -61,7 +61,7 @@ export const DetailModal = ({
                     <>
                         {canReplaceTransaction && (
                             <Modal.Button
-                                iconLeft="gauge"
+                                iconLeft={GaugeIcon}
                                 intent="neutral"
                                 priority="secondary"
                                 onClick={onChangeFeeClick}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 import { Translation } from '@suite/intl';
 import { getInstantStakeType } from '@suite-common/staking';
@@ -24,7 +24,6 @@ import { Modal } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
 import { useEvmNonceInfo } from 'src/hooks/wallet/useEvmNonceInfo';
-import { type AppState } from 'src/types/suite';
 import { type Account, type WalletAccountTransaction } from 'src/types/wallet';
 
 import { CancelTransactionModal } from './CancelTransaction/CancelTransactionModal';
@@ -35,8 +34,6 @@ import { DetailModal } from './Detail/DetailModal';
 const hasRbfParams = (
     tx: WalletAccountTransaction,
 ): tx is WalletAccountTransactionWithRequiredRbfParams => tx.rbfParams !== undefined;
-
-const selectWalletSelectedAccount = (state: AppState) => state.wallet.selectedAccount;
 
 type TxDetailModalProps = {
     txid: string;
@@ -67,28 +64,39 @@ export const TxDetailModal = ({
         selectTransactionByAccountKeyAndTxid(state, accountKey, txid),
     );
 
+    // A confirming (or replaced) tx is briefly evicted from the store: fetchAndUpdateAccountThunk
+    // dispatches removeTransaction before re-adding the confirmed record, so this selector returns
+    // null for a render or two. Without retention that flashes a "Transaction not found" error when
+    // the user opens this modal just as the tx confirms. Keep the last-known copy so a transient
+    // disappearance keeps the modal alive; once the confirmed record re-appears the cancel flow
+    // shows its "already confirmed" state (see isTxConfirmed in CancelTransactionModal).
+    const lastKnownTxRef = useRef(originalTx);
+    if (originalTx) {
+        lastKnownTxRef.current = originalTx;
+    }
+    const resolvedTx = originalTx ?? lastKnownTxRef.current;
+
     // Filter out internal transfers that are instant staking transactions
     const filteredInternalTransfers = useMemo(() => {
-        if (!originalTx) return [];
+        if (!resolvedTx) return [];
 
-        return originalTx.internalTransfers.filter(t => {
+        return resolvedTx.internalTransfers.filter(t => {
             const stakeType = getInstantStakeType(t, descriptor, symbol);
 
             return stakeType !== 'stake';
         });
-    }, [originalTx, descriptor, symbol]);
+    }, [resolvedTx, descriptor, symbol]);
 
     const tx = useMemo(() => {
-        if (!originalTx) return null;
+        if (!resolvedTx) return null;
 
         return {
-            ...originalTx,
+            ...resolvedTx,
             internalTransfers: filteredInternalTransfers,
         };
-    }, [originalTx, filteredInternalTransfers]);
+    }, [resolvedTx, filteredInternalTransfers]);
 
     const account = useSelector(state => selectAccountByKey(state, accountKey));
-    const selectedAccount = useSelector(selectWalletSelectedAccount);
     const nonceAccount = account?.networkType === 'ethereum' ? account : undefined;
     const { nonceInfo: fetchedNonceInfo } = useEvmNonceInfo(nonceAccount);
 
@@ -151,7 +159,7 @@ export const TxDetailModal = ({
     const canReplaceTransaction = hasRbfParams(tx) && isTransactionBumpable(tx, networkFeatures);
 
     const canCancelTransaction =
-        isTransactionCancellable(tx, isPending(tx), network.networkType) && !isNonceStuck;
+        isTransactionCancellable(tx, isPending(tx), networkFeatures) && !isNonceStuck;
 
     if (section === 'bump-fee' && canReplaceTransaction && !isNonceStuck) {
         return (
@@ -168,12 +176,7 @@ export const TxDetailModal = ({
         );
     }
 
-    if (
-        section === 'cancel-transaction' &&
-        canReplaceTransaction &&
-        !isNonceStuck &&
-        selectedAccount.status === 'loaded'
-    ) {
+    if (section === 'cancel-transaction' && hasRbfParams(tx) && canCancelTransaction) {
         return (
             <CancelTransactionModal
                 tx={tx}
@@ -181,7 +184,7 @@ export const TxDetailModal = ({
                 onBackClick={onBackClick}
                 onShowChained={onShowChained}
                 chainedTxs={chainedTxs}
-                selectedAccount={selectedAccount}
+                account={account}
                 nonceStatus={nonceStatus}
                 nextNonce={fetchedNonceInfo?.nextNonce}
             />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
@@ -41,6 +41,7 @@ type TxDetailModalProps = {
     symbol: Account['symbol'];
     deviceState: Account['deviceState'];
     flow: 'detail' | 'bump-fee' | 'cancel-transaction';
+    showCancelButton?: boolean;
     onCancel: () => void;
 };
 
@@ -50,6 +51,7 @@ export const TxDetailModal = ({
     symbol,
     deviceState,
     flow,
+    showCancelButton,
     onCancel,
 }: TxDetailModalProps) => {
     const [section, setSection] = useState<TxDetailModalProps['flow']>(flow);
@@ -158,8 +160,13 @@ export const TxDetailModal = ({
 
     const canReplaceTransaction = hasRbfParams(tx) && isTransactionBumpable(tx, networkFeatures);
 
+    // Cancel is only offered from the account transaction list (which reflects the cancel once
+    // it's broadcast). Other entry points open this modal without `showCancelButton`, so the
+    // Cancel button stays hidden there. Bump-fee is intentionally not gated this way.
     const canCancelTransaction =
-        isTransactionCancellable(tx, isPending(tx), networkFeatures) && !isNonceStuck;
+        isTransactionCancellable(tx, isPending(tx), networkFeatures) &&
+        !isNonceStuck &&
+        !!showCancelButton;
 
     if (section === 'bump-fee' && canReplaceTransaction && !isNonceStuck) {
         return (

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -88,11 +88,7 @@ export const TransactionItem = memo(
         const fee = formatNetworkAmount(transaction.fee, transaction.symbol);
         const showFeeRow = isTxFeePaid(transaction);
 
-        const isTxCancellable = isTransactionCancellable(
-            transaction,
-            isPending,
-            network.networkType,
-        );
+        const isTxCancellable = isTransactionCancellable(transaction, isPending, networkFeatures);
 
         const isTxBumpable =
             !isActionDisabled && isTransactionBumpable(transaction, networkFeatures);

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -128,25 +128,13 @@ export const TransactionItem = memo(
         const isCancelDisabled = nonceStatus !== 'ok';
 
         const renderNonceWarning = () => {
-            if (pendingEvmNonce === undefined || !fetchedNonceInfo) return null;
+            if (nonceStatus === 'ok' || !fetchedNonceInfo) return null;
 
-            const status = getPendingEvmNonceStatus(pendingEvmNonce, fetchedNonceInfo);
-            if (status === 'superseded')
-                return (
-                    <Translation
-                        id="TR_PENDING_NONCE_SUPERSEDED_WARNING"
-                        values={{ nonce: fetchedNonceInfo.nextNonce }}
-                    />
-                );
-            if (status === 'gap')
-                return (
-                    <Translation
-                        id="TR_BUMP_FEE_NONCE_GAP_WARNING"
-                        values={{ nonce: fetchedNonceInfo.nextNonce }}
-                    />
-                );
+            const values = { nonce: fetchedNonceInfo.nextNonce };
+            if (nonceStatus === 'superseded')
+                return <Translation id="TR_PENDING_NONCE_SUPERSEDED_WARNING" values={values} />;
 
-            return null;
+            return <Translation id="TR_BUMP_FEE_NONCE_GAP_WARNING" values={values} />;
         };
         const nonceWarning = renderNonceWarning();
 

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -148,6 +148,8 @@ export const TransactionItem = memo(
                     symbol: transaction.symbol,
                     deviceState: transaction.deviceState,
                     flow,
+                    // The tx list is the only entry point that reflects a cancel; enable the button here.
+                    showCancelButton: true,
                 }),
             );
         };

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -67,6 +67,10 @@ export type UserContextPayload =
           symbol: Account['symbol'];
           deviceState: Account['deviceState'];
           flow: 'detail' | 'bump-fee' | 'cancel-transaction';
+          // Cancel is only offered from the account tx list; other entry points (trade detail,
+          // trading approval, earn, notifications, coin control) can't reflect a cancel, so they
+          // leave this unset and the Cancel button stays hidden.
+          showCancelButton?: boolean;
       }
     | {
           type: 'review-transaction';

--- a/suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts
@@ -19,6 +19,7 @@ import {
     groupTokensTransactionsByContractAddress,
     groupTransactionsByDate,
     isPending,
+    isTransactionCancellable,
     parseTransactionDateKey,
     parseTransactionMonthKey,
 } from '../transactionUtils';
@@ -49,6 +50,59 @@ describe('transaction utils', () => {
                 const { blockHeight } = transaction;
                 expect(isPending(transaction)).toEqual(!blockHeight || blockHeight < 0);
             });
+        });
+    });
+
+    describe('isTransactionCancellable', () => {
+        // The function only checks for the presence of rbfParams, not their shape, so any valid
+        // value serves for the positive cases.
+        const rbfParams: WalletAccountTransaction['rbfParams'] = {
+            type: 'bitcoin',
+            txid: 'txid',
+            utxo: [],
+            outputs: [],
+            feeRate: '1',
+            baseFee: 144,
+        };
+
+        it('is cancellable for a pending sent tx with rbfParams on an rbf network', () => {
+            const tx = getWalletTransaction({ type: 'sent', rbfParams });
+            expect(isTransactionCancellable(tx, true, ['rbf', 'sign-verify'])).toBe(true);
+        });
+
+        it('is not cancellable for a received tx (never has rbfParams)', () => {
+            const tx = getWalletTransaction({ type: 'recv', rbfParams: undefined });
+            expect(isTransactionCancellable(tx, true, ['rbf'])).toBe(false);
+        });
+
+        it('is not cancellable for a pending tx without rbfParams (e.g. a non-replaceable swap)', () => {
+            const tx = getWalletTransaction({ type: 'sent', rbfParams: undefined });
+            expect(isTransactionCancellable(tx, true, ['rbf'])).toBe(false);
+        });
+
+        it('is not cancellable when the tx is not pending', () => {
+            const tx = getWalletTransaction({ type: 'sent', rbfParams });
+            expect(isTransactionCancellable(tx, false, ['rbf'])).toBe(false);
+        });
+
+        it('is not cancellable for a self tx', () => {
+            const tx = getWalletTransaction({ type: 'self', rbfParams });
+            expect(isTransactionCancellable(tx, true, ['rbf'])).toBe(false);
+        });
+
+        it('is not cancellable for a joint (coinjoin) tx', () => {
+            const tx = getWalletTransaction({ type: 'joint', rbfParams });
+            expect(isTransactionCancellable(tx, true, ['rbf'])).toBe(false);
+        });
+
+        it('is not cancellable on a network without the rbf feature (e.g. LTC, ETC)', () => {
+            const tx = getWalletTransaction({ type: 'sent', rbfParams });
+            expect(isTransactionCancellable(tx, true, ['sign-verify', 'graph'])).toBe(false);
+        });
+
+        it('is not cancellable when the network has no features', () => {
+            const tx = getWalletTransaction({ type: 'sent', rbfParams });
+            expect(isTransactionCancellable(tx, true, undefined)).toBe(false);
         });
     });
 

--- a/suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts
@@ -12,6 +12,7 @@ import {
     getEvmNonceInfo,
     getEvmNonceInfoFromConfirmedNonce,
     getEvmNonceStatus,
+    getPendingEvmNonceStatus,
     getRbfParams,
     getTargetAmount,
     getTransactionWithLowestNonce,
@@ -460,6 +461,7 @@ describe('transaction utils', () => {
                 confirmedNonce: 41,
                 nextNonce: 41,
                 pendingNonces: [],
+                confirmedNonces: [],
             });
         });
 
@@ -469,6 +471,7 @@ describe('transaction utils', () => {
                 confirmedNonce: 41,
                 nextNonce: 44,
                 pendingNonces: [41, 42, 43],
+                confirmedNonces: [],
             });
         });
 
@@ -478,6 +481,7 @@ describe('transaction utils', () => {
                 confirmedNonce: 41,
                 nextNonce: 42,
                 pendingNonces: [41, 43],
+                confirmedNonces: [],
             });
         });
 
@@ -489,6 +493,7 @@ describe('transaction utils', () => {
                 confirmedNonce: 41,
                 nextNonce: 42,
                 pendingNonces: [41, 43],
+                confirmedNonces: [],
             });
         });
 
@@ -499,6 +504,7 @@ describe('transaction utils', () => {
                 confirmedNonce: 41,
                 nextNonce: 44,
                 pendingNonces: [41, 42, 43],
+                confirmedNonces: [],
             });
         });
 
@@ -509,6 +515,7 @@ describe('transaction utils', () => {
                 confirmedNonce: 41,
                 nextNonce: 41,
                 pendingNonces: [43],
+                confirmedNonces: [],
             });
         });
 
@@ -525,6 +532,7 @@ describe('transaction utils', () => {
                 confirmedNonce: 42,
                 nextNonce: 43,
                 pendingNonces: [42],
+                confirmedNonces: [41],
             });
         });
     });
@@ -542,6 +550,7 @@ describe('transaction utils', () => {
                 confirmedNonce: 1418,
                 nextNonce: 1418,
                 pendingNonces: [],
+                confirmedNonces: [],
             });
         });
 
@@ -551,6 +560,7 @@ describe('transaction utils', () => {
                 confirmedNonce: 1418,
                 nextNonce: 1420,
                 pendingNonces: [1418, 1419],
+                confirmedNonces: [],
             });
         });
 
@@ -560,6 +570,7 @@ describe('transaction utils', () => {
                 confirmedNonce: 1418,
                 nextNonce: 1418,
                 pendingNonces: [1421],
+                confirmedNonces: [],
             });
         });
 
@@ -577,6 +588,7 @@ describe('transaction utils', () => {
                 confirmedNonce: 1418,
                 nextNonce: 1418,
                 pendingNonces: [],
+                confirmedNonces: [335753],
             });
         });
 
@@ -591,12 +603,84 @@ describe('transaction utils', () => {
                 confirmedNonce: 1419,
                 nextNonce: 1420,
                 pendingNonces: [1419],
+                confirmedNonces: [1418],
+            });
+        });
+
+        it('a locally-confirmed tx contiguous with a stale confirmedNonce bridges the just-confirmed slot', () => {
+            // Transient while a tx confirms: fetchAndUpdateAccountThunk records the lowest pending tx
+            // (nonce 1418) as confirmed in the tx list before it re-fetches account.misc.nonce, so the
+            // backend confirmedNonce still lags at 1418. The just-confirmed slot must still advance
+            // nextNonce past the contiguous pending 1419/1420, otherwise those higher pending txs
+            // would momentarily read as a nonce gap and flash a false warning in the tx list.
+            const confirmedTx1418 = getWalletTransaction({
+                blockHeight: 100,
+                type: 'sent',
+                ethereumSpecific: { nonce: 1418 } as any,
+            });
+            const transactions = [confirmedTx1418, pendingSentTx(1419), pendingSentTx(1420)];
+            expect(getEvmNonceInfoFromConfirmedNonce(1418, transactions)).toEqual({
+                confirmedNonce: 1418,
+                nextNonce: 1421,
+                pendingNonces: [1419, 1420],
+                confirmedNonces: [1418],
             });
         });
     });
 
+    describe('getPendingEvmNonceStatus', () => {
+        it('nonce below confirmedNonce with a confirmed tx at that nonce is superseded', () => {
+            // A different confirmed tx occupies 1470, so it is present in confirmedNonces.
+            const bounds = {
+                confirmedNonce: 1471,
+                nextNonce: 1472,
+                pendingNonces: [1471],
+                confirmedNonces: [1470],
+            };
+            expect(getPendingEvmNonceStatus(1470, bounds)).toBe('superseded');
+        });
+
+        it('nonce below confirmedNonce but with no confirmed tx there is ok (just-sent, list not caught up)', () => {
+            // Regression: right after sending, the live confirmed-nonce fetch already counts the nonce
+            // as confirmed while the just-broadcast tx has not landed in selectAccountTransactions yet,
+            // so nothing is confirmed at 1470 locally. Must NOT flash 'superseded' at a healthy tx.
+            const bounds = {
+                confirmedNonce: 1471,
+                nextNonce: 1471,
+                pendingNonces: [],
+                confirmedNonces: [],
+            };
+            expect(getPendingEvmNonceStatus(1470, bounds)).toBe('ok');
+        });
+
+        it('nonce above nextNonce is a gap', () => {
+            const bounds = {
+                confirmedNonce: 41,
+                nextNonce: 42,
+                pendingNonces: [],
+                confirmedNonces: [],
+            };
+            expect(getPendingEvmNonceStatus(44, bounds)).toBe('gap');
+        });
+
+        it('nonce within the pending range is ok', () => {
+            const bounds = {
+                confirmedNonce: 41,
+                nextNonce: 44,
+                pendingNonces: [41, 42, 43],
+                confirmedNonces: [],
+            };
+            expect(getPendingEvmNonceStatus(42, bounds)).toBe('ok');
+        });
+    });
+
     describe('getEvmNonceStatus', () => {
-        const bounds = { confirmedNonce: 41, nextNonce: 43, pendingNonces: [41, 42] };
+        const bounds = {
+            confirmedNonce: 41,
+            nextNonce: 43,
+            pendingNonces: [41, 42],
+            confirmedNonces: [],
+        };
 
         it('below confirmedNonce is superseded', () => {
             expect(getEvmNonceStatus(40, bounds)).toBe('superseded');

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -100,7 +100,15 @@ export const isTransactionBumpable = (
     networkFeatures: NetworkFeature[] | undefined,
 ) => !!tx.rbfParams && !!networkFeatures?.includes('rbf') && !tx.deadline && tx.type !== 'joint';
 
-export type EvmNonceInfo = { confirmedNonce: number; nextNonce: number; pendingNonces: number[] };
+export type EvmNonceInfo = {
+    confirmedNonce: number;
+    nextNonce: number;
+    pendingNonces: number[];
+    // The account's own locally-known confirmed nonces. Exposed so a 'superseded' reading can be
+    // corroborated against a real confirmed tx at that nonce (see getPendingEvmNonceStatus) rather
+    // than inferred from a scalar confirmedNonce that can transiently run ahead of the tx list.
+    confirmedNonces: number[];
+};
 
 const getOwnEvmNonceSets = (transactions: WalletAccountTransaction[]) => {
     const ownNonceTxs = transactions.filter(isSentTransaction);
@@ -166,7 +174,12 @@ export const getEvmNonceInfo = (
     let nextNonce = confirmedNonce;
     while (pendingNonceSet.has(nextNonce)) nextNonce += 1;
 
-    return { confirmedNonce, nextNonce, pendingNonces: [...pendingNonceSet] };
+    return {
+        confirmedNonce,
+        nextNonce,
+        pendingNonces: [...pendingNonceSet],
+        confirmedNonces: [...confirmedNonces],
+    };
 };
 
 /**
@@ -174,19 +187,34 @@ export const getEvmNonceInfo = (
  * live from the backend). Skips `getEvmNonceInfo`'s local-data reconciliation entirely — that
  * logic exists only to compensate for an unreliable `account.misc.nonce`, and applying it here
  * would let a single bad locally-known nonce override a correct backend answer. The only local
- * adjustment still needed is walking forward past the account's own contiguous pending txs, since
- * those are what a new send must avoid colliding with.
+ * adjustment still needed is walking forward past the account's own contiguous txs, since those are
+ * what a new send must avoid colliding with.
+ *
+ * The walk advances over both pending and locally-confirmed nonces. Advancing over pending covers
+ * the queue a new send must skip; advancing over confirmed bridges the brief window while a tx is
+ * confirming, when the tx list has already recorded it as confirmed but the backend `confirmedNonce`
+ * hasn't caught up yet (fetchAndUpdateAccountThunk updates the tx list before it re-fetches
+ * account.misc.nonce). Without bridging that just-confirmed slot, `nextNonce` would momentarily lag,
+ * making the higher still-pending txs read as a nonce gap and flash a false warning in the tx list.
+ * The walk stays contiguous from `confirmedNonce`, so an isolated bad/outlier local nonce can't
+ * inflate the result the way `getEvmNonceInfo`'s global-max floor would (a non-contiguous nonce is
+ * never reached).
  */
 export const getEvmNonceInfoFromConfirmedNonce = (
     confirmedNonce: number,
     transactions: WalletAccountTransaction[],
 ): EvmNonceInfo => {
-    const { pendingNonceSet } = getOwnEvmNonceSets(transactions);
+    const { confirmedNonces, pendingNonceSet } = getOwnEvmNonceSets(transactions);
 
     let nextNonce = confirmedNonce;
-    while (pendingNonceSet.has(nextNonce)) nextNonce += 1;
+    while (pendingNonceSet.has(nextNonce) || confirmedNonces.has(nextNonce)) nextNonce += 1;
 
-    return { confirmedNonce, nextNonce, pendingNonces: [...pendingNonceSet] };
+    return {
+        confirmedNonce,
+        nextNonce,
+        pendingNonces: [...pendingNonceSet],
+        confirmedNonces: [...confirmedNonces],
+    };
 };
 
 export type PendingEvmNonceStatus = 'ok' | 'superseded' | 'gap';
@@ -194,14 +222,26 @@ export type PendingEvmNonceStatus = 'ok' | 'superseded' | 'gap';
 /**
  * Whether an already-pending transaction's own nonce is stuck, given the account's bounds from
  * `getEvmNonceInfo`. Used by the transaction list and its detail modal to grey out/warn about a
- * pending tx that can never confirm. Deliberately ignores `pendingNonces` — a pending tx's own
- * nonce is trivially a member of that set, which would otherwise always read as a "replacement".
+ * pending tx that can never confirm.
+ *
+ * `superseded` requires *positive* corroboration: a locally-known confirmed tx must actually exist at
+ * that nonce (`confirmedNonces`). The scalar `confirmedNonce` is fetched live from the backend (see
+ * useEvmNonceInfo) and can transiently run ahead of Suite's own tx list — most visibly right after
+ * sending, when the backend already counts the just-broadcast nonce while that tx hasn't landed in
+ * `selectAccountTransactions` yet. Inferring supersession from `nonce < confirmedNonce` alone flashes
+ * a false "nonce already used" warning at a tx that is actually fine. Keying off a real confirmed tx
+ * at the nonce avoids that: during the transient nothing is confirmed there, so it stays `ok` and the
+ * list catches up; only a genuine confirmed tx occupying the slot reports `superseded`.
  */
 export const getPendingEvmNonceStatus = (
     nonce: number,
-    { confirmedNonce, nextNonce }: Pick<EvmNonceInfo, 'confirmedNonce' | 'nextNonce'>,
+    {
+        confirmedNonce,
+        nextNonce,
+        confirmedNonces,
+    }: Pick<EvmNonceInfo, 'confirmedNonce' | 'nextNonce' | 'confirmedNonces'>,
 ): PendingEvmNonceStatus => {
-    if (nonce < confirmedNonce) return 'superseded'; // already mined under another tx/txid
+    if (nonce < confirmedNonce && confirmedNonces.includes(nonce)) return 'superseded'; // slot taken by a confirmed tx
     if (nonce > nextNonce) return 'gap'; // a lower nonce is still missing
 
     return 'ok';

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -76,17 +76,24 @@ export const isPending = (tx: WalletAccountTransaction | AccountTransaction) => 
 export const isSentTransaction = (tx: WalletAccountTransaction | AccountTransaction) =>
     ['sent', 'self', 'contract'].includes(tx.type);
 
-// Shared by the transaction list and its detail modal so both agree on which pending
-// transactions offer a cancel/bump-fee action.
+// Shared by the transaction list and its detail modal so both agree on which pending transactions
+// offer a cancel action. Cancelling replaces the tx with a 0-value self-send at the same
+// nonce/inputs, so it needs both rbfParams (getRbfParams omits these for received 'recv' txs and for
+// swaps it cannot resolve as our own replaceable send) and a network that actually supports RBF.
+// Gating on the 'rbf' network feature — the same signal isTransactionBumpable uses — keeps the list
+// in sync with the detail modal, which only performs the cancel when the tx is replaceable. Without
+// both checks a dead "does nothing" cancel button would show for receive txs, non-replaceable swaps,
+// and coins whose networkType is bitcoin/ethereum but that lack RBF (e.g. LTC, BCH, DOGE, ZEC, ETC).
 export const isTransactionCancellable = (
-    tx: WalletAccountTransaction | AccountTransaction,
+    tx: Pick<WalletAccountTransaction, 'rbfParams' | 'type'>,
     isPendingTx: boolean,
-    networkType: NetworkType,
+    networkFeatures: NetworkFeature[] | undefined,
 ) =>
     isPendingTx &&
+    !!tx.rbfParams &&
     tx.type !== 'self' &&
     tx.type !== 'joint' &&
-    (networkType === 'bitcoin' || networkType === 'ethereum');
+    !!networkFeatures?.includes('rbf');
 
 export const isTransactionBumpable = (
     tx: Pick<WalletAccountTransaction, 'rbfParams' | 'deadline' | 'type'>,
@@ -212,7 +219,11 @@ export const getPendingEvmNonceStatus = (
  */
 export const getEvmNonceStatus = (
     nonce: number,
-    { confirmedNonce, nextNonce, pendingNonces }: EvmNonceInfo,
+    {
+        confirmedNonce,
+        nextNonce,
+        pendingNonces,
+    }: Pick<EvmNonceInfo, 'confirmedNonce' | 'nextNonce' | 'pendingNonces'>,
 ): 'ok' | 'superseded' | 'gap' | 'replacement' => {
     if (nonce < confirmedNonce) return 'superseded'; // already mined under another tx/txid
     if (pendingNonces.includes(nonce)) return 'replacement'; // collides with a known own pending tx


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Harden conditions for nonce warning display
- Reduce chances of a race-condition for cancelation submission

## Notes for QA

- Cancel of transfer
- Cancel of swap

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29633

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes focus on transaction detail modals (TxDetailModal, CancelTransaction components), the TransactionItem component, transaction utility functions, and modal type definitions. The primary risk is in transaction list rendering, transaction detail display, and cancel/replace transaction flows. Since all changed component files map to 131+ tests (broad global dependencies), only tests that specifically exercise transaction viewing, pending transaction behavior, transaction details, and output labeling are recommended. The unit test file for transactionUtils provides direct coverage of the utility changes but has no E2E mapping.

<details><summary><b>Changed files (9)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransaction.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/useCancelTransactionData.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/DetailModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx`
- `packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx`
- `suite-common/suite-types/src/modal.ts`
- `suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts`
- `suite-common/wallet-utils/src/transactionUtils.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test directly exercises TransactionItem rendering (pending/confirmed labels, transaction details modal with txid) and transaction list behavior. Changes to TransactionItem.tsx and transactionUtils.ts directly affect how pending and confirmed transactions are displayed, grouped, and labeled.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test covers transaction list display, searching transactions by address, and time-range filtering on account overview. Changes to TransactionItem.tsx and transactionUtils.ts directly impact how transaction items render and how transaction data is processed for display.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — Transaction export (PDF/CSV/JSON) relies on transactionUtils.ts for processing transaction data. Changes to transaction utility functions could affect how transactions are serialized for export.
- `suite/e2e/tests/wallet/pagination.test.ts` — Pagination test navigates paginated transaction lists and verifies transaction addresses are displayed correctly. TransactionItem.tsx changes could affect how individual transaction rows render within paginated views.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test labels transaction outputs and exports transactions as CSV verifying labels appear. It interacts with TransactionItem components (output labels on transactions) and the TxDetailModal for viewing transaction details. Changes to these components could affect output label display.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test sends transactions and verifies pending transaction list entries (including OP_RETURN content). It directly exercises TransactionItem rendering for pending transactions and transaction content verification.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test verifies pending staking transaction display with confirming/confirmed status transitions and speed-up buttons. The pending transaction rendering relies on TransactionItem and the CancelTransaction/speed-up functionality directly relates to the changed cancel transaction components.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Tests pending transaction display with speed-up buttons during unstaking flow. The speed-up functionality relates to cancel/replace transaction features in the changed CancelTransaction components.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Tests pending staking transaction display with speed-up button visibility. TransactionItem changes could affect how the speed-up button renders on pending staking transactions.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/suite-types/src/modal.ts`
- `suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts`

_Updated: 2026-07-13T14:32:36.676Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/cancel-tweaks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/cancel-tweaks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/cancel-tweaks&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-13T13:44:24.899Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-13T14:35:37.707Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/cancel-tweaks/web/](https://dev.suite.sldev.cz/suite-web/fix/cancel-tweaks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->