### PR TITLE
fix: stop console.warn leaking account descriptor/deviceState into native Sentry breadcrumbs

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -39,7 +39,8 @@ const update = (state: Account[], account: Account) => {
         }
     } else {
         console.warn(
-            `Tried to update account that does not exist: ${account.descriptor} (symbol: ${account.symbol})`,
+            // do not log the descriptor: it is confidential and would leak into Sentry breadcrumbs
+            `Tried to update account that does not exist (symbol: ${account.symbol}, type: ${account.accountType}, index: ${account.index})`,
         );
     }
 };

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -79,7 +79,10 @@ export const prepareAccountsReducer = createReducerWithExtraDeps(
                 const account = { ...action.payload, accountLabel, history };
 
                 if (state.some(accountEqualTo(account))) {
-                    console.warn('Duplicated account found, updating instead: ', account);
+                    console.warn(
+                        // do not log the whole account: descriptor/addresses/balance are confidential and would leak into Sentry breadcrumbs
+                        `Duplicated account found, updating instead (symbol: ${account.symbol}, type: ${account.accountType}, index: ${account.index})`,
+                    );
                     update(state, account);
                 } else {
                     // Keep the state sorted by coin so that consumers get the canonical order for free.

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -1092,13 +1092,12 @@ export const accountEqualTo = (a: Account) => (b: Account) =>
     (() => {
         // if the accounts seem equal but the descriptors are different
         if (a.descriptor !== b.descriptor) {
-            const { deviceState, symbol, accountType, index } = a;
+            const { symbol, accountType, index } = a;
+            // do not log deviceState or descriptors: they are confidential and would leak into Sentry breadcrumbs
             console.warn('Potentially equal accounts with different descriptors!', {
-                deviceState,
                 symbol,
                 accountType,
                 index,
-                descriptors: [a.descriptor, b.descriptor],
             });
         }
 


### PR DESCRIPTION
## Description

Stops confidential **account identifiers** (descriptor / xpub, `deviceState`, and the whole `Account` object — which embeds addresses and balances) from reaching Sentry through `console.warn` calls.

These are shared `suite-common` code paths. The per-platform capture behavior:

- **`console.warn` is not captured as a Sentry event** (`captureConsoleIntegration({ levels: ['error'] })`), but the default breadcrumb integration records it as a **breadcrumb**.
- On **Suite Web/Desktop** these console breadcrumbs are dropped in `beforeBreadcrumb` (`isConsole → null`), so nothing leaks there.
- On **suite-native** there is no `beforeBreadcrumb` filter, so `console.warn` breadcrumbs are attached — unredacted — to the next captured event.

Fixes (both `suite-common`, confidential identifiers only):

- **`wallet-core/accountsReducer.ts`** — the "account does not exist" warning logged `account.descriptor`; the duplicate-account warning logged the entire `Account` object. Both now log only `symbol` / `accountType` / `index`.
- **`wallet-utils/accountUtils.ts`** — `accountEqualTo` logged `deviceState` and both descriptors; both are now dropped.

None of the retained fields (`symbol`, `accountType`, `index`) are confidential.

> **Scope note:** deliberately narrowed to the unambiguous descriptor / `deviceState` / `Account` leaks. Two related-but-weaker cases from the sweep are intentionally **not** included here and will be handled separately (different severity, and one only fires on a `NaN` error path): the `console.error` amount/fee log in `sendFormUtils` and the exchange-quote `console.warn` in suite-native. When the exchange-quote one is redone it should keep logging `orderId` (useful, non-confidential) rather than reducing to boolean flags.

Split out from the continuously-improve sweep #29735.

## Notes for QA

Low risk — only changes what is written to `console.warn`, no functional/behavioral change. Worth a quick check that no account descriptor/xpub or `deviceState` appears in Sentry events/breadcrumbs (especially on mobile) after triggering these paths; the debug context (coin symbol / account type / index) is preserved.

## Related Issue

Part of the split-out series from #29735.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two core wallet infrastructure files — accountsReducer.ts (account state management) and accountUtils.ts (account utility functions) — both of which are imported by virtually all 131 E2E tests. Since these are extremely broad dependencies, the recommended strategy focuses on tests that most directly exercise account creation, discovery, selection, filtering, and display logic. High-priority tests cover wallet discovery, account addition, and account search where regressions would be immediately visible. Medium-priority tests cover account-specific flows (balance display, public keys, Cardano, passphrases, export) that exercise account state in meaningful ways. Tests unrelated to account management (analytics, backup, browser, firmware, guide, etc.) are omitted despite static coverage because the changed files are global utilities unlikely to affect those flows.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-core/src/accounts/accountsReducer.ts`
- `suite-common/wallet-utils/src/accountUtils.ts`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — This test directly exercises wallet discovery across multiple coin networks (BTC, ETH, LTC, etc.), which relies heavily on accountsReducer for managing discovered accounts and accountUtils for account processing. Changes to account state management or utility functions could break discovery completion or account visibility.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds different account types (normal, taproot, segwit, legacy) for multiple coins and verifies account counts increment correctly. It directly depends on accountsReducer for account creation/storage and accountUtils for account type resolution and path derivation.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Tests wallet discovery and standard wallet addition via device switcher, then verifies BTC account balance visibility. This directly exercises account creation in accountsReducer and account lookup/display logic in accountUtils.
- `suite/e2e/tests/wallet/account-search.test.ts` — Tests account search/filtering functionality which relies on accountUtils for account matching and filtering logic, and accountsReducer for the account state being searched. Changes could break account visibility or search behavior.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/wallet/public-keys.test.ts` — Verifies public key display for BTC, LTC, and ADA accounts by navigating to account details. This uses accountUtils for account identification/selection and accountsReducer for account state. Changes to account data structures could affect XPUB retrieval.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — Tests account balance display and updates after receiving BTC on regtest. Balance display depends on account state in accountsReducer and balance formatting/lookup in accountUtils.
- `suite/e2e/tests/dashboard/assets.test.ts` — Tests enabling new assets (ETH) via the Activate Assets modal and verifying they appear in grid/table views. Asset display relies on accountsReducer for storing discovered accounts and accountUtils for aggregating account data per network.
- `suite/e2e/tests/wallet/cardano.test.ts` — Opens a Cardano account and verifies account details (type description, derivation path, xpub), send form, and receive flow. Cardano accounts have unique handling in accountUtils and accountsReducer that could be affected by changes.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Tests multiple hidden wallet creation with unique accounts and address derivation per passphrase. Hidden wallet accounts are managed in accountsReducer with passphrase-specific logic, and accountUtils handles account differentiation between standard and hidden wallets.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — Tests wallet numbering for passphrase wallets after ejecting and re-adding wallets. Wallet/account numbering logic likely depends on accountsReducer state for tracking active accounts and accountUtils for wallet identification.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Tests discovery with custom Blockbook backends for BTC and LTC. Discovery completion depends on accountsReducer for account storage and accountUtils for account processing during discovery.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — Exports transactions across BTC, LTC, ETH, and ADA accounts. Account selection and transaction retrieval depend on accountsReducer state and accountUtils for locating the correct account data.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Tests enabling coins with custom backends and verifying account load states (empty vs error). Account load state management involves accountsReducer, and account status display relies on accountUtils.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — Tests global receive/send flows with account selection across ETH and BTC, including adding new accounts and displaying correct account labels with derivation paths. Account labeling and selection logic directly uses accountUtils.

</details>

_Updated: 2026-07-13T09:02:16.501Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-sentry-confidential-leaks/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-sentry-confidential-leaks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-sentry-confidential-leaks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-sentry-confidential-leaks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fix-sentry-confidential-leaks&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-13T09:05:24.979Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-13T09:05:09.574Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->