### PR TITLE
Fix(suite-desktop): desktop updater PGP race condition

### DIFF
--- a/packages/suite-desktop-core/src/libs/update-checker.ts
+++ b/packages/suite-desktop-core/src/libs/update-checker.ts
@@ -13,18 +13,24 @@ if (signingKey === undefined) {
 
 type GetSignatureFileProps = { feedURL: string; downloadedFile: string };
 
+const GET_SIGNATURE_TIMEOUT = 10_000; // [ms]
 /**
  * Get signature files, which are available next to installation files.
  */
 export const getSignatureFile = async ({ downloadedFile, feedURL }: GetSignatureFileProps) => {
+    const abortController = new AbortController();
+    const timeoutId = setTimeout(() => abortController.abort(), GET_SIGNATURE_TIMEOUT);
+
     try {
         const filename = path.basename(downloadedFile);
         const signatureFileURL = `${removeTrailingSlashes(feedURL)}/${filename}.asc`;
-        const signatureFile = await fetch(signatureFileURL);
+        const signatureFile = await fetch(signatureFileURL, { signal: abortController.signal });
 
-        return signatureFile.text();
+        return await signatureFile.text();
     } catch {
         return null;
+    } finally {
+        clearTimeout(timeoutId);
     }
 };
 

--- a/packages/suite-desktop-core/src/modules/auto-updater.ts
+++ b/packages/suite-desktop-core/src/modules/auto-updater.ts
@@ -186,6 +186,9 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
 
     autoUpdater.on('update-downloaded', async (info: UpdateDownloadedEvent) => {
         const { version, releaseDate, downloadedFile, releaseNotes } = info;
+        // Disable installation of the downloaded file before verification is complete
+        const previousAutoInstallOnAppQuit = autoUpdater.autoInstallOnAppQuit;
+        autoUpdater.autoInstallOnAppQuit = false;
 
         logger.info(SERVICE_NAME, [
             'Update downloaded:',
@@ -221,6 +224,7 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
             });
 
             logger.info(SERVICE_NAME, 'Signature of update file is valid');
+            autoUpdater.autoInstallOnAppQuit = previousAutoInstallOnAppQuit;
 
             mainWindowProxy.getInstance()?.webContents.send('update/downloaded', {
                 version,


### PR DESCRIPTION
## Description

Replicates https://github.com/trezor/trezor-suite-private/pull/214

## Notes for QA

See issue – most important is the happy path, that desktop update works on all platforms

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/212

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files (`update-checker.ts` and `auto-updater.ts`) are part of the Electron desktop auto-update infrastructure in `packages/suite-desktop-core`. None of the 94 candidate E2E tests exercise the auto-updater or update-checker functionality — these tests cover onboarding, wallet operations, trading, analytics, settings, metadata/labeling, TrezorConnect, and bridge lifecycle, but none verify the application update flow. No static coverage mapping exists for these files either. The risk of regression in user-facing flows is very low since auto-update logic is isolated from the core Suite UI. No E2E tests are recommended; manual or dedicated integration testing of the auto-update mechanism would be the appropriate verification strategy.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite-desktop-core/src/libs/update-checker.ts`
- `packages/suite-desktop-core/src/modules/auto-updater.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/suite-desktop-core/src/libs/update-checker.ts`
- `packages/suite-desktop-core/src/modules/auto-updater.ts`

_Updated: 2026-07-14T06:23:38.438Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/updater-pgp-verification-race&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/updater-pgp-verification-race&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-14T06:27:33.020Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-14T06:26:49.607Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/updater-pgp-verification-race/web/](https://dev.suite.sldev.cz/suite-web/fix/updater-pgp-verification-race/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->