### PR TITLE
fix(trading): open sell confirm immediately after partner selection

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -197,19 +197,16 @@ export const useTradingSellForm = (): TradingSellFormContextProps => {
             },
         });
 
-        const nextStep = async () => {
-            let isRedirecting = false;
+        const nextStep = () => {
+            dispatch(goto({ routeName: 'wallet-trading-sell-confirm' }));
 
-            // empty quoteId means the partner requests login first, requestTrade to get login screen
+            // Empty quoteId means the partner requests login first; keep the UI moving
+            // to confirm while the partner request continues in the background.
             if (
                 (sellInfo && sellUtils.needToRegisterOrVerifyBankAccount({ quote, sellInfo })) ||
                 !quote.quoteId
             ) {
-                ({ isRedirecting } = await handleSellTrade(quote));
-            }
-
-            if (!isRedirecting) {
-                dispatch(goto({ routeName: 'wallet-trading-sell-confirm' }));
+                void handleSellTrade(quote);
             }
         };
 


### PR DESCRIPTION
## Description

- Restore immediate navigation from Sell form to the confirm waiting-for-partner screen after selecting a partner.
- Keep the partner trade request running after the route change instead of blocking the form page first.
- Preserve the existing login or bank-account request handling for sell partners.

## Notes for QA

- In Trade > Sell on desktop, fill the form and click a partner offer, verify Suite opens the waiting-for-partner confirm screen immediately.
- In Trade > Sell on desktop, repeat with a partner that requires login or bank account setup, verify the confirm screen still opens and the partner flow continues.

## Related Issue

Resolve #29744

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to useTradingSellForm.ts, the core hook powering the sell trading form. This is a focused but high-risk change since it underpins all sell-related functionality including input validation, balance calculations, offer management, and transaction flow. The two sell-specific tests (sell-inputs and sell-solana) should be run unconditionally as they directly exercise the hook's behavior. The navigation test is medium priority as it only touches the form initialization path.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test directly exercises the sell form's input validation, percentage buttons, max button, custom fee handling, and currency switching — all of which are driven by the useTradingSellForm hook. Changes to this hook could break decimal validation, balance fraction calculations, fee subtraction logic, or fiat currency switching.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test covers the full sell flow end-to-end (filling the form, selecting offers, confirming, sending, and status polling) which relies heavily on useTradingSellForm for form state management, quote fetching, and trade submission. A regression in the hook would directly break offer display, confirmation details, or transaction initiation.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test verifies that navigating to the Sell form from various entry points opens with the correct cryptocurrency preselected. While it primarily tests navigation routing rather than form logic, the sell form initialization path passes through useTradingSellForm, so changes to initial state or form setup could cause the wrong coin to appear.

</details>

_Updated: 2026-07-13T10:40:39.602Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/29744-sell-waiting-for-partner/web/](https://dev.suite.sldev.cz/suite-web/fix/29744-sell-waiting-for-partner/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/29744-sell-waiting-for-partner&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/29744-sell-waiting-for-partner&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-13T10:43:41.511Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-13T10:43:25.882Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->