### PR TITLE
feat(suite-native): selectAccount in-app account picker

### DIFF
--- a/packages/connect-examples/mobile-expo/App.tsx
+++ b/packages/connect-examples/mobile-expo/App.tsx
@@ -79,6 +79,24 @@ export const App = () => {
         }
     };
 
+    const selectAccount = async () => {
+        try {
+            const response = await TrezorConnect.selectAccount({
+                coin: 'eth',
+            });
+            if (!response.success) {
+                setSuccessData(null);
+                setErrorData({ success: response.success });
+
+                return;
+            }
+            setErrorData(null);
+            setSuccessData(response);
+        } catch (error) {
+            console.error('error', error);
+        }
+    };
+
     useEffect(() => {
         const subscription = Linking.addEventListener('url', event => {
             TrezorConnect.handleDeeplink(event.url);
@@ -93,10 +111,18 @@ export const App = () => {
             <Button onPress={initialize} title="Initialize TrezorConnect" />
             <Button onPress={getAddress} title="Get Address" />
             <Button onPress={signMessage} title="Sign Message" />
+            <Button onPress={selectAccount} title="Select Account" />
 
             {successData && (
                 <View style={styles.dataContainer}>
                     <Text>Success: {successData.success ? 'Yes' : 'No'}</Text>
+                    {Array.isArray(successData.payload) &&
+                        successData.payload.map((account: any, index: number) => (
+                            <Text key={index}>
+                                Selected: {account.symbol} {account.path}{' '}
+                                {account.address ?? account.xpub}
+                            </Text>
+                        ))}
                     {successData.payload?.address && (
                         <Text>Address: {successData.payload?.address}</Text>
                     )}

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -652,6 +652,28 @@ export const messages = {
             message:
                 'The following accounts from {passphraseWalletLabel} on {deviceLabel} will be shared with {thirdParty}. Your private keys stay secure and are never exposed.',
         },
+        selectAccount: {
+            title: 'Select account',
+            description:
+                'Only the accounts you select are shared. Verify an address on your Trezor to confirm it before connecting.',
+            pickAccountDescription: 'Choose which account to pick an address from.',
+            exportedTitle: 'Accounts shared',
+            exportedDescription:
+                'You can verify the shared addresses on your Trezor to make sure they are correct.',
+            connect: 'Connect',
+            accountLabel: 'Account #{index}',
+            addressLabel: 'Address #{index}',
+            selectedCount: '{count} selected',
+            retry: 'Retry',
+            page: 'Page {page}',
+            accountType: {
+                normal: 'Normal',
+                taproot: 'Taproot',
+                segwit: 'SegWit',
+                legacy: 'Legacy',
+                ledger: 'Ledger',
+            },
+        },
         connectionStatus: {
             loading: 'Loading...',
             discoveryRunning: 'Discovery running...',

--- a/suite-native/module-connect-popup/src/components/SelectAccount.tsx
+++ b/suite-native/module-connect-popup/src/components/SelectAccount.tsx
@@ -1,0 +1,336 @@
+import { useEffect } from 'react';
+import { ScrollView } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
+
+import {
+    SELECT_ACCOUNT_PAGE_SIZE,
+    type SelectAccountCandidate,
+    type SelectAccountTypeTab,
+    connectPopupActions,
+    connectPopupBackToManualAccountsThunk,
+    connectPopupLoadSelectAccountPageThunk,
+    connectPopupResolveSelectAccountThunk,
+    connectPopupSelectManualAccountThunk,
+    connectPopupVerifySelectAccountThunk,
+    selectConnectPopupCall,
+} from '@suite-common/connect-popup';
+import { type AccountType } from '@suite-common/wallet-config';
+import {
+    Button,
+    HStack,
+    IconButton,
+    SegmentedControl,
+    Text,
+    TitleHeader,
+    VStack,
+} from '@suite-native/atoms';
+import { Translation, type TxKeyPath } from '@suite-native/intl';
+
+import { SelectAccountRow } from './SelectAccountRow';
+
+// Labels for the network's built-in account types; custom tabs carry their own `customLabel`.
+const ACCOUNT_TYPE_LABELS: Partial<Record<AccountType, TxKeyPath>> = {
+    normal: 'moduleConnectPopup.selectAccount.accountType.normal',
+    taproot: 'moduleConnectPopup.selectAccount.accountType.taproot',
+    segwit: 'moduleConnectPopup.selectAccount.accountType.segwit',
+    legacy: 'moduleConnectPopup.selectAccount.accountType.legacy',
+    ledger: 'moduleConnectPopup.selectAccount.accountType.ledger',
+};
+
+const tabLabel = (tab: SelectAccountTypeTab) => {
+    const labelKey = tab.accountType ? ACCOUNT_TYPE_LABELS[tab.accountType] : undefined;
+
+    return labelKey ? <Translation id={labelKey} /> : (tab.customLabel ?? tab.key);
+};
+
+export const SelectAccount = () => {
+    const dispatch = useDispatch();
+    const popupCall = useSelector(selectConnectPopupCall);
+
+    // Load the first page once the picker opens (the Connect method only sets up the state).
+    const isSelectAccount = popupCall?.state === 'select-account';
+    const isEmpty = isSelectAccount && popupCall.candidates.length === 0;
+    useEffect(() => {
+        if (isEmpty) {
+            dispatch(connectPopupLoadSelectAccountPageThunk({ page: 0 }));
+        }
+    }, [isEmpty, dispatch]);
+
+    if (popupCall?.state !== 'select-account') return null;
+
+    const {
+        options,
+        candidates,
+        selectedAccountTypeKey,
+        page,
+        exported,
+        totalCandidates,
+        manualPhase,
+        manualAccountIndex,
+    } = popupCall;
+    const { selectionType, minCount, maxCount, accountTypeTabs, addressSelection } = options;
+    // 'manual' is a two-phase flow: pick an account (drill-in, no export), then pick one of its
+    // used addresses (the actual export). Every other mode has a single, flat account-index list.
+    const isManualAccountPickPhase = addressSelection === 'manual' && manualPhase !== 'address';
+    const isManualAddressPhase = addressSelection === 'manual' && manualPhase === 'address';
+    const isMulti = selectionType === 'multi';
+    const activeTab =
+        accountTypeTabs.find(tab => tab.key === selectedAccountTypeKey) ?? accountTypeTabs[0]!;
+
+    const startIndex = page * SELECT_ACCOUNT_PAGE_SIZE;
+    const pageCandidates = candidates
+        .filter(
+            c =>
+                c.accountTypeKey === activeTab.key &&
+                c.accountIndex >= startIndex &&
+                c.accountIndex < startIndex + SELECT_ACCOUNT_PAGE_SIZE,
+        )
+        .sort((a, b) => a.accountIndex - b.accountIndex);
+
+    const selectedCandidates = candidates.filter(c => c.selected);
+    const selectedCount = selectedCandidates.length;
+    const isVerifying = candidates.some(c => c.verifying);
+    // Deriving accounts issues sequential getAccountInfo calls on the device. Any competing device
+    // call fired mid-discovery (verify, retry, or a fresh page/tab load) would contend for the same
+    // device and get cancelled — so those actions are blocked until the visible page has settled.
+    // Selection stays live: it's pure Redux state and touches no device.
+    const isDiscovering = pageCandidates.some(c => c.loading);
+
+    // Verification is always available but optional (mirrors AddressConfirmation) — connecting only
+    // requires a valid selection.
+    const canConfirm =
+        selectedCount >= minCount &&
+        (maxCount === undefined || selectedCount <= maxCount) &&
+        !isVerifying;
+
+    const toggle = (target: SelectAccountCandidate) => {
+        const isTarget = (c: SelectAccountCandidate) =>
+            c.accountIndex === target.accountIndex && c.accountTypeKey === target.accountTypeKey;
+
+        const next = candidates.map(c => {
+            if (selectionType === 'single') {
+                return { ...c, selected: isTarget(c) ? !c.selected : false };
+            }
+            if (!isTarget(c)) return c;
+            // respect maxCount when selecting a new one
+            if (!c.selected && maxCount !== undefined && selectedCount >= maxCount) return c;
+
+            return { ...c, selected: !c.selected };
+        });
+
+        dispatch(connectPopupActions.updateSelectAccount({ candidates: next }));
+    };
+
+    const verify = (candidate: SelectAccountCandidate) =>
+        dispatch(
+            connectPopupVerifySelectAccountThunk({
+                accountIndex: candidate.accountIndex,
+                accountTypeKey: candidate.accountTypeKey,
+            }),
+        );
+
+    // Manual account-pick phase: clicking a row drills in, it doesn't toggle a selection.
+    const selectManualAccount = (candidate: SelectAccountCandidate) =>
+        dispatch(connectPopupSelectManualAccountThunk({ accountIndex: candidate.accountIndex }));
+
+    const backToManualAccounts = () => dispatch(connectPopupBackToManualAccountsThunk());
+
+    const retry = () => dispatch(connectPopupLoadSelectAccountPageThunk({ page }));
+
+    const goToPage = (nextPage: number) => {
+        if (nextPage < 0 || isVerifying || isDiscovering) return;
+        dispatch(connectPopupLoadSelectAccountPageThunk({ page: nextPage }));
+    };
+
+    const selectAccountType = (tabKey: string) => {
+        if (tabKey === activeTab.key || isVerifying || isDiscovering) return;
+        dispatch(
+            connectPopupActions.updateSelectAccount({
+                selectedAccountTypeKey: tabKey,
+                page: 0,
+                // switching account type invalidates any account chosen in the manual address phase
+                manualPhase: addressSelection === 'manual' ? 'account' : undefined,
+                manualAccountIndex: undefined,
+            }),
+        );
+        dispatch(connectPopupLoadSelectAccountPageThunk({ page: 0 }));
+    };
+
+    const onConnect = () => dispatch(connectPopupResolveSelectAccountThunk({ confirmed: true }));
+    // Cancel (select phase) or close (exported phase) — the thunk routes based on `exported`.
+    const onFinish = () => dispatch(connectPopupResolveSelectAccountThunk({ confirmed: false }));
+
+    const rows = exported ? selectedCandidates : pageCandidates;
+
+    // Accounts can always be derived further, so there's no last page — except in the UTXO
+    // `addressSelection: 'manual'` flow, where `totalCandidates` bounds the used-address list.
+    const totalPages =
+        totalCandidates !== undefined
+            ? Math.max(1, Math.ceil(totalCandidates / SELECT_ACCOUNT_PAGE_SIZE))
+            : undefined;
+    const canGoPrev = page > 0 && !isVerifying && !isDiscovering;
+    const canGoNext =
+        (totalPages === undefined || page + 1 < totalPages) && !isVerifying && !isDiscovering;
+    const showPagination = !exported && (page > 0 || canGoNext);
+
+    let descriptionKey: TxKeyPath = 'moduleConnectPopup.selectAccount.description';
+    if (exported) {
+        descriptionKey = 'moduleConnectPopup.selectAccount.exportedDescription';
+    } else if (isManualAccountPickPhase) {
+        descriptionKey = 'moduleConnectPopup.selectAccount.pickAccountDescription';
+    }
+
+    let rowInteractionMode: 'toggle' | 'drillIn' | 'readOnly' = 'toggle';
+    if (exported) {
+        rowInteractionMode = 'readOnly';
+    } else if (isManualAccountPickPhase) {
+        rowInteractionMode = 'drillIn';
+    }
+
+    return (
+        <VStack testID="@popup/select-account" spacing="sp12" flex={1}>
+            <TitleHeader
+                title={
+                    <Translation
+                        id={
+                            exported
+                                ? 'moduleConnectPopup.selectAccount.exportedTitle'
+                                : 'moduleConnectPopup.selectAccount.title'
+                        }
+                    />
+                }
+                subtitle={<Translation id={descriptionKey} />}
+            />
+
+            {isManualAddressPhase && !exported && (
+                <Button
+                    intent="neutral"
+                    priority="secondary"
+                    iconLeft="arrowLeft"
+                    onPress={backToManualAccounts}
+                >
+                    <Translation
+                        id="moduleConnectPopup.selectAccount.accountLabel"
+                        values={{ index: (manualAccountIndex ?? 0) + 1 }}
+                    />
+                </Button>
+            )}
+
+            {accountTypeTabs.length > 1 && !exported && !isManualAddressPhase && (
+                <SegmentedControl
+                    selectedValue={activeTab.key}
+                    onValueChange={selectAccountType}
+                    options={accountTypeTabs.map(tab => ({
+                        value: tab.key,
+                        label: tabLabel(tab),
+                    }))}
+                />
+            )}
+
+            {isMulti && !exported && !isManualAccountPickPhase && (
+                <Text variant="body-sm" color="contentSecondary">
+                    <Translation
+                        id="moduleConnectPopup.selectAccount.selectedCount"
+                        values={{
+                            count: maxCount ? `${selectedCount}/${maxCount}` : selectedCount,
+                        }}
+                    />
+                </Text>
+            )}
+
+            <ScrollView style={{ flex: 1 }} showsVerticalScrollIndicator={false}>
+                <VStack spacing="sp8">
+                    {rows.map(candidate => (
+                        <SelectAccountRow
+                            key={`${candidate.accountTypeKey}-${candidate.accountIndex}`}
+                            candidate={candidate}
+                            label={
+                                <Translation
+                                    id={
+                                        isManualAddressPhase
+                                            ? 'moduleConnectPopup.selectAccount.addressLabel'
+                                            : 'moduleConnectPopup.selectAccount.accountLabel'
+                                    }
+                                    values={{ index: candidate.accountIndex + 1 }}
+                                />
+                            }
+                            interactionMode={rowInteractionMode}
+                            disabled={isVerifying}
+                            discovering={isDiscovering}
+                            onToggle={() =>
+                                isManualAccountPickPhase
+                                    ? selectManualAccount(candidate)
+                                    : toggle(candidate)
+                            }
+                            onVerify={() => verify(candidate)}
+                            onRetry={retry}
+                        />
+                    ))}
+                </VStack>
+            </ScrollView>
+
+            {showPagination && (
+                <HStack alignItems="center" justifyContent="space-between">
+                    <IconButton
+                        iconName="caretLeft"
+                        intent="neutral"
+                        priority="secondary"
+                        size="medium"
+                        isDisabled={!canGoPrev}
+                        onPress={() => goToPage(page - 1)}
+                    />
+                    <Text variant="body-sm" color="contentSecondary">
+                        <Translation
+                            id="moduleConnectPopup.selectAccount.page"
+                            values={{ page: page + 1 }}
+                        />
+                    </Text>
+                    <IconButton
+                        iconName="caretRight"
+                        intent="neutral"
+                        priority="secondary"
+                        size="medium"
+                        isDisabled={!canGoNext}
+                        onPress={() => goToPage(page + 1)}
+                    />
+                </HStack>
+            )}
+
+            <VStack spacing="sp8">
+                {exported ? (
+                    <Button
+                        testID="@popup/select-account/close"
+                        size="medium"
+                        isDisabled={isVerifying}
+                        onPress={onFinish}
+                    >
+                        <Translation id="generic.buttons.close" />
+                    </Button>
+                ) : (
+                    <>
+                        {!isManualAccountPickPhase && (
+                            <Button
+                                testID="@popup/select-account/confirm"
+                                size="medium"
+                                isDisabled={!canConfirm}
+                                onPress={onConnect}
+                            >
+                                <Translation id="moduleConnectPopup.selectAccount.connect" />
+                            </Button>
+                        )}
+                        <Button
+                            testID="@popup/select-account/cancel"
+                            size="medium"
+                            intent="neutral"
+                            priority="secondary"
+                            isDisabled={isVerifying}
+                            onPress={onFinish}
+                        >
+                            <Translation id="generic.buttons.cancel" />
+                        </Button>
+                    </>
+                )}
+            </VStack>
+        </VStack>
+    );
+};

--- a/suite-native/module-connect-popup/src/components/SelectAccountRow.tsx
+++ b/suite-native/module-connect-popup/src/components/SelectAccountRow.tsx
@@ -1,0 +1,164 @@
+import { type ReactNode } from 'react';
+
+import { type SelectAccountCandidate } from '@suite-common/connect-popup';
+import { isNetworkIconSymbol } from '@suite-common/icons';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import {
+    Box,
+    BoxSkeleton,
+    Button,
+    Card,
+    CheckBox,
+    HStack,
+    IconButton,
+    PressableOpacity,
+    Text,
+    VStack,
+} from '@suite-native/atoms';
+import { Icon, NetworkIcon } from '@suite-native/icons';
+import { Translation } from '@suite-native/intl';
+
+// 'toggle': checkbox-driven select/export (needs a value to be interactive).
+// 'drillIn': the whole row navigates onward (pick account -> view its addresses); no value needed
+//            since nothing is exported at this step.
+// 'readOnly': exported/read-only display, not clickable.
+type InteractionMode = 'toggle' | 'drillIn' | 'readOnly';
+
+type SelectAccountRowProps = {
+    candidate: SelectAccountCandidate;
+    // "Account #N" (account-index list) or "Address #N" (UTXO addressSelection: 'manual')
+    label: ReactNode;
+    interactionMode: InteractionMode;
+    disabled: boolean;
+    // Set while the picker is still deriving accounts on the device. Verifying or retrying now would
+    // fire a second, competing device call, so both actions are disabled until discovery settles.
+    discovering: boolean;
+    onToggle: () => void;
+    onVerify: () => void;
+    onRetry: () => void;
+};
+
+const truncateValue = (value: string) =>
+    value.length > 20 ? `${value.slice(0, 10)}…${value.slice(-6)}` : value;
+
+export const SelectAccountRow = ({
+    candidate,
+    label,
+    interactionMode,
+    disabled,
+    discovering,
+    onToggle,
+    onVerify,
+    onRetry,
+}: SelectAccountRowProps) => {
+    const { address, xpub, balance, symbol, loading, loadFailed, verifying, validated, selected } =
+        candidate;
+    // `address` (individual address) and `xpub` (whole-account, UTXO only) are mutually exclusive.
+    const displayValue = address ?? xpub;
+    const showCheckbox = interactionMode === 'toggle';
+    // 'drillIn' rows don't export a value, so they're interactive as soon as they've loaded.
+    const interactive =
+        interactionMode !== 'readOnly' &&
+        !disabled &&
+        !loading &&
+        !loadFailed &&
+        (interactionMode === 'toggle' ? !!displayValue : true);
+
+    const balanceText = (
+        <Text variant="body-sm" color="contentSecondary">
+            {balance ?? '0'} {getNetworkDisplaySymbol(symbol)}
+        </Text>
+    );
+
+    const renderRightColumn = () => {
+        if (loading) {
+            return <BoxSkeleton width={40} height={40} borderRadius={10} />;
+        }
+        if (loadFailed) {
+            return (
+                <Button
+                    intent="neutral"
+                    priority="secondary"
+                    size="medium"
+                    iconLeft="arrowsClockwise"
+                    isDisabled={disabled || discovering}
+                    onPress={onRetry}
+                >
+                    <Translation id="moduleConnectPopup.selectAccount.retry" />
+                </Button>
+            );
+        }
+        // 'drillIn' rows export nothing — the balance and a chevron signal navigation, no verify.
+        if (interactionMode === 'drillIn') {
+            return (
+                <HStack alignItems="center" spacing="sp4">
+                    {balanceText}
+                    <Icon name="caretRight" size="medium" color="contentTertiary" />
+                </HStack>
+            );
+        }
+        if (!displayValue) return null;
+
+        // Verification stays available even after export (mirrors AddressConfirmation), so the button
+        // shows for read-only/exported rows too. The button state is the "verified" indicator (brand
+        // check), keeping the row tight — a failed attempt adds a small warning icon.
+        return (
+            <HStack alignItems="center" spacing="sp8">
+                {validated === 'failed' && (
+                    <Icon name="warningCircle" size="mediumLarge" color="contentWarning" />
+                )}
+                <IconButton
+                    size="medium"
+                    intent={validated === 'valid' ? 'brand' : 'neutral'}
+                    priority={validated === 'valid' ? 'primary' : 'secondary'}
+                    iconName={validated === 'valid' ? 'checkCircle' : 'trezorDevices'}
+                    isLoading={verifying}
+                    isDisabled={disabled || discovering}
+                    onPress={onVerify}
+                />
+            </HStack>
+        );
+    };
+
+    // Second line under the label: the address/xpub plus its balance, side by side. 'drillIn' rows
+    // have no value — the chevron in the right column signals the action.
+    const renderSecondaryLine = () => {
+        if (loading) return <BoxSkeleton width={140} height={16} borderRadius={4} />;
+        if (interactionMode === 'drillIn') return null;
+
+        return (
+            <HStack alignItems="center" justifyContent="space-between" spacing="sp8">
+                <Text variant="body-sm" color="contentTertiary">
+                    {displayValue ? truncateValue(displayValue) : '—'}
+                </Text>
+                {balanceText}
+            </HStack>
+        );
+    };
+
+    const content = (
+        <Card noPadding>
+            <Box padding="sp12">
+                <HStack alignItems="center" spacing="sp12">
+                    {showCheckbox && (
+                        <CheckBox
+                            isChecked={selected}
+                            isDisabled={!interactive}
+                            onChange={onToggle}
+                        />
+                    )}
+                    {isNetworkIconSymbol(symbol) && <NetworkIcon symbol={symbol} size={24} />}
+                    <VStack flex={1} spacing="sp2">
+                        <Text variant="body-md-strong">{label}</Text>
+                        {renderSecondaryLine()}
+                    </VStack>
+                    {renderRightColumn()}
+                </HStack>
+            </Box>
+        </Card>
+    );
+
+    if (!interactive) return content;
+
+    return <PressableOpacity onPress={onToggle}>{content}</PressableOpacity>;
+};

--- a/suite-native/module-connect-popup/src/screens/ConnectPopupScreen.tsx
+++ b/suite-native/module-connect-popup/src/screens/ConnectPopupScreen.tsx
@@ -21,6 +21,7 @@ import { AddressConfirmation } from '../components/AddressConfirmation';
 import { ButtonRequestsOverlay } from '../components/ButtonRequestsOverlay';
 import { ConnectErrorMessage } from '../components/ConnectErrorMessage';
 import { PermissionConfirmation } from '../components/PermissionConfirmation';
+import { SelectAccount } from '../components/SelectAccount';
 import { TxSimulation } from '../components/TxSimulation';
 
 export const ConnectPopupScreen = () => {
@@ -82,6 +83,10 @@ export const ConnectPopupScreen = () => {
 
         if (popupCall?.state === 'address-confirmation') {
             return <AddressConfirmation />;
+        }
+
+        if (popupCall?.state === 'select-account') {
+            return <SelectAccount />;
         }
 
         if (popupCall?.state === 'tx-simulation') {


### PR DESCRIPTION
## Description

Adds the suite-native UI for the Connect `selectAccount` method — the mobile counterpart to the web `ConnectSelectAccount` modal from #28831. The shared flow (account derivation, on-device verification, pagination, single/multi/manual/xpub selection modes) already lives in `@suite-common/connect-popup`, so this only adds the platform-specific screen: a new `select-account` case in `ConnectPopupScreen` rendering `SelectAccount`/`SelectAccountRow`, plus the `moduleConnectPopup.selectAccount` translations. The design is adapted to mobile principles — `SegmentedControl` account-type tabs, a scrollable card list, compact prev/next pagination, an icon-only on-device verify button, and bottom action buttons.

## Notes for QA

Run the mobile app against trezor-user-env and trigger `selectAccount` from a 3rd-party app (or connect-explorer deeplink). Verify: the picker opens; single and multi (`selectionType`) selection work; prev/next pagination loads further account indices; the per-row verify button shows the address on the device (before and after connecting); Connect returns the selection and keeps the screen open with a Close button; Cancel / back returns a `Method_Cancel` error. UTXO `addressSelection` flows (`fullAccount` xpub, `firstFresh`, and the two-phase `manual` account→address pick) should behave as on desktop.

## Related Issue

Resolve #23799

## Screenshots:

<img width="300" alt="Simulator Screenshot - iPhone Air - 2026-08-11 at 17 09 41" src="https://github.com/user-attachments/assets/8153fc06-cd0f-43b9-a2e8-30206fb9e67d" />

<img width="300" alt="Simulator Screenshot - iPhone Air - 2026-08-11 at 17 09 44" src="https://github.com/user-attachments/assets/d0fd7988-48b5-48eb-9e3d-6bb5170a9f10" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=columbia&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=columbia&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=columbia&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are entirely in suite-native (mobile React Native) and the connect-examples/mobile-expo demo app. The provided test corpus consists only of suite/desktop web E2E tests, which do not exercise React Native mobile code paths. No test in this corpus directly or indirectly covers these changes, so no E2E runs are recommended here; mobile/suite-native tests would be required for meaningful coverage.

<details><summary><b>Changed files (5)</b></summary>

- `packages/connect-examples/mobile-expo/App.tsx`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-connect-popup/src/components/SelectAccount.tsx`
- `suite-native/module-connect-popup/src/components/SelectAccountRow.tsx`
- `suite-native/module-connect-popup/src/screens/ConnectPopupScreen.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (5)**
- `packages/connect-examples/mobile-expo/App.tsx`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-connect-popup/src/components/SelectAccount.tsx`
- `suite-native/module-connect-popup/src/components/SelectAccountRow.tsx`
- `suite-native/module-connect-popup/src/screens/ConnectPopupScreen.tsx`

_Updated: 2026-08-11T15:14:26.237Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-11T15:17:52.438Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-11T15:16:56.835Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/columbia/web/](https://dev.suite.sldev.cz/suite-web/columbia/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->