### PR TITLE
fix(suite): center icon component inside the wrapper

### DIFF
--- a/packages/components/src/components/Icon/Icon.tsx
+++ b/packages/components/src/components/Icon/Icon.tsx
@@ -75,6 +75,9 @@ const Container = styled.div<ContainerProps>`
     }
 
     flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
     ${withFrameProps}
 `;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue: 

Resolve: https://github.com/trezor/trezor-suite/issues/28319

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to the Icon component (`packages/components/src/components/Icon/Icon.tsx`), which is a foundational UI primitive used across the entire Trezor Suite application — it maps to all 129 E2E tests via transitive imports. Since this is a global shared component, the risk depends entirely on the nature of the change (props API change, rendering logic, styling). Most tests would only be affected if the Icon component fundamentally breaks (fails to render, crashes). A small set of tests that explicitly interact with icon-dependent UI elements (toggle buttons, close buttons, visual indicators) are recommended at medium priority to catch rendering regressions without running the full suite.

<details><summary><b>Changed files (1)</b></summary>

- `packages/components/src/components/Icon/Icon.tsx`

</details>

**Recommended tests (4)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/browser/safari.test.ts` — This test validates the unsupported browser warning page which includes icon elements (Desktop App download link, Chrome download link, security warning). An Icon component change could affect the rendering of these visual elements and the ARIA snapshot assertion would catch regressions.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — The discreet mode toggle (hideBalanceButton) likely renders an Icon (eye/eye-off). If the Icon component breaks, the toggle button may not render or be clickable, directly affecting this test's core flow of enabling discreet mode.
- `suite/e2e/tests/settings/general.test.ts` — This test changes theme (light/dark) and verifies visual elements. Icons are commonly theme-aware components, and this test validates that settings UI controls render and function correctly, which would catch Icon rendering regressions in a settings context.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/suite/guide.test.ts` — The guide panel open/close buttons (@guide/button-close, @guide/button-feedback) are likely Icon-based buttons. A breaking change to Icon could prevent the guide panel from opening or the feedback form from being accessible.

</details>

_Updated: 2026-07-10T12:02:26.467Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/28319-icon-generation-and-usage-refactor/web/](https://dev.suite.sldev.cz/suite-web/fix/28319-icon-generation-and-usage-refactor/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/28319-icon-generation-and-usage-refactor&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/28319-icon-generation-and-usage-refactor&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T12:05:52.084Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T12:05:13.448Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->