### PR TITLE
feat(suite): surface stablecoin yield error codes in UI, logs and analytics

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -33,7 +33,7 @@ import {
 import { getAccountIdentity, getMevProtectedTxData } from '@suite-common/wallet-utils';
 import TrezorConnect, { type StaticSessionId } from '@trezor/connect';
 
-import { getYieldErrorTranslationKey } from './signingHelpers';
+import { getYieldErrorCode } from './signingHelpers';
 
 type ClaimMerklReward = YieldAccountsRewards[number]['rewards'][number];
 
@@ -262,7 +262,9 @@ export const claimMerklRewardsThunk = createThunk(
                 dispatch(closeModal());
 
                 if (!pushResponse.success) {
-                    throw new Error(pushResponse.error.message);
+                    throw new Error(pushResponse.error.message, {
+                        cause: pushResponse.error.code ?? 'push-failed',
+                    });
                 }
 
                 dispatch(
@@ -311,14 +313,14 @@ export const claimMerklRewardsThunk = createThunk(
                     action: 'continue',
                     networkSymbol: account.symbol,
                     rewardCount: rewards.length,
-                    errorMessage: 'submit-failed',
+                    errorMessage: getYieldErrorCode(error),
                 },
             });
             dispatch(
                 stablecoinYieldActions.setError({
                     flowType: 'claim',
                     flowKey,
-                    error: getYieldErrorTranslationKey(error),
+                    errorCode: getYieldErrorCode(error),
                 }),
             );
         } finally {

--- a/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
@@ -15,15 +15,18 @@ import {
 } from '@suite-common/wallet-types';
 import { getAccountIdentity, getMevProtectedTxData } from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
+import { type Result, err, ok } from '@trezor/type-utils';
 
 import type { AppState, Dispatch } from 'src/types/suite';
 
-export const getYieldErrorTranslationKey = (error: unknown) =>
-    error instanceof Error &&
-    (error.cause === 'Device_InvalidState' || // incorrect passphrase submitted
-        error.cause === 'Method_Interrupted') // passphrase modal closed
-        ? 'TR_EARN_YIELD_ERROR_PASSPHRASE_INCORRECT'
-        : 'TR_EARN_YIELD_ERROR_GENERIC';
+// Only the machine-readable cause may be exposed (UI banner, analytics) — `error.message`
+// can contain account data and must stay in the console.
+export const getYieldErrorCode = (error: unknown) =>
+    error instanceof Error && typeof error.cause === 'string' ? error.cause : 'submit-failed';
+
+export type SendYieldTransactionOutcome = { type: 'pushed'; txid: string } | { type: 'cancelled' };
+
+export type SendYieldTransactionResult = Result<SendYieldTransactionOutcome, { code: string }>;
 
 export type SendYieldTransactionParams = {
     account: Account;
@@ -43,16 +46,16 @@ export const sendYieldTransaction = async ({
     dispatch,
     getState,
     selectedFee,
-}: SendYieldTransactionParams) => {
+}: SendYieldTransactionParams): Promise<SendYieldTransactionResult> => {
     const device = selectSelectedDevice(getState());
     const addressDisplayType = selectAddressDisplayType(getState());
 
     if (!device) {
-        throw new Error('Device not found.');
+        return err({ code: 'missing-device' });
     }
 
     if (account.networkType !== 'ethereum') {
-        throw new Error('Yield actions currently support only EVM accounts.');
+        return err({ code: 'unsupported-network' });
     }
 
     const transactionReview = buildStablecoinYieldTransactionReview({
@@ -93,10 +96,12 @@ export const sendYieldTransaction = async ({
 
             const { code } = signingResponse.error;
             if (code === 'Failure_ActionCancelled' || code === 'Method_Cancel') {
-                return;
+                return ok({ type: 'cancelled' });
             }
 
-            throw new Error(`${code}: ${signingResponse.error.message}`, { cause: code });
+            console.error(signingResponse.error);
+
+            return err({ code: code ?? 'sign-failed' });
         }
 
         dispatch(
@@ -111,7 +116,7 @@ export const sendYieldTransaction = async ({
         const isPushConfirmed = await dispatch(openDeferredModal({ type: 'review-transaction' }));
 
         if (!isPushConfirmed) {
-            return;
+            return ok({ type: 'cancelled' });
         }
 
         const isMevProtectionEnabled = selectIsMevProtectionEnabled(getState());
@@ -128,7 +133,9 @@ export const sendYieldTransaction = async ({
         dispatch(closeModal());
 
         if (!pushResponse.success) {
-            throw new Error(`${pushResponse.error.code}: ${pushResponse.error.message}`);
+            console.error(pushResponse.error);
+
+            return err({ code: pushResponse.error.code ?? 'push-failed' });
         }
 
         dispatch(
@@ -140,10 +147,7 @@ export const sendYieldTransaction = async ({
             }),
         );
 
-        return pushResponse.payload;
-    } catch (error) {
-        console.error(error);
-        throw error;
+        return ok({ type: 'pushed', txid: pushResponse.payload.txid });
     } finally {
         dispatch(stablecoinYieldActions.discardTransaction());
     }

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
@@ -8,11 +8,11 @@ import {
     type YieldFlowResolvedData,
     composeYieldDepositTransactionThunk,
     openYieldApproveModal,
-    setYieldGenericError,
+    setYieldError,
     stablecoinYieldActions,
 } from '@suite-common/wallet-core';
 
-import { getYieldErrorTranslationKey, sendYieldTransaction } from './signingHelpers';
+import { getYieldErrorCode, sendYieldTransaction } from './signingHelpers';
 
 type SubmitYieldDepositPayload = {
     flowKey: string;
@@ -36,7 +36,17 @@ export const submitYieldDepositThunk = createThunk(
             ).unwrap();
 
             if (result.type === 'error') {
-                setYieldGenericError({ dispatch, flowType, flowKey });
+                asTypedDesktopAnalytics(extra.services.analytics).report({
+                    type: events.yieldDepositEvent.name,
+                    payload: {
+                        type: 'error',
+                        action: 'continue',
+                        networkSymbol: flowData.account.symbol,
+                        vaultId: flowData.vault.id,
+                        errorMessage: result.reason,
+                    },
+                });
+                setYieldError({ dispatch, flowType, flowKey, errorCode: result.reason });
 
                 return;
             }
@@ -101,9 +111,25 @@ export const submitYieldDepositThunk = createThunk(
                 selectedFee,
             });
 
+            if (!sendResult.success) {
+                asTypedDesktopAnalytics(extra.services.analytics).report({
+                    type: events.yieldDepositEvent.name,
+                    payload: {
+                        type: 'error',
+                        action: 'continue',
+                        networkSymbol: flowData.account.symbol,
+                        vaultId: flowData.vault.id,
+                        errorMessage: sendResult.error.code,
+                    },
+                });
+                setYieldError({ dispatch, flowType, flowKey, errorCode: sendResult.error.code });
+
+                return;
+            }
+
             userAcceptedTxSimulation?.resolve();
 
-            if (!sendResult) {
+            if (sendResult.payload.type === 'cancelled') {
                 asTypedDesktopAnalytics(extra.services.analytics).report({
                     type: events.yieldDepositEvent.name,
                     payload: {
@@ -123,7 +149,7 @@ export const submitYieldDepositThunk = createThunk(
                     type: 'tx-yield-deposit',
                     descriptor: flowData.account.descriptor,
                     symbol: flowData.account.symbol,
-                    txid: sendResult.txid,
+                    txid: sendResult.payload.txid,
                 }),
             );
 
@@ -133,7 +159,7 @@ export const submitYieldDepositThunk = createThunk(
                     flowKey,
                     tx: {
                         type: flowType,
-                        txid: sendResult.txid,
+                        txid: sendResult.payload.txid,
                         amount,
                     },
                     receiptAmount: result.receiptAmount,
@@ -148,14 +174,14 @@ export const submitYieldDepositThunk = createThunk(
                     action: 'continue',
                     networkSymbol: flowData.account.symbol,
                     vaultId: flowData.vault.id,
-                    errorMessage: 'submit-failed',
+                    errorMessage: getYieldErrorCode(error),
                 },
             });
             dispatch(
                 stablecoinYieldActions.setError({
                     flowType,
                     flowKey,
-                    error: getYieldErrorTranslationKey(error),
+                    errorCode: getYieldErrorCode(error),
                 }),
             );
         } finally {

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
@@ -7,11 +7,12 @@ import {
     STABLECOIN_YIELD_PREFIX,
     type YieldFlowResolvedData,
     type YieldWithdrawFlowType,
+    setYieldError,
     stablecoinYieldActions,
 } from '@suite-common/wallet-core';
 
 import { composeYieldWithdrawTransaction } from './composeYieldWithdrawTransaction';
-import { getYieldErrorTranslationKey, sendYieldTransaction } from './signingHelpers';
+import { getYieldErrorCode, sendYieldTransaction } from './signingHelpers';
 
 type SubmitYieldWithdrawPayload = {
     flowKey: string;
@@ -83,9 +84,26 @@ export const submitYieldWithdrawThunk = createThunk(
                 selectedFee,
             });
 
+            if (!result.success) {
+                asTypedDesktopAnalytics(extra.services.analytics).report({
+                    type: events.yieldWithdrawEvent.name,
+                    payload: {
+                        type: 'error',
+                        operation: flowType,
+                        action: 'continue',
+                        networkSymbol: account.symbol,
+                        vaultId: flowData.vault.id,
+                        errorMessage: result.error.code,
+                    },
+                });
+                setYieldError({ dispatch, flowType, flowKey, errorCode: result.error.code });
+
+                return;
+            }
+
             userAcceptedTxSimulation?.resolve();
 
-            if (!result) {
+            if (result.payload.type === 'cancelled') {
                 asTypedDesktopAnalytics(extra.services.analytics).report({
                     type: events.yieldWithdrawEvent.name,
                     payload: {
@@ -106,7 +124,7 @@ export const submitYieldWithdrawThunk = createThunk(
                     type: 'tx-yield-withdraw',
                     descriptor: account.descriptor,
                     symbol: account.symbol,
-                    txid: result.txid,
+                    txid: result.payload.txid,
                 }),
             );
 
@@ -116,7 +134,7 @@ export const submitYieldWithdrawThunk = createThunk(
                     flowKey,
                     tx: {
                         type: flowType,
-                        txid: result.txid,
+                        txid: result.payload.txid,
                         amount,
                     },
                 }),
@@ -131,14 +149,14 @@ export const submitYieldWithdrawThunk = createThunk(
                     action: 'continue',
                     networkSymbol: flowData.account.symbol,
                     vaultId: flowData.vault.id,
-                    errorMessage: 'submit-failed',
+                    errorMessage: getYieldErrorCode(error),
                 },
             });
             dispatch(
                 stablecoinYieldActions.setError({
                     flowType,
                     flowKey,
-                    error: getYieldErrorTranslationKey(error),
+                    errorCode: getYieldErrorCode(error),
                 }),
             );
         } finally {

--- a/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
@@ -210,7 +210,13 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
                                             <Banner
                                                 intent="warning"
                                                 description={
-                                                    <Translation id={claimSession.error} />
+                                                    <>
+                                                        <Translation
+                                                            id={claimSession.error.message}
+                                                        />
+                                                        {claimSession.error.code &&
+                                                            ` (${claimSession.error.code})`}
+                                                    </>
                                                 }
                                             />
                                         )}

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -29,6 +29,7 @@ export const YieldDepositForm = () => {
         completedReceiptAmount,
         maxAmount,
         errorMessage,
+        errorCode,
         approveModalState,
         pendingTransaction,
         allowanceAmount,
@@ -153,7 +154,12 @@ export const YieldDepositForm = () => {
                             {errorMessage && (
                                 <Banner
                                     intent="warning"
-                                    description={<Translation id={errorMessage} />}
+                                    description={
+                                        <>
+                                            <Translation id={errorMessage} />
+                                            {errorCode && ` (${errorCode})`}
+                                        </>
+                                    }
                                 />
                             )}
 

--- a/packages/suite/src/components/earn/yield/hooks/useEnsureYieldDeviceSession.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useEnsureYieldDeviceSession.ts
@@ -4,7 +4,6 @@ import { useDevice } from '@suite/device';
 import { type YieldFlowType, stablecoinYieldActions } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 
-import { getYieldErrorTranslationKey } from 'src/actions/wallet/stablecoin-yield/signingHelpers';
 import { useDispatch } from 'src/hooks/suite';
 
 type UseEnsureYieldDeviceSessionParams = {
@@ -25,7 +24,7 @@ export const useEnsureYieldDeviceSession = ({
                 stablecoinYieldActions.setError({
                     flowType,
                     flowKey,
-                    error: 'TR_EARN_YIELD_ERROR_GENERIC',
+                    errorCode: 'missing-device-session',
                 }),
             );
 
@@ -54,9 +53,7 @@ export const useEnsureYieldDeviceSession = ({
             stablecoinYieldActions.setError({
                 flowType,
                 flowKey,
-                error: getYieldErrorTranslationKey(
-                    new Error(response.error.message, { cause: code }),
-                ),
+                errorCode: code ?? 'device-state-failed',
             }),
         );
 

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -76,6 +76,7 @@ export type UseYieldFlowResult = {
     completedAmount: string;
     completedReceiptAmount: string;
     errorMessage: TranslationKey | undefined;
+    errorCode: string | undefined;
     approveModalState: YieldApproveModalState | null;
     pendingTransaction: YieldPendingTransactionState | null;
     allowanceAmount: string;
@@ -346,7 +347,7 @@ export const useYieldFlow = ({
                 stablecoinYieldActions.setError({
                     flowType,
                     flowKey,
-                    error: 'TR_EARN_YIELD_ERROR_GENERIC',
+                    errorCode: 'missing-flow-tokens',
                 }),
             );
 
@@ -395,7 +396,7 @@ export const useYieldFlow = ({
                 stablecoinYieldActions.setError({
                     flowType,
                     flowKey,
-                    error: 'TR_EARN_YIELD_ERROR_GENERIC',
+                    errorCode: 'missing-flow-tokens',
                 }),
             );
 
@@ -466,7 +467,7 @@ export const useYieldFlow = ({
                 stablecoinYieldActions.setError({
                     flowType,
                     flowKey,
-                    error: 'TR_EARN_YIELD_ERROR_GENERIC',
+                    errorCode: 'missing-flow-tokens',
                 }),
             );
 
@@ -563,7 +564,8 @@ export const useYieldFlow = ({
         actionAmount: session.action.amount,
         completedAmount: session.result.completedAmount,
         completedReceiptAmount: session.result.completedReceiptAmount,
-        errorMessage: session.error ?? undefined,
+        errorMessage: session.error?.message,
+        errorCode: session.error?.code ?? undefined,
         approveModalState: session.approval.modalState,
         pendingTransaction: session.action.pendingTransaction,
         allowanceAmount,

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -24,6 +24,7 @@ export const YieldWithdrawForm = () => {
         receiptToken,
         maxAmount,
         errorMessage,
+        errorCode,
         pendingTransaction,
         isAmountEmpty,
         isAmountTooHigh,
@@ -128,7 +129,12 @@ export const YieldWithdrawForm = () => {
                         {errorMessage && (
                             <Banner
                                 intent="warning"
-                                description={<Translation id={errorMessage} />}
+                                description={
+                                    <>
+                                        <Translation id={errorMessage} />
+                                        {errorCode && ` (${errorCode})`}
+                                    </>
+                                }
                             />
                         )}
                     </>

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -71,6 +71,7 @@ export * from './stablecoin-yield/stablecoinYieldApprovalThunks';
 export * from './stablecoin-yield/stablecoinYieldConstants';
 export * from './stablecoin-yield/stablecoinYieldDepositThunks';
 export * from './stablecoin-yield/stablecoinYieldDeviceUtils';
+export * from './stablecoin-yield/stablecoinYieldErrors';
 export * from './stablecoin-yield/stablecoinYieldTypes';
 export * from './stablecoin-yield/stablecoinYieldUtils';
 export * from './stake/tron/tronStakeReducer';

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
@@ -17,7 +17,6 @@ import { getAllowanceSpender, getWithdrawRequestAmount } from './stablecoinYield
 import { fetchAllowance } from '../allowance/fetchAllowance';
 
 const YIELD_THUNK_PREFIX = `${STABLECOIN_YIELD_PREFIX}/thunk`;
-const YIELD_GENERIC_ERROR = 'TR_EARN_YIELD_ERROR_GENERIC';
 
 export type YieldSessionPayload = {
     flowType: YieldPositionFlowType;
@@ -41,8 +40,9 @@ type InitYieldAllowancePayload = YieldSessionDataPayload & {
     shouldSkipApprovalStep?: boolean;
 };
 
-type SetYieldGenericErrorParams = YieldSessionPayload & {
+type SetYieldErrorParams = YieldSessionPayload & {
     dispatch: Dispatch;
+    errorCode: string;
 };
 
 type GetApprovalContractAddressParams = {
@@ -69,16 +69,14 @@ type OpenYieldRevokeModalParams = YieldSessionDataPayload & {
     spender: string | null;
 };
 
-export const setYieldGenericError = ({
-    dispatch,
-    flowType,
-    flowKey,
-}: SetYieldGenericErrorParams) => {
+export const setYieldError = ({ dispatch, flowType, flowKey, errorCode }: SetYieldErrorParams) => {
+    console.error(`[stablecoin-yield] ${flowType} flow failed:`, errorCode);
+
     dispatch(
         stablecoinYieldActions.setError({
             flowType,
             flowKey,
-            error: YIELD_GENERIC_ERROR,
+            errorCode,
         }),
     );
 };
@@ -129,7 +127,12 @@ export const openYieldApproveModal = ({
     const contractAddress = getApprovalContractAddress({ flowType, flowData });
 
     if (!contractAddress) {
-        setYieldGenericError({ dispatch, flowType, flowKey });
+        setYieldError({
+            dispatch,
+            flowType,
+            flowKey,
+            errorCode: 'missing-approval-contract-address',
+        });
 
         return false;
     }
@@ -161,7 +164,7 @@ export const openYieldRevokeModal = ({
     spender,
 }: OpenYieldRevokeModalParams) => {
     if (!spender) {
-        setYieldGenericError({ dispatch, flowType, flowKey });
+        setYieldError({ dispatch, flowType, flowKey, errorCode: 'missing-revoke-spender' });
 
         return false;
     }
@@ -305,7 +308,12 @@ export const submitYieldApproveThunk = createThunk(
         });
 
         if (!requestAmount) {
-            setYieldGenericError({ dispatch, flowType, flowKey });
+            setYieldError({
+                dispatch,
+                flowType,
+                flowKey,
+                errorCode: 'missing-approval-request-amount',
+            });
 
             return;
         }
@@ -317,7 +325,12 @@ export const submitYieldApproveThunk = createThunk(
             const tokenContractAddress = flowData.token.contractAddress;
 
             if (!spender || !tokenContractAddress) {
-                setYieldGenericError({ dispatch, flowType, flowKey });
+                setYieldError({
+                    dispatch,
+                    flowType,
+                    flowKey,
+                    errorCode: 'missing-approval-params',
+                });
 
                 return;
             }
@@ -364,7 +377,7 @@ export const submitYieldApproveThunk = createThunk(
                 txType: 'approve',
             });
         } catch {
-            setYieldGenericError({ dispatch, flowType, flowKey });
+            setYieldError({ dispatch, flowType, flowKey, errorCode: 'approve-failed' });
         } finally {
             dispatch(stablecoinYieldActions.finishSubmittingApproval({ flowType, flowKey }));
         }

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.ts
@@ -12,8 +12,9 @@ import {
 import TrezorConnect from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
-import { getApprovalRequestAmount, setYieldGenericError } from './stablecoinYieldApprovalThunks';
+import { getApprovalRequestAmount, setYieldError } from './stablecoinYieldApprovalThunks';
 import { STABLECOIN_YIELD_PREFIX } from './stablecoinYieldConstants';
+import type { YieldDepositErrorReason } from './stablecoinYieldErrors';
 import { stablecoinYieldActions } from './stablecoinYieldReducer';
 import type { YieldFlowResolvedData } from './stablecoinYieldTypes';
 import {
@@ -27,13 +28,6 @@ import { selectRawNetworkFeeInfo } from '../fees/feesReducer';
 import { ethereumGetCurrentNonceThunk } from '../send/sendFormEthereumThunks';
 
 const YIELD_DEPOSIT_THUNK_PREFIX = `${STABLECOIN_YIELD_PREFIX}/thunk`;
-
-export type YieldDepositErrorReason =
-    | 'unsupported-network'
-    | 'missing-deposit-params'
-    | 'vault-chain-mismatch'
-    | 'missing-fee-level'
-    | 'compose-failed';
 
 export type PrepareYieldDepositResult =
     | {
@@ -201,12 +195,12 @@ export const prepareYieldDepositThunk = createThunk<
             ).unwrap();
 
             if (result.type === 'error') {
-                setYieldGenericError({ dispatch, flowType, flowKey });
+                setYieldError({ dispatch, flowType, flowKey, errorCode: result.reason });
             }
 
             return result;
         } catch {
-            setYieldGenericError({ dispatch, flowType, flowKey });
+            setYieldError({ dispatch, flowType, flowKey, errorCode: 'compose-failed' });
 
             return { type: 'error', reason: 'compose-failed' } as const;
         } finally {

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldErrors.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldErrors.ts
@@ -1,0 +1,83 @@
+// Message ids must exist in the desktop `suite/intl` messages — the desktop app renders
+// `session.error.message` directly via `<Translation>`.
+export type StablecoinYieldTranslationKey =
+    | 'TR_EARN_YIELD_ERROR_GENERIC'
+    | 'TR_EARN_YIELD_ERROR_PASSPHRASE_INCORRECT'
+    | 'TR_EARN_YIELD_ERROR_TRANSACTION_FAILED';
+
+export type YieldDepositErrorReason =
+    | 'unsupported-network'
+    | 'missing-deposit-params'
+    | 'vault-chain-mismatch'
+    | 'missing-fee-level'
+    | 'compose-failed';
+
+// Codes produced deliberately by the yield flows. Device/backend codes coming from
+// TrezorConnect responses (e.g. 'Failure_ActionCancelled') arrive as opaque strings on top
+// of this union. Codes are rendered in the UI banner and reported to analytics, so they
+// must never contain account or device data.
+export type StablecoinYieldKnownErrorCode =
+    | YieldDepositErrorReason
+    | 'missing-approval-contract-address'
+    | 'missing-revoke-spender'
+    | 'missing-approval-request-amount'
+    | 'missing-approval-params'
+    | 'approve-failed'
+    | 'missing-flow-tokens'
+    | 'missing-device'
+    | 'missing-device-session'
+    | 'device-state-failed'
+    | 'sign-failed'
+    | 'push-failed'
+    | 'transaction-failed'
+    | 'submit-failed';
+
+export type StablecoinYieldErrorState = {
+    message: StablecoinYieldTranslationKey;
+    code: string;
+};
+
+const KNOWN_ERROR_TRANSLATION_KEYS: Record<
+    StablecoinYieldKnownErrorCode,
+    StablecoinYieldTranslationKey
+> = {
+    'unsupported-network': 'TR_EARN_YIELD_ERROR_GENERIC',
+    'missing-deposit-params': 'TR_EARN_YIELD_ERROR_GENERIC',
+    'vault-chain-mismatch': 'TR_EARN_YIELD_ERROR_GENERIC',
+    'missing-fee-level': 'TR_EARN_YIELD_ERROR_GENERIC',
+    'compose-failed': 'TR_EARN_YIELD_ERROR_GENERIC',
+    'missing-approval-contract-address': 'TR_EARN_YIELD_ERROR_GENERIC',
+    'missing-revoke-spender': 'TR_EARN_YIELD_ERROR_GENERIC',
+    'missing-approval-request-amount': 'TR_EARN_YIELD_ERROR_GENERIC',
+    'missing-approval-params': 'TR_EARN_YIELD_ERROR_GENERIC',
+    'approve-failed': 'TR_EARN_YIELD_ERROR_GENERIC',
+    'missing-flow-tokens': 'TR_EARN_YIELD_ERROR_GENERIC',
+    'missing-device': 'TR_EARN_YIELD_ERROR_GENERIC',
+    'missing-device-session': 'TR_EARN_YIELD_ERROR_GENERIC',
+    'device-state-failed': 'TR_EARN_YIELD_ERROR_GENERIC',
+    'sign-failed': 'TR_EARN_YIELD_ERROR_GENERIC',
+    'push-failed': 'TR_EARN_YIELD_ERROR_GENERIC',
+    'transaction-failed': 'TR_EARN_YIELD_ERROR_TRANSACTION_FAILED',
+    'submit-failed': 'TR_EARN_YIELD_ERROR_GENERIC',
+};
+
+const PASSPHRASE_ERROR_CODES: string[] = [
+    'Device_InvalidState', // incorrect passphrase submitted
+    'Method_Interrupted', // passphrase modal closed
+];
+
+export const getYieldErrorTranslationKey = (code: string): StablecoinYieldTranslationKey => {
+    if (PASSPHRASE_ERROR_CODES.includes(code)) {
+        return 'TR_EARN_YIELD_ERROR_PASSPHRASE_INCORRECT';
+    }
+
+    return (
+        KNOWN_ERROR_TRANSLATION_KEYS[code as StablecoinYieldKnownErrorCode] ??
+        'TR_EARN_YIELD_ERROR_GENERIC'
+    );
+};
+
+export const buildYieldSessionError = (code: string): StablecoinYieldErrorState => ({
+    message: getYieldErrorTranslationKey(code),
+    code,
+});

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -10,6 +10,7 @@ import {
 import { isSafeObjectKey } from '@trezor/utils';
 
 import { STABLECOIN_YIELD_PREFIX, YIELD_FLOW_STEP_SEQUENCES } from './stablecoinYieldConstants';
+import { type StablecoinYieldErrorState, buildYieldSessionError } from './stablecoinYieldErrors';
 import {
     type StablecoinYieldClaimUnsignedTransaction,
     type YieldApproveModalState,
@@ -21,13 +22,6 @@ import {
 } from './stablecoinYieldTypes';
 import { getNextYieldFlowStep } from './stablecoinYieldUtils';
 import { transactionsActions } from '../transactions/transactionsActions';
-
-// Message ids must exist in the desktop `suite/intl` messages — the desktop app renders
-// `session.error` directly via `<Translation>`.
-type StablecoinYieldTranslationKey =
-    | 'TR_EARN_YIELD_ERROR_GENERIC'
-    | 'TR_EARN_YIELD_ERROR_PASSPHRASE_INCORRECT'
-    | 'TR_EARN_YIELD_ERROR_TRANSACTION_FAILED';
 
 type StablecoinYieldSerializedTx = {
     tx: string;
@@ -72,7 +66,7 @@ export type StablecoinYieldTxReviewState = {
 
 export type StablecoinYieldSessionState = {
     step: YieldFlowStepId;
-    error: StablecoinYieldTranslationKey | null;
+    error: StablecoinYieldErrorState | null;
     approval: {
         allowanceAmount: string | null;
         modalState: YieldApproveModalState | null;
@@ -224,12 +218,12 @@ export const stablecoinYieldSlice = createSlice({
             state,
             action: PayloadAction<
                 StablecoinYieldSessionActionPayload & {
-                    error: StablecoinYieldTranslationKey;
+                    errorCode: string;
                 }
             >,
         ) {
             withSession(state, action.payload, session => {
-                session.error = action.payload.error;
+                session.error = buildYieldSessionError(action.payload.errorCode);
             });
         },
         clearError(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
@@ -433,7 +427,7 @@ export const stablecoinYieldSlice = createSlice({
         transactionFailed(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
             withSession(state, action.payload, session => {
                 session.action.pendingTransaction = null;
-                session.error = 'TR_EARN_YIELD_ERROR_TRANSACTION_FAILED';
+                session.error = buildYieldSessionError('transaction-failed');
             });
         },
         storePrecomposedTransaction(


### PR DESCRIPTION
## Description

WIP - better diagnostics for stablecoin yield failures. Generic error banners now include a machine-readable error code (e.g. `vault-chain-mismatch`), the code is logged to console and reported in analytics instead of a blanket `submit-failed`. Adds a central error-code → message mapping in wallet-core and rewrites `sendYieldTransaction` to return `Result` per defensive-programming guidelines.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All 14 changed files relate to the stablecoin yield (earn/yield) feature — deposit, withdraw, claim flows, signing helpers, approval thunks, reducer, and error handling. None of the 151 candidate E2E tests cover stablecoin yield functionality. The existing staking tests (ETH, SOL, ADA) test native staking flows via Everstake, not ERC-20/stablecoin yield vaults. The YieldWithdrawForm.tsx file has broad static mapping (121 tests) because it's bundled into the main app entry point, but none of those tests exercise yield withdraw behavior. There are no E2E tests that exercise the earn/yield/deposit, earn/yield/withdraw, or earn/yield/claim routes with stablecoin-specific logic. This change set has zero meaningful E2E test coverage among the candidate tests.

<details><summary><b>Changed files (14)</b></summary>

- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts`
- `packages/suite/src/components/earn/yield/claim/YieldClaim.tsx`
- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/hooks/useEnsureYieldDeviceSession.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx`
- `suite-common/wallet-core/src/index.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldErrors.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (14)**
- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts`
- `packages/suite/src/components/earn/yield/claim/YieldClaim.tsx`
- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/hooks/useEnsureYieldDeviceSession.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx`
- `suite-common/wallet-core/src/index.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldErrors.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`

_Updated: 2026-07-09T16:17:07.175Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/stablecoin-yield-error-codes/web/](https://dev.suite.sldev.cz/suite-web/feat/stablecoin-yield-error-codes/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/stablecoin-yield-error-codes&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/stablecoin-yield-error-codes&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/stablecoin-yield-error-codes&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-09T16:21:00.598Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-09T16:20:54.525Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->