### PR TITLE
Redact confidential account data from staking error logs

### DIFF
--- a/suite-native/staking/src/stakeFormEthereumNativeThunks.ts
+++ b/suite-native/staking/src/stakeFormEthereumNativeThunks.ts
@@ -97,10 +97,7 @@ const prepareEthereumStakingContext = (
 
     const account = selectAccountByKey(state, accountKey);
     if (account?.networkType !== 'ethereum') {
-        return failed(
-            'Ethereum account not found.',
-            `Ethereum account not found for key ${accountKey}`,
-        );
+        return failed('Ethereum account not found.');
     }
 
     const { chainId } = getNetwork(account.symbol);
@@ -120,7 +117,7 @@ const prepareEthereumStakingContext = (
     if (!variant) {
         return failed(
             `Compose draft for ${stakeType} is missing.`,
-            `Form draft '${getFormDraftKey(stakeType, accountKey)}' is missing or incomplete.`,
+            `Compose draft for ${stakeType} is missing or incomplete.`,
         );
     }
 

--- a/suite-native/staking/src/stakeNativeThunks.ts
+++ b/suite-native/staking/src/stakeNativeThunks.ts
@@ -29,7 +29,7 @@ export const signStakeTransactionNativeThunk = createThunk<
     const account = selectAccountByKey(thunkApi.getState() as AccountsRootState, accountKey);
 
     if (!account) {
-        console.error(`${LOG_PREFIX}: Account not found for key ${accountKey}`);
+        console.error(`${LOG_PREFIX}: Account not found.`);
 
         return thunkApi.rejectWithValue({
             error: 'sign-transaction-failed',
@@ -74,7 +74,7 @@ export const pushStakeTransactionNativeThunk = createThunk<
     const account = selectAccountByKey(getState() as AccountsRootState, accountKey);
 
     if (!account) {
-        console.error(`${PUSH_LOG_PREFIX}: Account not found for key ${accountKey}`);
+        console.error(`${PUSH_LOG_PREFIX}: Account not found.`);
 
         return rejectWithValue({
             error: 'sign-transaction-failed',
@@ -93,8 +93,9 @@ export const pushStakeTransactionNativeThunk = createThunk<
     );
 
     if (pushSendFormTransactionThunk.rejected.match(pushAction)) {
-        const message = pushAction.payload?.metadata.error.message;
-        console.error(`${PUSH_LOG_PREFIX}: Push transaction failed: ${message}`);
+        console.error(
+            `${PUSH_LOG_PREFIX}: Push transaction failed with code: ${pushAction.payload?.error}`,
+        );
 
         return rejectWithValue(pushAction.payload);
     }


### PR DESCRIPTION
## Description

Native staking error paths logged full account keys (descriptor + static session id) and raw backend messages via `console.error`, which native Sentry can capture — leaking confidential account data off-device. These paths now log only low-cardinality metadata, with tests guarding against descriptor/session-id leaks.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29568