### PR TITLE
fix(suite-native-29477): show trade labels in used addresses list and screen heading

### DIFF
--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -41,6 +41,7 @@
         "@suite-common/wallet-utils": "workspace:*",
         "@suite-native/accounts": "workspace:*",
         "@suite-native/add-coin-account": "workspace:*",
+        "@suite-native/address": "workspace:*",
         "@suite-native/alerts": "workspace:*",
         "@suite-native/analytics": "workspace:*",
         "@suite-native/atoms": "workspace:*",

--- a/suite-native/module-trading/src/components/general/AccountList/AccountList.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountList.tsx
@@ -23,7 +23,6 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { AccountListAddressItem } from './AccountListAddressItem';
 import { AccountListFooter } from './AccountListFooter';
 import { AccountListItem } from './AccountListItem';
-import { AddressListEmptyComponent } from './AddressListEmptyComponent';
 import { NoAccountsComponent } from './NoAccountsComponent';
 import {
     type ReceiveAccountsListMode,
@@ -128,20 +127,12 @@ export const AccountList = ({
         <AccountListFooter hasTextualDivider={itemsCount > 0} onAddAccountTap={onAddAccountTap} />
     ) : null;
 
-    const filter = '';
-    const emptyComponent =
-        filter.length > 0 ? (
-            <AddressListEmptyComponent />
-        ) : (
-            <NoAccountsComponent isBottomRounded={isDeviceInViewOnlyMode} />
-        );
-
     return (
         <FlashList
             contentContainerStyle={applyStyle(contentContainerStyle, {
                 insetBottom,
             })}
-            ListEmptyComponent={emptyComponent}
+            ListEmptyComponent={<NoAccountsComponent isBottomRounded={isDeviceInViewOnlyMode} />}
             renderItem={internalRenderItem}
             ListFooterComponent={footer}
             data={internalData}

--- a/suite-native/module-trading/src/components/general/AccountList/AccountListAddressItem.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListAddressItem.tsx
@@ -1,6 +1,4 @@
-import { useSelector } from 'react-redux';
-
-import { type SuiteSyncDataRootState, selectSuiteSyncAddressLabel } from '@suite-common/suite-sync';
+import { AddressLabel } from '@suite-native/address';
 import { Text } from '@suite-native/atoms';
 import { AddressFormatter } from '@suite-native/formatters';
 import { type ReceiveAccount } from '@suite-native/trading-types';
@@ -25,16 +23,6 @@ export const AccountListAddressItem = ({
     const { applyStyle } = useNativeStyles();
     const { address } = receiveAccount;
 
-    const addressLabel = useSelector((state: SuiteSyncDataRootState) =>
-        address
-            ? selectSuiteSyncAddressLabel(
-                  state,
-                  receiveAccount.account.deviceState,
-                  address.address,
-              )
-            : null,
-    );
-
     if (!address) {
         return null;
     }
@@ -42,7 +30,13 @@ export const AccountListAddressItem = ({
     return (
         <AccountListBaseItem
             receiveAccount={receiveAccount}
-            label={addressLabel ?? <AddressFormatter value={address.address} format="full" />}
+            label={
+                <AddressLabel
+                    address={address.address}
+                    deviceStaticSessionId={receiveAccount.account.deviceState}
+                    fallback={<AddressFormatter value={address.address} format="full" />}
+                />
+            }
             isAddressDetail={true}
             info={
                 <Text variant="body-sm" style={applyStyle(labelTextStyle)}>

--- a/suite-native/module-trading/src/components/general/AccountList/AddressListEmptyComponent.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AddressListEmptyComponent.tsx
@@ -1,9 +1,0 @@
-import { Translation } from '@suite-native/intl';
-import { EmptyComponent } from '@suite-native/trading-atoms';
-
-export const AddressListEmptyComponent = () => (
-    <EmptyComponent
-        title={<Translation id="moduleTrading.accountScreen.addressEmpty.title" />}
-        description={<Translation id="moduleTrading.accountScreen.addressEmpty.description" />}
-    />
-);

--- a/suite-native/module-trading/src/screens/TradingReceiveAccountsPickerScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingReceiveAccountsPickerScreen.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { type RouteProp, useRoute } from '@react-navigation/native';
 
+import { AccountLabel } from '@suite-native/accounts';
 import { AccountTypeDecisionBottomSheet, useAddCoinAccount } from '@suite-native/add-coin-account';
 import { Translation } from '@suite-native/intl';
 import {
@@ -16,9 +17,28 @@ import {
     selectBuySelectedReceiveAccount,
     selectExchangeSelectedReceiveAccount,
 } from '@suite-native/trading-state';
+import { type ReceiveAccount } from '@suite-native/trading-types';
 
 import { AccountList } from '../components/general/AccountList/AccountList';
 import { type ReceiveAccountsListMode } from '../hooks/general/useReceiveAccountsListData';
+
+const HeaderTitle = ({
+    pickerMode,
+    selectedReceiveAccount,
+}: {
+    pickerMode: ReceiveAccountsListMode;
+    selectedReceiveAccount: ReceiveAccount | undefined;
+}) => {
+    if (pickerMode === 'account') {
+        return <Translation id="moduleTrading.accountScreen.titleStep1" />;
+    }
+
+    if (selectedReceiveAccount?.account) {
+        return <AccountLabel account={selectedReceiveAccount.account} />;
+    }
+
+    return selectedReceiveAccount?.account.accountLabel;
+};
 
 export const TradingReceiveAccountsPickerScreen = () => {
     const {
@@ -50,15 +70,20 @@ export const TradingReceiveAccountsPickerScreen = () => {
 
     const handleAddAccountConfirmTap = () => handleAccountTypeConfirmation(flowType);
 
-    const title =
-        pickerMode === 'account' ? (
-            <Translation id="moduleTrading.accountScreen.titleStep1" />
-        ) : (
-            selectedReceiveAccount?.account.accountLabel
-        );
-
     return (
-        <Screen header={<ScreenHeader title={title} closeActionType="back" />}>
+        <Screen
+            header={
+                <ScreenHeader
+                    title={
+                        <HeaderTitle
+                            pickerMode={pickerMode}
+                            selectedReceiveAccount={selectedReceiveAccount}
+                        />
+                    }
+                    closeActionType="back"
+                />
+            }
+        >
             <AccountList
                 symbol={symbol}
                 pickerMode={pickerMode}

--- a/suite-native/module-trading/tsconfig.json
+++ b/suite-native/module-trading/tsconfig.json
@@ -48,6 +48,7 @@
         },
         { "path": "../accounts" },
         { "path": "../add-coin-account" },
+        { "path": "../address" },
         { "path": "../alerts" },
         { "path": "../analytics" },
         { "path": "../atoms" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13672,6 +13672,7 @@ __metadata:
     "@suite-common/wallet-utils": "workspace:*"
     "@suite-native/accounts": "workspace:*"
     "@suite-native/add-coin-account": "workspace:*"
+    "@suite-native/address": "workspace:*"
     "@suite-native/alerts": "workspace:*"
     "@suite-native/analytics": "workspace:*"
     "@suite-native/atoms": "workspace:*"


### PR DESCRIPTION
## Description
- Use `AddressLabel` component from `@suite-native/address`.
- Keep the address fallback
- Remove the empty address list component path and always show the no-accounts empty state for the picker list.

## Notes for QA

## Related Issue
Resolve: https://github.com/trezor/trezor-suite/issues/29477

## Screenshots:
<img width="320" alt="simulator_screenshot_2EEA1F83-E60D-47CD-B19B-252BD212AB93" src="https://github.com/user-attachments/assets/91774418-92c5-43b0-8a1d-313a6899c8c8" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All changed files are under `suite-native/module-trading/`, which is the React Native mobile trading module. The changes affect mobile-specific components (AccountList, AccountListAddressItem, AddressListEmptyComponent, TradingReceiveAccountsPickerScreen) and build configuration (package.json, tsconfig.json). None of the 117 candidate E2E tests cover suite-native code — they all target the web/desktop Suite application (Playwright-based browser and Electron tests). There is no meaningful risk of regression in the web/desktop E2E test suite from these mobile-only changes, so no tests are recommended.

<details><summary><b>Changed files (6)</b></summary>

- `suite-native/module-trading/package.json`
- `suite-native/module-trading/src/components/general/AccountList/AccountList.tsx`
- `suite-native/module-trading/src/components/general/AccountList/AccountListAddressItem.tsx`
- `suite-native/module-trading/src/components/general/AccountList/AddressListEmptyComponent.tsx`
- `suite-native/module-trading/src/screens/TradingReceiveAccountsPickerScreen.tsx`
- `suite-native/module-trading/tsconfig.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (6)**
- `suite-native/module-trading/package.json`
- `suite-native/module-trading/src/components/general/AccountList/AccountList.tsx`
- `suite-native/module-trading/src/components/general/AccountList/AccountListAddressItem.tsx`
- `suite-native/module-trading/src/components/general/AccountList/AddressListEmptyComponent.tsx`
- `suite-native/module-trading/src/screens/TradingReceiveAccountsPickerScreen.tsx`
- `suite-native/module-trading/tsconfig.json`

_Updated: 2026-07-10T10:20:51.435Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/29477-mobile-trade-labels-not-shown-in-used-addresses-list-and-screen-heading/web/](https://dev.suite.sldev.cz/suite-web/fix/29477-mobile-trade-labels-not-shown-in-used-addresses-list-and-screen-heading/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/29477-mobile-trade-labels-not-shown-in-used-addresses-list-and-screen-heading&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/29477-mobile-trade-labels-not-shown-in-used-addresses-list-and-screen-heading&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/29477-mobile-trade-labels-not-shown-in-used-addresses-list-and-screen-heading&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T10:24:46.390Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T10:20:35.548Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->