### PR TITLE
fix(suite-native): use expected address

### DIFF
--- a/suite-native/app/e2e/tests/receive.test.ts
+++ b/suite-native/app/e2e/tests/receive.test.ts
@@ -38,7 +38,7 @@ describe('Receive [@androidOnly @T3T1 @T3W1]', () => {
         await onAccountReceive.tapShowAddressButton();
         await TrezorUserEnvLink.pressYes();
         await onAccountReceive.verifyReceiveAddress(
-            'bc1q s9al wrln 4e28 se4t q2nc 8dnn vskg 83qe xuj7 s9',
+            'bc1q czeu 64q3 86jv rdd7 ks8g m3t9 jfwa rs83 xlma n6',
         );
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Probably stale address in test expect
<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/failing-e2e-generate-device-confirmed-address&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->