### PR TITLE
Gate native ETH claim card and review CTA on canClaim

### DIFF
--- a/suite-native/module-earn/src/components/StakeClaimableCard.tsx
+++ b/suite-native/module-earn/src/components/StakeClaimableCard.tsx
@@ -15,6 +15,7 @@ import {
     type StackNavigationProps,
 } from '@suite-native/navigation';
 import {
+    selectCanClaimByAccountKey,
     selectClaimableAmountByAccountKey,
     useSelector as useNativeStakingSelector,
 } from '@suite-native/staking';
@@ -50,6 +51,10 @@ export const StakeClaimableCard = ({ accountKey }: StakeClaimableCardProps) => {
         useNativeStakingSelector(state => selectClaimableAmountByAccountKey(state, accountKey)) ??
         '0';
 
+    const canClaim = useNativeStakingSelector(state =>
+        selectCanClaimByAccountKey(state, accountKey),
+    );
+
     const { isClaimingDisabled, claimingMessageContent } = useMessageSystemStaking(symbol);
 
     const handlePress = useCallback(() => {
@@ -63,6 +68,7 @@ export const StakeClaimableCard = ({ accountKey }: StakeClaimableCardProps) => {
     if (
         !symbol ||
         !isPositiveBalance(claimableAmount) ||
+        !canClaim ||
         !isSupportedStakingNetworkSymbol(symbol)
     ) {
         return null;

--- a/suite-native/module-earn/src/screens/ClaimReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/ClaimReviewScreen.tsx
@@ -136,6 +136,7 @@ export const ClaimReviewScreen = () => {
                         onPress={handleReviewAndSign}
                         isDisabled={
                             !claimFormState ||
+                            !canClaimInstantly ||
                             isInsufficientFeeBalance ||
                             isFeeUnavailable ||
                             isPrecomposeError ||


### PR DESCRIPTION
## Description

The native ETH claim path could reach claim review whenever claimableAmount was positive, even when the account wasn't actually claimable. This gates the StakeClaimableCard and the claim review CTA on the same canClaim state used by the other native claim entry points, plus adds tests for a positive claimableAmount with canClaim === false.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29569