### PR TITLE
Message system: Add Tor 0.4.8 EOL notification

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2026-06-23T12:00:00+00:00",
-    "sequence": 147,
+    "timestamp": "2026-07-13T12:00:00+00:00",
+    "sequence": 148,
     "actions": [
         {
             "conditions": [
@@ -1726,6 +1726,62 @@
                         "flag": false
                     }
                 ]
+            }
+        },
+        {
+            "conditions": [
+                {
+                    "settings": [
+                        {
+                            "tor": true
+                        }
+                    ],
+                    "environment": {
+                        "desktop": "<26.3.1",
+                        "mobile": "!",
+                        "web": "!"
+                    }
+                }
+            ],
+            "message": {
+                "id": "8155b6f1-d8da-45d5-83b3-0d8663a130d0",
+                "priority": 95,
+                "dismissible": false,
+                "variant": "warning",
+                "category": "banner",
+                "content": {
+                    "en": "Tor release included in this app will stop working on September 1st, 2026. Update Trezor Suite to continue using Tor.",
+                    "es": "La versión de Tor incluida en esta aplicación dejará de funcionar el 1 de septiembre de 2026. Actualiza Trezor Suite para seguir usando Tor.",
+                    "cs": "Verze Tor obsažená v této aplikaci přestane fungovat 1. září 2026. Aktualizujte Trezor Suite, abyste mohli Tor nadále používat.",
+                    "ru": "Версия Tor, включённая в это приложение, перестанет работать 1 сентября 2026 года. Обновите Trezor Suite, чтобы продолжить использовать Tor.",
+                    "ja": "このアプリに含まれるTorのバージョンは2026年9月1日に動作を停止します。Torを引き続き使用するには、Trezor Suiteをアップデートしてください。",
+                    "hu": "Az alkalmazásban lévő Tor verzió 2026. szeptember 1-jén leáll. Frissítse a Trezor Suite-ot a Tor további használatához.",
+                    "it": "La versione di Tor inclusa in questa app smetterà di funzionare il 1° settembre 2026. Aggiorna Trezor Suite per continuare a usare Tor.",
+                    "fr": "La version de Tor incluse dans cette application cessera de fonctionner le 1er septembre 2026. Mettez à jour Trezor Suite pour continuer à utiliser Tor.",
+                    "de": "Die in dieser App enthaltene Tor-Version funktioniert ab dem 1. September 2026 nicht mehr. Aktualisiere Trezor Suite, um Tor weiterhin nutzen zu können.",
+                    "tr": "Bu uygulamadaki Tor sürümü 1 Eylül 2026'da çalışmayı durduracak. Tor'u kullanmaya devam etmek için Trezor Suite'i güncelleyin.",
+                    "pt": "A versão do Tor incluída neste aplicativo deixará de funcionar em 1º de setembro de 2026. Atualize o Trezor Suite para continuar usando o Tor.",
+                    "uk": "Версія Tor, що входить до цього додатку, перестане працювати 1 вересня 2026 року. Оновіть Trezor Suite, щоб продовжити використовувати Tor."
+                },
+                "cta": {
+                    "action": "internal-link",
+                    "link": "settings-index",
+                    "anchor": "@general-settings/version-with-update",
+                    "label": {
+                        "en": "Update Trezor Suite",
+                        "es": "Actualizar Trezor Suite",
+                        "cs": "Aktualizovat Trezor Suite",
+                        "ru": "Обновить Trezor Suite",
+                        "ja": "Trezor Suiteのアップデート",
+                        "hu": "Frissítés Trezor Suite",
+                        "it": "Aggiorna Trezor Suite",
+                        "fr": "Mettre à jour Trezor Suite",
+                        "de": "Trezor Suite aktualisieren",
+                        "tr": "Trezor Suite'i Güncelle",
+                        "pt": "Atualizar Trezor Suite",
+                        "uk": "Оновити Trezor Suite"
+                    }
+                }
             }
         }
     ],


### PR DESCRIPTION
## Description

Add Tor 0.4.8 EOL notification, urging users using Suite <26.3 to update.

**Please check/fix message localization!**

<img width="900" height="353" alt="image" src="https://github.com/user-attachments/assets/8bdb56e3-bd1e-4bc3-a07a-dd9cbe01d380" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `suite-common/message-system/config/config.v1.json`, which is a JSON configuration file for the message system (remote messages, banners, prompts). No static test coverage mapping exists for this file, and none of the 118 analyzed E2E tests directly exercise message system configuration loading or rendering of remote messages driven by this config. While some tests (e.g., the guide test, onboarding tests) might indirectly encounter message system banners, there is no concrete evidence from the test analyses that any specific test's assertions would be affected by changes to this config file. The risk is low — this is a data/content change rather than a logic change, and no targeted E2E tests are recommended.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/message-system/config/config.v1.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-common/message-system/config/config.v1.json`

_Updated: 2026-07-13T11:30:46.019Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tor-update-notification/web/](https://dev.suite.sldev.cz/suite-web/feat/tor-update-notification/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tor-update-notification&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tor-update-notification&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tor-update-notification&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-13T11:34:16.160Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-13T11:33:05.445Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->