### PR TITLE
fix(suite): validate Solana unstake amount entered in fiat

### DIFF
--- a/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeForm.tsx
+++ b/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeForm.tsx
@@ -7,6 +7,7 @@ import { Banner, Card, Column, InfoItem, Link, Tooltip } from '@trezor/component
 import { BigNumber } from '@trezor/utils';
 
 import { getStakingHelpCenterLink } from 'src/components/earn/utils/getStakingHelpCenterLink';
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
 import { SolanaStakingLimitBanner } from 'src/components/suite/modals/ReduxModal/UserContextModal/SolanaStakingLimitBanner';
 import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useWithdrawalFormContext } from 'src/hooks/earn/useWithdrawalForm';
@@ -51,6 +52,11 @@ export const UnstakeForm = () => {
 
     const renderClickableUnstakeAmount = (amount: string) => (
         <Link onClick={() => onCryptoAmountChange(amount)}>{amount}</Link>
+    );
+    const renderUnstakeAmountFiat = (amount: string) => (
+        <BaseCurrencyValue amount={amount} symbol={account.symbol} showApproximationIndicator>
+            {({ value }) => (value ? <>&nbsp;({value})</> : null)}
+        </BaseCurrencyValue>
     );
     const shouldShowInstantWithdrawalEthAmount =
         approximatedInstantEthAmount && BigNumber(approximatedInstantEthAmount).gt(0);
@@ -108,8 +114,16 @@ export const UnstakeForm = () => {
                                                         higher: renderClickableUnstakeAmount(
                                                             unstakeAmountBounds.closestHigher,
                                                         ),
+                                                        higherFiat: renderUnstakeAmountFiat(
+                                                            unstakeAmountBounds.closestHigher,
+                                                        ),
                                                         lower: unstakeAmountBounds.closestLower
                                                             ? renderClickableUnstakeAmount(
+                                                                  unstakeAmountBounds.closestLower,
+                                                              )
+                                                            : undefined,
+                                                        lowerFiat: unstakeAmountBounds.closestLower
+                                                            ? renderUnstakeAmountFiat(
                                                                   unstakeAmountBounds.closestLower,
                                                               )
                                                             : undefined,

--- a/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeInputs.tsx
+++ b/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeInputs.tsx
@@ -19,6 +19,7 @@ import {
     validateFiatLimits,
     validateMin,
     validateSolanaUnstakeAmount,
+    validateSolanaUnstakeFiatAmount,
 } from 'src/utils/suite/validation';
 
 export const UnstakeInputs = () => {
@@ -69,6 +70,11 @@ export const UnstakeInputs = () => {
                 localCurrency: baseCurrencyCode,
                 formatter: CryptoAmountFormatter,
                 fiatFormatter: BaseCurrencyAmountFormatter,
+                decimals: network.decimals,
+                rate: currentRate?.rate,
+            }),
+            solanaUnstakeAmount: validateSolanaUnstakeFiatAmount(translationString, {
+                account,
                 decimals: network.decimals,
                 rate: currentRate?.rate,
             }),

--- a/packages/suite/src/hooks/earn/useWithdrawalForm.ts
+++ b/packages/suite/src/hooks/earn/useWithdrawalForm.ts
@@ -206,6 +206,12 @@ export const useWithdrawalForm = ({ account }: UseWithdrawalFormProps): Withdraw
 
     const onCryptoAmountChange = useCallback(
         async (amount: string) => {
+            setValue(CRYPTO_INPUT, amount, {
+                shouldDirty: true,
+                shouldValidate: true,
+            });
+            setValue(OUTPUT_AMOUNT, amount || '', { shouldDirty: true, shouldValidate: true });
+
             if (currentRate) {
                 const fiatValue = toFiatCurrency({ amount, rate: currentRate?.rate })?.toFixed(
                     2,
@@ -217,11 +223,6 @@ export const useWithdrawalForm = ({ account }: UseWithdrawalFormProps): Withdraw
                 });
             }
 
-            setValue(CRYPTO_INPUT, amount, {
-                shouldDirty: true,
-                shouldValidate: true,
-            });
-            setValue(OUTPUT_AMOUNT, amount || '', { shouldDirty: true, shouldValidate: true });
             await composeRequest(CRYPTO_INPUT);
         },
         [composeRequest, currentRate, setValue],

--- a/packages/suite/src/utils/suite/validation.ts
+++ b/packages/suite/src/utils/suite/validation.ts
@@ -14,6 +14,7 @@ import {
     isDecimalsValid,
     isInteger,
     networkAmountToSmallestUnit,
+    toFiatCurrency,
 } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { BigNumber } from '@trezor/utils';
@@ -148,16 +149,50 @@ export const validateSolanaUnstakeAmount =
 
         const symbol = getNetworkDisplaySymbol(account.symbol);
 
+        // the fiat approximations are only rendered in the rich <Translation> banner
         return bounds.closestLower
             ? translationString('TR_STAKE_SOL_INVALID_UNSTAKE_AMOUNT', {
                   lower: bounds.closestLower,
                   higher: bounds.closestHigher,
                   symbol,
+                  lowerFiat: '',
+                  higherFiat: '',
               })
             : translationString('TR_STAKE_SOL_INVALID_UNSTAKE_AMOUNT_HIGHER_ONLY', {
                   higher: bounds.closestHigher,
                   symbol,
+                  higherFiat: '',
               });
+    };
+
+interface ValidateSolanaUnstakeFiatAmountOptions {
+    account: Account;
+    decimals: number;
+    rate?: number;
+}
+
+export const validateSolanaUnstakeFiatAmount =
+    (
+        translationString: TranslationFunction,
+        { account, decimals, rate }: ValidateSolanaUnstakeFiatAmountOptions,
+    ) =>
+    (value: string, formValues?: { outputs?: { amount?: string }[] }) => {
+        if (!value) return;
+
+        const cryptoAmount = fromBaseCurrencyToCryptoUnit({ fiatAmount: value, rate })?.toFixed(
+            decimals,
+        );
+        if (!cryptoAmount) return;
+
+        const outputAmount = formValues?.outputs?.[0]?.amount;
+        const isFiatOfOutputAmount =
+            !!outputAmount &&
+            toFiatCurrency({ amount: outputAmount, rate })?.toFixed(2, BigNumber.ROUND_FLOOR) ===
+                value;
+
+        return validateSolanaUnstakeAmount(translationString, { account })(
+            isFiatOfOutputAmount ? outputAmount : cryptoAmount,
+        );
     };
 
 interface ValidateFiatLimitsOptions {

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11475,12 +11475,12 @@ export const messages = defineMessages({
     TR_STAKE_SOL_INVALID_UNSTAKE_AMOUNT: {
         id: 'TR_STAKE_SOL_INVALID_UNSTAKE_AMOUNT',
         defaultMessage:
-            "Due to recent Solana blockchain changes, this amount can't be unstaked. Try {higher} {symbol} or more, or {lower} {symbol} or less.",
+            "Due to recent Solana blockchain changes, this amount can't be unstaked. Try {higher} {symbol}{higherFiat} or more, or {lower} {symbol}{lowerFiat} or less.",
     },
     TR_STAKE_SOL_INVALID_UNSTAKE_AMOUNT_HIGHER_ONLY: {
         id: 'TR_STAKE_SOL_INVALID_UNSTAKE_AMOUNT_HIGHER_ONLY',
         defaultMessage:
-            "Due to recent Solana blockchain changes, this amount can't be unstaked. Try {higher} {symbol} or more.",
+            "Due to recent Solana blockchain changes, this amount can't be unstaked. Try {higher} {symbol}{higherFiat} or more.",
     },
     TR_STAKE_FIND_OUT_MORE: {
         id: 'TR_STAKE_FIND_OUT_MORE',


### PR DESCRIPTION
## Description
The Solana unstake amount validation (`solanaUnstakeAmount` rule) was registered only on the crypto amount input. When the user switches the `InputWithOptions` form to fiat, the crypto input is unmounted and react-hook-form skips rules of unmounted Controllers, so an amount that Solana can't unstake exactly passed validation and was silently adjusted to the closest possible amount during signing.

The invalid-unstake-amount banner now also shows a fiat approximation next to each suggested amount, e.g. `2.61 SOL (≈ $350.12)`. The parenthesis is omitted when no fiat rate is available, and the plain-text validator message (fallback when the banner cannot compute bounds) is unchanged.

Crowdin is updated.

Follow-up of https://github.com/trezor/trezor-suite/pull/29545

## Related Issue
Resolve #29687

## Screenshots:
<img width="539" height="849" alt="Screenshot 2026-07-12 at 10 49 19" src="https://github.com/user-attachments/assets/7fecf80a-f593-4fea-af95-bf4fc5123450" />

<img width="538" height="709" alt="Screenshot 2026-07-12 at 10 49 23" src="https://github.com/user-attachments/assets/d2d55f25-a243-4b4e-81e3-b6ddd46635d3" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on the unstaking/withdrawal form UI (UnstakeForm.tsx, UnstakeInputs.tsx), the withdrawal form hook (useWithdrawalForm.ts), shared validation utilities (validation.ts), and translation messages (messages.ts). The highest risk is in the ETH/ADA/SOL unstake flows which directly use these components. Medium risk exists for staking flows that share validation infrastructure. Although all 5 changed files map to 129 tests via static analysis, this is because they're bundled into the main Suite app — the actual functional impact is limited to staking/unstaking flows. The validation.ts and messages.ts changes warrant watching staking form validation tests as well.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeForm.tsx`
- `packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeInputs.tsx`
- `packages/suite/src/hooks/earn/useWithdrawalForm.ts`
- `packages/suite/src/utils/suite/validation.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test directly exercises the ETH unstaking flow including the unstake form, amount inputs, and device confirmation — exactly the UI components changed in UnstakeForm.tsx, UnstakeInputs.tsx, and the useWithdrawalForm.ts hook. It validates unstake amounts, fee display, and the full unstake-to-claim lifecycle.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — The Cardano unstake test exercises the unstaking modal and form flow, which uses the same UnstakeForm/UnstakeInputs components and useWithdrawalForm hook. Changes to validation logic or form rendering would directly affect this test's unstake modal and fee display assertions.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — The Solana unstake test exercises the unstaking form pre-filling, amount display, and device confirmation flow. The UnstakeForm and UnstakeInputs components along with useWithdrawalForm are directly involved in the unstake modal shown in this test.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates staking form input validation including minimum amounts, decimal limits, insufficient funds errors, percentage buttons, and max button calculations. While it focuses on the staking (not unstaking) form, it likely shares validation utilities from validation.ts and the useWithdrawalForm hook may share patterns with the staking form hook.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test covers the full ETH staking lifecycle including the staking form. Changes to validation.ts (shared validation utilities) and messages.ts (translation keys used in staking UI) could affect staking form behavior and displayed strings.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — The stake-more test exercises staking dashboard amounts and the staking form for additional ETH stakes. Shared validation logic from validation.ts and translation keys from messages.ts are used in these flows.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL initial staking uses staking form components that share validation infrastructure with the unstake form. Changes to validation.ts could affect input validation behavior in this test.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — SOL stake-more exercises the staking form and amount validation which shares infrastructure with the unstake form through validation.ts. Translation key changes in messages.ts could also affect displayed strings.
- `suite/e2e/tests/staking/ada/claim.test.ts` — ADA claim test exercises the claim rewards flow which shares staking UI infrastructure. The validation.ts changes and messages.ts translation changes could affect fee display and amount formatting in the claim modal.
- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking test uses staking form components and validation utilities. Changes to validation.ts may affect staking amount validation and messages.ts changes could affect staking modal translations.

</details>

_Updated: 2026-07-12T09:04:31.699Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/29687-sol-unstake-fiat-validation/web/](https://dev.suite.sldev.cz/suite-web/fix/29687-sol-unstake-fiat-validation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/29687-sol-unstake-fiat-validation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/29687-sol-unstake-fiat-validation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-12T09:07:37.572Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-12T09:07:44.887Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

