### PR TITLE
Pass stake data slice to stakingDataNeedsRefetch

### DIFF
--- a/suite-common/wallet-core/src/stake/stakeThunks.ts
+++ b/suite-common/wallet-core/src/stake/stakeThunks.ts
@@ -5,6 +5,7 @@ import { type TimerId } from '@trezor/type-utils';
 
 import { stakeDataActions } from './stakeDataSlice';
 import { type StakeRootState } from './stakeReducerTypes';
+import { selectStake } from './stakeSelectors';
 import { selectEnabledNetworks } from '../settings/walletSettingsReducer';
 
 const STAKE_MODULE = '@common/wallet-core/stake';
@@ -30,7 +31,7 @@ export const initStakeDataThunk = createThunk(
         if (isBtcOnly) return;
 
         // because fetch only happens every 5 minutes we fetch according all devices in case a device is changed within those 5 minutes
-        const needsRefetch = stakingDataNeedsRefetch(getState());
+        const needsRefetch = stakingDataNeedsRefetch(selectStake(getState()).data);
 
         if (!needsRefetch) return;
 


### PR DESCRIPTION
## Description

`initStakeDataThunk` passed the root state to `stakingDataNeedsRefetch` instead of the stake data slice, so the cache and loading fields read `undefined` and every periodic check refetched. Fixes the argument and adds tests for the fresh-cache, loading, and stale cases.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29572