### PR TITLE
feat(connect)!: drop multi-form coin input, accept the shortcut only

### DIFF
--- a/packages/connect-common/src/types/api/account/getAccountInfo.ts
+++ b/packages/connect-common/src/types/api/account/getAccountInfo.ts
@@ -2,10 +2,11 @@ import type { BlockchainLinkParams } from '@trezor/blockchain-link';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 
 import type { AccountInfo, DiscoveryAccountType } from '../../account';
+import type { CoinSymbol } from '../../coinInfo';
 import type { BundledParams, Params, Response } from '../../params';
 
 export interface GetAccountInfo extends Omit<BlockchainLinkParams<'getAccountInfo'>, 'descriptor'> {
-    coin: string;
+    coin: CoinSymbol;
     identity?: string;
     path?: string;
     descriptor?: string;

--- a/packages/connect-common/src/types/api/account/getAddress.ts
+++ b/packages/connect-common/src/types/api/account/getAddress.ts
@@ -2,6 +2,7 @@ import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import type { Static } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
 
+import { CoinSymbolParam } from '../../coinInfo';
 import type { Address as AddressShared, BundledParams, Params, Response } from '../../params';
 import { GetAddress as GetAddressShared } from '../../params';
 
@@ -9,7 +10,7 @@ export type GetAddress = Static<typeof GetAddress>;
 export const GetAddress = Type.Composite([
     GetAddressShared,
     Type.Object({
-        coin: Type.Optional(Type.String()),
+        coin: Type.Optional(CoinSymbolParam()),
         crossChain: Type.Optional(Type.Boolean()),
         multisig: Type.Optional(PROTO.MultisigRedeemScriptType),
         scriptType: Type.Optional(PROTO.InternalInputScriptType),

--- a/packages/connect-common/src/types/api/account/getPublicKey.ts
+++ b/packages/connect-common/src/types/api/account/getPublicKey.ts
@@ -2,6 +2,7 @@ import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import type { Static } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
 
+import { CoinSymbolParam } from '../../coinInfo';
 import type { BundledParams, Params, Response } from '../../params';
 import { GetPublicKey as GetPublicKeyShared, PublicKey } from '../../params';
 
@@ -10,9 +11,9 @@ export const GetPublicKey = Type.Intersect([
     GetPublicKeyShared,
     Type.Object({
         coin: Type.Optional(
-            Type.String({
+            CoinSymbolParam({
                 description:
-                    'determines network definition specified in coins.json file. Coin shortcut, name or label can be used. If coin is not set API will try to get network definition from path.',
+                    'determines network definition specified in coins.json file. The coin shortcut (a CoinSymbol, e.g. "btc") is used. If coin is not set API will try to get network definition from path.',
                 default: 'btc',
             }),
         ),

--- a/packages/connect-common/src/types/api/bitcoin/common.ts
+++ b/packages/connect-common/src/types/api/bitcoin/common.ts
@@ -5,6 +5,7 @@ import type { Static } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
 
 import type { AccountTransaction } from '../../account';
+import { type CoinSymbol, CoinSymbolParam } from '../../coinInfo';
 import type { ProtoWithDerivationPath } from '../../params';
 import { DerivationPath } from '../../params';
 
@@ -13,7 +14,7 @@ import { DerivationPath } from '../../params';
 export type SignMessage = Static<typeof SignMessage>;
 export const SignMessage = Type.Object({
     path: DerivationPath,
-    coin: Type.Optional(Type.String()),
+    coin: Type.Optional(CoinSymbolParam()),
     message: Type.String(),
     hex: Type.Optional(Type.Boolean()),
     no_script_type: Type.Optional(Type.Boolean()),
@@ -84,7 +85,7 @@ export interface SignTransaction {
         addresses: AccountAddresses;
         transactions?: AccountTransaction[]; // refTxs in different format. see refTxs/validateReferencedTransactions
     };
-    coin: string;
+    coin: CoinSymbol;
     identity?: string;
     locktime?: number;
     timestamp?: number;
@@ -117,6 +118,6 @@ export const VerifyMessage = Type.Object({
     address: Type.String(),
     signature: Type.String(),
     message: Type.String(),
-    coin: Type.String(),
+    coin: CoinSymbolParam(),
     hex: Type.Optional(Type.Boolean()),
 });

--- a/packages/connect-common/src/types/api/bitcoin/composeTransaction.ts
+++ b/packages/connect-common/src/types/api/bitcoin/composeTransaction.ts
@@ -13,6 +13,7 @@ import type {
     TransactionInputOutputSortingStrategy,
 } from '@trezor/utxo-lib';
 
+import type { CoinSymbol } from '../../coinInfo';
 import type { Params, Response } from '../../params';
 
 // for convenience ComposeOutput `type: "payment"` field is not required by @trezor/connect api
@@ -24,7 +25,7 @@ export type ComposeOutput = Exclude<ComposeOutputBase, { type: 'payment' }> | Co
 
 export type ComposeParams = {
     outputs: ComposeOutput[];
-    coin: string;
+    coin: CoinSymbol;
     identity?: string;
     account?: undefined;
     feeLevels?: undefined;
@@ -45,7 +46,7 @@ export type ComposeUtxo = AccountUtxo & Partial<ComposeInputBase>;
 
 export type PrecomposeParams = {
     outputs: ComposeOutput[];
-    coin: string;
+    coin: CoinSymbol;
     identity?: string;
     account: {
         path: string;

--- a/packages/connect-common/src/types/api/blockchain/blockchainSetCustomBackend.ts
+++ b/packages/connect-common/src/types/api/blockchain/blockchainSetCustomBackend.ts
@@ -1,8 +1,8 @@
-import type { BlockchainLink } from '../../coinInfo';
+import type { BlockchainLink, CoinSymbol } from '../../coinInfo';
 import type { CommonParams, Response } from '../../params';
 
 export type BlockchainSetCustomBackend = CommonParams & {
-    coin: string;
+    coin: CoinSymbol;
     blockchainLink?: BlockchainLink;
 };
 

--- a/packages/connect-common/src/types/api/blockchain/pushTransaction.ts
+++ b/packages/connect-common/src/types/api/blockchain/pushTransaction.ts
@@ -5,6 +5,7 @@
 import type { Static } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
 
+import { CoinSymbolParam } from '../../coinInfo';
 import type { Params, Response } from '../../params';
 
 export type PushTransaction = Static<typeof PushTransaction>;
@@ -16,7 +17,7 @@ export const PushTransaction = Type.Object({
             disableAlternativeRPC: Type.Optional(Type.Boolean()),
         }),
     ]),
-    coin: Type.String(),
+    coin: CoinSymbolParam(),
     identity: Type.Optional(Type.String()),
 });
 

--- a/packages/connect-common/src/types/api/device/getOwnershipId.ts
+++ b/packages/connect-common/src/types/api/device/getOwnershipId.ts
@@ -2,13 +2,14 @@ import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import type { Static } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
 
+import { CoinSymbolParam } from '../../coinInfo';
 import type { BundledParams, Params, Response } from '../../params';
 import { DerivationPath } from '../../params';
 
 export type GetOwnershipId = Static<typeof GetOwnershipId>;
 export const GetOwnershipId = Type.Object({
     path: DerivationPath,
-    coin: Type.Optional(Type.String()),
+    coin: Type.Optional(CoinSymbolParam()),
     multisig: Type.Optional(PROTO.MultisigRedeemScriptType),
     scriptType: Type.Optional(PROTO.InternalInputScriptType),
 });

--- a/packages/connect-common/src/types/api/device/getOwnershipProof.ts
+++ b/packages/connect-common/src/types/api/device/getOwnershipProof.ts
@@ -2,13 +2,14 @@ import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import type { Static } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
 
+import { CoinSymbolParam } from '../../coinInfo';
 import type { BundledParams, Params, Response } from '../../params';
 import { DerivationPath } from '../../params';
 
 export type GetOwnershipProof = Static<typeof GetOwnershipProof>;
 export const GetOwnershipProof = Type.Object({
     path: DerivationPath,
-    coin: Type.Optional(Type.String()),
+    coin: Type.Optional(CoinSymbolParam()),
     multisig: Type.Optional(PROTO.MultisigRedeemScriptType),
     scriptType: Type.Optional(PROTO.InternalInputScriptType),
     userConfirmation: Type.Optional(Type.Boolean()),

--- a/packages/connect-common/src/types/api/selectAccount.ts
+++ b/packages/connect-common/src/types/api/selectAccount.ts
@@ -1,6 +1,7 @@
 import type { Static } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
 
+import { CoinSymbolParam } from '../coinInfo';
 import type { Params, Response } from '../params';
 
 // Account derivation variant. Mirrors the `type` values in `ACCOUNT_TYPES`
@@ -55,7 +56,7 @@ export const AddressSelection = Type.Union([
 export type SelectAccount = Static<typeof SelectAccount>;
 export const SelectAccount = Type.Object({
     // Network to select an account for, e.g. 'eth' | 'btc' | 'ada'.
-    coin: Type.String(),
+    coin: CoinSymbolParam(),
     selectionType: Type.Optional(SelectionType),
     // Allowed account types, each shown as its own tab in the picker. Entries are either one of
     // the network's built-in types, or a custom derivation path with its own label. If omitted,

--- a/packages/connect-common/src/types/api/solana/common.ts
+++ b/packages/connect-common/src/types/api/solana/common.ts
@@ -2,6 +2,7 @@ import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import type { Static } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
 
+import { CoinSymbolParam } from '../../coinInfo';
 import { PublicKey } from '../../params';
 
 // solanaGetPublicKey
@@ -76,7 +77,7 @@ const SolanaComposeTransactionCommon = {
         }),
     ),
     memo: Type.Optional(Type.String()),
-    coin: Type.Optional(Type.String()),
+    coin: Type.Optional(CoinSymbolParam()),
     identity: Type.Optional(Type.String()),
 };
 

--- a/packages/connect-common/src/types/coinInfo.ts
+++ b/packages/connect-common/src/types/coinInfo.ts
@@ -1,5 +1,5 @@
 import { DeviceModelInternal } from '@trezor/device-utils';
-import type { Static } from '@trezor/schema-utils';
+import type { Static, StringOptions } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
 
 import { FeeLevel } from './fees';
@@ -196,3 +196,12 @@ const coinSymbolSet: ReadonlySet<string> = new Set(coinSymbols);
 // Strict on the canonical lowercase form; callers accepting mixed case should lowercase first
 // (the coin guard in @trezor/connect compares case-insensitively).
 export const isCoinSymbol = (value: string): value is CoinSymbol => coinSymbolSet.has(value);
+
+// TypeBox schema factory for the public `coin` method param. Its static type narrows to
+// `CoinSymbol` (so a non-shortcut coin such as `'bitcoin'` fails type-check), while runtime
+// validation stays a plain string: an unrecognised coin resolves to `undefined` in `getCoinInfo`
+// and is handled per-method (path fallback or `Method_UnknownCoin`), never rejected by the schema
+// here. Options (e.g. `description`, `default`) are forwarded so methods that document their `coin`
+// param stay call-site consistent with those that do not.
+export const CoinSymbolParam = (options?: StringOptions) =>
+    Type.Unsafe<CoinSymbol>(Type.String(options));

--- a/packages/connect-common/src/types/params.ts
+++ b/packages/connect-common/src/types/params.ts
@@ -4,6 +4,7 @@ import type { Static, TSchema } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
 import type { Err, Ok } from '@trezor/type-utils';
 
+import type { CoinSymbol } from './coinInfo';
 import type { DeviceState, DeviceUniquePath } from './device';
 import type { SerializedError } from '../constants/errors';
 
@@ -44,7 +45,7 @@ export const Bundle = <T extends TSchema>(type: T) =>
 export type BundledParams<T> = CommonParams & Bundle<T>;
 
 export interface CommonParamsWithCoin extends CommonParams {
-    coin: string;
+    coin: CoinSymbol;
     identity?: string; // ensures that different backend connections are opened for different identities
 }
 

--- a/packages/connect-explorer/src/constants/descriptions.ts
+++ b/packages/connect-explorer/src/constants/descriptions.ts
@@ -4,7 +4,7 @@ export const descriptionDictionary: Record<string, string> = {
     chunkify: 'Display the result in chunks for better readability. Default is false',
     suppressBackupWarning:
         'By default, this method will emit an event to show a warning if the wallet does not have a backup. This option suppresses the message.',
-    coin: 'determines network definition specified in coins.json file. Coin shortcut, name or label can be used. If coin is not set API will try to get network definition from path.',
+    coin: 'determines network definition specified in coins.json file. The coin shortcut (a CoinSymbol, e.g. btc) is used. If coin is not set API will try to get network definition from path.',
     crossChain:
         'Advanced feature. Use it only if you are know what you are doing. Allows to generate address between chains. For example Bitcoin path on Litecoin network will display cross chain address in Litecoin format.',
     unlockPath: 'the result of TrezorConnect.unlockPath method',

--- a/packages/connect-explorer/src/pages/methods/bitcoin/composeTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/composeTransaction.mdx
@@ -32,7 +32,7 @@ export const PrecomposeSchema = Type.Object({
 
 export const paramDescriptions = {
     outputs: 'Array of output objects described [below](#accepted-output-objects)',
-    coin: 'determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used.',
+    coin: 'determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut` (a `CoinSymbol`, e.g. `btc`) is used.',
     push: 'determines if composed transaction will be broadcasted into blockchain network. Default is set to false.',
     sequence: 'transaction input field used in RBF or locktime transactions',
     account:

--- a/packages/connect-explorer/src/pages/methods/bitcoin/getAddress.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/getAddress.mdx
@@ -20,7 +20,7 @@ export const paramDescriptions = {
     path: 'minimum length is `5`. [read more](/details/path)',
     address: 'address for validation (read `Handle button request` section below)',
     showOnTrezor: 'determines if address will be displayed on device. Default is set to `true`',
-    coin: 'determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used. If `coin` is not set API will try to get network definition from `path`.',
+    coin: 'determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut` (a `CoinSymbol`, e.g. `btc`) is used. If `coin` is not set API will try to get network definition from `path`.',
     crossChain:
         'Advanced feature. Use it only if you are know what you are doing. Allows to generate address between chains. For example Bitcoin path on Litecoin network will display cross chain address in Litecoin format.',
     chunkify:

--- a/packages/connect-explorer/src/pages/methods/bitcoin/getPublicKey.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/getPublicKey.mdx
@@ -18,7 +18,7 @@ import getPublicKey from '../../../data/methods/bitcoin/getPublicKey.ts';
 
 export const paramDescriptions = {
     path: 'minimum length is `1`. [read more](/details/path)',
-    coin: 'determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used. If `coin` is not set API will try to get network definition from `path`.',
+    coin: 'determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut` (a `CoinSymbol`, e.g. `btc`) is used. If `coin` is not set API will try to get network definition from `path`.',
     scriptType: 'used to distinguish between various address formats (non-segwit, segwit, etc.).',
     ignoreXpubMagic: 'ignore SLIP-0132 XPUB magic, use xpub/tpub prefix for all account types.',
     ecdsaCurveName: 'ECDSA curve name to use',

--- a/packages/connect-explorer/src/pages/methods/bitcoin/signMessage.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/signMessage.mdx
@@ -15,7 +15,7 @@ import signMessage from '../../../data/methods/bitcoin/signMessage.ts';
 export const paramDescriptions = {
     path: 'minimum length is `3`. [read more](/details/path)',
     message: '',
-    coin: 'Determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used. If `coin` is not set API will try to get network definition from `path`.',
+    coin: 'Determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut` (a `CoinSymbol`, e.g. `btc`) is used. If `coin` is not set API will try to get network definition from `path`.',
     hex: 'convert message from hex',
 };
 

--- a/packages/connect-explorer/src/pages/methods/bitcoin/signTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/signTransaction.mdx
@@ -45,7 +45,7 @@ export const SignTransactionSchema = Type.Object({
 export const paramDescriptions = {
     coin:
         '> Determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file.\n' +
-        '> Coin `shortcut`, `name` or `label` can be used.\n',
+        '> Coin `shortcut` (a `CoinSymbol`, e.g. `btc`) is used.\n',
     inputs: 'of [PROTO.TxInputType](https://github.com/trezor/trezor-suite/blob/develop/packages/protobuf/src/definitions/messages-bitcoin.ts)',
     outputs:
         'of [PROTO.TxOutputType](https://github.com/trezor/trezor-suite/blob/develop/packages/protobuf/src/definitions/messages-bitcoin.ts)',

--- a/packages/connect-explorer/src/pages/methods/bitcoin/verifyMessage.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/verifyMessage.mdx
@@ -16,7 +16,7 @@ export const paramDescriptions = {
     address: 'signer address,',
     message: 'signed message,',
     signature: 'signature in base64 format,',
-    coin: 'Determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used.',
+    coin: 'Determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut` (a `CoinSymbol`, e.g. `btc`) is used.',
     hex: 'convert message from hex',
 };
 

--- a/packages/connect-explorer/src/pages/methods/cardano/cardanoComposeTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/cardano/cardanoComposeTransaction.mdx
@@ -36,7 +36,7 @@ const result = await TrezorConnect.cardanoComposeTransaction(params);
 // Get account info
 const accountInfo = await TrezorConnect.getAccountInfo({
     path: "m/1852'/1815'/0'/0/0",
-    coin: 'cardano',
+    coin: 'ada',
     details: 'txs',
 });
 const account = accountInfo.payload;

--- a/packages/connect-explorer/src/pages/methods/common/getAccountInfo.mdx
+++ b/packages/connect-explorer/src/pages/methods/common/getAccountInfo.mdx
@@ -32,7 +32,7 @@ export const UsingPathSchema = Type.Object({
     }),
     coin: Type.String({
         description:
-            'determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used.',
+            'determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut` (a `CoinSymbol`, e.g. `btc`) is used.',
     }),
 });
 
@@ -42,7 +42,7 @@ export const UsingPubkeySchema = Type.Object({
     }),
     coin: Type.String({
         description:
-            'determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used.',
+            'determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut` (a `CoinSymbol`, e.g. `btc`) is used.',
     }),
 });
 
@@ -94,7 +94,7 @@ export const GetAccountInfoSchema = Type.Intersect([
 
 export const paramDescriptions = {
     path: 'minimum length is `3`. [read more](/details/path)',
-    coin: 'determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used.',
+    coin: 'determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut` (a `CoinSymbol`, e.g. `btc`) is used.',
     descriptor: 'public key or address of account',
     page: 'transaction history page index, subject of `details: txs`',
     pageSize: 'transaction history page size, subject of `details: txs`',

--- a/packages/connect-explorer/src/pages/methods/common/pushTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/common/pushTransaction.mdx
@@ -14,7 +14,7 @@ import pushTransaction from '../../../data/methods/common/pushTransaction.ts';
 
 export const paramDescriptions = {
     tx: 'serialized transaction,',
-    coin: 'Determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used.',
+    coin: 'Determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut` (a `CoinSymbol`, e.g. `btc`) is used.',
 };
 
 ## Push transaction

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -24,6 +24,13 @@ Features:
 
 Breaking changes:
 
+- The `coin` parameter now accepts only the lowercase coin **shortcut** (the `CoinSymbol` set); network **names** and **labels** are no longer accepted, and the `coin` type is narrowed from `string` to `CoinSymbol`, so a non-shortcut value now fails at compile time as well as at runtime. Resolution is uniform across all coin families (previously Bitcoin matched name/shortcut/label, misc matched name/shortcut, and EVM matched shortcut only). Migration — use the shortcut everywhere:
+    - `getAddress({ coin: 'Bitcoin', … })` → `getAddress({ coin: 'btc', … })`
+    - `getAccountInfo({ coin: 'Bitcoin Cash', … })` → `getAccountInfo({ coin: 'bch', … })`
+    - `composeTransaction({ coin: 'cardano', … })` → `composeTransaction({ coin: 'ada', … })`
+
+    A former name/label passed to a path-taking method (`getAddress`, `getPublicKey`, …) now derives the network from `path`, exactly as it does when `coin` is omitted; methods without a path fallback (`getAccountInfo`, `selectAccount`, `verifyMessage`, `composeTransaction`, `signTransaction`, `signMessage`, `getOwnershipId`, `getOwnershipProof`, and the `blockchain*` family) throw `Method_UnknownCoin`. The complete list of accepted shortcuts is the [`CoinSymbol`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/types/coinInfo.ts) type.
+
 - `getAccountDescriptor` has been removed. The per-coin `*GetPublicKey` methods (`getPublicKey`, `ethereumGetPublicKey`, `cardanoGetPublicKey`, `solanaGetPublicKey`, `tezosGetPublicKey`) now return the same fields after the response-shape unification, so the dedicated descriptor entry point is no longer needed. Consumers that previously called `getAccountDescriptor` should call the appropriate `*GetPublicKey` for the target coin. Field mapping from the old `getAccountDescriptor` payload:
     - `payload.descriptor` → Bitcoin: `result.descriptor` on `getPublicKey`. Non-Bitcoin coins did not return a descriptor; use `result.displayablePublicKey` for the canonical user-facing form.
     - `payload.path` (serialized string) → `result.serializedPath` on every `*GetPublicKey`.

--- a/packages/connect/e2e/__fixtures__/getAccountInfo.ts
+++ b/packages/connect/e2e/__fixtures__/getAccountInfo.ts
@@ -7,7 +7,7 @@ export default {
         {
             description: 'Bitcoin (P2SH): first account using path',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 path: "m/49'/0'/0'",
             },
             result: {
@@ -18,7 +18,7 @@ export default {
         {
             description: 'Bitcoin (P2PKH): first account using path',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 path: "m/44'/0'/0'",
             },
             result: {
@@ -29,7 +29,7 @@ export default {
         {
             description: 'Testnet (P2SH): empty account using path',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 path: "m/49'/1'/256'",
             },
             result: {
@@ -43,7 +43,7 @@ export default {
         {
             description: 'Bitcoin (P2SH): account from descriptor',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 descriptor:
                     'ypub6Y5EDdQK9nQzpNeMtgXxhBB3SoLk2SyR2MFLQYsBkAusAHpaQNxTTwefgnL9G3oFGrRS9VkVvyY1SaApFAzQPZ99wto5etdReeE3XFkkMZt',
             },
@@ -56,7 +56,7 @@ export default {
         {
             description: 'Bitcoin (P2PKH): account from descriptor',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 descriptor:
                     'xpub6DExuxjQ16sWy5TF4KkLV65YGqCJ5pyv7Ej7d9yJNAXz7C1M9intqszXfaNZG99KsDJdQ29wUKBTZHZFXUaPbKTZ5Z6f4yowNvAQ8fEJw2G',
             },
@@ -114,7 +114,7 @@ export default {
         {
             description: 'invalid path',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 path: "m/49'/0'",
             },
             result: false,

--- a/packages/connect/e2e/__fixtures__/getAddress.ts
+++ b/packages/connect/e2e/__fixtures__/getAddress.ts
@@ -28,7 +28,7 @@ export default {
             description: 'Bitcoin p2sh first address (path as array)',
             params: {
                 path: [2147483697, 2147483648, 2147483648, 0, 0],
-                coin: 'Bitcoin',
+                coin: 'btc',
             },
             result: {
                 address: '3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX',
@@ -68,7 +68,7 @@ export default {
             description: 'Testnet p2sh first address',
             params: {
                 path: "m/49'/1'/0'/0/0",
-                coin: 'tbtc',
+                coin: 'test',
             },
             result: {
                 address: '2N4dH9yn4eYnnjHTYpN9xDmuMRS2k1AHWd8',
@@ -78,7 +78,7 @@ export default {
             description: 'Bitcoin Cash first address',
             params: {
                 path: "m/44'/145'/0'/0/0",
-                coin: 'bcash',
+                coin: 'bch',
             },
             result: {
                 address: 'bitcoincash:qzqxk2q6rhy3j9fnnc00m08g4n5dm827xv2dmtjzzp',

--- a/packages/connect/e2e/__fixtures__/getAddressSegwit.ts
+++ b/packages/connect/e2e/__fixtures__/getAddressSegwit.ts
@@ -7,7 +7,7 @@ export default {
         {
             description: "m/49'/0'/0'/0/0",
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 path: "m/49'/0'/0'/0/0",
                 showOnTrezor: true,
             },
@@ -18,7 +18,7 @@ export default {
         {
             description: "m/49'/0'/0'/0/1",
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 path: "m/49'/0'/0'/0/1",
                 showOnTrezor: true,
             },
@@ -29,7 +29,7 @@ export default {
         {
             description: "m/49'/0'/0'/1/0",
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 path: "m/49'/0'/0'/1/0",
                 showOnTrezor: true,
             },
@@ -40,7 +40,7 @@ export default {
         {
             description: "m/49'/0'/0'/1/1",
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 path: "m/49'/0'/0'/1/1",
                 showOnTrezor: true,
             },

--- a/packages/connect/e2e/__fixtures__/getOwnershipId.ts
+++ b/packages/connect/e2e/__fixtures__/getOwnershipId.ts
@@ -44,8 +44,8 @@ export default {
                 bundle: [
                     { path: "m/84'/0'/0'/1/0", coin: 'btc' },
                     { path: "m/86'/0'/0'/1/0", coin: 'btc' },
-                    { path: "m/49'/1'/0'/1/0", coin: 'testnet' },
-                    { path: "m/44'/1'/0'/1/0", coin: 'testnet' },
+                    { path: "m/49'/1'/0'/1/0", coin: 'test' },
+                    { path: "m/44'/1'/0'/1/0", coin: 'test' },
                 ],
             },
             result: [

--- a/packages/connect/e2e/__fixtures__/getOwnershipProof.ts
+++ b/packages/connect/e2e/__fixtures__/getOwnershipProof.ts
@@ -79,8 +79,8 @@ export default {
                 bundle: [
                     { path: "m/84'/0'/0'/1/0", coin: 'btc' },
                     { path: "m/86'/0'/0'/1/0", coin: 'btc' },
-                    { path: "m/49'/1'/0'/0/0", coin: 'testnet' },
-                    { path: "m/44'/1'/0'/0/0", coin: 'testnet' },
+                    { path: "m/49'/1'/0'/0/0", coin: 'test' },
+                    { path: "m/44'/1'/0'/0/0", coin: 'test' },
                 ],
             },
             result: [

--- a/packages/connect/e2e/__fixtures__/getPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/getPublicKey.ts
@@ -25,7 +25,7 @@ export default {
             description: 'Bitcoin p2tr first account',
             params: {
                 path: "m/86'/0'/0'",
-                coin: 'bitcoin',
+                coin: 'btc',
             },
             result: {
                 xpub: 'xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7',
@@ -86,7 +86,7 @@ export default {
             description: 'Bitcoin p2sh first account (path as array)',
             params: {
                 path: [2147483697, 2147483648, 2147483648],
-                coin: 'Bitcoin',
+                coin: 'btc',
             },
             result: {
                 xpub: 'xpub6DExuxjQ16sWy5TF4KkLV65YGqCJ5pyv7Ej7d9yJNAXz7C1M9intqszXfaNZG99KsDJdQ29wUKBTZHZFXUaPbKTZ5Z6f4yowNvAQ8fEJw2G',
@@ -107,7 +107,7 @@ export default {
             description: 'Bitcoin p2pkh first account',
             params: {
                 path: "m/44'/0'/0'",
-                coin: 'bitcoin',
+                coin: 'btc',
             },
             result: {
                 xpub: 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH',
@@ -126,7 +126,7 @@ export default {
             description: 'Bitcoin p2tr first account (showOnTrezor)',
             params: {
                 path: "m/86'/0'/0'",
-                coin: 'bitcoin',
+                coin: 'btc',
                 showOnTrezor: true,
             },
             result: {
@@ -172,7 +172,7 @@ export default {
             description: 'Bitcoin p2pkh first account (showOnTrezor)',
             params: {
                 path: "m/44'/0'/0'",
-                coin: 'bitcoin',
+                coin: 'btc',
                 showOnTrezor: true,
             },
             result: {
@@ -201,7 +201,7 @@ export default {
             description: 'Invalid path (too short)',
             params: {
                 path: [0, 1],
-                coin: 'Litecoin',
+                coin: 'ltc',
             },
             result: false,
         },

--- a/packages/connect/e2e/__fixtures__/signMessage.ts
+++ b/packages/connect/e2e/__fixtures__/signMessage.ts
@@ -17,7 +17,7 @@ export default {
         {
             description: 'BTC: p2pkh',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 path: "m/44'/0'/0'/0/0",
                 message: 'This is an example of a signed message.',
             },
@@ -32,7 +32,7 @@ export default {
         {
             description: 'BTC: p2sh (segwit)',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 path: "m/49'/0'/0'/0/0",
                 message: 'This is an example of a signed message.',
             },
@@ -47,7 +47,7 @@ export default {
         {
             description: 'BTC: bech32 (segwit-native)',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 path: "m/84'/0'/0'/0/0",
                 message: 'This is an example of a signed message.',
             },
@@ -62,7 +62,7 @@ export default {
         {
             description: 'BTC: long message',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 path: "m/44'/0'/0'/0/0",
                 message: 'VeryLongMessage!'.repeat(64),
             },
@@ -77,7 +77,7 @@ export default {
         {
             description: 'BTC: p2sh long message',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 path: "m/49'/0'/0'/0/0",
                 message: 'VeryLongMessage!'.repeat(64),
             },
@@ -92,7 +92,7 @@ export default {
         {
             description: 'BTC: bech32 long message',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 path: "m/84'/0'/0'/0/0",
                 message: 'VeryLongMessage!'.repeat(64),
             },
@@ -107,7 +107,7 @@ export default {
         // {
         //     description: 'NFKD message',
         //     params: {
-        //         coin: 'Bitcoin',
+        //         coin: 'btc',
         //         path: "m/44'/0'/0'/0/1",
         //         // message: 'Pr\u030ci\u0301s\u030cerne\u030c z\u030clut\u030couc\u030cky\u0301 ku\u030an\u030c u\u0301pe\u030cl d\u030ca\u0301belske\u0301 o\u0301dy za\u0301ker\u030cny\u0301 uc\u030cen\u030c be\u030cz\u030ci\u0301 pode\u0301l zo\u0301ny u\u0301lu\u030a',
         //         message: 'Příšerně žluťoučký kůň úpěl ďábelské ódy zákeřný učeň běží podél zóny úlů',
@@ -120,7 +120,7 @@ export default {
         {
             description: 'NFC message',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 path: "m/44'/0'/0'/0/1",
                 message:
                     'P\u0159\xed\u0161ern\u011b \u017elu\u0165ou\u010dk\xfd k\u016f\u0148 \xfap\u011bl \u010f\xe1belsk\xe9 \xf3dy z\xe1ke\u0159n\xfd u\u010de\u0148 b\u011b\u017e\xed pod\xe9l z\xf3ny \xfal\u016f',
@@ -136,7 +136,7 @@ export default {
         {
             description: 'TESTNET: p2pkh',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 path: "m/44'/1'/0'/0/0",
                 message: 'This is an example of a signed message.',
             },
@@ -151,7 +151,7 @@ export default {
         {
             description: 'TESTNET: p2sh',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 path: "m/49'/1'/0'/0/0",
                 message: 'This is an example of a signed message.',
             },
@@ -166,7 +166,7 @@ export default {
         {
             description: 'TESTNET: bech32',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 path: "m/84'/1'/0'/0/0",
                 message: 'This is an example of a signed message.',
             },
@@ -181,7 +181,7 @@ export default {
         {
             description: 'BCH',
             params: {
-                coin: 'Bcash',
+                coin: 'bch',
                 path: "m/44'/145'/0'/0/0",
                 message: 'This is an example of a signed message.',
             },
@@ -196,7 +196,7 @@ export default {
         {
             description: 'BTC no_script_type p2pkh',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 path: "m/44'/0'/0'/0/0",
                 message: 'This is an example of a signed message.',
                 no_script_type: true,
@@ -213,7 +213,7 @@ export default {
         {
             description: 'BTC no_script_type p2sh',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 path: "m/49'/0'/0'/0/0",
                 message: 'This is an example of a signed message.',
                 no_script_type: true,
@@ -230,7 +230,7 @@ export default {
         {
             description: 'BTC no_script_type p2wpkh',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 path: "m/84'/0'/0'/0/0",
                 message: 'This is an example of a signed message.',
                 no_script_type: true,
@@ -248,7 +248,7 @@ export default {
             description: 'Message over maximum limit allowed by T1B1',
             skip: ['2'],
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 path: "m/84'/0'/0'/0/0",
                 message: 'a'.repeat(1024 + 1),
             },

--- a/packages/connect/e2e/__fixtures__/signTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/signTransaction.ts
@@ -79,7 +79,7 @@ export default {
                     },
                 ],
                 refTxs: TX_CACHE(['e5040e']),
-                coin: 'Testnet',
+                coin: 'test',
             },
             result: {
                 serializedTx:
@@ -106,7 +106,7 @@ export default {
                     },
                 ],
                 refTxs: TX_CACHE(['25fee5']),
-                coin: 'Testnet',
+                coin: 'test',
             },
             result: {
                 serializedTx:
@@ -175,7 +175,7 @@ export default {
                     },
                 ],
                 refTxs: TX_CACHE(['bb5169']),
-                coin: 'testnet',
+                coin: 'test',
             },
             result: {
                 serializedTx:
@@ -239,7 +239,7 @@ export default {
                 ],
                 outputs,
                 refTxs: TX_CACHE(['58d56a']),
-                coin: 'testnet',
+                coin: 'test',
             },
             result: {
                 serializedTx,
@@ -250,7 +250,7 @@ export default {
         {
             description: 'Bitcoin (P2PKH): fee too high',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 inputs: [
                     {
                         address_n: "m/44'/0'/0'/0/10",
@@ -278,7 +278,7 @@ export default {
         {
             description: 'Bitcoin (P2PKH): not enough funds',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 inputs: [
                     {
                         address_n: "m/44'/0'/0'/0/0",
@@ -302,7 +302,7 @@ export default {
         {
             description: 'Testnet (P2PKH): spend coinbase',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/44'/1'/0'/0/0",
@@ -330,7 +330,7 @@ export default {
             // tx e5040e1bc1ae766v7ffb9e5248e90b2fb93cd9150234151ce90e14ab2f5933bcd
             description: 'Testnet (P2PKH): two changes',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/44'/1'/0'/0/0",
@@ -369,7 +369,7 @@ export default {
         {
             description: 'Testnet (P2PKH): p2pkh input, p2sh output',
             params: {
-                coin: 'testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/44'/1'/0'/0/2",
@@ -396,7 +396,7 @@ export default {
         {
             description: 'Testnet (P2PKH): big amount',
             params: {
-                coin: 'testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/44'/1'/0'/0/6",
@@ -423,7 +423,7 @@ export default {
         {
             description: 'Testnet (P2PKH): change on mainchain allowed',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/44'/1'/0'/0/0",

--- a/packages/connect/e2e/__fixtures__/signTransactionBcash.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionBcash.ts
@@ -9,7 +9,7 @@ export default {
         {
             description: 'Bcash: 1 input, 1 output, 1 change',
             params: {
-                coin: 'Bcash',
+                coin: 'bch',
                 inputs: [
                     {
                         address_n: "m/44'/145'/0'/0/0",
@@ -45,7 +45,7 @@ export default {
         {
             description: 'Bcash: 2 inputs, 1 output, no change',
             params: {
-                coin: 'Bcash',
+                coin: 'bch',
                 inputs: [
                     {
                         address_n: "m/44'/145'/0'/1/0",
@@ -85,7 +85,7 @@ export default {
         {
             description: 'Bcash: legacy address in output',
             params: {
-                coin: 'Bcash',
+                coin: 'bch',
                 inputs: [
                     {
                         address_n: "m/44'/145'/0'/1/0",

--- a/packages/connect/e2e/__fixtures__/signTransactionBech32.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionBech32.ts
@@ -9,7 +9,7 @@ export default {
         {
             description: 'Testnet (Bech32/P2WPKH): 1 input, 3 outputs',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/84'/1'/0'/0/0",
@@ -52,7 +52,7 @@ export default {
         {
             description: 'Testnet (Bech32/P2WPKH): 3 inputs, no change',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/84'/1'/0'/0/0",
@@ -105,7 +105,7 @@ export default {
         {
             description: 'Testnet (Bech32/P2WPKH): 1 input, OP_RETURN output + change',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/84'/1'/0'/1/4",

--- a/packages/connect/e2e/__fixtures__/signTransactionBgold.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionBgold.ts
@@ -20,7 +20,7 @@ export default {
         {
             description: 'Bgold: 1 input, 1output, 1 change',
             params: {
-                coin: 'Bgold',
+                coin: 'btg',
                 inputs: [
                     {
                         address_n: "m/44'/156'/0'/0/0",
@@ -54,7 +54,7 @@ export default {
         {
             description: 'Bgold: 2 inputs, 1 output, no change',
             params: {
-                coin: 'Bgold',
+                coin: 'btg',
                 inputs: [
                     {
                         address_n: "m/44'/156'/0'/0/0",
@@ -91,7 +91,7 @@ export default {
         {
             description: 'Bgold (P2SH): 1 input, 2 outputs, no change',
             params: {
-                coin: 'Bgold',
+                coin: 'btg',
                 inputs: [
                     {
                         address_n: "m/49'/156'/0'/1/0",
@@ -125,7 +125,7 @@ export default {
         {
             description: 'Bgold (P2SH): 1 input, 1output, 1 change',
             params: {
-                coin: 'Bgold',
+                coin: 'btg',
                 inputs: [
                     {
                         address_n: "m/49'/156'/0'/1/0",
@@ -159,7 +159,7 @@ export default {
         {
             description: 'Bgold (P2SH): spend multisig input',
             params: {
-                coin: 'Bgold',
+                coin: 'btg',
                 inputs: [
                     {
                         address_n: "m/49'/156'/1'/1/0",

--- a/packages/connect/e2e/__fixtures__/signTransactionDoge.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionDoge.ts
@@ -12,7 +12,7 @@ export default {
             skip: ['>1.11.0', '>2.5.0'], // test works only in FW lower than 1.11.1 and 2.5.1
             description: 'Doge: big amounts',
             params: {
-                coin: 'Doge',
+                coin: 'doge',
                 inputs: [
                     {
                         address_n: "m/44'/3'/0'/1/0",

--- a/packages/connect/e2e/__fixtures__/signTransactionExternal.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionExternal.ts
@@ -15,7 +15,7 @@ export default {
             // "error": "signing.c:1021:Unsupported script type.",
             skip: ['1', '<2.3.2'],
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         amount: '31000000',
@@ -79,7 +79,7 @@ export default {
             // "error": "signing.c:1021:Unsupported script type.",
             skip: ['1', '<2.3.2'],
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         amount: '123456789',
@@ -136,7 +136,7 @@ export default {
             // "error": "signing.c:1021:Unsupported script type.",
             skip: ['1', '<2.3.2'],
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/84'/1'/0'/0/0",
@@ -188,7 +188,7 @@ export default {
             // "error": "messages.c:231:bytes overflow",
             skip: ['1', '<2.3.2'],
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/84'/1'/0'/0/0",
@@ -235,7 +235,7 @@ export default {
             // "error": "signing.c:1021:Unsupported script type.",
             skip: ['1', '<2.4.3'],
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/86'/1'/0'/0/1",
@@ -299,7 +299,7 @@ export default {
             // "error": "signing.c:1021:Unsupported script type.",
             skip: ['1', '<2.4.4'], // bug in prev implementation https://github.com/trezor/trezor-firmware/pull/2034
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         amount: '100000',
@@ -353,7 +353,7 @@ export default {
                 mnemonic: 'mnemonic_abandon', // <- important, external input is from all-all (previous case)
             },
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         amount: '100892',

--- a/packages/connect/e2e/__fixtures__/signTransactionMultisig.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionMultisig.ts
@@ -44,7 +44,7 @@ export default {
         {
             description: 'Testnet (multisig): 2 of 3 (sign with 1st key)',
             params: {
-                coin: 'testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/48'/1'/1'/0'/0/0",
@@ -77,7 +77,7 @@ export default {
         {
             description: 'Testnet (multisig): 2 of 3 (sign with 3rd key)',
             params: {
-                coin: 'testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/48'/1'/3'/0'/0/0",
@@ -112,7 +112,7 @@ export default {
         {
             description: 'Testnet (multisig): 15 of 15 (sign with 15th key)',
             params: {
-                coin: 'testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/48'/1'/1'/0'/0/14",
@@ -165,7 +165,7 @@ export default {
                 mnemonic: 'mnemonic_12',
             },
             params: {
-                coin: 'testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/48'/1'/1'/0'/0/0",
@@ -206,7 +206,7 @@ export default {
                     'solar segment strike patrol broccoli witness praise tennis fat elegant yellow menu favorite upgrade grace pulp subject tribe impact head west museum pulse term',
             },
             params: {
-                coin: 'testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: [2147483696, 2147483649, 2147483648, 2147483650, 0, 13],

--- a/packages/connect/e2e/__fixtures__/signTransactionMultisigChange.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionMultisigChange.ts
@@ -73,7 +73,7 @@ export default {
         {
             description: 'Testnet (multisig): external external',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [input1, input2],
                 outputs: [
                     {
@@ -97,7 +97,7 @@ export default {
         {
             description: 'Testnet (multisig): external internal',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [input1, input2],
                 outputs: [
                     {
@@ -121,7 +121,7 @@ export default {
         {
             description: 'Testnet (multisig): internal internal',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [input1, input2],
                 outputs: [
                     {
@@ -145,7 +145,7 @@ export default {
         {
             description: 'Testnet (multisig): external external',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [input1, input2],
                 outputs: [
                     {

--- a/packages/connect/e2e/__fixtures__/signTransactionMultisigPubkeysOrder.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionMultisigPubkeysOrder.ts
@@ -30,7 +30,7 @@ export default {
         {
             description: 'Testnet (multisig): 2 of 3 (unorderd)',
             params: {
-                coin: 'testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/48'/1'/1'/0'/0/0",
@@ -65,7 +65,7 @@ export default {
         {
             description: 'Testnet (multisig): 2 of 3 (errors when ordered gives wrong key))',
             params: {
-                coin: 'testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/48'/1'/1'/0'/0/0",

--- a/packages/connect/e2e/__fixtures__/signTransactionPaymentRequest.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionPaymentRequest.ts
@@ -15,7 +15,7 @@ export default {
             description: 'Testnet (Bech32/P2WPKH): Payment request success',
             skip: ['1', '<2.9.4'], // payment requests are not implemented in T1B1 and proto was changed in 2.9.4
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/84'/1'/0'/0/0",

--- a/packages/connect/e2e/__fixtures__/signTransactionReplace.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionReplace.ts
@@ -9,7 +9,7 @@ export default {
         {
             description: 'Bitcoin (RBF): P2PKH bump fee',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 inputs: [
                     {
                         address_n: "m/44'/0'/0'/0/4",
@@ -50,7 +50,7 @@ export default {
         {
             description: 'Testnet (RBF): P2PKH in P2SH, remove change',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/49'/1'/0'/0/4",
@@ -95,7 +95,7 @@ export default {
         {
             description: 'Testnet (RBF): Bech32/P2WPKH finalize',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/84'/1'/0'/0/2",
@@ -140,7 +140,7 @@ export default {
             skip: ['1'], // disable this for T1B1. Failure_DataError: messages.c:224:missing required field
             description: 'Testnet (RBF): Meld transactions',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/49'/1'/0'/0/4",
@@ -221,7 +221,7 @@ export default {
         {
             description: 'Testnet (RBF): with OP_RETURN output',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/84'/1'/1'/0/14",
@@ -265,7 +265,7 @@ export default {
         {
             description: 'Testnet (RBF): add new utxo and change output',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/84'/1'/0'/0/65",
@@ -316,7 +316,7 @@ export default {
         {
             description: 'Testnet (RBF): decrease output',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/49'/1'/0'/0/4",
@@ -362,7 +362,7 @@ export default {
             description: 'Testnet (RBF): Taproot',
             skip: ['<1.10.4', '<2.4.3'],
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/86'/1'/0'/1/0",

--- a/packages/connect/e2e/__fixtures__/signTransactionSegwit.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionSegwit.ts
@@ -9,7 +9,7 @@ export default {
         {
             description: 'Testnet (P2SH): 1 input, 2 outputs, no change',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/49'/1'/0'/1/0",
@@ -42,7 +42,7 @@ export default {
         {
             description: 'Testnet (P2SH): 1 input, 2 outputs, 1 change',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/49'/1'/0'/1/0",
@@ -75,7 +75,7 @@ export default {
         {
             description: 'Testnet (P2SH): send multisig',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/49'/1'/1'/1/0",

--- a/packages/connect/e2e/__fixtures__/signTransactionTaproot.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionTaproot.ts
@@ -13,7 +13,7 @@ export default {
             description: 'Testnet (P2TR): send Taproot',
             skip: ['<1.10.4', '<2.4.3'],
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/86'/1'/0'/1/0",
@@ -43,7 +43,7 @@ export default {
             description: 'Testnet (P2TR): 2 inputs, 1 output, 1 change',
             skip: ['<1.10.4', '<2.4.3'],
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/86'/1'/0'/0/0",
@@ -85,7 +85,7 @@ export default {
             description: 'Testnet: send mixed inputs to mixed outputs',
             skip: ['<1.10.4', '<2.4.3'],
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 inputs: [
                     {
                         address_n: "m/49'/1'/1'/0/0",

--- a/packages/connect/e2e/__fixtures__/signTransactionZcash.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionZcash.ts
@@ -11,7 +11,7 @@ export default {
             description: 'Zcash: inputs v1, no change',
             skip: ['>1.8.3', '>2.1.8'], // test works only in FW range [1.8.1 - 1.8.3] and [2.1.1 - 2.1.8]
             params: {
-                coin: 'Zcash',
+                coin: 'zec',
                 inputs: [
                     {
                         address_n: "m/44'/133'/0'/0/2",
@@ -47,7 +47,7 @@ export default {
             description: 'Zcash: input v2, no change',
             skip: ['>1.8.3', '>2.1.8'], // test works only in FW range [1.8.1 - 1.8.3] and [2.1.1 - 2.1.8]
             params: {
-                coin: 'Zcash',
+                coin: 'zec',
                 inputs: [
                     {
                         address_n: "m/44'/133'/0'/0/0",
@@ -76,7 +76,7 @@ export default {
             // Inputs from https://zec.trezor.io/tx/e2802f0118d9f41f68b65f2b9f4a7c2efc876aee4e8c4b48c4a4deef6b7c0c28
             description: 'Zcash: unsupported inputs v3, with change',
             params: {
-                coin: 'Zcash',
+                coin: 'zec',
                 version: 3,
                 overwintered: true,
                 versionGroupId: 0x03c48270,
@@ -128,7 +128,7 @@ export default {
             description: 'Zcash: input v4',
             skip: ['<1.9.0', '<2.2.0', '>1.11.0', '>2.5.0'],
             params: {
-                coin: 'Zcash',
+                coin: 'zec',
                 version: 4,
                 overwintered: true,
                 versionGroupId: 0x892f2085,

--- a/packages/connect/e2e/__fixtures__/verifyMessage.ts
+++ b/packages/connect/e2e/__fixtures__/verifyMessage.ts
@@ -7,7 +7,7 @@ export default {
         {
             description: 'uncompressed pubkey - ok',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 address: '1JwSSubhmg6iPtRjtyqhUYYH7bZg3Lfy1T',
                 signature: Buffer.from(
                     '1ba77e01a9e17ba158b962cfef5f13dfed676ffc2b4bada24e58f784458b52b97421470d001d53d5880cf5e10e76f02be3e80bf21e18398cbd41e8c3b4af74c8c2',
@@ -25,7 +25,7 @@ export default {
         {
             description: 'compressed pubkey - wrong sig',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 address: '1JwSSubhmg6iPtRjtyqhUYYH7bZg3Lfy1T',
                 signature: Buffer.from(
                     '1ba77e01a9e17ba158b962cfef5f13dfed676ffc2b4bada24e58f784458b52b97421470d001d53d5880cf5e10e76f02be3e80bf21e18398cbd41e8c3b4af74c800',
@@ -38,7 +38,7 @@ export default {
         {
             description: 'compressed pubkey - wrong msg',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 address: '1JwSSubhmg6iPtRjtyqhUYYH7bZg3Lfy1T',
                 signature: Buffer.from(
                     '1ba77e01a9e17ba158b962cfef5f13dfed676ffc2b4bada24e58f784458b52b97421470d001d53d5880cf5e10e76f02be3e80bf21e18398cbd41e8c3b4af74c8c2',
@@ -51,7 +51,7 @@ export default {
         {
             description: 'compressed pubkey - ok',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 address: '1C7zdTfnkzmr13HfA2vNm5SJYRK6nEKyq8',
                 signature: Buffer.from(
                     '1f44e3e461f7ca9f57c472ce1a28214df1de1dadefb6551a32d1907b80c74d5a1fbfd6daaba12dd8cb06699ce3f6941fbe0f3957b5802d13076181046e741eaaaf',
@@ -66,7 +66,7 @@ export default {
         {
             description: 'trezor pubkey - wrong sig',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 address: '1C7zdTfnkzmr13HfA2vNm5SJYRK6nEKyq8',
                 signature: Buffer.from(
                     '1f44e3e461f7ca9f57c472ce1a28214df1de1dadefb6551a32d1907b80c74d5a1fbfd6daaba12dd8cb06699ce3f6941fbe0f3957b5802d13076181046e741eaa00',
@@ -79,7 +79,7 @@ export default {
         {
             description: 'trezor pubkey - ok',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 address: '14LmW5k4ssUrtbAB4255zdqv3b4w1TuX9e',
                 signature: Buffer.from(
                     '209e23edf0e4e47ff1dec27f32cd78c50e74ef018ee8a6adf35ae17c7a9b0dd96f48b493fd7dbab03efb6f439c6383c9523b3bbc5f1a7d158a6af90ab154e9be80',
@@ -97,7 +97,7 @@ export default {
         {
             description: 'trezor pubkey - wrong msg',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 address: '14LmW5k4ssUrtbAB4255zdqv3b4w1TuX9e',
                 signature: Buffer.from(
                     '209e23edf0e4e47ff1dec27f32cd78c50e74ef018ee8a6adf35ae17c7a9b0dd96f48b493fd7dbab03efb6f439c6383c9523b3bbc5f1a7d158a6af90ab154e9be80',
@@ -110,7 +110,7 @@ export default {
         {
             description: 'verify long',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 address: '14LmW5k4ssUrtbAB4255zdqv3b4w1TuX9e',
                 signature: Buffer.from(
                     '205ff795c29aef7538f8b3bdb2e8add0d0722ad630a140b6aefd504a5a895cbd867cbb00981afc50edd0398211e8d7c304bb8efa461181bc0afa67ea4a720a89ed',
@@ -125,7 +125,7 @@ export default {
         {
             description: 'verify bcash',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 address: '1KzXE97kV7DrpxCViCN3HbGbiKhzzPM7TQ',
                 signature: Buffer.from(
                     '1cc694f0f23901dfe3603789142f36a3fc582d0d5c0ec7215cf2ccd641e4e37228504f3d4dc3eea28bbdbf5da27c49d4635c097004d9f228750ccd836a8e1460c0',

--- a/packages/connect/e2e/__fixtures__/verifyMessageSegwit.ts
+++ b/packages/connect/e2e/__fixtures__/verifyMessageSegwit.ts
@@ -7,7 +7,7 @@ export default {
         {
             description: 'trezor pubkey - ok',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 address: '3CwYaeWxhpXXiHue3ciQez1DLaTEAXcKa1',
                 signature: Buffer.from(
                     '249e23edf0e4e47ff1dec27f32cd78c50e74ef018ee8a6adf35ae17c7a9b0dd96f48b493fd7dbab03efb6f439c6383c9523b3bbc5f1a7d158a6af90ab154e9be80',
@@ -22,7 +22,7 @@ export default {
         {
             description: 'trezor pubkey - wrong sig',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 address: '3CwYaeWxhpXXiHue3ciQez1DLaTEAXcKa1',
                 signature: Buffer.from(
                     '249e23edf0e4e47ff1dec27f32cd78c50e74ef018ee8a6adf35ae17c7a9b0dd96f48b493fd7dbab03efb6f439c6383c9523b3bbc5f1a7d158a6af90ab154e9be00',
@@ -35,7 +35,7 @@ export default {
         {
             description: 'trezor pubkey - wrong msg',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 address: '3CwYaeWxhpXXiHue3ciQez1DLaTEAXcKa1',
                 signature: Buffer.from(
                     '249e23edf0e4e47ff1dec27f32cd78c50e74ef018ee8a6adf35ae17c7a9b0dd96f48b493fd7dbab03efb6f439c6383c9523b3bbc5f1a7d158a6af90ab154e9be80',
@@ -48,7 +48,7 @@ export default {
         {
             description: 'verify long',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 address: '3CwYaeWxhpXXiHue3ciQez1DLaTEAXcKa1',
                 signature: Buffer.from(
                     '245ff795c29aef7538f8b3bdb2e8add0d0722ad630a140b6aefd504a5a895cbd867cbb00981afc50edd0398211e8d7c304bb8efa461181bc0afa67ea4a720a89ed',
@@ -63,7 +63,7 @@ export default {
         {
             description: 'verify testnet',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 address: '2N4VkePSzKH2sv5YBikLHGvzUYvfPxV6zS9',
                 signature: Buffer.from(
                     '249e23edf0e4e47ff1dec27f32cd78c50e74ef018ee8a6adf35ae17c7a9b0dd96f48b493fd7dbab03efb6f439c6383c9523b3bbc5f1a7d158a6af90ab154e9be80',

--- a/packages/connect/e2e/__fixtures__/verifyMessageSegwitNative.ts
+++ b/packages/connect/e2e/__fixtures__/verifyMessageSegwitNative.ts
@@ -7,7 +7,7 @@ export default {
         {
             description: 'trezor pubkey - ok',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 address: 'bc1qyjjkmdpu7metqt5r36jf872a34syws33s82q2j',
                 signature: Buffer.from(
                     '289e23edf0e4e47ff1dec27f32cd78c50e74ef018ee8a6adf35ae17c7a9b0dd96f48b493fd7dbab03efb6f439c6383c9523b3bbc5f1a7d158a6af90ab154e9be80',
@@ -22,7 +22,7 @@ export default {
         {
             description: 'trezor pubkey - wrong sig',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 address: 'bc1qyjjkmdpu7metqt5r36jf872a34syws33s82q2j',
                 signature: Buffer.from(
                     '289e23edf0e4e47ff1dec27f32cd78c50e74ef018ee8a6adf35ae17c7a9b0dd96f48b493fd7dbab03efb6f439c6383c9523b3bbc5f1a7d158a6af90ab154e9be00',
@@ -35,7 +35,7 @@ export default {
         {
             description: 'trezor pubkey - wrong msg',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 address: 'bc1qyjjkmdpu7metqt5r36jf872a34syws33s82q2j',
                 signature: Buffer.from(
                     '289e23edf0e4e47ff1dec27f32cd78c50e74ef018ee8a6adf35ae17c7a9b0dd96f48b493fd7dbab03efb6f439c6383c9523b3bbc5f1a7d158a6af90ab154e9be80',
@@ -48,7 +48,7 @@ export default {
         {
             description: 'verify long',
             params: {
-                coin: 'Bitcoin',
+                coin: 'btc',
                 address: 'bc1qyjjkmdpu7metqt5r36jf872a34syws33s82q2j',
                 signature: Buffer.from(
                     '285ff795c29aef7538f8b3bdb2e8add0d0722ad630a140b6aefd504a5a895cbd867cbb00981afc50edd0398211e8d7c304bb8efa461181bc0afa67ea4a720a89ed',
@@ -63,7 +63,7 @@ export default {
         {
             description: 'verify testnet',
             params: {
-                coin: 'Testnet',
+                coin: 'test',
                 address: 'tb1qyjjkmdpu7metqt5r36jf872a34syws336p3n3p',
                 signature: Buffer.from(
                     '289e23edf0e4e47ff1dec27f32cd78c50e74ef018ee8a6adf35ae17c7a9b0dd96f48b493fd7dbab03efb6f439c6383c9523b3bbc5f1a7d158a6af90ab154e9be80',

--- a/packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts
+++ b/packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts
@@ -52,7 +52,7 @@ describe('TrezorConnect.authorizeCoinjoin', () => {
                 maxCoordinatorFeeRate: 500000, // 5% => 0.005 * 10**8;
                 maxFeePerKvbyte: 3500,
                 path: "m/10025'/1'/0'/1'",
-                coin: 'Testnet',
+                coin: 'test',
                 scriptType: 'SPENDTAPROOT',
             });
 
@@ -72,7 +72,7 @@ describe('TrezorConnect.authorizeCoinjoin', () => {
                 '0f7777772e6578616d706c652e636f6d0000000000000000000000000000000000000000000000000000000000000001';
 
             const proof = await TrezorConnect.getOwnershipProof({
-                coin: 'Testnet',
+                coin: 'test',
                 path: "m/10025'/1'/0'/1'/1/0",
                 scriptType: 'SPENDTAPROOT',
                 userConfirmation: true, // ButtonRequest is not emitted because of preauthorization
@@ -159,7 +159,7 @@ describe('TrezorConnect.authorizeCoinjoin', () => {
                     },
                 ],
                 coinjoinRequest,
-                coin: 'testnet',
+                coin: 'test',
                 preauthorized: true,
                 unlockPath: unlockPath.payload, // NOTE: unlock path is required for validation, it will be removed in future
                 serialize: false,
@@ -236,7 +236,7 @@ describe('TrezorConnect.authorizeCoinjoin', () => {
             maxCoordinatorFeeRate: 500000, // 5% => 0.005 * 10**8;
             maxFeePerKvbyte: 3500,
             path: "m/10025'/1'/0'/1'",
-            coin: 'Testnet',
+            coin: 'test',
             scriptType: 'SPENDTAPROOT',
         } as const;
 

--- a/packages/connect/e2e/tests/device/cancel.test.ts
+++ b/packages/connect/e2e/tests/device/cancel.test.ts
@@ -1,11 +1,12 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import TrezorConnect from '@trezor/connect';
+import type { CoinSymbol } from '@trezor/connect-common';
 import type { TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
 import { Model } from '@trezor/trezor-user-env-link';
 
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
-const getAddress = (showOnTrezor: boolean, coin: string = 'regtest') =>
+const getAddress = (showOnTrezor: boolean, coin: CoinSymbol = 'regtest') =>
     TrezorConnect.getAddress({
         path: "m/84'/1'/0'/0/0",
         coin,
@@ -35,7 +36,7 @@ const assertGetAddressWorks = async () => {
     // validate that further communication is possible without any glitch
     TrezorConnect.on('ui-request_passphrase', passphraseHandler(''));
     TrezorConnect.on('ui-request_confirmation', addressHandler());
-    const getAddressResponse = await getAddress(false, 'testnet');
+    const getAddressResponse = await getAddress(false, 'test');
     expect(getAddressResponse).toMatchObject({
         success: true,
         payload: { address: 'tb1qkvwu9g3k2pdxewfqr7syz89r3gj557l3uuf9r9' },

--- a/packages/connect/e2e/tests/device/cancelCoinjoinAuthorization.test.ts
+++ b/packages/connect/e2e/tests/device/cancelCoinjoinAuthorization.test.ts
@@ -30,7 +30,7 @@ describe('TrezorConnect.cancelCoinjoinAuthorization', () => {
             maxCoordinatorFeeRate: 500000, // 5% => 0.005 * 10**8;
             maxFeePerKvbyte: 3500,
             path: "m/10025'/1'/0'/1'",
-            coin: 'Testnet',
+            coin: 'test',
             scriptType: 'SPENDTAPROOT',
         });
 
@@ -41,7 +41,7 @@ describe('TrezorConnect.cancelCoinjoinAuthorization', () => {
             '0f7777772e6578616d706c652e636f6d0000000000000000000000000000000000000000000000000000000000000001';
 
         const proof = await TrezorConnect.getOwnershipProof({
-            coin: 'Testnet',
+            coin: 'test',
             path: "m/10025'/1'/0'/1'/1/0",
             scriptType: 'SPENDTAPROOT',
             userConfirmation: true,
@@ -56,7 +56,7 @@ describe('TrezorConnect.cancelCoinjoinAuthorization', () => {
         expect(cancelAuthResult.payload.message).toBe('Authorization cancelled');
 
         const proof2 = await TrezorConnect.getOwnershipProof({
-            coin: 'Testnet',
+            coin: 'test',
             path: "m/10025'/1'/0'/1'/1/0",
             scriptType: 'SPENDTAPROOT',
             userConfirmation: true,

--- a/packages/connect/e2e/tests/device/unlockPath.test.ts
+++ b/packages/connect/e2e/tests/device/unlockPath.test.ts
@@ -32,7 +32,7 @@ describe('TrezorConnect.unlockPath', () => {
         const address = await TrezorConnect.getAddress({
             path: "m/10025'/1'/0'/1'/0/0",
             unlockPath: unlockPath.payload,
-            coin: 'Testnet',
+            coin: 'test',
         });
         if (!address.success) throw new Error(address.error.message);
 
@@ -43,7 +43,7 @@ describe('TrezorConnect.unlockPath', () => {
         const address2 = await TrezorConnect.getAddress({
             path: "m/10025'/1'/0'/1'/0/1",
             unlockPath: unlockPath.payload,
-            coin: 'Testnet',
+            coin: 'test',
         });
         if (!address2.success) throw new Error(address2.error.message);
 
@@ -58,13 +58,13 @@ describe('TrezorConnect.unlockPath', () => {
                     path: "m/10025'/1'/0'/1'/0/0",
                     unlockPath: unlockPath.payload,
                     showOnTrezor: false,
-                    coin: 'Testnet',
+                    coin: 'test',
                 },
                 {
                     path: "m/10025'/1'/0'/1'/0/1",
                     unlockPath: unlockPath.payload,
                     showOnTrezor: false,
-                    coin: 'Testnet',
+                    coin: 'test',
                 },
             ],
         });
@@ -83,7 +83,7 @@ describe('TrezorConnect.unlockPath', () => {
         const changeAddress = await TrezorConnect.getAddress({
             path: "m/10025'/1'/0'/1'/1/1",
             unlockPath: unlockPath.payload,
-            coin: 'Testnet',
+            coin: 'test',
         });
         if (changeAddress.success) throw new Error('Expected error');
         expect(changeAddress.error).toMatchObject({ message: 'Forbidden key path' });
@@ -92,7 +92,7 @@ describe('TrezorConnect.unlockPath', () => {
         const otherAccount = await TrezorConnect.getAddress({
             path: "m/10025'/1'/1'/1'/0/0",
             unlockPath: unlockPath.payload,
-            coin: 'Testnet',
+            coin: 'test',
         });
         if (otherAccount.success) throw new Error('Expected error');
         expect(otherAccount.error).toMatchObject({ message: 'Forbidden key path' });
@@ -112,7 +112,7 @@ describe('TrezorConnect.unlockPath', () => {
         const unlockedPublicKey = await TrezorConnect.getPublicKey({
             path: "m/10025'/1'/0'/1'",
             unlockPath: unlockPath.payload,
-            coin: 'Testnet',
+            coin: 'test',
         });
 
         if (!unlockedPublicKey.success) throw new Error(unlockedPublicKey.error.message);
@@ -128,13 +128,13 @@ describe('TrezorConnect.unlockPath', () => {
                     path: "m/10025'/1'/0'/1'",
                     unlockPath: unlockPath.payload,
                     showOnTrezor: true,
-                    coin: 'Testnet',
+                    coin: 'test',
                 },
                 {
                     path: "m/10025'/1'/1'/1'",
                     unlockPath: unlockPath.payload,
                     showOnTrezor: true,
-                    coin: 'Testnet',
+                    coin: 'test',
                 },
             ],
         });
@@ -154,7 +154,7 @@ describe('TrezorConnect.unlockPath', () => {
 
         const forbiddenPublicKey = await TrezorConnect.getPublicKey({
             path: "m/10025'/1'/0'/1'",
-            coin: 'Testnet',
+            coin: 'test',
         });
 
         if (forbiddenPublicKey.success) throw new Error('Expected error');
@@ -197,7 +197,7 @@ describe('TrezorConnect.unlockPath', () => {
                     script_type: 'PAYTOADDRESS' as const,
                 },
             ],
-            coin: 'Testnet',
+            coin: 'test' as const,
         };
 
         const unlockedSignTx = await TrezorConnect.signTransaction({

--- a/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
@@ -62,7 +62,7 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
         this.hasBundle = hasBundle;
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Cardano'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Cardano')];
+        this.requiredFirmwareCoins = [getMiscNetwork('ada')];
     }
 
     get requiredPermissions(): PermissionRequest[] {

--- a/packages/connect/src/api/cardano/api/cardanoGetNativeScriptHash.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetNativeScriptHash.ts
@@ -64,7 +64,7 @@ export default class CardanoGetNativeScriptHash extends AbstractMethod<
 
         super(message, params);
         this.requiredDeviceCapabilities = ['Capability_Cardano'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Cardano')];
+        this.requiredFirmwareCoins = [getMiscNetwork('ada')];
     }
 
     get requiredPermissions(): PermissionRequest[] {

--- a/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
@@ -51,7 +51,7 @@ export default class CardanoGetPublicKey extends AbstractMethod<'cardanoGetPubli
             batch => batch.suppressBackupWarning || !batch.proto.show_display,
         );
         this.requiredDeviceCapabilities = ['Capability_Cardano'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Cardano')];
+        this.requiredFirmwareCoins = [getMiscNetwork('ada')];
     }
 
     get requiredPermissions(): PermissionRequest[] {

--- a/packages/connect/src/api/cardano/api/cardanoSignMessage.ts
+++ b/packages/connect/src/api/cardano/api/cardanoSignMessage.ts
@@ -64,7 +64,7 @@ export default class CardanoSignMessage extends AbstractMethod<
 
         super(message, params);
 
-        this.requiredFirmwareCoins = [getMiscNetwork('Cardano')];
+        this.requiredFirmwareCoins = [getMiscNetwork('ada')];
     }
 
     get requiredPermissions(): PermissionRequest[] {

--- a/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
+++ b/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
@@ -233,7 +233,7 @@ export default class CardanoSignTransaction extends AbstractMethod<
         super(message, params);
 
         this.requiredDeviceCapabilities = ['Capability_Cardano'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Cardano')];
+        this.requiredFirmwareCoins = [getMiscNetwork('ada')];
     }
 
     get requiredPermissions(): PermissionRequest[] {

--- a/packages/connect/src/api/getOwnershipId.ts
+++ b/packages/connect/src/api/getOwnershipId.ts
@@ -5,6 +5,7 @@ import {
     UI_REQUEST,
     createUiMessage,
 } from '@trezor/connect-common';
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
@@ -26,8 +27,12 @@ export default class GetOwnershipId extends AbstractMethod<
 
         const preprocessed = payload.bundle.map(batch => {
             const address_n = validatePath(batch.path, 1);
+            const coinInfo = getBitcoinNetwork(batch.coin || address_n);
+            if (batch.coin && !coinInfo) {
+                throw ERRORS.TypedError('Method_UnknownCoin');
+            }
 
-            return { batch, address_n, coinInfo: getBitcoinNetwork(batch.coin || address_n) };
+            return { batch, address_n, coinInfo };
         });
 
         const params = preprocessed.map(({ batch, address_n, coinInfo }) => {

--- a/packages/connect/src/api/getOwnershipProof.ts
+++ b/packages/connect/src/api/getOwnershipProof.ts
@@ -5,6 +5,7 @@ import {
     UI_REQUEST,
     createUiMessage,
 } from '@trezor/connect-common';
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
@@ -26,8 +27,12 @@ export default class GetOwnershipProof extends AbstractMethod<
 
         const preprocessed = payload.bundle.map(batch => {
             const address_n = validatePath(batch.path, 1);
+            const coinInfo = getBitcoinNetwork(batch.coin || address_n);
+            if (batch.coin && !coinInfo) {
+                throw ERRORS.TypedError('Method_UnknownCoin');
+            }
 
-            return { batch, address_n, coinInfo: getBitcoinNetwork(batch.coin || address_n) };
+            return { batch, address_n, coinInfo };
         });
 
         const params = preprocessed.map(({ batch, address_n, coinInfo }) => {

--- a/packages/connect/src/api/monero/api/moneroGetAddress.ts
+++ b/packages/connect/src/api/monero/api/moneroGetAddress.ts
@@ -56,7 +56,7 @@ export default class MoneroGetAddress extends AbstractMethod<'moneroGetAddress',
         this.hasBundle = hasBundle;
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Monero'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Monero')];
+        this.requiredFirmwareCoins = [getMiscNetwork('xmr')];
     }
 
     get requiredPermissions(): PermissionRequest[] {

--- a/packages/connect/src/api/monero/api/moneroGetWatchKey.ts
+++ b/packages/connect/src/api/monero/api/moneroGetWatchKey.ts
@@ -36,7 +36,7 @@ export default class MoneroGetWatchKeyMethod extends AbstractMethod<'moneroGetWa
         super(message, params);
 
         this.requiredDeviceCapabilities = ['Capability_Monero'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Monero')];
+        this.requiredFirmwareCoins = [getMiscNetwork('xmr')];
     }
 
     get requiredPermissions(): PermissionRequest[] {

--- a/packages/connect/src/api/monero/api/moneroKeyImageSync.ts
+++ b/packages/connect/src/api/monero/api/moneroKeyImageSync.ts
@@ -115,7 +115,7 @@ export default class MoneroKeyImageSyncMethod extends AbstractMethod<'moneroKeyI
         super(message, params);
 
         this.requiredDeviceCapabilities = ['Capability_Monero'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Monero')];
+        this.requiredFirmwareCoins = [getMiscNetwork('xmr')];
     }
 
     get requiredPermissions(): PermissionRequest[] {

--- a/packages/connect/src/api/monero/api/moneroSignTransaction.ts
+++ b/packages/connect/src/api/monero/api/moneroSignTransaction.ts
@@ -179,7 +179,7 @@ export default class MoneroSignTransactionMethod extends AbstractMethod<
         super(message, params);
 
         this.requiredDeviceCapabilities = ['Capability_Monero'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Monero')];
+        this.requiredFirmwareCoins = [getMiscNetwork('xmr')];
     }
 
     get info() {

--- a/packages/connect/src/api/ripple/api/rippleGetAddress.ts
+++ b/packages/connect/src/api/ripple/api/rippleGetAddress.ts
@@ -9,7 +9,7 @@ export default class RippleGetAddress extends AbstractMiscGetAddress<'rippleGetA
     constructor(message: MethodMessage<'rippleGetAddress'>) {
         super(message, 3);
         this.requiredDeviceCapabilities = ['Capability_Ripple'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Ripple')];
+        this.requiredFirmwareCoins = [getMiscNetwork('xrp')];
     }
 
     get info() {

--- a/packages/connect/src/api/ripple/api/rippleSignTransaction.ts
+++ b/packages/connect/src/api/ripple/api/rippleSignTransaction.ts
@@ -51,7 +51,7 @@ export default class RippleSignTransaction extends AbstractMethod<
         super(message, params);
 
         this.requiredDeviceCapabilities = ['Capability_Ripple'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Ripple')];
+        this.requiredFirmwareCoins = [getMiscNetwork('xrp')];
     }
 
     get requiredPermissions(): PermissionRequest[] {

--- a/packages/connect/src/api/signMessage.ts
+++ b/packages/connect/src/api/signMessage.ts
@@ -2,6 +2,7 @@
 
 import type { BitcoinNetworkInfo, PermissionRequest } from '@trezor/connect-common';
 import { SignMessage as SignMessageSchema } from '@trezor/connect-common';
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
@@ -26,6 +27,9 @@ export default class SignMessage extends AbstractMethod<'signMessage', Params> {
         let coinInfo;
         if (payload.coin) {
             coinInfo = getBitcoinNetwork(payload.coin);
+            if (!coinInfo) {
+                throw ERRORS.TypedError('Method_UnknownCoin');
+            }
             validateCoinPath(path, coinInfo);
         } else {
             coinInfo = getBitcoinNetwork(path);

--- a/packages/connect/src/api/solana/api/solanaGetAddress.ts
+++ b/packages/connect/src/api/solana/api/solanaGetAddress.ts
@@ -7,7 +7,7 @@ export default class SolanaGetAddress extends AbstractMiscGetAddress<'solanaGetA
     constructor(message: MethodMessage<'solanaGetAddress'>) {
         super(message, 2);
         this.requiredDeviceCapabilities = ['Capability_Solana'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Solana')];
+        this.requiredFirmwareCoins = [getMiscNetwork('sol')];
     }
 
     get info() {

--- a/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
+++ b/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
@@ -42,7 +42,7 @@ export default class SolanaGetPublicKey extends AbstractMethod<
         this.hasBundle = hasBundle;
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Solana'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Solana')];
+        this.requiredFirmwareCoins = [getMiscNetwork('sol')];
     }
 
     get requiredPermissions(): PermissionRequest[] {

--- a/packages/connect/src/api/solana/api/solanaSignTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaSignTransaction.ts
@@ -69,7 +69,7 @@ export default class SolanaSignTransaction extends AbstractMethod<'solanaSignTra
         super(message, params);
 
         this.requiredDeviceCapabilities = ['Capability_Solana'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Solana')];
+        this.requiredFirmwareCoins = [getMiscNetwork('sol')];
     }
 
     get requiredPermissions(): PermissionRequest[] {

--- a/packages/connect/src/api/stellar/api/stellarGetAddress.ts
+++ b/packages/connect/src/api/stellar/api/stellarGetAddress.ts
@@ -9,7 +9,7 @@ export default class StellarGetAddress extends AbstractMiscGetAddress<'stellarGe
     constructor(message: MethodMessage<'stellarGetAddress'>) {
         super(message, 3);
         this.requiredDeviceCapabilities = ['Capability_Stellar'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Stellar')];
+        this.requiredFirmwareCoins = [getMiscNetwork('xlm')];
     }
 
     get info() {

--- a/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
+++ b/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
@@ -46,7 +46,7 @@ export default class StellarSignTransaction extends AbstractMethod<
         super(message, params);
 
         this.requiredDeviceCapabilities = ['Capability_Stellar'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Stellar')];
+        this.requiredFirmwareCoins = [getMiscNetwork('xlm')];
     }
 
     get requiredPermissions(): PermissionRequest[] {

--- a/packages/connect/src/api/tezos/api/tezosGetAddress.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetAddress.ts
@@ -9,7 +9,7 @@ export default class TezosGetAddress extends AbstractMiscGetAddress<'tezosGetAdd
     constructor(message: MethodMessage<'tezosGetAddress'>) {
         super(message, 3);
         this.requiredDeviceCapabilities = ['Capability_Tezos'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Tezos')];
+        this.requiredFirmwareCoins = [getMiscNetwork('xtz')];
     }
 
     get info() {

--- a/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
@@ -43,7 +43,7 @@ export default class TezosGetPublicKey extends AbstractMethod<
 
         this.hasBundle = hasBundle;
         this.requiredDeviceCapabilities = ['Capability_Tezos'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Tezos')];
+        this.requiredFirmwareCoins = [getMiscNetwork('xtz')];
     }
 
     get requiredPermissions(): PermissionRequest[] {

--- a/packages/connect/src/api/tezos/api/tezosSignTransaction.ts
+++ b/packages/connect/src/api/tezos/api/tezosSignTransaction.ts
@@ -26,7 +26,7 @@ export default class TezosSignTransaction extends AbstractMethod<
 
         super(message, params);
         this.requiredDeviceCapabilities = ['Capability_Tezos'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Tezos')];
+        this.requiredFirmwareCoins = [getMiscNetwork('xtz')];
     }
 
     get requiredPermissions(): PermissionRequest[] {

--- a/packages/connect/src/api/tron/api/tronGetAddress.ts
+++ b/packages/connect/src/api/tron/api/tronGetAddress.ts
@@ -7,7 +7,7 @@ export default class TronGetAddress extends AbstractMiscGetAddress<'tronGetAddre
     constructor(message: MethodMessage<'tronGetAddress'>) {
         super(message, 2);
         this.requiredDeviceCapabilities = ['Capability_Tron'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Tron')];
+        this.requiredFirmwareCoins = [getMiscNetwork('trx')];
     }
 
     get info() {

--- a/packages/connect/src/api/tron/api/tronSignTransaction.ts
+++ b/packages/connect/src/api/tron/api/tronSignTransaction.ts
@@ -128,7 +128,7 @@ export default class TronSignTransaction extends AbstractMethod<'tronSignTransac
 
         super(message, params);
         this.requiredDeviceCapabilities = ['Capability_Tron'];
-        this.requiredFirmwareCoins = [getMiscNetwork('Tron')];
+        this.requiredFirmwareCoins = [getMiscNetwork('trx')];
     }
 
     get requiredPermissions(): PermissionRequest[] {

--- a/packages/connect/src/backend/fees/__tests__/BitcoinFeeLevels.test.ts
+++ b/packages/connect/src/backend/fees/__tests__/BitcoinFeeLevels.test.ts
@@ -39,7 +39,7 @@ describe('BitcoinFeeLevels', () => {
     });
 
     it('fetches Bitcoin smart FeeLevels with exact match', async () => {
-        const coinInfo = getBitcoinNetwork('Bitcoin');
+        const coinInfo = getBitcoinNetwork('btc');
         if (!coinInfo) throw new Error('coinInfo is missing');
         const coinInfoMock = { ...coinInfo, defaultFees: defaultFeesMock };
 
@@ -58,7 +58,7 @@ describe('BitcoinFeeLevels', () => {
     });
 
     it('fetches Bitcoin smart FeeLevels with some unknown results in response', async () => {
-        const coinInfo = getBitcoinNetwork('Bitcoin');
+        const coinInfo = getBitcoinNetwork('btc');
         if (!coinInfo) throw new Error('coinInfo is missing');
         const coinInfoMock = { ...coinInfo, defaultFees: defaultFeesMock };
 
@@ -75,7 +75,7 @@ describe('BitcoinFeeLevels', () => {
     });
 
     it('fetches Bitcoin smart FeeLevels with custom fee level', async () => {
-        const coinInfo = getBitcoinNetwork('Bitcoin');
+        const coinInfo = getBitcoinNetwork('btc');
         if (!coinInfo) throw new Error('coinInfo is missing');
         const coinInfoMock = { ...coinInfo, defaultFees: defaultFeesMock };
 
@@ -102,7 +102,7 @@ describe('BitcoinFeeLevels', () => {
     });
 
     it('fetches Testnet smart FeeLevels with some unknown results in response', async () => {
-        const coinInfo = getBitcoinNetwork('Testnet');
+        const coinInfo = getBitcoinNetwork('test');
         if (!coinInfo) throw new Error('coinInfo is missing');
         // testnet has only one fee level 'normal'
         // @ts-expect-error: indexing with noUncheckedIndexedAccess

--- a/packages/connect/src/data/__tests__/coinInfo.test.ts
+++ b/packages/connect/src/data/__tests__/coinInfo.test.ts
@@ -1,6 +1,45 @@
-import { getAllNetworks, getCoinInfo, getUniqueNetworks } from '../coinInfo';
+import { getAllNetworks, getCoinInfo, getMiscNetwork, getUniqueNetworks } from '../coinInfo';
 
 describe('data/coinInfo', () => {
+    it('resolves a coin string by shortcut only (network name / label no longer accepted)', () => {
+        // the lowercase shortcut resolves, case-insensitively, across all families
+        expect(getCoinInfo('btc')?.shortcut).toBe('BTC');
+        expect(getCoinInfo('BTC')?.shortcut).toBe('BTC');
+        expect(getCoinInfo('ada')?.shortcut).toBe('ADA');
+        expect(getCoinInfo('eth')?.shortcut).toBe('ETH');
+
+        // the network name and label forms are no longer accepted (D2/D3)
+        expect(getCoinInfo('bitcoin')).toBeUndefined();
+        expect(getCoinInfo('Bitcoin Cash')).toBeUndefined();
+        expect(getCoinInfo('cardano')).toBeUndefined();
+    });
+
+    it('resolves every misc firmware-gating shortcut (requiredFirmwareCoins is never [undefined])', () => {
+        // the shortcut forms the misc api methods pass to getMiscNetwork() to build
+        // requiredFirmwareCoins — a wrong form would silently become [undefined] (D1)
+        ['ada', 'xrp', 'xmr', 'trx', 'xlm', 'sol', 'xtz', 'nostr'].forEach(shortcut => {
+            expect(getMiscNetwork(shortcut)).toBeDefined();
+        });
+    });
+
+    it('no coin name or label collides with a different coin shortcut', () => {
+        // guards against a coins.json regeneration reintroducing a name/label that shadows
+        // another coin's shortcut. Only the bitcoin (name + label) and misc (name) resolvers ever
+        // matched these forms; the ethereum resolver was always shortcut-only, so an EVM coin's
+        // label (the shared native-currency symbol, e.g. 'ETH') was never a resolution key.
+        const networks = getAllNetworks();
+        const shortcutOwner = new Map(networks.map(n => [n.shortcut.toLowerCase(), n.shortcut]));
+        networks.forEach(n => {
+            if (n.type === 'ethereum') return;
+            const forms = n.type === 'bitcoin' ? [n.name, n.label] : [n.name];
+            forms.forEach(form => {
+                const ownerShortcut = shortcutOwner.get(form.toLowerCase());
+                // a coin's own name/label may equal its own shortcut, but never a different coin's
+                expect(ownerShortcut === undefined || ownerShortcut === n.shortcut).toBe(true);
+            });
+        });
+    });
+
     it('getUniqueNetworks', () => {
         const inputs = [
             getCoinInfo('btc'),

--- a/packages/connect/src/data/coinInfo.ts
+++ b/packages/connect/src/data/coinInfo.ts
@@ -20,14 +20,9 @@ export const getBitcoinNetwork = (
     pathOrName: DerivationPath,
 ): Readonly<BitcoinNetworkInfo> | undefined => {
     if (typeof pathOrName === 'string') {
-        const name = pathOrName.toLowerCase();
+        const shortcut = pathOrName.toLowerCase();
 
-        return bitcoinNetworks.find(
-            n =>
-                n.name.toLowerCase() === name ||
-                n.shortcut.toLowerCase() === name ||
-                n.label.toLowerCase() === name,
-        );
+        return bitcoinNetworks.find(n => n.shortcut.toLowerCase() === shortcut);
     }
     // @ts-expect-error: indexing with noUncheckedIndexedAccess
     const pathElement: number = pathOrName[1];
@@ -56,11 +51,9 @@ export const getMiscNetwork = (
     pathOrName: DerivationPath,
 ): Readonly<MiscNetworkInfo> | undefined => {
     if (typeof pathOrName === 'string') {
-        const name = pathOrName.toLowerCase();
+        const shortcut = pathOrName.toLowerCase();
 
-        return miscNetworks.find(
-            n => n.name.toLowerCase() === name || n.shortcut.toLowerCase() === name,
-        );
+        return miscNetworks.find(n => n.shortcut.toLowerCase() === shortcut);
     }
     // @ts-expect-error: indexing with noUncheckedIndexedAccess
     const miscPathElement: number = pathOrName[1];

--- a/packages/connect/src/utils/__tests__/buildOutputDescriptor.test.ts
+++ b/packages/connect/src/utils/__tests__/buildOutputDescriptor.test.ts
@@ -173,7 +173,7 @@ describe('utils/buildOutputDescriptor', () => {
             expect(
                 buildOutputDescriptor({
                     account: 0,
-                    coin: 'Ethereum',
+                    coin: 'eth',
                     scriptType: 'SPENDWITNESS',
                     xpub: XPUB,
                 }),


### PR DESCRIPTION
## Description

Narrows `@trezor/connect`'s public `coin` string input to a single canonical form — the lowercase shortcut (the `CoinSymbol` set) — resolved uniformly across all coin families, and narrows the `coin` **type** to `CoinSymbol` so a non-shortcut value now breaks at compile time, not only at runtime. Implements #29669.

**Core resolution.** `getBitcoinNetwork` and `getMiscNetwork` drop their network-name/label match branches; all three family resolvers now match by shortcut only (the `slip44`/path branch is unchanged). `getCoinInfo('bitcoin')` / `getCoinInfo('Bitcoin Cash')` / `getCoinInfo('cardano')` now return `undefined`; `getCoinInfo('btc')` / `'ada'` / `'eth'` still resolve, case-insensitively.

**Internal firmware-gating (D1).** The 21 misc `getMiscNetwork('<Name>')` call sites that build `requiredFirmwareCoins` were migrated to the shortcut form (Cardano→`ada`, Ripple→`xrp`, Monero→`xmr`, Tron→`trx`, Stellar→`xlm`, Solana→`sol`, Tezos→`xtz`; Nostr already resolves by shortcut). A regression assertion guards that every one resolves, so no method's `requiredFirmwareCoins` can silently become `[undefined]`.

**Signing-path correction (D2, security-relevant).** `signMessage`, `getOwnershipId` and `getOwnershipProof` previously let a provided-but-unresolved `coin` fall through as `coin_name: undefined`, which firmware silently defaults to Bitcoin (a wrong-network signature). They now throw `Method_UnknownCoin` on a provided-but-unresolved coin, consistent with `signTransaction` / `verifyMessage`. Path-fallback methods (`getAddress`, `getPublicKey`, …) still derive from `path` when the coin does not resolve, exactly as for an omitted `coin`.

**Type narrowing (D3).** The public `coin` param is narrowed from `Type.String()` / `string` to `CoinSymbol` on every method that takes it, via a shared `CoinSymbolParam = Type.Unsafe<CoinSymbol>(Type.String())` that keeps runtime validation string-permissive (so the D2 / path-fallback behavior above is preserved) while breaking a non-shortcut value at compile time. Covers the TypeBox schemas, the plain-TS param interfaces, and the shared `CommonParamsWithCoin`. No `suite` / `suite-common` / `suite-native` change is needed — every caller already passes a `NetworkSymbol`, which is a subset of `CoinSymbol` (verified: the full repo type-check is green).

**Docs + fixtures.** Every method doc and the shared `descriptions.ts` now advertise the shortcut only (the `account/getPublicKey.ts` TypeBox `description` too), the `cardanoComposeTransaction` example uses `coin: 'ada'`, and the connect unit + e2e fixtures were migrated off the name/label forms to the shortcut. A collision-safety assertion fails if any bitcoin/misc coin name/label ever equals a different coin's shortcut.

## Validation

Local (this environment has no device emulator, so the device-e2e proof gate runs in CI):

- `type-check` — green across 205 projects (confirms no downstream `suite` / `suite-common` breakage from the type narrowing).
- `lint:js` (affected) — green.
- `@trezor/connect` unit — 550 passing, including the new `coinInfo` regression assertions.
- `@trezor/connect-common` unit — green.

## Notes for the reviewer

- **No version-number bump.** `@trezor/connect` is already at `10.0.0-alpha.1` — an unreleased major (9→10) still accumulating breaking changes. This change is documented under that existing v10 breaking-changes list rather than triggering a spurious bump to 11 (v10 has not shipped). The "semver-major" requirement is already satisfied by v10.
- **`buildOutputDescriptor` was intentionally not migrated.** Its `coin` argument is the resolved `coinInfo.name` (an internal network name), not the public shortcut param — its unit fixtures correctly keep the `'Bitcoin'` / `'Testnet'` / `'Regtest'` name form.
- The collision-safety assertion is scoped to the bitcoin (name + label) and misc (name) families — the ethereum resolver was always shortcut-only, so an EVM coin's `label` (the shared native-currency symbol, e.g. `ETH`) was never a resolution key and does not count as a collision.

## Notes for QA

Real QA surface — the `coin` param is now shortcut-only, so a name/label input that used to resolve now fails:

- **Signing-semantics regression (highest risk):** `signMessage`, `getOwnershipId` and `getOwnershipProof` now throw `Method_UnknownCoin` on a provided-but-unresolved `coin` instead of silently defaulting to Bitcoin. Verify per-coin message signing / ownership flows across the misc families (Cardano, Ripple, Monero, Tron, Stellar, Solana, Tezos) still succeed with the correct network.
- **Per-coin firmware-range gating:** the 21 misc firmware-gating call sites were migrated to the shortcut form. Verify each coin's firmware-version gating still applies (a method blocked on old firmware stays blocked, a supported one still works).
- **Path-fallback methods unchanged:** `getAddress` / `getPublicKey` etc. still derive from `path` when `coin` is omitted/unresolved — receive/address flows should be unaffected.
- All in-repo callers already pass a `NetworkSymbol` (a subset of `CoinSymbol`), so Suite/native flows need no code change; the risk is behavioral in the connect API itself.

## Team
- **Product owner:** mroz22 — owns the spec and the plan decisions
- **Reviewer:** None pinned — CODEOWNERS covers `packages/connect` and auto-requests its owners (szymonlesisz / marekrjpolak, excluding the author) at the PR handoff
- **Eng owner:** szymonlesisz — owns the D1/D2 approach; breaking public API across ~14 methods plus a signing-semantics correction warrants one
- **Tester:** needed — real QA surface: per-coin firmware-range gating and the `signMessage` / `getOwnershipId` / `getOwnershipProof` signing-semantics regression across the misc families; assigned at the test station

Closes #29669

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPpVjCfZ8SSG9jRR474y6E)_

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily modifies TypeScript type definitions and API implementations across the @trezor/connect and @trezor/connect-common packages. The changes span type definitions for getAddress, getAccountInfo, selectAccount, coinInfo, bitcoin transaction types, Solana common types, and params, plus API implementations for Cardano (5 files), Solana (3 files), signMessage, ownership APIs, and several other coin-specific APIs. Most changes are in type definition files that are imported by 131+ tests, making them broad global dependencies — only tests that directly exercise the affected Connect APIs (getAddress, signTransaction, signMessage, selectAccount, getAccountInfo, Cardano/Solana operations) warrant targeted testing. The connect/e2e fixtures and unit tests have no Suite E2E coverage but are tested separately in the connect package's own test suite.

<details><summary><b>Changed files (70)</b></summary>

- `packages/connect-common/src/types/api/account/getAccountInfo.ts`
- `packages/connect-common/src/types/api/account/getAddress.ts`
- `packages/connect-common/src/types/api/account/getPublicKey.ts`
- `packages/connect-common/src/types/api/bitcoin/common.ts`
- `packages/connect-common/src/types/api/bitcoin/composeTransaction.ts`
- `packages/connect-common/src/types/api/blockchain/blockchainSetCustomBackend.ts`
- `packages/connect-common/src/types/api/blockchain/pushTransaction.ts`
- `packages/connect-common/src/types/api/device/getOwnershipId.ts`
- `packages/connect-common/src/types/api/device/getOwnershipProof.ts`
- `packages/connect-common/src/types/api/selectAccount.ts`
- `packages/connect-common/src/types/api/solana/common.ts`
- `packages/connect-common/src/types/coinInfo.ts`
- `packages/connect-common/src/types/params.ts`
- `packages/connect-explorer/src/constants/descriptions.ts`
- `packages/connect/e2e/__fixtures__/getAccountInfo.ts`
- `packages/connect/e2e/__fixtures__/getAddress.ts`
- `packages/connect/e2e/__fixtures__/getAddressSegwit.ts`
- `packages/connect/e2e/__fixtures__/getOwnershipId.ts`
- `packages/connect/e2e/__fixtures__/getOwnershipProof.ts`
- `packages/connect/e2e/__fixtures__/getPublicKey.ts`
- `packages/connect/e2e/__fixtures__/signMessage.ts`
- `packages/connect/e2e/__fixtures__/signTransaction.ts`
- `packages/connect/e2e/__fixtures__/signTransactionBcash.ts`
- `packages/connect/e2e/__fixtures__/signTransactionBech32.ts`
- `packages/connect/e2e/__fixtures__/signTransactionBgold.ts`
- `packages/connect/e2e/__fixtures__/signTransactionDoge.ts`
- `packages/connect/e2e/__fixtures__/signTransactionExternal.ts`
- `packages/connect/e2e/__fixtures__/signTransactionMultisig.ts`
- `packages/connect/e2e/__fixtures__/signTransactionMultisigChange.ts`
- `packages/connect/e2e/__fixtures__/signTransactionMultisigPubkeysOrder.ts`
- `packages/connect/e2e/__fixtures__/signTransactionPaymentRequest.ts`
- `packages/connect/e2e/__fixtures__/signTransactionReplace.ts`
- `packages/connect/e2e/__fixtures__/signTransactionSegwit.ts`
- `packages/connect/e2e/__fixtures__/signTransactionTaproot.ts`
- `packages/connect/e2e/__fixtures__/signTransactionZcash.ts`
- `packages/connect/e2e/__fixtures__/verifyMessage.ts`
- `packages/connect/e2e/__fixtures__/verifyMessageSegwit.ts`
- `packages/connect/e2e/__fixtures__/verifyMessageSegwitNative.ts`
- `packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts`
- `packages/connect/e2e/tests/device/cancel.test.ts`
- `packages/connect/e2e/tests/device/cancelCoinjoinAuthorization.test.ts`
- `packages/connect/e2e/tests/device/unlockPath.test.ts`
- `packages/connect/src/api/cardano/api/cardanoGetAddress.ts`
- `packages/connect/src/api/cardano/api/cardanoGetNativeScriptHash.ts`
- `packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts`
- `packages/connect/src/api/cardano/api/cardanoSignMessage.ts`
- `packages/connect/src/api/cardano/api/cardanoSignTransaction.ts`
- `packages/connect/src/api/getOwnershipId.ts`
- `packages/connect/src/api/getOwnershipProof.ts`
- `packages/connect/src/api/monero/api/moneroGetAddress.ts`
- `packages/connect/src/api/monero/api/moneroGetWatchKey.ts`
- `packages/connect/src/api/monero/api/moneroKeyImageSync.ts`
- `packages/connect/src/api/monero/api/moneroSignTransaction.ts`
- `packages/connect/src/api/ripple/api/rippleGetAddress.ts`
- `packages/connect/src/api/ripple/api/rippleSignTransaction.ts`
- `packages/connect/src/api/signMessage.ts`
- `packages/connect/src/api/solana/api/solanaGetAddress.ts`
- `packages/connect/src/api/solana/api/solanaGetPublicKey.ts`
- `packages/connect/src/api/solana/api/solanaSignTransaction.ts`
- `packages/connect/src/api/stellar/api/stellarGetAddress.ts`
- `packages/connect/src/api/stellar/api/stellarSignTransaction.ts`
- `packages/connect/src/api/tezos/api/tezosGetAddress.ts`
- `packages/connect/src/api/tezos/api/tezosGetPublicKey.ts`
- `packages/connect/src/api/tezos/api/tezosSignTransaction.ts`
- `packages/connect/src/api/tron/api/tronGetAddress.ts`
- `packages/connect/src/api/tron/api/tronSignTransaction.ts`
- `packages/connect/src/backend/fees/__tests__/BitcoinFeeLevels.test.ts`
- `packages/connect/src/data/__tests__/coinInfo.test.ts`
- `packages/connect/src/data/coinInfo.ts`
- `packages/connect/src/utils/__tests__/buildOutputDescriptor.test.ts`

</details>

**Recommended tests (28)**

<details><summary>🔴 <b>High priority (11)</b></summary>

- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Directly exercises TrezorConnect.getAddress which is affected by changes to packages/connect-common/src/types/api/account/getAddress.ts and the connect API layer. The test verifies single/bundle address export, on-device verification, and error handling.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Directly exercises TrezorConnect.getAccountInfo which is affected by changes to packages/connect-common/src/types/api/account/getAccountInfo.ts. The test verifies the account selection modal and successful account info retrieval.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — Directly exercises TrezorConnect.selectAccount which is affected by the changed selectAccount.ts type definitions. Tests multi/single selection, cancellation, and privacy (xpub/publicKey exclusion).
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Directly exercises TrezorConnect.signTransaction for Bitcoin, affected by changes to bitcoin/common.ts types and the connect API layer. The test verifies the multi-step device confirmation flow.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Directly exercises TrezorConnect.ethereumSignMessage which uses the signMessage API that was changed in packages/connect/src/api/signMessage.ts. Tests the full signing flow including permissions and device confirmation.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Exercises TrezorConnect.ethereumSignTransaction which depends on the changed params.ts and coinInfo.ts types. Tests the full Ethereum transaction signing flow through Connect.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Has a direct static mapping to packages/connect/src/api/signMessage.ts which was changed. Tests Bitcoin message signing (standard and Electrum formats) and verification end-to-end.
- `suite/e2e/tests/wallet/cardano.test.ts` — Directly mapped to 4 changed Cardano connect API files (cardanoGetAddress, cardanoGetPublicKey, cardanoGetNativeScriptHash, cardanoSignMessage, cardanoSignTransaction). Tests Cardano account details, public key reveal, send form, and receive address verification.
- `suite/e2e/tests/wallet/receive.test.ts` — Directly mapped to solanaGetAddress.ts, tronGetAddress.ts, and tronSignTransaction.ts changes. Tests receive address flows for BTC, ETH, SOL, and TRX — verifying device display matches clipboard.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — Directly mapped to cardanoGetAddress.ts, cardanoGetNativeScriptHash.ts, cardanoSignMessage.ts, and cardanoSignTransaction.ts changes. Tests Cardano address verification behind a passphrase-protected wallet.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Directly mapped to solanaSignTransaction.ts which was changed. Tests the full Solana send-max flow including device confirmation of address, amount, and fee.

</details>

<details><summary>🟡 <b>Medium priority (12)</b></summary>

- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — Tests Ethereum message signing and verification which uses the signMessage API path changed in packages/connect/src/api/signMessage.ts, though it's not directly statically mapped.
- `suite/e2e/tests/wallet/public-keys.test.ts` — Directly mapped to cardanoGetPublicKey.ts, cardanoGetNativeScriptHash.ts, cardanoSignMessage.ts, and cardanoSignTransaction.ts. Tests XPUB display for BTC, LTC, and ADA accounts.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Directly mapped to cardanoSignTransaction.ts, cardanoGetNativeScriptHash.ts, and cardanoSignMessage.ts changes. Tests Cardano staking reward claiming with on-device transaction confirmation.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Directly mapped to cardanoSignTransaction.ts changes. Tests the full Cardano staking flow including stake key registration and delegation confirmed on device.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Directly mapped to cardanoSignTransaction.ts changes. Tests Cardano unstaking with stake key deregistration confirmed on device.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Directly mapped to solanaSignTransaction.ts which was changed. Tests first-time SOL staking with on-device transaction signing.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Directly mapped to solanaSignTransaction.ts which was changed. Tests SOL unstaking and claiming flows with device confirmation.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Directly mapped to solanaSignTransaction.ts. Tests SOL-to-BTC swap with on-device Solana transaction signing and confirmation.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Tests TrezorConnect.getAddress and cardanoGetAddress popup flows which are affected by the getAddress type changes and cardanoGetAddress API changes. Validates the full popup permission/confirmation lifecycle.
- `suite/e2e/tests/trezor-connect/error.test.ts` — Tests TrezorConnect error handling for invalid derivation paths, which exercises the params validation layer changed in params.ts and coinInfo.ts.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests TrezorConnect permissions flow using getAddress, which is directly affected by the getAddress type definition changes. Validates permission granting, remembering, and revoking.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Tests DOGE send flow which exercises the bitcoin/common.ts types (transaction signing). Validates error handling for amounts exceeding MAX_SAFE_INTEGER.

</details>

<details><summary>🟢 <b>Low priority (5)</b></summary>

- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Directly mapped to solanaSignTransaction.ts. Tests additional SOL staking which uses the same Solana signing path, but is a variant of the initial-stake test.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Mapped to solanaSignTransaction.ts. Tests SOL-to-USDC swap with Solana transaction signing on device.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Mapped to solanaSignTransaction.ts. Tests USDT-to-BTC swap with Solana token transaction signing.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Mapped to solanaSignTransaction.ts. Tests SOL sell flow with on-device Solana transaction confirmation.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Tests TrezorConnect.getAddress via webextension popup, covering the same getAddress type path but through a different integration channel.

</details>

⚠️ **Changes with no test coverage (52)**
- `packages/connect-common/src/types/api/account/getPublicKey.ts`
- `packages/connect-common/src/types/api/bitcoin/composeTransaction.ts`
- `packages/connect-common/src/types/api/blockchain/blockchainSetCustomBackend.ts`
- `packages/connect-common/src/types/api/blockchain/pushTransaction.ts`
- `packages/connect-common/src/types/api/device/getOwnershipId.ts`
- `packages/connect-common/src/types/api/device/getOwnershipProof.ts`
- `packages/connect-explorer/src/constants/descriptions.ts`
- `packages/connect/e2e/__fixtures__/getAccountInfo.ts`
- `packages/connect/e2e/__fixtures__/getAddress.ts`
- `packages/connect/e2e/__fixtures__/getAddressSegwit.ts`
- `packages/connect/e2e/__fixtures__/getOwnershipId.ts`
- `packages/connect/e2e/__fixtures__/getOwnershipProof.ts`
- `packages/connect/e2e/__fixtures__/getPublicKey.ts`
- `packages/connect/e2e/__fixtures__/signMessage.ts`
- `packages/connect/e2e/__fixtures__/signTransaction.ts`
- `packages/connect/e2e/__fixtures__/signTransactionBcash.ts`
- `packages/connect/e2e/__fixtures__/signTransactionBech32.ts`
- `packages/connect/e2e/__fixtures__/signTransactionBgold.ts`
- `packages/connect/e2e/__fixtures__/signTransactionDoge.ts`
- `packages/connect/e2e/__fixtures__/signTransactionExternal.ts`
- `packages/connect/e2e/__fixtures__/signTransactionMultisig.ts`
- `packages/connect/e2e/__fixtures__/signTransactionMultisigChange.ts`
- `packages/connect/e2e/__fixtures__/signTransactionMultisigPubkeysOrder.ts`
- `packages/connect/e2e/__fixtures__/signTransactionPaymentRequest.ts`
- `packages/connect/e2e/__fixtures__/signTransactionReplace.ts`
- `packages/connect/e2e/__fixtures__/signTransactionSegwit.ts`
- `packages/connect/e2e/__fixtures__/signTransactionTaproot.ts`
- `packages/connect/e2e/__fixtures__/signTransactionZcash.ts`
- `packages/connect/e2e/__fixtures__/verifyMessage.ts`
- `packages/connect/e2e/__fixtures__/verifyMessageSegwit.ts`
- `packages/connect/e2e/__fixtures__/verifyMessageSegwitNative.ts`
- `packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts`
- `packages/connect/e2e/tests/device/cancel.test.ts`
- `packages/connect/e2e/tests/device/cancelCoinjoinAuthorization.test.ts`
- `packages/connect/e2e/tests/device/unlockPath.test.ts`
- `packages/connect/src/api/getOwnershipId.ts`
- `packages/connect/src/api/getOwnershipProof.ts`
- `packages/connect/src/api/monero/api/moneroGetAddress.ts`
- `packages/connect/src/api/monero/api/moneroGetWatchKey.ts`
- `packages/connect/src/api/monero/api/moneroKeyImageSync.ts`
- `packages/connect/src/api/monero/api/moneroSignTransaction.ts`
- `packages/connect/src/api/ripple/api/rippleGetAddress.ts`
- `packages/connect/src/api/ripple/api/rippleSignTransaction.ts`
- `packages/connect/src/api/solana/api/solanaGetPublicKey.ts`
- `packages/connect/src/api/stellar/api/stellarGetAddress.ts`
- `packages/connect/src/api/stellar/api/stellarSignTransaction.ts`
- `packages/connect/src/api/tezos/api/tezosGetAddress.ts`
- `packages/connect/src/api/tezos/api/tezosGetPublicKey.ts`
- `packages/connect/src/api/tezos/api/tezosSignTransaction.ts`
- `packages/connect/src/backend/fees/__tests__/BitcoinFeeLevels.test.ts`
- `packages/connect/src/data/__tests__/coinInfo.test.ts`
- `packages/connect/src/utils/__tests__/buildOutputDescriptor.test.ts`

_Updated: 2026-07-14T09:08:10.320Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/conveyor/29669-connect-coin-shortcut-only/web/](https://dev.suite.sldev.cz/suite-web/conveyor/29669-connect-coin-shortcut-only/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=conveyor/29669-connect-coin-shortcut-only&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=conveyor/29669-connect-coin-shortcut-only&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=conveyor/29669-connect-coin-shortcut-only&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-14T09:09:57.067Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-14T09:10:18.017Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->
