### PR TITLE
feat: sync linked issue status in Suite project on PR open/draft/ready

### DIFF
--- a/.github/workflows/bot-sync-issue-status.yml
+++ b/.github/workflows/bot-sync-issue-status.yml
@@ -1,0 +1,132 @@
+name: "[Bot] Sync linked issue status on PR open/draft/ready"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - converted_to_draft
+
+env:
+  PROJECT_ID: PVT_kwDOAD9FD84AAuwj
+  STATUS_FIELD_ID: PVTSSF_lADOAD9FD84AAuwjzgAYi50
+  IN_PROGRESS_OPTION_ID: 98236657
+  NEEDS_REVIEW_OPTION_ID: badedff6
+  # Later-stage statuses that must never be regressed by this workflow
+  GUARDED_OPTION_IDS: "97926e6f 93108e06 0f23d421 a9d19930"
+
+jobs:
+  sync-issue-status:
+    name: Sync linked issue status
+    runs-on: ubuntu-latest
+    if: github.repository == 'trezor/trezor-suite'
+    steps:
+      - name: Determine target status
+        id: target
+        run: |
+          if [ "${{ github.event.pull_request.draft }}" == "true" ]; then
+            echo "option_id=${{ env.IN_PROGRESS_OPTION_ID }}" >> "$GITHUB_OUTPUT"
+            echo "status_name=In progress" >> "$GITHUB_OUTPUT"
+          else
+            echo "option_id=${{ env.NEEDS_REVIEW_OPTION_ID }}" >> "$GITHUB_OUTPUT"
+            echo "status_name=Needs review" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate GitHub App token
+        id: trezor-bot-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ secrets.TREZOR_BOT_APP_ID }}
+          private-key: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
+
+      - name: Find linked issues and sync their status
+        env:
+          GH_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
+          TARGET_OPTION_ID: ${{ steps.target.outputs.option_id }}
+          TARGET_STATUS_NAME: ${{ steps.target.outputs.status_name }}
+        run: |
+          # 1. Find issues this PR will close (same pattern as check-project-assignment.yml)
+          LINKED_ISSUE_IDS=$(gh api graphql -f query='
+          query($owner: String!, $repo: String!, $number: Int!) {
+            repository(owner: $owner, name: $repo) {
+              pullRequest(number: $number) {
+                closingIssuesReferences(first: 10) {
+                  nodes { id number }
+                }
+              }
+            }
+          }' -F owner=${{ github.repository_owner }} -F repo=${{ github.event.repository.name }} \
+             -F number=${{ github.event.pull_request.number }} \
+             --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[] | .id')
+
+          if [ -z "$LINKED_ISSUE_IDS" ]; then
+            echo "No linked issues found on this PR — nothing to sync."
+            exit 0
+          fi
+
+          for ISSUE_ID in $LINKED_ISSUE_IDS; do
+            echo "Processing linked issue node $ISSUE_ID"
+
+            # 2. Get this issue's item in the Suite project + its current Status option
+            RESPONSE=$(gh api graphql -f query='
+              query($content_id: ID!) {
+                node(id: $content_id) {
+                  ... on Issue {
+                    projectItems(first: 10) {
+                      nodes {
+                        id
+                        project { id }
+                        fieldValues(first: 20) {
+                          nodes {
+                            ... on ProjectV2ItemFieldSingleSelectValue {
+                              field { ... on ProjectV2SingleSelectField { id } }
+                              optionId
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }' -f content_id="$ISSUE_ID")
+
+            PROJECT_ITEM=$(echo "$RESPONSE" | jq -r \
+              ".data.node.projectItems.nodes[] | select(.project.id == \"${{ env.PROJECT_ID }}\")")
+
+            ITEM_ID=$(echo "$PROJECT_ITEM" | jq -r '.id // empty')
+            if [ -z "$ITEM_ID" ]; then
+              echo "  Issue not tracked in the Suite project — skipping."
+              continue
+            fi
+
+            CURRENT_STATUS=$(echo "$PROJECT_ITEM" | jq -r \
+              ".fieldValues.nodes[] | select(.field?.id == \"${{ env.STATUS_FIELD_ID }}\") | .optionId // empty")
+
+            if echo "${{ env.GUARDED_OPTION_IDS }}" | tr ' ' '\n' | grep -qx "$CURRENT_STATUS"; then
+              echo "  Current status ($CURRENT_STATUS) is a later-stage status — skipping to avoid regressing it."
+              continue
+            fi
+
+            if [ "$CURRENT_STATUS" == "$TARGET_OPTION_ID" ]; then
+              echo "  Already set to '$TARGET_STATUS_NAME' — skipping."
+              continue
+            fi
+
+            # 3. Set the Status field
+            gh api graphql -f query='
+              mutation($project: ID!, $item: ID!, $field: ID!, $value: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $project
+                  itemId: $item
+                  fieldId: $field
+                  value: { singleSelectOptionId: $value }
+                }) {
+                  projectV2Item { id }
+                }
+              }' -f project=${{ env.PROJECT_ID }} \
+                 -f item="$ITEM_ID" \
+                 -f field=${{ env.STATUS_FIELD_ID }} \
+                 -f value="$TARGET_OPTION_ID"
+
+            echo "  ✅ Status set to '$TARGET_STATUS_NAME'"
+          done


### PR DESCRIPTION
## Description

Adds a new bot workflow, `.github/workflows/bot-sync-issue-status.yml`, that keeps a PR's linked issue(s) in sync with the PR's lifecycle in the "Suite" GitHub Project (org `trezor`, [project 58](https://github.com/orgs/trezor/projects/58)):

- When a PR is **opened** or marked **ready for review**, and it's linked to an issue (via `Fixes #...` / closing keywords), the linked issue's `Status` is set to **🔎 Needs review**.
- When a PR is **converted to draft**, the linked issue's `Status` is set back to **🏃‍♀️ In progress**.

To avoid regressing work that's already further along, the update is skipped if the issue's current status is already `Needs QA`, `QA In progress`, `Approved`, or `Blocked`. It's also skipped if the status is already at the target value, or if the issue isn't tracked in the Suite project.

This follows the same pattern already used by `bot-needs-qa.yml` and `check-project-assignment.yml`: a `trezor-bot` GitHub App token for auth (default `GITHUB_TOKEN` can't write to org-level Projects v2), and inline `gh api graphql` calls using `closingIssuesReferences` to resolve linked issues.

## Notes for QA

This only affects GitHub Project automation, not app behavior — no in-app QA is needed. To verify the workflow itself once merged:
1. Open a PR linked to a test issue in the Suite project (e.g. include `Fixes #<issue>` in the description) → confirm the issue's Status becomes `Needs review`.
2. Convert that PR to draft → confirm Status changes to `In progress`.
3. Mark it ready for review again → confirm Status goes back to `Needs review`.
4. Manually set the issue's Status to `Approved` or `Blocked`, then re-trigger `ready_for_review`/`converted_to_draft` on its linked PR → confirm the status is left untouched (guard against regressing later-stage statuses).
5. Check the workflow run logs (Actions tab) for the corresponding PR event to confirm the skip/update reasoning matches what's expected in each case above.

## Related Issue

Resolve N/A — this is a net-new automation, not tied to an existing issue.

## Screenshots:

N/A (workflow-only change, no UI).

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/sync-issue-status-on-pr-events/web/](https://dev.suite.sldev.cz/suite-web/feat/sync-issue-status-on-pr-events/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/sync-issue-status-on-pr-events&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/sync-issue-status-on-pr-events&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T15:35:10.768Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T15:34:22.736Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->