### PR TITLE
fix(wallet-utils): derive fresh Cardano accounts with the correct derivationType

### DIFF
--- a/suite-common/wallet-utils/src/__tests__/prepareNewAccountPayload.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/prepareNewAccountPayload.test.ts
@@ -1,0 +1,56 @@
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { type AccountType, type NetworkAccount } from '@suite-common/wallet-config';
+import TrezorConnect from '@trezor/connect';
+
+import { prepareNewAccountPayload } from '../accountUtils';
+
+jest.mock('@trezor/connect', () => ({
+    __esModule: true,
+    default: { getAccountInfo: jest.fn() },
+}));
+
+const mockGetAccountInfo = TrezorConnect.getAccountInfo as jest.Mock;
+
+const device = mockSuiteDevice({ state: { staticSessionId: 'session-1' } });
+
+const callPayload = (accountType: AccountType, networkSymbol: 'ada' | 'btc', bip43Path: string) =>
+    prepareNewAccountPayload({
+        accountType,
+        networkSymbol,
+        index: 0,
+        selectedAccount: { bip43Path } as NetworkAccount,
+        device,
+    });
+
+beforeEach(() => {
+    mockGetAccountInfo.mockReset();
+    mockGetAccountInfo.mockResolvedValue({
+        success: true,
+        payload: { descriptor: 'descriptor', empty: true },
+    });
+});
+
+describe('prepareNewAccountPayload derivationType', () => {
+    // Cardano derives a different key per account type; getAccountDescriptor defaults to
+    // ICARUS_TREZOR (2) when derivationType is omitted, so a fresh `normal` ADA account must be
+    // derived with ICARUS (1) to stay consistent with discovery and selectAccount's on-device verify.
+    it.each<[AccountType, number]>([
+        ['normal', 1], // ICARUS
+        ['legacy', 2], // ICARUS_TREZOR
+        ['ledger', 0], // LEDGER
+    ])('passes derivationType %s -> %i for Cardano', async (accountType, expected) => {
+        await callPayload(accountType, 'ada', "m/1852'/1815'/i'");
+
+        expect(mockGetAccountInfo).toHaveBeenCalledTimes(1);
+        expect(mockGetAccountInfo).toHaveBeenCalledWith(
+            expect.objectContaining({ coin: 'ada', derivationType: expected }),
+        );
+    });
+
+    it('leaves derivationType undefined for non-Cardano networks', async () => {
+        await callPayload('normal', 'btc', "m/84'/0'/i'");
+
+        expect(mockGetAccountInfo).toHaveBeenCalledTimes(1);
+        expect(mockGetAccountInfo.mock.calls[0][0].derivationType).toBeUndefined();
+    });
+});

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -46,6 +46,7 @@ import { HELP_CENTER_ADDRESSES_URL, HELP_CENTER_TAPROOT_URL } from '@trezor/urls
 import { BigNumber, arrayDistinct, bufferUtils, typedObjectKeys } from '@trezor/utils';
 
 import { convertAmountSubunitsToUnits, formatNetworkAmount } from './amountUtils';
+import { getDerivationType } from './cardanoUtils';
 import { toFiatCurrency } from './fiatConverterUtils';
 import { getFiatRateKey } from './fiatRatesUtils';
 import { getAccountTotalStakingBalance } from './stakingUtils';
@@ -1155,9 +1156,18 @@ export const prepareNewAccountPayload = async ({
 
     if (!newPath || !device.state?.staticSessionId) return new Error('Missing path');
 
+    // Cardano derives a different key per account type (normal -> ICARUS, legacy -> ICARUS_TREZOR,
+    // ledger -> LEDGER). Without derivationType, getAccountDescriptor defaults to ICARUS_TREZOR, so a
+    // fresh `normal` ADA account would be derived with the legacy key — inconsistent with discovery
+    // and with selectAccount's on-device verify. Compute it here (rather than per caller) so no caller
+    // can reintroduce the omission; other network types ignore derivationType.
+    const derivationType =
+        network.networkType === 'cardano' ? getDerivationType(accountType) : undefined;
+
     const res = await TrezorConnect.getAccountInfo({
         path: newPath,
         coin: networkSymbol,
+        derivationType,
         device: {
             path: device.path,
             instance: device.instance,


### PR DESCRIPTION
## Summary

[`prepareNewAccountPayload`](https://github.com/trezor/trezor-suite/blob/c35fe9f5d7913735afb637535e7ae46ca47dccb3/suite-common/wallet-utils/src/accountUtils.ts#L1129) — the shared "derive one not-yet-discovered account on the device to preview it" helper — called `getAccountInfo` without a `derivationType`, so `getAccountDescriptor` defaults to `ICARUS_TREZOR (2)`. For Cardano the correct derivation is per account type (`normal → ICARUS (1)`, `legacy → ICARUS_TREZOR (2)`, `ledger → LEDGER (0)`), so a fresh `normal` ADA account was derived with the legacy key instead of ICARUS. This exports the wrong-derivation xpub/address to a third-party app via `selectAccount`, and its own on-device Verify (which correctly uses `getDerivationType`) then fails; the same defect persists a wrong descriptor through "Add account → next account" (Suite + suite-native).

## Approach

Compute `derivationType` **inside the helper** (resolved decision A) — `network.networkType === 'cardano' ? getDerivationType(accountType) : undefined` — and pass it to the `getAccountInfo` call. The helper already receives `accountType` and resolves the network, so this fixes the root cause for `selectAccount` and both Add-Account flows in one place with **zero caller edits**, and a future caller cannot reintroduce the omission. Non-Cardano networks ignore `derivationType` (`getAccountDescriptor`'s bitcoin/ethereum branches never read it), so the change is inert for them.

## Testing

`yarn workspace @suite-common/wallet-utils test:unit prepareNewAccountPayload` — a new deterministic regression guard (`prepareNewAccountPayload.test.ts`) mocks `TrezorConnect.getAccountInfo` and asserts the exact `derivationType` passed for a fresh account: Cardano `normal → 1`, `legacy → 2`, `ledger → 0`, and `undefined` for a non-Cardano network. It fails on the pre-fix code (which passed no `derivationType`). Type-check and lint green.

**Note — deviation from the plan's sketched test surface.** The plan's acceptance criteria named a Cardano **suite-e2e** in `tests/trezor-connect/selectAccount.test.ts` as the guard. Per the conveyor CONVENTIONS ("Tests — survey first, signal not mandate"), I chose a focused unit test instead: it locks the exact code changed (the `derivationType` value on the derive path), is deterministic, and runs in CI without the emulator — whereas the plan itself flags the Cardano `getAccountInfo` e2e path as WS-cache / websocket-timeout-prone (cf. #27539). The existing selectAccount e2e still runs unchanged in CI. If the reviewer prefers the e2e guard as well, that can be added as a follow-up — flagging the choice here for the gate.

Closes #29643

## Team
- **Product owner:** mroz22 — owns the spec and the plan decisions
- **Reviewer:** _resolved at the PR handoff (CODEOWNERS covers wallet-utils / connect-popup / suite / suite-native); no fallback pinned (decision C → none)_
- **Eng owner:** _none — contained derivation-plumbing fix, not architecturally significant_
- **Tester:** _none — the regression guard is the unit test (see Testing note); no separate QA sign-off surface_

---
_Generated by [Claude Code](https://claude.ai/code/session_016zTmSjjQmDP2y1bKcUacA6)_

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch a core wallet utility file (accountUtils.ts) and its associated unit test (prepareNewAccountPayload.test.ts), which together govern how new accounts are constructed and labeled across the wallet. Since accountUtils.ts is a broad, widely-imported utility (132 static matches), most of its dependents are unrelated UI flows and were excluded; only tests that directly exercise account creation, discovery, or account payload/type/path assembly were kept. Recommended strategy: prioritize add-account-types and discovery-related E2E tests to validate account construction across BTC-like and non-BTC coins, with lower-priority coverage for public key/backend-specific account tests.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-utils/src/__tests__/prepareNewAccountPayload.test.ts`
- `suite-common/wallet-utils/src/accountUtils.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test directly exercises adding new accounts of various types (normal, taproot, segwit, legacy, ETH, ADA) and verifies analytics payloads for path/symbol/type — this is precisely the account-creation payload logic that prepareNewAccountPayload.test.ts and accountUtils.ts changes would affect.
- `suite/e2e/tests/wallet/discovery.test.ts` — Discovery relies heavily on account utility functions to construct and label discovered accounts across many networks (BTC, ETH, LTC, etc.), making it a strong candidate to catch regressions in accountUtils.ts logic used during account creation/discovery.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test covers standard wallet discovery and account balance display after ejecting/re-adding a wallet, which depends on account construction logic in accountUtils.ts.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Custom backend discovery for BTC/LTC exercises account discovery and construction pathways that likely use accountUtils helpers, making it useful to validate no regression in account payload generation.
- `suite/e2e/tests/settings/coins.test.ts` — Activating multiple coin networks and verifying accounts appear correctly on the dashboard relies on account creation logic that could be impacted by changes to accountUtils.ts.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/public-keys.test.ts` — This test verifies XPUB display for newly activated BTC/LTC/ADA accounts, which touches account metadata derived from accountUtils, though it's a narrower path (public key display) than account creation itself.

</details>

_Updated: 2026-07-20T09:38:51.292Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/29643-cardano-fresh-account-derivation/web/](https://dev.suite.sldev.cz/suite-web/fix/29643-cardano-fresh-account-derivation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/29643-cardano-fresh-account-derivation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/29643-cardano-fresh-account-derivation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/29643-cardano-fresh-account-derivation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-20T09:42:11.768Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-20T09:41:19.716Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->