### PR TITLE
fix(suite-native): add missing vault label to yield tx confirmation modal

### DIFF
--- a/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts
+++ b/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts
@@ -48,6 +48,7 @@ type UnresolvedYieldFlowData = {
     vault: YieldDtoV2 | null;
     vaultTokenName: string | null;
     vaultTokenSymbol: string | null;
+    vaultName: string | null;
 };
 
 type YieldFlowDataResolved = {
@@ -65,6 +66,7 @@ type YieldFlowDataResolved = {
     vault: YieldDtoV2;
     vaultTokenName: string;
     vaultTokenSymbol: string;
+    vaultName: string;
 };
 
 export type ResolvedYieldFlowData = UnresolvedYieldFlowData | YieldFlowDataResolved;
@@ -93,6 +95,7 @@ const defaultFlowData: ResolvedYieldFlowData = {
     vault: null,
     vaultTokenName: null,
     vaultTokenSymbol: null,
+    vaultName: null,
 };
 
 export const resolveYieldFlowData = ({
@@ -130,6 +133,7 @@ export const resolveYieldFlowData = ({
     const providerName = capitalizeFirstLetter(vault.providerId);
     const vaultTokenName = vault.outputToken?.name;
     const vaultTokenSymbol = vault.outputToken.symbol;
+    const vaultName = vault.metadata.name ?? vaultTokenName;
     const bonusRewardToken = getBonusRewardToken(vault.rewardRate.components, vault.token);
     const resolvedVaultData = {
         apy,
@@ -139,6 +143,7 @@ export const resolveYieldFlowData = ({
         vault,
         vaultTokenName,
         vaultTokenSymbol,
+        vaultName,
     };
 
     if (!network) {

--- a/suite-native/module-earn/src/screens/YieldDepositReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositReviewScreen.tsx
@@ -27,13 +27,14 @@ type NavigationProps = StackNavigationProps<
 export const YieldDepositReviewScreen = () => {
     const route = useRoute<RouteProps>();
     const navigation = useNavigation<NavigationProps>();
-    const { flowData, flowKey, resolutionStatus, vaultTokenName } = useResolvedYieldFlowData(
+    const { flowData, flowKey, resolutionStatus, vaultName } = useResolvedYieldFlowData(
         route.params,
     );
     const device = useSelector(selectSelectedDevice);
     const session = useSelector((state: StablecoinYieldRootState) =>
         selectStablecoinYieldSessionByFlowKey(state, 'deposit', flowKey),
     );
+
     const actionReview = session?.action.review;
     const review = useMemo(
         () =>
@@ -46,7 +47,7 @@ export const YieldDepositReviewScreen = () => {
         [actionReview],
     );
     const preview = useMemo(() => {
-        if (!review || !device || !flowData || vaultTokenName === null) {
+        if (!review || !device || !flowData || vaultName === null) {
             return null;
         }
 
@@ -55,9 +56,9 @@ export const YieldDepositReviewScreen = () => {
             flowData,
             review,
             type: 'deposit',
-            vaultName: vaultTokenName,
+            vaultName,
         });
-    }, [device, flowData, review, vaultTokenName]);
+    }, [device, flowData, review, vaultName]);
 
     useEffect(() => {
         if (resolutionStatus !== 'resolved') {

--- a/suite-native/module-earn/src/screens/YieldWithdrawReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawReviewScreen.tsx
@@ -43,7 +43,7 @@ const isYieldWithdrawScreenReview = (
 export const YieldWithdrawReviewScreen = () => {
     const route = useRoute<RouteProps>();
     const navigation = useNavigation<NavigationProps>();
-    const { flowData, flowKey, resolutionStatus, vaultTokenName } = useResolvedYieldFlowData(
+    const { flowData, flowKey, resolutionStatus, vaultName } = useResolvedYieldFlowData(
         route.params,
     );
     const device = useSelector(selectSelectedDevice);
@@ -55,6 +55,7 @@ export const YieldWithdrawReviewScreen = () => {
     const formDraft = useSelector((state: FormDraftRootState) =>
         formDraftKey ? selectFormDraft<FormState>(state, formDraftKey) : undefined,
     );
+
     const actionReview = session?.action.review;
     const review = useMemo(
         () => (isYieldWithdrawScreenReview(actionReview, flowType) ? actionReview : null),
@@ -69,14 +70,7 @@ export const YieldWithdrawReviewScreen = () => {
     }, [flowData, flowType]);
     const selectedFee = useMemo(() => getSelectedEvmFeeFromFormDraft(formDraft), [formDraft]);
     const preview = useMemo(() => {
-        if (
-            !review ||
-            !device ||
-            !flowData ||
-            !reviewToken ||
-            !selectedFee ||
-            vaultTokenName === null
-        ) {
+        if (!review || !device || !flowData || !reviewToken || !selectedFee || vaultName === null) {
             return null;
         }
 
@@ -87,9 +81,9 @@ export const YieldWithdrawReviewScreen = () => {
             reviewToken,
             selectedFee,
             type: 'withdraw',
-            vaultName: vaultTokenName,
+            vaultName,
         });
-    }, [device, flowData, review, reviewToken, selectedFee, vaultTokenName]);
+    }, [device, flowData, review, reviewToken, selectedFee, vaultName]);
 
     useEffect(() => {
         if (resolutionStatus !== 'resolved') {


### PR DESCRIPTION
## Description

Add missing `Vault` label to yield transaction confirmation modal.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29269

## Screenshots:

<table>
<tr>
<td>
<img width="100%" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-13 at 11 11 28" src="https://github.com/user-attachments/assets/79d1d86d-1efb-4e79-8ec6-73375381229f" />
</td>
<td>
<img width="100%" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-13 at 11 11 54" src="https://github.com/user-attachments/assets/bef1d4b3-bf54-48e4-9915-3321af3d54ed" />
</td>
</tr>
</table>

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/yield-tx-review-missing-vault&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->