### PR TITLE
fix(suite-native): wrap tx simulation asset summary text

### DIFF
--- a/suite-native/tx-simulation/src/components/EvmTxSimulationAssetAmount.tsx
+++ b/suite-native/tx-simulation/src/components/EvmTxSimulationAssetAmount.tsx
@@ -7,7 +7,6 @@ import { Box, Text, type TextProps } from '@suite-native/atoms';
 type EvmTxSimulationAssetAmountProps = {
     fiatAmount?: BaseCurrencyAmount;
     fiatSign?: ReactNode;
-    isInline?: boolean;
     summary?: string;
     summaryColor: TextProps['color'];
 };
@@ -15,7 +14,6 @@ type EvmTxSimulationAssetAmountProps = {
 export const EvmTxSimulationAssetAmount = ({
     fiatAmount,
     fiatSign,
-    isInline,
     summary,
     summaryColor,
 }: EvmTxSimulationAssetAmountProps) => {
@@ -24,9 +22,7 @@ export const EvmTxSimulationAssetAmount = ({
     return (
         <>
             <Box flex={1}>
-                <Text color={summaryColor} numberOfLines={isInline ? 1 : undefined}>
-                    {summary}
-                </Text>
+                <Text color={summaryColor}>{summary}</Text>
             </Box>
             {!!fiatAmount && (
                 <Text color="contentSecondary">

--- a/suite-native/tx-simulation/src/components/EvmTxSimulationStackedAsset.tsx
+++ b/suite-native/tx-simulation/src/components/EvmTxSimulationStackedAsset.tsx
@@ -27,7 +27,6 @@ export const EvmTxSimulationStackedAsset = ({
                                 : undefined
                         }
                         fiatSign="+ "
-                        isInline
                         summary={inAmount.summary}
                         summaryColor="contentBrand"
                     />
@@ -42,7 +41,6 @@ export const EvmTxSimulationStackedAsset = ({
                                 : undefined
                         }
                         fiatSign="- "
-                        isInline
                         summary={outAmount.summary}
                         summaryColor="contentCritical"
                     />
@@ -53,7 +51,6 @@ export const EvmTxSimulationStackedAsset = ({
                     <HStack key={`spender-${index}`} alignItems="center" spacing="sp8">
                         <EvmTxSimulationAssetAmount
                             fiatAmount={spender.exposure.usd_price}
-                            isInline
                             summary={spender.summary}
                             summaryColor="contentSecondary"
                         />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Wrap the asset summary text in the tx simulation review sheet to a new line instead of truncating it with an ellipsis, so the token symbol stays visible.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29524

## Screenshots:

<img width="1206" height="2622" alt="simulator_screenshot_B7940B7A-C00C-43D4-A5A1-8576E94DC76B" src="https://github.com/user-attachments/assets/c3c801d9-fef6-4bcd-ad94-f677244c3769" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native-tx-simulation-wrap-summary&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->