### PR TITLE
test(e2e): improve watcher management

### DIFF
--- a/suite/e2e/support/common.ts
+++ b/suite/e2e/support/common.ts
@@ -78,10 +78,11 @@ export const formatEvmAddress = (address: string) => {
 export const formatAddressWithNewlines = (address: string) =>
     formatEvmAddress(address).replace(REGEXP_ADDRESS_CHUNKS, '$1\n');
 
-// This function is used to override automatic fixtures that we want to skip in specific tests.
+// This overrides any auto fixture in tests that opt out of it; the skipped value is undefined, so
+// consumers of an optional fixture must guard against it (e.g. watcher?.stop()).
 /* eslint-disable react-hooks/rules-of-hooks */
-export async function skipFixture({}, use: (r: void) => Promise<void>) {
-    await use();
+export async function skipFixture<T = void>({}, use: (fixture: T | undefined) => Promise<void>) {
+    await use(undefined);
 }
 /* eslint-enable react-hooks/rules-of-hooks */
 

--- a/suite/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/suite/e2e/support/testExtends/suiteBaseFixture.ts
@@ -10,7 +10,7 @@ import { getUrl, isDesktopProject } from '../common';
 import { currentsTest } from './currentsFixture';
 import { enhancePage } from './enhancePage';
 import { PlaywrightTarget, SuiteTestOptions } from './suiteTestOptions';
-import { jsExceptionWatcher, toastErrorWatcher } from './watchers';
+import { Watcher, jsExceptionWatcher, toastErrorWatcher } from './watchers';
 import { DeviceFixture } from '../device';
 import { wipeAndRestartEvoluServer } from '../helpers/evoluClient';
 import { electronSetup, electronTeardown, trezorUserEnvStuckProtection, webSetup } from '../setup';
@@ -30,8 +30,8 @@ type SuiteBaseFixture = {
     trezorUserEnv: TrezorUserEnv;
     electronApp: ElectronApplication | undefined;
     page: Page;
-    jsExceptionWatcher: void;
-    toastErrorWatcher: void;
+    jsExceptionWatcher: Watcher | undefined;
+    toastErrorWatcher: Watcher | undefined;
     coverageMapCollector: void;
 };
 
@@ -101,7 +101,16 @@ const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
             });
 
             if (!model || !firmwareVersion) {
-                await use(undefined as unknown as DeviceFixture);
+                await use(
+                    new Proxy({} as DeviceFixture, {
+                        get(_target, prop) {
+                            throw new Error(
+                                `"device" fixture is unavailable: this test set no model/firmwareVersion. ` +
+                                    `Tag it with a device model before using device.${String(prop)}.`,
+                            );
+                        },
+                    }),
+                );
 
                 return;
             }
@@ -185,5 +194,15 @@ const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
         { auto: true },
     ],
 });
+
+// Stopping our watchers right after test, so we don't collect irrelevant errors caused by teardown phase
+suiteBaseTest.afterEach(
+    async ({ jsExceptionWatcher: jsWatcher, toastErrorWatcher: toastWatcher }) => {
+        await suiteBaseTest.step('Stopping watchers', () => {
+            jsWatcher?.stop();
+            toastWatcher?.stop();
+        });
+    },
+);
 
 export { suiteBaseTest };

--- a/suite/e2e/support/testExtends/watchers.ts
+++ b/suite/e2e/support/testExtends/watchers.ts
@@ -5,6 +5,8 @@ import { inspect } from 'node:util';
 
 export type CapturedToast = { testId: string; intent: string; text: string };
 
+export type Watcher = { stop: () => void };
+
 const formatError = (error: unknown): string => {
     if (error instanceof Error) {
         let output = error.stack || `${error.name}: ${error.message}`;
@@ -68,13 +70,13 @@ const isToastIgnored = (toast: CapturedToast, ignoreToastErrors: string[]): bool
 
 export const jsExceptionWatcher = async (
     { page, ignoreJSExceptions }: { page: Page; ignoreJSExceptions: string[] },
-    use: () => Promise<void>,
+    use: (watcher: Watcher) => Promise<void>,
     testInfo: TestInfo,
 ) => {
     const errors: Error[] = [];
     const ignored: Error[] = [];
 
-    page.on('pageerror', (error: Error) => {
+    const onPageError = (error: Error) => {
         const message = error?.message || '';
 
         if (isExceptionIgnored(message, ignoreJSExceptions)) {
@@ -82,9 +84,10 @@ export const jsExceptionWatcher = async (
         } else {
             errors.push(error);
         }
-    });
+    };
+    page.on('pageerror', onPageError);
 
-    await use();
+    await use({ stop: () => page.off('pageerror', onPageError) });
 
     if (ignored.length > 0) {
         testInfo.annotations.push({
@@ -102,13 +105,16 @@ export const jsExceptionWatcher = async (
 
 export const toastErrorWatcher = async (
     { page, ignoreToastErrors }: { page: Page; ignoreToastErrors: string[] },
-    use: () => Promise<void>,
+    use: (watcher: Watcher) => Promise<void>,
     testInfo: TestInfo,
 ) => {
     const captured: CapturedToast[] = [];
+    let recording = true;
 
     await page.exposeFunction('__reportToast', (toast: CapturedToast) => {
-        captured.push(toast);
+        if (recording) {
+            captured.push(toast);
+        }
     });
 
     // Inject into the already-loaded page so the observer is active for the whole test.
@@ -116,7 +122,11 @@ export const toastErrorWatcher = async (
     // Register for any subsequent full navigations within the test.
     await page.addInitScript(installToastObserver);
 
-    await use();
+    await use({
+        stop: () => {
+            recording = false;
+        },
+    });
 
     const unexpected = captured.filter(toast => !isToastIgnored(toast, ignoreToastErrors));
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Our e2e tests have two watchers running during every tests. One collects JS exceptions, the other toast errors. If any non ignored exceptions/errors are collected -> test is failed in teardown. 

Recently few tests failed due to this. Because in teardown phase we are stopping mocks by cutting off WebSocket communication with our app which as a result thrown JS exception. That is false negative result. Teardown is about making the environment ready for next test, not about shutting things gracefully.

Solution: Watchers now provide means to stop their recording. Extra test.afterEach was added to main fixture file in which we stop recordings of both watchers. That way we are collecting only errors and exceptions from the intended test.

## Verification

Ran the real `jsExceptionWatcher` / `toastErrorWatcher` functions against a live Chromium page, replicating the fixture wiring + the `afterEach` `stop()` boundary.

| # | Scenario | Expected | Result |
|---|----------|----------|--------|
| 1 | JS exception **during body** | fail (recorded) | ✅ threw as expected |
| 2 | JS exception **during teardown** | pass (ignored) | ✅ passed |
| 3 | JS exception in body matching `ignoreJSExceptions` | pass (annotated only) | ✅ passed |
| 4 | Critical toast **during body** | fail (recorded) | ✅ threw as expected |
| 5 | Critical toast **during teardown** | pass (ignored) | ✅ passed |
| 6 | Toast in body matching `ignoreToastErrors` | pass | ✅ passed |

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-fixes-7-13/web/](https://dev.suite.sldev.cz/suite-web/test-fixes-7-13/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-fixes-7-13&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-fixes-7-13&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-13T09:52:38.214Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-13T09:52:34.293Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->