### PR TITLE
chore(suite): bump beta version to 26.8.0

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite",
-    "suiteVersion": "26.7.0",
+    "suiteVersion": "26.8.0",
     "version": "1.0.0",
     "private": true,
     "scripts": {


### PR DESCRIPTION
## Description

PR to bump beta Suite version

## Notes for QA

Regular procedure of bumping the Suite version, just check it is updated accordingly in the app settings.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `packages/suite/package.json`, which typically involves dependency version bumps, script changes, or metadata updates. Without knowing the specific diff content, this change has no direct functional impact on any particular test's code path. A `package.json` change could affect build/bundling behavior broadly (e.g., a major dependency upgrade could break anything), but no specific test can be singled out as more relevant than another based solely on the file path. If the change is a dependency version bump, a smoke test of the app loading (e.g., onboarding or version page) would be prudent, but there is insufficient evidence to recommend any specific E2E test with concrete reasoning. If the CI system requires a sanity check, consider running a minimal smoke suite outside of this recommendation framework.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/package.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/suite/package.json`

_Updated: 2026-07-10T12:15:48.069Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/bump-suite-version-26.8.0/web/](https://dev.suite.sldev.cz/suite-web/chore/bump-suite-version-26.8.0/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bump-suite-version-26.8.0&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bump-suite-version-26.8.0&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T12:22:01.375Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T12:19:25.502Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->