### PR TITLE
chore(suite-native): add commentary on legacy labelling in AccountRenameButton

### DIFF
--- a/suite-native/module-accounts-management/src/components/AccountRenameButton.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountRenameButton.tsx
@@ -22,6 +22,11 @@ export const AccountRenameButton = ({ accountKey }: AccountRenameModalProps) => 
         if (isLabellingAllowed) {
             handleAddLabel(openModal);
         } else {
+            /*
+             This flow edits the legacy MMKV labelling. It is reached by connecting T1B1 or T2T1 with Suite Sync turned off.
+             Only Account labels were implemented in the legacy system, that's why other labelling UI is simply hidden in this case.
+             Note that labels created/edited this way will be overidden by Suite Sync, if it is turned on on the same wallet.
+            */
             openModal();
         }
     };


### PR DESCRIPTION
## Description

Add commentary instead of closed #29754, which was a misunderstanding.

## Notes for QA

noop, only code commentary