### PR TITLE
fix(suite-utils): normalize browser name to a spaceless token in getBrowserName

### DIFF
--- a/suite-common/suite-utils/src/userAgent.ts
+++ b/suite-common/suite-utils/src/userAgent.ts
@@ -33,7 +33,7 @@ export const getCpuArch = async () => {
     return architecture ?? '';
 };
 export const getBrowserName = () => {
-    const browserName = getUserAgentParser().getBrowser().name?.replace(' ', '');
+    const browserName = getUserAgentParser().getBrowser().name?.replaceAll(' ', '');
 
     return browserName?.toLowerCase() || '';
 };


### PR DESCRIPTION
## Description

Fixes a non-global `String.replace` in `getBrowserName`:

[`suite-common/suite-utils/src/userAgent.ts:36`](https://github.com/trezor/trezor-suite/blob/70da5a314052a0da8bcff7c4877d18ea2e4dc0d3/suite-common/suite-utils/src/userAgent.ts#L36):

```diff
- const browserName = getUserAgentParser().getBrowser().name?.replace(' ', '');
+ const browserName = getUserAgentParser().getBrowser().name?.replaceAll(' ', '');
```

`getBrowserName()` returns a **canonical identifier token** (spaceless + lowercase), not a display name — the rest of the app compares against that token. `ua-parser-js` returns human-readable names (`"Mobile Chrome"`, `"Avast Secure Browser"`), which this function normalizes. That the canonical form is spaceless is provable: the supported-browser list uses [`name: 'mobilechrome'`](https://github.com/trezor/trezor-suite/blob/51f5bc12ea379d7c55be294ea429a98055e46a5d/packages/suite-data/src/browser-detection/index.ts#L104) (ua-parser returns `"Mobile Chrome"`), and the sibling normalizers `getOsName` / `getOsNameWeb` in the same file already use `replaceAll`.

`.replace(' ', '')` strips only the first space, so the bug appears **only for names with 2+ spaces (3+ words)** — the security-suite browsers: *Avast / AVG / Avira / Norton Secure Browser*, *Smart Lenovo Secure Browser*. For those, the token became `"avastsecure browser"` instead of `"avastsecurebrowser"`.

Matching is an **exact key-lookup, not a substring test** — [`messageSystemUtils.ts:112`](https://github.com/trezor/trezor-suite/blob/51f5bc12ea379d7c55be294ea429a98055e46a5d/suite-common/message-system/src/messageSystemUtils.ts#L112) does `condition[currentBrowserName]` — so a residual space makes the lookup miss. Affected consumers: message-system browser targeting ([`messageSystemUtils.ts:311`](https://github.com/trezor/trezor-suite/blob/51f5bc12ea379d7c55be294ea429a98055e46a5d/suite-common/message-system/src/messageSystemUtils.ts#L311); a targeted rule silently doesn't apply — narrow, since configs usually only target chrome/firefox/chromium), analytics normalization ([`analytics.ts:90`](https://github.com/trezor/trezor-suite/blob/51f5bc12ea379d7c55be294ea429a98055e46a5d/packages/suite/src/utils/suite/analytics.ts#L90)), and support-log / web-THP-hostname strings ([`logger/utils.ts:150`](https://github.com/trezor/trezor-suite/blob/51f5bc12ea379d7c55be294ea429a98055e46a5d/suite-common/logger/src/utils.ts#L150), [`getWebThpHostName.ts`](https://github.com/trezor/trezor-suite/blob/51f5bc12ea379d7c55be294ea429a98055e46a5d/packages/suite-web/src/support/getWebThpHostName.ts#L4)).

## A more defensive variant (deferred, not in this PR)

The message-system config is JSON validated by [`config.schema.v1.json`](https://github.com/trezor/trezor-suite/blob/51f5bc12ea379d7c55be294ea429a98055e46a5d/suite-common/message-system/schema/config.schema.v1.json#L382) (open `additionalProperties`). A JSON-Schema `"propertyNames": { "pattern": "^[a-z0-9._-]+$" }` on the `browser` object would reject a spaced/upper-cased key at config-authoring time. This can't be done at the TS type level (the `Browser` interface's `[k: string]: Version` index signature can't express "no spaces"), and it's **orthogonal** to this fix — it guards config authors, whereas the real symptom is the runtime token, which this PR fixes. Kept out to stay minimal.

Split out from the continuously-improve sweep #29735.

## Notes for QA

One-line normalization change; no effect on funds, signing, or transaction data. Only observable on browsers with 3+ word names (Avast/AVG/Avira/Norton Secure Browser, Smart Lenovo Secure Browser): the browser token used for message-system targeting / analytics is now spaceless. Otherwise no action needed.

## Related Issue

Part of the split-out series from #29735.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-nonglobal-replace/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-nonglobal-replace/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-nonglobal-replace&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-nonglobal-replace&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fix-nonglobal-replace&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-13T13:42:32.649Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-13T13:25:42.662Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to `userAgent.ts`, a utility responsible for parsing browser/OS information from the user agent string. This is a broadly imported utility (131 tests), but its primary direct impact is on browser detection/compatibility gating and analytics event reporting. The highest risk is breaking browser support detection (Firefox/Safari tests) and corrupting analytics metadata (browser/OS fields in SuiteReady events). Most other tests import this transitively and are unlikely to be affected by changes to user agent parsing logic.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/suite-utils/src/userAgent.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/browser/firefox.test.ts` — This test directly validates browser detection and compatibility. The userAgent.ts module is the core utility for parsing and identifying browsers, and this test specifically checks that Firefox is recognized as a supported browser with no unsupported-browser warning shown.
- `suite/e2e/tests/browser/safari.test.ts` — This test directly validates browser detection for Safari/WebKit, checking that the unsupported browser warning page is displayed. Changes to userAgent.ts could cause Safari to be incorrectly identified as supported or vice versa, breaking this core browser-gating behavior.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — The SuiteReady analytics event captures browser name, OS name, and OS version — all derived from user agent parsing. Changes to userAgent.ts could alter the values reported in these analytics fields, which this test explicitly asserts on.
- `suite/e2e/tests/settings/autodetect.test.ts` — This test validates autodetection of browser locale and color scheme preferences. User agent parsing may feed into the autodetect logic for language and theme, and changes could affect how the browser environment is interpreted.

</details>

_Updated: 2026-07-13T13:40:02.017Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->