### PR TITLE
fix(suite-native): reset trade sheet list scroll imperatively instead of remounting

### DIFF
--- a/suite-native/atoms/src/Sheet/BottomSheetFlashList.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetFlashList.tsx
@@ -78,8 +78,10 @@ export const BottomSheetFlashList = <TItem,>({
 
     // Imperative scroll reset.
     useEffect(() => {
-        flashListRef.current?.scrollToOffset({ offset: 0, animated: false });
-    }, [scrollResetKey]);
+        if (isVisible) {
+            flashListRef.current?.scrollToOffset({ offset: 0, animated: false });
+        }
+    }, [scrollResetKey, isVisible]);
 
     const dismissSheet = useCallback(() => {
         bottomSheetModalRef.current?.dismiss();
@@ -143,12 +145,13 @@ export const BottomSheetFlashList = <TItem,>({
         >
             <FlashList
                 ref={flashListRef}
+                maintainVisibleContentPosition={{ disabled: true }}
                 renderScrollComponent={BottomSheetListScrollComponent}
                 renderItem={renderFlashListItem}
-                {...flashListProps}
                 contentContainerStyle={applyStyle(sheetContentContainerStyle, {
                     insetBottom,
                 })}
+                {...flashListProps}
             />
         </BottomSheetModal>
     );

--- a/suite-native/atoms/src/Sheet/BottomSheetFlashList.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetFlashList.tsx
@@ -8,7 +8,7 @@ import {
     BottomSheetModal,
     useBottomSheetScrollableCreator,
 } from '@gorhom/bottom-sheet';
-import { FlashList, type FlashListProps } from '@shopify/flash-list';
+import { FlashList, type FlashListProps, type FlashListRef } from '@shopify/flash-list';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
@@ -30,7 +30,7 @@ export type BottomSheetFlashListProps<TItem> = {
     subtitle?: ReactNode;
     estimatedListHeight?: number;
     handleComponent?: ((props: BottomSheetFlashListHandleProps) => ReactNode) | null;
-    flashListKey?: string;
+    scrollResetKey?: string;
     renderItem: (
         info: FlashListRenderItemInfo<TItem>,
         sheetControls: BottomSheetFlashListControls,
@@ -66,7 +66,7 @@ export const BottomSheetFlashList = <TItem,>({
     subtitle,
     estimatedListHeight = 0,
     handleComponent,
-    flashListKey,
+    scrollResetKey,
     renderItem,
     ...flashListProps
 }: BottomSheetFlashListProps<TItem>) => {
@@ -74,6 +74,12 @@ export const BottomSheetFlashList = <TItem,>({
     const { bottom: insetBottom } = useSafeAreaInsets();
 
     const bottomSheetModalRef = useRef<BottomSheetModal>(null);
+    const flashListRef = useRef<FlashListRef<TItem>>(null);
+
+    // Imperative scroll reset.
+    useEffect(() => {
+        flashListRef.current?.scrollToOffset({ offset: 0, animated: false });
+    }, [scrollResetKey]);
 
     const dismissSheet = useCallback(() => {
         bottomSheetModalRef.current?.dismiss();
@@ -136,9 +142,9 @@ export const BottomSheetFlashList = <TItem,>({
             keyboardBehavior="fillParent"
         >
             <FlashList
+                ref={flashListRef}
                 renderScrollComponent={BottomSheetListScrollComponent}
                 renderItem={renderFlashListItem}
-                key={flashListKey}
                 {...flashListProps}
                 contentContainerStyle={applyStyle(sheetContentContainerStyle, {
                     insetBottom,

--- a/suite-native/module-trading/src/components/buy/BuyTradeableAssetsSheet.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyTradeableAssetsSheet.tsx
@@ -6,7 +6,7 @@ import {
 
 export type BuyTradeableAssetsSheetProps = Omit<
     TradeableAssetsSheetProps,
-    'assets' | 'onFilterChange' | 'onSelectedNetworkFilter' | 'flashListKey'
+    'assets' | 'onFilterChange' | 'onSelectedNetworkFilter' | 'scrollResetKey'
 >;
 
 const SHEET_TEST_ID = '@trading/buy/receive-asset-sheet';
@@ -15,16 +15,14 @@ export const BuyTradeableAssetsSheet = (props: BuyTradeableAssetsSheetProps) => 
     const { filteredData, filterValue, setFilterValue, setFilterSymbol } =
         useBuyTradeableAssetsFilteredData();
 
-    // re-mount FLashList component when filterValue changes (resets scroll position)
-    const flashListKey = 'buy_tradeable_assets-' + filterValue;
-
     return (
         <TradeableAssetSheet
             assets={filteredData}
             onFilterChange={setFilterValue}
             {...props}
             onSelectedNetworkFilter={setFilterSymbol}
-            flashListKey={flashListKey}
+            // reset scroll position when filterValue changes
+            scrollResetKey={filterValue}
             testID={SHEET_TEST_ID}
         />
     );

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeTradeableAssetsSheet.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeTradeableAssetsSheet.tsx
@@ -6,7 +6,7 @@ import {
 
 export type ExchangeTradeableAssetsSheetProps = Omit<
     TradeableAssetsSheetProps,
-    'assets' | 'onFilterChange' | 'onSelectedNetworkFilter' | 'flashListKey'
+    'assets' | 'onFilterChange' | 'onSelectedNetworkFilter' | 'scrollResetKey'
 >;
 
 const SHEET_TEST_ID = '@trading/exchange/receive-asset-sheet';
@@ -15,16 +15,14 @@ export const ExchangeTradeableAssetsSheet = (props: ExchangeTradeableAssetsSheet
     const { filteredData, filterValue, setFilterValue, setFilterSymbol } =
         useExchangeBuyTradeableAssetsFilteredData();
 
-    // re-mount FlashList component when filterValue changes (resets scroll position)
-    const flashListKey = 'exchange_tradeable_assets-' + filterValue;
-
     return (
         <TradeableAssetSheet
             assets={filteredData}
             onFilterChange={setFilterValue}
             {...props}
             onSelectedNetworkFilter={setFilterSymbol}
-            flashListKey={flashListKey}
+            // reset scroll position when filterValue changes
+            scrollResetKey={filterValue}
             testID={SHEET_TEST_ID}
         />
     );

--- a/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencySheet.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencySheet.tsx
@@ -50,9 +50,6 @@ export const FiatCurrencySheet = memo(
             [setFilterValue, translate, searchInputTestId],
         );
 
-        // re-mount FLashList component when filterValue changes (resets scroll position)
-        const flashListKey = 'fiat_currencies_list-' + filterValue;
-
         return (
             <BottomSheetSectionList<FiatCurrencyItem>
                 isVisible={isVisible}
@@ -71,7 +68,8 @@ export const FiatCurrencySheet = memo(
                 )}
                 data={filteredData}
                 keyExtractor={keyExtractor}
-                flashListKey={flashListKey}
+                // reset scroll position when filterValue changes
+                scrollResetKey={filterValue}
                 ItemSeparatorComponent={ItemSeparator}
                 noSingletonSectionHeader
             />

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheet.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheet.tsx
@@ -95,7 +95,7 @@ export const MyAssetSheet = memo(
                         />
                     );
                 }}
-                flashListKey={filterValue}
+                scrollResetKey={filterValue}
             />
         );
     },

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheet.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheet.tsx
@@ -21,7 +21,7 @@ export type TradeableAssetsSheetProps = {
     assets: TradeableAsset[];
     onFilterChange: (value: string) => void;
     onSelectedNetworkFilter: (symbol: NetworkSymbol | undefined) => void;
-    flashListKey: string;
+    scrollResetKey: string;
     testID?: string;
 };
 
@@ -42,7 +42,7 @@ export const TradeableAssetSheet = memo(
         assets,
         onFilterChange,
         onSelectedNetworkFilter,
-        flashListKey,
+        scrollResetKey,
         testID,
     }: TradeableAssetsSheetProps) => {
         const listData = useFavouriteAssetsSectionList(assets);
@@ -76,7 +76,7 @@ export const TradeableAssetSheet = memo(
                         closeSheet();
                     })
                 }
-                flashListKey={flashListKey}
+                scrollResetKey={scrollResetKey}
                 noSingletonSectionHeader
                 testID={testID}
             />

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheet.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheet.test.tsx
@@ -18,7 +18,7 @@ describe('TradeableAssetSheet', () => {
                 isVisible={true}
                 onFilterChange={jest.fn}
                 onSelectedNetworkFilter={jest.fn}
-                flashListKey="test-key"
+                scrollResetKey="test-key"
                 {...props}
             />,
         );

--- a/suite-native/module-trading/src/hooks/general/useTradeableAssetsFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradeableAssetsFilteredData.ts
@@ -1,123 +1,93 @@
 import { useMemo, useState } from 'react';
 
+import { type CryptoId } from 'invity-api';
+
 import { normalizeForSearch } from '@suite-common/suite-utils';
-import { cryptoIdToSymbol, useListDataFilter } from '@suite-common/trading';
+import { cryptoIdToSymbol } from '@suite-common/trading';
 import { type NetworkSymbol, getNetworkByCoingeckoId } from '@suite-common/wallet-config';
 import { type TradeableAsset } from '@suite-native/trading-types';
 
-const doesContractAddressIncludeValue = (asset: TradeableAsset, value: string) => {
-    if (!asset.contractAddress) {
-        return false;
-    }
-
-    return normalizeForSearch(asset.contractAddress).includes(value);
+type AssetSearchFields = {
+    name: string;
+    symbol: string;
+    networkName: string;
+    networkSymbol: string;
+    contractAddress: string;
 };
 
-const doesSymbolIncludeValue = (asset: TradeableAsset, value: string) =>
-    normalizeForSearch(asset.symbol).includes(value);
-
-const doesNameIncludeValue = (asset: TradeableAsset, value: string) =>
-    normalizeForSearch(asset.name).includes(value);
-
-const doesNetworkNameIncludeValue = (asset: TradeableAsset, value: string) => {
+const getAssetSearchFields = (asset: TradeableAsset): AssetSearchFields => {
     const network = getNetworkByCoingeckoId(asset.networkId);
-    if (!network) {
-        return false;
-    }
 
-    return normalizeForSearch(network.name).includes(value);
+    return {
+        name: normalizeForSearch(asset.name),
+        symbol: normalizeForSearch(asset.symbol),
+        networkName: network ? normalizeForSearch(network.name) : '',
+        networkSymbol: network ? normalizeForSearch(network.symbol) : '',
+        contractAddress: asset.contractAddress ? normalizeForSearch(asset.contractAddress) : '',
+    };
 };
 
-const doesNetworkSymbolIncludeValue = (asset: TradeableAsset, value: string) => {
-    const network = getNetworkByCoingeckoId(asset.networkId);
-    if (!network) {
-        return false;
-    }
+const doesAssetMatchQuery = (searchFields: AssetSearchFields, query: string): boolean =>
+    searchFields.name.includes(query) ||
+    searchFields.symbol.includes(query) ||
+    searchFields.networkName.includes(query) ||
+    searchFields.networkSymbol.includes(query) ||
+    searchFields.contractAddress.includes(query);
 
-    return normalizeForSearch(network.symbol).includes(value);
-};
+const getAssetWeight = (searchFields: AssetSearchFields, query: string): number => {
+    const { name, symbol, networkName, networkSymbol, contractAddress } = searchFields;
 
-const filterCallback = (asset: TradeableAsset, filterValue: string): boolean => {
-    const normalizedFilterValue = normalizeForSearch(filterValue);
-
-    return (
-        doesNameIncludeValue(asset, normalizedFilterValue) ||
-        doesSymbolIncludeValue(asset, normalizedFilterValue) ||
-        doesNetworkNameIncludeValue(asset, normalizedFilterValue) ||
-        doesNetworkSymbolIncludeValue(asset, normalizedFilterValue) ||
-        doesContractAddressIncludeValue(asset, normalizedFilterValue)
-    );
-};
-
-const sortCallback = (a: TradeableAsset, b: TradeableAsset, filterValue: string): number => {
-    const query = normalizeForSearch(filterValue);
-    if (!query) {
+    if (name === query) {
         return 0;
     }
-
-    const getWeight = (asset: TradeableAsset): number => {
-        const name = normalizeForSearch(asset.name);
-        const symbol = normalizeForSearch(asset.symbol);
-        const network = getNetworkByCoingeckoId(asset.networkId);
-        const networkName = normalizeForSearch(network?.name ?? '');
-        const networkSymbol = normalizeForSearch(network?.symbol ?? '');
-        const contractAddress = asset.contractAddress?.toLowerCase() ?? '';
-
-        if (name === query) {
-            return 0;
-        }
-        if (symbol === query) {
-            return 1;
-        }
-        if (name.startsWith(query)) {
-            return 2;
-        }
-        if (symbol.startsWith(query)) {
-            return 3;
-        }
-        if (name.includes(query)) {
-            return 4;
-        }
-        if (symbol.includes(query)) {
-            return 5;
-        }
-        if (networkName === query) {
-            return 6;
-        }
-        if (networkSymbol === query) {
-            return 7;
-        }
-        if (networkName.startsWith(query)) {
-            return 8;
-        }
-        if (networkSymbol.startsWith(query)) {
-            return 9;
-        }
-        if (networkName.includes(query)) {
-            return 10;
-        }
-        if (networkSymbol.includes(query)) {
-            return 11;
-        }
-        if (contractAddress.startsWith(query)) {
-            return 12;
-        }
-
-        return 13;
-    };
-
-    const weightA = getWeight(a);
-    const weightB = getWeight(b);
-
-    if (weightA !== weightB) {
-        return weightA - weightB;
+    if (symbol === query) {
+        return 1;
+    }
+    if (name.startsWith(query)) {
+        return 2;
+    }
+    if (symbol.startsWith(query)) {
+        return 3;
+    }
+    if (name.includes(query)) {
+        return 4;
+    }
+    if (symbol.includes(query)) {
+        return 5;
+    }
+    if (networkName === query) {
+        return 6;
+    }
+    if (networkSymbol === query) {
+        return 7;
+    }
+    if (networkName.startsWith(query)) {
+        return 8;
+    }
+    if (networkSymbol.startsWith(query)) {
+        return 9;
+    }
+    if (networkName.includes(query)) {
+        return 10;
+    }
+    if (networkSymbol.includes(query)) {
+        return 11;
+    }
+    if (contractAddress.startsWith(query)) {
+        return 12;
     }
 
-    return a.name.localeCompare(b.name);
+    return 13;
 };
 
 export const useTradeableAssetsFilteredData = ({ assets }: { assets: TradeableAsset[] }) => {
     const [filterSymbol, setFilterSymbol] = useState<NetworkSymbol | undefined>(undefined);
+    const [filterValue, setFilterValue] = useState('');
+
+    const searchFieldsByAsset = useMemo(
+        () => new Map(assets.map(asset => [asset, getAssetSearchFields(asset)])),
+        [assets],
+    );
 
     const assetsFilteredByNetwork = useMemo(() => {
         if (!filterSymbol) {
@@ -127,11 +97,33 @@ export const useTradeableAssetsFilteredData = ({ assets }: { assets: TradeableAs
         return assets.filter(a => filterSymbol === cryptoIdToSymbol(a.cryptoId));
     }, [assets, filterSymbol]);
 
-    const { setFilterValue, filteredData, filterValue } = useListDataFilter(
-        assetsFilteredByNetwork,
-        filterCallback,
-        sortCallback,
-    );
+    const filteredData = useMemo(() => {
+        const query = normalizeForSearch(filterValue);
+        if (!query) {
+            return assetsFilteredByNetwork;
+        }
+
+        const matchingAssets: TradeableAsset[] = [];
+        const weightByAsset = new Map<CryptoId, number>();
+
+        assetsFilteredByNetwork.forEach(asset => {
+            const searchFields = searchFieldsByAsset.get(asset);
+            if (searchFields && doesAssetMatchQuery(searchFields, query)) {
+                matchingAssets.push(asset);
+                weightByAsset.set(asset.cryptoId, getAssetWeight(searchFields, query));
+            }
+        });
+
+        return matchingAssets.sort((a, b) => {
+            const weightA = weightByAsset.get(a.cryptoId) ?? 0;
+            const weightB = weightByAsset.get(b.cryptoId) ?? 0;
+            if (weightA !== weightB) {
+                return weightA - weightB;
+            }
+
+            return a.name.localeCompare(b.name);
+        });
+    }, [assetsFilteredByNetwork, searchFieldsByAsset, filterValue]);
 
     const filterValueWithNetwork = `Network:${filterSymbol ? filterSymbol : 'all'};Search:${filterValue}`;
 

--- a/suite-native/trading-atoms/src/hooks/useSectionList.tsx
+++ b/suite-native/trading-atoms/src/hooks/useSectionList.tsx
@@ -1,7 +1,6 @@
 import { type ReactElement, type ReactNode, useMemo } from 'react';
-import { FadeIn, FadeOut } from 'react-native-reanimated';
 
-import { AnimatedBox, type BottomSheetFlashListControls, Text } from '@suite-native/atoms';
+import { type BottomSheetFlashListControls, Box, Text } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { exhaustive } from '@trezor/type-utils';
 
@@ -197,11 +196,7 @@ const renderInternalItem = <T, U>({
             const { key, sectionData, title } = item;
 
             return (
-                <AnimatedBox
-                    paddingVertical={renderSectionHeader ? undefined : 'sp12'}
-                    entering={FadeIn}
-                    exiting={FadeOut}
-                >
+                <Box paddingVertical={renderSectionHeader ? undefined : 'sp12'}>
                     {renderSectionHeader ? (
                         renderSectionHeader(title, { sectionData, key })
                     ) : (
@@ -209,30 +204,22 @@ const renderInternalItem = <T, U>({
                             {item.title}
                         </Text>
                     )}
-                </AnimatedBox>
+                </Box>
             );
         }
 
         case 'item':
             return (
-                <AnimatedBox
-                    entering={FadeIn}
-                    exiting={FadeOut}
-                    style={applyStyle(itemStyle ?? defaultItemStyle, item.config)}
-                >
+                <Box style={applyStyle(itemStyle ?? defaultItemStyle, item.config)}>
                     {renderItem(item.item, item.config, sheetControls)}
-                </AnimatedBox>
+                </Box>
             );
 
         case 'emptySection':
             return (
-                <AnimatedBox
-                    entering={FadeIn}
-                    exiting={FadeOut}
-                    style={applyStyle(itemStyle ?? defaultItemStyle, item.config)}
-                >
+                <Box style={applyStyle(itemStyle ?? defaultItemStyle, item.config)}>
                     {SectionEmptyComponent}
-                </AnimatedBox>
+                </Box>
             );
 
         default:

--- a/suite-native/trading-residence/src/components/CountrySheet/CountrySheet.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountrySheet.tsx
@@ -56,9 +56,6 @@ export const CountrySheet = memo(
             [filteredData],
         );
 
-        // re-mount FLashList component when filterValue changes (resets scroll position)
-        const flashListKey = 'countries_list-' + filterValue;
-
         return (
             <BottomSheetSectionList<TradingCountryOption>
                 isVisible={isVisible}
@@ -77,7 +74,8 @@ export const CountrySheet = memo(
                 )}
                 data={listData}
                 keyExtractor={keyExtractor}
-                flashListKey={flashListKey}
+                // reset scroll position when filterValue changes
+                scrollResetKey={filterValue}
                 extraData={selectedCountryId}
                 testID={bottomSheetTestId}
                 ItemSeparatorComponent={ItemSeparator}

--- a/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionSheet.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionSheet.tsx
@@ -70,8 +70,6 @@ export const CountrySubdivisionSheet = memo(
             [filteredData],
         );
 
-        const flashListKey = 'country_subdivisions_list-' + filterValue;
-
         return (
             <BottomSheetSectionList<TradingCountrySubdivisionOption>
                 isVisible={isVisible}
@@ -99,7 +97,8 @@ export const CountrySubdivisionSheet = memo(
                 )}
                 data={listData}
                 keyExtractor={keyExtractor}
-                flashListKey={flashListKey}
+                // reset scroll position when filterValue changes
+                scrollResetKey={filterValue}
                 extraData={selectedSubdivisionId}
                 testID={bottomSheetTestId}
                 noSingletonSectionHeader


### PR DESCRIPTION
## Description

Typing in a trade sheet search field remounted the FlashList (React `key` derived from filter value) to reset scroll position. Remounting the sheet's registered scrollable mid-keyboard triggers a Fabric commit that strips reanimated's container transform, so the sheet visually disappears (regression after RN 0.85 / reanimated 4.3 upgrade). Replaced the remount with an imperative `scrollToOffset` reset (`flashListKey` prop renamed to `scrollResetKey`).

* Optimize asset filter perf which was causing unsolved bug with the sheet  

## Notes for QA

In Trade sheets with search (swap/buy asset picker, my assets, fiat currency, country/subdivision): typing filters the list without the sheet dismissing, and changing the filter resets list scroll to top.

## Related Issue

Resolve #29501

## Screenshots:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/trade-asset-picker-dismiss&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->