### PR TITLE
suite(e2e):add test for banner after onboarding

### DIFF
--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -44,6 +44,8 @@ export class OnboardingPage {
     readonly deviceCompromisedModal: Locator;
     readonly pairingInputAtIndex = (index: number) =>
         this.page.getByTestId('@modal/thp-paring').locator('input').nth(index);
+    readonly onboardingFeedbackBanner: Locator;
+    readonly onboardingFeedbackBannerCTAButton: Locator;
 
     constructor(
         public page: Page,
@@ -82,6 +84,12 @@ export class OnboardingPage {
         this.finalButton = this.page.getByTestId('@onboarding/final-button');
         this.continueAtYourOwnRiskButton = this.page.getByTestId('@continue-to-suite');
         this.deviceCompromisedModal = this.page.getByTestId('@device-compromised');
+        this.onboardingFeedbackBanner = this.page.getByTestId(
+            '@dashboard/onboarding-feedback-banner',
+        );
+        this.onboardingFeedbackBannerCTAButton = this.page.getByTestId(
+            '@dashboard/onboarding-feedback-banner/button',
+        );
     }
 
     @step()

--- a/suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts
@@ -64,11 +64,14 @@ test.describe('Onboarding - create wallet', { tag: ['@T3W1'] }, () => {
 
             await test.step('Finish wallet creation', async () => {
                 await onboardingPage.finalButton.click();
+                await expect(onboardingPage.onboardingFeedbackBanner).toBeVisible();
+                await onboardingPage.onboardingFeedbackBannerCTAButton.click();
                 await dashboardPage.discoveryEmptyPrimaryButton.click();
                 await assetsSection.enableNetworkViaActivateAssetsModal(['btc', 'eth']);
 
                 await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({ timeout: 30_000 });
                 await expect(dashboardPage.walletReady).toBeVisible({ timeout: 30_000 });
+                await expect(onboardingPage.onboardingFeedbackBanner).toBeHidden();
             });
         },
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

adding a test for onboarding feedback banner after onboarding

## Description

<!--- Describe your changes in detail -->

## Notes for QA
 no QA needed
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/add-onboarding-feedback-banner/web/](https://dev.suite.sldev.cz/suite-web/test/add-onboarding-feedback-banner/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/add-onboarding-feedback-banner&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/add-onboarding-feedback-banner&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T09:15:17.433Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T09:16:06.840Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->