### PR TITLE
refactor(connect-web): remove dead hosted-channel event re-emit

### DIFF
--- a/packages/connect-web/src/popup/abstract.ts
+++ b/packages/connect-web/src/popup/abstract.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 
 import * as ERRORS from '@trezor/connect-common/src/constants/errors';
-import { type CoreEventMessage, DEVICE_EVENT, POPUP } from '@trezor/connect-common/src/events';
+import { type CoreEventMessage, POPUP } from '@trezor/connect-common/src/events';
 import {
     type AbstractMessageChannel,
     type Message,
@@ -123,8 +123,6 @@ export abstract class Popup extends EventEmitter {
         } else if (message.type === POPUP.CLOSED) {
             await this.close();
             this.handlePopupClosed();
-        } else if (message.event === DEVICE_EVENT) {
-            this.emit(DEVICE_EVENT, message);
         }
     }
 


### PR DESCRIPTION
## Description

Removes dead event wiring from the Connect v10 hosted popup channel.

`Popup.handleCoreMessage` in `packages/connect-web/src/popup/abstract.ts` had an `else if (message.event === DEVICE_EVENT) { this.emit(DEVICE_EVENT, message) }` branch that could never fire. Under Connect v10 the hosted channels (web popup / webextension / desktop-ws) are call/response only: nothing posts an event-shaped message onto the popup channel, and nothing subscribes to the re-emitted `DEVICE_EVENT` on the popup instance. Events are delivered on the in-module channel (`@trezor/connect` / `core-in-module.ts`) only. The dead branch and its now-unused `DEVICE_EVENT` import are deleted; the `CoreEventMessage` and `POPUP` imports stay in use.

No docs change here: the v10 event model — the event API (`on` / `off` / `removeAllListeners`) is available only in `@trezor/connect`, not in the thin `@trezor/connect-web` / `@trezor/connect-webextension` / `@trezor/connect-mobile` packages — is already documented on `develop` by the `events.mdx` / `events.md` notice added in 70f198ab90. The original branch also edited `events.mdx`; that edit was dropped during the rebase onto `develop` in favour of the already-merged, more accurate notice, so this PR now carries only the code deletion.

Closes #29649

## Notes for QA

No dedicated QA needed — behaviour-preserving deletion of dead code on the hosted (web / webextension / desktop-ws) Connect channels. The removed branch had no producer of event-shaped messages and no subscriber, verified across the whole repo (`createDeviceMessage`, the only builder of `{ event: DEVICE_EVENT }`, is called exclusively by the in-module Core in `packages/connect/src/core/index.ts` and never reaches the hosted popup channel). Event delivery on the in-module `@trezor/connect` channel used by Trezor Suite is untouched. Blast radius is limited to `@trezor/connect-web`; the TrezorConnect popup lifecycle (open / close / focus / permissions) and all call/response flows are unaffected. Sanity check if desired: any TrezorConnect popup flow in Suite Web (getAddress, signTransaction, selectAccount) behaves exactly as before.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to packages/connect-web/src/popup/abstract.ts, which implements the core popup window lifecycle logic (opening, closing, focusing, cancelling, and detecting blocked popups) used by TrezorConnect's web/webextension popup flow. No static coverage mapping exists, so tests were inferred from the LLM analysis of connect-related e2e tests that specifically exercise popup open/close/focus/cancel/block behavior. The two connectPopupWeb/Webextension tests are the most direct and comprehensive coverage of this exact code path and should be run unconditionally; permissions and silentMode tests share meaningful popup-reuse logic and are recommended at medium priority, while simpler connect tests (error, getAddress) are only weakly related and marked low.

<details><summary><b>Changed files (1)</b></summary>

- `packages/connect-web/src/popup/abstract.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test directly exercises the connect-web popup lifecycle (opening, cancelling, force-closing, focusing existing popups, popup-blocked detection) which is the core behavior implemented in packages/connect-web/src/popup/abstract.ts. Any regression in popup handling logic would be immediately visible here.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test covers popup open/close/focus/cancel behavior from a webextension context, exercising the same abstract popup management code path (recovery after force-close, focusing existing popup instead of opening a new one) that was changed.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/permissions.test.ts` — This test relies on the permissions modal reappearing/not reappearing via popup calls and repeated TrezorConnect requests, which depends on correct popup instance management from the abstract popup module.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Silent mode behavior depends on how the popup module handles bringing the app to the foreground on subsequent calls, which is directly tied to popup lifecycle logic in abstract.ts.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/error.test.ts` — This test verifies basic TrezorConnect initialization and error display, which indirectly touches the popup/connect flow but doesn't specifically exercise popup lifecycle edge cases like closing/reopening.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This test uses the connect permissions modal and popup-driven address confirmation flow, so a popup lifecycle regression could surface here, though it is not the primary focus of this test.

</details>

_Updated: 2026-07-19T07:08:29.527Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/29649-connect-events-cleanup/web/](https://dev.suite.sldev.cz/suite-web/refactor/29649-connect-events-cleanup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/29649-connect-events-cleanup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/29649-connect-events-cleanup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T18:40:11.286Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T18:39:43.450Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->
