### PR TITLE
docs: update development-on-windows.md

### DIFF
--- a/docs/misc/development-on-windows.md
+++ b/docs/misc/development-on-windows.md
@@ -9,13 +9,12 @@ Running the dev environment natively on Windows is not most straightforward, but
 
 ### Prerequisites
 
-- Install Python preferably via the [Python for Windows installer](https://www.python.org/downloads/windows/), maybe Microsoft Store could work too
+- Install Python preferably via the [Python for Windows installer](https://www.python.org/downloads/windows/), not from Microsoft Store
 - Install [latest Visual Studio Community](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community) with C++ build tools
     - **Make sure** to install the "Desktop development with C++" workload **and include** "C++ Clang Tools for Windows"
     - _FYI: it's necessary so that yarn packages with native code can be built, `node-gyp` depends on it: [details](https://github.com/nodejs/node-gyp?tab=readme-ov-file#on-windows)_
 - Install [git](https://git-scm.com/downloads/win) using the installer and make sure to include git bash for Windows
-- ~Install nodeJS version as per [.nvmrc](https://github.com/trezor/trezor-suite/blob/develop/.nvmrc)~
-- **TEMPORARY: Use >=25.4.0 instead!** (as of writing, the 24 version in `.nvrmc` has no support for Visual Studio 2026)
+- Install nodeJS version as per [.nvmrc](https://github.com/trezor/trezor-suite/blob/develop/.nvmrc)
     - nvm is not well supported on Windows, but manual nodeJS installation from `.msi` will work.
         - Do **not** check build tools with Chocolatey (already installed with Visual Studio, that's more reliable)
 - Enable [Yarn](https://yarnpkg.com/getting-started/install) through npm


### PR DESCRIPTION
## Description

update development-on-windows.md docs:

- support for VS 2026 has landed in nodeJS 24.14 so the `.nvmrc` version is now usable for Windows
- python from MS store is a huge pain, better to use the .exe installer