### PR TITLE
test(suite): poc passthru trading mocks for sol and eth swap

### DIFF
--- a/packages/e2e-utils/src/index.ts
+++ b/packages/e2e-utils/src/index.ts
@@ -2,6 +2,8 @@ export * from './currentsApi';
 export { BackendWebsocketServerMock } from './mocks/backendServer';
 export { SolanaRpcServerMock, PASSTHROUGH } from './mocks/solanaRpcServerMock';
 export type { SolanaRpcHandler } from './mocks/solanaRpcServerMock';
+export { BlockbookProxyMock } from './mocks/blockbookProxyMock';
+export type { BlockbookWsHandler } from './mocks/blockbookProxyMock';
 export { DropboxMock } from './mocks/dropbox';
 export { GoogleMock } from './mocks/google';
 export { GitHubReporterBase, InitializationState } from './githubReporter/gitHubReporterBase';

--- a/packages/e2e-utils/src/mocks/blockbookProxyMock.ts
+++ b/packages/e2e-utils/src/mocks/blockbookProxyMock.ts
@@ -1,0 +1,111 @@
+import { WebSocket, WebSocketServer } from 'ws';
+
+import { getFreePort } from '@trezor/node-utils';
+
+import { PASSTHROUGH } from './solanaRpcServerMock';
+
+export type BlockbookWsHandler = (params: unknown) => unknown | typeof PASSTHROUGH;
+
+type BlockbookRequest = { id?: string; method?: string; params?: unknown };
+
+/**
+ * Local Blockbook WebSocket proxy used in e2e tests. Unlike Playwright's `page.route`, it
+ * intercepts at the network destination, so it also serves the blockchain-link worker where
+ * `page.routeWebSocket` cannot reach. Set it as a custom Blockbook backend via its `url`.
+ *
+ * Every frame is forwarded to the live upstream backend except methods with a registered
+ * handler, which are answered locally (return PASSTHROUGH from a handler to forward anyway).
+ */
+export class BlockbookProxyMock {
+    private readonly handlers = new Map<string, BlockbookWsHandler>();
+    private server?: WebSocketServer;
+    private port?: number;
+    private proxiedFrames = 0;
+
+    constructor(private readonly upstreamUrl: string) {}
+
+    get url(): string {
+        if (this.port === undefined) {
+            throw new Error('BlockbookProxyMock is not running');
+        }
+
+        return `ws://localhost:${this.port}`;
+    }
+
+    // Number of frames forwarded to the live upstream through this proxy.
+    get passthroughCount() {
+        return this.proxiedFrames;
+    }
+
+    setHandler(method: string, handler: BlockbookWsHandler) {
+        this.handlers.set(method, handler);
+    }
+
+    async start() {
+        const [port] = await getFreePort();
+        this.port = port;
+
+        await new Promise<void>((resolve, reject) => {
+            this.server = new WebSocketServer({ port });
+            this.server.on('connection', client => this.handleConnection(client));
+            this.server.on('listening', () => resolve());
+            this.server.on('error', error => reject(error));
+        });
+    }
+
+    async stop() {
+        const { server } = this;
+        this.server = undefined;
+        this.port = undefined;
+        if (!server) {
+            return;
+        }
+        server.clients.forEach(client => client.terminate());
+        await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+
+    private handleConnection(client: WebSocket) {
+        // Trezor blockbook instances reject websocket handshakes without a User-Agent (403).
+        const upstream = new WebSocket(this.upstreamUrl, {
+            headers: { 'User-Agent': 'Trezor Suite e2e' },
+        });
+        const queuedFrames: string[] = [];
+
+        upstream.on('open', () => {
+            queuedFrames.forEach(frame => upstream.send(frame));
+            queuedFrames.length = 0;
+        });
+        upstream.on('message', data => client.send(data.toString()));
+        upstream.on('close', () => client.close());
+        upstream.on('error', () => client.close());
+
+        client.on('message', data => {
+            const frame = data.toString();
+            let request: BlockbookRequest = {};
+            try {
+                request = JSON.parse(frame);
+            } catch {
+                // Non-JSON frames are forwarded untouched.
+            }
+            const handler = request.method ? this.handlers.get(request.method) : undefined;
+
+            if (handler) {
+                const result = handler(request.params);
+                if (result !== PASSTHROUGH) {
+                    client.send(JSON.stringify({ id: request.id, data: result }));
+
+                    return;
+                }
+            }
+
+            this.proxiedFrames += 1;
+            if (upstream.readyState === WebSocket.OPEN) {
+                upstream.send(frame);
+            } else {
+                queuedFrames.push(frame);
+            }
+        });
+        client.on('close', () => upstream.terminate());
+        client.on('error', () => upstream.terminate());
+    }
+}

--- a/packages/e2e-utils/src/mocks/solanaRpcServerMock.ts
+++ b/packages/e2e-utils/src/mocks/solanaRpcServerMock.ts
@@ -27,6 +27,7 @@ export class SolanaRpcServerMock {
     private subscriptionServer?: WebSocketServer;
     private port?: number;
     private nextSubscriptionId = 1;
+    private proxiedRequests = 0;
 
     constructor(private readonly upstreamUrl: string) {}
 
@@ -36,6 +37,12 @@ export class SolanaRpcServerMock {
         }
 
         return `http://localhost:${this.port}`;
+    }
+
+    // Number of requests forwarded to the live upstream. Non-zero value proves the mock is
+    // actually serving the backend, so a broadcast cannot slip past it to a real endpoint.
+    get passthroughCount(): number {
+        return this.proxiedRequests;
     }
 
     setHandler(method: string, handler: SolanaRpcHandler): void {
@@ -155,6 +162,7 @@ export class SolanaRpcServerMock {
     }
 
     private async proxyToUpstream(rawBody: Buffer, response: http.ServerResponse) {
+        this.proxiedRequests += 1;
         try {
             const upstreamResponse = await fetch(this.upstreamUrl, {
                 method: 'POST',

--- a/suite/e2e/support/fixtures.ts
+++ b/suite/e2e/support/fixtures.ts
@@ -6,6 +6,7 @@ import { EvoluClient } from './helpers/evoluClient';
 import { IndexedDbFixture } from './indexedDb';
 import { BlockbookMock } from './mocks/blockBookMock';
 import { MetadataMock } from './mocks/metadataMock';
+import { PassthruTradingMock } from './mocks/passthruTradingMock';
 import { SolanaStakingMock } from './mocks/solanaStakingMock';
 import { TradingMock } from './mocks/tradingMock';
 import { AnalyticsSection } from './pageObjects/analyticsSection';
@@ -50,6 +51,7 @@ type Fixtures = {
     blockbookMock: BlockbookMock;
     solanaStakingMock: SolanaStakingMock;
     tradingMock: TradingMock;
+    passthruTradingMock: PassthruTradingMock;
     connectPermissionsModal: ConnectPermissionsModal;
     connectSelectAccountModal: ConnectSelectAccountModal;
     stakingSection: StakingSection;
@@ -127,6 +129,11 @@ const test = suiteBaseTest.extend<Fixtures>({
     },
     tradingMock: async ({ page }, use) => {
         await use(new TradingMock(page));
+    },
+    passthruTradingMock: async ({ page }, use) => {
+        const passthruTradingMock = new PassthruTradingMock(page);
+        await use(passthruTradingMock);
+        await passthruTradingMock.stop();
     },
     connectSelectAccountModal: async ({ page }, use) => {
         await use(new ConnectSelectAccountModal(page));

--- a/suite/e2e/support/mocks/passthruTradingMock.ts
+++ b/suite/e2e/support/mocks/passthruTradingMock.ts
@@ -1,0 +1,174 @@
+import { Page } from '@playwright/test';
+import type { ExchangeTrade } from 'invity-api';
+
+import { BlockbookProxyMock, PASSTHROUGH, SolanaRpcServerMock } from '@trezor/e2e-utils';
+
+import { invityEndpoint } from '../../fixtures/invity';
+import {
+    getSignatureStatusesResponse,
+    sendTransactionResponse,
+} from '../../fixtures/solana-responses';
+import { step } from '../common';
+
+const base58Alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+const encodeBase58 = (bytes: Uint8Array) => {
+    let num = BigInt(`0x${Buffer.from(bytes).toString('hex')}`);
+    let encoded = '';
+
+    while (num > 0n) {
+        encoded = base58Alphabet[Number(num % 58n)] + encoded;
+        num /= 58n;
+    }
+
+    for (const byte of bytes) {
+        if (byte !== 0) {
+            break;
+        }
+        encoded = `1${encoded}`;
+    }
+
+    return encoded;
+};
+
+// Suite polls the signature derived from the signed tx, not the one returned by the RPC.
+// A single-signer tx starts with the signature count byte followed by the 64-byte signature.
+const extractTxSignature = (base64Tx: string) =>
+    encodeBase58(Buffer.from(base64Tx, 'base64').subarray(1, 65));
+
+const solUpstreamUrl = 'https://sol.trezor.io/';
+const ethUpstreamUrl = 'wss://eth1.trezor.io/websocket';
+const fakeEthTxid = '0x1b4e7dfff573a40ae04daafa67798ee5984345a2bde5e5387d77493a6029690c';
+
+// Passthrough mock for swap tests running against live backends and live Invity API.
+// Everything passes through untouched except the transaction broadcast, which is
+// blocked so no funds ever leave the account.
+export class PassthruTradingMock {
+    readonly watchPollPeriod = '00:30';
+
+    private blockedTxSignatures: string[] = [];
+    private blockedEthSends = 0;
+    private liveTrade: ExchangeTrade | null = null;
+    private solProxy: SolanaRpcServerMock | null = null;
+    private ethProxy: BlockbookProxyMock | null = null;
+
+    constructor(private page: Page) {
+        this.validatePassphraseEnv();
+    }
+
+    get blockedSendCount() {
+        return this.blockedTxSignatures.length + this.blockedEthSends;
+    }
+
+    // Number of live requests that flowed through the passthrough proxies. Non-zero value
+    // proves the interception is active, so a broadcast cannot slip through it.
+    get passthroughCount() {
+        return (this.solProxy?.passthroughCount ?? 0) + (this.ethProxy?.passthroughCount ?? 0);
+    }
+
+    get liveTradeSendAddress() {
+        if (!this.liveTrade?.sendAddress) {
+            throw new Error('Live trade response was not captured yet');
+        }
+
+        return this.liveTrade.sendAddress;
+    }
+
+    // Solana RPC is HTTP, but page.route misses the blockchain-link worker on desktop. A local
+    // passthrough backend (set as custom backend) forwards every method to the live upstream and
+    // answers only the broadcast locally, so the same test can run on web and desktop.
+    @step()
+    async blockSolanaSends() {
+        this.solProxy = new SolanaRpcServerMock(solUpstreamUrl);
+
+        // IMPORTANT: answering this method locally is what prevents actually sending crypto
+        this.solProxy.setHandler('sendTransaction', ([base64Tx]) => {
+            this.blockedTxSignatures.push(extractTxSignature(String(base64Tx ?? '')));
+
+            return sendTransactionResponse('0').result;
+        });
+
+        // Suite polls the tx-derived signature; fake confirmation only for blocked sends,
+        // other signature queries stay live.
+        this.solProxy.setHandler('getSignatureStatuses', ([signatures]) =>
+            (signatures as string[])?.some(signature =>
+                this.blockedTxSignatures.includes(signature),
+            )
+                ? getSignatureStatusesResponse('0').result
+                : PASSTHROUGH,
+        );
+
+        await this.solProxy.start();
+
+        return this.solProxy.url;
+    }
+
+    // ETH talks to Blockbook over WebSocket from a blockchain-link worker, out of reach of
+    // page.route/routeWebSocket. A local passthrough proxy (set as custom backend) forwards
+    // everything to the live upstream and answers only the broadcast locally.
+    @step()
+    async blockEthSends() {
+        this.ethProxy = new BlockbookProxyMock(ethUpstreamUrl);
+        // IMPORTANT: answering this method locally is what prevents actually sending crypto
+        this.ethProxy.setHandler('sendTransaction', () => {
+            this.blockedEthSends += 1;
+
+            return { result: fakeEthTxid };
+        });
+        await this.ethProxy.start();
+
+        return this.ethProxy.url;
+    }
+
+    async stop() {
+        await this.solProxy?.stop();
+        await this.ethProxy?.stop();
+    }
+
+    // Resolves with the live trade response (real order, real deposit address) once
+    // Suite requests it. Must be called before the request is triggered.
+    async waitForLiveTrade() {
+        const response = await this.page.waitForResponse(invityEndpoint.swapTrade);
+        this.liveTrade = (await response.json()) as ExchangeTrade;
+
+        return this.liveTrade;
+    }
+
+    // The provider never receives the blocked payment, so the live watch endpoint would
+    // never progress - watch status responses are the one Invity endpoint we mock.
+    @step()
+    async routeSwapWatch(status: string) {
+        await this.page.route(invityEndpoint.swapWatch, async route => {
+            await route.fulfill({ json: { status, sendAddress: this.liveTrade?.sendAddress } });
+        });
+    }
+
+    // A stale in-flight poll can still carry the previous status, so keep advancing
+    // the clock until a response with the target status is actually observed.
+    @step()
+    async advanceToWatchStatus(status: string) {
+        await this.routeSwapWatch(status);
+
+        for (let attempt = 0; attempt < 5; attempt++) {
+            const watchResponsePromise = this.page
+                .waitForResponse(invityEndpoint.swapWatch, { timeout: 35_000 })
+                .catch(() => null);
+            await this.page.clock.fastForward(this.watchPollPeriod);
+
+            const response = await watchResponsePromise;
+            if (response && (await response.json()).status === status) {
+                return;
+            }
+        }
+
+        throw new Error(`Watch response with status ${status} was not observed`);
+    }
+
+    validatePassphraseEnv = () => {
+        if (!process.env.PASSPHRASE) {
+            throw new Error(
+                'PASSPHRASE not provided in env variables. Check suite/e2e/docs/e2e-playwright-suite.md.',
+            );
+        }
+    };
+}

--- a/suite/e2e/tests/trading-poc/passthru-swap-eth-to-btc.test.ts
+++ b/suite/e2e/tests/trading-poc/passthru-swap-eth-to-btc.test.ts
@@ -1,0 +1,183 @@
+import { TranslationKey } from '@suite/intl';
+import { toChecksumAddress } from '@suite-common/address';
+import { getCryptoId } from '@suite-common/trading';
+import { localizeNumber } from '@suite-common/wallet-utils';
+
+import { getCompanyNameFromList } from '../../fixtures/invity';
+import { formatAddressWithNewlines } from '../../support/common';
+import { expect, test } from '../../support/fixtures';
+import { transformAddress } from '../../support/testExtends/customMatchers';
+
+const sendAmount = '0.03';
+const formattedSendAmount = `${localizeNumber(sendAmount)} ETH`;
+const accountLabel = 'Ethereum #1';
+
+const transactionStates = [
+    {
+        transactionStatus: 'CONFIRMING',
+        displayedText: 'TR_EXCHANGE_DETAIL_SENDING_TRANSACTION',
+    },
+    {
+        transactionStatus: 'CONVERTING',
+        displayedText: 'TR_TRADING_DETAIL_PROCESSING',
+        translationValues: (providerName: string) => ({ providerName, type: 'swap' }),
+    },
+    {
+        transactionStatus: 'SUCCESS',
+        displayedText: 'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',
+    },
+];
+
+test.describe('Trading POC - passthru swap ETH', { tag: ['@T3W1', '@T3T1'] }, () => {
+    test.use({ deviceSetup: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
+
+    test.beforeEach(
+        async ({
+            onboardingPage,
+            dashboardPage,
+            settingsPage,
+            walletPage,
+            passthruTradingMock,
+        }) => {
+            // ETH broadcasts go over the Blockbook websocket, so the blocking passthrough
+            // proxy must be set as a custom backend before discovery starts.
+            const ethBackendUrl = await passthruTradingMock.blockEthSends();
+
+            await onboardingPage.completeOnboarding();
+            await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
+            await settingsPage.enableNetworkWithCustomBackend('eth', 'blockbook', ethBackendUrl);
+            await dashboardPage.navigateTo();
+            await dashboardPage.deviceSwitchingOpenButton.click();
+            await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
+            await walletPage.openSwapTrading({ symbol: 'eth' });
+        },
+    );
+
+    test('Swap ETH to BTC with live quotes and blocked send', async ({
+        tradingPage,
+        page,
+        device,
+        devicePrompt,
+        passthruTradingMock,
+    }) => {
+        await test.step('Fill in a Swap form', async () => {
+            await tradingPage.fillSwapForm({
+                amount: sendAmount,
+                sellAsset: {
+                    searchFilter: accountLabel,
+                    networkSymbol: 'eth',
+                },
+                buyAsset: {
+                    searchFilter: 'Bitcoin',
+                    assetCryptoId: getCryptoId('btc'),
+                },
+                selectReceiveAddress: async () => {
+                    await tradingPage.receiveAccount.selectSuiteReceiveAccount(0, 'btc');
+                },
+            });
+        });
+
+        let receiveAmount: string;
+        let providerName: string;
+        // The live trade (real deposit address) is created when the best offer is confirmed,
+        // so arm the listener before that click to avoid racing the request.
+        let liveTradePromise: ReturnType<typeof passthruTradingMock.waitForLiveTrade>;
+
+        await test.step('Confirm the Swap trade', async () => {
+            await expect(tradingPage.quotes.bestOfferAmount).toHaveText(/^\d+(\.\d+)?\s+BTC$/);
+            const [amount] = (await tradingPage.quotes.bestOfferAmount.innerText()).split(' ');
+            receiveAmount = localizeNumber(amount ?? '');
+            liveTradePromise = passthruTradingMock.waitForLiveTrade();
+            await tradingPage.swapBestOfferButton.click();
+            await page.expectReduxObjectNotToBeEmpty('wallet.trading.composedTransactionInfo', {
+                timeout: 15_000,
+            });
+        });
+
+        await test.step('Open modal and verify recipient on prompt and device', async () => {
+            await tradingPage.confirmation.openConfirmAndSendModal();
+            const liveTrade = await liveTradePromise;
+            providerName = getCompanyNameFromList(liveTrade.exchange ?? '', 'swapList');
+            const sendAddress = passthruTradingMock.liveTradeSendAddress;
+
+            await expect(devicePrompt.headerParagraph).toContainText(accountLabel);
+            await expect(devicePrompt.outputValueOf('address')).toHaveText(
+                formatAddressWithNewlines(sendAddress),
+            );
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [transformAddress(toChecksumAddress(sendAddress), 'evmTetragrams')],
+                    actions: { right_button: 'Continue' },
+                },
+                T3T1: {
+                    header: { title: 'Address', subtitle: 'Recipient' },
+                },
+            });
+            await devicePrompt.waitForPromptAndConfirm();
+        });
+
+        await test.step('Verify amount and fee on prompt and device', async () => {
+            // ETH's send review shows the fee on the modal; the amount is verified on the device.
+            await expect(devicePrompt.cryptoAmountOf('fee')).toHaveTextGreaterThan(0);
+
+            // Fee is live, so read the displayed maximum fee and expect the device to echo it.
+            const maximumFee = (
+                await devicePrompt.cryptoAmountWithSymbolOf('fee').innerText()
+            ).trim();
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [
+                        ['Amount'],
+                        [formattedSendAmount],
+                        ['Maximum fee'],
+                        device.wrapText(maximumFee, { isAmount: true }),
+                    ],
+                    actions: { right_button: 'Hold to sign' },
+                },
+                T3T1: {
+                    header: { title: 'Summary' },
+                },
+            });
+            await devicePrompt.waitForFinalPromptAndConfirm();
+            await expect(devicePrompt.sendButton).toBeEnabled();
+        });
+
+        await test.step('Send crypto to provider (broadcast blocked by mock)', async () => {
+            // Hard gate: live traffic must have flowed through the blocking proxy already.
+            expect(passthruTradingMock.passthroughCount).toBeGreaterThan(0);
+
+            await passthruTradingMock.routeSwapWatch('SENDING');
+            await page.clock.install();
+            await devicePrompt.sendButton.click();
+
+            await expect.poll(() => passthruTradingMock.blockedSendCount).toBeGreaterThan(0);
+
+            await expect(tradingPage.swapToastSendAccount).toContainText(accountLabel);
+            await expect(tradingPage.swapToastReceiveAccount).toContainText('Bitcoin #1');
+            await expect(tradingPage.swapToastSendAmount).toContainText(sendAmount);
+            await expect(tradingPage.swapToastReceiveAmount).toContainText(receiveAmount);
+        });
+
+        for (const { transactionStatus, displayedText, translationValues } of transactionStates) {
+            await test.step(`Wait for status change to ${displayedText}`, async () => {
+                await passthruTradingMock.advanceToWatchStatus(transactionStatus);
+                await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                    displayedText as TranslationKey,
+                    translationValues ? { values: translationValues(providerName) } : undefined,
+                );
+            });
+        }
+
+        await test.step('Verify transaction detail values', async () => {
+            await expect(tradingPage.confirmation.cryptoAmount.first()).toHaveText(
+                formattedSendAmount,
+            );
+            await expect(tradingPage.confirmation.cryptoAmount.last()).toHaveText(
+                `${receiveAmount} BTC`,
+            );
+            await expect(tradingPage.confirmation.provider).toBeVisible();
+        });
+    });
+});

--- a/suite/e2e/tests/trading-poc/passthru-swap-sol-to-btc.test.ts
+++ b/suite/e2e/tests/trading-poc/passthru-swap-sol-to-btc.test.ts
@@ -1,0 +1,176 @@
+import { TranslationKey } from '@suite/intl';
+import { getCryptoId } from '@suite-common/trading';
+import { localizeNumber } from '@suite-common/wallet-utils';
+
+import { getCompanyNameFromList } from '../../fixtures/invity';
+import { formatAddressWithNewlines } from '../../support/common';
+import { expect, test } from '../../support/fixtures';
+import { transformAddress } from '../../support/testExtends/customMatchers';
+
+const sendAmount = '0.5';
+const formattedSendAmount = `${localizeNumber(sendAmount)} SOL`;
+const accountLabel = 'Solana #1';
+
+const transactionStates = [
+    {
+        transactionStatus: 'CONFIRMING',
+        displayedText: 'TR_EXCHANGE_DETAIL_SENDING_TRANSACTION',
+    },
+    {
+        transactionStatus: 'CONVERTING',
+        displayedText: 'TR_TRADING_DETAIL_PROCESSING',
+        translationValues: (providerName: string) => ({ providerName, type: 'swap' }),
+    },
+    {
+        transactionStatus: 'SUCCESS',
+        displayedText: 'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',
+    },
+];
+
+test.describe('Trading POC - passthru swap', { tag: ['@T3W1', '@T3T1'] }, () => {
+    test.use({ deviceSetup: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
+
+    test.beforeEach(
+        async ({
+            onboardingPage,
+            dashboardPage,
+            settingsPage,
+            walletPage,
+            passthruTradingMock,
+        }) => {
+            // Solana broadcasts go through the blockchain-link worker, so the blocking
+            // passthrough backend must be set as a custom backend before discovery starts.
+            const solBackendUrl = await passthruTradingMock.blockSolanaSends();
+
+            await onboardingPage.completeOnboarding();
+            await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
+            await settingsPage.enableNetworkWithCustomBackend('sol', 'solana', solBackendUrl);
+            await dashboardPage.navigateTo();
+            await dashboardPage.deviceSwitchingOpenButton.click();
+            await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
+            await walletPage.openSwapTrading({ symbol: 'sol' });
+        },
+    );
+
+    test('Swap SOL to BTC with live quotes and blocked send', async ({
+        tradingPage,
+        page,
+        device,
+        devicePrompt,
+        passthruTradingMock,
+    }) => {
+        await test.step('Fill in a Swap form', async () => {
+            await tradingPage.fillSwapForm({
+                amount: sendAmount,
+                sellAsset: {
+                    searchFilter: accountLabel,
+                    networkSymbol: 'sol',
+                },
+                buyAsset: {
+                    searchFilter: 'Bitcoin',
+                    assetCryptoId: getCryptoId('btc'),
+                },
+                selectReceiveAddress: async () => {
+                    await tradingPage.receiveAccount.selectSuiteReceiveAccount(0, 'btc');
+                },
+            });
+        });
+
+        let receiveAmount: string;
+        let providerName: string;
+        // The live trade (real deposit address) is created when the best offer is confirmed,
+        // so arm the listener before that click to avoid racing the request.
+        let liveTradePromise: ReturnType<typeof passthruTradingMock.waitForLiveTrade>;
+
+        await test.step('Confirm the Swap trade', async () => {
+            await expect(tradingPage.quotes.bestOfferAmount).toHaveText(/^\d+(\.\d+)?\s+BTC$/);
+            const [amount] = (await tradingPage.quotes.bestOfferAmount.innerText()).split(' ');
+            receiveAmount = localizeNumber(amount ?? '');
+            liveTradePromise = passthruTradingMock.waitForLiveTrade();
+            await tradingPage.waitForSolanaFeesAndClickSwapBestOffer();
+        });
+
+        await test.step('Open modal and verify recipient on prompt and device', async () => {
+            await tradingPage.confirmation.openConfirmAndSendModal();
+            const liveTrade = await liveTradePromise;
+            providerName = getCompanyNameFromList(liveTrade.exchange ?? '', 'swapList');
+            const sendAddress = passthruTradingMock.liveTradeSendAddress;
+
+            await expect(devicePrompt.headerParagraph).toContainText(accountLabel);
+            await expect(devicePrompt.outputValueOf('address')).toHaveText(
+                formatAddressWithNewlines(sendAddress),
+            );
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Recipient' },
+                    body: [transformAddress(sendAddress, 'fullLine')],
+                    actions: { right_button: 'Continue' },
+                },
+            });
+            await devicePrompt.waitForPromptAndConfirm();
+        });
+
+        await test.step('Verify amount and fee on prompt and device', async () => {
+            await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
+                formattedSendAmount,
+            );
+            await expect(devicePrompt.cryptoAmountOf('fee')).toHaveTextGreaterThan(0);
+
+            // Fee is live, so read the displayed fee and expect the device to echo it.
+            const solanaFee = (await devicePrompt.cryptoAmountOf('fee').innerText()).trim();
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [
+                        ['Amount:'],
+                        [formattedSendAmount],
+                        ['Transaction fee'],
+                        device.wrapText(`${solanaFee} SOL`, { wrapByWords: true }),
+                    ],
+                    actions: { right_button: 'Hold to sign' },
+                },
+                T3T1: {
+                    header: { title: 'Summary' },
+                },
+            });
+            await devicePrompt.waitForFinalPromptAndConfirm();
+            await expect(devicePrompt.sendButton).toBeEnabled();
+        });
+
+        await test.step('Send crypto to provider (broadcast blocked by mock)', async () => {
+            // Hard gate: live traffic must have flowed through the blocking route already.
+            expect(passthruTradingMock.passthroughCount).toBeGreaterThan(0);
+
+            await passthruTradingMock.routeSwapWatch('SENDING');
+            await page.clock.install();
+            await devicePrompt.sendButton.click();
+
+            await expect.poll(() => passthruTradingMock.blockedSendCount).toBeGreaterThan(0);
+
+            await expect(tradingPage.swapToastSendAccount).toContainText(accountLabel);
+            await expect(tradingPage.swapToastReceiveAccount).toContainText('Bitcoin #1');
+            await expect(tradingPage.swapToastSendAmount).toContainText(sendAmount);
+            await expect(tradingPage.swapToastReceiveAmount).toContainText(receiveAmount);
+        });
+
+        for (const { transactionStatus, displayedText, translationValues } of transactionStates) {
+            await test.step(`Wait for status change to ${displayedText}`, async () => {
+                await passthruTradingMock.advanceToWatchStatus(transactionStatus);
+                await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                    displayedText as TranslationKey,
+                    translationValues ? { values: translationValues(providerName) } : undefined,
+                );
+            });
+        }
+
+        await test.step('Verify transaction detail values', async () => {
+            await expect(tradingPage.confirmation.cryptoAmount.first()).toHaveText(
+                formattedSendAmount,
+            );
+            await expect(tradingPage.confirmation.cryptoAmount.last()).toHaveText(
+                `${receiveAmount} BTC`,
+            );
+            await expect(tradingPage.confirmation.provider).toBeVisible();
+        });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

POC alternative to how we mock our e2e trading tests. To be evaluated over a week and then adopted+refactored or ditched completely.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/poc-minimalist-trade-mock/web/](https://dev.suite.sldev.cz/suite-web/poc-minimalist-trade-mock/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=poc-minimalist-trade-mock&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=poc-minimalist-trade-mock&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-12T07:13:15.542Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-12T07:12:36.951Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->