### PR TITLE
fix(suite): show Trezor logo in sidebar when no device is selected

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { selectShouldDisplayDeviceCompromised } from '@suite/authenticity-checks';
 import { TrafficLightOffset } from '@suite/macos';
 import { suiteSettingsActions } from '@suite/settings';
-import { selectDevicesCount, selectSelectedDevice } from '@suite-common/device';
+import { selectSelectedDevice } from '@suite-common/device';
 import { Box, Icon, ResizableBox } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
 import { TrezorLogoIcon } from '@trezor/icons';
@@ -62,9 +62,9 @@ type WalletSwitcherProps = {
 };
 
 const WalletSwitcher = ({ isCollapsed }: WalletSwitcherProps) => {
-    const devicesCount = useSelector(selectDevicesCount);
+    const selectedDevice = useSelector(selectSelectedDevice);
 
-    if (devicesCount > 0) {
+    if (selectedDevice) {
         return <DeviceSelector />;
     }
 


### PR DESCRIPTION
> [!IMPORTANT]
> **NOT READY FOR REVIEW**

## Description

The sidebar header chose between the Trezor logo and `DeviceSelector` based on the device **count**: the logo rendered only when the Redux device list was empty. However, `DeviceSelector` renders nothing visible when no device is **selected** (`SidebarDeviceStatus` returns `null` without a selected device and the caret is gated on `selectedDevice?.state`). Any state with devices in the list but no selection therefore left the top-left corner completely blank — no logo, no device pill.

Reachable cases:
- device disconnected during onboarding/firmware flows clears the selection (`disconnectDeviceThunk`) while remembered wallets remain in the list,
- `selectDeviceThunk` called with a stale device reference dispatches `selectDevice(undefined)` although other devices exist,
- transient window at app start before `initDevices` autoselects a remembered wallet.

The header now gates on `selectSelectedDevice` instead, so the logo shows whenever there is no selected device to display.

## Notes for QA

- With a remembered wallet in the app, disconnect the device during the firmware update flow, then return to Dashboard — the sidebar should show the Trezor logo instead of an empty header.
- Regular flows (device connected/selected, wallet switching, eject, collapsed sidebar) should be unaffected: the device pill renders exactly as before whenever a device is selected.

## Related Issue

Resolve #29673

## Screenshots:

Before: blank top-left corner (no logo, no device selector) with "Connect & unlock your Trezor" empty dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to the Sidebar component within SuiteLayout, which is a widely-used layout component rendered on virtually every page. Since it maps to 129 tests, most tests are only incidentally affected. The highest-risk areas are tests that directly interact with sidebar-specific UI elements: account search/filtering, account labels in the sidebar, account list management, and sidebar navigation buttons. The recommended strategy focuses on tests that exercise sidebar-interactive features rather than tests that merely render within the layout.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/account-search.test.ts` — The Sidebar component directly contains the account search functionality and account list. This test exercises account search filtering within the sidebar, which would be directly affected by changes to Sidebar.tsx.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — The Sidebar houses navigation elements and account buttons that are used when navigating between dashboard and wallet views. This test verifies asset visibility and navigation flows that pass through the sidebar layout.
- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test directly interacts with account labels and account buttons in the sidebar (@account-menu components), searches for accounts by label, and verifies label display — all rendered within the Sidebar component.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds accounts and verifies account counts in the sidebar account list, including filtering accounts. Changes to the Sidebar could affect how accounts are displayed and counted.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test uses the sidebar's transaction search functionality (walletPage.transactionSearch) to filter transactions by address within the account view, which is part of the sidebar-managed layout.
- `suite/e2e/tests/trading/navigation.test.ts` — This test exercises multiple navigation entry points including sidebar elements (swap sidebar button, account switching) to verify trading form navigation. Sidebar layout changes could break these navigation paths.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — The discreet mode toggle (hideBalanceButton) and device switcher are typically rendered in or near the sidebar/header area. Changes to Sidebar.tsx could affect the placement or visibility of the hide balance button.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test uses the device switcher (which may be part of or adjacent to the Sidebar) to eject and add wallets, then verifies account balance visibility — interactions that flow through the sidebar layout.
- `suite/e2e/tests/wallet/pagination.test.ts` — This test opens a specific BTC legacy account from the sidebar account list and navigates paginated transactions. A sidebar rendering issue could prevent account selection.

</details>

_Updated: 2026-07-10T10:03:03.888Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/sidebar-logo-no-selected-device/web/](https://dev.suite.sldev.cz/suite-web/fix/sidebar-logo-no-selected-device/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sidebar-logo-no-selected-device&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T10:06:08.744Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T10:06:02.344Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->