### PR TITLE
fix(trading): hide receive address in trade form

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -187,9 +187,10 @@ export const TradingExchangeFormInputs = () => {
                     />
                 </TradingFormSection>
             </TradingFormCard>
+
             {receiveCryptoSelect && (
                 <TradingFormCard>
-                    {receiveCryptoSelect && !isLoading && <TradingReceiveAddress />}
+                    {!isLoading && <TradingReceiveAddress />}
                     {!!quotes.length && (
                         <TradingFormFees
                             feeInfo={feeInfo}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddress.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddress.tsx
@@ -45,7 +45,7 @@ export const TradingReceiveAddress = () => {
                 alignItems="center"
                 justifyContent="space-between"
                 padding={{
-                    vertical: selectedAccount && receiveAddress ? 12 : 16,
+                    vertical: selectedAccount && receiveAddress ? 20 : 16,
                     horizontal: 20,
                 }}
             >
@@ -61,28 +61,19 @@ export const TradingReceiveAddress = () => {
                 <Row gap={16}>
                     <Column alignItems="flex-end">
                         {selectedAccount && receiveAddress ? (
-                            <>
-                                <Text
-                                    typographyStyle="body-md"
-                                    as="div"
-                                    data-testid="@trading/selected-receive-account"
-                                    ellipsisLineCount={1}
-                                    maxWidth={200}
-                                >
-                                    <AccountLabeling
-                                        account={selectedAccount}
-                                        accountTypeBadgeSize="small"
-                                        showAccountTypeBadge
-                                    />
-                                </Text>
-                                <Address
-                                    value={receiveAddress}
-                                    typographyStyle="body-sm"
-                                    intent="neutral"
-                                    priority="secondary"
-                                    isTruncated
+                            <Text
+                                typographyStyle="body-md"
+                                as="div"
+                                data-testid="@trading/selected-receive-account"
+                                ellipsisLineCount={1}
+                                maxWidth={200}
+                            >
+                                <AccountLabeling
+                                    account={selectedAccount}
+                                    accountTypeBadgeSize="small"
+                                    showAccountTypeBadge
                                 />
-                            </>
+                            </Text>
                         ) : (
                             <>
                                 {receiveAddress ? (


### PR DESCRIPTION
## Description

- hide the selected receive address in the desktop trade form when a Suite account is selected
- keep the receiving account row label visible and show the selected account name only
- increase the vertical padding of the selected receiving account row from 12 px to 20 px
- keep the lower swap section rendered only after a receive asset is selected

## Notes for QA

- In Trading Buy on desktop, select a Suite receive account and verify the lower Receiving account row shows the account name without the address.
- In Trading Swap on desktop, select a receive asset and verify the lower section appears with the Receiving account row before provider details.
- In Trading Buy or Swap, switch to a non-Suite receive address flow and verify the address is still shown when no Suite account is selected.

## Related Issue

Resolve #28187

## Screenshots:

<img width="952" height="523" alt="image" src="https://github.com/user-attachments/assets/270dd689-255e-4e33-b16c-0812af80824c" />
<img width="950" height="653" alt="image" src="https://github.com/user-attachments/assets/13935d01-95e2-40d2-a440-3b426206f68e" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two key trading UI components: TradingExchangeFormInputs (the swap form input fields including asset pickers and amount inputs) and TradingReceiveAddress (the receive address selection component used across buy, sell, and swap flows). Both are shared components mapping to 15+ tests, so the testing strategy focuses on tests that most directly exercise form input interaction and receive address selection. The highest priority tests are those that explicitly fill swap forms, select assets, and choose receive accounts. Buy and sell flow tests are medium priority since they primarily exercise TradingReceiveAddress. Fee-focused and navigation tests are lower priority as they only transitively depend on these components.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddress.tsx`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test directly exercises swap form inputs (asset picker, crypto/fiat amount inputs, fraction buttons, validation errors) which are rendered by TradingExchangeFormInputs. It also tests receive account selection which uses TradingReceiveAddress. Changes to either component could break input behavior, validation, or asset selection.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test fills in the swap form (exercising TradingExchangeFormInputs) and selects a receive address (exercising TradingReceiveAddress), then completes the full swap flow including confirmation and status tracking. It validates the complete happy path through both changed components.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test fills the swap form with cross-chain assets (SOL to USDC on ETH) and explicitly selects a Suite receive account, directly exercising both TradingExchangeFormInputs for form filling and TradingReceiveAddress for receive address selection across different networks.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test selects a receive address for the buy flow, directly exercising TradingReceiveAddress. It also fills buy form inputs (fiat amount). Changes to the receive address component could break receive account selection in the buy flow.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test fills a sell form and completes the send flow including device confirmation. The confirmation screen shows a destination address, and the TradingReceiveAddress component may be involved in address display/selection during the sell offer confirmation.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — This test swaps a Solana token (USDT) to Bitcoin, filling the swap form and selecting a receive address. It exercises both changed components in a token-to-coin scenario which may have distinct code paths in TradingExchangeFormInputs.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — This test swaps between two SPL tokens (USDT to USDC) on Solana, filling the swap form and selecting a receive account. Token-to-token swaps on the same network may exercise distinct logic in TradingExchangeFormInputs asset selection.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This test fills in a swap form for a DEX (LI.FI) swap flow, which may exercise different code paths in TradingExchangeFormInputs compared to CEX swaps. The DEX confirmation also shows receive address details.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test adds a new Suite receive account for ETH during the buy flow, specifically testing the 'add new receive account' path in TradingReceiveAddress which is a distinct code path from selecting an existing account.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test validates sell form input behaviors (decimal validation, fraction buttons, max calculation, currency switching) which share form input infrastructure with TradingExchangeFormInputs. Changes to form input components could affect sell form validation.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test specifically fills a swap form with a buy asset from a disabled network (XLM), testing an edge case in TradingExchangeFormInputs asset selection logic where the target network is not enabled.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test verifies that navigating to swap/buy/sell forms from various entry points opens with the correct cryptocurrency preselected. Changes to TradingExchangeFormInputs could affect which asset is displayed after navigation.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test fills the swap form (using TradingExchangeFormInputs) but primarily focuses on custom fee settings. Changes to the form inputs component could prevent reaching the fee configuration step.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test selects a Solana SPL token via asset picker and selects a receive account in the buy flow. Changes to TradingReceiveAddress could affect receive account selection for token buys.

</details>

_Updated: 2026-07-13T10:15:31.209Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/28187-trading-receive-account-section/web/](https://dev.suite.sldev.cz/suite-web/fix/28187-trading-receive-account-section/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/28187-trading-receive-account-section&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/28187-trading-receive-account-section&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-13T10:18:45.856Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-13T10:18:12.273Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->