### PR TITLE
chore(build): Tryng to not burn all CPU cores in developement.

### DIFF
--- a/packages/suite-build/configs/dev.webpack.config.ts
+++ b/packages/suite-build/configs/dev.webpack.config.ts
@@ -9,6 +9,7 @@ import { getPathForProject } from '../utils/path';
 
 const distPath = path.join(getPathForProject(project), 'build');
 const config: webpack.Configuration = {
+    parallelism: 3,
     stats: {
         children: true,
         errorDetails: true,

--- a/packages/suite-desktop-core/webpack/core.webpack.config.ts
+++ b/packages/suite-desktop-core/webpack/core.webpack.config.ts
@@ -76,6 +76,7 @@ const dependencies = Object.keys(pkg.dependencies);
 const config: webpack.Configuration = {
     target: 'electron-main',
     mode: isDev ? 'development' : 'production',
+    ...(isDev ? { parallelism: 3 } : {}),
     devtool: 'source-map',
     // Note that the entries key is important, it sets the the output file name in dist/
     entry: [


### PR DESCRIPTION
## Description

Limiting webpack to 3 CPU cores, to not burn and cripple the whole dev-station while webpack hot-reaload

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-07-10T13:15:05.703Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/limit-build-parallelism/web/](https://dev.suite.sldev.cz/suite-web/chore/limit-build-parallelism/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/limit-build-parallelism&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/limit-build-parallelism&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T13:18:54.782Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T13:18:46.271Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->