### PR TITLE
refactor: remove dead code (bluetooth, wallet-utils)

### DIFF
--- a/suite-common/bluetooth/src/manufacturerDataUtils.ts
+++ b/suite-common/bluetooth/src/manufacturerDataUtils.ts
@@ -42,10 +42,6 @@ const serializeFilterPolicy = (policy?: BluetoothFilterPolicy) => {
     return value;
 };
 
-Object.keys(MODEL_BLE_CODE)
-    .map(k => Number(k))
-    .find(k => MODEL_BLE_CODE[k]);
-
 const serializeDeviceModel = (m: DeviceModelInternal) =>
     Object.keys(MODEL_BLE_CODE)
         .map(k => Number(k))

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -278,7 +278,6 @@ const constructOldFlow = ({
                         token: precomposedTx.token,
                     },
                 );
-                outputs.push();
             }
         });
     } else {


### PR DESCRIPTION
## Description

Removes two pieces of dead code (no behavior change). Both are `refactor`-type deletions grouped together only because they are the exact same kind of change:

- **`suite-common/bluetooth` `manufacturerDataUtils.ts`** — a stray unassigned `Object.keys().map().find()` expression whose result was computed and immediately discarded.
- **`suite-common/wallet-utils` `reviewTransactionUtils.ts`** — a dead no-op `outputs.push()` (called with no arguments) in the Stellar branch of `constructOldFlow`.

Split out from the continuously-improve sweep #29735.

## Notes for QA

No QA needed — pure dead-code removal, no runtime behavior change. Type-check and unit tests cover both files.

## Related Issue

Part of the split-out series from #29735.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies two files: reviewTransactionUtils.ts (a transaction review utility used broadly in send/swap/sell/staking flows) and manufacturerDataUtils.ts (a Bluetooth utility with no test coverage). The reviewTransactionUtils change is high-risk because it directly affects how transaction details (addresses, amounts, fees) are prepared for user review on both the Suite UI and hardware device display. The recommended strategy focuses on tests that explicitly exercise transaction review/confirmation flows — send transactions across multiple networks (ETH, SOL, Base, DOGE, LTC), swap/sell trading flows, and staking transactions. The Bluetooth utility has no E2E test coverage.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/bluetooth/src/manufacturerDataUtils.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.ts`

</details>

**Recommended tests (16)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading-poc/passthru-swap-eth-to-btc.test.ts` — This test exercises a full swap transaction flow including confirm-and-send modal where the user reviews recipient address, send amount, and maximum fee on both the app and hardware device. reviewTransactionUtils is directly involved in composing and reviewing transaction details before signing.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test verifies the full Ethereum send flow including detailed review of gas limit, max fee per gas, priority fee, and total amount on both Suite UI and device display. reviewTransactionUtils directly handles the transaction review data preparation for this flow.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test validates the Review & Send modal for Solana transactions, checking recipient address, amount, and fee display on both the app and device. reviewTransactionUtils is responsible for preparing the review data shown in this modal.
- `suite/e2e/tests/wallet/send-base.test.ts` — This test performs a full Base (EVM L2) send transaction with custom Ethereum fees, verifying gas limit, fee rates, and amounts on both the app prompt and device screen. It also checks Redux state wallet.send.serializedTx after confirmation, directly exercising reviewTransactionUtils.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test verifies transaction confirmation details (amount, total, fee, address) on the device prompt modal for a DOGE send, and checks error handling for invalid amounts during signing. reviewTransactionUtils prepares this review data.

</details>

<details><summary>🟡 <b>Medium priority (11)</b></summary>

- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test sends LTC using the send form with broadcast mode and max amount, confirming via device prompt. The transaction review flow uses reviewTransactionUtils for preparing confirmation data.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test exercises multiple send form scenarios including locktime, OP_RETURN, and unit switching on regtest, all of which go through transaction review before submission. reviewTransactionUtils handles the review preparation.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test initiates a BTC sell transaction and verifies device prompt details (address, amount, fee). The send confirmation step relies on reviewTransactionUtils to compose transaction review data.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test confirms a Solana sell transaction on the device with address, total crypto amount, and fee verification. The review/send step depends on reviewTransactionUtils.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This test performs a DEX swap with detailed review of gas limit, fee rates, amounts, and contract details on the device prompt. The transaction review preparation directly uses reviewTransactionUtils.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test verifies custom Bitcoin fee display (fee rate, total amount) on the device confirmation prompt during a swap. reviewTransactionUtils is responsible for computing and formatting these review values.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test sets custom Ethereum gas parameters and verifies gas limit, max fee per gas, priority fee, and calculated maximum fee on both UI and device. reviewTransactionUtils handles this fee review data.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test confirms an Ethereum sell with custom gas fees and verifies the device prompt shows the correct address and crypto amount. The review step uses reviewTransactionUtils.
- `suite/e2e/tests/trading-poc/passthru-swap-sol-to-btc.test.ts` — This test reviews a SOL-to-BTC swap transaction on the device prompt, verifying address, amount, and fee. The review data is prepared by reviewTransactionUtils.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test confirms an ETH staking transaction on the device, showing staking amount and fee. The transaction review preparation leverages reviewTransactionUtils.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test confirms a SOL staking transaction on the device with amount, rent, and fee details. The review flow depends on reviewTransactionUtils for data preparation.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/bluetooth/src/manufacturerDataUtils.ts`

_Updated: 2026-07-13T08:38:19.530Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/cleanup-remove-dead-code/web/](https://dev.suite.sldev.cz/suite-web/mroz22/cleanup-remove-dead-code/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/cleanup-remove-dead-code&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/cleanup-remove-dead-code&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/cleanup-remove-dead-code&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-13T08:41:41.735Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-13T08:40:57.397Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->