### PR TITLE
fix(suite): Fix trezor logo

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { selectShouldDisplayDeviceCompromised } from '@suite/authenticity-checks';
 import { TrafficLightOffset } from '@suite/macos';
 import { suiteSettingsActions } from '@suite/settings';
-import { selectDevicesCount, selectSelectedDevice } from '@suite-common/device';
+import { selectIsAnyDeviceSelected, selectSelectedDevice } from '@suite-common/device';
 import { Box, Icon, ResizableBox } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
 import { TrezorLogo } from '@trezor/product-components';
@@ -61,9 +61,9 @@ type WalletSwitcherProps = {
 };
 
 const WalletSwitcher = ({ isCollapsed }: WalletSwitcherProps) => {
-    const devicesCount = useSelector(selectDevicesCount);
+    const isAnyDeviceSelected = useSelector(selectIsAnyDeviceSelected);
 
-    if (devicesCount > 0) {
+    if (isAnyDeviceSelected) {
         return <DeviceSelector />;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- sometimes logo was not showing. There was empty case in the condition. Now it should be fixed
- it happens when no device connected and saved but some mess is in the storage

## Notes for QA

- needs to be checked if logo is showing in all use cases ideally 

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29673

## Screenshots:

before

<img width="2870" height="1494" alt="image" src="https://github.com/user-attachments/assets/213249ec-f5ed-4aac-88ed-f6e5dbe2202a" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to the Sidebar component, which is a shared layout component rendered across virtually all Suite views (hence 129 tests mapping to it). The risk is moderate — most tests only transitively depend on the Sidebar being present, but a few tests directly exercise Sidebar-specific features like account search/filtering, account labels, sidebar navigation buttons, and account list rendering. The recommended strategy focuses on the small set of tests that directly interact with Sidebar-specific UI elements rather than running all 129 tests.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/account-search.test.ts` — The Sidebar component directly contains the account search/filter UI and account list. This test exercises account search filtering within the sidebar, making it the most directly affected test by any Sidebar changes.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test searches for transactions by address using the sidebar's transaction search functionality and navigates accounts via the sidebar. Changes to Sidebar layout could affect account navigation and search interactions.
- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test interacts heavily with account labels in the sidebar (@account-menu elements), searches accounts by label, and verifies label visibility. The Sidebar renders the account menu where labels and search are displayed.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test verifies that account balance values in the sidebar are hidden/revealed in discreet mode, and interacts with the hide balance button which may be rendered in or near the Sidebar component.
- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates to swap from the sidebar (openSwapSidebarButton) and verifies account-level trading entry points. The Sidebar renders navigation items including the swap button, making it sensitive to Sidebar layout changes.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — This test verifies that the staking sub-account item appears in the left sidebar after staking ADA. A Sidebar layout change could affect whether sidebar sub-account items render correctly.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds accounts and verifies account counts in the sidebar account list. Changes to Sidebar rendering could affect how newly added accounts appear in the sidebar.

</details>

_Updated: 2026-07-10T11:01:40.504Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-trezor-logo/web/](https://dev.suite.sldev.cz/suite-web/fix-trezor-logo/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-trezor-logo&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-trezor-logo&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T11:05:09.095Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T11:05:03.745Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->