### PR TITLE
feat(trading): [RELEASE ONLY] poll trade api watch endpoint after nat…

### DIFF
--- a/suite-common/trading/src/hooks/useTradingExchangeWatchApproval.ts
+++ b/suite-common/trading/src/hooks/useTradingExchangeWatchApproval.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { type Account } from '@suite-common/wallet-types';
+
+import { useSelector } from './useSelector';
+import { selectTradingExchangeSelectedQuote } from '../selectors/tradingSelectors';
+import { exchangeThunks } from '../thunks/exchange';
+
+const POLLING_TIME = 5000;
+
+export type UseTradingExchangeWatchApprovalProps = {
+    account: Account | undefined;
+    isEnabled: boolean;
+};
+
+export const useTradingExchangeWatchApproval = ({
+    account,
+    isEnabled,
+}: UseTradingExchangeWatchApprovalProps) => {
+    const dispatch = useDispatch();
+    const status = useSelector(state => selectTradingExchangeSelectedQuote(state)?.status);
+
+    useEffect(() => {
+        if (!isEnabled || !account || status !== 'APPROVAL_PENDING') {
+            return;
+        }
+
+        let refreshCount = 1;
+        const intervalId = setInterval(() => {
+            dispatch(exchangeThunks.watchExchangeApprovalThunk({ account, refreshCount }));
+            refreshCount += 1;
+        }, POLLING_TIME);
+
+        return () => clearInterval(intervalId);
+    }, [account, status, isEnabled, dispatch]);
+};

--- a/suite-common/trading/src/index.ts
+++ b/suite-common/trading/src/index.ts
@@ -12,6 +12,7 @@ export * from './hooks/useProviderMetadataChangeEffect';
 export * from './hooks/useTradingFiatValues';
 export * from './hooks/useExchangeFiatDeviation';
 export * from './hooks/useApprovalStep';
+export * from './hooks/useTradingExchangeWatchApproval';
 export * from './hooks/useTradingRefetchScheduler';
 export {
     type TransactionStatus,

--- a/suite-common/trading/src/thunks/exchange/index.ts
+++ b/suite-common/trading/src/thunks/exchange/index.ts
@@ -7,6 +7,7 @@ import { selectExchangeQuoteThunk } from './selectExchangeQuoteThunk';
 import { sendDexTransactionThunk } from './sendDexTransactionThunk';
 import { sendTransactionThunk } from './sendTransactionThunk';
 import { signDataAndConfirmThunk } from './signDataAndConfirmThunk';
+import { watchExchangeApprovalThunk } from './watchExchangeApprovalThunk';
 
 export const exchangeThunks = {
     loadInfoThunk: loadExchangeInfoThunk,
@@ -18,4 +19,5 @@ export const exchangeThunks = {
     signDataAndConfirmThunk,
     sendDexTransactionThunk,
     sendTransactionThunk,
+    watchExchangeApprovalThunk,
 };

--- a/suite-common/trading/src/thunks/exchange/watchExchangeApprovalThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/watchExchangeApprovalThunk.ts
@@ -1,0 +1,47 @@
+import { createThunk } from '@suite-common/redux-utils';
+import { type Account } from '@suite-common/wallet-types';
+
+import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
+import { invityAPI } from '../../invityAPI';
+import { tradingExchangeActions } from '../../reducers/exchangeReducer';
+import { selectTradingExchangeSelectedQuote } from '../../selectors/tradingSelectors';
+
+export type WatchExchangeApprovalThunkProps = {
+    account: Account;
+    refreshCount: number;
+};
+
+// Read-only watch poll: saves the quote only when the backend advances its status.
+export const watchExchangeApprovalThunk = createThunk(
+    `${TRADING_EXCHANGE_THUNK_PREFIX}/watchExchangeApproval`,
+    async ({ account, refreshCount }: WatchExchangeApprovalThunkProps, { dispatch, getState }) => {
+        const selectedQuote = selectTradingExchangeSelectedQuote(getState());
+
+        if (!selectedQuote) {
+            return undefined;
+        }
+
+        invityAPI.createInvityAPIKey(account.descriptor);
+
+        const response = await invityAPI.watchTrade<'exchange'>(
+            selectedQuote,
+            'exchange',
+            refreshCount,
+        );
+
+        if (!response.status || response.status === selectedQuote.status) {
+            return undefined;
+        }
+
+        const updatedQuote = {
+            ...selectedQuote,
+            status: response.status,
+            error: response.error,
+            approvalType: undefined,
+        };
+
+        dispatch(tradingExchangeActions.saveSelectedQuote(updatedQuote));
+
+        return updatedQuote;
+    },
+);

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/NoAccountsComponent.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/NoAccountsComponent.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
 import { NoAccountsComponent } from '../NoAccountsComponent';
@@ -25,14 +26,22 @@ describe('NoAccountsComponent', () => {
     it('should render for not connected device', () => {
         const { queryByText } = renderNoAccountsComponent({ isConnected: false });
 
-        expect(queryByText('You need to connect your device to add new account.')).toBeTruthy();
+        expect(
+            queryByText(
+                getTranslation('moduleTrading.accountScreen.accountEmpty.viewOnly.description'),
+            ),
+        ).toBeTruthy();
     });
 
     it('should render for no account but connected device', () => {
         const { queryByText } = renderNoAccountsComponent({ isConnected: true });
 
         expect(
-            queryByText('It seems that you don’t have any account matching selected asset.'),
+            queryByText(
+                getTranslation(
+                    'moduleTrading.accountScreen.accountEmpty.networkNotEnabled.description',
+                ),
+            ),
         ).toBeTruthy();
     });
 
@@ -43,7 +52,11 @@ describe('NoAccountsComponent', () => {
         });
 
         expect(
-            queryByText('You don’t have an account for this asset imported in Portfolio Tracker.'),
+            queryByText(
+                getTranslation(
+                    'moduleTrading.accountScreen.accountEmpty.portfolioTracker.description',
+                ),
+            ),
         ).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/screens/TradingConfirmingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingConfirmingScreen.tsx
@@ -1,12 +1,11 @@
-import { useCallback, useEffect, useEffectEvent, useRef } from 'react';
+import { useEffect, useEffectEvent, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-
-import { useFocusEffect } from '@react-navigation/native';
 
 import {
     selectTradingExchangeSelectedQuote,
     tradingExchangeActions,
     useAllowanceTxTracking,
+    useTradingExchangeWatchApproval,
 } from '@suite-common/trading';
 import { sendFormActions } from '@suite-common/wallet-core';
 import {
@@ -19,7 +18,6 @@ import { useExchangeAnalyticsStepReport } from '@suite-native/trading-analytics'
 import { useTransactionStatusOverride } from '@suite-native/trading-debug';
 import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
 import { useTransactionDetails } from '@suite-native/transaction-management';
-import { exhaustive } from '@trezor/type-utils';
 
 import { ConfirmationQuoteDebugView } from '../components/exchange/Confirmation/ConfirmationQuoteDebugView';
 import { ExchangeConfirmationHeader } from '../components/exchange/Confirmation/ExchangeConfirmationHeader';
@@ -27,7 +25,6 @@ import { ExchangeConfirmationInfo } from '../components/exchange/Confirmation/Ex
 import { ExchangeConfirmationTitle } from '../components/exchange/Confirmation/ExchangeConfirmationTitle';
 import { ExploreInBlockchainButton } from '../components/exchange/Confirmation/ExploreInBlockchainButton';
 import { TradingDeviceConnectionGuard } from '../components/general/TradingDeviceConnectionGuard';
-import { useApprovalFlow } from '../hooks/exchange/Approval/useApprovalFlow';
 
 export type TradingConfirmingScreenProps = StackProps<
     RootStackParamList,
@@ -49,9 +46,7 @@ export const TradingConfirmingScreen = ({
         flowType === 'approve' ? 'approval-confirming' : 'revoke-confirming',
     );
 
-    const { confirmApproval } = useApprovalFlow();
-
-    const hasConfirmedRef = useRef(false);
+    const hasNavigatedRef = useRef(false);
 
     const {
         status: originalStatus,
@@ -79,7 +74,11 @@ export const TradingConfirmingScreen = ({
         txid: approvalTxid,
     });
 
-    const { isConfirmed, isFailed, isPending } = status;
+    const { isConfirmed, isFailed: isTxFailed } = status;
+
+    const isFailed = isTxFailed || activeQuote?.status === 'ERROR';
+
+    const isPending = !isFailed && activeQuote?.status === 'APPROVAL_PENDING';
 
     useEffect(() => {
         const unsubscribe = navigation.addListener('beforeRemove', e => {
@@ -99,92 +98,53 @@ export const TradingConfirmingScreen = ({
         return unsubscribe;
     }, [dispatch, navigation, reportToAnalytics]);
 
-    useFocusEffect(
-        useCallback(() => {
-            if (!isConfirmed || !activeQuote || hasConfirmedRef.current) return;
+    useTradingExchangeWatchApproval({
+        account: sendAccount,
+        isEnabled: isConfirmed && flowType !== 'revoke',
+    });
 
-            hasConfirmedRef.current = true;
+    useEffect(() => {
+        if (!activeQuote || hasNavigatedRef.current || !isConfirmed) {
+            return;
+        }
 
-            const handleConfirmed = async () => {
-                switch (flowType) {
-                    case 'approve': {
-                        const response = await confirmApproval(activeQuote);
+        if (flowType === 'revoke') {
+            hasNavigatedRef.current = true;
+            dispatch(sendFormActions.dispose());
+            dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
+            navigation.popToTop();
+            reportToAnalytics('continue');
 
-                        if (response?.status === 'APPROVAL_PENDING') {
-                            // we know it was confirmed, so we can set the status to CONFIRM even if it came as APPROVAL_PENDING
-                            // that is basically what api does (but it takes time)
-                            // so we need to do it here to avoid the approval screen transition through useExchangeFlow
-                            dispatch(
-                                tradingExchangeActions.saveSelectedQuote({
-                                    ...response,
-                                    status: 'CONFIRM',
-                                }),
-                            );
-                        }
+            return;
+        }
 
-                        if (!response) {
-                            // confirmApproval already sets the error state — stay on this screen.
-                            hasConfirmedRef.current = false;
+        if (activeQuote.status === 'CONFIRM') {
+            hasNavigatedRef.current = true;
+            dispatch(sendFormActions.dispose());
+            navigation.popToTop();
+            navigation.push(RootStackRoutes.TradingExchangePreview, { isApproved: true });
+            reportToAnalytics('continue');
 
-                            return;
-                        }
+            return;
+        }
 
-                        dispatch(sendFormActions.dispose());
-                        navigation.popToTop();
-                        navigation.push(RootStackRoutes.TradingExchangePreview, {
-                            isApproved: true,
-                        });
-                        break;
-                    }
-
-                    case 'revoke-and-approve':
-                        dispatch(sendFormActions.dispose());
-                        // The post-revoke quote carries the revoke transaction's
-                        // approvalSendTxHash and approvalType: 'ZERO'. Strip them so the
-                        // next confirmApproval call requests a fresh approval rather than
-                        // re-using the revoke txid as the approval txid.
-                        if (activeQuote) {
-                            dispatch(
-                                tradingExchangeActions.saveSelectedQuote({
-                                    ...activeQuote,
-                                    approvalSendTxHash: undefined,
-                                    approvalType: undefined,
-                                    status: 'APPROVAL_REQ',
-                                }),
-                            );
-                        }
-                        navigation.popToTop();
-                        navigation.push(RootStackRoutes.TradingExchangeApproval, {
-                            isRevoked: true,
-                        });
-                        break;
-
-                    case 'revoke':
-                        dispatch(sendFormActions.dispose());
-                        dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
-                        navigation.popToTop();
-                        break;
-
-                    default:
-                        exhaustive(flowType);
-                }
-
-                reportToAnalytics('continue');
-            };
-
-            void handleConfirmed().catch(() => {
-                hasConfirmedRef.current = false;
+        if (activeQuote.status === 'APPROVAL_REQ') {
+            hasNavigatedRef.current = true;
+            dispatch(sendFormActions.dispose());
+            dispatch(
+                tradingExchangeActions.saveSelectedQuote({
+                    ...activeQuote,
+                    approvalSendTxHash: undefined,
+                    approvalType: undefined,
+                }),
+            );
+            navigation.popToTop();
+            navigation.push(RootStackRoutes.TradingExchangeApproval, {
+                isRevoked: flowType === 'revoke-and-approve',
             });
-        }, [
-            isConfirmed,
-            activeQuote,
-            flowType,
-            confirmApproval,
-            dispatch,
-            navigation,
-            reportToAnalytics,
-        ]),
-    );
+            reportToAnalytics('continue');
+        }
+    }, [activeQuote, flowType, isConfirmed, dispatch, navigation, reportToAnalytics]);
 
     return (
         <TradingDeviceConnectionGuard>

--- a/suite-native/module-trading/src/screens/__tests__/TradingConfirmingScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingConfirmingScreen.test.tsx
@@ -26,14 +26,6 @@ jest.mock('@suite-common/device', () => ({
     selectIsDeviceConnected: () => true,
 }));
 
-const mockConfirmApproval = jest.fn().mockResolvedValue({});
-
-jest.mock('../../hooks/exchange/Approval/useApprovalFlow', () => ({
-    useApprovalFlow: () => ({
-        confirmApproval: mockConfirmApproval,
-    }),
-}));
-
 const mockUseTransactionDetails = useTransactionDetails as jest.Mock;
 
 const testQuote = exchangeQuotes[0];
@@ -42,6 +34,7 @@ const mockAddListener = jest.fn(
     (
         _event: string,
         _listener: (e: {
+            preventDefault?: () => void;
             data: { action: { type: string; payload?: { count?: number } } };
         }) => void,
     ) => jest.fn(),
@@ -117,7 +110,6 @@ describe('TradingConfirmingScreen', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-        mockConfirmApproval.mockResolvedValue({});
         store = createTradingLightStore({ tradeType: 'exchange' });
         store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
         mockUseAllowanceTxTracking.mockReturnValue({
@@ -167,13 +159,18 @@ describe('TradingConfirmingScreen', () => {
         expect(mockNavigation.push).not.toHaveBeenCalled();
     });
 
-    it('approve: navigates to TradingExchangePreview after confirmApproval succeeds', async () => {
+    it('approve: navigates to TradingExchangePreview when the quote status becomes CONFIRM', () => {
         mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
 
         renderScreen({ flowType: 'approve' });
 
-        await act(async () => {
-            await Promise.resolve(); // flush confirmApproval promise
+        expect(mockNavigation.push).not.toHaveBeenCalled();
+
+        // Simulate the backend advancing the status (what the watch poll saves).
+        act(() => {
+            store.dispatch(
+                tradingExchangeActions.saveSelectedQuote({ ...testQuote, status: 'CONFIRM' }),
+            );
         });
 
         expect(mockNavigation.popToTop).toHaveBeenCalled();
@@ -182,31 +179,13 @@ describe('TradingConfirmingScreen', () => {
         });
     });
 
-    it('approve: saves quote with CONFIRM status when confirmApproval returns APPROVAL_PENDING', async () => {
+    it('approve: does not navigate while status stays APPROVAL_PENDING', () => {
         mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
-        mockConfirmApproval.mockResolvedValue({ ...testQuote, status: 'APPROVAL_PENDING' });
-
-        renderScreen({ flowType: 'approve' });
-
-        await act(async () => {
-            await Promise.resolve();
-        });
-
-        expect(selectTradingExchangeSelectedQuote(store.getState())).toEqual(
-            expect.objectContaining({ status: 'CONFIRM' }),
+        store.dispatch(
+            tradingExchangeActions.saveSelectedQuote({ ...testQuote, status: 'APPROVAL_PENDING' }),
         );
-        expect(mockNavigation.popToTop).toHaveBeenCalled();
-    });
-
-    it('approve: does not navigate when confirmApproval fails', async () => {
-        mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
-        mockConfirmApproval.mockResolvedValue(undefined);
 
         renderScreen({ flowType: 'approve' });
-
-        await act(async () => {
-            await Promise.resolve();
-        });
 
         expect(mockNavigation.popToTop).not.toHaveBeenCalled();
         expect(mockNavigation.push).not.toHaveBeenCalled();
@@ -224,28 +203,31 @@ describe('TradingConfirmingScreen', () => {
         );
         mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
 
-        const dispatchSpy = jest.spyOn(store, 'dispatch');
-
         renderScreen({ flowType: 'revoke-and-approve' });
+
+        expect(mockNavigation.push).not.toHaveBeenCalled();
+
+        // Simulate the backend reporting the follow-up approval is required.
+        act(() => {
+            store.dispatch(
+                tradingExchangeActions.saveSelectedQuote({
+                    ...testQuote,
+                    approvalType: 'ZERO',
+                    approvalSendTxHash: 'revoke-txid',
+                    status: 'APPROVAL_REQ',
+                }),
+            );
+        });
 
         expect(mockNavigation.popToTop).toHaveBeenCalled();
         expect(mockNavigation.push).toHaveBeenCalledWith(RootStackRoutes.TradingExchangeApproval, {
             isRevoked: true,
         });
-        const dispatchedActions = dispatchSpy.mock.calls.map(([action]) => action);
-        // savePreselectedQuote action no longer exists; assert against the action-type string.
-        expect(
-            dispatchedActions.find(
-                (action: any) => action?.type === '@trading-exchange/savePreselectedQuote',
-            ),
-        ).toBeUndefined();
         const persisted = selectTradingExchangeSelectedQuote(store.getState());
         expect(persisted).toBeDefined();
         expect(persisted?.approvalSendTxHash).toBeUndefined();
         expect(persisted?.approvalType).toBeUndefined();
         expect(persisted?.status).toBe('APPROVAL_REQ');
-
-        dispatchSpy.mockRestore();
     });
 
     it('revoke: pops to top and clears selectedQuote', () => {
@@ -306,6 +288,27 @@ describe('TradingConfirmingScreen', () => {
         expect(selectTradingExchangeSelectedQuote(store.getState())).toEqual(testQuote);
     });
 
+    it('surfaces a backend error status and allows leaving without confirmation', () => {
+        mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
+        store.dispatch(tradingExchangeActions.saveSelectedQuote({ ...testQuote, status: 'ERROR' }));
+
+        const { getByText } = renderScreen({ flowType: 'approve' });
+
+        expect(
+            getByText(getTranslation('moduleTrading.tradingConfirmationScreen.error')),
+        ).toBeOnTheScreen();
+        expect(mockNavigation.push).not.toHaveBeenCalled();
+
+        const preventDefault = jest.fn();
+        const [, listener] =
+            mockAddListener.mock.calls.find(([event]) => event === 'beforeRemove') ?? [];
+        act(() => {
+            listener?.({ preventDefault, data: { action: { type: 'GO_BACK' } } });
+        });
+
+        expect(preventDefault).not.toHaveBeenCalled();
+    });
+
     describe('analytics', () => {
         it('should report approval-confirming visit ', () => {
             renderScreen();
@@ -337,14 +340,15 @@ describe('TradingConfirmingScreen', () => {
             expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);
         });
 
-        it('should report continue when on navigation to next screen', async () => {
+        it('should report continue when on navigation to next screen', () => {
             mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
-            mockConfirmApproval.mockResolvedValue({ ...testQuote, status: 'APPROVAL_PENDING' });
 
             renderScreen({ flowType: 'approve' });
 
-            await act(async () => {
-                await Promise.resolve();
+            act(() => {
+                store.dispatch(
+                    tradingExchangeActions.saveSelectedQuote({ ...testQuote, status: 'CONFIRM' }),
+                );
             });
 
             expect(mockAnalyticsReport).toHaveBeenCalledWith('approval-confirming', 'continue');

--- a/suite-native/trading-browser-auth/src/components/__tests__/ProviderConfirmationStatusInfo.test.tsx
+++ b/suite-native/trading-browser-auth/src/components/__tests__/ProviderConfirmationStatusInfo.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { type ProviderConfirmationStatus } from '@suite-native/trading-types';
 
@@ -29,9 +30,22 @@ describe('ProviderConfirmationStatusInfo', () => {
     );
 
     it.each<[string, ProviderConfirmationStatus]>([
-        ['Provider is confirming your sell', 'window_closed_incomplete'],
-        ['Waiting for the provider’s receive address', 'window_closed_with_success'],
-        ['Your sell couldn’t be completed', 'confirmation_failed'],
+        [
+            getTranslation('moduleTrading.tradingSellPreviewScreen.providerStatus.confirming'),
+            'window_closed_incomplete',
+        ],
+        [
+            getTranslation(
+                'moduleTrading.tradingSellPreviewScreen.providerStatus.waitingForAddress',
+            ),
+            'window_closed_with_success',
+        ],
+        [
+            getTranslation(
+                'moduleTrading.tradingSellPreviewScreen.providerStatus.cannotBeCompletedAlert.title',
+            ),
+            'confirmation_failed',
+        ],
     ])(
         'should render "%s" when providerConfirmationStatus is [%s]',
         (expectedTitle, providerConfirmationStatus) => {

--- a/suite-native/trading-provider-utils/src/components/__tests__/Footer.test.tsx
+++ b/suite-native/trading-provider-utils/src/components/__tests__/Footer.test.tsx
@@ -66,7 +66,7 @@ describe('Footer', () => {
         const { getByText } = renderFooter({ currentProviderMetadata: exchangeCexdirect });
 
         expect(getByText(/Cexdirect/)).toBeOnTheScreen();
-        await userEvent.press(getByText('Trezor’s Terms of Use'));
+        await userEvent.press(getByText('Terms apply'));
 
         expect(mockOpenLink).toHaveBeenCalledTimes(1);
         expect(mockOpenLink).toHaveBeenCalled();

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/__tests__/FeeOptionErrorMessage.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/__tests__/FeeOptionErrorMessage.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { FeeOptionErrorMessage } from '../FeeOptionErrorMessage';
@@ -9,7 +10,7 @@ describe('FeeOptionErrorMessage', () => {
     it('should render error message when visible', () => {
         const { getByText, queryByTestId } = renderFeeOptionErrorMessage(true);
 
-        expect(getByText('You don’t have enough balance to use this fee.')).toBeTruthy();
+        expect(getByText(getTranslation('transactionManagement.fees.error'))).toBeTruthy();
         expect(queryByTestId('@transactionManagement/fee-option-error-message')).toBeTruthy();
     });
 


### PR DESCRIPTION
## Description

Native exchange approval/revoke confirming flow. Replaces the force-`CONFIRM` hack: previously, once the approval/revoke tx confirmed on-chain the screen called `confirmApproval` once and locally overwrote `APPROVAL_PENDING` -> `CONFIRM`, guessing the backend had caught up. Now it polls the read-only trade api watch endpoint (`watchExchangeApprovalThunk` via `useTradingExchangeWatchApproval`, every 5s) after on-chain confirmation and navigates on the backend-reported quote status: `CONFIRM` -> swap preview, `APPROVAL_REQ` -> approval screen.

Also removes the orphaned desktop `watchApproval` hook/form code (dead on `develop`; superseded by desktop `useApprovalStep`).

## Notes for QA

Native DEX swap. Approve a token then confirm the swap; and the revoke-then-approve path. Verify the confirming screen advances to the correct next step only after the backend confirms (no premature navigation), and that a plain revoke still finishes as before.

## Related Issue

Resolve #29511

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/dex-approvals&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->