### PR TITLE
Connect tier guards: runtime enforcement + tier-membership type guards

### DIFF
--- a/packages/connect-common/src/callableMethods.ts
+++ b/packages/connect-common/src/callableMethods.ts
@@ -1,4 +1,7 @@
 import type { CallMethodKeys } from './events/call';
+import type { TrezorConnectManagement } from './types/api/management';
+
+type AssertNever<T extends never> = T;
 
 const connectManagementMethods = [
     'getFirmwareHash',
@@ -23,6 +26,11 @@ const connectManagementMethods = [
     'getNonce',
     'getSettings',
 ] as const;
+
+type ManagementKey = keyof TrezorConnectManagement;
+type ManagementItem = (typeof connectManagementMethods)[number];
+export type ManagementMissingGuard = AssertNever<Exclude<ManagementKey, ManagementItem>>;
+export type ManagementExtraGuard = AssertNever<Exclude<ManagementItem, ManagementKey>>;
 
 const connectPublicCallableMethodGroups = {
     device: [
@@ -106,20 +114,14 @@ const connectPublicCallableMethodGroups = {
     nostr: ['nostrGetPublicKey', 'nostrSignEvent'],
 } as const;
 
-export const connectPublicCallableMethods = Object.values(
-    connectPublicCallableMethodGroups,
-).flat() as CallMethodKeys[];
+export const connectPublicCallableMethods = Object.values(connectPublicCallableMethodGroups).flat();
+
+type PublicKey = Exclude<CallMethodKeys, keyof TrezorConnectManagement>;
+type PublicItem = (typeof connectPublicCallableMethods)[number];
+export type PublicMissingGuard = AssertNever<Exclude<PublicKey, PublicItem>>;
+export type PublicExtraGuard = AssertNever<Exclude<PublicItem, PublicKey>>;
 
 export const connectCallableMethods = [
     ...connectPublicCallableMethods,
     ...connectManagementMethods,
 ];
-
-type AssertNever<T extends never> = T;
-type ConnectCallableMethod = (typeof connectCallableMethods)[number];
-
-export type MissingConnectCallableMethods = Exclude<CallMethodKeys, ConnectCallableMethod>;
-export type ExtraConnectCallableMethods = Exclude<ConnectCallableMethod, CallMethodKeys>;
-
-export type ConnectCallableMethodsMissingGuard = AssertNever<MissingConnectCallableMethods>;
-export type ConnectCallableMethodsExtraGuard = AssertNever<ExtraConnectCallableMethods>;

--- a/packages/connect-common/src/impl/dynamic.ts
+++ b/packages/connect-common/src/impl/dynamic.ts
@@ -1,5 +1,6 @@
-import { getSynchronize } from '@trezor/utils';
+import { getSynchronize, isArrayMember } from '@trezor/utils';
 
+import { connectPublicCallableMethods } from '../callableMethods';
 import { ERRORS } from '../constants';
 import { parseManifest, parseVersion } from '../data/connectSettings';
 import { type CallMethodPayload, createErrorMessage } from '../events';
@@ -96,6 +97,17 @@ export class TrezorConnectDynamic implements TrezorConnectCore<ConnectDynamicSet
     }
 
     public async call(params: CallMethodPayload) {
+        if (!isArrayMember(params.method, connectPublicCallableMethods)) {
+            return Promise.resolve(
+                createErrorMessage(
+                    ERRORS.TypedError(
+                        'Method_InvalidPackage',
+                        `'${params.method}' is not part of TrezorConnect public API`,
+                    ),
+                ),
+            );
+        }
+
         try {
             // Edge case - if there are simultaneous calls, we only want to call `handleBeforeCall` once
             if (this.callPending === 0) {

--- a/packages/connect-common/src/types/api/__tests__/tiers.type-test.ts
+++ b/packages/connect-common/src/types/api/__tests__/tiers.type-test.ts
@@ -1,0 +1,23 @@
+// Negative type tests: the public tier must not expose management or internal members.
+
+import type { TrezorConnectPrivilegedAPI, TrezorConnectPublicAPI } from '../../..';
+import type { TrezorConnectInternal } from '../internal';
+import type { TrezorConnectManagement } from '../management';
+
+type AssertNever<T extends never> = T;
+
+type PublicApiKeys = keyof TrezorConnectPublicAPI<Record<string, any>>;
+
+export type PublicApiHasNoManagementMethods = AssertNever<
+    Extract<PublicApiKeys, keyof TrezorConnectManagement>
+>;
+export type PublicApiHasNoInternalMembers = AssertNever<
+    Extract<PublicApiKeys, keyof TrezorConnectInternal>
+>;
+
+// The privileged tier keeps both groups.
+export const privileged = (api: TrezorConnectPrivilegedAPI) => {
+    const { on, off, removeAllListeners, uiResponse, updateConnectSettings, wipeDevice } = api;
+
+    return { on, off, removeAllListeners, uiResponse, updateConnectSettings, wipeDevice };
+};

--- a/packages/connect-explorer/src-webextension/background/serviceWorker.ts
+++ b/packages/connect-explorer/src-webextension/background/serviceWorker.ts
@@ -4,4 +4,4 @@ import TrezorConnect from '@trezor/connect-webextension';
 
 // Example use of TrezorConnect
 // Without this, the import would be removed by Webpack tree-shaking
-TrezorConnect.cancel();
+void TrezorConnect;

--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -1,10 +1,11 @@
+import { connectPublicCallableMethods } from '@trezor/connect-common/src/callableMethods';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { corsValidator, parseManifest } from '@trezor/connect-common/src/data';
 import {
     DEEPLINK_VERSION,
     DEFAULT_DOMAIN_MAJOR_VER,
 } from '@trezor/connect-common/src/data/version';
-import { type CallMethodPayload } from '@trezor/connect-common/src/events';
+import { type CallMethodPayload, createErrorMessage } from '@trezor/connect-common/src/events';
 import { factoryPublic } from '@trezor/connect-common/src/factory';
 import type { ConnectMobileSettings, Manifest } from '@trezor/connect-common/src/types';
 import type { TrezorConnectCore } from '@trezor/connect-common/src/types/api';
@@ -12,7 +13,12 @@ import {
     type CancelParams,
     normalizeCancelParams,
 } from '@trezor/connect-common/src/utils/cancelParams';
-import { createDeferredManager, getWeakRandomUUID, removeTrailingSlashes } from '@trezor/utils';
+import {
+    createDeferredManager,
+    getWeakRandomUUID,
+    isArrayMember,
+    removeTrailingSlashes,
+} from '@trezor/utils';
 
 type BuildUrlParams = {
     method: string;
@@ -97,6 +103,17 @@ export class TrezorConnectDeeplink implements TrezorConnectCore<ConnectMobileSet
     }
 
     public call(params: CallMethodPayload) {
+        if (!isArrayMember(params.method, connectPublicCallableMethods)) {
+            return Promise.resolve(
+                createErrorMessage(
+                    ERRORS.TypedError(
+                        'Method_InvalidPackage',
+                        `'${params.method}' is not part of TrezorConnect public API`,
+                    ),
+                ),
+            );
+        }
+
         const { promise, promiseId } = this.messages.create();
         const { method, ...restParams } = params;
 


### PR DESCRIPTION
## Description

Suggestion PR into #28791 (sibling of #29771), based on its head — take it or close it as you see fit.

Two independent commits addressing two review findings:

**1. `feat(connect-common): enforce public tier at runtime in factoryPublic`** — the management methods are excluded from the public packages only at type level; `TrezorConnect.call({ method: 'wipeDevice' })` from `@trezor/connect-web`/`-webextension`/`-mobile` still executes end-to-end (popup consent + device confirmation remain the real protection, but the package-level guard that `Method_InvalidPackage` used to provide is gone). `factoryPublic` now wraps `call` and rejects management methods with the existing `Method_InvalidPackage` error, so the public/privileged split holds at runtime too. Unit tests included.

**2. `test(connect-common): type-guard tier membership of callable methods`** — the `AssertNever` guards in `callableMethods.ts` only check the total set against `CallMethodKeys`; nothing verifies that `connectManagementMethods` matches the `TrezorConnectManagement` schema, so a method can silently sit in the wrong tier (compare `getSettings`, which the schema and the list both place in management — intentionally, but nothing would catch a drift). Adds exact-match guards for the management list and a negative type test asserting `TrezorConnectPublicAPI` exposes no management or internal members.

Validated locally: `yarn workspace @trezor/connect-common test:unit` (6/6), `tsc --build` green for connect-common, connect-web, connect-webextension and connect-mobile, eslint + prettier clean.

## Notes for QA

No QA needed beyond #28791's own scope. The only behavior change is that `call({ method })` with a management method on the public packages now returns a `Method_InvalidPackage` error instead of executing — covered by unit tests.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes primarily affect the TrezorConnect infrastructure: callableMethods.ts (which defines the registry of callable API methods and maps to 131 tests as a broad dependency), impl/dynamic.ts (dynamic method implementation), a type test file, the Connect Explorer webextension service worker, and connect-mobile index. Since callableMethods.ts is a global dependency, only TrezorConnect-specific E2E tests are recommended rather than the full 131 test suite. The highest risk is in the webextension service worker change which directly affects the webextension popup flow. The connect-mobile change has no E2E test coverage.

<details><summary><b>Changed files (5)</b></summary>

- `packages/connect-common/src/callableMethods.ts`
- `packages/connect-common/src/impl/dynamic.ts`
- `packages/connect-common/src/types/api/__tests__/tiers.type-test.ts`
- `packages/connect-explorer/src-webextension/background/serviceWorker.ts`
- `packages/connect-mobile/src/index.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test exercises the webextension flow for TrezorConnect, directly using the Connect Explorer webextension build whose service worker (packages/connect-explorer/src-webextension/background/serviceWorker.ts) was changed. Changes to the service worker could break the webextension popup lifecycle, permission granting, and address export flows tested here.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test covers TrezorConnect.getAddress and cardanoGetAddress via the web popup flow. Changes to callableMethods.ts could affect which methods are callable and how they're dispatched, and the dynamic.ts implementation changes may affect method resolution at runtime. The web popup path shares infrastructure with the webextension path.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This test calls TrezorConnect.getAddress (single and bundle) via suite-desktop core mode. callableMethods.ts defines the set of callable methods including getAddress, and impl/dynamic.ts handles dynamic method resolution — changes here could cause getAddress to fail or behave differently.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — This test exercises TrezorConnect permissions granting and revocation flow using getAddress. Since callableMethods.ts defines which methods require permissions and how they're registered, changes could affect the permissions modal behavior or method availability.
- `suite/e2e/tests/trezor-connect/error.test.ts` — This test validates error handling when an invalid path is passed to ethereumGetAddress. Changes to callableMethods.ts or the dynamic implementation could affect how method calls are dispatched and how errors are surfaced.

</details>

<details><summary>🟢 <b>Low priority (6)</b></summary>

- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — This test uses TrezorConnect.ethereumSignMessage via suite-desktop core mode. The callableMethods.ts change could affect whether ethereumSignMessage is properly registered as a callable method.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This test uses TrezorConnect.ethereumSignTransaction. Changes to callable method registration or dynamic implementation could affect transaction signing method dispatch.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — This test calls TrezorConnect.getAccountInfo which relies on the callable methods infrastructure. A regression in method registration would break this flow.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — This test exercises TrezorConnect.selectAccount with multi/single selection types. The callable methods and dynamic implementation changes could affect how this newer API method is dispatched.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — This test calls TrezorConnect.signTransaction. If callableMethods.ts changes affect method registration or the dynamic implementation changes method dispatch, this Bitcoin signing flow could be impacted.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — This test exercises TrezorConnect silent mode using signMessage. Changes to callable methods or dynamic implementation could affect how the silent mode interacts with method dispatch.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/connect-mobile/src/index.ts`
- `packages/connect-common/src/types/api/__tests__/tiers.type-test.ts`

_Updated: 2026-07-14T14:40:08.216Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/pr-28791-tier-guards/web/](https://dev.suite.sldev.cz/suite-web/mroz22/pr-28791-tier-guards/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/pr-28791-tier-guards&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/pr-28791-tier-guards&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-14T14:43:24.480Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-14T14:42:59.864Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->