### PR TITLE
fix(suite-native): use correct T3W1 pagination graphics in DeviceScreenPagination

### DIFF
--- a/suite-native/module-receive/src/components/DeviceScreenPagination.tsx
+++ b/suite-native/module-receive/src/components/DeviceScreenPagination.tsx
@@ -74,14 +74,14 @@ const deviceModelToSvg: Record<PaginationCompatibleDeviceModel, PaginationModelM
     },
     [DeviceModelInternal.T3W1]: {
         paginationPrefixSvg: require('../../assets/addressPaginationPrefixT2T1.svg'),
-        paginationSuffixSvg: require('../../assets/addressPaginationPrefixT2T1.svg'),
+        paginationSuffixSvg: require('../../assets/addressPaginationSuffixT2T1.svg'),
         paginatorPrefixX: 0,
         paginatorPrefixY: 4,
         paginatorSuffixX: 182.5,
         paginatorSuffixY: 82,
 
         pagerSvg1: require('../../assets/pager1T2T1.svg'),
-        pagerSvg2: require('../../assets/pager1T2T1.svg'),
+        pagerSvg2: require('../../assets/pager2T2T1.svg'),
         pagerX: 260,
         pagerY: 30,
         paginationSvgWidth: 40,


### PR DESCRIPTION
### Description

Fixes a copy-paste bug in the T3W1 device config of `DeviceScreenPagination`. Two SVG slots referenced the wrong asset:

- `paginationSuffixSvg` pointed at `addressPaginationPrefixT2T1.svg` (the prefix graphic) instead of `addressPaginationSuffixT2T1.svg`.
- `pagerSvg2` pointed at `pager1T2T1.svg` instead of `pager2T2T1.svg`.

As a result, T3W1 users viewing a 2-page address saw the wrong pagination/pager graphics rendered on the device-screen preview. The other device configs already used the correct suffix/pager2 assets; this brings T3W1 in line.

### Related Issue

Split out from a larger staging branch as a standalone single-purpose fix.

### Notes for QA

Low blast radius — a single suite-native (mobile) component that renders the on-device address screen preview. To verify: on a T3W1 device, open the Receive flow for an address long enough to span 2 pages and confirm the suffix pagination graphic and the second pager dot render correctly (matching what the physical device shows). No effect on other device models or on desktop/web.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fix-t3w1-pagination-graphics&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->