### PR TITLE
fix(connect-popup): log only { code, method } for popup error sinks

### DIFF
--- a/suite-common/connect-popup/src/connectPopupErrorSummary.test.ts
+++ b/suite-common/connect-popup/src/connectPopupErrorSummary.test.ts
@@ -1,0 +1,52 @@
+import { connectPopupErrorSummary } from './connectPopupErrorSummary';
+
+// Fake confidential path — must never survive into the summary.
+const CONFIDENTIAL_PATH = "m/84'/0'/7'/0/3";
+
+describe('connectPopupErrorSummary', () => {
+    it('returns only { code, method } — no message/stack body reaches the sink', () => {
+        const result = connectPopupErrorSummary('getAddress', {
+            message: `Derivation failed at ${CONFIDENTIAL_PATH}`,
+            code: 'Failure_UnknownCode',
+        });
+
+        expect(Object.keys(result).sort()).toEqual(['code', 'method']);
+        expect(result).toEqual({ code: 'Failure_UnknownCode', method: 'getAddress' });
+    });
+
+    it('never leaks a confidential path embedded in the error message', () => {
+        // `res.error` shape: a serialized error whose message can carry app-influenced input.
+        const result = connectPopupErrorSummary('getPublicKey', {
+            message: `bad path ${CONFIDENTIAL_PATH}`,
+            code: 'Method_InvalidParameter',
+        });
+
+        expect(JSON.stringify(result)).not.toContain(CONFIDENTIAL_PATH);
+        expect(result.code).toBe('Method_InvalidParameter');
+    });
+
+    it('never leaks a confidential path embedded in a thrown Error message or stack', () => {
+        // The catch-block sites pass the raw thrown value (`unknown`).
+        const error = new Error(`derivation error for ${CONFIDENTIAL_PATH}`);
+        (error as Error & { code?: string }).code = 'Failure_ActionCancelled';
+
+        const result = connectPopupErrorSummary('cardanoGetAddress', error);
+
+        expect(JSON.stringify(result)).not.toContain(CONFIDENTIAL_PATH);
+        expect(result).toEqual({ code: 'Failure_ActionCancelled', method: 'cardanoGetAddress' });
+    });
+
+    it('falls back to Failure_UnknownCode for a codeless thrown error', () => {
+        const result = connectPopupErrorSummary('getAddress', new Error('boom'));
+
+        expect(result).toEqual({ code: 'Failure_UnknownCode', method: 'getAddress' });
+    });
+
+    it('falls back to Failure_UnknownCode for a non-Error payload without a code', () => {
+        // A non-Error payload has no `code`, so the summary must still emit a safe constant.
+        const result = connectPopupErrorSummary('getAddress', `bad path ${CONFIDENTIAL_PATH}`);
+
+        expect(JSON.stringify(result)).not.toContain(CONFIDENTIAL_PATH);
+        expect(result).toEqual({ code: 'Failure_UnknownCode', method: 'getAddress' });
+    });
+});

--- a/suite-common/connect-popup/src/connectPopupErrorSummary.test.ts
+++ b/suite-common/connect-popup/src/connectPopupErrorSummary.test.ts
@@ -4,14 +4,13 @@ import { connectPopupErrorSummary } from './connectPopupErrorSummary';
 const CONFIDENTIAL_PATH = "m/84'/0'/7'/0/3";
 
 describe('connectPopupErrorSummary', () => {
-    it('returns only { code, method } — no message/stack body reaches the sink', () => {
+    it('summarizes to a leak-free { code, method } string — no message/stack body reaches the sink', () => {
         const result = connectPopupErrorSummary('getAddress', {
             message: `Derivation failed at ${CONFIDENTIAL_PATH}`,
             code: 'Failure_UnknownCode',
         });
 
-        expect(Object.keys(result).sort()).toEqual(['code', 'method']);
-        expect(result).toEqual({ code: 'Failure_UnknownCode', method: 'getAddress' });
+        expect(result).toBe('{ code: Failure_UnknownCode, method: getAddress }');
     });
 
     it('never leaks a confidential path embedded in the error message', () => {
@@ -21,8 +20,8 @@ describe('connectPopupErrorSummary', () => {
             code: 'Method_InvalidParameter',
         });
 
-        expect(JSON.stringify(result)).not.toContain(CONFIDENTIAL_PATH);
-        expect(result.code).toBe('Method_InvalidParameter');
+        expect(result).not.toContain(CONFIDENTIAL_PATH);
+        expect(result).toBe('{ code: Method_InvalidParameter, method: getPublicKey }');
     });
 
     it('never leaks a confidential path embedded in a thrown Error message or stack', () => {
@@ -32,21 +31,21 @@ describe('connectPopupErrorSummary', () => {
 
         const result = connectPopupErrorSummary('cardanoGetAddress', error);
 
-        expect(JSON.stringify(result)).not.toContain(CONFIDENTIAL_PATH);
-        expect(result).toEqual({ code: 'Failure_ActionCancelled', method: 'cardanoGetAddress' });
+        expect(result).not.toContain(CONFIDENTIAL_PATH);
+        expect(result).toBe('{ code: Failure_ActionCancelled, method: cardanoGetAddress }');
     });
 
     it('falls back to Failure_UnknownCode for a codeless thrown error', () => {
         const result = connectPopupErrorSummary('getAddress', new Error('boom'));
 
-        expect(result).toEqual({ code: 'Failure_UnknownCode', method: 'getAddress' });
+        expect(result).toBe('{ code: Failure_UnknownCode, method: getAddress }');
     });
 
     it('falls back to Failure_UnknownCode for a non-Error payload without a code', () => {
         // A non-Error payload has no `code`, so the summary must still emit a safe constant.
         const result = connectPopupErrorSummary('getAddress', `bad path ${CONFIDENTIAL_PATH}`);
 
-        expect(JSON.stringify(result)).not.toContain(CONFIDENTIAL_PATH);
-        expect(result).toEqual({ code: 'Failure_UnknownCode', method: 'getAddress' });
+        expect(result).not.toContain(CONFIDENTIAL_PATH);
+        expect(result).toBe('{ code: Failure_UnknownCode, method: getAddress }');
     });
 });

--- a/suite-common/connect-popup/src/connectPopupErrorSummary.ts
+++ b/suite-common/connect-popup/src/connectPopupErrorSummary.ts
@@ -5,8 +5,11 @@ import { serializeError } from '@trezor/connect-common/src/constants/errors';
 // scrubbed (redactSentryEvent), so logging a whole Connect error leaks its message/stack — which can
 // embed a derivation path, address, or tx data — off-device. `code` (constant enum) and `method` are
 // the only leak-free fields. See #29663.
-export const connectPopupErrorSummary = (method: CallMethodKeys, error: unknown) => ({
+//
+// The summary is a string, not an object: captureConsoleIntegration renders a non-Error object arg
+// through `[object Object]` into the Sentry message, so an object would collapse every popup error
+// into one useless, ungrouped issue. A string keeps the leak-free `{ code, method }` readable in the
+// event message and lets Sentry group by it.
+export const connectPopupErrorSummary = (method: CallMethodKeys, error: unknown) =>
     // Default because serializeError yields a `code` only for an `Error`, not for other payloads.
-    code: serializeError(error).code ?? 'Failure_UnknownCode',
-    method,
-});
+    `{ code: ${serializeError(error).code ?? 'Failure_UnknownCode'}, method: ${method} }`;

--- a/suite-common/connect-popup/src/connectPopupErrorSummary.ts
+++ b/suite-common/connect-popup/src/connectPopupErrorSummary.ts
@@ -1,0 +1,12 @@
+import { type CallMethodKeys } from '@trezor/connect';
+import { serializeError } from '@trezor/connect-common/src/constants/errors';
+
+// Sentry's captureConsoleIntegration turns every `console.error` into an event whose body is not
+// scrubbed (redactSentryEvent), so logging a whole Connect error leaks its message/stack — which can
+// embed a derivation path, address, or tx data — off-device. `code` (constant enum) and `method` are
+// the only leak-free fields. See #29663.
+export const connectPopupErrorSummary = (method: CallMethodKeys, error: unknown) => ({
+    // Default because serializeError yields a `code` only for an `Error`, not for other payloads.
+    code: serializeError(error).code ?? 'Failure_UnknownCode',
+    method,
+});

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -39,6 +39,7 @@ import type { Bip43PathTemplate } from '@trezor/crypto-utils';
 import { resolveAfter } from '@trezor/utils';
 
 import { connectPopupActions } from './connectPopupActions';
+import { connectPopupErrorSummary } from './connectPopupErrorSummary';
 import { getPermissionDeferred, getPopupCallDeferred } from './connectPopupPromiseManager';
 import {
     type ConnectPopupStateRootState,
@@ -255,7 +256,7 @@ export const connectPopupCallInnerThunk = createThunk<
 
             getPopupCallDeferred().resolve(response);
         } catch (error) {
-            console.error('connectPopupCallThunk', error);
+            console.error('connectPopupCallThunk', connectPopupErrorSummary(params.method, error));
             if (error?.error === 'switching-device') {
                 // Do nothing, call will be restarted after device switch
                 return;
@@ -456,7 +457,10 @@ export const connectPopupVerifyAddressThunk = createThunk<
                 }),
             );
         } catch (error) {
-            console.error('connectPopupVerifyAddressThunk', error);
+            console.error(
+                'connectPopupVerifyAddressThunk',
+                connectPopupErrorSummary(call.method, error),
+            );
             dispatch(
                 connectPopupActions.confirmAddresses({
                     exported: call.exported,
@@ -987,7 +991,10 @@ export const connectPopupVerifySelectAccountThunk = createThunk<
                     derivationType: getDerivationType(accountType),
                 });
                 if (!res.success) {
-                    console.error('connectPopupVerifySelectAccountThunk (xpub)', res.error);
+                    console.error(
+                        'connectPopupVerifySelectAccountThunk (xpub)',
+                        connectPopupErrorSummary(call.method, res.error),
+                    );
                 }
                 patchCandidate({ verifying: false, validated: res.success ? 'valid' : 'failed' });
 
@@ -1023,7 +1030,10 @@ export const connectPopupVerifySelectAccountThunk = createThunk<
             });
 
             if (!res.success) {
-                console.error('connectPopupVerifySelectAccountThunk', res.error);
+                console.error(
+                    'connectPopupVerifySelectAccountThunk',
+                    connectPopupErrorSummary(call.method, res.error),
+                );
             }
             patchCandidate({
                 verifying: false,
@@ -1031,7 +1041,10 @@ export const connectPopupVerifySelectAccountThunk = createThunk<
                 mac: res.success ? res.payload.mac : undefined,
             });
         } catch (error) {
-            console.error('connectPopupVerifySelectAccountThunk', error);
+            console.error(
+                'connectPopupVerifySelectAccountThunk',
+                connectPopupErrorSummary(call.method, error),
+            );
             patchCandidate({ verifying: false, validated: 'failed' });
         }
     },

--- a/suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts
@@ -10,6 +10,7 @@ import { getSerializedPath } from '@trezor/connect-common';
 import type { Bip43Path } from '@trezor/crypto-utils';
 
 import { connectPopupActions } from '../connectPopupActions';
+import { connectPopupErrorSummary } from '../connectPopupErrorSummary';
 import { type PostCallHookParams, type PreCallHookParams } from './types';
 import { createPlaceholderAccount } from './utils';
 
@@ -83,7 +84,10 @@ const preCallHook = async <M extends CallMethodKeys>({
         }
     } catch (error) {
         // If an error occurs it's not a problem, we just fall back to generic UI
-        console.error(`Error in Connect Popup ${method} hook:`, error);
+        console.error(
+            `Error in Connect Popup ${method} hook:`,
+            connectPopupErrorSummary(method, error),
+        );
     }
 };
 

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -17,6 +17,7 @@ import { getSerializedPath, validatePath } from '@trezor/connect-common';
 import type { Bip43Path } from '@trezor/crypto-utils';
 
 import { connectPopupActions } from '../connectPopupActions';
+import { connectPopupErrorSummary } from '../connectPopupErrorSummary';
 import { createPlaceholderAccount } from './utils';
 import { getPermissionDeferred } from '../connectPopupPromiseManager';
 import { selectConnectPopupCall } from '../connectPopupReducer';
@@ -167,7 +168,10 @@ const preCallHook = async <M extends CallMethodKeys>({
         }
     } catch (error) {
         // If an error occurs it's not a problem, we just fall back to generic UI
-        console.error(`Error in Connect Popup ${method} hook:`, error);
+        console.error(
+            `Error in Connect Popup ${method} hook:`,
+            connectPopupErrorSummary(method, error),
+        );
         if (error.code === 'Method_Cancel') {
             // User cancelled the operation
             throw error;

--- a/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
@@ -12,6 +12,7 @@ import { getSerializedPath, validatePath } from '@trezor/connect-common';
 import type { Bip43Path } from '@trezor/crypto-utils';
 
 import { connectPopupActions } from '../connectPopupActions';
+import { connectPopupErrorSummary } from '../connectPopupErrorSummary';
 import { getPermissionDeferred } from '../connectPopupPromiseManager';
 import { type PostCallHookParams, type PreCallHookParams } from './types';
 import { createPlaceholderAccount } from './utils';
@@ -97,7 +98,10 @@ const preCallHook = async <M extends CallMethodKeys>({
         }
     } catch (error) {
         // If an error occurs it's not a problem, we just fall back to generic UI
-        console.error(`Error in Connect Popup ${method} hook:`, error);
+        console.error(
+            `Error in Connect Popup ${method} hook:`,
+            connectPopupErrorSummary(method, error),
+        );
         if (error.code === 'Method_Cancel') {
             // User cancelled the operation
             throw error;

--- a/suite-common/connect-popup/src/methodHooks/stellarSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/stellarSignTransaction.ts
@@ -8,6 +8,7 @@ import { getSerializedPath, validatePath } from '@trezor/connect-common';
 import type { Bip43Path } from '@trezor/crypto-utils';
 
 import { connectPopupActions } from '../connectPopupActions';
+import { connectPopupErrorSummary } from '../connectPopupErrorSummary';
 import { getPermissionDeferred } from '../connectPopupPromiseManager';
 import { type PostCallHookParams, type PreCallHookParams } from './types';
 import { createPlaceholderAccount } from './utils';
@@ -78,7 +79,10 @@ const preCallHook = async <M extends CallMethodKeys>({
         }
     } catch (error) {
         // If an error occurs it's not a problem, we just fall back to generic UI
-        console.error(`Error in Connect Popup ${method} hook:`, error);
+        console.error(
+            `Error in Connect Popup ${method} hook:`,
+            connectPopupErrorSummary(method, error),
+        );
         if (error.code === 'Method_Cancel') {
             throw error;
         }


### PR DESCRIPTION
## Summary

Defense-in-depth privacy fix. Several `console.error` sinks in `@suite-common/connect-popup` logged the whole Connect error object. The Suite renderer installs Sentry's `captureConsoleIntegration({ levels: ['error'] })`, and `redactSentryEvent` does not scrub the message/exception body — so the full error (whose message/stack can embed a confidential input such as a derivation path or a signed transaction's outputs) reached Sentry unscrubbed once the user has consented to analytics.

This replaces every whole-error log in the package with a leak-free `{ code, method }` summary via a shared helper `connectPopupErrorSummary`:
- `connectPopupCallThunkInner` catch-all ([`connectPopupThunks.ts:215`](https://github.com/trezor/trezor-suite/blob/75fca1fa16/suite-common/connect-popup/src/connectPopupThunks.ts#L215)) — the broadest sink: it catches the raw error from **every** Connect method routed through the popup (including `signTransaction` / `ethereumSignTransaction` / `solanaSignTransaction` / `pushTransaction`), so it could carry the richest confidential payload.
- `connectPopupVerifySelectAccountThunk` — the xpub, address, and catch sites.
- `connectPopupVerifyAddressThunk` — the identical sibling catch site.
- The three sign-transaction method hooks ([`bitcoin`](https://github.com/trezor/trezor-suite/blob/75fca1fa16/suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts#L87) / [`ethereum`](https://github.com/trezor/trezor-suite/blob/75fca1fa16/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts#L171) / [`solana`](https://github.com/trezor/trezor-suite/blob/75fca1fa16/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts#L70)) — same leak class, tx-signing data in scope.

`code` is a constant enum (`connect-common/src/constants/errors.ts`) and `method` is the Connect method name; neither can carry account/device secrets.

## Notes for QA

No functional or UI change. The only observable difference is what a caught popup error prints to the dev console / forwards to Sentry: a `{ code, method }` summary instead of the full error object. Errors still surface in the UI exactly as before. Suggested smoke check via the connect popup: `selectAccount`, `getAddress` (verify-address flow), and a `signTransaction` for BTC / ETH / SOL — trigger a failure and confirm the flow still recovers and shows its error state. Blast radius is limited to `@suite-common/connect-popup` logging.

## Team
- **Product owner:** mroz22 — owns the spec and the plan decisions (incl. the D3 scope revision above).
- **Reviewer:** martykan — fallback (`/suite-common/connect-popup` is not in CODEOWNERS, so no reviewer is auto-requested; szymonlesisz alternate).
- **Eng owner:** None — contained one-line-per-site logging change routed through one shared helper.
- **Tester:** required — this touches a privacy-to-Sentry path; do not merge on author-only. The sign-off surface is the unit assertion that `connectPopupErrorSummary` returns only `{ code, method }` and that a confidential path embedded in an error message or a thrown `Error` stack never survives into the summary. The popup flows are exercised by the connect e2e suite.

Closes #29663

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are narrowly scoped to the Trezor Connect popup package: error-summary rendering, popup thunks, and method hooks for Bitcoin/Ethereum/Solana/Stellar signTransaction. The highest regression risk is in Connect sign-transaction flows and error display. Running the targeted Trezor Connect E2E tests for signTransaction (BTC/ETH), error handling, and core popup lifecycle provides strong coverage without executing the 139 transitively mapped suites that do not exercise Connect popup paths.

<details><summary><b>Changed files (7)</b></summary>

- `suite-common/connect-popup/src/connectPopupErrorSummary.test.ts`
- `suite-common/connect-popup/src/connectPopupErrorSummary.ts`
- `suite-common/connect-popup/src/connectPopupThunks.ts`
- `suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/stellarSignTransaction.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/error.test.ts` — Directly exercises the Connect popup error screen path that renders error summaries from connectPopupErrorSummary.ts. A regression here would surface invalid-path or transaction-signing errors incorrectly to users.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Calls TrezorConnect.ethereumSignTransaction end-to-end, which routes through the changed ethereumSignTransaction.ts method hook and connectPopupThunks.ts. This is the exact code path changed for Ethereum transaction signing.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Calls TrezorConnect.signTransaction for Bitcoin, exercising the changed bitcoinSignTransaction.ts method hook and the thunk-driven confirmation prompts. Directly validates the Bitcoin signing hook behavior.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Covers the core Connect popup lifecycle—permissions, address confirmation, cancellation, and popup reopening—which depends on connectPopupThunks.ts and error handling paths. A regression in shared popup state could break these flows.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Validates the Connect popup flow from a webextension context, relying on the same thunks and permission/address-confirmation UI. Regression in popup thunk state could manifest differently in extension popups.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Exercises the Connect permissions modal and address confirmation UI, both driven by connectPopupThunks.ts. While it doesn't call signTransaction, it shares the popup orchestration code changed in the thunks.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Focuses on permission granting, remembering, and revocation—functionality managed by connectPopupThunks.ts. Changes to popup thunks could break permission persistence or the connect-apps settings UI.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — Uses TrezorConnect.selectAccount and its account-selection modal, which flows through connectPopupThunks.ts for permissions and modal state. Verifies multi/single selection and on-device verification paths that share popup infrastructure.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests silent-mode permission behavior and focus suppression, which are governed by connectPopupThunks.ts and the permissions state. Regression in thunk-managed permissions could affect focus or silent-mode flags.
- `suite/e2e/tests/trezor-connect/upfrontPermissions.test.ts` — Validates requestedPermissions handling in the permissions modal, directly tied to connectPopupThunks.ts. Changes to permission thunk logic could break upfront declaration batching.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/connect-popup/src/connectPopupErrorSummary.test.ts`
- `suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/stellarSignTransaction.ts`

_Updated: 2026-09-04T09:37:20.260Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/conveyor/29663-connect-popup-verify-log-summary/web/](https://dev.suite.sldev.cz/suite-web/conveyor/29663-connect-popup-verify-log-summary/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=conveyor/29663-connect-popup-verify-log-summary&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=conveyor/29663-connect-popup-verify-log-summary&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=conveyor/29663-connect-popup-verify-log-summary&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-04T09:39:13.670Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-04T09:39:23.271Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->


