### PR TITLE
fix(suite): merge backend reconnect banner text into a single message

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/BackendDisconnected.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/BackendDisconnected.tsx
@@ -30,15 +30,14 @@ const DisconnectedNotification = ({
                 </Banner.Button>
             }
             description={
-                <>
+                countdownSeconds ? (
+                    <Translation
+                        id="TR_BACKEND_DISCONNECTED_RECONNECTING"
+                        values={{ time: countdownSeconds }}
+                    />
+                ) : (
                     <Translation id="TR_BACKEND_DISCONNECTED" />
-                    {countdownSeconds ? (
-                        <Translation
-                            id="TR_BACKEND_RECONNECTING"
-                            values={{ time: countdownSeconds }}
-                        />
-                    ) : null}
-                </>
+                )
             }
         />
     );

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1570,9 +1570,17 @@ export const messages = defineMessages({
         defaultMessage: 'Unable to connect. Wait a moment and try again.',
         id: 'TR_BACKEND_DISCONNECTED',
     },
+    TR_BACKEND_DISCONNECTED_RECONNECTING: {
+        defaultMessage:
+            'Unable to connect. Wait a moment and try again. Reconnecting in {time} sec...',
+        description:
+            'Banner shown when a blockchain backend is disconnected and an automatic reconnect countdown is running',
+        id: 'TR_BACKEND_DISCONNECTED_RECONNECTING',
+    },
     TR_BACKEND_RECONNECTING: {
         defaultMessage: 'Reconnecting in {time} sec...',
-        description: 'Should start with dot, continuation of TR_BACKEND_DISCONNECTED',
+        description:
+            'Backend row subtitle in debug settings while a reconnect countdown is running',
         id: 'TR_BACKEND_RECONNECTING',
     },
     TR_HOMESCREEN_GALLERY: {


### PR DESCRIPTION
## Description
Fix missing dot in the reconnect string. It is now just one translation id so this should eliminate errors.

## Related Issue
Resolve #29712

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change modifies the BackendDisconnected account banner component and the global intl messages file. The BackendDisconnected component is part of the WalletLayout and is shown when a custom backend loses connectivity. While it maps to 129 tests via static analysis (indicating it's part of a broadly imported layout), the actual risk is concentrated in tests that specifically exercise custom backend configuration and backend error states. The messages.ts file has no static test coverage data but is a global dependency; changes there are most likely to surface in tests that assert specific translation keys. The recommended strategy focuses on custom backend and discovery tests as highest priority, with broader coverage tests at lower priority.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/wallet/WalletLayout/AccountBanners/BackendDisconnected.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test configures custom backends and verifies discovery error states (TR_ACCOUNT_EXCEPTION_DISCOVERY_ERROR) when a wrong backend URL is used. The BackendDisconnected banner component is directly relevant to displaying backend connection issues on account pages, and messages.ts changes could affect the translation keys used in these error/banner states.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends for BTC and LTC and verifies discovery completes successfully. The BackendDisconnected component is the banner shown when a custom backend is disconnected, making this test directly exercise the changed component's display context.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — This test enables networks, configures custom backends (ETH blockbook), and verifies custom backend indicators. Changes to the BackendDisconnected banner could affect how backend status is displayed when custom backends are configured.
- `suite/e2e/tests/wallet/without-device.test.ts` — This test verifies disconnected device banners and connection modals. While focused on device disconnection, it exercises the wallet layout where AccountBanners (including BackendDisconnected) render, and the disconnected-device-banner pattern is closely related to the changed component's purpose.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coins and tests discovery resilience including page reload during discovery. The BackendDisconnected banner may appear transiently during discovery interruptions, and changes to it could affect the reload/recovery flow.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test crawls all routes and validates links. Changes to messages.ts could introduce broken or malformed translation strings that affect link rendering across the app. It also covers the /accounts route where BackendDisconnected would render.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-07-11T16:57:17.872Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/29712-backend-reconnect-banner-text/web/](https://dev.suite.sldev.cz/suite-web/fix/29712-backend-reconnect-banner-text/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/29712-backend-reconnect-banner-text&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/29712-backend-reconnect-banner-text&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-11T17:00:54.249Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-11T16:59:51.504Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->