### PR TITLE
fix(suite-common): fix tron account activation fees in send form

### DIFF
--- a/suite-common/wallet-core/src/send/tron/sendFormTronThunks.ts
+++ b/suite-common/wallet-core/src/send/tron/sendFormTronThunks.ts
@@ -129,6 +129,18 @@ export const composeTronTransactionFeeLevelsThunk = createThunk<
 
         const bytes = bandwidthEstimate.payload.bandwidth;
 
+        const [firstComposeOutput] = formState.outputs;
+
+        if (!firstComposeOutput) {
+            return rejectWithValue({
+                error: 'fee-levels-compose-failed',
+                message: 'Missing transaction output.',
+            });
+        }
+
+        const isNewAccount =
+            calldata.data === null && (await isNewTronAccount(firstComposeOutput.address, account));
+
         const feeLevel =
             calldata.data !== null
                 ? await estimateContractCallFeeLevel({
@@ -144,6 +156,7 @@ export const composeTronTransactionFeeLevelsThunk = createThunk<
                       availableFreeBandwidth:
                           account.misc?.tronResources?.availableFreeBandwidth ?? 0,
                       bytes,
+                      isNewAccount,
                   });
 
         if ('error' in feeLevel) {
@@ -154,18 +167,6 @@ export const composeTronTransactionFeeLevelsThunk = createThunk<
                 message: feeLevel.error,
             });
         }
-
-        const [firstComposeOutput] = formState.outputs;
-
-        if (!firstComposeOutput) {
-            return rejectWithValue({
-                error: 'fee-levels-compose-failed',
-                message: 'Missing transaction output.',
-            });
-        }
-
-        const isNewAccount =
-            calldata.data === null && (await isNewTronAccount(firstComposeOutput.address, account));
 
         const tx = calculate(
             account.availableBalance,

--- a/suite-common/wallet-utils/src/__tests__/tronUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/tronUtils.test.ts
@@ -1,7 +1,7 @@
 import { type GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
 import { type TronAccountExtraData } from '@trezor/blockchain-link-types';
 
-import { calculateTronFeeBreakdown } from '../tronUtils';
+import { calculateTronFeeBreakdown, computeBandwidthFeeLevel } from '../tronUtils';
 
 const makeTrc20Tx = (overrides: Record<string, unknown> = {}): GeneralPrecomposedTransaction =>
     ({
@@ -38,6 +38,58 @@ const makeTronResources = (
     totalBandwidthLimit: 0,
     totalBandwidthWeight: 0,
     ...overrides,
+});
+
+describe(computeBandwidthFeeLevel.name, () => {
+    it('returns zero fee when free bandwidth covers the transaction', () => {
+        const result = computeBandwidthFeeLevel({
+            availableStakedBandwidth: 0,
+            availableFreeBandwidth: 300,
+            bytes: 300,
+        });
+        expect(result.feePerTx).toBe('0');
+    });
+
+    it('charges the per-byte price when no bandwidth covers the transaction', () => {
+        const result = computeBandwidthFeeLevel({
+            availableStakedBandwidth: 0,
+            availableFreeBandwidth: 0,
+            bytes: 300,
+        });
+        expect(result.feePerTx).toBe('300000');
+    });
+
+    it('new account: free bandwidth is not accepted — charges the flat create-account fee', () => {
+        // The network refuses free bandwidth for account-creating transfers and burns
+        // the flat 0.1 TRX `getCreateAccountFee` instead of the per-byte price.
+        const result = computeBandwidthFeeLevel({
+            availableStakedBandwidth: 0,
+            availableFreeBandwidth: 600,
+            bytes: 300,
+            isNewAccount: true,
+        });
+        expect(result.feePerTx).toBe('100000');
+    });
+
+    it('new account: staked bandwidth covers the transaction — zero fee', () => {
+        const result = computeBandwidthFeeLevel({
+            availableStakedBandwidth: 300,
+            availableFreeBandwidth: 0,
+            bytes: 300,
+            isNewAccount: true,
+        });
+        expect(result.feePerTx).toBe('0');
+    });
+
+    it('new account: insufficient staked bandwidth — charges the flat create-account fee', () => {
+        const result = computeBandwidthFeeLevel({
+            availableStakedBandwidth: 100,
+            availableFreeBandwidth: 0,
+            bytes: 300,
+            isNewAccount: true,
+        });
+        expect(result.feePerTx).toBe('100000');
+    });
 });
 
 describe(calculateTronFeeBreakdown.name, () => {
@@ -132,6 +184,36 @@ describe(calculateTronFeeBreakdown.name, () => {
         );
         expect(result?.trxBurned.toString()).toBe('0.01');
         expect(result?.coveredEnergy.toNumber()).toBe(1000);
+    });
+
+    it('native TRX to new account: free bandwidth is not accepted — burns create-account fee', () => {
+        // Tx: bandwidth: 300, activates the recipient account
+        // Account: free bandwidth: 300, staked bandwidth: 0
+        // Expected: trxBurned: 0.1 TRX (flat create-account fee), coveredBandwidth: 0
+        const tx = {
+            ...makeNativeTrxTx(),
+            accountActivationFee: '1000000',
+        } as GeneralPrecomposedTransaction;
+        const result = calculateTronFeeBreakdown(tx, makeTronResources(), 'trx');
+        expect(result?.trxBurned.toString()).toBe('0.1');
+        expect(result?.coveredBandwidth.toNumber()).toBe(0);
+    });
+
+    it('native TRX to new account: staked bandwidth covers — 0 TRX burned', () => {
+        // Tx: bandwidth: 300, activates the recipient account
+        // Account: free bandwidth: 0, staked bandwidth: 300
+        // Expected: trxBurned: 0 TRX, coveredBandwidth: 300
+        const tx = {
+            ...makeNativeTrxTx(),
+            accountActivationFee: '1000000',
+        } as GeneralPrecomposedTransaction;
+        const result = calculateTronFeeBreakdown(
+            tx,
+            makeTronResources({ availableFreeBandwidth: 0, availableStakedBandwidth: 300 }),
+            'trx',
+        );
+        expect(result?.trxBurned.toNumber()).toBe(0);
+        expect(result?.coveredBandwidth.toNumber()).toBe(300);
     });
 
     it('native TRX with memo: adds 1 TRX memo fee on top of bandwidth', () => {

--- a/suite-common/wallet-utils/src/tronUtils.ts
+++ b/suite-common/wallet-utils/src/tronUtils.ts
@@ -9,17 +9,33 @@ import { subunitsToUnits } from './amountUtils';
 
 export const TRON_MEMO_FEE_SUN = 1_000_000;
 
+// The `getCreateAccountFee` chain parameter: a transfer that activates the recipient account
+// is charged this flat fee instead of the per-byte bandwidth price, and only staked bandwidth
+// (never the free daily allotment) can cover it.
+export const TRON_CREATE_ACCOUNT_FEE_SUN = 100_000;
+
 export type TronFeeLevel = ResponseTypes.EstimateFee['payload'][number];
 
 export const computeBandwidthFeeLevel = ({
     availableStakedBandwidth,
     availableFreeBandwidth,
     bytes,
+    isNewAccount = false,
 }: {
     availableStakedBandwidth: number;
     availableFreeBandwidth: number;
     bytes: number;
+    isNewAccount?: boolean;
 }): TronFeeLevel => {
+    if (isNewAccount) {
+        const feeInSun = availableStakedBandwidth < bytes ? TRON_CREATE_ACCOUNT_FEE_SUN : 0;
+
+        return {
+            feePerTx: String(feeInSun),
+            feePerUnit: String(tronUtils.TRON_BANDWIDTH_SUN_PRICE),
+        };
+    }
+
     const availableBandwidth = Math.max(availableStakedBandwidth, availableFreeBandwidth);
     const feeInSun = availableBandwidth < bytes ? bytes * tronUtils.TRON_BANDWIDTH_SUN_PRICE : 0;
 
@@ -52,8 +68,10 @@ export const calculateTronFeeBreakdown = (
     const energyConsumed = 'energyConsumed' in tx ? (tx.energyConsumed ?? 0) : 0;
     const bandwidthBytes = tx.bytes ?? 0;
 
-    const isBandwidthCovered =
-        Math.max(availableStakedBandwidth, availableFreeBandwidth) >= bandwidthBytes;
+    const isNewAccount = 'accountActivationFee' in tx && !!tx.accountActivationFee;
+    const isBandwidthCovered = isNewAccount
+        ? availableStakedBandwidth >= bandwidthBytes
+        : Math.max(availableStakedBandwidth, availableFreeBandwidth) >= bandwidthBytes;
     const coveredBandwidth = new BigNumber(isBandwidthCovered ? bandwidthBytes : 0);
     const coveredEnergy = new BigNumber(Math.min(availableEnergy, energyConsumed));
 
@@ -61,9 +79,10 @@ export const calculateTronFeeBreakdown = (
     const memoFeeSun = new BigNumber(('memoFee' in tx && tx.memoFee) || 0);
 
     if (!isContractCall) {
-        const bandwidthBurnSun = new BigNumber(
-            isBandwidthCovered ? 0 : bandwidthBytes * tronUtils.TRON_BANDWIDTH_SUN_PRICE,
-        );
+        const uncoveredBandwidthSun = isNewAccount
+            ? TRON_CREATE_ACCOUNT_FEE_SUN
+            : bandwidthBytes * tronUtils.TRON_BANDWIDTH_SUN_PRICE;
+        const bandwidthBurnSun = new BigNumber(isBandwidthCovered ? 0 : uncoveredBandwidthSun);
         const trxBurned = toTrx(bandwidthBurnSun.plus(memoFeeSun), symbol);
 
         return { trxBurned, coveredEnergy, coveredBandwidth };


### PR DESCRIPTION
## Description

Account activation fee in Tron seems to have worked partly by accident. This PR aims to incorporate logic of `1 TRX` activation fee + available staked bandwidth or `0.1 TRX` otherwise.

https://developers.tron.network/docs/account#account-activation


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are narrowly scoped to TRX/Tron-specific utilities (tronUtils.ts) and the Tron send form thunks (sendFormTronThunks.ts). Both changed files map to 131 tests via broad transitive imports, but none of the 153 candidate E2E tests directly exercise Tron send functionality. There is no dedicated Tron send E2E test in the candidate list. The unit test file (tronUtils.test.ts) has no E2E coverage mapping, which is expected since it's a unit test. The only test with a plausible connection is the receive test which covers TRX address verification. The risk is low for E2E regressions since the changes are Tron-specific and the broad static mappings are due to shared package re-exports rather than direct usage.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/wallet-core/src/send/tron/sendFormTronThunks.ts`
- `suite-common/wallet-utils/src/__tests__/tronUtils.test.ts`
- `suite-common/wallet-utils/src/tronUtils.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — This test verifies receiving TRX transactions including address format validation and device display. Changes to tronUtils.ts could affect TRX address handling or formatting used in the receive flow.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-utils/src/__tests__/tronUtils.test.ts`

_Updated: 2026-07-13T12:57:22.938Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tron-account-activation-fees/web/](https://dev.suite.sldev.cz/suite-web/fix/tron-account-activation-fees/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tron-account-activation-fees&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tron-account-activation-fees&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/tron-account-activation-fees&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-13T13:01:20.643Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-13T13:00:31.621Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->