### PR TITLE
Don't cancel signing on successful staking review push

### DIFF
--- a/suite-native/module-earn/src/hooks/useEarnReviewBackNavigation.ts
+++ b/suite-native/module-earn/src/hooks/useEarnReviewBackNavigation.ts
@@ -7,6 +7,7 @@ import {
     type AccountsRootState,
     cancelSignSendFormTransactionThunk,
     selectAccountByKey,
+    sendFormActions,
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { AppTabsRoutes, RootStackRoutes, useDisableIOSGesture } from '@suite-native/navigation';
@@ -40,6 +41,11 @@ export const useEarnReviewBackNavigation = (
     useDisableIOSGesture();
 
     const isCancellationAlertVisibleRef = useRef(false);
+    const isReviewNavigationSuccessRef = useRef(false);
+
+    const markReviewNavigationSuccess = useCallback(() => {
+        isReviewNavigationSuccessRef.current = true;
+    }, []);
 
     const navigateToStakingHome = useCallback(() => {
         if (!account) {
@@ -70,8 +76,15 @@ export const useEarnReviewBackNavigation = (
         };
 
         const unsubscribe = navigation.addListener('beforeRemove', e => {
-            const isClosingWholeFlow = e.data.action.type === CLOSE_FLOW_ACTION_TYPE;
-            const isLeavingReview = REVIEW_EXIT_ACTION_TYPES.includes(e.data.action.type);
+            if (isReviewNavigationSuccessRef.current) {
+                dispatch(sendFormActions.discardTransaction());
+
+                return;
+            }
+
+            const actionType = e.data.action.type;
+            const isClosingWholeFlow = actionType === CLOSE_FLOW_ACTION_TYPE;
+            const isLeavingReview = REVIEW_EXIT_ACTION_TYPES.includes(actionType);
 
             if (!isLeavingReview || !isTransactionReviewInProgress) {
                 cleanup();
@@ -128,5 +141,5 @@ export const useEarnReviewBackNavigation = (
         navigation.dispatch(StackActions.popToTop());
     }, [navigation]);
 
-    return { navigateBack, closeReview };
+    return { navigateBack, closeReview, markReviewNavigationSuccess };
 };

--- a/suite-native/module-earn/src/hooks/useHandleOnEarnTransactionReview.ts
+++ b/suite-native/module-earn/src/hooks/useHandleOnEarnTransactionReview.ts
@@ -36,7 +36,10 @@ export const useHandleOnEarnTransactionReview = ({
     accountKey,
     stakeType,
 }: HandleOnEarnTransactionReviewProps) => {
-    const { closeReview } = useEarnReviewBackNavigation(stakeType, accountKey);
+    const { closeReview, markReviewNavigationSuccess } = useEarnReviewBackNavigation(
+        stakeType,
+        accountKey,
+    );
 
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
@@ -123,5 +126,5 @@ export const useHandleOnEarnTransactionReview = ({
         stakeType,
     ]);
 
-    return { handleSign, handlePush, closeReview };
+    return { handleSign, handlePush, closeReview, markReviewNavigationSuccess };
 };

--- a/suite-native/module-earn/src/hooks/useNavigateAfterPushedTransaction.ts
+++ b/suite-native/module-earn/src/hooks/useNavigateAfterPushedTransaction.ts
@@ -64,10 +64,12 @@ const navigateToPushedTransactionAction = ({
 
 type UseNavigateAfterPushedTransactionParams = {
     accountKey: AccountKey;
+    markReviewNavigationSuccess: () => void;
 };
 
 export const useNavigateAfterPushedTransaction = ({
     accountKey,
+    markReviewNavigationSuccess,
 }: UseNavigateAfterPushedTransactionParams) => {
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
@@ -102,11 +104,19 @@ export const useNavigateAfterPushedTransaction = ({
 
     useEffect(() => {
         if (txid && isTransactionProcessedByBackend && networkSymbol) {
+            markReviewNavigationSuccess();
             navigation.dispatch(
                 navigateToPushedTransactionAction({ accountKey, symbol: networkSymbol, txid }),
             );
         }
-    }, [accountKey, isTransactionProcessedByBackend, navigation, networkSymbol, txid]);
+    }, [
+        accountKey,
+        isTransactionProcessedByBackend,
+        markReviewNavigationSuccess,
+        navigation,
+        networkSymbol,
+        txid,
+    ]);
 
     useEffect(() => {
         if (!txid) return undefined;

--- a/suite-native/module-earn/src/screens/ClaimTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/ClaimTransactionDataReviewScreen.tsx
@@ -43,12 +43,16 @@ export const ClaimTransactionDataReviewScreen = ({
 
     const precomposedTransaction = useEarnSelectedPrecomposedTransaction('claim', accountKey);
 
-    const { handleSign, handlePush, closeReview } = useHandleOnEarnTransactionReview({
-        accountKey,
-        stakeType: 'claim',
-    });
+    const { handleSign, handlePush, closeReview, markReviewNavigationSuccess } =
+        useHandleOnEarnTransactionReview({
+            accountKey,
+            stakeType: 'claim',
+        });
 
-    const { trackPushedTransaction } = useNavigateAfterPushedTransaction({ accountKey });
+    const { trackPushedTransaction } = useNavigateAfterPushedTransaction({
+        accountKey,
+        markReviewNavigationSuccess,
+    });
 
     const { showTimer, secondsLeft, isPastDeadline, isBroadcasting, onRetry, isRetryDisabled } =
         useEarnTxValidityFlow({

--- a/suite-native/module-earn/src/screens/EarnTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnTransactionDataReviewScreen.tsx
@@ -43,12 +43,16 @@ export const EarnTransactionDataReviewScreen = ({
 
     const precomposedTransaction = useEarnSelectedPrecomposedTransaction('stake', accountKey);
 
-    const { handleSign, handlePush, closeReview } = useHandleOnEarnTransactionReview({
-        accountKey,
-        stakeType: 'stake',
-    });
+    const { handleSign, handlePush, closeReview, markReviewNavigationSuccess } =
+        useHandleOnEarnTransactionReview({
+            accountKey,
+            stakeType: 'stake',
+        });
 
-    const { trackPushedTransaction } = useNavigateAfterPushedTransaction({ accountKey });
+    const { trackPushedTransaction } = useNavigateAfterPushedTransaction({
+        accountKey,
+        markReviewNavigationSuccess,
+    });
 
     const { showTimer, secondsLeft, isPastDeadline, isBroadcasting, onRetry, isRetryDisabled } =
         useEarnTxValidityFlow({

--- a/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
@@ -43,12 +43,16 @@ export const UnstakeTransactionDataReviewScreen = ({
 
     const precomposedTransaction = useEarnSelectedPrecomposedTransaction('unstake', accountKey);
 
-    const { handleSign, handlePush, closeReview } = useHandleOnEarnTransactionReview({
-        accountKey,
-        stakeType: 'unstake',
-    });
+    const { handleSign, handlePush, closeReview, markReviewNavigationSuccess } =
+        useHandleOnEarnTransactionReview({
+            accountKey,
+            stakeType: 'unstake',
+        });
 
-    const { trackPushedTransaction } = useNavigateAfterPushedTransaction({ accountKey });
+    const { trackPushedTransaction } = useNavigateAfterPushedTransaction({
+        accountKey,
+        markReviewNavigationSuccess,
+    });
 
     const { showTimer, secondsLeft, isPastDeadline, isBroadcasting, onRetry, isRetryDisabled } =
         useEarnTxValidityFlow({


### PR DESCRIPTION
## Description

Completing a staking review navigated forward via CommonActions.reset, which the cleanup hook mistook for a cancellation and ran the cancel-signing thunk. Success now tears the send form down natively, keeping the cancel thunk for real cancellation only.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29570