### PR TITLE
fix(suite-common): adjust representative assets

### DIFF
--- a/suite-common/wallet-config/src/representativeAssets.ts
+++ b/suite-common/wallet-config/src/representativeAssets.ts
@@ -25,15 +25,15 @@ const representativeAssets: Partial<Record<NetworkSymbol, readonly Representativ
         { symbol: 'BNB' },
         { symbol: 'USDT', contract: '0x55d398326f99059ff775485246999027b3197955' },
         { symbol: 'CAKE', contract: '0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82' },
-        { symbol: 'XRP', contract: '0x1d2f0da169ceb9fc7b3144628db156f3f6c60dbe' },
-        { symbol: 'BTCB', contract: '0x7130d2a12b9bcbfae4f2634d864a1ee1ce3ead9c' },
+        { symbol: 'ETH', contract: '0x2170ed0880ac9a755fd29b2688956bd959f933f8' },
+        { symbol: 'USDC', contract: '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d' },
     ],
     arb: [
         { symbol: 'ARB', contract: '0x912ce59144191c1204e64559fe8253a0e49e6548' },
+        { symbol: 'ETH' },
         { symbol: 'USDC', contract: '0xaf88d065e77c8cc2239327c5edb3a432268e5831' },
         { symbol: 'GMX', contract: '0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a' },
         { symbol: 'LINK', contract: '0xf97f4df75117a78c1a5a0dbb814af92458539fb4' },
-        { symbol: 'WETH', contract: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1' },
     ],
     base: [
         { symbol: 'ETH' },
@@ -44,16 +44,16 @@ const representativeAssets: Partial<Record<NetworkSymbol, readonly Representativ
     ],
     op: [
         { symbol: 'OP', contract: '0x4200000000000000000000000000000000000042' },
+        { symbol: 'ETH' },
         { symbol: 'USDC', contract: '0x0b2c639c533813f4aa9d7837caf62653d097ff85' },
         { symbol: 'SNX', contract: '0x8700daec35af8ff88c16bdf0418774cb3d7599b4' },
         { symbol: 'VELO', contract: '0x9560e827af36c94d2ac33a39bce1fe78631088db' },
-        { symbol: 'WETH', contract: '0x4200000000000000000000000000000000000006' },
     ],
     avax: [
         { symbol: 'AVAX' },
         { symbol: 'USDC', contract: '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e' },
         { symbol: 'JOE', contract: '0x6e84a6216ea6dacc71ee8e6b0a5b7322eebc0fdd' },
-        { symbol: 'BTC.b', contract: '0x152b9d0fdc40c096757f570a51e494bd4b943e50' },
+        { symbol: 'WETH.e', contract: '0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB' },
         { symbol: 'QI', contract: '0x8729438eb15e2c8b576fcc6aecda6a148776c0f5' },
     ],
     sol: [

--- a/suite-native/coin-enabling/src/components/CryptoIconSet.tsx
+++ b/suite-native/coin-enabling/src/components/CryptoIconSet.tsx
@@ -12,7 +12,7 @@ export type CryptoIconSetProps = {
     symbol: NetworkSymbol;
 };
 
-const ICON_SIZE = 20;
+const ICON_SIZE = 24;
 const RING_WIDTH = 2;
 const ICONS_OVERLAP = 8;
 
@@ -22,7 +22,7 @@ const bubbleStyle = prepareNativeStyle<{ isFirst: boolean; zIndex: number }>(
         justifyContent: 'center',
         width: ICON_SIZE + RING_WIDTH * 2,
         height: ICON_SIZE + RING_WIDTH * 2,
-        marginLeft: isFirst ? 0 : -ICONS_OVERLAP,
+        marginLeft: isFirst ? -RING_WIDTH : -ICONS_OVERLAP,
         borderRadius: utils.borders.radii.round,
         backgroundColor: utils.colors.surfaceFillRaised,
         zIndex,
@@ -34,7 +34,7 @@ const countStyle = prepareNativeStyle(utils => ({
     justifyContent: 'center',
     height: ICON_SIZE + RING_WIDTH * 2,
     marginLeft: -ICONS_OVERLAP + utils.spacings.sp2,
-    paddingHorizontal: utils.spacings.sp4,
+    paddingHorizontal: utils.spacings.sp6,
     borderRadius: utils.borders.radii.round,
     backgroundColor: utils.colors.elementFillNeutralSofter,
     zIndex: 0,

--- a/suite-native/coin-enabling/src/components/MainnetNetworkListItemContent.tsx
+++ b/suite-native/coin-enabling/src/components/MainnetNetworkListItemContent.tsx
@@ -30,7 +30,6 @@ export const MainnetNetworkListItemContent = ({
             <Box>
                 <VStack justifyContent="flex-start" flex={1}>
                     <NetworkIcon symbol={symbol} size="extraLarge" />
-
                     <Box paddingLeft="sp12">
                         <RepresentativeAssetsConnectorSvg />
                     </Box>
@@ -51,7 +50,6 @@ export const MainnetNetworkListItemContent = ({
                     </HStack>
                     <Divider style={applyStyle(dividerStyle)} />
                 </VStack>
-
                 <HStack spacing="sp12" justifyContent="space-between" alignItems="center">
                     <CryptoIconSet symbol={symbol} />
                     <NetworkBackendsButton symbol={symbol} />


### PR DESCRIPTION
## Description

- Correct size and margin for crypto icon set used.
- Representative assets adjusted as requested.

## Related Issue

Resolve #29737

## Screenshots:
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/b03fcc32-6d33-45b7-ac83-5f563e6a0b7f" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set has low overall risk. The two suite-native files (CryptoIconSet.tsx, MainnetNetworkListItemContent.tsx) are mobile-only components with no web E2E test coverage. The representativeAssets.ts file is a broadly imported wallet-config module that maps to 131 tests, but most of those tests only transitively depend on it. Only tests that directly exercise asset display, coin activation, or asset picker functionality have a plausible connection to representative asset changes. A small targeted set of 2-3 tests focused on asset rendering and coin enabling should provide sufficient confidence.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/wallet-config/src/representativeAssets.ts`
- `suite-native/coin-enabling/src/components/CryptoIconSet.tsx`
- `suite-native/coin-enabling/src/components/MainnetNetworkListItemContent.tsx`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test exercises the Assets section on the dashboard including enabling new coins and verifying asset contents in grid/table views. Changes to representativeAssets.ts could affect which assets are displayed or how they are represented in the asset list, making this the most directly relevant test.
- `suite/e2e/tests/settings/coins.test.ts` — This test covers activating mainnet/testnet assets via the coins settings page and the Activate Assets modal on the dashboard. representativeAssets.ts likely influences which coins appear in the activation UI and how networks are represented, making this test relevant.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates trading flows from asset cards and account pages for multiple coins (BTC, ETH, LTC). If representativeAssets.ts changes how assets are identified or grouped, it could affect asset picker behavior in the trading navigation flow.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-native/coin-enabling/src/components/CryptoIconSet.tsx`
- `suite-native/coin-enabling/src/components/MainnetNetworkListItemContent.tsx`

_Updated: 2026-07-13T11:13:00.934Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/common/representative-assets/web/](https://dev.suite.sldev.cz/suite-web/fix/common/representative-assets/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/common/representative-assets&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/common/representative-assets&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/common/representative-assets&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-13T11:16:08.291Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-13T11:15:44.830Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->