### PR TITLE
Share stake max reserve policy across desktop and native

### DIFF
--- a/packages/suite/src/hooks/earn/useStakeForm.ts
+++ b/packages/suite/src/hooks/earn/useStakeForm.ts
@@ -17,6 +17,7 @@ import {
     fromWei,
     getConvertedOrDefaultFeeInfo,
     getFiatRateKey,
+    getMaxStakeAmount,
     getStakingLimitsByNetworkSymbol,
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
@@ -286,27 +287,24 @@ export const useStakeForm = ({ account }: UseStakeFormProps): StakeContextValues
     );
 
     const setMax = useCallback(async () => {
-        if (amountLimits == null || stakingLimits == null) {
+        if (stakingLimits == null) {
             return;
         }
 
         setValue('setMaxOutputId', 0, { shouldDirty: true });
         clearErrors([FIAT_INPUT, CRYPTO_INPUT]);
 
-        let amount = new BigNumber(amountLimits.maxCrypto ?? '');
+        const amount = getMaxStakeAmount({
+            balance: account.formattedBalance,
+            symbol: account.symbol,
+        });
 
-        if (amount.gt(stakingLimits.MIN_BALANCE_FOR_STAKING)) {
-            amount = new BigNumber(account.formattedBalance).minus(
-                stakingLimits.MIN_FOR_WITHDRAWALS,
-            );
-        }
+        setValue(CRYPTO_INPUT, amount, { shouldDirty: true, shouldValidate: true });
 
-        setValue(CRYPTO_INPUT, amount.toString(), { shouldDirty: true, shouldValidate: true });
-
-        await onCryptoAmountChange(amount.toString(), 'max');
+        await onCryptoAmountChange(amount, 'max');
     }, [
         account.formattedBalance,
-        amountLimits,
+        account.symbol,
         clearErrors,
         onCryptoAmountChange,
         setValue,

--- a/suite-common/wallet-utils/src/__fixtures__/stakingUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/stakingUtils.ts
@@ -1,4 +1,4 @@
-import { type NetworkType } from '@suite-common/wallet-config';
+import { type NetworkSymbol, type NetworkType } from '@suite-common/wallet-config';
 import { UNSTAKING_ETH_PERIOD } from '@suite-common/wallet-constants';
 import { SOLANA_EPOCH_DAYS } from '@trezor/network-solana/constants';
 
@@ -77,5 +77,86 @@ export const getUnstakingPeriodInDaysFixture: GetUnstakingPeriodInDaysFixture[] 
             exitTime: 0,
         },
         result: 0,
+    },
+];
+
+type GetMaxStakeAmountFixture = {
+    description: string;
+    args: {
+        balance: string;
+        symbol: NetworkSymbol | undefined;
+    };
+    result: string;
+};
+
+export const getMaxStakeAmountFixture: GetMaxStakeAmountFixture[] = [
+    {
+        description:
+            'SOL: reserves the withdrawal amount (0.02), not just the fee buffer, when the balance is well above the staking minimum',
+        args: { balance: '5', symbol: 'sol' },
+        result: '4.98',
+    },
+    {
+        description:
+            'SOL: takes the fee-buffer-only branch because balance minus the fee buffer (0.005) does not exceed MIN_BALANCE_FOR_STAKING (1.02)',
+        args: { balance: '1.01', symbol: 'sol' },
+        result: '1.005',
+    },
+    {
+        description:
+            'SOL: at the exact fee-buffer branch boundary (balance minus the fee buffer equals MIN_BALANCE_FOR_STAKING), still takes the fee-buffer-only branch',
+        args: { balance: '1.025', symbol: 'sol' },
+        result: '1.02',
+    },
+    {
+        description:
+            'SOL: one cent above the boundary, switches to the withdrawal-reserve branch; this is a known non-monotonic step inherited from desktop (max amount drops from 1.02 to 1.006 as balance rises), not something this shared helper introduces',
+        args: { balance: '1.026', symbol: 'sol' },
+        result: '1.006',
+    },
+    {
+        description: 'SOL: caps the result at the protocol maximum stake amount',
+        args: { balance: '10000005', symbol: 'sol' },
+        result: '10000000',
+    },
+    {
+        description:
+            'SOL: never returns a negative amount when the balance is below the fee buffer',
+        args: { balance: '0.001', symbol: 'sol' },
+        result: '0',
+    },
+    {
+        description:
+            'ETH: withdrawal reserve equals the fee buffer (both 0.005), so max leaves 0.005 regardless of the branch',
+        args: { balance: '5', symbol: 'eth' },
+        result: '4.995',
+    },
+    {
+        description: 'returns 0 (fails safe, reserves everything) for a non-staking network symbol',
+        args: { balance: '5', symbol: 'btc' },
+        result: '0',
+    },
+    {
+        description: 'TRX: below the withdrawal-branch threshold, reserves the full fee buffer (5)',
+        args: { balance: '6', symbol: 'trx' },
+        result: '1',
+    },
+    {
+        description:
+            'TRX: just above the threshold, reserves only the withdrawal amount (0.01) instead of the 5 TRX fee buffer, a steep cliff inherited from desktop',
+        args: { balance: '6.02', symbol: 'trx' },
+        result: '6.01',
+    },
+    {
+        description:
+            'ADA: withdrawal reserve is 0, so once above the fee buffer the max amount is the full balance',
+        args: { balance: '5', symbol: 'ada' },
+        result: '5',
+    },
+    {
+        description:
+            'ADA: never returns a negative amount when the balance is below the fee buffer',
+        args: { balance: '0.001', symbol: 'ada' },
+        result: '0',
     },
 ];

--- a/suite-common/wallet-utils/src/stakingUtils.test.ts
+++ b/suite-common/wallet-utils/src/stakingUtils.test.ts
@@ -1,5 +1,8 @@
-import { getUnstakingPeriodInDaysFixture } from './__fixtures__/stakingUtils';
-import { getUnstakingPeriodInDays } from './stakingUtils';
+import {
+    getMaxStakeAmountFixture,
+    getUnstakingPeriodInDaysFixture,
+} from './__fixtures__/stakingUtils';
+import { getMaxStakeAmount, getUnstakingPeriodInDays } from './stakingUtils';
 
 describe('getUnstakingPeriodInDays', () => {
     getUnstakingPeriodInDaysFixture.forEach(test => {
@@ -7,6 +10,18 @@ describe('getUnstakingPeriodInDays', () => {
             const result = getUnstakingPeriodInDays(test.args.networkType, {
                 withdrawTime: test.args.withdrawTime,
                 exitTime: test.args.exitTime,
+            });
+            expect(result).toEqual(test.result);
+        });
+    });
+});
+
+describe('getMaxStakeAmount', () => {
+    getMaxStakeAmountFixture.forEach(test => {
+        it(test.description, () => {
+            const result = getMaxStakeAmount({
+                balance: test.args.balance,
+                symbol: test.args.symbol,
             });
             expect(result).toEqual(test.result);
         });

--- a/suite-common/wallet-utils/src/stakingUtils.ts
+++ b/suite-common/wallet-utils/src/stakingUtils.ts
@@ -162,6 +162,29 @@ export const getStakingLimitsByNetworkSymbol = (
     }
 };
 
+interface GetMaxStakeAmount {
+    balance: string;
+    symbol: NetworkSymbol | undefined;
+}
+
+export const getMaxStakeAmount = ({ balance, symbol }: GetMaxStakeAmount): string => {
+    const limits = getStakingLimitsByNetworkSymbol(symbol);
+    if (!limits) return '0';
+
+    const balanceBN = new BigNumber(balance);
+
+    const balanceMinusFeeBuffer = BigNumber.max(
+        balanceBN.minus(limits.MIN_BALANCE_FOR_FEE_BUFFER),
+        0,
+    );
+
+    const maxAmount = balanceMinusFeeBuffer.gt(limits.MIN_BALANCE_FOR_STAKING)
+        ? BigNumber.max(balanceBN.minus(limits.MIN_FOR_WITHDRAWALS), 0)
+        : balanceMinusFeeBuffer;
+
+    return BigNumber.min(maxAmount, limits.MAX_AMOUNT_FOR_STAKING).toFixed();
+};
+
 export const getStakingDataForNetwork = (
     account?: Account,
 ): Omit<StakingPoolExtended, 'contract' | 'name'> | undefined => {

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2665,8 +2665,8 @@ export const messages = {
             amountLabel: 'Amount',
             stakeMaxButton: 'Stake max',
             unstakeMaxButton: 'Unstake max',
-            withdrawalFeesBanner:
-                "We've left {amount} {displaySymbol} in your account so you can pay withdrawal fees.",
+            withdrawalFeesRecommendation:
+                "It's recommended to leave {amount} {displaySymbol} so you can pay for withdrawal fees.",
             insufficientBalanceBanner:
                 'Not enough {displaySymbol}. Staking requires at least {minAmount} {displaySymbol} plus network fees.',
             insufficientBalanceBannerButton: 'Buy {displaySymbol}',

--- a/suite-native/module-earn/src/components/EarnMaxButton.tsx
+++ b/suite-native/module-earn/src/components/EarnMaxButton.tsx
@@ -11,7 +11,7 @@ import { type AccountKey, type StakeType } from '@suite-common/wallet-types';
 import {
     formatNetworkAmount,
     getDecimalsForBaseCurrency,
-    getStakingLimitsByNetworkSymbol,
+    getMaxStakeAmount,
 } from '@suite-common/wallet-utils';
 import { HStack, Switch, Text } from '@suite-native/atoms';
 import { useCryptoFiatConverters } from '@suite-native/formatters';
@@ -64,20 +64,9 @@ export const EarnMaxButton = ({
             return stakedBalance ?? '0';
         }
 
-        const limits = getStakingLimitsByNetworkSymbol(symbol);
         const availableAmount = formatNetworkAmount(account!.availableBalance, symbol);
-        const buffer = limits?.MIN_BALANCE_FOR_FEE_BUFFER ?? 0;
 
-        const balanceMinusBuffer = BigNumber.max(new BigNumber(availableAmount).minus(buffer), 0);
-
-        if (
-            limits?.MAX_AMOUNT_FOR_STAKING &&
-            balanceMinusBuffer.gt(limits.MAX_AMOUNT_FOR_STAKING)
-        ) {
-            return limits.MAX_AMOUNT_FOR_STAKING.toFixed();
-        }
-
-        return balanceMinusBuffer.toFixed();
+        return getMaxStakeAmount({ balance: availableAmount, symbol });
     };
 
     const setMaxAmount = () => {

--- a/suite-native/module-earn/src/components/EarnWithdrawalFeesBanner.tsx
+++ b/suite-native/module-earn/src/components/EarnWithdrawalFeesBanner.tsx
@@ -26,24 +26,22 @@ export const EarnWithdrawalFeesBanner = ({ accountKey, symbol }: EarnWithdrawalF
 
     const { displaySymbol } = getNetwork(symbol);
     const formattedBalance = formatNetworkAmount(account.availableBalance, symbol);
-    const maxStakeAmount = new BigNumber(formattedBalance).minus(limits.MIN_BALANCE_FOR_FEE_BUFFER);
 
     const isVisible =
         !hasError &&
         !!amountValue &&
-        new BigNumber(amountValue).gte(maxStakeAmount) &&
-        maxStakeAmount.gt(0);
+        new BigNumber(formattedBalance).minus(amountValue).lt(limits.MIN_FOR_WITHDRAWALS);
 
     if (!isVisible) return null;
 
     return (
         <InlineAlertBox
-            intent="info"
+            intent="warning"
             title={
                 <Translation
-                    id="earn.earnFormScreen.withdrawalFeesBanner"
+                    id="earn.earnFormScreen.withdrawalFeesRecommendation"
                     values={{
-                        amount: limits.MIN_BALANCE_FOR_FEE_BUFFER.toString(),
+                        amount: limits.MIN_FOR_WITHDRAWALS.toString(),
                         displaySymbol,
                     }}
                 />


### PR DESCRIPTION
## Description

Native and desktop reserved different amounts on "Stake max" (native kept only the fee buffer, desktop also the withdrawal reserve), so for Solana native could leave less than desktop. A shared `getMaxStakeAmount` helper in `suite-common` now drives both, with per-network differences kept explicit and tested.

## QA notes

- Desktop's `setMax` now goes through the shared helper too, so it incidentally gains the `MAX_AMOUNT_FOR_STAKING` cap and a negative-amount clamp to `'0'` that its previous bespoke calculation didn't have. Both are improvements and practically unreachable with real balances, but worth knowing if desktop's max-amount numbers are being diffed against the old logic.
- Native's withdrawal-fees banner no longer always claims the full withdrawal reserve is left after "Stake max" — when `getMaxStakeAmount` takes its fee-buffer-only branch (or a manually typed amount only clears the fee-buffer schema rule), the banner now shows a vaguer "a small amount" message instead of a specific, previously-inflated figure.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29575

## Screenshots

<img width="371" height="493" alt="Screenshot 2026-07-19 at 16 59 54" src="https://github.com/user-attachments/assets/b0a3fcec-1ae0-4a49-9a36-081ea928de4c" />