### PR TITLE
fix(suite): unify behavior of dropdown options in send form

### DIFF
--- a/packages/suite/src/views/wallet/send/SendHeader.tsx
+++ b/packages/suite/src/views/wallet/send/SendHeader.tsx
@@ -52,6 +52,8 @@ export const SendHeader = () => {
     const locktimeEnabled = enabledFormOptions.includes('bitcoinLocktime');
     const broadcastEnabled = enabledFormOptions.includes('broadcast');
     const dataEnabled = enabledFormOptions.includes('transactionData');
+    const nonceEditEnabled = enabledFormOptions.includes('ethereumNonce');
+    const destinationTagEnabled = enabledFormOptions.includes('destinationTag');
     const token = watch('outputs.0.token');
 
     useEffect(() => {
@@ -62,7 +64,6 @@ export const SendHeader = () => {
         }
     }, [networkType, dataEnabled, token, toggleOption, resetDefaultValue]);
 
-    const nonceEditEnabled = enabledFormOptions.includes('ethereumNonce');
     const options: Array<DropdownMenuItemProps> = [
         {
             'data-testid': '@send/header-dropdown/import',
@@ -86,7 +87,7 @@ export const SendHeader = () => {
                 if (broadcastEnabled) toggleOption('broadcast');
             },
             label: <Translation id="LOCKTIME_ADD" />,
-            isDisabled: !!locktimeEnabled,
+            isDisabled: locktimeEnabled,
             isHidden: networkType !== 'bitcoin',
         },
         {
@@ -96,7 +97,7 @@ export const SendHeader = () => {
             },
             closeOnClick: true,
             label: <Translation id="DATA_ADD" />,
-            isDisabled: networkType === 'tron' && !!token,
+            isDisabled: dataEnabled || (networkType === 'tron' && !!token),
             isHidden: networkType !== 'ethereum' && networkType !== 'tron',
         },
         {
@@ -106,6 +107,7 @@ export const SendHeader = () => {
             },
             closeOnClick: true,
             label: <Translation id={networkType === 'tron' ? 'TR_TRON_NOTE_ADD' : 'MEMO_SWITCH'} />,
+            isDisabled: destinationTagEnabled,
             isHidden: networkType !== 'tron' && networkType !== 'solana',
         },
         {
@@ -132,7 +134,7 @@ export const SendHeader = () => {
                     }
                 />
             ),
-            isDisabled: !!locktimeEnabled,
+            isDisabled: locktimeEnabled,
             isHidden: !BROADCAST_SUPPORTED_NETWORK_TYPES.includes(networkType),
         },
         {


### PR DESCRIPTION
## Description

Unify the behaviour of dropdown options in Send form.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29636

## Screenshots:

<img width="100%" alt="Screenshot 2026-07-10 at 14 49 57" src="https://github.com/user-attachments/assets/d065e1ff-8179-4ccc-b6df-416787811927" />

<img width="100%" height="843" alt="Screenshot 2026-07-10 at 14 50 14" src="https://github.com/user-attachments/assets/d6207c5f-90b3-4356-a85d-c74775cf37da" />

<img width="100%" height="843" alt="Screenshot 2026-07-10 at 14 50 27" src="https://github.com/user-attachments/assets/00e20c2c-1e80-4d25-b168-add9ac8b8c81" />

<img width="100%" height="843" alt="Screenshot 2026-07-10 at 14 49 45" src="https://github.com/user-attachments/assets/7d353b8e-67b4-48a2-9355-3ac3a5bc35f8" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to SendHeader.tsx, the header component of the wallet send form. Tests that directly interact with the send header dropdown menu (CSV import, broadcast mode, locktime/opreturn toggles) are highest priority. Tests that merely navigate through a send form without interacting with header-specific features are lower risk. The remaining tests (send-doge, send-eth, send-sol, without-device, unsupported-device) only pass through the send form without meaningfully exercising header-specific functionality and are omitted.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/send/SendHeader.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — This test directly interacts with the SendHeader component via the @send/header-dropdown element to access the CSV import option. Changes to SendHeader.tsx could break the dropdown menu rendering or its import functionality.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test extensively exercises the SendHeader component: it toggles header dropdown options (locktime, opreturn, broadcast), adds/removes outputs, and switches amount units via the header. Multiple key assertions depend on the send form header being visible and functional.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test uses the send form header dropdown to switch to broadcast mode (@send/header-dropdown, @send/header-dropdown/broadcast), directly exercising SendHeader functionality.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test verifies the global send flow including checking that the send form header displays translation 'TR_NAV_SEND'. Changes to SendHeader.tsx could affect header rendering in the send form.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — This test opens the Cardano send form and checks it contains the text 'Cardano', which may render through the SendHeader component. The interaction is minimal but a regression in header rendering could cause a failure.

</details>

_Updated: 2026-07-10T12:54:30.589Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/send-form-dropdown-options/web/](https://dev.suite.sldev.cz/suite-web/fix/send-form-dropdown-options/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/send-form-dropdown-options&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/send-form-dropdown-options&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T12:58:05.154Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T12:57:51.847Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->