### PR TITLE
feat(suite-native): add experiments manager screen to dev utils

### DIFF
--- a/suite-common/message-system/src/__tests__/useMessageSystemExperimentForm.test.ts
+++ b/suite-common/message-system/src/__tests__/useMessageSystemExperimentForm.test.ts
@@ -1,0 +1,124 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { type Experiments } from '@suite-common/suite-types';
+import {
+    act,
+    configureMockStore,
+    extraDependenciesCommonMock,
+    renderHookWithStoreProvider,
+} from '@suite-common/test-utils';
+
+import { messageSystemInitialState, prepareMessageSystemReducer } from '../messageSystemReducer';
+import { type MessageSystemState } from '../messageSystemTypes';
+import { getDefaultExperiment } from '../messageSystemUtils';
+import { useMessageSystemExperimentForm } from '../useMessageSystemExperimentForm';
+
+// jsdom 20 lacks crypto.randomUUID, which getDefaultExperiment relies on
+if (typeof globalThis.crypto.randomUUID !== 'function') {
+    let counter = 0;
+    Object.defineProperty(globalThis.crypto, 'randomUUID', {
+        value: () => `00000000-0000-4000-8000-${`${counter++}`.padStart(12, '0')}`,
+    });
+}
+
+const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
+
+const createStore = (experiments: Experiments[] = []) =>
+    configureMockStore({
+        extra: {},
+        reducer: combineReducers({ messageSystem: messageSystemReducer }),
+        preloadedState: {
+            messageSystem: {
+                ...messageSystemInitialState,
+                config: {
+                    version: 1,
+                    timestamp: '2023-01-01',
+                    sequence: 1,
+                    actions: [],
+                    experiments,
+                },
+            } as unknown as MessageSystemState,
+        },
+    });
+
+const renderForm = (store = createStore()) =>
+    renderHookWithStoreProvider(() => useMessageSystemExperimentForm(), { store });
+
+describe('useMessageSystemExperimentForm', () => {
+    it('initializes with a valid default experiment', () => {
+        const { result } = renderForm();
+
+        const parsed = JSON.parse(result.current.formData);
+
+        expect(parsed.experiment.groups).toHaveLength(2);
+        expect(result.current.parsedData).toEqual(parsed);
+        expect(result.current.validationErrors).toEqual([]);
+        expect(result.current.isValid).toBe(true);
+        expect(result.current.canFormat).toBe(true);
+    });
+
+    it('reports a JSON error for unparsable input', () => {
+        const { result } = renderForm();
+
+        act(() => {
+            result.current.setFormData('{ not json');
+        });
+
+        expect(result.current.parsedData).toBeNull();
+        expect(result.current.isValid).toBe(false);
+        expect(result.current.validationErrors).toHaveLength(1);
+        expect(result.current.validationErrors[0]?.field).toBe('JSON');
+        expect(result.current.canFormat).toBe(false);
+    });
+
+    it('surfaces yup errors for a schema-invalid experiment', () => {
+        const { result } = renderForm();
+        const { experiment, conditions } = getDefaultExperiment();
+        const { groups, ...experimentWithoutGroups } = experiment;
+        const schemaInvalidExperiment = { experiment: experimentWithoutGroups, conditions };
+
+        act(() => {
+            result.current.setFormData(JSON.stringify(schemaInvalidExperiment));
+        });
+
+        expect(result.current.parsedData).toEqual(schemaInvalidExperiment);
+        expect(result.current.canFormat).toBe(true);
+        expect(result.current.isValid).toBe(false);
+        expect(
+            result.current.validationErrors.some(error => error.field === 'experiment.groups'),
+        ).toBe(true);
+    });
+
+    it('rejects a duplicate experiment id', () => {
+        const existing = getDefaultExperiment();
+        const { result } = renderForm(createStore([existing]));
+
+        const duplicate = getDefaultExperiment();
+        duplicate.experiment.id = existing.experiment.id;
+
+        act(() => {
+            result.current.setFormData(JSON.stringify(duplicate, null, 2));
+        });
+
+        expect(result.current.isValid).toBe(false);
+        expect(result.current.validationErrors[0]?.field).toBe('experiment.id');
+        expect(result.current.validationErrors[0]?.message).toContain('must be unique');
+    });
+
+    it('restores a valid default via applyPreset after edits', () => {
+        const { result } = renderForm();
+
+        act(() => {
+            result.current.setFormData('{ not json');
+        });
+
+        expect(result.current.isValid).toBe(false);
+
+        act(() => {
+            result.current.applyPreset();
+        });
+
+        expect(result.current.isValid).toBe(true);
+        expect(result.current.parsedData).toEqual(JSON.parse(result.current.formData));
+    });
+});

--- a/suite-common/message-system/src/index.ts
+++ b/suite-common/message-system/src/index.ts
@@ -16,5 +16,6 @@ export * from './ExperimentWrapper';
 export * from './featureFlagUtils';
 export * from './useConditionControls';
 export * from './useExperiment';
+export * from './useMessageSystemExperimentForm';
 export * from './useMessageSystemMessageForm';
 export * from './useMessageSystemStaking';

--- a/suite-common/message-system/src/messageSystemFormCore.ts
+++ b/suite-common/message-system/src/messageSystemFormCore.ts
@@ -1,0 +1,55 @@
+import { yup } from '@suite-common/validators';
+
+import { type ValidateError, stripFieldFromMessage } from './messageSystemValidation';
+
+type ParseAndValidateJsonFormArgs<TValidated> = {
+    formData: string;
+    // Throws yup.ValidationError when the parsed value does not match the schema.
+    validate: (parsed: unknown) => TValidated;
+    getDuplicateIdError: (validated: TValidated) => ValidateError | null;
+    formatFieldError?: (message: string) => string;
+};
+
+type ParseAndValidateJsonFormResult<TParsed> = {
+    parsedData: TParsed | null;
+    validationErrors: ValidateError[];
+};
+
+export const parseAndValidateJsonForm = <TParsed, TValidated>({
+    formData,
+    validate,
+    getDuplicateIdError,
+    formatFieldError,
+}: ParseAndValidateJsonFormArgs<TValidated>): ParseAndValidateJsonFormResult<TParsed> => {
+    let parsedData: TParsed | null = null;
+
+    try {
+        parsedData = JSON.parse(formData);
+
+        const validatedData = validate(parsedData);
+
+        const duplicateIdError = getDuplicateIdError(validatedData);
+
+        return { parsedData, validationErrors: duplicateIdError ? [duplicateIdError] : [] };
+    } catch (error) {
+        if (error instanceof SyntaxError) {
+            const { message } = error;
+
+            return { parsedData: null, validationErrors: [{ field: 'JSON', message }] };
+        }
+
+        if (error instanceof yup.ValidationError) {
+            const errors = (error.inner?.length ? error.inner : [error]).map(e => ({
+                field: e.path ?? 'value',
+                message: formatFieldError ? formatFieldError(e.message) : e.message,
+            }));
+
+            return { parsedData, validationErrors: stripFieldFromMessage(errors) };
+        }
+
+        return {
+            parsedData: null,
+            validationErrors: [{ field: 'JSON', message: 'Unknown error occurred' }],
+        };
+    }
+};

--- a/suite-common/message-system/src/useMessageSystemExperimentForm.ts
+++ b/suite-common/message-system/src/useMessageSystemExperimentForm.ts
@@ -1,57 +1,53 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import { type Action, type Category } from '@suite-common/suite-types';
+import { type Experiments } from '@suite-common/suite-types';
 
 import { parseAndValidateJsonForm } from './messageSystemFormCore';
 import { selectMessageSystemConfig } from './messageSystemSelectors';
-import { getDefaultActionByCategory } from './messageSystemUtils';
-import { validateMessageForm } from './messageSystemValidation';
+import { getDefaultExperiment } from './messageSystemUtils';
+import { validateExperimentForm } from './messageSystemValidation';
 
-type UseMessageSystemMessageFormArgs = {
+type UseMessageSystemExperimentFormArgs = {
     // Maps a raw yup error message (e.g. the 'TR_REQUIRED_FIELD' key) to a display string.
     formatFieldError?: (message: string) => string;
 };
 
-export const useMessageSystemMessageForm = ({
+export const useMessageSystemExperimentForm = ({
     formatFieldError,
-}: UseMessageSystemMessageFormArgs = {}) => {
+}: UseMessageSystemExperimentFormArgs = {}) => {
     const config = useSelector(selectMessageSystemConfig);
     const [formData, setFormData] = useState<string>(() =>
-        JSON.stringify(getDefaultActionByCategory('banner'), null, 2),
+        JSON.stringify(getDefaultExperiment(), null, 2),
     );
-    const messageIds = useMemo(
-        () => new Set(config?.actions.map(action => action.message.id)),
+    const experimentIds = useMemo(
+        () => new Set(config?.experiments?.map(experiment => experiment.experiment.id)),
         [config],
     );
 
     const { parsedData, validationErrors } = useMemo(
         () =>
-            parseAndValidateJsonForm<Action, ReturnType<typeof validateMessageForm>>({
+            parseAndValidateJsonForm<Experiments, ReturnType<typeof validateExperimentForm>>({
                 formData,
-                validate: validateMessageForm,
+                validate: validateExperimentForm,
                 getDuplicateIdError: validated =>
-                    messageIds.has(validated.message.id)
+                    experimentIds.has(validated.experiment.id)
                         ? {
-                              field: 'message.id',
-                              message: `must be unique. “${validated.message.id}” is already in use.`,
+                              field: 'experiment.id',
+                              message: `must be unique. “${validated.experiment.id}” is already in use.`,
                           }
                         : null,
                 formatFieldError,
             }),
-        [formData, formatFieldError, messageIds],
+        [formData, formatFieldError, experimentIds],
     );
 
     const formatJSON = useCallback(() => {
         setFormData(JSON.stringify(parsedData, null, 2));
     }, [parsedData]);
 
-    const applyPreset = useCallback((category: Category) => {
-        setFormData(JSON.stringify(getDefaultActionByCategory(category), null, 2));
-    }, []);
-
-    const resetForm = useCallback(() => {
-        setFormData(JSON.stringify(getDefaultActionByCategory('banner'), null, 2));
+    const applyPreset = useCallback(() => {
+        setFormData(JSON.stringify(getDefaultExperiment(), null, 2));
     }, []);
 
     return {
@@ -63,6 +59,6 @@ export const useMessageSystemMessageForm = ({
         canFormat: parsedData !== null,
         formatJSON,
         applyPreset,
-        resetForm,
+        resetForm: applyPreset,
     };
 };

--- a/suite-native/app-init/package.json
+++ b/suite-native/app-init/package.json
@@ -20,6 +20,7 @@
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/walletconnect": "workspace:*",
         "@suite-native/analytics-redux": "workspace:*",
+        "@suite-native/message-system": "workspace:*",
         "@suite-native/settings": "workspace:*",
         "@suite-native/state": "workspace:*"
     }

--- a/suite-native/app-init/src/appInitThunks.ts
+++ b/suite-native/app-init/src/appInitThunks.ts
@@ -20,6 +20,7 @@ import {
 } from '@suite-common/wallet-core';
 import { walletConnectInitThunk } from '@suite-common/walletconnect';
 import { initAnalyticsThunk } from '@suite-native/analytics-redux';
+import { revalidateMessageSystemThunk } from '@suite-native/message-system';
 import { selectEarnYieldWorkerBaseUrl, selectIsOnboardingFinished } from '@suite-native/settings';
 import { setIsAppReady } from '@suite-native/state';
 
@@ -74,6 +75,9 @@ export const applicationInit = createThunk(
 
         dispatch(initAnalyticsThunk());
         dispatch(initMessageSystemThunk());
+        // Validity of messages and experiments is not persisted, recompute it
+        // over the rehydrated config instead of waiting for a config re-fetch.
+        dispatch(revalidateMessageSystemThunk());
 
         // Select latest remembered device or Portfolio Tracker device.
         dispatch(initDevices());

--- a/suite-native/app-init/tsconfig.json
+++ b/suite-native/app-init/tsconfig.json
@@ -24,6 +24,7 @@
             "path": "../../suite-common/walletconnect"
         },
         { "path": "../analytics-redux" },
+        { "path": "../message-system" },
         { "path": "../settings" },
         { "path": "../state" }
     ]

--- a/suite-native/app/src/navigation/RootStackNavigator.tsx
+++ b/suite-native/app/src/navigation/RootStackNavigator.tsx
@@ -21,7 +21,11 @@ import {
     WalletConnectSwitchAccountScreen,
 } from '@suite-native/module-connect-popup';
 import { DemoAccountQuestionnaireStackNavigator } from '@suite-native/module-demo-account-questionnaire';
-import { DevUtilsScreen, MessageSystemManagerScreen } from '@suite-native/module-dev-utils';
+import {
+    DevUtilsScreen,
+    MessageSystemExperimentsScreen,
+    MessageSystemManagerScreen,
+} from '@suite-native/module-dev-utils';
 import {
     BackupFailedModalScreen,
     DeviceOnboardingStackNavigator,
@@ -247,6 +251,10 @@ export const RootStackNavigator = () => {
             <RootStack.Screen
                 name={RootStackRoutes.MessageSystemManager}
                 component={MessageSystemManagerScreen}
+            />
+            <RootStack.Screen
+                name={RootStackRoutes.MessageSystemExperiments}
+                component={MessageSystemExperimentsScreen}
             />
             <RootStack.Screen name={RootStackRoutes.ConnectPopup} component={ConnectPopupScreen} />
             <RootStack.Screen

--- a/suite-native/message-system/src/index.ts
+++ b/suite-native/message-system/src/index.ts
@@ -1,6 +1,7 @@
 export { ExperimentWrapper } from '@suite-common/message-system';
 
 export * from './messageSystemMiddleware';
+export * from './messageSystemThunks';
 export * from './components/ContextMessage';
 export * from './components/MessageSystemBannerRenderer';
 export * from './components/KillswitchMessageScreen';

--- a/suite-native/message-system/src/messageSystemMiddleware.ts
+++ b/suite-native/message-system/src/messageSystemMiddleware.ts
@@ -1,54 +1,32 @@
 import { isAnyOf } from '@reduxjs/toolkit';
 
-import { deviceActions, selectSelectedDevice } from '@suite-common/device';
-import { geolocationActions, selectCountryCode } from '@suite-common/geolocation';
-import {
-    categorizeMessages,
-    getValidExperimentIds,
-    getValidMessages,
-    messageSystemActions,
-    selectMessageSystemConfig,
-} from '@suite-common/message-system';
+import { deviceActions } from '@suite-common/device';
+import { geolocationActions } from '@suite-common/geolocation';
+import { messageSystemActions } from '@suite-common/message-system';
 import { createMiddleware } from '@suite-common/redux-utils';
 import { changeNetworks } from '@suite-common/wallet-core';
-import { selectDeviceEnabledDiscoveryNetworkSymbols } from '@suite-native/discovery';
+
+import { revalidateMessageSystemThunk } from './messageSystemThunks';
 
 const isAnyOfMessageSystemAffectingActions = isAnyOf(
     messageSystemActions.fetchSuccessUpdate,
     messageSystemActions.addMessage,
     messageSystemActions.removeMessage,
+    messageSystemActions.addExperiment,
+    messageSystemActions.removeExperiment,
     deviceActions.selectDevice,
     deviceActions.connectDevice,
     changeNetworks,
     geolocationActions.setCountryCode,
 );
 
-export const messageSystemMiddleware = createMiddleware((action, { next, dispatch, getState }) => {
+export const messageSystemMiddleware = createMiddleware((action, { next, dispatch }) => {
     // The action has to be handled by the reducer first to apply its
     // changes first, because this middleware expects already updated state.
     next(action);
 
     if (isAnyOfMessageSystemAffectingActions(action)) {
-        const config = selectMessageSystemConfig(getState());
-        const device = selectSelectedDevice(getState());
-        const enabledNetworks = selectDeviceEnabledDiscoveryNetworkSymbols(getState());
-        const countryCode = selectCountryCode(getState());
-
-        const validationParams = {
-            device,
-            settings: {
-                tor: false, // not supported in suite-native
-                enabledNetworks,
-            },
-            countryCode,
-        };
-        const validMessages = getValidMessages(config, validationParams);
-        const validExperimentIds = getValidExperimentIds(config, validationParams);
-
-        const categorizedValidMessages = categorizeMessages(validMessages);
-
-        dispatch(messageSystemActions.updateValidMessages(categorizedValidMessages));
-        dispatch(messageSystemActions.updateValidExperiments(validExperimentIds));
+        dispatch(revalidateMessageSystemThunk());
     }
 
     return action;

--- a/suite-native/message-system/src/messageSystemThunks.ts
+++ b/suite-native/message-system/src/messageSystemThunks.ts
@@ -1,0 +1,40 @@
+import { selectSelectedDevice } from '@suite-common/device';
+import { selectCountryCode } from '@suite-common/geolocation';
+import {
+    categorizeMessages,
+    getValidExperimentIds,
+    getValidMessages,
+    messageSystemActions,
+    selectMessageSystemConfig,
+} from '@suite-common/message-system';
+import { createThunk } from '@suite-common/redux-utils';
+import { selectDeviceEnabledDiscoveryNetworkSymbols } from '@suite-native/discovery';
+
+const ACTION_PREFIX = '@suite-native/message-system';
+
+export const revalidateMessageSystemThunk = createThunk(
+    `${ACTION_PREFIX}/revalidate`,
+    (_, { dispatch, getState }) => {
+        const config = selectMessageSystemConfig(getState());
+        const device = selectSelectedDevice(getState());
+        const enabledNetworks = selectDeviceEnabledDiscoveryNetworkSymbols(getState());
+        const countryCode = selectCountryCode(getState());
+
+        const validationParams = {
+            device,
+            settings: {
+                tor: false, // not supported in suite-native
+                enabledNetworks,
+            },
+            countryCode,
+        };
+
+        const validMessages = getValidMessages(config, validationParams);
+        const validExperimentIds = getValidExperimentIds(config, validationParams);
+
+        const categorizedValidMessages = categorizeMessages(validMessages);
+
+        dispatch(messageSystemActions.updateValidMessages(categorizedValidMessages));
+        dispatch(messageSystemActions.updateValidExperiments(validExperimentIds));
+    },
+);

--- a/suite-native/module-dev-utils/src/components/MessageSystemAddExperimentForm.tsx
+++ b/suite-native/module-dev-utils/src/components/MessageSystemAddExperimentForm.tsx
@@ -1,0 +1,92 @@
+import { useDispatch } from 'react-redux';
+
+import {
+    messageSystemActions,
+    useConditionControls,
+    useMessageSystemExperimentForm,
+} from '@suite-common/message-system';
+import { type Condition } from '@suite-common/suite-types';
+import { Button, Input, Select, Text, VStack } from '@suite-native/atoms';
+
+export const MessageSystemAddExperimentForm = () => {
+    const dispatch = useDispatch();
+
+    const {
+        formData,
+        setFormData,
+        parsedData,
+        validationErrors,
+        isValid,
+        canFormat,
+        formatJSON,
+        applyPreset,
+        resetForm,
+    } = useMessageSystemExperimentForm();
+
+    const { availableConditionOptions, canAddCondition, addCondition } = useConditionControls(
+        parsedData,
+        setFormData,
+    );
+
+    const handleAddCondition = (conditionKey: keyof Condition | '') => {
+        if (conditionKey === '') {
+            return;
+        }
+        addCondition(conditionKey);
+    };
+
+    const handleAddExperiment = () => {
+        if (parsedData) {
+            dispatch(messageSystemActions.addExperiment(parsedData));
+            resetForm();
+        }
+    };
+
+    return (
+        <VStack spacing="sp12">
+            <Text variant="body-md-strong">Add new experiment</Text>
+            <Button intent="neutral" priority="secondary" size="medium" onPress={applyPreset}>
+                Default experiment
+            </Button>
+            {canAddCondition && (
+                <Select<keyof Condition | ''>
+                    title="Add condition"
+                    items={[...availableConditionOptions]}
+                    value=""
+                    onSelectItem={handleAddCondition}
+                    isLabelShown
+                />
+            )}
+            <Input
+                label="Experiment JSON"
+                value={formData}
+                onChangeText={setFormData}
+                multiline
+                autoCapitalize="none"
+                autoCorrect={false}
+                hasError={!isValid}
+            />
+            {isValid ? (
+                <Text variant="body-sm">Config is valid</Text>
+            ) : (
+                validationErrors.map((error, index) => (
+                    <Text key={`${error.field}-${index}`} variant="body-sm" color="contentCritical">
+                        {error.field} {error.message}
+                    </Text>
+                ))
+            )}
+            <Button
+                intent="neutral"
+                priority="secondary"
+                size="medium"
+                isDisabled={!canFormat}
+                onPress={formatJSON}
+            >
+                Format JSON
+            </Button>
+            <Button size="medium" isDisabled={!isValid} onPress={handleAddExperiment}>
+                Add experiment
+            </Button>
+        </VStack>
+    );
+};

--- a/suite-native/module-dev-utils/src/components/MessageSystemCard.tsx
+++ b/suite-native/module-dev-utils/src/components/MessageSystemCard.tsx
@@ -59,6 +59,16 @@ export const MessageSystemCard = () => {
                     >
                         Message manager
                     </Button>
+                    <Button
+                        intent="neutral"
+                        priority="secondary"
+                        size="medium"
+                        onPress={() =>
+                            navigation.navigate(RootStackRoutes.MessageSystemExperiments)
+                        }
+                    >
+                        Experiments
+                    </Button>
                 </VStack>
                 <Text variant="body-md-strong">Valid messages:</Text>
                 <VStack spacing="sp8">

--- a/suite-native/module-dev-utils/src/components/MessageSystemExperimentItem.tsx
+++ b/suite-native/module-dev-utils/src/components/MessageSystemExperimentItem.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+
+import {
+    EXPERIMENT_MAP,
+    type ExperimentsItemType,
+    buildExperimentGroupRanges,
+    getActiveExperimentGroup,
+    getExperimentGroupByInclusion,
+    getInclusionFromInstanceId,
+    messageSystemActions,
+} from '@suite-common/message-system';
+import { type Experiments } from '@suite-common/suite-types';
+import { Button, Card, Input, Text, VStack } from '@suite-native/atoms';
+import { useCopyToClipboard } from '@suite-native/clipboard';
+
+type MessageSystemExperimentItemProps = {
+    experimentsItem: Experiments;
+    isActive: boolean;
+    isManuallyAdded: boolean;
+    instanceId?: string;
+    inclusionOverride?: number;
+    onRemove: (id: string) => void;
+};
+
+const formatRange = (start: number, end: number) => (start === end ? '∅' : `[${start}, ${end})`);
+
+const clampInclusion = (value: number) => Math.min(99, Math.max(0, value));
+
+export const MessageSystemExperimentItem = ({
+    experimentsItem,
+    isActive,
+    isManuallyAdded,
+    instanceId,
+    inclusionOverride,
+    onRemove,
+}: MessageSystemExperimentItemProps) => {
+    const dispatch = useDispatch();
+    const copyToClipboard = useCopyToClipboard();
+
+    const { conditions, experiment: rawExperiment } = experimentsItem;
+    const experiment = rawExperiment as ExperimentsItemType;
+    const experimentName =
+        experiment.id in EXPERIMENT_MAP ? EXPERIMENT_MAP[experiment.id] : undefined;
+
+    const inclusion = instanceId ? getInclusionFromInstanceId(instanceId, experiment.id) : 0;
+    const effectiveInclusion = inclusionOverride ?? inclusion;
+    const assignedGroup =
+        inclusionOverride != undefined
+            ? getExperimentGroupByInclusion({
+                  groups: experiment.groups,
+                  inclusion: inclusionOverride,
+              })
+            : getActiveExperimentGroup({ experiment, instanceId });
+    const ranges = buildExperimentGroupRanges(experiment.groups);
+
+    const [inclusionText, setInclusionText] = useState<string>(String(effectiveInclusion));
+
+    useEffect(() => {
+        setInclusionText(String(effectiveInclusion));
+    }, [effectiveInclusion]);
+
+    const handleInclusionSubmit = () => {
+        const parsed = Number.parseInt(inclusionText, 10);
+        if (Number.isNaN(parsed)) {
+            setInclusionText(String(effectiveInclusion));
+
+            return;
+        }
+        const clamped = clampInclusion(parsed);
+        setInclusionText(String(clamped));
+        dispatch(
+            messageSystemActions.setExperimentInclusionOverride({
+                id: experiment.id,
+                inclusion: clamped,
+            }),
+        );
+    };
+
+    const handleResetInclusion = () => {
+        dispatch(messageSystemActions.clearExperimentInclusionOverride(experiment.id));
+    };
+
+    return (
+        <Card>
+            <VStack spacing="sp8">
+                <Text variant="body-sm-strong">{experiment.id}</Text>
+                {experimentName ? (
+                    <Text variant="body-xs">Name: {experimentName}</Text>
+                ) : (
+                    <Text variant="body-xs" color="contentWarning">
+                        Unknown experiment
+                    </Text>
+                )}
+                <VStack spacing="sp2">
+                    <Text variant="body-xs">Active: {isActive ? 'yes' : 'no'}</Text>
+                    <Text variant="body-xs">Source: {isManuallyAdded ? 'in-app' : 'file'}</Text>
+                    <Text variant="body-xs">Assigned group: {assignedGroup?.variant ?? 'N/A'}</Text>
+                    <Text variant="body-xs">
+                        Inclusion: {effectiveInclusion}
+                        {inclusionOverride != undefined ? ' (override)' : ''}
+                    </Text>
+                </VStack>
+                <VStack spacing="sp2">
+                    <Text variant="body-xs">Groups:</Text>
+                    {ranges.map(({ group, range }, index) => {
+                        const isAssigned =
+                            group.variant === assignedGroup?.variant &&
+                            group.percentage === assignedGroup?.percentage;
+
+                        return (
+                            <Text
+                                key={`${group.variant}-${index}`}
+                                variant="body-xs"
+                                color={isAssigned ? 'contentBrand' : 'contentPrimary'}
+                            >
+                                {group.variant} ({group.percentage} %){' '}
+                                {formatRange(range.start, range.end)}
+                            </Text>
+                        );
+                    })}
+                </VStack>
+                <Text variant="body-xs">{JSON.stringify(conditions, null, 2)}</Text>
+                <Input
+                    label="Inclusion override (0-99)"
+                    value={inclusionText}
+                    onChangeText={setInclusionText}
+                    onEndEditing={handleInclusionSubmit}
+                    keyboardType="number-pad"
+                />
+                <Button
+                    intent="neutral"
+                    priority="secondary"
+                    size="medium"
+                    isDisabled={inclusionOverride == undefined}
+                    onPress={handleResetInclusion}
+                >
+                    Reset inclusion
+                </Button>
+                <Button
+                    intent="neutral"
+                    priority="secondary"
+                    size="medium"
+                    onPress={() =>
+                        copyToClipboard(
+                            JSON.stringify({ conditions, experiment: rawExperiment }, null, 2),
+                        )
+                    }
+                >
+                    Copy
+                </Button>
+                {isManuallyAdded && (
+                    <Button
+                        intent="critical"
+                        priority="secondary"
+                        size="medium"
+                        onPress={() => onRemove(experiment.id)}
+                    >
+                        Remove
+                    </Button>
+                )}
+            </VStack>
+        </Card>
+    );
+};

--- a/suite-native/module-dev-utils/src/index.ts
+++ b/suite-native/module-dev-utils/src/index.ts
@@ -1,2 +1,3 @@
 export * from './screens/DevUtilsScreen';
+export * from './screens/MessageSystemExperimentsScreen';
 export * from './screens/MessageSystemManagerScreen';

--- a/suite-native/module-dev-utils/src/screens/MessageSystemExperimentsScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/MessageSystemExperimentsScreen.tsx
@@ -1,0 +1,84 @@
+import { useMemo, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { selectAnalyticsInstanceId } from '@suite-common/analytics-redux';
+import {
+    messageSystemActions,
+    selectAllExperimentInclusionOverrides,
+    selectAllManuallyAddedExperimentIds,
+    selectAllValidExperiments,
+    selectMessageSystemConfig,
+} from '@suite-common/message-system';
+import { Box, CheckBox, Divider, Text, VStack } from '@suite-native/atoms';
+import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
+
+import { MessageSystemAddExperimentForm } from '../components/MessageSystemAddExperimentForm';
+import { MessageSystemExperimentItem } from '../components/MessageSystemExperimentItem';
+
+export const MessageSystemExperimentsScreen = () => {
+    const config = useSelector(selectMessageSystemConfig);
+    const allValidExperiments = useSelector(selectAllValidExperiments);
+    const allManuallyAddedExperimentIds = useSelector(selectAllManuallyAddedExperimentIds);
+    const allExperimentInclusionOverrides = useSelector(selectAllExperimentInclusionOverrides);
+    const instanceId = useSelector(selectAnalyticsInstanceId);
+    const dispatch = useDispatch();
+
+    const [showActive, setShowActive] = useState<boolean>(true);
+
+    const validExperimentIdSet = useMemo(
+        () => new Set(allValidExperiments.map(experiment => experiment.id)),
+        [allValidExperiments],
+    );
+
+    const filteredExperiments = useMemo(() => {
+        const experiments = config?.experiments ?? [];
+        if (!showActive) {
+            return experiments;
+        }
+
+        return experiments.filter(({ experiment }) => validExperimentIdSet.has(experiment.id));
+    }, [config, showActive, validExperimentIdSet]);
+
+    const handleRemove = (id: string) => {
+        dispatch(messageSystemActions.removeExperiment(id));
+    };
+
+    return (
+        <Screen
+            header={
+                <DynamicScreenHeader
+                    title="Experiments"
+                    subtitle={`${allValidExperiments.length} active of ${config?.experiments?.length ?? 0}`}
+                />
+            }
+        >
+            <VStack spacing="sp16">
+                <Box flexDirection="row" justifyContent="space-between" alignItems="center">
+                    <Text>Show only active</Text>
+                    <CheckBox
+                        isChecked={showActive}
+                        onChange={() => setShowActive(prev => !prev)}
+                    />
+                </Box>
+                {filteredExperiments.length === 0 && <Text variant="body-sm">No experiments.</Text>}
+                {filteredExperiments.map((experimentsItem, index) => (
+                    <MessageSystemExperimentItem
+                        key={`${experimentsItem.experiment.id}-${index}`}
+                        experimentsItem={experimentsItem}
+                        isActive={validExperimentIdSet.has(experimentsItem.experiment.id)}
+                        isManuallyAdded={
+                            !!allManuallyAddedExperimentIds?.[experimentsItem.experiment.id]
+                        }
+                        instanceId={instanceId}
+                        inclusionOverride={
+                            allExperimentInclusionOverrides?.[experimentsItem.experiment.id]
+                        }
+                        onRemove={handleRemove}
+                    />
+                ))}
+                <Divider />
+                <MessageSystemAddExperimentForm />
+            </VStack>
+        </Screen>
+    );
+};

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -443,6 +443,7 @@ export type RootStackParamList = {
     [RootStackRoutes.TransactionDetailStack]: NavigatorScreenParams<TransactionDetailStackParamList>;
     [RootStackRoutes.DevUtils]: undefined;
     [RootStackRoutes.MessageSystemManager]: undefined;
+    [RootStackRoutes.MessageSystemExperiments]: undefined;
     [RootStackRoutes.AccountAssets]: {
         accountKey: AccountKey;
         tab?: AccountAssetsTab;

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -19,6 +19,7 @@ export enum RootStackRoutes {
     ClaimTransactionDataReview = 'ClaimTransactionDataReview',
     DevUtils = 'DevUtils',
     MessageSystemManager = 'MessageSystemManager',
+    MessageSystemExperiments = 'MessageSystemExperiments',
     AccountSettings = 'AccountSettings',
     TransactionDetailStack = 'TransactionDetailStack',
     ReceiveStack = 'ReceiveStack',

--- a/suite/message-system/package.json
+++ b/suite/message-system/package.json
@@ -16,7 +16,6 @@
         "@suite-common/dependency-injection": "workspace:*",
         "@suite-common/message-system": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
-        "@suite-common/validators": "workspace:*",
         "@suite/external-links": "workspace:*",
         "@suite/intl": "workspace:*",
         "@suite/router": "workspace:*",

--- a/suite/message-system/src/debugSettings/MessageSystemForm/MessageSystemFormExperiment.tsx
+++ b/suite/message-system/src/debugSettings/MessageSystemForm/MessageSystemFormExperiment.tsx
@@ -1,18 +1,12 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useCallback, useState } from 'react';
+import { useDispatch } from 'react-redux';
 
 import { useTranslation } from '@suite/intl';
 import {
-    type ValidateError,
-    getDefaultExperiment,
     messageSystemActions,
-    selectMessageSystemConfig,
-    stripFieldFromMessage,
     useConditionControls,
-    validateExperimentForm,
+    useMessageSystemExperimentForm,
 } from '@suite-common/message-system';
-import { type Experiments } from '@suite-common/suite-types';
-import { yup } from '@suite-common/validators';
 import { Button, Column, Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -20,84 +14,38 @@ import { MessageSystemJsonEditor } from './MessageSystemJsonEditor';
 import { MessageSystemExperimentToolbar } from '../MessageSystemExperiment/MessageSystemExperimentToolbar';
 
 export const MessageSystemFormExperiment = () => {
-    const defaultAction = JSON.stringify(getDefaultExperiment(), null, 2);
-    const config = useSelector(selectMessageSystemConfig);
     const [showForm, setShowForm] = useState(false);
-    const [formData, setFormData] = useState<string>(defaultAction);
-    const [parsedData, setParsedData] = useState<Experiments | null>(null);
-    const [validationErrors, setValidationErrors] = useState<ValidateError[]>([]);
+    const { translationString } = useTranslation();
+    const dispatch = useDispatch();
+
+    const formatFieldError = useCallback(
+        (message: string) =>
+            message === 'TR_REQUIRED_FIELD' ? translationString(message) : message,
+        [translationString],
+    );
+
+    const {
+        formData,
+        setFormData,
+        parsedData,
+        validationErrors,
+        isValid,
+        canFormat,
+        formatJSON,
+        applyPreset,
+        resetForm,
+    } = useMessageSystemExperimentForm({ formatFieldError });
+
     const { availableConditionOptions, canAddCondition, addCondition } = useConditionControls(
         parsedData,
         setFormData,
     );
-    const { translationString } = useTranslation();
-    const dispatch = useDispatch();
-
-    const isValid = validationErrors.length === 0;
-
-    const experimentIds = useMemo(
-        () => new Set(config?.experiments?.map(experiment => experiment.experiment.id)),
-        [config],
-    );
-
-    useEffect(() => {
-        try {
-            const parsed = JSON.parse(formData);
-            setParsedData(parsed);
-
-            const validatedData = validateExperimentForm(parsed);
-
-            if (experimentIds.has(validatedData.experiment.id)) {
-                setValidationErrors([
-                    {
-                        field: 'experiment.id',
-                        message: `must be unique. “${validatedData.experiment.id}” is already in use.`,
-                    },
-                ]);
-            } else {
-                setValidationErrors([]);
-            }
-        } catch (error) {
-            if (error instanceof SyntaxError) {
-                const { message } = error;
-                setParsedData(null);
-                setValidationErrors([{ field: 'JSON', message }]);
-
-                return;
-            }
-
-            if (error instanceof yup.ValidationError) {
-                const errors = (error.inner?.length ? error.inner : [error]).map(e => ({
-                    field: e.path ?? 'value',
-                    message:
-                        e.message === 'TR_REQUIRED_FIELD'
-                            ? translationString(e.message)
-                            : e.message,
-                }));
-
-                setValidationErrors(stripFieldFromMessage(errors));
-
-                return;
-            }
-
-            setParsedData(null);
-            setValidationErrors([{ field: 'JSON', message: 'Unknown error occurred' }]);
-        }
-    }, [formData, experimentIds, translationString]);
-
-    const formatJSON = useCallback(() => {
-        setFormData(JSON.stringify(parsedData, null, 2));
-    }, [parsedData]);
-
-    const handlePresetForm = useCallback(() => {
-        setFormData(JSON.stringify(getDefaultExperiment(), null, 2));
-    }, []);
 
     const handleAddExperiment = () => {
         if (parsedData) {
             dispatch(messageSystemActions.addExperiment(parsedData));
             setShowForm(false);
-            setFormData(defaultAction);
+            resetForm();
         }
     };
 
@@ -114,14 +62,14 @@ export const MessageSystemFormExperiment = () => {
             <MessageSystemExperimentToolbar
                 availableConditions={availableConditionOptions}
                 canAddCondition={canAddCondition}
-                onPreset={handlePresetForm}
+                onPreset={applyPreset}
                 onAddCondition={addCondition}
             />
 
             <MessageSystemJsonEditor
                 value={formData}
                 isValid={isValid}
-                canFormat={parsedData !== null}
+                canFormat={canFormat}
                 errors={validationErrors}
                 onChange={setFormData}
                 onFormat={formatJSON}

--- a/suite/message-system/tsconfig.json
+++ b/suite/message-system/tsconfig.json
@@ -15,9 +15,6 @@
         {
             "path": "../../suite-common/suite-types"
         },
-        {
-            "path": "../../suite-common/validators"
-        },
         { "path": "../external-links" },
         { "path": "../intl" },
         { "path": "../router" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11773,6 +11773,7 @@ __metadata:
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/walletconnect": "workspace:*"
     "@suite-native/analytics-redux": "workspace:*"
+    "@suite-native/message-system": "workspace:*"
     "@suite-native/settings": "workspace:*"
     "@suite-native/state": "workspace:*"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -15129,7 +15129,6 @@ __metadata:
     "@suite-common/dependency-injection": "workspace:*"
     "@suite-common/message-system": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
-    "@suite-common/validators": "workspace:*"
     "@suite/external-links": "workspace:*"
     "@suite/intl": "workspace:*"
     "@suite/router": "workspace:*"


### PR DESCRIPTION
## Description

Ports the desktop message-system experiments editor to mobile. New `Experiments` screen in Dev utils (button in the Message system card next to "Message manager"): lists config experiments with active state, assigned A/B group and group ranges, inclusion override via numeric 0-99 input (apply on submit, reset button), copy to clipboard, remove for manually added ones, and an add-experiment JSON form with live schema validation.

The form state machine is extracted to a shared core in `@suite-common/message-system` (`parseAndValidateJsonForm`): `useMessageSystemMessageForm` is refactored onto it (API unchanged) and a new `useMessageSystemExperimentForm` is consumed by both the desktop debug form (replacing its inlined validation effect) and the new native form.

## Notes for QA

Dev utils only, no production surface. On mobile: Dev utils → Message system → Experiments; verify list/filter, inclusion override changes the assigned group (and `useExperiment` consumers), add/remove of an unsigned experiment. On desktop: Settings → Debug → Experiments modal must behave as before (validation, presets, add).

## Related Issue

## Screenshots:


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily touches the message-system feature (form logic, experiment forms, debug UI) across suite-common, suite-native, and suite (web) packages, plus suite-native navigation/app-init wiring. Web E2E test coverage for message-system debug forms and experiments is very thin — only one web test (promo-banner-events) exercises adjacent debug-tab/banner functionality, and the six statically-mapped Suite Sync tests only incidentally import useMessageSystemMessageForm.ts without exercising its logic directly. Since suite-native has no Playwright E2E suite in this repository, most of the changed suite-native files (app-init, navigation, module-dev-utils, message-system) have no E2E coverage at all; verification for those should rely on native unit/integration tests. Recommended strategy: run promo-banner-events.test.ts as the most relevant web E2E check, and treat the Suite Sync tests as low-value smoke checks only if time permits.

<details><summary><b>Changed files (22)</b></summary>

- `suite-common/message-system/src/__tests__/useMessageSystemExperimentForm.test.ts`
- `suite-common/message-system/src/index.ts`
- `suite-common/message-system/src/messageSystemFormCore.ts`
- `suite-common/message-system/src/useMessageSystemExperimentForm.ts`
- `suite-common/message-system/src/useMessageSystemMessageForm.ts`
- `suite-native/app-init/package.json`
- `suite-native/app-init/src/appInitThunks.ts`
- `suite-native/app-init/tsconfig.json`
- `suite-native/app/src/navigation/RootStackNavigator.tsx`
- `suite-native/message-system/src/index.ts`
- `suite-native/message-system/src/messageSystemMiddleware.ts`
- `suite-native/message-system/src/messageSystemThunks.ts`
- `suite-native/module-dev-utils/src/components/MessageSystemAddExperimentForm.tsx`
- `suite-native/module-dev-utils/src/components/MessageSystemCard.tsx`
- `suite-native/module-dev-utils/src/components/MessageSystemExperimentItem.tsx`
- `suite-native/module-dev-utils/src/index.ts`
- `suite-native/module-dev-utils/src/screens/MessageSystemExperimentsScreen.tsx`
- `suite-native/navigation/src/navigators.ts`
- `suite-native/navigation/src/routes.ts`
- `suite/message-system/package.json`
- `suite/message-system/src/debugSettings/MessageSystemForm/MessageSystemFormExperiment.tsx`
- `suite/message-system/tsconfig.json`

</details>

**Recommended tests (6)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — This test uses the debug tab to add promo banners, which is part of the message-system driven dashboard banner feature; changes to useMessageSystemMessageForm.ts (core message system form logic) could affect how banners/messages are rendered or triggered.

</details>

<details><summary>🟢 <b>Low priority (5)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — Statically mapped to useMessageSystemMessageForm.ts, but this test's core behavior (label sync) is unrelated to message-system forms; only included due to static coverage overlap with no direct functional connection to the change.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — Statically mapped to useMessageSystemMessageForm.ts, but this test focuses on Suite Sync wallet/account labeling, not message system forms; low confidence of actual impact.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — Statically mapped to useMessageSystemMessageForm.ts, but this test verifies Evolu relay label syncing, unrelated to message-system experiment/message forms; low confidence.
- `suite/e2e/tests/metadata/suite-sync/unsupported-device.test.ts` — Statically mapped to useMessageSystemMessageForm.ts, but this test covers unsupported-device banners for Suite Sync, not the message-system form logic itself; low confidence.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — Statically mapped to useMessageSystemMessageForm.ts, but this test covers label CRUD sync operations, not message-system form rendering; low confidence.

</details>

⚠️ **Changes with no test coverage (21)**
- `suite-common/message-system/src/__tests__/useMessageSystemExperimentForm.test.ts`
- `suite-common/message-system/src/index.ts`
- `suite-common/message-system/src/messageSystemFormCore.ts`
- `suite-common/message-system/src/useMessageSystemExperimentForm.ts`
- `suite-native/app-init/package.json`
- `suite-native/app-init/src/appInitThunks.ts`
- `suite-native/app-init/tsconfig.json`
- `suite-native/app/src/navigation/RootStackNavigator.tsx`
- `suite-native/message-system/src/index.ts`
- `suite-native/message-system/src/messageSystemMiddleware.ts`
- `suite-native/message-system/src/messageSystemThunks.ts`
- `suite-native/module-dev-utils/src/components/MessageSystemAddExperimentForm.tsx`
- `suite-native/module-dev-utils/src/components/MessageSystemCard.tsx`
- `suite-native/module-dev-utils/src/components/MessageSystemExperimentItem.tsx`
- `suite-native/module-dev-utils/src/index.ts`
- `suite-native/module-dev-utils/src/screens/MessageSystemExperimentsScreen.tsx`
- `suite-native/navigation/src/navigators.ts`
- `suite-native/navigation/src/routes.ts`
- `suite/message-system/package.json`
- `suite/message-system/src/debugSettings/MessageSystemForm/MessageSystemFormExperiment.tsx`
- `suite/message-system/tsconfig.json`

_Updated: 2026-07-20T22:21:49.249Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native-message-system-experiments/web/](https://dev.suite.sldev.cz/suite-web/feat/native-message-system-experiments/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native-message-system-experiments&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native-message-system-experiments&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native-message-system-experiments&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-20T22:25:46.821Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-20T22:25:01.557Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->