### PR TITLE
fix(suite-native): don't show AccountRenameButton for T1B1,T2T1

### DIFF
--- a/suite-native/module-accounts-management/src/components/AccountRenameButton.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountRenameButton.tsx
@@ -18,12 +18,10 @@ export const AccountRenameButton = ({ accountKey }: AccountRenameModalProps) => 
     const isLabellingAllowed = useSelector(selectIsLabellingAllowed);
     const { handleAddLabel, isInProgress } = useTurnOnSuiteSyncGuard();
 
+    if (!isLabellingAllowed) return null;
+
     const handleTriggerAccountRename = () => {
-        if (isLabellingAllowed) {
-            handleAddLabel(openModal);
-        } else {
-            openModal();
-        }
+        handleAddLabel(openModal);
     };
 
     return (


### PR DESCRIPTION
## Description

Do not show `AccountRenameButton` if not supported (e.g. when using T1B1, T2T1), this will make it consistent with other label editing UI, such as `AddressLabelEditable`, `EditableLabelLayout` and others.

## Related Issue

Resolve #29749

## Screenshots:

**Before:**

<img width="419" height="925" alt="Image" src="https://github.com/user-attachments/assets/54d26db5-ffaf-4b76-a01d-c726227293ba" />

**After:**

<img width="417" height="927" alt="Screenshot from 2026-07-13 14-00-14" src="https://github.com/user-attachments/assets/80fd69a5-1f43-4867-a599-39d0e20175cf" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/account-rename-label-with-older-models&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->