### PR TITLE
fix(suite): Guide search - show info instead of no results

### DIFF
--- a/packages/suite/src/components/guide/GuideSearch.tsx
+++ b/packages/suite/src/components/guide/GuideSearch.tsx
@@ -8,7 +8,7 @@ import { Box, CardList, Icon, Input, Paragraph, Spinner } from '@trezor/componen
 import { typography } from '@trezor/theme';
 
 import { GuideNode } from 'src/components/guide';
-import { useGuideSearch } from 'src/hooks/guide';
+import { MIN_QUERY_LENGTH, useGuideSearch } from 'src/hooks/guide';
 
 const PreviewContent = styled.div`
     white-space: nowrap;
@@ -47,7 +47,7 @@ export const GuideSearch = ({ pageRoot, setSearchActive }: GuideSearchProps) => 
     const inputRef = useRef<HTMLInputElement | null>(null);
 
     const { translationString } = useTranslation();
-    const { searchResult, loading } = useGuideSearch(query, pageRoot);
+    const { searchResult, loading, isQueryTooShort } = useGuideSearch(query, pageRoot);
 
     useEffect(() => {
         setSearchActive?.(!!searchResult.length || !!query);
@@ -94,7 +94,21 @@ export const GuideSearch = ({ pageRoot, setSearchActive }: GuideSearchProps) => 
                 </CardList>
             ) : (
                 query &&
-                !loading && (
+                !loading &&
+                (isQueryTooShort ? (
+                    <Paragraph
+                        data-testid="@guide/search/min-query-length"
+                        typographyStyle="body-md"
+                        intent="neutral"
+                        priority="secondary"
+                        margin={{ top: 16 }}
+                    >
+                        <Translation
+                            id="TR_GUIDE_SEARCH_MIN_QUERY_LENGTH"
+                            values={{ count: MIN_QUERY_LENGTH }}
+                        />
+                    </Paragraph>
+                ) : (
                     <Paragraph
                         data-testid="@guide/search/no-results"
                         typographyStyle="body-md"
@@ -104,7 +118,7 @@ export const GuideSearch = ({ pageRoot, setSearchActive }: GuideSearchProps) => 
                     >
                         <Translation id="TR_ACCOUNT_SEARCH_NO_RESULTS" />
                     </Paragraph>
-                )
+                ))
             )}
         </Box>
     );

--- a/packages/suite/src/hooks/guide/index.ts
+++ b/packages/suite/src/hooks/guide/index.ts
@@ -1,6 +1,6 @@
 export { useGuide, GUIDE_ANIMATION_DURATION_MS } from './useGuide';
 export { useGuideLoadArticle } from './useGuideLoadArticle';
 export { useGuideOpenNode } from './useGuideOpenNode';
-export { useGuideSearch } from './useGuideSearch';
+export { useGuideSearch, MIN_QUERY_LENGTH } from './useGuideSearch';
 export { useGuideKeyboard } from './useGuideKeyboard';
 export { useGuideDesktopMenu } from './useGuideDesktopMenu';

--- a/packages/suite/src/hooks/guide/useGuideSearch.ts
+++ b/packages/suite/src/hooks/guide/useGuideSearch.ts
@@ -5,7 +5,7 @@ import { type GuideArticle, type GuideCategory } from '@suite-common/suite-types
 import { loadPageMarkdownFile } from 'src/hooks/guide/useGuideLoadArticle';
 
 const SEARCH_DELAY = 300;
-const MIN_QUERY_LENGTH = 3;
+export const MIN_QUERY_LENGTH = 3;
 const MAX_RESULTS = 5;
 
 type PageMap = {
@@ -38,6 +38,11 @@ const removeAccents = (str: string) =>
         .normalize('NFD') // decouple accents from ascii characters
         .replace(/[\u0300-\u036f]/g, ''); // remove accent characters
 
+const sanitizeQuery = (query: string) =>
+    removeAccents(query)
+        .replace(/\W+/g, ' ') // replace every non-word char sequence with a single space
+        .trim();
+
 const searchInFile = (url: string, query: string, markdown: string) => {
     const sanitized = removeAccents(markdown)
         .replace(/[\\#*]/g, '') // remove some markdown syntax
@@ -54,9 +59,7 @@ const searchInFile = (url: string, query: string, markdown: string) => {
 };
 
 const search = async (query: string, pageMap: PageMap): Promise<SearchResult[]> => {
-    const querySanitized = removeAccents(query)
-        .replace(/\W+/g, ' ') // replace every non-word char sequence with a single space
-        .trim();
+    const querySanitized = sanitizeQuery(query);
     const results =
         querySanitized.length < MIN_QUERY_LENGTH
             ? []
@@ -116,8 +119,12 @@ export const useGuideSearch = (query: string, pageRoot: GuideCategory | null) =>
         };
     }, [query, pageMap]);
 
+    const isQueryTooShort =
+        query.trim().length > 0 && sanitizeQuery(query).length < MIN_QUERY_LENGTH;
+
     return {
         searchResult,
         loading,
+        isQueryTooShort,
     };
 };

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -7826,6 +7826,10 @@ export const messages = defineMessages({
         id: 'TR_GUIDE_SUPPORT_AND_FEEDBACK',
         defaultMessage: 'Help & Support',
     },
+    TR_GUIDE_SEARCH_MIN_QUERY_LENGTH: {
+        id: 'TR_GUIDE_SEARCH_MIN_QUERY_LENGTH',
+        defaultMessage: 'Type at least {count} characters to search.',
+    },
     TR_GUIDE_KEYBOARD_SHORTCUTS: {
         id: 'TR_GUIDE_KEYBOARD_SHORTCUTS',
         defaultMessage: 'Keyboard shortcuts',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

we don't show "no results" text when user input less than 3 characters (we don't search in this case)

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before

<img width="366" height="331" alt="image" src="https://github.com/user-attachments/assets/93a9b716-52ad-44f2-8b76-5c5d77856faa" />


after
<img width="364" height="286" alt="image" src="https://github.com/user-attachments/assets/1636a2b8-cf31-4d96-9c93-1808644cc380" />


--- 

search with no results
<img width="372" height="351" alt="image" src="https://github.com/user-attachments/assets/f72a2370-31d5-4833-bbc7-4eaf99fcdc66" />

search with result
<img width="374" height="492" alt="image" src="https://github.com/user-attachments/assets/194faaf9-ab26-4bb7-b65e-5653aaaf4138" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on the Guide search feature (GuideSearch component, useGuideSearch hook, guide hooks index) plus translation files. The primary risk is breaking the guide's search functionality — finding articles, displaying results, and handling empty states. The two guide-specific E2E tests (suite-guide.test.ts and guide.test.ts) are critical to run. The translation file changes (en-US.json and messages.ts) map to nearly all tests but are extremely unlikely to cause regressions in unrelated flows unless specific translation keys used by the guide were modified or removed.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite-data/files/translations/en-US.json`
- `packages/suite/src/components/guide/GuideSearch.tsx`
- `packages/suite/src/hooks/guide/index.ts`
- `packages/suite/src/hooks/guide/useGuideSearch.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/general/suite-guide.test.ts` — This test directly exercises the Guide panel's search functionality ('Install firmware' article lookup) and bug report submission. The changed files include GuideSearch.tsx (the search component) and useGuideSearch.ts (the search hook), which are the core of guide search behavior tested here.
- `suite/e2e/tests/suite/guide.test.ts` — This test covers guide panel open/close, article search with valid queries ('trezor'), 'no results' state for nonsensical queries, and feedback submission. It directly validates the GuideSearch component and useGuideSearch hook behavior including search results rendering and empty state display.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/suite/bug-report-form.test.ts` — This test exercises the Guide panel's support/feedback section including bug report submission. While not directly testing search, it exercises the guide panel infrastructure that shares the same component tree as GuideSearch, and translation key changes in messages.ts could affect guide panel text.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite-data/files/translations/en-US.json`

_Updated: 2026-07-10T08:06:52.782Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/guide-search-fix-show-info-instead-of-no-results/web/](https://dev.suite.sldev.cz/suite-web/guide-search-fix-show-info-instead-of-no-results/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=guide-search-fix-show-info-instead-of-no-results&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=guide-search-fix-show-info-instead-of-no-results&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T08:15:13.931Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T08:15:10.903Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->