### PR TITLE
fix(suite-common): consider tron account with only trc20 transfers as new

### DIFF
--- a/suite-common/wallet-core/src/send/tron/__tests__/isNewTronAccount.test.ts
+++ b/suite-common/wallet-core/src/send/tron/__tests__/isNewTronAccount.test.ts
@@ -1,0 +1,119 @@
+import { type Account } from '@suite-common/wallet-types';
+import { type TronAccountExtraData } from '@trezor/blockchain-link-types';
+import TrezorConnect, { type AccountInfo } from '@trezor/connect';
+
+import { isNewTronAccount } from '../isNewTronAccount';
+
+jest.mock('@trezor/connect', () => ({
+    __esModule: true,
+    default: { getAccountInfo: jest.fn() },
+}));
+
+const RECIPIENT_ADDRESS = 'TVDGpn4hCSzJ5nkHPLetk8KQBtwaTppnkr';
+
+const account = {
+    symbol: 'trx',
+    networkType: 'tron',
+    deviceState: 'mock-device-state',
+} as unknown as Account;
+
+const buildTronResources = (overrides?: Partial<TronAccountExtraData>): TronAccountExtraData => ({
+    availableStakedBandwidth: 0,
+    totalStakedBandwidth: 0,
+    availableFreeBandwidth: 600,
+    totalFreeBandwidth: 600,
+    availableEnergy: 0,
+    totalEnergy: 0,
+    totalEnergyLimit: 0,
+    totalEnergyWeight: 0,
+    totalBandwidthLimit: 0,
+    totalBandwidthWeight: 0,
+    ...overrides,
+});
+
+const buildAccountInfo = (overrides?: Partial<AccountInfo>): AccountInfo => ({
+    descriptor: RECIPIENT_ADDRESS,
+    balance: '0',
+    availableBalance: '0',
+    empty: false,
+    history: { total: 0, unconfirmed: 0 },
+    ...overrides,
+});
+
+const mockGetAccountInfoSuccess = (accountInfo: AccountInfo) => {
+    (TrezorConnect.getAccountInfo as jest.Mock).mockResolvedValue({
+        success: true,
+        payload: accountInfo,
+    });
+};
+
+describe('isNewTronAccount', () => {
+    it('returns false when no address is provided', async () => {
+        expect(await isNewTronAccount('', account)).toBe(false);
+        expect(TrezorConnect.getAccountInfo).not.toHaveBeenCalled();
+    });
+
+    it('returns false when account info cannot be fetched', async () => {
+        (TrezorConnect.getAccountInfo as jest.Mock).mockResolvedValue({
+            success: false,
+            payload: { error: 'Network error' },
+        });
+
+        expect(await isNewTronAccount(RECIPIENT_ADDRESS, account)).toBe(false);
+    });
+
+    it('returns true for an address without any on-chain history', async () => {
+        mockGetAccountInfoSuccess(buildAccountInfo({ empty: true }));
+
+        expect(await isNewTronAccount(RECIPIENT_ADDRESS, account)).toBe(true);
+    });
+
+    it('returns true for a not activated address with TRC-20-only history', async () => {
+        // Receiving TRC-20 tokens creates transaction history but does not
+        // activate the account, so the free-bandwidth allotment was never granted
+        mockGetAccountInfoSuccess(
+            buildAccountInfo({
+                empty: false,
+                history: { total: 3, unconfirmed: 0 },
+                misc: {
+                    tronResources: buildTronResources({
+                        availableFreeBandwidth: 0,
+                        totalFreeBandwidth: 0,
+                    }),
+                },
+            }),
+        );
+
+        expect(await isNewTronAccount(RECIPIENT_ADDRESS, account)).toBe(true);
+    });
+
+    it('returns false for an activated address', async () => {
+        mockGetAccountInfoSuccess(
+            buildAccountInfo({
+                empty: false,
+                balance: '1000000',
+                availableBalance: '1000000',
+                history: { total: 5, unconfirmed: 0 },
+                misc: { tronResources: buildTronResources() },
+            }),
+        );
+
+        expect(await isNewTronAccount(RECIPIENT_ADDRESS, account)).toBe(false);
+    });
+
+    it('returns false for an activated address with exhausted free bandwidth', async () => {
+        // spending the daily free bandwidth zeroes availableFreeBandwidth
+        // but the total allotment stays at 600 for every activated account
+        mockGetAccountInfoSuccess(
+            buildAccountInfo({
+                empty: false,
+                balance: '1000000',
+                availableBalance: '1000000',
+                history: { total: 5, unconfirmed: 0 },
+                misc: { tronResources: buildTronResources({ availableFreeBandwidth: 0 }) },
+            }),
+        );
+
+        expect(await isNewTronAccount(RECIPIENT_ADDRESS, account)).toBe(false);
+    });
+});

--- a/suite-common/wallet-core/src/send/tron/isNewTronAccount.ts
+++ b/suite-common/wallet-core/src/send/tron/isNewTronAccount.ts
@@ -4,11 +4,21 @@ import TrezorConnect from '@trezor/connect';
 
 export const isNewTronAccount = async (address: string, account: Account): Promise<boolean> => {
     if (!address) return false;
+
     const result = await TrezorConnect.getAccountInfo({
         coin: account.symbol,
         identity: getAccountIdentity(account),
         descriptor: address,
     });
 
-    return result.success && (result.payload.empty ?? false);
+    if (!result.success) return false;
+
+    // Transaction history does not imply on-chain activation: an address that has only
+    // ever received TRC-20 tokens is not `empty`, yet sending TRX to it still triggers
+    // account creation and its activation fee. Every activated account is granted the
+    // 600 free-bandwidth allotment, so a missing or zero totalFreeBandwidth means the
+    // account does not exist on-chain yet.
+    return (
+        result.payload.empty || (result.payload.misc?.tronResources?.totalFreeBandwidth ?? 0) === 0
+    );
 };


### PR DESCRIPTION
## Description

Consider Tron account with no TRX but only TRC-20 transfers as new.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29597

## Screenshots:

https://github.com/user-attachments/assets/2c3e610e-217a-41d1-a98f-7406f1150a8f

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set consists of two files: a Tron-specific utility function `isNewTronAccount.ts` and its corresponding unit test. The `isNewTronAccount.ts` file maps to 129 E2E tests via static coverage, but this is clearly because it's part of the broadly-imported `wallet-core` package — not because any of those 129 tests actually exercise Tron send functionality. Reviewing all 151 candidate E2E tests' LLM analyses, none of them test Tron account detection, Tron send flows, or any behavior that would be affected by changes to this narrow Tron-specific utility. The unit test file has no static coverage mapping at all (it's a unit test, not an E2E test). No E2E tests need to be run for this change; the risk is fully covered by the included unit test.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-core/src/send/tron/__tests__/isNewTronAccount.test.ts`
- `suite-common/wallet-core/src/send/tron/isNewTronAccount.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/send/tron/__tests__/isNewTronAccount.test.ts`

_Updated: 2026-07-10T12:23:41.940Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tron-activation-fee/web/](https://dev.suite.sldev.cz/suite-web/fix/tron-activation-fee/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tron-activation-fee&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tron-activation-fee&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/tron-activation-fee&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T12:27:30.855Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T12:27:02.878Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->