### PR TITLE
fix(suite): prevent clipping of selected account group outline in sidebar

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
@@ -25,6 +25,7 @@ const Section = styled.div<{ $selected?: boolean; $isSidebarCollapsed?: boolean 
 
     outline: 1px solid
         ${({ theme, $selected }) => ($selected ? theme.elementBorderNeutralSofter : 'transparent')};
+    outline-offset: -1px;
     padding: ${spacingsPx.xxs};
     margin: 0 -${spacingsPx.xxs};
 


### PR DESCRIPTION
## Description
If account with tokens is first in the sidebar, there was a problem with border. It is not anymore.

## Notes for QA
1) check account with tokens so that there is border around account + tokens in the sidebar

## Related Issue
Resolve #29713

## Screenshots:

<img width="301" height="373" alt="Screenshot 2026-07-12 at 10 12 33" src="https://github.com/user-attachments/assets/1bb709c3-c92a-45ce-91b2-8d20e9e8f674" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to AccountItemsGroup.tsx, which is a component in the wallet sidebar's accounts menu responsible for grouping and rendering account items. While this file is statically imported by 129 tests (indicating it's a broadly-used layout component), only tests that directly interact with the account sidebar menu — searching, filtering, adding accounts, or verifying account visibility — are meaningfully at risk. The recommended strategy focuses on account search/filter and account type management tests as high priority, with a few medium-priority tests covering discovery and account navigation flows.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/account-search.test.ts` — AccountItemsGroup is the component that renders account items in the accounts menu sidebar. This test directly exercises account search/filtering which shows/hides account items rendered by AccountItemsGroup. Changes to how account items are grouped or rendered would directly break this test's assertions about account visibility.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds accounts of various types (normal, taproot, segwit, legacy) and verifies account counts by type. AccountItemsGroup directly controls how accounts are grouped and rendered in the sidebar menu, so changes here could affect account type grouping, counting, and display.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test interacts with account labels in the sidebar menu (clicking account buttons, searching accounts by label), which are rendered within AccountItemsGroup. Changes to the component could affect how labeled accounts are displayed and searched.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test verifies that after discovery completes, all activated coins have visible account balances (balanceOfAccount). AccountItemsGroup renders these account items in the sidebar, so changes could affect whether discovered accounts are properly displayed.
- `suite/e2e/tests/wallet/pagination.test.ts` — This test navigates to a specific BTC legacy account via the accounts menu. AccountItemsGroup controls how account types (legacy, segwit, etc.) are grouped in the sidebar, which is the entry point for selecting the account in this test.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test enables new coins and verifies they appear correctly in the assets section. While it primarily tests the dashboard assets view, enabling new networks triggers account discovery which populates AccountItemsGroup in the sidebar.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test checks account balance display via balanceOfAccount and accountLabel selectors. AccountItemsGroup renders account items that include balance information, so rendering changes could affect balance visibility.

</details>

_Updated: 2026-07-11T13:12:19.424Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/29713-sidebar-group-outline-clipped/web/](https://dev.suite.sldev.cz/suite-web/fix/29713-sidebar-group-outline-clipped/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/29713-sidebar-group-outline-clipped&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/29713-sidebar-group-outline-clipped&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-11T13:16:00.051Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-11T13:15:51.158Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->