### PR TITLE
test(e2e-canary): move canary nightly run from friday to sunday

### DIFF
--- a/.github/workflows/test-suite-web-desktop-e2e-canary.yml
+++ b/.github/workflows/test-suite-web-desktop-e2e-canary.yml
@@ -9,7 +9,7 @@ permissions:
 
 on:
   schedule:
-    - cron: "0 6 * * 5"
+    - cron: "0 1 * * 0"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Moved to 1:00 am to no conflict with a develop web build and deploy

<!--- Provide a general summary of your changes in the Title above -->

## Description

Originally at 6 am in Friday -> we had several instances where somebody merged to develop at that time and develop web instance got build and re-deployed which caused several of tests from this canary run to fail and mark false negative fail due to environment issues.
Having it on Sunday solve the problem and also provides the information on Monday to analyze and consult with the teams.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/move-canary-sunday/web/](https://dev.suite.sldev.cz/suite-web/move-canary-sunday/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=move-canary-sunday&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=move-canary-sunday&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-12T07:38:38.434Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-12T07:37:43.211Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->