### PR TITLE
fix(trading): keep swap approval prefetch errors on form

### DIFF
--- a/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
@@ -446,6 +446,60 @@ describe('confirmExchangeTradeThunk', () => {
         expect(!!response).toBeFalsy();
     });
 
+    it('should keep a failed approvalFlow trade with orderId on the form instead of routing to detail', async () => {
+        const {
+            store,
+            returnUrl,
+            receiveAddress,
+            account,
+            trade,
+            mockProcessResponseData,
+            mockNextStep,
+            mockTriggerAnalyticsTradeConfirmation,
+        } = getMocks();
+
+        const mockResponse = {
+            status: 'ERROR',
+            orderId: 'orderId',
+            error: 'Server error',
+        };
+        const tradeResponse = { ...trade, ...mockResponse } as ExchangeTrade;
+
+        invityAPI.doExchangeTrade = () => Promise.resolve(tradeResponse);
+
+        const response = await store
+            .dispatch(
+                exchangeThunks.confirmTradeThunk({
+                    returnUrl,
+                    receiveAddress,
+                    account,
+                    trade,
+                    approvalFlow: true,
+                    nextStep: mockNextStep,
+                    triggerAnalyticsTradeConfirmation: mockTriggerAnalyticsTradeConfirmation,
+                    processResponseData: mockProcessResponseData,
+                }),
+            )
+            .unwrap();
+
+        const { trading } = store.getState().wallet;
+        const { exchange } = trading;
+
+        const toastAction = store
+            .getActions()
+            .find(action => action.type === 'mockedLogErrorThunk');
+
+        expect(toastAction?.payload).toEqual({
+            tradingType: 'exchange',
+            errorMessage: { code: 'unknown', message: 'Server error' },
+        });
+        expect(exchange.transactionId).toBeUndefined();
+        expect(exchange.selectedQuote).toEqual(tradeResponse);
+        expect(mockNextStep).not.toHaveBeenCalled();
+        expect(trading.trades).toEqual([]);
+        expect(!!response).toBeFalsy();
+    });
+
     describe('should return true from confirmation for approval and sign transaction', () => {
         it.each([
             [

--- a/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
@@ -113,7 +113,10 @@ export const confirmExchangeTradeThunk = createThunk(
         ) {
             dispatch(tradingExchangeActions.saveSelectedQuote(response));
 
-            if (response.status === 'ERROR' && response.orderId) {
+            const shouldRouteFailedTradeToDetail =
+                !approvalFlow && response.status === 'ERROR' && !!response.orderId;
+
+            if (shouldRouteFailedTradeToDetail) {
                 dispatch(
                     tradingActions.saveTrade({
                         tradeType: 'exchange',


### PR DESCRIPTION
## Description

- Prevent swap approval prefetch errors with an `orderId` from routing users straight to failed transaction detail.
- Keep `approvalFlow` exchange errors on the swap form and reuse the existing trading error handling there.
- Add regression coverage for `ERROR` responses with an `orderId` during exchange approval prefetch.

## Notes for QA

- In Swap, select a 1inch classic quote and stay on the form until a provider or quote refresh error occurs, verify the form stays open and the error is shown there instead of opening Transaction failed.
- In Swap, trigger a failed exchange confirm after an order is created, verify the app still opens the trade detail with Transaction failed.

## Related Issue

Resolve #29691

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on the exchange trade confirmation thunk (confirmExchangeTradeThunk.ts) and its unit test. The thunk is responsible for confirming swap/exchange trades in the trading flow. Despite mapping statically to 131 tests (indicating it's bundled into a broad dependency), only swap/exchange-related E2E tests actually exercise this code path. The unit test file has no E2E coverage (as expected for a unit test). The recommended strategy is to prioritize the swap E2E tests that directly exercise full trade confirmation flows (coin-to-coin, coin-to-token, token-to-coin, token-to-token, DEX), with medium priority for swap history and fee-specific tests.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts`
- `suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/swap-coins.test.ts` — This test exercises the full swap (exchange) flow from SOL to BTC including trade confirmation, status transitions (CONFIRMING → CONVERTING → SUCCESS), and transaction detail verification. The changed confirmExchangeTradeThunk directly handles exchange trade confirmation logic, making this a direct functional test of the changed code.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests swapping SOL to USDC token including confirming the swap trade, verifying toast notifications, and checking transaction detail success status. The exchange trade confirmation thunk is central to processing these swap confirmations.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping USDT token to BTC through the exchange/swap interface, including trade confirmation and success verification. This directly exercises the confirmExchangeTradeThunk for token-to-coin swap scenarios.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests swapping SPL tokens (USDT to USDC) through the trading/swap feature including trade confirmation and transaction detail success status. Directly exercises the exchange trade confirmation path for token-to-token swaps.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Tests DEX swap via LI.FI including trade confirmation, broadcasting the signed transaction, and status transitions (CONFIRM → CONVERTING → SUCCESS). DEX swaps use a different code path within the exchange confirmation thunk, providing important variant coverage.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-history.test.ts` — Tests viewing swap/exchange trade history including status labels (SUCCESS, ERROR, CONFIRMING) and trade detail pages. Changes to confirmExchangeTradeThunk could affect how trade records are stored and displayed in history.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests the Bitcoin swap flow with custom fee settings including confirming the swap offer and verifying fee display on the device prompt. The confirmation step uses the exchange trade thunk.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests Ethereum swap flow with custom gas fee parameters through the swap confirmation modal. The composed transaction info populated during confirmation is directly related to the exchange trade thunk.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swapping a token to an asset on a disabled network, verifying provider info is displayed in swap quotes. While it doesn't complete a full trade confirmation, it tests the exchange flow setup that precedes the thunk.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form input validation (amounts, fraction buttons, provider selection) which feeds into the exchange confirmation flow. Changes to the thunk are unlikely to affect input validation, but the composed transaction info is checked indirectly.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts`

_Updated: 2026-07-13T08:59:40.888Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/29691-swap-form-error-detail-redirect/web/](https://dev.suite.sldev.cz/suite-web/fix/29691-swap-form-error-detail-redirect/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/29691-swap-form-error-detail-redirect&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/29691-swap-form-error-detail-redirect&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/29691-swap-form-error-detail-redirect&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-13T09:03:24.991Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-13T09:03:02.831Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->