### PR TITLE
Disable iOS swipe-back during staking review

### DIFF
--- a/suite-native/module-earn/src/hooks/useEarnReviewBackNavigation.ts
+++ b/suite-native/module-earn/src/hooks/useEarnReviewBackNavigation.ts
@@ -9,7 +9,7 @@ import {
     selectAccountByKey,
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { AppTabsRoutes, RootStackRoutes } from '@suite-native/navigation';
+import { AppTabsRoutes, RootStackRoutes, useDisableIOSGesture } from '@suite-native/navigation';
 import {
     type TransactionReviewOutputsState,
     selectIsTransactionReviewInProgress,
@@ -36,6 +36,8 @@ export const useEarnReviewBackNavigation = (
     const dispatch = useDispatch();
     const navigation = useNavigation();
     const showReviewCancellationAlert = useShowReviewCancellationAlert();
+
+    useDisableIOSGesture();
 
     const isCancellationAlertVisibleRef = useRef(false);
 


### PR DESCRIPTION
## Description

On iOS, the earn stake, unstake, and claim review screens allowed the native swipe-back gesture to pop the screen without hitting the `beforeRemove` cancellation guard, skipping cleanup and the confirmation prompt. This disables that gesture during staking review, so all back navigation goes through the confirmation path. Android is unaffected.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29571