### PR TITLE
fix: report transaction size in bytes, not weight units

### DIFF
--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -275,7 +275,7 @@ export const getBroadcastedTxDetails = ({
         hex: tx.toHex(),
         hash: tx.getHash().toString('hex'),
         txid: tx.getId(),
-        size: tx.weight(),
+        size: tx.byteLength(),
         vsize: tx.virtualSize(),
     };
 };

--- a/packages/connect/src/api/bitcoin/createPendingTx.test.ts
+++ b/packages/connect/src/api/bitcoin/createPendingTx.test.ts
@@ -1,0 +1,24 @@
+import { Transaction, networks } from '@trezor/utxo-lib';
+
+import { createPendingTransaction } from './createPendingTx';
+
+describe('helpers/createPendingTransaction', () => {
+    // A minimal legacy (non-segwit) transaction. For legacy txs weight() === 4 * byteLength(),
+    // so it cleanly distinguishes the byte size from the weight units.
+    const hex =
+        '01000000016d20f69067ad1ffd50ee7c0f377dde2c932ccb03e84b5659732da99c20f1f650010000006b483045022100a200ea1278c3d32251a63c56f5f0861f48167c61d84de8d951eac1204856ccd402201fc03f446557bcbcef1e473616bb7bddc96561b656b7ddd6b419501543ed5044012102a7a079c1ef9916b289c2ff21a992c808d0de3dfcf8a9f163205c5c9e21f55d5cffffffff0110270000000000001976a914de9b2a8da088824e8fe51debea566617d851537888ac00000000';
+
+    it('reports size in bytes (byteLength), not weight units', () => {
+        const tx = Transaction.fromHex(hex, { network: networks.bitcoin });
+        const pending = createPendingTransaction(tx, {
+            addresses: { used: [], unused: [], change: [] },
+            inputs: [],
+            outputs: [],
+        });
+
+        expect(pending.size).toBe(tx.byteLength());
+        expect(pending.vsize).toBe(tx.virtualSize());
+        // Guards the regression: weight() is 4x the byte size for a legacy tx.
+        expect(pending.size).not.toBe(tx.weight());
+    });
+});

--- a/packages/connect/src/api/bitcoin/createPendingTx.ts
+++ b/packages/connect/src/api/bitcoin/createPendingTx.ts
@@ -42,7 +42,7 @@ export const createPendingTransaction = (
         blockTime: Math.floor(Date.now() / 1000),
         confirmations: 0,
         vsize: tx.virtualSize(),
-        size: tx.weight(),
+        size: tx.byteLength(),
         value: valueOut.toString(),
         valueIn: valueIn.toString(),
         fees: valueIn.minus(valueOut).toString(),


### PR DESCRIPTION
## Description

Two identical, independent fixes for the same bug: a locally-constructed transaction reported its `size` as **weight units** (`tx.weight()`) instead of **serialized byte length** (`tx.byteLength()`).

- **`packages/connect`** — `createPendingTransaction` ([`createPendingTx.ts`](https://github.com/trezor/trezor-suite/blob/babcaefa0a09c1da6b98e14f59d98a5371596349/packages/connect/src/api/bitcoin/createPendingTx.ts#L45)), the optimistic pending tx returned as `response.signedTransaction` after a BTC send is signed ([`signTransaction.ts:373`](https://github.com/trezor/trezor-suite/blob/9d35bb594cf9408044d57f424bae2d4053a3d983/packages/connect/src/api/signTransaction.ts#L373)).
- **`packages/coinjoin`** — `getBroadcastedTxDetails` ([`roundUtils.ts`](https://github.com/trezor/trezor-suite/blob/babcaefa0a09c1da6b98e14f59d98a5371596349/packages/coinjoin/src/utils/roundUtils.ts#L278)), the details object for a broadcasted coinjoin round transaction.

```diff
  vsize: tx.virtualSize(),   // correct — virtual bytes
- size: tx.weight(),         // wrong — weight units (BIP141), up to ~4x the byte size
+ size: tx.byteLength(),     // correct — raw serialized bytes, matching blockbook's `size`
```

Bitcoin has three distinct "sizes": `byteLength` (raw serialized bytes — what blockbook's `size` means), `weight` (BIP141 weight units = `base×3 + total`), and `vsize` (`weight/4`, virtual bytes). `size` must be byte length; it was getting weight. The inflation is **exactly 4x for legacy transactions** and **~2.5–3.5x for SegWit** (the witness discount shrinks the ratio). `vsize` was already correct in both places.

## Impact analysis

The honest picture is layered — this is mostly a data-correctness / consistency fix, with one concrete user-visible symptom.

**Not affected — the primary fee rate is correct.** The `feeRate` field shown in the transaction detail modal is computed from **vsize**, not size ([`blockbook.ts:350-352`](https://github.com/trezor/trezor-suite/blob/9d35bb594cf9408044d57f424bae2d4053a3d983/packages/blockchain-link-utils/src/blockbook.ts#L350-L352): `fee / vsize`), and `vsize` was correct. The detail view also guards with `tx.feeRate ? tx.feeRate : getFeeRate(tx)` ([`BasicTxDetails.tsx:183`](https://github.com/trezor/trezor-suite/blob/9d35bb594cf9408044d57f424bae2d4053a3d983/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx#L183)), so for freshly-created pending txs (which always have `feeRate`) the buggy value is never read there.

**Affected — the "Bump fee" (RBF) modal shows a too-low current fee rate.** [`ChangeFee.tsx:77`](https://github.com/trezor/trezor-suite/blob/9d35bb594cf9408044d57f424bae2d4053a3d983/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee.tsx#L77) renders the *"Current fee: X sat/vB"* label via `getFeeRate(tx)` **directly, without the `tx.feeRate ||` guard**. `getFeeRate` divides `fee / tx.details.size` ([`transactionUtils.ts:822-824`](https://github.com/trezor/trezor-suite/blob/9d35bb594cf9408044d57f424bae2d4053a3d983/suite-common/wallet-utils/src/transactionUtils.ts#L822-L824)), and `details.size` carries the buggy weight value. So when a user opens **Bump fee** on a **pending BTC send** — exactly the window where RBF applies — the displayed current fee rate reads **up to ~4x too low**. It is an informational label (it does not change the new fee the user picks), but it can mislead toward under-bumping. After this fix that label reads correctly (modulo a pre-existing sat/byte-vs-sat/vB rounding quirk, see below).

**Self-healing.** The wrong `size` lives in `details.size` of the pending tx in Redux and IndexedDB only until the transaction confirms, at which point the tx is replaced by the blockbook-fetched version with the correct byte size ([`transactionsReducer.ts`](https://github.com/trezor/trezor-suite/blob/9d35bb594cf9408044d57f424bae2d4053a3d983/suite-common/wallet-core/src/transactions/transactionsReducer.ts#L102) pending→confirmed reconciliation). Historical/confirmed transactions were never affected.

**Latent risk removed.** `getFeeRate` is also used as a fallback wherever `tx.feeRate` might be missing (old blockbook instances that don't send `vsize`, or pre-`blockchain-link@2.1.5` locally-saved txs). On such a path the buggy size would have produced the same ~4x-too-low fee rate. This fix removes that landmine.

**Never leaves the device.** The value is not sent to analytics, Sentry, or any backend request.

**Out of scope (pre-existing).** `getFeeRate` divides by `size` while the UI labels the result `sat/vB`; a strictly correct sat/vByte would divide by `vsize`. This fix makes `size` correct (so the label goes from grossly wrong to within the witness-discount margin) but does not change `getFeeRate` to use `vsize` — that is a separate latent inconsistency, not touched here.

## Tests

Ships the unit test from the connect fix ([`createPendingTx.test.ts`](https://github.com/trezor/trezor-suite/blob/babcaefa0a09c1da6b98e14f59d98a5371596349/packages/connect/src/api/bitcoin/__tests__/createPendingTx.test.ts)): builds a legacy tx (where `weight() === 4 × byteLength()`, cleanly separating the two) and asserts `pending.size === tx.byteLength()`, `pending.vsize === tx.virtualSize()`, and `pending.size !== tx.weight()` as a regression guard. The coinjoin change is the identical one-liner in the sibling helper and is covered by analogy.

Split out from the continuously-improve sweep #29735.

## Notes for QA

Focus on the **Bump fee (RBF)** flow for a **pending BTC transaction**: the *"Current fee"* rate shown in the bump-fee modal should now match the fee rate shown in the transaction detail (previously it read several times lower for the pending window). Also worth a sanity check on a completed coinjoin round's transaction details. No impact on Ethereum (fee shown via gas fields, not size), on confirmed transactions, or on the actual fees paid — this only affects a displayed rate for locally-constructed pending txs. Low blast radius.

## References

Authoritative definitions of the three distinct transaction "sizes" this fix distinguishes:

- [BIP141 — Segregated Witness, *Transaction size calculations*](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#transaction-size-calculations) — the canonical spec: *weight = base size × 3 + total size*, *virtual size = weight / 4 (rounded up)*.
- [Learn Me A Bitcoin — *Transaction Size: Bytes, Weight, and Virtual Bytes*](https://learnmeabitcoin.com/technical/transaction/size/) — plain-English explainer of why `size` (raw bytes), `weight` (weight units), and `vsize` (virtual bytes) differ, and which one a feerate should use.
- [Bitcoin Wiki — *Weight units*](https://en.bitcoin.it/wiki/Weight_units) — background on the weight metric and the SegWit witness discount.
- [bitcoinjs-lib `Transaction` methods](https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/ts_src/transaction.ts) — `byteLength()`, `weight()`, and `virtualSize()`: the exact API that `@trezor/utxo-lib` (a bitcoinjs-lib fork) exposes and this code calls.

## Related Issue

Part of the split-out series from #29735.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-tx-size-bytes-not-weight&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-tx-size-bytes-not-weight&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-04T07:28:11.131Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-04T07:26:55.025Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->