### PR TITLE
fix(suite-native): key yield txReview by flow identity

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -203,6 +203,8 @@ export const claimMerklRewardsThunk = createThunk(
                     precomposedForm: formState,
                     availableRewards,
                     accountKey: account.key,
+                    flowKey,
+                    flowType: 'claim',
                 }),
             );
 

--- a/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
@@ -3,6 +3,7 @@ import { selectSelectedDevice } from '@suite-common/device';
 import { buildStablecoinYieldTransactionReview } from '@suite-common/earn-stablecoin/src/signing';
 import {
     type YieldFlowDisplayToken,
+    type YieldFlowType,
     selectAddressDisplayType,
     selectIsMevProtectionEnabled,
     stablecoinYieldActions,
@@ -30,6 +31,8 @@ export type SendYieldTransactionParams = {
     amount: string;
     token: YieldFlowDisplayToken;
     unsignedTransaction: string;
+    flowKey: string;
+    flowType: YieldFlowType;
     dispatch: Dispatch;
     getState: () => AppState;
     selectedFee: EvmSelectedFee | null;
@@ -40,6 +43,8 @@ export const sendYieldTransaction = async ({
     amount,
     token,
     unsignedTransaction,
+    flowKey,
+    flowType,
     dispatch,
     getState,
     selectedFee,
@@ -70,6 +75,8 @@ export const sendYieldTransaction = async ({
             precomposedTx: precomposedTransaction,
             precomposedForm: formState,
             accountKey: account.key,
+            flowKey,
+            flowType,
         }),
     );
 

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
@@ -96,6 +96,8 @@ export const submitYieldDepositThunk = createThunk(
                 amount,
                 token: flowData.token,
                 unsignedTransaction: result.unsignedTransaction,
+                flowKey,
+                flowType,
                 dispatch,
                 getState,
                 selectedFee,

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
@@ -78,6 +78,8 @@ export const submitYieldWithdrawThunk = createThunk(
                 amount,
                 token: reviewToken,
                 unsignedTransaction,
+                flowKey,
+                flowType,
                 dispatch,
                 getState,
                 selectedFee,

--- a/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldReducer.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldReducer.test.ts
@@ -1,3 +1,6 @@
+import type { FormState, PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+
 import {
     type StablecoinYieldState,
     getStablecoinYieldSessionKey,
@@ -5,7 +8,7 @@ import {
     stablecoinYieldActions,
     stablecoinYieldReducer,
 } from '../stablecoinYieldReducer';
-import type { YieldFlowType } from '../stablecoinYieldTypes';
+import type { YieldFlowType, YieldPendingTransactionState } from '../stablecoinYieldTypes';
 
 const FLOW_KEY = 'account-key:yield-id:0xtoken';
 
@@ -125,6 +128,87 @@ describe('stablecoinYieldReducer', () => {
             );
 
             expect(getSession(state, 'deposit')?.step).toBe('approve');
+        });
+
+        it('preserves the in-flight pending transaction when entering modify mode', () => {
+            const pendingTransaction: YieldPendingTransactionState = {
+                type: 'deposit',
+                txid: '0xpendingtxid',
+                amount: '100',
+            };
+            const state = stablecoinYieldReducer(
+                stablecoinYieldReducer(
+                    initSession('deposit'),
+                    stablecoinYieldActions.setPendingTx({
+                        flowType: 'deposit',
+                        flowKey: FLOW_KEY,
+                        tx: pendingTransaction,
+                    }),
+                ),
+                stablecoinYieldActions.enterModifyMode({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.action.pendingTransaction).toEqual(
+                pendingTransaction,
+            );
+        });
+    });
+
+    describe('txReview', () => {
+        const ACCOUNT_KEY = mockAccountKey({
+            symbol: 'eth',
+            descriptor: '0xfffffffffffffffffffffffffffffffffffffffe',
+            deviceStaticSessionId: '1stTestnetAddress@device_id:0',
+        });
+        const precomposedForm = { selectedFee: 'custom' } as unknown as FormState;
+        const precomposedTx = { type: 'final', fee: '1' } as unknown as PrecomposedTransactionFinal;
+        const serializedTx = { tx: '0xsignedtx', symbol: 'eth' } as const;
+
+        const storePrecomposed = (state: StablecoinYieldState) =>
+            stablecoinYieldReducer(
+                state,
+                stablecoinYieldActions.storePrecomposedTransaction({
+                    precomposedTx,
+                    precomposedForm,
+                    accountKey: ACCOUNT_KEY,
+                    flowKey: FLOW_KEY,
+                    flowType: 'deposit',
+                }),
+            );
+
+        it('tags the precomposed transaction with the flow identity and timestamp', () => {
+            const before = new Date().getTime();
+            const state = storePrecomposed(initialStablecoinYieldState);
+
+            expect(state.txReview.accountKey).toBe(ACCOUNT_KEY);
+            expect(state.txReview.flowKey).toBe(FLOW_KEY);
+            expect(state.txReview.flowType).toBe('deposit');
+            expect(state.txReview.createdTimestamp).toBeGreaterThanOrEqual(before);
+            expect(state.txReview.serializedTx).toBeUndefined();
+        });
+
+        it('clears the flow identity when the transaction is discarded', () => {
+            const state = stablecoinYieldReducer(
+                stablecoinYieldReducer(
+                    storePrecomposed(initialStablecoinYieldState),
+                    stablecoinYieldActions.storeSignedTransaction({ serializedTx }),
+                ),
+                stablecoinYieldActions.discardTransaction(),
+            );
+
+            expect(state.txReview).toEqual({
+                precomposedTx: undefined,
+                precomposedForm: undefined,
+                availableRewards: undefined,
+                serializedTx: undefined,
+                accountKey: undefined,
+                flowKey: undefined,
+                flowType: undefined,
+                createdTimestamp: undefined,
+            });
         });
     });
 });

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -68,6 +68,9 @@ export type StablecoinYieldTxReviewState = {
     availableRewards?: YieldClaimReward[];
     serializedTx?: StablecoinYieldSerializedTx;
     accountKey?: AccountKey;
+    flowKey?: string;
+    flowType?: YieldFlowType;
+    createdTimestamp?: number;
 };
 
 export type StablecoinYieldSessionState = {
@@ -141,6 +144,9 @@ export const initialStablecoinYieldTxReviewState: StablecoinYieldTxReviewState =
     availableRewards: undefined,
     serializedTx: undefined,
     accountKey: undefined,
+    flowKey: undefined,
+    flowType: undefined,
+    createdTimestamp: undefined,
 };
 
 export const initialStablecoinYieldState: StablecoinYieldState = {
@@ -311,7 +317,8 @@ export const stablecoinYieldSlice = createSlice({
             withSession(state, action.payload, session => {
                 session.approval.isModifyMode = true;
                 session.approval.modalState = null;
-                session.action.pendingTransaction = null;
+                // The pendingTransaction is intentionally preserved — an in-flight action tx must
+                // stay tracked so its confirmation is still processed into `completeAction`.
                 session.action.review = null;
                 session.error = null;
                 session.action.amount = action.payload.amount ?? session.action.amount;
@@ -438,17 +445,22 @@ export const stablecoinYieldSlice = createSlice({
         },
         storePrecomposedTransaction(
             state,
-            action: PayloadAction<{
-                precomposedTx: PrecomposedTransactionFinal;
-                precomposedForm: FormState;
-                availableRewards?: YieldClaimReward[];
-                accountKey: AccountKey;
-            }>,
+            action: PayloadAction<
+                StablecoinYieldSessionActionPayload & {
+                    precomposedTx: PrecomposedTransactionFinal;
+                    precomposedForm: FormState;
+                    availableRewards?: YieldClaimReward[];
+                    accountKey: AccountKey;
+                }
+            >,
         ) {
             state.txReview.precomposedTx = action.payload.precomposedTx;
             state.txReview.precomposedForm = action.payload.precomposedForm;
             state.txReview.availableRewards = action.payload.availableRewards;
             state.txReview.accountKey = action.payload.accountKey;
+            state.txReview.flowKey = action.payload.flowKey;
+            state.txReview.flowType = action.payload.flowType;
+            state.txReview.createdTimestamp = new Date().getTime();
             state.txReview.serializedTx = undefined;
         },
         storeSignedTransaction(
@@ -463,6 +475,9 @@ export const stablecoinYieldSlice = createSlice({
             state.txReview.availableRewards = undefined;
             state.txReview.serializedTx = undefined;
             state.txReview.accountKey = undefined;
+            state.txReview.flowKey = undefined;
+            state.txReview.flowType = undefined;
+            state.txReview.createdTimestamp = undefined;
         },
     },
     extraReducers: builder => {

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -281,6 +281,29 @@ export const buildYieldUnsignedTransaction = ({
     };
 };
 
+type YieldTxReviewFlowIdentity = {
+    accountKey?: AccountKey;
+    flowKey?: string;
+    flowType?: YieldFlowType;
+    createdTimestamp?: number;
+};
+
+type YieldTxReviewFlowMatchParams = {
+    accountKey: AccountKey;
+    flowKey: string;
+    flowType: YieldFlowType;
+    notBefore?: number;
+};
+
+export const isYieldTxReviewForFlow = (
+    txReview: YieldTxReviewFlowIdentity,
+    { accountKey, flowKey, flowType, notBefore }: YieldTxReviewFlowMatchParams,
+) =>
+    txReview.accountKey === accountKey &&
+    txReview.flowKey === flowKey &&
+    txReview.flowType === flowType &&
+    (notBefore === undefined || (txReview.createdTimestamp ?? 0) >= notBefore);
+
 export const splitYieldPendingTransaction = (
     pendingTransaction: YieldPendingTransactionState | null,
     actionKind: YieldFlowType,

--- a/suite-native/module-earn/src/__tests__/yieldClaimThunks.test.ts
+++ b/suite-native/module-earn/src/__tests__/yieldClaimThunks.test.ts
@@ -133,6 +133,8 @@ const prepareSignedClaimReview = (store: ReturnType<typeof buildStore>) => {
             precomposedTx: precomposedTransaction,
             precomposedForm,
             accountKey: account.key,
+            flowKey: account.key,
+            flowType: 'claim',
         }),
     );
     store.dispatch(
@@ -211,6 +213,38 @@ describe('pushYieldClaimReviewThunk', () => {
             serializedTx: undefined,
             accountKey: undefined,
         });
+    });
+
+    it('rejects the push when the signed tx belongs to a different flow key', async () => {
+        const store = buildStore();
+        prepareSignedClaimReview(store);
+
+        const otherFlowKey = 'other-flow-key';
+        store.dispatch(
+            stablecoinYieldActions.initSession({ flowType: 'claim', flowKey: otherFlowKey }),
+        );
+        store.dispatch(
+            stablecoinYieldActions.storeActionReviewData({
+                flowType: 'claim',
+                flowKey: otherFlowKey,
+                rewards,
+                unsignedTransaction,
+            }),
+        );
+
+        const action = await store.dispatch(
+            pushYieldClaimReviewThunk({
+                account,
+                flowKey: otherFlowKey,
+            }) as any,
+        );
+
+        expect(isRejected(action)).toBe(true);
+        expect(action.payload).toEqual({
+            error: 'push-transaction-failed',
+            message: 'Transaction not found.',
+        });
+        expect(pushTransactionMock).not.toHaveBeenCalled();
     });
 
     it('maps replacement push failure to pending conflict and clears review tx state', async () => {

--- a/suite-native/module-earn/src/__tests__/yieldTransactionThunks.test.ts
+++ b/suite-native/module-earn/src/__tests__/yieldTransactionThunks.test.ts
@@ -1,0 +1,275 @@
+import { combineReducers, isFulfilled, isRejected } from '@reduxjs/toolkit';
+
+import { configureMockStore } from '@suite-common/test-utils';
+import {
+    type StablecoinYieldRootState,
+    type YieldFlowResolvedData,
+    type YieldPositionFlowType,
+    selectStablecoinYieldSession,
+    selectStablecoinYieldTxReview,
+    stablecoinYieldActions,
+    stablecoinYieldReducer,
+    synchronizeSentTransactionThunk,
+} from '@suite-common/wallet-core';
+import {
+    type Account,
+    type FormState,
+    type PrecomposedTransactionFinal,
+} from '@suite-common/wallet-types';
+import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import TrezorConnect from '@trezor/connect';
+import { type StaticSessionId } from '@trezor/device-utils';
+
+import { pushYieldActionReviewThunk } from '../yieldTransactionThunks';
+
+jest.mock('@trezor/connect', () => ({
+    __esModule: true,
+    ...jest.requireActual('@trezor/connect'),
+    default: {
+        pushTransaction: jest.fn().mockResolvedValue({
+            success: true,
+            payload: { txid: '0xpushedtxid' },
+        }),
+    },
+}));
+
+jest.mock('@suite-common/wallet-core', () => ({
+    __esModule: true,
+    ...jest.requireActual('@suite-common/wallet-core'),
+    synchronizeSentTransactionThunk: jest.fn(params => ({
+        type: 'test/synchronizeSentTransactionThunk',
+        payload: params,
+    })),
+}));
+
+const STATIC_SESSION_ID: StaticSessionId = '1stTestnetAddress@device_id:0';
+const FLOW_KEY = 'flow-key';
+const OTHER_FLOW_KEY = 'other-flow-key';
+
+const buildAccount = (descriptor: string) => {
+    const accountKey = mockAccountKey({
+        symbol: 'eth',
+        descriptor,
+        deviceStaticSessionId: STATIC_SESSION_ID,
+    });
+
+    return {
+        symbol: 'eth',
+        networkType: 'ethereum',
+        key: accountKey,
+        deviceState: STATIC_SESSION_ID,
+        descriptor,
+        path: "m/44'/60'/0'/0/0",
+        visible: true,
+    } as unknown as Account;
+};
+
+const account = buildAccount('0xfffffffffffffffffffffffffffffffffffffffe');
+const otherAccount = buildAccount('0xfffffffffffffffffffffffffffffffffffffffd');
+
+const buildFlowData = (flowAccount: Account) =>
+    ({ account: flowAccount }) as unknown as YieldFlowResolvedData;
+
+const precomposedForm = {
+    outputs: [],
+    selectedFee: 'custom',
+    feePerUnit: '20',
+    feeLimit: '21000',
+    options: ['broadcast', 'transactionData'],
+    transactionData: '0x1234',
+    isCoinControlEnabled: false,
+    hasCoinControlBeenOpened: false,
+    selectedUtxos: [],
+} as unknown as FormState;
+
+const precomposedTransaction = {
+    type: 'final',
+    fee: '420000000000000',
+    feePerByte: '20',
+    feeLimit: '21000',
+    totalSpent: '420000000000000',
+    bytes: 0,
+    inputs: [],
+    outputs: [{ address: '0x0000000000000000000000000000000000000001', amount: '0' }],
+    outputsPermutation: [0],
+} satisfies PrecomposedTransactionFinal;
+
+const pushTransactionMock = TrezorConnect.pushTransaction as jest.Mock;
+const synchronizeSentTransactionThunkMock = synchronizeSentTransactionThunk as unknown as jest.Mock;
+
+const buildStore = () =>
+    configureMockStore({
+        reducer: combineReducers({
+            wallet: combineReducers({
+                stablecoinYield: stablecoinYieldReducer,
+            }),
+        }),
+    });
+
+type PrepareParams = {
+    store: ReturnType<typeof buildStore>;
+    flowType: YieldPositionFlowType;
+    flowKey: string;
+};
+
+const prepareActionReview = ({ store, flowType, flowKey }: PrepareParams) => {
+    store.dispatch(stablecoinYieldActions.initSession({ flowType, flowKey }));
+    store.dispatch(
+        stablecoinYieldActions.storeActionReviewData({
+            flowType,
+            flowKey,
+            amount: '100',
+            receiptAmount: '99',
+            unsignedTransaction: '0xunsignedtx',
+        }),
+    );
+};
+
+const storeSignedTransaction = ({
+    flowType,
+    flowKey,
+    store,
+}: PrepareParams & { store: ReturnType<typeof buildStore> }) => {
+    store.dispatch(
+        stablecoinYieldActions.storePrecomposedTransaction({
+            precomposedTx: precomposedTransaction,
+            precomposedForm,
+            accountKey: account.key,
+            flowKey,
+            flowType,
+        }),
+    );
+    store.dispatch(
+        stablecoinYieldActions.storeSignedTransaction({
+            serializedTx: {
+                tx: '0xsignedtx',
+                symbol: account.symbol,
+            },
+        }),
+    );
+};
+
+type DispatchPushParams = {
+    store: ReturnType<typeof buildStore>;
+    flowType: YieldPositionFlowType;
+    flowKey: string;
+    flowAccount?: Account;
+};
+
+const dispatchPush = async ({
+    store,
+    flowType,
+    flowKey,
+    flowAccount = account,
+}: DispatchPushParams) => {
+    const action = await store.dispatch(
+        pushYieldActionReviewThunk({
+            flowData: buildFlowData(flowAccount),
+            flowKey,
+            flowType,
+        }) as any,
+    );
+
+    if (isFulfilled(action)) return { ok: true as const, txid: action.payload.txid };
+    if (isRejected(action)) return { ok: false as const, error: action.payload };
+
+    throw new Error('Unexpected dispatch outcome.');
+};
+
+describe('pushYieldActionReviewThunk', () => {
+    beforeEach(() => {
+        jest.spyOn(Date, 'now').mockReturnValue(1234567890);
+        pushTransactionMock.mockClear();
+        synchronizeSentTransactionThunkMock.mockClear();
+        pushTransactionMock.mockResolvedValue({
+            success: true,
+            payload: { txid: '0xpushedtxid' },
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('pushes the signed deposit tx and stores pending deposit metadata', async () => {
+        const store = buildStore();
+        prepareActionReview({ store, flowType: 'deposit', flowKey: FLOW_KEY });
+        storeSignedTransaction({ store, flowType: 'deposit', flowKey: FLOW_KEY });
+
+        const result = await dispatchPush({ store, flowType: 'deposit', flowKey: FLOW_KEY });
+
+        expect(result).toEqual({ ok: true, txid: '0xpushedtxid' });
+        expect(pushTransactionMock).toHaveBeenCalledWith({
+            tx: '0xsignedtx',
+            coin: account.symbol,
+            identity: account.deviceState,
+        });
+        expect(synchronizeSentTransactionThunkMock).toHaveBeenCalledWith({
+            selectedAccount: account,
+            precomposedTransaction,
+            precomposedForm,
+            txid: '0xpushedtxid',
+        });
+
+        const state = store.getState() as StablecoinYieldRootState;
+        const session = selectStablecoinYieldSession(state, 'deposit', FLOW_KEY);
+
+        expect(session.action.pendingTransaction).toEqual({
+            type: 'deposit',
+            txid: '0xpushedtxid',
+            amount: '100',
+            fee: precomposedTransaction.fee,
+            submittedAt: 1234567890,
+        });
+        expect(selectStablecoinYieldTxReview(state).serializedTx).toBeUndefined();
+    });
+
+    it('rejects the push when the signed tx belongs to a different account', async () => {
+        const store = buildStore();
+        prepareActionReview({ store, flowType: 'deposit', flowKey: FLOW_KEY });
+        storeSignedTransaction({ store, flowType: 'deposit', flowKey: FLOW_KEY });
+
+        const result = await dispatchPush({
+            store,
+            flowType: 'deposit',
+            flowKey: FLOW_KEY,
+            flowAccount: otherAccount,
+        });
+
+        expect(result).toEqual({
+            ok: false,
+            error: { error: 'push-transaction-failed', message: 'Transaction not found.' },
+        });
+        expect(pushTransactionMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects the withdraw push when the signed tx belongs to a deposit flow', async () => {
+        const store = buildStore();
+        prepareActionReview({ store, flowType: 'deposit', flowKey: FLOW_KEY });
+        storeSignedTransaction({ store, flowType: 'deposit', flowKey: FLOW_KEY });
+        prepareActionReview({ store, flowType: 'withdraw', flowKey: FLOW_KEY });
+
+        const result = await dispatchPush({ store, flowType: 'withdraw', flowKey: FLOW_KEY });
+
+        expect(result).toEqual({
+            ok: false,
+            error: { error: 'push-transaction-failed', message: 'Transaction not found.' },
+        });
+        expect(pushTransactionMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects the push when the signed tx belongs to a different flow key', async () => {
+        const store = buildStore();
+        prepareActionReview({ store, flowType: 'deposit', flowKey: FLOW_KEY });
+        storeSignedTransaction({ store, flowType: 'deposit', flowKey: FLOW_KEY });
+        prepareActionReview({ store, flowType: 'deposit', flowKey: OTHER_FLOW_KEY });
+
+        const result = await dispatchPush({ store, flowType: 'deposit', flowKey: OTHER_FLOW_KEY });
+
+        expect(result).toEqual({
+            ok: false,
+            error: { error: 'push-transaction-failed', message: 'Transaction not found.' },
+        });
+        expect(pushTransactionMock).not.toHaveBeenCalled();
+    });
+});

--- a/suite-native/module-earn/src/hooks/useYieldClaimReview.ts
+++ b/suite-native/module-earn/src/hooks/useYieldClaimReview.ts
@@ -7,6 +7,7 @@ import { isRejected } from '@reduxjs/toolkit';
 import { selectIsDeviceConnected } from '@suite-common/device';
 import {
     type StablecoinYieldRootState,
+    isYieldTxReviewForFlow,
     selectStablecoinYieldTxReview,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
@@ -58,7 +59,16 @@ export const useYieldClaimReview = ({
     const txReview = useSelector((state: StablecoinYieldRootState) =>
         selectStablecoinYieldTxReview(state),
     );
-    const isClaimSigned = txReview.accountKey === account.key && !!txReview.serializedTx;
+    // A leftover signed tx from a previous review of the same account must not appear
+    // as signed here, hence the flow identity and `notBefore` guard.
+    const [reviewOpenedAt] = useState(() => Date.now());
+    const isClaimSigned =
+        isYieldTxReviewForFlow(txReview, {
+            accountKey: account.key,
+            flowKey,
+            flowType: 'claim',
+            notBefore: reviewOpenedAt,
+        }) && !!txReview.serializedTx;
     const claimStatus: YieldReviewStatus =
         claimActionStatus === 'idle' && isClaimSigned ? 'signed' : claimActionStatus;
     const { leaveReviewFromDeviceCancel, markReviewNavigationSuccess } =

--- a/suite-native/module-earn/src/hooks/useYieldDepositReview.ts
+++ b/suite-native/module-earn/src/hooks/useYieldDepositReview.ts
@@ -8,6 +8,7 @@ import { selectIsDeviceConnected } from '@suite-common/device';
 import {
     type StablecoinYieldRootState,
     type YieldFlowResolvedData,
+    isYieldTxReviewForFlow,
     selectStablecoinYieldTxReview,
 } from '@suite-common/wallet-core';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
@@ -61,7 +62,16 @@ export const useYieldDepositReview = ({
     const txReview = useSelector((state: StablecoinYieldRootState) =>
         selectStablecoinYieldTxReview(state),
     );
-    const isDepositSigned = txReview.accountKey === flowData.account.key && !!txReview.serializedTx;
+    // A leftover signed tx from a previous review of the same account must not appear
+    // as signed here, hence the flow identity and `notBefore` guard.
+    const [reviewOpenedAt] = useState(() => Date.now());
+    const isDepositSigned =
+        isYieldTxReviewForFlow(txReview, {
+            accountKey: flowData.account.key,
+            flowKey,
+            flowType: 'deposit',
+            notBefore: reviewOpenedAt,
+        }) && !!txReview.serializedTx;
     const depositStatus: YieldReviewStatus =
         depositActionStatus === 'idle' && isDepositSigned ? 'signed' : depositActionStatus;
     const { leaveReviewFromDeviceCancel, markReviewNavigationSuccess } =

--- a/suite-native/module-earn/src/hooks/useYieldWithdrawReview.ts
+++ b/suite-native/module-earn/src/hooks/useYieldWithdrawReview.ts
@@ -11,6 +11,7 @@ import {
     type YieldFlowDisplayToken,
     type YieldFlowResolvedData,
     type YieldWithdrawFlowType,
+    isYieldTxReviewForFlow,
     selectFormDraft,
     selectStablecoinYieldTxReview,
 } from '@suite-common/wallet-core';
@@ -78,8 +79,16 @@ export const useYieldWithdrawReview = ({
         selectFormDraft<FormState>(state, formDraftKey),
     );
     const selectedFee = useMemo(() => getSelectedEvmFeeFromFormDraft(formDraft), [formDraft]);
+    // A leftover signed tx from a previous review of the same account must not appear
+    // as signed here, hence the flow identity and `notBefore` guard.
+    const [reviewOpenedAt] = useState(() => Date.now());
     const isWithdrawSigned =
-        txReview.accountKey === flowData.account.key && !!txReview.serializedTx;
+        isYieldTxReviewForFlow(txReview, {
+            accountKey: flowData.account.key,
+            flowKey,
+            flowType,
+            notBefore: reviewOpenedAt,
+        }) && !!txReview.serializedTx;
     const withdrawStatus: YieldReviewStatus =
         withdrawActionStatus === 'idle' && isWithdrawSigned ? 'signed' : withdrawActionStatus;
     const { leaveReviewFromDeviceCancel, markReviewNavigationSuccess } =

--- a/suite-native/module-earn/src/yieldClaimThunks.ts
+++ b/suite-native/module-earn/src/yieldClaimThunks.ts
@@ -3,6 +3,7 @@ import { buildClaimTransactionReview } from '@suite-common/earn-stablecoin/src/s
 import { createThunk } from '@suite-common/redux-utils';
 import {
     formDraftActions,
+    isYieldTxReviewForFlow,
     selectAddressDisplayType,
     selectDeepCopyOfFormDraft,
     selectStablecoinYieldSession,
@@ -125,6 +126,8 @@ export const signYieldClaimReviewThunk = createThunk<
                 precomposedForm: formState,
                 availableRewards,
                 accountKey: account.key,
+                flowKey,
+                flowType: 'claim',
             }),
         );
 
@@ -151,7 +154,11 @@ export const signYieldClaimReviewThunk = createThunk<
         const currentTxReview = selectStablecoinYieldTxReview(getState());
 
         if (
-            currentTxReview.accountKey !== account.key ||
+            !isYieldTxReviewForFlow(currentTxReview, {
+                accountKey: account.key,
+                flowKey,
+                flowType: 'claim',
+            }) ||
             currentTxReview.precomposedForm !== formState ||
             currentTxReview.precomposedTx !== precomposedTransaction
         ) {
@@ -190,7 +197,11 @@ export const pushYieldClaimReviewThunk = createThunk<
 
         if (
             review?.type !== 'claim' ||
-            txReview.accountKey !== account.key ||
+            !isYieldTxReviewForFlow(txReview, {
+                accountKey: account.key,
+                flowKey,
+                flowType: 'claim',
+            }) ||
             !serializedTx ||
             !precomposedForm ||
             !precomposedTx

--- a/suite-native/module-earn/src/yieldTransactionThunks.ts
+++ b/suite-native/module-earn/src/yieldTransactionThunks.ts
@@ -5,6 +5,7 @@ import {
     type YieldFlowDisplayToken,
     type YieldFlowResolvedData,
     type YieldPositionFlowType,
+    isYieldTxReviewForFlow,
     selectAddressDisplayType,
     selectStablecoinYieldSession,
     selectStablecoinYieldTxReview,
@@ -101,6 +102,8 @@ export const signYieldActionReviewThunk = createThunk<
                 precomposedTx: precomposedTransaction,
                 precomposedForm: formState,
                 accountKey: flowData.account.key,
+                flowKey,
+                flowType,
             }),
         );
 
@@ -127,7 +130,11 @@ export const signYieldActionReviewThunk = createThunk<
         const currentTxReview = selectStablecoinYieldTxReview(getState());
 
         if (
-            currentTxReview.accountKey !== flowData.account.key ||
+            !isYieldTxReviewForFlow(currentTxReview, {
+                accountKey: flowData.account.key,
+                flowKey,
+                flowType,
+            }) ||
             currentTxReview.precomposedForm !== formState ||
             currentTxReview.precomposedTx !== precomposedTransaction
         ) {
@@ -158,13 +165,23 @@ export const pushYieldActionReviewThunk = createThunk<
     `${YIELD_TRANSACTION_THUNK_PREFIX}/pushActionReview`,
     async ({ flowData, flowKey, flowType }, { dispatch, getState, rejectWithValue }) => {
         const session = selectStablecoinYieldSession(getState(), flowType, flowKey);
-        const { precomposedForm, precomposedTx, serializedTx } =
-            selectStablecoinYieldTxReview(getState());
+        const txReview = selectStablecoinYieldTxReview(getState());
+        const { precomposedForm, precomposedTx, serializedTx } = txReview;
         const {
             action: { review },
         } = session;
 
-        if (review?.type !== flowType || !serializedTx || !precomposedForm || !precomposedTx) {
+        if (
+            review?.type !== flowType ||
+            !isYieldTxReviewForFlow(txReview, {
+                accountKey: flowData.account.key,
+                flowKey,
+                flowType,
+            }) ||
+            !serializedTx ||
+            !precomposedForm ||
+            !precomposedTx
+        ) {
             return rejectWithValue({
                 error: 'push-transaction-failed',
                 message: 'Transaction not found.',


### PR DESCRIPTION
## Description

`stablecoinYield.txReview` is a single global slot keyed only by `accountKey`, so a stale or wrong-flow signed tx could theoretically be shown or pushed as another flow's transaction. This PR tags the slot with `flowKey` + `flowType` + `createdTimestamp` and checks the flow identity in the push thunks, race guards, and `isSigned` derivations. It also stops `enterModifyMode` from discarding an in-flight `pendingTransaction`.

I was not able to reproduce the bug manually — instrumentation (done with the agent) showed the `beforeRemove` cleanup catches all navigation paths, including root-level resets. The fix is defense-in-depth; reproduction is covered by the new unit tests.

## Notes for QA

No behavior change expected. Sanity-check the mobile yield deposit/withdraw/claim flows (sign + submit), including cancelling a review mid-signing.

## Related Issue

Resolve #29535

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on stablecoin yield functionality: deposit, withdraw, and claim thunks, a reducer, utility functions, and their unit tests. Most changes are in suite-native (mobile) hooks/thunks and suite-common shared code. The 129-test static mapping is a false positive — these files are bundled into the main Suite app but stablecoin yield is a specialized feature with no dedicated E2E test coverage. The only plausibly affected E2E tests are the ETH staking tests, which share Ethereum signing infrastructure (signingHelpers.ts). The risk is low for E2E regressions since the changes are well-scoped to stablecoin yield, and the unit tests in the changeset provide primary coverage.

<details><summary><b>Changed files (14)</b></summary>

- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts`
- `suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldReducer.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts`
- `suite-native/module-earn/src/__tests__/yieldClaimThunks.test.ts`
- `suite-native/module-earn/src/__tests__/yieldTransactionThunks.test.ts`
- `suite-native/module-earn/src/hooks/useYieldClaimReview.ts`
- `suite-native/module-earn/src/hooks/useYieldDepositReview.ts`
- `suite-native/module-earn/src/hooks/useYieldWithdrawReview.ts`
- `suite-native/module-earn/src/yieldClaimThunks.ts`
- `suite-native/module-earn/src/yieldTransactionThunks.ts`

</details>

**Recommended tests (4)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — The changed files include stablecoin yield deposit/withdraw/claim thunks and the stablecoinYieldReducer, which share infrastructure with the ETH staking flow (signing helpers, Ethereum transaction composition). While stablecoin yield is distinct from ETH staking, both use similar Ethereum signing and transaction submission patterns. A regression in signingHelpers.ts could plausibly affect this flow.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — The unstake flow exercises Ethereum transaction signing and claim flows that share patterns with the stablecoin yield withdraw and claim thunks. Changes to signingHelpers.ts could affect shared signing utilities used across yield and staking contexts.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Stake-more exercises ETH deposit transactions similar to the yield deposit thunk pattern. If signingHelpers.ts contains shared Ethereum signing logic used by both staking and stablecoin yield, changes could affect this test's transaction flow.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — The staking form validates amounts and interacts with the staking/earn UI. The stablecoinYieldReducer and utils changes could affect shared earn/staking state that the form reads from, though stablecoin yield is a separate feature from ETH staking.

</details>

⚠️ **Changes with no test coverage (14)**
- `suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldReducer.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts`
- `suite-native/module-earn/src/__tests__/yieldClaimThunks.test.ts`
- `suite-native/module-earn/src/__tests__/yieldTransactionThunks.test.ts`
- `suite-native/module-earn/src/hooks/useYieldClaimReview.ts`
- `suite-native/module-earn/src/hooks/useYieldDepositReview.ts`
- `suite-native/module-earn/src/hooks/useYieldWithdrawReview.ts`
- `suite-native/module-earn/src/yieldClaimThunks.ts`
- `suite-native/module-earn/src/yieldTransactionThunks.ts`

_Updated: 2026-07-10T11:58:50.041Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-tx-review-flow-identity/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-tx-review-flow-identity/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-tx-review-flow-identity&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-tx-review-flow-identity&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/yield-tx-review-flow-identity&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T12:02:28.393Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T12:02:05.437Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->