### PR TITLE
Refactor/toast component

### DIFF
--- a/packages/components/src/components/Icon/Icon.tsx
+++ b/packages/components/src/components/Icon/Icon.tsx
@@ -49,6 +49,7 @@ type ContainerProps = {
     $size: IconSize;
     $intent?: IconIntent;
     $priority?: IconPriority;
+    $isInverse: boolean;
     $isDisabled: boolean;
     $color?: Color;
 } & TransientProps<AllowedFrameProps>;
@@ -60,7 +61,7 @@ const Container = styled.div<ContainerProps>`
     `}
 
     path {
-        fill: ${({ $intent, $priority = 'primary', $isDisabled, $color, theme }) => {
+        fill: ${({ $intent, $priority = 'primary', $isInverse, $isDisabled, $color, theme }) => {
             if ($color !== undefined) {
                 return theme[$color];
             }
@@ -69,7 +70,7 @@ const Container = styled.div<ContainerProps>`
                 return 'currentColor';
             }
 
-            return mapIntentToCSS($intent ?? 'neutral', $priority, $isDisabled, theme);
+            return mapIntentToCSS($intent ?? 'neutral', $priority, $isInverse, $isDisabled, theme);
         }};
         transition: fill 0.14s;
     }
@@ -84,6 +85,7 @@ const Container = styled.div<ContainerProps>`
 
 export type IconBaseProps = AllowedFrameProps & {
     size?: IconSize;
+    isInverse?: boolean;
     onClick?: (e: MouseEvent<HTMLDivElement> | KeyboardEvent<Element>) => void;
     'data-testid'?: string;
 };
@@ -99,6 +101,7 @@ export const Icon = ({
     size = 24,
     intent,
     priority = 'primary',
+    isInverse = false,
     isDisabled = false,
     color,
     onClick,
@@ -127,6 +130,7 @@ export const Icon = ({
             $size={size}
             $intent={intent}
             $priority={priority}
+            $isInverse={isInverse}
             $isDisabled={isDisabled}
             $color={color}
             data-testid={dataTest}

--- a/packages/components/src/components/Icon/utils.ts
+++ b/packages/components/src/components/Icon/utils.ts
@@ -3,8 +3,10 @@ import { type DefaultTheme } from 'styled-components';
 import { type CSSColor, type Color } from '@trezor/theme';
 
 import { type IconIntent, type IconPriority } from './types';
+import { addAlphaToHex } from '../../utils/utils';
 
-const colorMap: Record<Exclude<IconIntent, 'neutral'>, Color> = {
+const colorMap: Record<IconIntent, Color> = {
+    neutral: 'contentPrimary',
     brand: 'contentBrand',
     info: 'contentInfo',
     warning: 'contentWarning',
@@ -12,14 +14,19 @@ const colorMap: Record<Exclude<IconIntent, 'neutral'>, Color> = {
     accentViolet: 'contentAccentViolet',
 };
 
-const neutralColorMap: Record<IconPriority, Color> = {
-    primary: 'contentPrimary',
-    secondary: 'contentSecondary',
+const inverseColorMap: Record<IconIntent, Color> = {
+    neutral: 'contentOnDarkPrimary',
+    brand: 'contentOnDarkBrand',
+    info: 'contentOnDarkInfo',
+    warning: 'contentOnDarkWarning',
+    critical: 'contentOnDarkCritical',
+    accentViolet: 'contentOnDarkAccentViolet',
 };
 
 export const mapIntentToCSS = (
     intent: IconIntent,
     priority: IconPriority,
+    isInverse: boolean,
     isDisabled: boolean,
     theme: DefaultTheme,
 ): CSSColor => {
@@ -27,7 +34,7 @@ export const mapIntentToCSS = (
         return theme.contentDisabled;
     }
 
-    const token = intent === 'neutral' ? neutralColorMap[priority] : colorMap[intent];
+    const color = theme[(isInverse ? inverseColorMap : colorMap)[intent]];
 
-    return theme[token];
+    return priority === 'primary' ? color : addAlphaToHex(color, 0.74);
 };

--- a/packages/components/src/components/Markdown/Markdown.tsx
+++ b/packages/components/src/components/Markdown/Markdown.tsx
@@ -7,7 +7,7 @@ import { typography } from '@trezor/theme';
 const StyledMarkdown = styled.div`
     ${typography['body-sm']}
 
-    color: ${({ theme }) => theme.contentPrimary};
+    color: currentcolor;
 
     h1,
     h2,
@@ -15,7 +15,7 @@ const StyledMarkdown = styled.div`
     h4,
     h5,
     h6 {
-        color: ${({ theme }) => theme.contentPrimary};
+        color: currentcolor;
     }
 
     h1 {

--- a/packages/components/src/components/Note/Note.tsx
+++ b/packages/components/src/components/Note/Note.tsx
@@ -20,6 +20,7 @@ export type NoteProps = AllowedFrameProps & {
     gap?: SpacingValues;
     children: ReactNode;
     'data-testid'?: string;
+    isInverse?: boolean;
 };
 
 export const Note = ({
@@ -31,16 +32,25 @@ export const Note = ({
     intent = 'neutral',
     priority = 'secondary',
     isDisabled = false,
+    isInverse = false,
     'data-testid': dataTestId,
 }: NoteProps) => (
     <Row gap={gap} margin={margin} minWidth={minWidth}>
-        <Icon as={icon} size={16} intent={intent} priority={priority} isDisabled={isDisabled} />
+        <Icon
+            as={icon}
+            size={16}
+            intent={intent}
+            priority={priority}
+            isDisabled={isDisabled}
+            isInverse={isInverse}
+        />
         <Paragraph
             data-testid={dataTestId}
             typographyStyle="body-sm"
             intent={intent}
             priority={priority}
             isDisabled={isDisabled}
+            isInverse={isInverse}
         >
             {children}
         </Paragraph>

--- a/packages/components/src/components/ShortcutBadge/ShortcutBadge.stories.tsx
+++ b/packages/components/src/components/ShortcutBadge/ShortcutBadge.stories.tsx
@@ -13,3 +13,10 @@ export const ShortcutBadge: StoryObj<ShortcutBadgeProps> = {
         shortcut: ['CTRL', 'KEY_P'],
     },
 };
+
+export const Inverse: StoryObj<ShortcutBadgeProps> = {
+    args: {
+        shortcut: ['CTRL', 'KEY_P'],
+        isInverse: true,
+    },
+};

--- a/packages/components/src/components/ShortcutBadge/ShortcutBadge.tsx
+++ b/packages/components/src/components/ShortcutBadge/ShortcutBadge.tsx
@@ -4,7 +4,6 @@ import { isMacOs } from '@trezor/env-utils';
 import { borders, spacingsPx } from '@trezor/theme';
 
 import { type KeyboardKey, type Keys, keyboardKeys } from './keyboardKeys';
-import { addAlphaToHex } from '../../utils/utils';
 import { Row } from '../Flex/Flex';
 import { Text } from '../typography/Text/Text';
 
@@ -15,11 +14,11 @@ const Wrapper = styled.div`
     }
 `;
 
-const ShortcutContainer = styled.div`
-    background-color: ${({ theme }) => addAlphaToHex(theme.borderNeutralDark, 0.09)};
+const ShortcutContainer = styled.div<{ $isInverse: boolean }>`
+    background-color: ${({ theme, $isInverse }) =>
+        $isInverse ? theme.elementFillOnDarkNeutralSoft : theme.elementFillNeutralSoft};
     border-radius: ${borders.radii.xxs};
     padding: 0 ${spacingsPx.xxs};
-    border: 1px solid ${({ theme }) => theme.elementBorderOnDarkNeutralSofter};
 
     /* Slashed zero so the "0" key is distinguishable from the letter "O". */
     font-variant-numeric: slashed-zero;
@@ -27,9 +26,10 @@ const ShortcutContainer = styled.div`
 
 export type ShortcutBadgeProps = {
     shortcut: Keys[];
+    isInverse?: boolean;
 };
 
-export const ShortcutBadge = ({ shortcut }: ShortcutBadgeProps) => {
+export const ShortcutBadge = ({ shortcut, isInverse = false }: ShortcutBadgeProps) => {
     const isMac = isMacOs();
 
     return (
@@ -43,7 +43,7 @@ export const ShortcutBadge = ({ shortcut }: ShortcutBadgeProps) => {
                             : keyObject.value;
 
                         return (
-                            <ShortcutContainer key={`key-${key}-${index}`}>
+                            <ShortcutContainer key={`key-${key}-${index}`} $isInverse={isInverse}>
                                 {value}
                             </ShortcutContainer>
                         );

--- a/packages/components/src/components/Toast/Toast.stories.tsx
+++ b/packages/components/src/components/Toast/Toast.stories.tsx
@@ -1,8 +1,9 @@
-import { type ArgTypes, type Meta, type StoryObj } from '@storybook/react';
+import { type Meta, type StoryObj } from '@storybook/react';
 
 import * as generatedIcons from '@trezor/icons';
 
 import { Toast as ToastComponent, type ToastProps } from './Toast';
+import { toastIntents } from './types';
 
 const meta: Meta<typeof ToastComponent> = {
     title: 'Toast',
@@ -10,52 +11,73 @@ const meta: Meta<typeof ToastComponent> = {
 };
 export default meta;
 
-const args: Partial<ToastProps> | undefined = {
-    content: 'This is a toast message.',
-    intent: 'info',
-    icon: undefined,
-    dismissible: true,
-    onDismiss: () => alert('Toast closed'),
-};
-
-const argTypes: Partial<ArgTypes<ToastProps>> | undefined = {
-    content: {
-        type: 'string',
-    },
-    icon: {
-        options: ['none', ...Object.keys(generatedIcons)],
-        mapping: { none: undefined, ...generatedIcons },
-        control: {
-            type: 'select',
+const actionSets: Record<string, ToastProps['actions']> = {
+    None: undefined,
+    'One right action': [
+        {
+            label: 'Retry',
+            onClick: () => alert('Retry clicked'),
+            position: 'right',
         },
-    },
-    dismissible: {
-        control: {
-            type: 'boolean',
+    ],
+    'Two right actions': [
+        {
+            label: 'Action A',
+            onClick: () => alert('Action A clicked'),
+            position: 'right',
         },
-    },
+        {
+            label: 'Action B',
+            onClick: () => alert('Action B clicked'),
+            position: 'right',
+        },
+    ],
+    'One bottom action': [
+        {
+            label: 'Learn more',
+            onClick: () => alert('Learn more clicked'),
+            position: 'bottom',
+        },
+    ],
 };
 
-export const Default: StoryObj<ToastProps> = {
-    args,
-    argTypes,
-};
-
-export const WithActions: StoryObj<ToastProps> = {
+export const Toast: StoryObj<ToastProps> = {
     args: {
-        ...args,
-        actions: [
-            {
-                label: 'Action A',
-                onClick: () => alert('Action A clicked'),
-                position: 'right',
-            },
-            {
-                label: 'Action B',
-                onClick: () => alert('Action B clicked'),
-                position: 'right',
-            },
-        ],
+        content: 'This is a toast message.',
+        intent: 'info',
+        icon: undefined,
+        actions: undefined,
+        dismissible: true,
+        onDismiss: () => alert('Toast closed'),
     },
-    argTypes,
+    argTypes: {
+        content: {
+            type: 'string',
+        },
+        intent: {
+            options: toastIntents,
+            control: {
+                type: 'select',
+            },
+        },
+        icon: {
+            options: ['none', ...Object.keys(generatedIcons)],
+            mapping: { none: undefined, ...generatedIcons },
+            control: {
+                type: 'select',
+            },
+        },
+        dismissible: {
+            control: {
+                type: 'boolean',
+            },
+        },
+        actions: {
+            options: Object.keys(actionSets),
+            mapping: actionSets,
+            control: {
+                type: 'select',
+            },
+        },
+    },
 };

--- a/packages/components/src/components/Toast/Toast.tsx
+++ b/packages/components/src/components/Toast/Toast.tsx
@@ -1,58 +1,20 @@
 import { type ReactNode } from 'react';
 
-import styled from 'styled-components';
-
 import { XIcon } from '@trezor/icons';
-import { borders, spacings, spacingsPx } from '@trezor/theme';
-import { hexToRgba } from '@trezor/utils';
 
 import { type ToastAction, type ToastIntent } from './types';
-import { mapToastIntentToIcon, mapToastVariantToColor, normalizeToastActions } from './utils';
+import {
+    mapToastIntentToBackgroundColor,
+    mapToastIntentToBorderColor,
+    mapToastIntentToIcon,
+    normalizeToastActions,
+} from './utils';
+import { Box } from '../Box/Box';
 import { Column, Row } from '../Flex/Flex';
 import { Icon, type IconComponent } from '../Icon/Icon';
 import { Button } from '../buttons/Button/Button';
 import { IconButton } from '../buttons/IconButton/IconButton';
 import { Text } from '../typography/Text/Text';
-
-const Container = styled.div<{ $variant: ToastIntent }>`
-    display: flex;
-    align-items: center;
-    min-height: 3.25rem;
-
-    padding-inline: ${spacingsPx.md};
-    padding-block: ${spacingsPx.xs};
-
-    font-size: 1rem;
-    color: ${({ theme }) => theme.contentPrimary};
-
-    overflow-wrap: anywhere;
-    word-break: normal;
-
-    border-radius: ${borders.radii.xs};
-    position: relative;
-
-    background: ${({ theme }) => hexToRgba(theme.surfaceFillSticky, 0.5)};
-    backdrop-filter: blur(12px);
-
-    &::after {
-        content: '';
-        position: absolute;
-        inset: 0;
-        pointer-events: none;
-        border-radius: inherit;
-        border: 1px solid ${({ theme }) => hexToRgba(theme.borderNeutral, 0.1)};
-    }
-
-    &::before {
-        content: '';
-        position: absolute;
-        inset: 0;
-        pointer-events: none;
-        border-left: ${spacingsPx.xxs} solid
-            ${({ theme, $variant }) => theme[mapToastVariantToColor($variant)]};
-        border-radius: inherit;
-    }
-`;
 
 export type ToastProps = {
     icon?: IconComponent;
@@ -87,50 +49,74 @@ export const Toast = ({
             priority={action.priority}
             onClick={action.onClick}
             size="small"
+            isInverse={intent === 'neutral'}
         >
             {action.label}
         </Button>
     );
 
     return (
-        <Container data-testid={dataTestBase} data-toast-intent={intent} $variant={intent}>
-            <Row gap={spacings.sm} justifyContent="space-between" flex="1">
-                {showIcon && (
-                    <Icon
-                        as={icon ?? mapToastIntentToIcon(intent)}
-                        color={mapToastVariantToColor(intent)}
-                    />
-                )}
-
-                <Column gap={spacings.xs} flex="1">
-                    {typeof content === 'string' || typeof content === 'number' ? (
-                        <Text typographyStyle="body-md-strong">{content}</Text>
-                    ) : (
-                        content
+        <div data-testid={dataTestBase} data-toast-intent={intent}>
+            <Box
+                borderRadius={8}
+                backgroundColor={mapToastIntentToBackgroundColor(intent)}
+                shadow="surfaceShadowModeless"
+                borderWidth={1}
+                borderColor={mapToastIntentToBorderColor(intent)}
+                padding={{ horizontal: 16, vertical: 12 }}
+            >
+                <Row gap={16} justifyContent="space-between" width="100%">
+                    {showIcon && (
+                        <Icon
+                            size={20}
+                            as={icon ?? mapToastIntentToIcon(intent)}
+                            intent={intent}
+                            isInverse={intent === 'neutral'}
+                        />
                     )}
 
-                    <Row gap={spacings.xs}>
-                        {bottomActions.map((action, index) => renderActionButton(action, index))}
+                    <Column gap={8} flex="1">
+                        <Text
+                            overflowWrap="anywhere"
+                            wordBreak="normal"
+                            intent={intent}
+                            priority="primary"
+                            isInverse={intent === 'neutral'}
+                            typographyStyle="body-sm"
+                            as="div"
+                        >
+                            {content}
+                        </Text>
+
+                        <Row gap={8}>
+                            {bottomActions.map((action, index) =>
+                                renderActionButton(action, index),
+                            )}
+                        </Row>
+                    </Column>
+
+                    <Row gap={8}>
+                        {rightActions.map((action, index) => renderActionButton(action, index))}
+                        {dismissible && (
+                            <IconButton
+                                icon={XIcon}
+                                size="small"
+                                intent={intent}
+                                priority="secondary"
+                                onClick={onDismiss}
+                                data-testid={`${dataTestBase}/close`}
+                                aria-label="Close toast"
+                                isInverse={intent === 'neutral'}
+                                tooltip={
+                                    dismissTooltip
+                                        ? { content: dismissTooltip }
+                                        : { isActive: false }
+                                }
+                            />
+                        )}
                     </Row>
-                </Column>
-
-                <Row gap={spacings.xs}>
-                    {rightActions.map((action, index) => renderActionButton(action, index))}
                 </Row>
-
-                {dismissible && (
-                    <IconButton
-                        icon={XIcon}
-                        size="small"
-                        intent="neutral"
-                        priority="secondary"
-                        onClick={onDismiss}
-                        data-testid={`${dataTestBase}/close`}
-                        aria-label="Close toast"
-                        tooltip={dismissTooltip ? { content: dismissTooltip } : { isActive: false }}
-                    />
-                )}
-            </Row>
-        </Container>
+            </Box>
+        </div>
     );
 };

--- a/packages/components/src/components/Toast/utils.ts
+++ b/packages/components/src/components/Toast/utils.ts
@@ -16,16 +16,28 @@ export const mapToastIntentToIcon = (intent: ToastIntent): IconComponent => {
     return iconMap[intent];
 };
 
-export const mapToastVariantToColor = (variant: ToastIntent): Color => {
-    const colorMap: Record<ToastIntent, Color> = {
-        brand: 'contentBrand',
-        info: 'contentInfo',
-        warning: 'contentWarning',
-        critical: 'contentCritical',
-        neutral: 'contentSecondary',
+export const mapToastIntentToBackgroundColor = (intent: ToastIntent): Color => {
+    const backgroundColorMap: Record<ToastIntent, Color> = {
+        brand: 'surfaceFillModelessBrand',
+        info: 'surfaceFillModelessInfo',
+        warning: 'surfaceFillModelessWarning',
+        critical: 'surfaceFillModelessCritical',
+        neutral: 'surfaceFillModelessNeutralDark',
     };
 
-    return colorMap[variant];
+    return backgroundColorMap[intent];
+};
+
+export const mapToastIntentToBorderColor = (intent: ToastIntent): Color => {
+    const borderColorMap: Record<ToastIntent, Color> = {
+        brand: 'surfaceBorderModelessBrand',
+        info: 'surfaceBorderModelessInfo',
+        warning: 'surfaceBorderModelessWarning',
+        critical: 'surfaceBorderModelessCritical',
+        neutral: 'surfaceBorderModelessNeutralDark',
+    };
+
+    return borderColorMap[intent];
 };
 
 export const normalizeToastActions = (actions: ToastAction[] = [], toastIntent: ToastIntent) =>

--- a/packages/components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.stories.tsx
@@ -55,9 +55,6 @@ export const Tooltip: StoryObj<TooltipProps> = {
         tooltipMaxWidth: {
             type: 'number',
         },
-        title: {
-            control: 'text',
-        },
         placement: {
             control: 'select',
             options: [

--- a/packages/components/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.test.tsx
@@ -1,12 +1,23 @@
+import { type ReactNode } from 'react';
+
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from 'styled-components';
 
 import { Tooltip } from './Tooltip';
+import { intermediaryTheme } from '../../config/colors';
+
+const renderWithTheme = (children: ReactNode) =>
+    render(
+        <ThemeProvider theme={{ ...intermediaryTheme.light, variant: 'light' }}>
+            {children}
+        </ThemeProvider>,
+    );
 
 describe('Tooltip', () => {
     it('should show tooltip on hover when isActive is true', async () => {
         const tooltipContent = 'Tooltip Content';
-        render(
+        renderWithTheme(
             <Tooltip delayShow={0} content={tooltipContent} isActive={true}>
                 <button>Hover me</button>
             </Tooltip>,
@@ -24,7 +35,7 @@ describe('Tooltip', () => {
 
     it('should show tooltip on hover when isActive is not defined (default behavior)', async () => {
         const tooltipContent = 'Tooltip Content';
-        render(
+        renderWithTheme(
             <Tooltip delayShow={0} content={tooltipContent}>
                 <button id="hover-me">Hover me</button>
             </Tooltip>,
@@ -42,7 +53,7 @@ describe('Tooltip', () => {
 
     it('should not show tooltip on hover when isActive is false', async () => {
         const tooltipContent = 'Tooltip Content';
-        render(
+        renderWithTheme(
             <Tooltip delayShow={0} content={tooltipContent} isActive={false}>
                 <button>Hover me</button>
             </Tooltip>,
@@ -60,7 +71,7 @@ describe('Tooltip', () => {
 
     it('should hide tooltip when mouse leaves trigger element', async () => {
         const tooltipContent = 'Tooltip Content';
-        render(
+        renderWithTheme(
             <Tooltip isActive delayShow={0} delayHide={0} content={tooltipContent}>
                 <button>Hover me</button>
             </Tooltip>,
@@ -87,7 +98,7 @@ describe('Tooltip', () => {
 
     it('should apply the cursor prop to the content wrapper', () => {
         const tooltipContent = 'Tooltip Content';
-        render(
+        renderWithTheme(
             <Tooltip content={tooltipContent} cursor="pointer">
                 <button>Hover me</button>
             </Tooltip>,

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -1,7 +1,7 @@
 import { type MutableRefObject, type ReactNode } from 'react';
 
 import { type Placement, type ShiftOptions } from '@floating-ui/react';
-import styled, { ThemeProvider } from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 
 import { QuestionIcon } from '@trezor/icons';
 import { type ZIndexValues, spacingsPx, zIndices } from '@trezor/theme';
@@ -10,7 +10,6 @@ import { TooltipArrow } from './TooltipArrow';
 import { TooltipBox, type TooltipBoxProps } from './TooltipBox';
 import { TOOLTIP_DELAY_SHORT, type TooltipDelay } from './TooltipDelay';
 import { TooltipContent, TooltipFloatingUi, TooltipTrigger } from './TooltipFloatingUi';
-import { intermediaryTheme } from '../../config/colors';
 import {
     type FrameProps,
     type FramePropsKeys,
@@ -85,7 +84,6 @@ export const Tooltip = ({
     offset = 12,
     content,
     addon,
-    title,
     isOpen,
     hasArrow = true,
     hasIcon = false,
@@ -96,6 +94,7 @@ export const Tooltip = ({
     as = 'div',
     ...rest
 }: TooltipProps) => {
+    const theme = useTheme();
     const frameProps = pickAndPrepareFrameProps(
         rest,
         allowedTooltipFrameProps,
@@ -106,7 +105,6 @@ export const Tooltip = ({
     }
 
     const delayConfiguration = { open: delayShow, close: delayHide };
-    const tooltipTheme = { variant: 'dark' as const, ...intermediaryTheme.dark };
 
     return (
         <TooltipFloatingUi
@@ -125,31 +123,24 @@ export const Tooltip = ({
                 </Content>
             </TooltipTrigger>
 
-            <ThemeProvider theme={tooltipTheme}>
-                <TooltipContent
-                    data-testid="@tooltip"
-                    style={{ zIndex }}
-                    arrowRender={
-                        hasArrow
-                            ? props => (
-                                  <TooltipArrow
-                                      {...props}
-                                      fill={tooltipTheme.surfaceFillModelessNeutralDark}
-                                  />
-                              )
-                            : undefined
-                    }
-                    appendTo={appendTo}
-                    onClick={e => e.stopPropagation()}
-                >
-                    <TooltipBox
-                        content={content}
-                        addon={addon}
-                        tooltipMaxWidth={tooltipMaxWidth}
-                        title={title}
-                    />
-                </TooltipContent>
-            </ThemeProvider>
+            <TooltipContent
+                data-testid="@tooltip"
+                style={{ zIndex }}
+                arrowRender={
+                    hasArrow
+                        ? props => (
+                              <TooltipArrow
+                                  {...props}
+                                  fill={theme.surfaceFillModelessNeutralDark}
+                              />
+                          )
+                        : undefined
+                }
+                appendTo={appendTo}
+                onClick={e => e.stopPropagation()}
+            >
+                <TooltipBox content={content} addon={addon} tooltipMaxWidth={tooltipMaxWidth} />
+            </TooltipContent>
         </TooltipFloatingUi>
     );
 };

--- a/packages/components/src/components/Tooltip/TooltipBox.tsx
+++ b/packages/components/src/components/Tooltip/TooltipBox.tsx
@@ -1,55 +1,39 @@
-import { type ReactElement, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 
 import { Box } from '../Box/Box';
 import { Column, Row } from '../Flex/Flex';
 import { Text } from '../typography/Text/Text';
 
-export const TOOLTIP_BORDER_RADIUS = 12;
-
 export type TooltipBoxProps = {
     content: ReactNode;
     tooltipMaxWidth?: string | number;
     addon?: ReactNode;
-    title?: ReactElement;
 };
 
 type TooltipBoxExtendedProps = TooltipBoxProps & Required<Pick<TooltipBoxProps, 'tooltipMaxWidth'>>;
 
-export const TooltipBox = ({ addon, tooltipMaxWidth, content, title }: TooltipBoxExtendedProps) => {
-    const hasTitleOrAddon = !!title || !!addon;
-
-    return (
-        <Box
-            maxWidth={tooltipMaxWidth}
-            tabIndex={-1}
-            borderRadius={TOOLTIP_BORDER_RADIUS}
-            backgroundColor="surfaceFillModelessNeutralDark"
-            borderColor="surfaceBorderModelessNeutralDark"
-            borderWidth={1}
-            shadow="surfaceShadowModeless"
-            padding={hasTitleOrAddon ? 12 : { vertical: 6, horizontal: 8 }}
-        >
-            <Column gap={12}>
-                {hasTitleOrAddon && (
-                    <Row gap={12} justifyContent="space-between">
-                        {title && (
-                            <Text typographyStyle="body-sm" color="contentPrimaryInverse">
-                                {title}
-                            </Text>
-                        )}
-                        {addon && <Box margin={{ left: 'auto' }}>{addon}</Box>}
-                    </Row>
-                )}
-
-                <Text
-                    typographyStyle="body-sm"
-                    as="div"
-                    color="contentPrimary"
-                    overflowWrap="anywhere"
-                >
-                    {content}
-                </Text>
-            </Column>
-        </Box>
-    );
-};
+export const TooltipBox = ({ addon, tooltipMaxWidth, content }: TooltipBoxExtendedProps) => (
+    <Box
+        maxWidth={tooltipMaxWidth}
+        tabIndex={-1}
+        borderRadius={12}
+        backgroundColor="surfaceFillModelessNeutralDark"
+        borderColor="surfaceBorderModelessNeutralDark"
+        borderWidth={1}
+        shadow="surfaceShadowModeless"
+        padding={{ vertical: 6, horizontal: 8 }}
+    >
+        <Column gap={6}>
+            <Text
+                typographyStyle="body-sm"
+                as="div"
+                isInverse
+                intent="neutral"
+                overflowWrap="anywhere"
+            >
+                {content}
+            </Text>
+            {addon && <Row>{addon}</Row>}
+        </Column>
+    </Box>
+);

--- a/packages/components/src/components/typography/Text/Text.tsx
+++ b/packages/components/src/components/typography/Text/Text.tsx
@@ -69,6 +69,7 @@ type ColorProps = {
 } & {
     $intent?: TextIntent;
     $priority?: TextPriority;
+    $isInverse?: boolean;
     $isDisabled?: boolean;
     $color?: Color;
 };
@@ -76,6 +77,7 @@ type ColorProps = {
 const getColorForText = ({
     $intent,
     $priority = 'primary',
+    $isInverse,
     $isDisabled,
     theme,
     $color,
@@ -99,13 +101,14 @@ const getColorForText = ({
     }
 
     return css`
-        color: ${mapIntentToCSS($intent, $priority, theme)};
+        color: ${mapIntentToCSS($intent, $priority, $isInverse ?? false, theme)};
     `;
 };
 
 type StyledTextProps = {
     $intent?: TextIntent;
     $priority?: TextPriority;
+    $isInverse?: boolean;
     $isDisabled?: boolean;
     $color?: Color;
     $isMonospaced?: boolean;
@@ -141,6 +144,7 @@ const StyledText = styled.span<StyledTextProps>`
 
 export type TextProps = Pick<HTMLProps<HTMLElement>, 'onCopy' | 'onClick'> & {
     children: ReactNode;
+    isInverse?: boolean;
     isMonospaced?: boolean;
     isHighlighted?: boolean;
     isTabular?: boolean;
@@ -154,6 +158,7 @@ export type TextProps = Pick<HTMLProps<HTMLElement>, 'onCopy' | 'onClick'> & {
 export const Text = ({
     intent,
     priority = 'primary',
+    isInverse = false,
     isDisabled = false,
     color,
     children,
@@ -174,6 +179,7 @@ export const Text = ({
         <StyledText
             $intent={intent}
             $priority={priority}
+            $isInverse={isInverse}
             $isDisabled={isDisabled}
             $color={color}
             as={as}

--- a/packages/components/src/components/typography/Text/utils.ts
+++ b/packages/components/src/components/typography/Text/utils.ts
@@ -14,12 +14,22 @@ const colorMap: Record<TextIntent, Color> = {
     accentViolet: 'contentAccentViolet',
 };
 
+const inverseColorMap: Record<TextIntent, Color> = {
+    brand: 'contentOnDarkBrand',
+    neutral: 'contentOnDarkPrimary',
+    info: 'contentOnDarkInfo',
+    warning: 'contentOnDarkWarning',
+    critical: 'contentOnDarkCritical',
+    accentViolet: 'contentOnDarkAccentViolet',
+};
+
 export const mapIntentToCSS = (
     intent: TextIntent,
     priority: TextPriority,
+    isInverse: boolean,
     theme: DefaultTheme,
 ): CSSColor => {
-    const color = theme[colorMap[intent]];
+    const color = theme[(isInverse ? inverseColorMap : colorMap)[intent]];
 
     return priority === 'primary' ? color : addAlphaToHex(color, 0.74);
 };

--- a/packages/product-components/src/components/Notifications/ExchangeInfoNotification.tsx
+++ b/packages/product-components/src/components/Notifications/ExchangeInfoNotification.tsx
@@ -31,7 +31,7 @@ export const ExchangeInfoNotification = ({
             <Row gap={8} alignItems="center">
                 <ExchangeAssetWithFallback asset={send} />
                 <ExchangeAmountWithSymbol amount={sendAmount} asset={send} />
-                <Icon as={ArrowRightIcon} intent="neutral" priority="secondary" size={20} />
+                <Icon as={ArrowRightIcon} size={20} />
                 <ExchangeAssetWithFallback asset={receive} />
                 <ExchangeAmountWithSymbol amount={receiveAmount} asset={receive} />
             </Row>

--- a/packages/product-components/src/components/TooltipRow/TooltipRow.tsx
+++ b/packages/product-components/src/components/TooltipRow/TooltipRow.tsx
@@ -24,8 +24,8 @@ export const TooltipRow = ({
         <Column alignItems="start">
             <Text>{header}</Text>
             <Row gap={4}>
-                <Icon as={icon} intent={intent} size={12} priority="secondary" />
-                <Text intent={intent} priority="secondary">
+                <Icon as={icon} intent={intent} size={12} isInverse />
+                <Text intent={intent} isInverse>
                     {children}
                 </Text>
             </Row>

--- a/packages/suite/src/components/firmware/FirmwareOffer.tsx
+++ b/packages/suite/src/components/firmware/FirmwareOffer.tsx
@@ -6,7 +6,7 @@ import {
     getFwUpdateVersion,
     parseFirmwareChangelog,
 } from '@suite-common/suite-utils';
-import { Column, H4, Icon, Row, Text, TextButton, Tooltip } from '@trezor/components';
+import { Column, Icon, Row, Text, TextButton, Tooltip } from '@trezor/components';
 import { type FirmwareType } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { ArrowRightIcon } from '@trezor/icons';
@@ -85,30 +85,31 @@ export const FirmwareOffer = ({ isCustomFirmware, targetFirmwareType }: Firmware
                 </Text>
                 <Tooltip
                     hasIcon
-                    title={
-                        parsedChangelog ? (
-                            <H4>
-                                <Translation
-                                    id="TR_VERSION"
-                                    values={{ version: parsedChangelog.versionString }}
-                                />
-                            </H4>
-                        ) : undefined
-                    }
-                    addon={
-                        parsedChangelog ? (
-                            <TextButton
-                                size="small"
-                                intent="neutral"
-                                priority="secondary"
-                                href={changelogUrl}
-                            >
-                                <Translation id="TR_VIEW_ALL" />
-                            </TextButton>
-                        ) : undefined
-                    }
                     content={
-                        <Column>
+                        <Column padding={4} gap={4}>
+                            {parsedChangelog && (
+                                <Row justifyContent="space-between">
+                                    <Text
+                                        typographyStyle="body-sm-strong"
+                                        isInverse
+                                        intent="neutral"
+                                    >
+                                        <Translation
+                                            id="TR_VERSION"
+                                            values={{ version: parsedChangelog.versionString }}
+                                        />
+                                    </Text>
+                                    <TextButton
+                                        size="small"
+                                        intent="neutral"
+                                        priority="secondary"
+                                        href={changelogUrl}
+                                        isInverse
+                                    >
+                                        <Translation id="TR_VIEW_ALL" />
+                                    </TextButton>
+                                </Row>
+                            )}
                             {parsedChangelog ? (
                                 <MarkdownWithComponents>
                                     {parsedChangelog.changelog}

--- a/packages/suite/src/components/guide/GuideButton.tsx
+++ b/packages/suite/src/components/guide/GuideButton.tsx
@@ -37,7 +37,7 @@ export const GuideButton = () => {
                         content: (
                             <Row gap={8}>
                                 <Translation id="TR_GUIDE_SUPPORT_AND_FEEDBACK" />
-                                <ShortcutBadge shortcut={['F1']} />
+                                <ShortcutBadge shortcut={['F1']} isInverse />
                             </Row>
                         ),
                         placement: 'top',

--- a/packages/suite/src/components/guide/OpenGuideFromTooltip.tsx
+++ b/packages/suite/src/components/guide/OpenGuideFromTooltip.tsx
@@ -1,46 +1,22 @@
 import { type MouseEvent } from 'react';
 
-import { transparentize } from 'polished';
-import styled from 'styled-components';
-
 import { Translation } from '@suite/intl';
-import { Icon } from '@trezor/components';
+import { TextButton } from '@trezor/components';
 import { LightbulbIcon } from '@trezor/icons';
-import { borders, spacingsPx, typography } from '@trezor/theme';
 
 import { useGuideOpenNode } from 'src/hooks/guide';
 
-const OpenGuideLink = styled.span`
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: ${spacingsPx.xxs};
-    padding: ${spacingsPx.xxxs} ${spacingsPx.xs};
-    border-radius: ${borders.radii.sm};
-    color: ${({ theme }) => theme.contentWarning};
-    ${typography['body-sm']};
-    overflow: visible;
-    cursor: pointer;
-
-    &:hover {
-        background: ${({ theme }) => transparentize(0.9, theme.elementFillWarningBold)};
-    }
-`;
-
 type OpenGuideFromTooltipProps = {
     id: string;
-    'data-testid'?: string;
 };
 
-export const OpenGuideFromTooltip = ({
-    id,
-    'data-testid': dataTest,
-}: OpenGuideFromTooltipProps) => {
+export const OpenGuideFromTooltip = ({ id }: OpenGuideFromTooltipProps) => {
     const { openNodeById } = useGuideOpenNode();
 
     return (
-        <OpenGuideLink
-            data-testid={dataTest}
+        <TextButton
+            intent="neutral"
+            priority="secondary"
             onClick={(e: MouseEvent<any>) => {
                 e.stopPropagation();
                 openNodeById(id);
@@ -49,8 +25,7 @@ export const OpenGuideFromTooltip = ({
             isInverse
             iconLeft={LightbulbIcon}
         >
-            <Icon size={12} intent="warning" as={LightbulbIcon} />
             <Translation id="TR_LEARN" />
-        </OpenGuideLink>
+        </TextButton>
     );
 };

--- a/packages/suite/src/components/guide/OpenGuideFromTooltip.tsx
+++ b/packages/suite/src/components/guide/OpenGuideFromTooltip.tsx
@@ -45,6 +45,9 @@ export const OpenGuideFromTooltip = ({
                 e.stopPropagation();
                 openNodeById(id);
             }}
+            size="small"
+            isInverse
+            iconLeft={LightbulbIcon}
         >
             <Icon size={12} intent="warning" as={LightbulbIcon} />
             <Translation id="TR_LEARN" />

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
@@ -114,7 +114,7 @@ export const DeviceSelector = () => {
                     content={
                         <Row gap={spacings.sm} alignItems="center">
                             <Translation id="TR_GUIDE_KEYBOARD_SHORTCUTS_SWITCH_DEVICE" />
-                            <ShortcutBadge shortcut={['ALT', 'KEY_W']} />
+                            <ShortcutBadge shortcut={['ALT', 'KEY_W']} isInverse />
                         </Row>
                     }
                 >

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
@@ -64,7 +64,7 @@ export const DeviceStatus = ({
                         content={
                             <Row gap={16} alignItems="center">
                                 {content}
-                                <ShortcutBadge shortcut={['ALT', 'KEY_W']} />
+                                <ShortcutBadge shortcut={['ALT', 'KEY_W']} isInverse />
                             </Row>
                         }
                     >

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx
@@ -116,7 +116,7 @@ const NavItem = ({
                 shortcut ? (
                     <Row gap={spacings.sm}>
                         <Title nameId={nameId} values={values} />
-                        <ShortcutBadge shortcut={shortcut} />
+                        <ShortcutBadge shortcut={shortcut} isInverse />
                     </Row>
                 ) : (
                     <Title nameId={nameId} values={values} />

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/DebugAndExperimental.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/DebugAndExperimental.tsx
@@ -25,7 +25,7 @@ const DebugAndExperimentalTooltip = ({
                 icon={CheckIcon}
                 intent="brand"
                 header={<Translation id="TR_EXPERIMENTAL_FEATURES_ALLOW" />}
-                leftItem={<Icon as={AtomIcon} intent="warning" size={16} />}
+                leftItem={<Icon as={AtomIcon} intent="warning" isInverse size={16} />}
             >
                 <Translation id="TR_QUICK_ACTION_DEBUG_EAP_EXPERIMENTAL_ENABLED" />
             </TooltipRow>
@@ -35,7 +35,7 @@ const DebugAndExperimentalTooltip = ({
                 icon={CheckIcon}
                 intent="brand"
                 header={<Translation id="TR_EARLY_ACCESS" />}
-                leftItem={<Icon as={StarFourIcon} intent="info" size={16} />}
+                leftItem={<Icon as={StarFourIcon} intent="info" isInverse size={16} />}
             >
                 <Translation id="TR_QUICK_ACTION_DEBUG_EAP_EXPERIMENTAL_ENABLED" />
             </TooltipRow>
@@ -45,7 +45,7 @@ const DebugAndExperimentalTooltip = ({
                 icon={CheckIcon}
                 intent="brand"
                 header="Debug Mode"
-                leftItem={<Icon as={DotOutlineFilledIcon} intent="critical" size={16} />}
+                leftItem={<Icon as={DotOutlineFilledIcon} intent="critical" isInverse size={16} />}
             >
                 <Translation id="TR_QUICK_ACTION_DEBUG_EAP_EXPERIMENTAL_ENABLED" />
             </TooltipRow>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/HideBalances.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/HideBalances.tsx
@@ -27,7 +27,7 @@ export const HideBalances = () => {
                 content: (
                     <Row gap={8}>
                         {translationString(translationLabel)}
-                        <ShortcutBadge shortcut={['ALT', 'KEY_H']} />
+                        <ShortcutBadge shortcut={['ALT', 'KEY_H']} isInverse />
                     </Row>
                 ),
             }}

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/NavBackends.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/NavBackends.tsx
@@ -35,6 +35,7 @@ const BackendRow = ({
                         typographyStyle="body-xs"
                         intent="neutral"
                         priority="secondary"
+                        isInverse
                         case="capitalize"
                     >
                         {type}
@@ -60,7 +61,7 @@ export const NavBackends = ({ customBackends }: NavBackendsProps) => {
                     <BackendRow key={backend.symbol} backend={backend} blockchain={blockchain} />
                 ))}
             </Column>
-            <Note>
+            <Note isInverse>
                 <Translation id="TR_OTHER_COINS_USE_DEFAULT_BACKEND" />
             </Note>
         </Column>

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeader.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeader.tsx
@@ -58,6 +58,7 @@ export function CollapsibleFeesHeader({
                             intent="neutral"
                             priority="secondary"
                             href={HELP_CENTER_TRANSACTION_FEES_URL}
+                            isInverse
                         >
                             <Translation id="TR_LEARN" />
                         </TextButton>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx
@@ -47,7 +47,7 @@ export const AddAccountButton = ({ device }: AddAccountButtonProps) => {
             content={
                 <Row gap={spacings.sm}>
                     <Translation id="TR_ADD_ACCOUNT" />
-                    <ShortcutBadge shortcut={['ALT', 'KEY_A']} />
+                    <ShortcutBadge shortcut={['ALT', 'KEY_A']} isInverse />
                 </Row>
             }
         >

--- a/packages/suite/src/views/dashboard/DashboardFooter.tsx
+++ b/packages/suite/src/views/dashboard/DashboardFooter.tsx
@@ -49,15 +49,15 @@ const StoreBadgeWithQr = ({ url, image, analyticsPayload }: StoreBadgeWithQrProp
             cursor={isBelowTablet ? 'not-allowed' : undefined}
             content={
                 <Column alignItems="center" gap={10} padding={{ top: 4 }}>
-                    <SvgImage image={image} height={26} color="contentPrimary" />
+                    <SvgImage image={image} height={26} color="contentOnDarkPrimary" />
                     <Box
                         height={140}
                         width={140}
                         padding={4}
-                        backgroundColor="elementFillContrast"
+                        backgroundColor="elementFillOnDarkContrast"
                         borderRadius={6}
                     >
-                        <QrCode value={url} color="contentPrimaryInverse" />
+                        <QrCode value={url} color="contentOnDarkPrimaryInverse" />
                     </Box>
                 </Column>
             }

--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
@@ -83,8 +83,12 @@ const getNoFirmwareChecklist = (isBelowTablet: boolean) =>
                         strong: chunks => (
                             <Tooltip
                                 placement={isBelowTablet ? 'top' : 'left'}
-                                title={<Translation id="TR_HOLOGRAM_STEP_HEADING" />}
-                                content={<Hologram />}
+                                content={
+                                    <Column>
+                                        <Translation id="TR_HOLOGRAM_STEP_HEADING" />
+                                        <Hologram />
+                                    </Column>
+                                }
                                 display="inline-flex"
                                 as="span"
                                 hasIcon

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
@@ -38,12 +38,17 @@ type DeviceItemProps = {
 };
 
 const ListItem = ({ children, icon }: { children: ReactNode; icon: IconComponent }) => (
-    <List.Item bulletComponent={<Icon as={icon} intent="neutral" priority="secondary" size={20} />}>
+    <List.Item
+        bulletComponent={
+            <Icon as={icon} intent="neutral" priority="secondary" isInverse size={20} />
+        }
+    >
         <Paragraph
             typographyStyle="body-md"
             intent="neutral"
             priority="secondary"
             textWrap="pretty"
+            isInverse
         >
             {children}
         </Paragraph>
@@ -135,6 +140,7 @@ export const DeviceItem = ({ device, instances, onCancel }: DeviceItemProps) => 
                                                     onTooltipClose();
                                                     onCancel?.();
                                                 }}
+                                                isInverse
                                             >
                                                 <Translation id="TR_DEVICE_DISCONNECTED_TOOLTIP_BUTTON_PRIMARY" />
                                             </Button>
@@ -142,6 +148,7 @@ export const DeviceItem = ({ device, instances, onCancel }: DeviceItemProps) => 
                                                 size="small"
                                                 intent="neutral"
                                                 priority="secondary"
+                                                isInverse
                                                 onClick={() => {
                                                     onTooltipClose();
                                                     dispatch(

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
@@ -118,6 +118,7 @@ export const FilterAction = () => {
                         priority="secondary"
                         size="small"
                         onClick={handleClose}
+                        isInverse
                         data-testid="@hideScamTransactionsTooltip/gotIt"
                     >
                         <Translation id="TR_GOT_IT_BUTTON" />


### PR DESCRIPTION
## Notes for QA
- updated the Toast component

## Screenshots:
<img width="599" height="89" alt="image" src="https://github.com/user-attachments/assets/a5d786cc-3ed4-4184-84a6-39707a023fe5" />
<img width="602" height="90" alt="image" src="https://github.com/user-attachments/assets/3c3cd038-d5a3-45f3-b848-7b3260872062" />
<img width="599" height="88" alt="image" src="https://github.com/user-attachments/assets/61a0ee7f-cc20-4ec2-8678-81174b9a70a5" />
<img width="596" height="86" alt="image" src="https://github.com/user-attachments/assets/f1b9aae6-49a0-42c5-aa10-74116e492f97" />
<img width="597" height="91" alt="image" src="https://github.com/user-attachments/assets/32487e02-a252-4c40-9476-0b67711fe601" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily modifies UI presentation components: shared primitives (Icon, Tooltip, Toast, Text, Note, Markdown, ShortcutBadge) and Suite-specific layout/navigation components (DeviceSelector, DeviceStatus, DeviceItem, NavigationItem, sidebar QuickActions, GuideButton, CollapsibleFeesHeader, AddAccountButton, FilterAction, SecurityCheck, FirmwareOffer, DashboardFooter). Since most shared components map to 131+ tests, the risk of a catastrophic break is low (these are likely styling/prop changes), but targeted tests should verify the specific UI surfaces that were directly modified. The recommended strategy focuses on tests that exercise the specific changed components: guide panel, device switcher/status, discreet mode toggle, add account button, fee headers, authenticity check, and toast notifications.

<details><summary><b>Changed files (32)</b></summary>

- `packages/components/src/components/Icon/Icon.tsx`
- `packages/components/src/components/Icon/utils.ts`
- `packages/components/src/components/Markdown/Markdown.tsx`
- `packages/components/src/components/Note/Note.tsx`
- `packages/components/src/components/ShortcutBadge/ShortcutBadge.stories.tsx`
- `packages/components/src/components/ShortcutBadge/ShortcutBadge.tsx`
- `packages/components/src/components/Toast/Toast.stories.tsx`
- `packages/components/src/components/Toast/Toast.tsx`
- `packages/components/src/components/Toast/utils.ts`
- `packages/components/src/components/Tooltip/Tooltip.stories.tsx`
- `packages/components/src/components/Tooltip/Tooltip.test.tsx`
- `packages/components/src/components/Tooltip/Tooltip.tsx`
- `packages/components/src/components/Tooltip/TooltipBox.tsx`
- `packages/components/src/components/typography/Text/Text.tsx`
- `packages/components/src/components/typography/Text/utils.ts`
- `packages/product-components/src/components/Notifications/ExchangeInfoNotification.tsx`
- `packages/product-components/src/components/TooltipRow/TooltipRow.tsx`
- `packages/suite/src/components/firmware/FirmwareOffer.tsx`
- `packages/suite/src/components/guide/GuideButton.tsx`
- `packages/suite/src/components/guide/OpenGuideFromTooltip.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/DebugAndExperimental.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/HideBalances.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/NavBackends.tsx`
- `packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeader.tsx`
- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx`
- `packages/suite/src/views/dashboard/DashboardFooter.tsx`
- `packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx`
- `packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx`
- `packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx`

</details>

**Recommended tests (21)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/suite/guide.test.ts` — Directly exercises the GuideButton component (GuideButton.tsx changed) and OpenGuideFromTooltip.tsx. The test opens/closes the guide panel, navigates guide content, submits feedback, and searches — all flows that render the GuideButton and tooltip-based guide openers.
- `suite/e2e/tests/general/suite-guide.test.ts` — Another guide panel test that opens the panel, submits bug reports, and searches for articles — directly exercising GuideButton.tsx and OpenGuideFromTooltip.tsx changes.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Directly exercises the HideBalances sidebar quick action (HideBalances.tsx changed) by toggling discreet mode and verifying balance hiding/revealing via hover. Also exercises the device switcher wallet fiat amount which uses DeviceSelector/DeviceStatus.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Directly tests device status display ('TR_USE_HERE', 'TR_CONNECTED') which is rendered by DeviceStatus.tsx (changed). Also exercises the device switching panel rendered by DeviceSelector.tsx and DeviceItem.tsx (both changed).
- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — Directly exercises the SecurityCheck component (SecurityCheck.tsx changed) during the device authenticity check step of onboarding. A rendering regression here would block onboarding.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Directly exercises the AddAccountButton component (AddAccountButton.tsx changed) by clicking the add account button, opening the modal, and adding accounts of various types.

</details>

<details><summary>🟡 <b>Medium priority (13)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — Exercises the device switcher panel (DeviceItem.tsx, DeviceSelector.tsx changed) to verify wallet labeling and numbering when adding/ejecting hidden wallets.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Exercises the device switcher with wallet labels (DeviceItem.tsx changed), passphrase input modals, and mismatch dialogs. Also verifies wallet entries appear correctly in the switcher panel.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Exercises the device switcher (DeviceItem.tsx, DeviceSelector.tsx changed) to eject wallet and add standard wallet. Balance display on wallet page could be affected by Text/typography changes.
- `suite/e2e/tests/settings/passphrase.test.ts` — Asserts on toast notification visibility and disappearance (@toast/settings-applied). Toast.tsx and Toast/utils.ts were changed, which could affect rendering or auto-dismiss behavior.
- `suite/e2e/tests/backup/t2t1-fail.test.ts` — Asserts on toast notification visibility ('backup-failed' toast). Toast.tsx was changed. Also exercises device status indicators affected by DeviceStatus.tsx changes.
- `suite/e2e/tests/suite/bug-report-form.test.ts` — Opens the guide panel (GuideButton.tsx changed) and submits a bug report, asserting on a success toast notification (Toast.tsx changed).
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Exercises the NavBackends sidebar quick action (NavBackends.tsx changed) which shows custom backend indicators in the sidebar. Also tests backend configuration UI.
- `suite/e2e/tests/wallet/transactions.test.ts` — Exercises the transaction list filter/search functionality. FilterAction.tsx was changed, which handles the transaction list filter action component used for searching transactions.
- `suite/e2e/tests/wallet/account-search.test.ts` — Tests account search/filtering in the wallet sidebar. NavigationItem.tsx (sidebar navigation item) was changed and could affect how accounts are rendered in the sidebar menu.
- `suite/e2e/tests/staking/staking-form.test.ts` — Exercises the CollapsibleFeesHeader component (changed) which renders fee information in staking forms. The test validates fee display, amount validation, and input switching.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Directly exercises custom Ethereum fee settings (gas limit, max fee per gas) displayed through CollapsibleFeesHeader.tsx (changed). Validates fee values on both UI and device prompt.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Exercises custom Bitcoin fee settings through CollapsibleFeesHeader.tsx (changed). Validates fee rate display on both the UI modal and hardware device.
- `suite/e2e/tests/firmware/custom-firmware.test.ts` — Exercises the firmware installation flow where FirmwareOffer.tsx (changed) renders the firmware offer/details UI. A rendering regression could break the custom firmware install flow.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/settings/forget-device.test.ts` — Exercises the device switcher and device status indicators (DeviceSelector.tsx, DeviceStatus.tsx changed). Verifies forget device modal and discovery state which involves these components.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — FilterAction.tsx was changed and is part of the transaction list view. While the test focuses on pending/confirmed status labels rather than filtering, a rendering issue could affect the transaction list layout.

</details>

⚠️ **Changes with no test coverage (7)**
- `packages/components/src/components/ShortcutBadge/ShortcutBadge.stories.tsx`
- `packages/components/src/components/Toast/Toast.stories.tsx`
- `packages/components/src/components/Tooltip/Tooltip.stories.tsx`
- `packages/components/src/components/Tooltip/Tooltip.test.tsx`
- `packages/product-components/src/components/Notifications/ExchangeInfoNotification.tsx`
- `packages/product-components/src/components/TooltipRow/TooltipRow.tsx`
- `packages/suite/src/views/dashboard/DashboardFooter.tsx`

_Updated: 2026-07-13T11:55:18.512Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/toast-component/web/](https://dev.suite.sldev.cz/suite-web/refactor/toast-component/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/toast-component&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/toast-component&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-13T11:58:05.345Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-13T11:57:40.880Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->