### PR TITLE
fix: batch of independent bug fixes (continuously-improve sweep, consolidated + pruned)

### DIFF
--- a/packages/blockchain-link/src/workers/evm-rpc/mappers/transaction.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/mappers/transaction.ts
@@ -34,9 +34,11 @@ export const mapGetTransactionResponse = ({
     block,
     userAddress,
 }: MapTransactionParams): Responses.GetTransaction => {
-    const { value, gasPrice } = tx;
-    const { gasUsed } = receipt;
-    const fee = (gasUsed * (gasPrice ?? 0n)).toString(10);
+    const { value } = tx;
+    const { gasUsed, effectiveGasPrice } = receipt;
+    // `tx.gasPrice` is undefined for EIP-1559 (type-2) transactions, so the actual price paid must
+    // be read from the receipt's `effectiveGasPrice` — otherwise the fee would be 0 for every type-2 tx.
+    const fee = (gasUsed * effectiveGasPrice).toString(10);
 
     const blockTime = block ? Number(block.timestamp) : 0;
     const blockHash = tx.blockHash || '';
@@ -102,7 +104,7 @@ export const mapGetTransactionResponse = ({
                 nonce: tx.nonce,
                 gasLimit: Number(tx.gas),
                 gasUsed: Number(receipt.gasUsed),
-                gasPrice: gasPrice?.toString(),
+                gasPrice: effectiveGasPrice.toString(),
                 data: tx.input,
             },
         },

--- a/packages/blockchain-link/tests/unit/evmRpcTransactionMapper.test.ts
+++ b/packages/blockchain-link/tests/unit/evmRpcTransactionMapper.test.ts
@@ -1,0 +1,44 @@
+import type { Block, Transaction, TransactionReceipt } from 'viem';
+
+import { mapGetTransactionResponse } from '../../src/workers/evm-rpc/mappers/transaction';
+
+const baseTx = {
+    hash: '0xdeadbeef',
+    from: '0xfrom',
+    to: '0xto',
+    value: 1000n,
+    nonce: 7,
+    gas: 21000n,
+    input: '0x',
+    blockHash: '0xblock',
+    blockNumber: 123n,
+} as unknown as Transaction;
+
+const baseReceipt = {
+    status: 'success',
+    gasUsed: 21000n,
+    effectiveGasPrice: 5n,
+} as unknown as TransactionReceipt;
+
+const block = { timestamp: 42n } as unknown as Block;
+
+describe('mapGetTransactionResponse fee', () => {
+    // Regression: EIP-1559 (type-2) transactions have `tx.gasPrice === undefined`; the actual price
+    // paid lives in the receipt's `effectiveGasPrice`. Deriving the fee from `tx.gasPrice` produced 0.
+    it('derives the fee from receipt.effectiveGasPrice for an EIP-1559 tx', () => {
+        const tx = { ...baseTx, gasPrice: undefined } as unknown as Transaction;
+
+        const { payload } = mapGetTransactionResponse({ tx, receipt: baseReceipt, block });
+
+        expect(payload.fee).toBe('105000'); // 21000 * 5
+        expect(payload.ethereumSpecific?.gasPrice).toBe('5');
+    });
+
+    it('still uses effectiveGasPrice for a legacy tx', () => {
+        const tx = { ...baseTx, gasPrice: 5n } as unknown as Transaction;
+
+        const { payload } = mapGetTransactionResponse({ tx, receipt: baseReceipt, block });
+
+        expect(payload.fee).toBe('105000');
+    });
+});

--- a/packages/coinjoin/src/client/round/outputDecomposition.ts
+++ b/packages/coinjoin/src/client/round/outputDecomposition.ts
@@ -230,7 +230,7 @@ const findCredentialsForTarget = (
     maxValue: number,
 ): [middleware.Credentials, middleware.Credentials] | undefined => {
     // sort descending. higher possibility for match
-    const sorted = credentials.sort((a, b) => (a.Value > b.Value ? -1 : 1));
+    const sorted = credentials.sort((a, b) => b.Value - a.Value);
 
     // find one Credential big enough to cover requested target
     const bigCredential = sorted.find(cre => cre.Value >= target);
@@ -361,7 +361,7 @@ const createOutputsCredentials = async (params: CreateOutputsCredentials): Promi
             options.logger.info(`Vsize dust: ${vsizeDust}`);
             options.logger.info('Decomposition completed');
 
-            return result.sort((a, b) => (a.amount > b.amount ? -1 : 1));
+            return result.sort((a, b) => b.amount - a.amount);
         }
 
         // try to create another output

--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -275,7 +275,7 @@ export const getBroadcastedTxDetails = ({
         hex: tx.toHex(),
         hash: tx.getHash().toString('hex'),
         txid: tx.getId(),
-        size: tx.weight(),
+        size: tx.byteLength(),
         vsize: tx.virtualSize(),
     };
 };

--- a/packages/connect/src/api/bitcoin/createPendingTx.test.ts
+++ b/packages/connect/src/api/bitcoin/createPendingTx.test.ts
@@ -1,0 +1,24 @@
+import { Transaction, networks } from '@trezor/utxo-lib';
+
+import { createPendingTransaction } from './createPendingTx';
+
+describe('helpers/createPendingTransaction', () => {
+    // A minimal legacy (non-segwit) transaction. For legacy txs weight() === 4 * byteLength(),
+    // so it cleanly distinguishes the byte size from the weight units.
+    const hex =
+        '01000000016d20f69067ad1ffd50ee7c0f377dde2c932ccb03e84b5659732da99c20f1f650010000006b483045022100a200ea1278c3d32251a63c56f5f0861f48167c61d84de8d951eac1204856ccd402201fc03f446557bcbcef1e473616bb7bddc96561b656b7ddd6b419501543ed5044012102a7a079c1ef9916b289c2ff21a992c808d0de3dfcf8a9f163205c5c9e21f55d5cffffffff0110270000000000001976a914de9b2a8da088824e8fe51debea566617d851537888ac00000000';
+
+    it('reports size in bytes (byteLength), not weight units', () => {
+        const tx = Transaction.fromHex(hex, { network: networks.bitcoin });
+        const pending = createPendingTransaction(tx, {
+            addresses: { used: [], unused: [], change: [] },
+            inputs: [],
+            outputs: [],
+        });
+
+        expect(pending.size).toBe(tx.byteLength());
+        expect(pending.vsize).toBe(tx.virtualSize());
+        // Guards the regression: weight() is 4x the byte size for a legacy tx.
+        expect(pending.size).not.toBe(tx.weight());
+    });
+});

--- a/packages/connect/src/api/bitcoin/createPendingTx.ts
+++ b/packages/connect/src/api/bitcoin/createPendingTx.ts
@@ -42,7 +42,7 @@ export const createPendingTransaction = (
         blockTime: Math.floor(Date.now() / 1000),
         confirmations: 0,
         vsize: tx.virtualSize(),
-        size: tx.weight(),
+        size: tx.byteLength(),
         value: valueOut.toString(),
         valueIn: valueIn.toString(),
         fees: valueIn.minus(valueOut).toString(),

--- a/packages/connect/src/api/bitcoin/refTx.test.ts
+++ b/packages/connect/src/api/bitcoin/refTx.test.ts
@@ -49,6 +49,52 @@ describe('core/methods/tx/refTx', () => {
         ).toEqual(false);
     });
 
+    it('validateReferencedTransactions applies the ZEC v5 exemption for input reference txs', () => {
+        // A valid provided refTx, unrelated to the spent input below.
+        const providedRefTx = {
+            hash: '43d273d3caf41759ad843474f960fbf80ff2ec961135d018b61e9fab3ad1fc06',
+            version: 1,
+            lock_time: 1287124,
+            inputs: [
+                {
+                    prev_hash: 'e294c4c172c3d87991b0369e45d6af8584be92914d01e3060fad1ed31d12ff00',
+                    prev_index: 0,
+                    script_sig: '',
+                    sequence: 4294967293,
+                },
+            ],
+            bin_outputs: [
+                {
+                    amount: 10000000,
+                    script_pubkey: 'a914051877a0cc43165e48975c1e62bdef3b6c942a3887',
+                },
+            ],
+        };
+        // The input references a tx that is NOT provided, so a strict validation would throw.
+        const params = {
+            transactions: [providedRefTx],
+            inputs: [
+                {
+                    prev_hash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                    prev_index: 0,
+                },
+            ],
+            outputs: [],
+            coinInfo: { shortcut: 'ZEC' },
+        };
+
+        // Zcash NU5 (v5) transactions don't need input reference txs (matches the authoritative
+        // requireReferencedTransactions check in signTransaction) — validation must not throw.
+        expect(() =>
+            validateReferencedTransactions({ ...params, version: 5 } as any),
+        ).not.toThrow();
+
+        // Older Zcash versions still require them.
+        expect(() => validateReferencedTransactions({ ...params, version: 4 } as any)).toThrow(
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa not provided',
+        );
+    });
+
     it('getReferencedTransactions', () => {
         const inputs = [
             { prev_hash: 'abcd' },

--- a/packages/connect/src/api/bitcoin/refTx.ts
+++ b/packages/connect/src/api/bitcoin/refTx.ts
@@ -252,16 +252,22 @@ export const validateReferencedTransactions = ({
     outputs,
     addresses,
     coinInfo,
+    version,
 }: {
     transactions?: (RefTransaction | AccountTransaction)[];
     inputs: PROTO.TxInputType[];
     outputs: PROTO.TxOutputType[];
     addresses?: AccountAddresses;
     coinInfo: BitcoinNetworkInfo;
+    version?: number;
 }): RefTransaction[] | undefined => {
     if (!Array.isArray(transactions) || transactions.length === 0) return; // allow empty, they will be downloaded later...
-    // collect sets of transactions defined by inputs/outputs
-    const refTxs = requireReferencedTransactions(inputs) ? getReferencedTransactions(inputs) : [];
+    // collect sets of transactions defined by inputs/outputs. Pass coinInfo/version so the
+    // ZEC/TAZ v5 exemption matches the authoritative fetch path (requireReferencedTransactions
+    // in signTransaction); otherwise a v5 tx would spuriously demand input reference txs here.
+    const refTxs = requireReferencedTransactions(inputs, { version }, coinInfo)
+        ? getReferencedTransactions(inputs)
+        : [];
     const origTxs = getOrigTransactions(inputs, outputs); // NOTE: origTxs are used in RBF
     const transformedTxs: RefTransaction[] = transactions.map(tx => {
         // transform AccountTransaction to RefTransaction

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -113,12 +113,30 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
                 'two sources of referential transactions were passed. payload.refTxs have precedence',
             );
         }
+        const options = enhanceSignTx(
+            {
+                lock_time: payload.locktime,
+                timestamp: payload.timestamp,
+                version: payload.version,
+                expiry: payload.expiry,
+                overwintered: payload.overwintered,
+                version_group_id: payload.versionGroupId,
+                branch_id: payload.branchId,
+                amount_unit: payload.amountUnit,
+                serialize: payload.serialize,
+                coinjoin_request: payload.coinjoinRequest,
+                chunkify: typeof payload.chunkify === 'boolean' ? payload.chunkify : false,
+            },
+            coinInfo,
+        );
+
         const refTxs = validateReferencedTransactions({
             transactions: payload.refTxs || payload.account?.transactions,
             inputs,
             outputs,
             coinInfo,
             addresses: payload.account?.addresses,
+            version: options.version,
         });
 
         const outputsWithAmount = outputs.filter(
@@ -149,22 +167,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             paymentRequests,
             refTxs,
             addresses: payload.account ? payload.account.addresses : undefined,
-            options: enhanceSignTx(
-                {
-                    lock_time: payload.locktime,
-                    timestamp: payload.timestamp,
-                    version: payload.version,
-                    expiry: payload.expiry,
-                    overwintered: payload.overwintered,
-                    version_group_id: payload.versionGroupId,
-                    branch_id: payload.branchId,
-                    amount_unit: payload.amountUnit,
-                    serialize: payload.serialize,
-                    coinjoin_request: payload.coinjoinRequest,
-                    chunkify: typeof payload.chunkify === 'boolean' ? payload.chunkify : false,
-                },
-                coinInfo,
-            ),
+            options,
             coinInfo,
             identity: payload.identity,
             push: typeof payload.push === 'boolean' ? payload.push : false,

--- a/packages/connect/src/device/thp/handshake.ts
+++ b/packages/connect/src/device/thp/handshake.ts
@@ -73,8 +73,8 @@ export const thpHandshake = async (device: IDevice, unlockPin = false) => {
 
     const settings = settingsStore.get('thp');
     // sort credentials by autoconnect field
-    const knownCredentials = (settings?.knownCredentials || []).sort(cre =>
-        cre.autoconnect ? -1 : 1,
+    const knownCredentials = (settings?.knownCredentials || []).sort(
+        (a, b) => (a.autoconnect ? -1 : 1) - (b.autoconnect ? -1 : 1),
     );
     const tryToUnlock = unlockPin ? 1 : 0;
 

--- a/packages/product-components/src/components/PasswordStrengthIndicator/PasswordStrengthIndicator.tsx
+++ b/packages/product-components/src/components/PasswordStrengthIndicator/PasswordStrengthIndicator.tsx
@@ -38,7 +38,7 @@ const Line = styled.div<LineProps>`
 type OptionalZXCVBNScore = ZXCVBNScore | undefined;
 
 const getColor = (score: OptionalZXCVBNScore, password: string) => {
-    if (password === '' || Number.isNaN(score)) return 'transparent';
+    if (password === '' || score === undefined) return 'transparent';
     switch (score) {
         case 0:
         case 1:

--- a/packages/suite-desktop-core/src/modules/coinjoin.ts
+++ b/packages/suite-desktop-core/src/modules/coinjoin.ts
@@ -98,7 +98,10 @@ export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) 
                     logger.debug(SERVICE_NAME, `${BACKEND_CHANNEL} call ${method}`);
                     if (method === 'disable') {
                         backend.dispose();
-                        backends.splice(backends.indexOf(backend), 1);
+                        const backendIndex = backends.indexOf(backend);
+                        if (backendIndex !== -1) {
+                            backends.splice(backendIndex, 1);
+                        }
 
                         return Promise.resolve();
                     }
@@ -157,7 +160,10 @@ export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) 
                         }
                     }
                     if (method === 'disable') {
-                        clients.splice(clients.indexOf(client), 1);
+                        const clientIndex = clients.indexOf(client);
+                        if (clientIndex !== -1) {
+                            clients.splice(clientIndex, 1);
+                        }
 
                         if (clients.length === 0) {
                             logger.debug(SERVICE_NAME, `${CLIENT_CHANNEL} binary stop`);

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
@@ -104,7 +104,7 @@ export const AddTokenModal = ({ onCancel }: AddTokenModalProps) => {
                 type: events.addTokenEvent.name,
                 payload: {
                     networkSymbol: account.symbol,
-                    addedNth: account.tokens ? account.tokens.length + 1 : 0,
+                    addedNth: account.tokens?.length ? account.tokens.length + 1 : 1,
                     token: tokenInfo[0]?.symbol?.toLowerCase() || '',
                 },
             });

--- a/packages/suite/src/middlewares/wallet/replaceByFeeErrorMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/replaceByFeeErrorMiddleware.test.ts
@@ -1,0 +1,58 @@
+import { transactionsActions } from '@suite-common/wallet-core';
+
+import { type AppState, type Dispatch } from 'src/types/suite';
+
+import { replaceByFeeErrorMiddleware } from './replaceByFeeErrorMiddleware';
+
+jest.mock('../../actions/wallet/send/replaceByFeeErrorThunk', () => ({
+    replaceByFeeErrorThunk: jest.fn(() => ({ type: 'mocked-replace-by-fee-error-thunk' })),
+}));
+
+const PREV_TXID = 'aaaa';
+
+const invoke = (transactions: { txid: string; blockHeight?: number }[], precomposedTx: unknown) => {
+    const dispatch = jest.fn() as unknown as Dispatch;
+    const api = {
+        getState: () => ({ wallet: { send: { precomposedTx } } }) as AppState,
+        dispatch,
+    };
+    const next = jest.fn(action => action) as unknown as Dispatch;
+    const action = {
+        type: transactionsActions.addTransaction.type,
+        payload: { transactions },
+    };
+
+    // @ts-expect-error partial action/api shapes are sufficient for this unit
+    replaceByFeeErrorMiddleware(api)(next)(action);
+
+    return { dispatch, next };
+};
+
+const rbfPrecomposedTx = { rbfType: 'bump-fee', prevTxid: PREV_TXID };
+
+describe('replaceByFeeErrorMiddleware', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('dispatches the RBF error when the replaced transaction gets mined', () => {
+        const { dispatch } = invoke([{ txid: PREV_TXID, blockHeight: 100 }], rbfPrecomposedTx);
+        expect(dispatch).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not dispatch when the replaced transaction is re-added while still pending', () => {
+        // blockbook reports pending txs with blockHeight -1; this must not be treated as "mined"
+        const { dispatch } = invoke([{ txid: PREV_TXID, blockHeight: -1 }], rbfPrecomposedTx);
+        expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('does not dispatch when the replaced transaction is not present in the batch', () => {
+        const { dispatch } = invoke([{ txid: 'bbbb', blockHeight: 100 }], rbfPrecomposedTx);
+        expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('does not dispatch when the pending transaction is not an RBF transaction', () => {
+        const { dispatch } = invoke([{ txid: PREV_TXID, blockHeight: 100 }], {
+            prevTxid: PREV_TXID,
+        });
+        expect(dispatch).not.toHaveBeenCalled();
+    });
+});

--- a/packages/suite/src/middlewares/wallet/replaceByFeeErrorMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/replaceByFeeErrorMiddleware.ts
@@ -1,7 +1,7 @@
 import { type MiddlewareAPI } from 'redux';
 
 import { transactionsActions } from '@suite-common/wallet-core/';
-import { isRbfTransaction } from '@suite-common/wallet-utils';
+import { isPending, isRbfTransaction } from '@suite-common/wallet-utils';
 
 import { type Action, type AppState, type Dispatch } from 'src/types/suite';
 
@@ -30,7 +30,10 @@ export const replaceByFeeErrorMiddleware =
 
         const addedTransaction = transactions.find(tx => tx.txid === precomposedTx.prevTxid);
 
-        if (addedTransaction?.blockHeight !== undefined) {
+        // Fire only when the previous transaction was actually mined. A pending re-add of the same
+        // transaction (blockbook reports pending txs with blockHeight -1, so blockHeight !== undefined
+        // was true for those too) must not trigger the "already mined" error.
+        if (addedTransaction && !isPending(addedTransaction)) {
             api.dispatch(replaceByFeeErrorThunk());
         }
 

--- a/packages/suite/src/reducers/wallet/graphReducer.ts
+++ b/packages/suite/src/reducers/wallet/graphReducer.ts
@@ -74,7 +74,9 @@ const remove = (draft: GraphState, accounts: Account[]) => {
         );
         affected.forEach(d => {
             const index = draft.data.indexOf(d);
-            draft.data.splice(index, 1);
+            if (index !== -1) {
+                draft.data.splice(index, 1);
+            }
         });
     });
     updateError(draft);

--- a/suite-common/assets/src/__fixtures__/assets.ts
+++ b/suite-common/assets/src/__fixtures__/assets.ts
@@ -40,3 +40,16 @@ export const assetsFixtureSingleAsset: AssetFiatBalance[] = [
         fiatBalance: asBaseCurrencyAmount(new BigNumber('98.26')),
     },
 ];
+
+// A NaN fiat balance must not poison the total nor produce a NaN percentage for itself
+// or for the other (valid) assets.
+export const assetsFixtureWithNaNBalance: AssetFiatBalance[] = [
+    {
+        symbol: 'btc',
+        fiatBalance: asBaseCurrencyAmount(new BigNumber(NaN)),
+    },
+    {
+        symbol: 'eth',
+        fiatBalance: asBaseCurrencyAmount(new BigNumber('50')),
+    },
+];

--- a/suite-common/assets/src/utils.test.ts
+++ b/suite-common/assets/src/utils.test.ts
@@ -41,4 +41,20 @@ describe('calculateAssetsPercentage', () => {
         expect(btc?.fiatPercentage).toBeCloseTo(100);
         expect(btc?.fiatPercentageOffset).toBe(0);
     });
+
+    it('calculateAssetsPercentage - NaN balance does not poison other assets', () => {
+        const assetsWithPercentage = calculateAssetsPercentage(
+            fixtures.assetsFixtureWithNaNBalance,
+        );
+        const btc = assetsWithPercentage[0];
+        const eth = assetsWithPercentage[1];
+
+        // the NaN asset itself contributes nothing
+        expect(btc?.fiatPercentage).toBe(0);
+        expect(btc?.fiatPercentageOffset).toBe(0);
+
+        // the valid asset still gets a real percentage instead of NaN
+        expect(eth?.fiatPercentage).toBeCloseTo(100);
+        expect(eth?.fiatPercentageOffset).toBe(0);
+    });
 });

--- a/suite-common/assets/src/utils.ts
+++ b/suite-common/assets/src/utils.ts
@@ -13,12 +13,16 @@ export interface AssetFiatBalanceWithPercentage extends AssetFiatBalance {
 export const calculateAssetsPercentage = <T>(
     assetsData: Array<AssetFiatBalance & T>,
 ): Array<AssetFiatBalanceWithPercentage & T> => {
-    const fiatTotal = assetsData.reduce((sum, next) => sum + Number(next.fiatBalance), 0);
+    const fiatTotal = assetsData.reduce((sum, next) => {
+        const value = Number(next.fiatBalance);
+
+        return sum + (Number.isNaN(value) ? 0 : value);
+    }, 0);
     let previousPercentage = 0;
 
     return assetsData.map(asset => {
         const fiatBalance = Number(asset.fiatBalance);
-        if (fiatTotal === 0 || Number.isNaN(asset.fiatBalance) || fiatBalance === 0) {
+        if (fiatTotal === 0 || Number.isNaN(fiatBalance) || fiatBalance === 0) {
             return { ...asset, fiatPercentage: 0, fiatPercentageOffset: 0 };
         }
 

--- a/suite-common/graph/src/graphDataFetching.ts
+++ b/suite-common/graph/src/graphDataFetching.ts
@@ -428,7 +428,7 @@ export const getMultipleAccountBalanceHistoryWithFiat = async ({
         // use 1 year into past and return zeroes for the range
         if (startOfTimeFrameDate.getTime() === endOfTimeFrameDate.getTime()) {
             const startDate = startOfTimeFrameDate;
-            startDate.setDate(startDate.getHours() - 8760);
+            startDate.setHours(startDate.getHours() - 8760);
 
             return [
                 ...getTimestampsInTimeFrame(startDate, endOfTimeFrameDate, numberOfPoints - 1),

--- a/suite-common/graph/src/graphDataFetching.ts
+++ b/suite-common/graph/src/graphDataFetching.ts
@@ -417,11 +417,16 @@ export const getMultipleAccountBalanceHistoryWithFiat = async ({
     if (!startOfTimeFrameDate) {
         // if startOfTimeFrameDate is not provided, it means we want to show all available data
         // so we need to find the oldest date balance movement in all accounts
-        startOfTimeFrameDate = pipe(
+        const oldestBalanceMovementTimestamp = findOldestBalanceMovementTimestamp(
             accountsWithBalanceHistoryFlattened,
-            findOldestBalanceMovementTimestamp,
-            fromUnixTime,
         );
+
+        // findOldestBalanceMovementTimestamp returns Infinity when there are no balance movements
+        // at all (Math.min of an empty list). Anchor the range to the end of the time frame so the
+        // no-movements branch below fires with a valid start date instead of an Invalid Date.
+        startOfTimeFrameDate = Number.isFinite(oldestBalanceMovementTimestamp)
+            ? fromUnixTime(oldestBalanceMovementTimestamp)
+            : new Date(endOfTimeFrameDate);
 
         // if there were no balance movements at all,
         // findOldestBalanceMovementTimestamp resulted with start date being the same as end date

--- a/suite-common/graph/src/graphUtils.test.ts
+++ b/suite-common/graph/src/graphUtils.test.ts
@@ -382,4 +382,16 @@ describe(findOldestBalanceMovementTimestamp.name, () => {
 
         expect(findOldestBalanceMovementTimestamp(balanceHistory)).toBe(2);
     });
+
+    it('returns a non-finite value when there are no balance movements at all', () => {
+        // Math.min of an empty list is Infinity; callers must guard for it (fromUnixTime(Infinity)
+        // is an Invalid Date) rather than assume a real timestamp is returned.
+        const noMovements: AccountWithBalanceHistory[] = [
+            { symbol: 'btc', descriptor: 'awdawd', balanceHistory: [] },
+            { symbol: 'eth', descriptor: 'awdawd', balanceHistory: [] },
+        ];
+
+        expect(Number.isFinite(findOldestBalanceMovementTimestamp(noMovements))).toBe(false);
+        expect(Number.isFinite(findOldestBalanceMovementTimestamp([]))).toBe(false);
+    });
 });

--- a/suite-common/logger/src/utils.test.ts
+++ b/suite-common/logger/src/utils.test.ts
@@ -1,9 +1,20 @@
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
-import { type DiscoveryStatus, asAccountDescriptor } from '@suite-common/wallet-types';
+import { accountsActions } from '@suite-common/wallet-core';
+import {
+    type Account,
+    type DiscoveryStatus,
+    asAccountDescriptor,
+} from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { type StaticSessionId } from '@trezor/connect';
 
-import { REDACTED_REPLACEMENT, redactAccount, redactDevice, redactDiscovery } from './utils';
+import {
+    REDACTED_REPLACEMENT,
+    redactAccount,
+    redactAction,
+    redactDevice,
+    redactDiscovery,
+} from './utils';
 
 describe('logsUtils', () => {
     const account = mockWalletAccount({
@@ -49,6 +60,21 @@ describe('logsUtils', () => {
                     label: REDACTED_REPLACEMENT,
                 },
             });
+        });
+    });
+
+    describe('redactAction', () => {
+        it('redacts the account of an updateSelectedAccount log entry', () => {
+            const entry = {
+                datetime: 'Thu, 01 Jan 1970 00:00:00 GMT',
+                type: accountsActions.updateSelectedAccount.type,
+                payload: { account },
+            };
+
+            const redactedAccount = (redactAction(entry).payload as { account: Account }).account;
+
+            expect(redactedAccount.descriptor).toBe(REDACTED_REPLACEMENT);
+            expect(redactedAccount.deviceState).toBe(REDACTED_REPLACEMENT);
         });
     });
 

--- a/suite-common/logger/src/utils.ts
+++ b/suite-common/logger/src/utils.ts
@@ -159,16 +159,19 @@ export const redactDiscovery = (
 };
 
 export const redactAction = (action: LogEntry): LogEntry => {
-    let payload: LogEntry['payload'];
-
     if (accountsActions.updateSelectedAccount.match(action)) {
-        payload = {
-            ...action.payload,
-            account: redactAccount(action.payload?.account),
-            network: undefined,
-            discovery: undefined,
+        return {
+            ...action,
+            payload: {
+                ...action.payload,
+                account: redactAccount(action.payload?.account),
+                network: undefined,
+                discovery: undefined,
+            },
         };
     }
+
+    let payload: LogEntry['payload'];
 
     switch (action.type) {
         case accountsActions.createAccount.type:

--- a/suite-common/message-system/src/messageSystemUtils.ts
+++ b/suite-common/message-system/src/messageSystemUtils.ts
@@ -224,15 +224,21 @@ export const isDeviceCompatible = (deviceConditions: Device[], device?: TrezorDe
             thpProperties: thpPropertiesCondition,
         } = deviceCondition;
 
+        // createVersionRange returns null for '!' / undefined, which by design must not match
+        // (see isVersionCompatible for the same handling).
+        const firmwareRange = createVersionRange(firmwareCondition);
+        const bootloaderRange = createVersionRange(bootloaderCondition);
+
         return (
             modelCondition.toLowerCase() === deviceInternalModel &&
             (vendorCondition.toLowerCase() === deviceVendor || vendorCondition === '*') &&
             (variantCondition.toLowerCase() === deviceFwType || variantCondition === '*') &&
             (firmwareRevisionCondition.toLowerCase() === deviceFwRevision.toLowerCase() ||
                 firmwareRevisionCondition === '*') &&
-            (semver.satisfies(deviceFwVersion, createVersionRange(firmwareCondition)!) ||
+            ((firmwareRange !== null && semver.satisfies(deviceFwVersion, firmwareRange)) ||
                 firmwareCondition === '*') &&
-            (semver.satisfies(deviceBootloaderVersion, createVersionRange(bootloaderCondition)!) ||
+            ((bootloaderRange !== null &&
+                semver.satisfies(deviceBootloaderVersion, bootloaderRange)) ||
                 bootloaderCondition === '*') &&
             isThpPropertiesCompatible(thpPropertiesCondition, device.thp?.properties)
         );

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -392,7 +392,7 @@ export const getDeviceInstances = (
             if (!a.instance) return -1;
             if (!b.instance) return 1;
 
-            return a.instance > b.instance ? 1 : -1;
+            return a.instance - b.instance;
         }) as AcquiredDevice[];
 };
 

--- a/suite-common/transaction-search/src/__fixtures__/searchTransactions.fixture.ts
+++ b/suite-common/transaction-search/src/__fixtures__/searchTransactions.fixture.ts
@@ -139,6 +139,12 @@ export const searchTransactionsFixture = [
         ],
     },
     {
+        // A non-numeric value after an operator must not match any transaction.
+        description: 'Non-numeric operator search matches nothing',
+        search: '!= notanumber',
+        result: [],
+    },
+    {
         description: 'Date search',
         search: '2020-12-03',
         result: [

--- a/suite-common/transaction-search/src/simpleSearchTransactions.ts
+++ b/suite-common/transaction-search/src/simpleSearchTransactions.ts
@@ -127,9 +127,8 @@ export const simpleSearchTransactions = (
         }
 
         // Is number?
-        if (!Number.isNaN(search)) {
-            const amount = new BigNumber(search);
-
+        const amount = new BigNumber(search);
+        if (!amount.isNaN()) {
             return transactions.filter(t => numberSearchFilter(t, amount, searchOperator));
         }
 
@@ -139,7 +138,7 @@ export const simpleSearchTransactions = (
     const txsToSearch: string[] = [];
 
     // Searching for an amount (without operator)
-    if (!Number.isNaN(search)) {
+    if (!new BigNumber(search).isNaN()) {
         const foundTxsForNumber = transactions.flatMap(transaction => {
             const targetAmounts = getTargetAmounts(transaction);
             if (targetAmounts.filter(targetAmount => targetAmount.includes(search)).length === 0) {

--- a/suite-common/wallet-core/src/accounts/accountsSelectors.ts
+++ b/suite-common/wallet-core/src/accounts/accountsSelectors.ts
@@ -172,7 +172,7 @@ export const selectVisibleNonEmptyDeviceAccountsByNetworkSymbol = createMemoized
     accounts =>
         pipe(
             accounts,
-            A.filter(account => !account.empty || account.visible),
+            A.filter(account => !account.empty && account.visible),
             returnStableArrayIfEmpty,
         ),
 );

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesReducer.test.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesReducer.test.ts
@@ -1,0 +1,62 @@
+import { extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { type Timestamp } from '@suite-common/wallet-types';
+import { getFiatRateKeyFromTicker } from '@suite-common/wallet-utils';
+import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
+
+import { fiatRatesInitialState, prepareFiatRatesReducer } from './fiatRatesReducer';
+import { updateFiatRatesThunk } from './fiatRatesThunks';
+import { type FiatRatesState } from './fiatRatesTypes';
+
+// The reducer is exercised directly (not via store.dispatch) because a mock store swallows the
+// exception thrown inside a reducer, which would hide the very crash this suite guards against.
+const fiatRatesReducer = prepareFiatRatesReducer(extraDependenciesCommonMock);
+
+const BASE_CURRENCY = 'usd' as BaseCurrencyCode;
+
+const rejectedAction = (tickers: { symbol: string }[]) =>
+    updateFiatRatesThunk.rejected(new Error('boom'), 'req-id', {
+        tickers,
+        baseCurrencyCode: BASE_CURRENCY,
+        rateType: 'current',
+        fetchAttemptTimestamp: 0 as Timestamp,
+    } as any);
+
+describe('fiatRatesReducer updateFiatRatesThunk.rejected', () => {
+    it('does not throw for a testnet ticker with no state entry (pending skips testnet)', () => {
+        // Regression: the rejected handler used to index the entry unconditionally, so a testnet
+        // ticker (never seeded by the pending handler) crashed with "Cannot set property 'error'
+        // of undefined".
+        expect(() =>
+            fiatRatesReducer(fiatRatesInitialState, rejectedAction([{ symbol: 'test' }])),
+        ).not.toThrow();
+    });
+
+    it('does not throw for a non-testnet ticker whose entry was removed mid-flight', () => {
+        expect(() =>
+            fiatRatesReducer(fiatRatesInitialState, rejectedAction([{ symbol: 'btc' }])),
+        ).not.toThrow();
+    });
+
+    it('records the error on an existing non-testnet entry', () => {
+        const key = getFiatRateKeyFromTicker({ symbol: 'btc' }, BASE_CURRENCY);
+        const preloaded: FiatRatesState = {
+            current: {
+                [key]: {
+                    lastSuccessfulFetchTimestamp: 0 as Timestamp,
+                    lastTickerTimestamp: 0 as Timestamp,
+                    isLoading: true,
+                    error: null,
+                    ticker: { symbol: 'btc' },
+                },
+            },
+            lastWeek: {},
+            historic: {},
+        };
+
+        const next = fiatRatesReducer(preloaded, rejectedAction([{ symbol: 'btc' }]));
+
+        const entry = next.current[key];
+        expect(entry?.isLoading).toBe(false);
+        expect(entry?.error).toContain('boom');
+    });
+});

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesReducer.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesReducer.ts
@@ -107,12 +107,21 @@ export const prepareFiatRatesReducer = createReducerWithExtraDeps(
                 const errorMessage = `${action.error?.message}\n${action.error?.stack}`;
 
                 tickers.forEach(ticker => {
+                    if (isTestnet(ticker.symbol)) {
+                        return;
+                    }
+
                     const fiatRateKey = getFiatRateKeyFromTicker(ticker, baseCurrencyCode);
-                    const rates = state[rateType];
-                    // @ts-expect-error: indexing with noUncheckedIndexedAccess
-                    const rateEntry: (typeof rates)[string] = rates[fiatRateKey];
-                    rateEntry.error = errorMessage;
-                    rateEntry.isLoading = false;
+                    const currentRate = state[rateType]?.[fiatRateKey];
+
+                    // The pending handler skips testnet tickers and can be raced by a state reset
+                    // (e.g. currency change), so the entry may not exist here.
+                    if (!currentRate) {
+                        return;
+                    }
+
+                    currentRate.error = errorMessage;
+                    currentRate.isLoading = false;
                 });
             })
             .addCase(updateTxsFiatRatesThunk.fulfilled, (state, action) => {

--- a/suite-common/wallet-utils/src/balanceUtils.test.ts
+++ b/suite-common/wallet-utils/src/balanceUtils.test.ts
@@ -16,6 +16,7 @@ test('formatBalanceUtils', () => {
     expect(formatCoinBalance('1000')).toEqual('1,000');
     expect(formatCoinBalance('1000.0001')).toEqual('1,000.0001');
     expect(formatCoinBalance('1000.000000001')).toEqual('1,000.00');
+    expect(formatCoinBalance('1001.000000001')).toEqual('1,001.00');
     expect(formatCoinBalance('2600.1')).toEqual('2,600.1');
     expect(formatCoinBalance('200000')).toEqual('200,000');
     expect(formatCoinBalance('2000000')).toEqual('2,000,000');

--- a/suite-common/wallet-utils/src/balanceUtils.ts
+++ b/suite-common/wallet-utils/src/balanceUtils.ts
@@ -35,7 +35,7 @@ export const formatCoinBalance = (value: string, locale: Locale = 'en-US') => {
         const fixedBalanceBig = new BigNumber(fixedBalance);
 
         // indicate the dust
-        const noDecimalsLeft = fixedBalanceBig.modulo(2).toFixed() === '0';
+        const noDecimalsLeft = fixedBalanceBig.isInteger();
         if (noDecimalsLeft) {
             return localizeNumber(fixedBalanceBig, locale, 2);
         }

--- a/suite-common/walletconnect/src/adapters/bitcoin.ts
+++ b/suite-common/walletconnect/src/adapters/bitcoin.ts
@@ -220,7 +220,7 @@ export const getChainId = (network: Network) => {
     return [];
 };
 
-export const getNamespace = (accounts: Account[]) => {
+export const getNamespace = (accounts: Account[]): Record<string, WalletConnectNamespace> => {
     const bip122 = {
         chains: [],
         accounts: [],
@@ -244,6 +244,10 @@ export const getNamespace = (accounts: Account[]) => {
             bip122.accounts.push(`${network.caipId}:${firstAddress}`);
         }
     });
+
+    if (bip122.chains.length === 0) {
+        return {};
+    }
 
     return { bip122 };
 };

--- a/suite-native/device-mutex/src/DeviceAccessMutex.test.ts
+++ b/suite-native/device-mutex/src/DeviceAccessMutex.test.ts
@@ -105,10 +105,12 @@ describe('RequestPrioritizedDeviceAccess', () => {
         // Execute prioritized task.
         await requestPrioritizedDeviceAccess(deviceAccessCallbackMock);
 
-        // The prioritized task should be put at the beginning of the queue, so after its execution,
-        // so there should be still the rest of the tasks in the queue.
+        // The prioritized task was put at the beginning of the queue (position 0), so it ran
+        // right after task 0 finished, skipping all previously queued tasks.
+        // After the prioritized task finishes: task 1 has been dequeued and is running,
+        // tasks 2, 3, 4 remain in the queue.
         expect(deviceAccessMutex.isLocked).toBe(true);
-        expect(deviceAccessMutex.taskQueue.length).toBe(2);
+        expect(deviceAccessMutex.taskQueue.length).toBe(3);
     });
 });
 
@@ -132,6 +134,28 @@ describe('clearAndUnlockDeviceAccessQueue', () => {
         }
 
         // Mutex should be unlocked and empty after clearing the queue.
+        expect(deviceAccessMutex.isLocked).toBe(false);
+        expect(deviceAccessMutex.taskQueue.length).toBe(0);
+    });
+
+    test('prioritized task is cancelled by clearing the queue', async () => {
+        // Reset shared singleton state possibly left over from previous tests.
+        clearAndUnlockDeviceAccessQueue();
+
+        // Hold the lock so the prioritized request has to wait in the queue. Locking
+        // synchronously (no timer callback) keeps the setup free of leaked timers and
+        // lets us reach the clearing call without an await where a stray task could run.
+        void deviceAccessMutex.lock();
+        const prioritizedTask = requestPrioritizedDeviceAccess(deviceAccessCallbackMock);
+
+        expect(deviceAccessMutex.isLocked).toBe(true);
+        expect(deviceAccessMutex.taskQueue.length).toBe(1);
+
+        clearAndUnlockDeviceAccessQueue();
+
+        // The prioritized waiter must be rejected like any other queued task instead of
+        // resolving `true` and running its device callback after the queue was cleared.
+        expect(await prioritizedTask).toBe(DEVICE_ACCESS_ERROR);
         expect(deviceAccessMutex.isLocked).toBe(false);
         expect(deviceAccessMutex.taskQueue.length).toBe(0);
     });

--- a/suite-native/device-mutex/src/DeviceAccessMutex.ts
+++ b/suite-native/device-mutex/src/DeviceAccessMutex.ts
@@ -11,9 +11,9 @@ class DeviceAccessMutex {
 
     prioritizedLock() {
         if (this.isLocked) {
-            return new Promise(resolve => {
+            return new Promise<boolean>(resolve => {
                 // Put prioritized task at the beginning of the queue.
-                this.taskQueue.splice(1, 0, () => resolve(true));
+                this.taskQueue.unshift(resolve);
             });
         }
         this.isLocked = true;

--- a/suite/coinjoin/src/__fixtures__/coinjoinReducer.ts
+++ b/suite/coinjoin/src/__fixtures__/coinjoinReducer.ts
@@ -162,6 +162,67 @@ export const actionFixtures = [
             ],
         },
     },
+    {
+        description: 'addTxCandidate adds a candidate for a new roundId',
+        initialState: {
+            ...initialState,
+            accounts: [account],
+        },
+        actions: [
+            {
+                type: COINJOIN.SESSION_TX_CANDIDATE,
+                payload: { accountKey: 'A', roundId: '00' },
+            },
+        ],
+        result: {
+            ...initialState,
+            accounts: [{ ...account, transactionCandidates: [{ roundId: '00' }] }],
+        },
+    },
+    {
+        description: 'addTxCandidate deduplicates a repeated roundId',
+        initialState: {
+            ...initialState,
+            accounts: [account],
+        },
+        actions: [
+            {
+                type: COINJOIN.SESSION_TX_CANDIDATE,
+                payload: { accountKey: 'A', roundId: '00' },
+            },
+            {
+                type: COINJOIN.SESSION_TX_CANDIDATE,
+                payload: { accountKey: 'A', roundId: '00' },
+            },
+        ],
+        result: {
+            ...initialState,
+            accounts: [{ ...account, transactionCandidates: [{ roundId: '00' }] }],
+        },
+    },
+    {
+        description: 'addTxCandidate keeps candidates with distinct roundIds',
+        initialState: {
+            ...initialState,
+            accounts: [account],
+        },
+        actions: [
+            {
+                type: COINJOIN.SESSION_TX_CANDIDATE,
+                payload: { accountKey: 'A', roundId: '00' },
+            },
+            {
+                type: COINJOIN.SESSION_TX_CANDIDATE,
+                payload: { accountKey: 'A', roundId: '11' },
+            },
+        ],
+        result: {
+            ...initialState,
+            accounts: [
+                { ...account, transactionCandidates: [{ roundId: '00' }, { roundId: '11' }] },
+            ],
+        },
+    },
 ];
 
 export const selectorFixtures = [

--- a/suite/coinjoin/src/coinjoinReducer.ts
+++ b/suite/coinjoin/src/coinjoinReducer.ts
@@ -209,7 +209,7 @@ const addTxCandidate = (
     if (!account.transactionCandidates) {
         account.transactionCandidates = [];
     }
-    if (!account.transactionCandidates.some(tx => tx.roundId !== payload.roundId)) {
+    if (!account.transactionCandidates.some(tx => tx.roundId === payload.roundId)) {
         account.transactionCandidates.push({ roundId: payload.roundId });
     }
 };

--- a/suite/e2e/support/common.ts
+++ b/suite/e2e/support/common.ts
@@ -9,7 +9,7 @@ import { validJws } from '@suite-common/message-system/src/__fixtures__/messageS
 import { type TradingCountryCode, regional } from '@suite-common/trading';
 import { getAccountDecimals, localizeNumber } from '@suite-common/wallet-utils';
 import { Model } from '@trezor/trezor-user-env-link';
-import { BigNumber, splitStringEveryNCharacters } from '@trezor/utils';
+import { BigNumber, splitStringEveryNCharacters, versionUtils } from '@trezor/utils';
 
 import { PlaywrightTarget } from './testExtends/suiteTestOptions';
 import { PercentageOfBalanceParams } from './types';
@@ -109,8 +109,13 @@ export const findLatestVersionForModel = (model: Model): string => {
     const firmwareVersions = releases.firmware;
     const versions = Object.keys(firmwareVersions);
 
-    // Sort versions in descending order
-    versions.sort((a, b) => (a > b ? -1 : 1));
+    // Sort versions in descending order (semantic, not lexicographic)
+    versions.sort((a, b) => {
+        if (versionUtils.isNewer(a, b)) return -1;
+        if (versionUtils.isNewer(b, a)) return 1;
+
+        return 0;
+    });
 
     // Find the latest version supporting our model
     for (const version of versions) {


### PR DESCRIPTION
## Description

An **umbrella / staging branch** for a systematic "continuously improve" bug-fix sweep. It is **rebased onto the latest `develop` and pruned** to a curated set: after peeling off the split-out PRs and dropping the low-value / latent / dead commits, the branch now holds **18 commits** —

- the **#28977 consolidation** commit, plus **11 commits that already have their own open split-out PRs** (linked below), and
- **6 remaining split-out candidates** not yet peeled off:
  - `fix(graph)` — balance-history fallback jumped ~24 years back instead of 1 year (`Date.setDate` misuse).
  - `fix(graph)` — empty balance movements in "show all data" produced `Math.min(Infinity)` → Invalid Date.
  - `fix(wallet-utils)` — dust check used `% 2` instead of an integer check, formatting odd amounts inconsistently.
  - `fix(walletconnect)` — bitcoin adapter `getNamespace` returned an empty namespace (missing the guard its sibling adapters have).
  - `fix(message-system)` — `createVersionRange` result was passed to `semver.satisfies` without a null-check.
  - `fix(suite-native)` — `omitSensitiveSubstring` searched the closing delimiter from the string start instead of after the prefix (redaction helper; direction to be verified).

Each commit is a single self-contained fix with its own explanation in the commit body. Commit messages follow Conventional Commits; `type(scope)` reflects the owning package so the eventual split is mechanical. Please review the individual commits rather than the squashed diff.

The **dropped** commits (Tier D telemetry-only + Tier E latent/dead/refactor, plus several marginal UX/edge fixes, and the `omitSensitiveSubstring` redaction tweak) were removed from the branch after assessment — they are intentionally **not** carried here.

**Every remaining fix now has its own split-out PR** (linked below); this branch is fully peeled and kept only as the staging/consolidation record.

## Notes for QA

No dedicated QA pass needed on this umbrella branch — QA will happen on the split-out PRs. Blast radius is wide but each change is tiny and localized. Areas touched if smoke-testing is desired: trading (buy/sell/exchange forms & toasts), coinjoin anonymity indicator, send-form fee/timeout handling, EVM nonce & EIP-1559 fee display, staking cards, account/type filtering & search, and Sentry reporting (verify no confidential values appear in events/breadcrumbs).

## Related Issue

Umbrella for a series of split-out fix PRs (to be linked here as they are opened).

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/gnhf/continuously-improve-682865/web/](https://dev.suite.sldev.cz/suite-web/gnhf/continuously-improve-682865/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=gnhf/continuously-improve-682865&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=gnhf/continuously-improve-682865&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=gnhf/continuously-improve-682865&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T15:24:58.291Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T15:26:08.347Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

## Split-out PRs

- #29738 — refactor: remove dead code (bluetooth, wallet-utils) [#16, #27]
- #29739 — fix: stop console.warn leaking account descriptor/deviceState into native Sentry breadcrumbs [#66, #84]
- #29747 — fix: report transaction size in bytes, not weight units [#18, #33]
- #29759 — fix(suite-utils): normalize browser name to a spaceless token in getBrowserName [#36]
- #29761 — fix(wallet-core): guard testnet tickers in fiatRatesReducer rejected handler [#43]
- #29763 — fix(assets): guard the converted number in calculateAssetsPercentage [#7]
- #29765 — fix(blockchain-link): derive EIP-1559 fee from effectiveGasPrice [#19]
- #29770 — fix(connect-web): recover the iframe after a transient init failure [#44]
- #29773 — fix(suite): don't treat a pending RBF-replaced tx as mined in replaceByFeeErrorMiddleware [#21]
- #29829 — fix(components): avoid rendering a stray "0" for empty arrays [#71]
- #29835 — fix(coinjoin): restore per-roundId dedup in addTxCandidate [#50]
- #29836 — fix(connect): use a valid two-argument sort comparator in thpHandshake [#28]
- #29841 — fix(connect): skip input reference txs for Zcash v5 in validateReferencedTransactions [#69]
- #30010 — fix(logger): redact the account in updateSelectedAccount log entries [#35]
- #30016 — fix(transaction-search): don't return all transactions for a non-numeric `!=` search [#29]
- #30603 — fix(graph): jump exactly one year back in balance-history fallback [#25]
- #30604 — fix(graph): guard empty balance movements in show-all-data path [#18]
- #30605 — fix(wallet-utils): use integer check instead of modulo 2 in dust check [#42]
- #30606 — fix(walletconnect): return empty namespace when there are no matching bitcoin accounts [#8]
- #30607 — fix(message-system): null-check createVersionRange in isDeviceCompatible [#37]

### Extracted / deferred

- `console.error` amount/fee redaction (`sendFormUtils`) and the suite-native exchange-quote `console.warn` were **removed from this branch** — lower severity (one only fires on a `NaN` error path), to be handled separately if at all. The Sentry split PR (#29739) was narrowed to the unambiguous descriptor / `deviceState` leaks accordingly.
- Two sign-timeout return-type tweaks (send-form + Ethereum stake) were **removed** as not-well-understood / low-confidence, per maintainer preference to not ship changes we can't confidently explain.
- The `advancedSearchTransactions` OR-fallback non-global `replace` fix was **removed** — kept the sweep minimal (edge-case only: a transaction search with redundant `||`).
- The `findBestCompatibleRelease` bootloader-version fix (#14) was **removed** — the buggy branch is unreachable in production (the only caller gates `min_bootloader_version` behind a present bootloader version, so the null-bootloader branch never runs).
- The `DeviceAccessMutex` prioritized-lock fix (#6) was **removed** — it is already covered by a separate open PR (#29392, which also goes further with clearQueue cancellation).
- The `serializeFilterPolicy` `user_disconnected` fix (#13) was **removed** — latent: the serialized manufacturer-data `data` field is dropped at the IPC boundary (the Rust `KnownDevice` struct is `id`+`macAddress` only) and the backend reads BLE advertisement data fresh, so the flag has no functional consumer.
- The trading/staking cluster (#4 positive-balance selector, #52 exchange approvalFlow, #56 sell active-trade guard, #63 Cardano staking reward estimate, #72 sell error toast, #74 sell selector shape) was **removed** from this sweep — to be handled/reviewed separately.

## Consolidated with the second small-bug staging branch (#28977)
This branch is now **rebased onto develop** and is the single staging branch for the sweep. It absorbs the fixes unique to `mroz22/logic-bug-fixes-staging` (#28977) that are not yet on develop; the 4 already-merged ones from that branch (EIP-712 sizing, HTTP status, bytesToHumanReadable, removeAccount guard) arrive via the rebase. The open split-out PRs from #28977 now target this umbrella:
- #29181 — fix(connect-popup): tear down placeholder accounts when a sign call throws
- #29392 — fix(device-mutex): prioritizedLock enqueue at front
- #30011 — fix(suite-desktop-core, icons): operator precedence in two log statements
- #30012 — fix(suite-desktop-core): guard coinjoin splice(indexOf) on disable race