### PR TITLE
fix(assets): guard the converted number in calculateAssetsPercentage

### DIFF
--- a/suite-common/assets/src/tests/assets.test.ts
+++ b/suite-common/assets/src/tests/assets.test.ts
@@ -41,4 +41,20 @@ describe('calculateAssetsPercentage', () => {
         expect(btc?.fiatPercentage).toBeCloseTo(100);
         expect(btc?.fiatPercentageOffset).toBe(0);
     });
+
+    it('calculateAssetsPercentage - NaN balance does not poison other assets', () => {
+        const assetsWithPercentage = calculateAssetsPercentage(
+            fixtures.assetsFixtureWithNaNBalance,
+        );
+        const btc = assetsWithPercentage[0];
+        const eth = assetsWithPercentage[1];
+
+        // the NaN asset itself contributes nothing
+        expect(btc?.fiatPercentage).toBe(0);
+        expect(btc?.fiatPercentageOffset).toBe(0);
+
+        // the valid asset still gets a real percentage instead of NaN
+        expect(eth?.fiatPercentage).toBeCloseTo(100);
+        expect(eth?.fiatPercentageOffset).toBe(0);
+    });
 });

--- a/suite-common/assets/src/tests/fixtures/assets.ts
+++ b/suite-common/assets/src/tests/fixtures/assets.ts
@@ -40,3 +40,16 @@ export const assetsFixtureSingleAsset: AssetFiatBalance[] = [
         fiatBalance: asBaseCurrencyAmount(new BigNumber('98.26')),
     },
 ];
+
+// A NaN fiat balance must not poison the total nor produce a NaN percentage for itself
+// or for the other (valid) assets.
+export const assetsFixtureWithNaNBalance: AssetFiatBalance[] = [
+    {
+        symbol: 'btc',
+        fiatBalance: asBaseCurrencyAmount(new BigNumber(NaN)),
+    },
+    {
+        symbol: 'eth',
+        fiatBalance: asBaseCurrencyAmount(new BigNumber('50')),
+    },
+];

--- a/suite-common/assets/src/utils.ts
+++ b/suite-common/assets/src/utils.ts
@@ -13,12 +13,16 @@ export interface AssetFiatBalanceWithPercentage extends AssetFiatBalance {
 export const calculateAssetsPercentage = <T>(
     assetsData: Array<AssetFiatBalance & T>,
 ): Array<AssetFiatBalanceWithPercentage & T> => {
-    const fiatTotal = assetsData.reduce((sum, next) => sum + Number(next.fiatBalance), 0);
+    const fiatTotal = assetsData.reduce((sum, next) => {
+        const value = Number(next.fiatBalance);
+
+        return sum + (Number.isNaN(value) ? 0 : value);
+    }, 0);
     let previousPercentage = 0;
 
     return assetsData.map(asset => {
         const fiatBalance = Number(asset.fiatBalance);
-        if (fiatTotal === 0 || Number.isNaN(asset.fiatBalance) || fiatBalance === 0) {
+        if (fiatTotal === 0 || Number.isNaN(fiatBalance) || fiatBalance === 0) {
             return { ...asset, fiatPercentage: 0, fiatPercentageOffset: 0 };
         }
 


### PR DESCRIPTION
## Description

`calculateAssetsPercentage` computes each asset's share of total portfolio value (for the dashboard asset-allocation ring + per-coin percentages). It had **two compounding defects**, both around a `NaN` fiat balance:

**1. The total is poisoned** — [`utils.ts:16`](https://github.com/trezor/trezor-suite/blob/1c60438a8b283515bb84ae2206b6056993337277/suite-common/assets/src/utils.ts#L16):
```js
const fiatTotal = assetsData.reduce((sum, next) => sum + Number(next.fiatBalance), 0);
```
`Number(BigNumber(NaN))` is `NaN`, and `sum + NaN` stays `NaN` for the rest of the reduce. So a **single** `NaN` balance makes `fiatTotal = NaN`, and then `(100 / NaN) * fiatBalance = NaN` for **every** asset — not just the bad one.

**2. The safety guard is dead code** — [`utils.ts:21`](https://github.com/trezor/trezor-suite/blob/1c60438a8b283515bb84ae2206b6056993337277/suite-common/assets/src/utils.ts#L21):
```js
if (fiatTotal === 0 || Number.isNaN(asset.fiatBalance) || fiatBalance === 0) { ... }
```
`asset.fiatBalance` is a **BigNumber object**, not a number. `Number.isNaN(anObject)` is **always `false`** (unlike the global `isNaN`, `Number.isNaN` does not coerce). So this check never fires — a classic wrong-variable slip: it should test `fiatBalance` (the `Number(...)` result one line above), not `asset.fiatBalance`.

## Impact if it fires (both platforms, verified)

A single `NaN` balance breaks the allocation visualization for **all** assets:
- **Desktop** — the tooltip shows a literal **"NaN%"** ([`AssetCoinLogo.tsx:32`](https://github.com/trezor/trezor-suite/blob/1c60438a8b283515bb84ae2206b6056993337277/packages/suite/src/views/dashboard/AssetsView/AssetCoinLogo.tsx#L32) → [`localizePercentage.ts:21`](https://github.com/trezor/trezor-suite/blob/1c60438a8b283515bb84ae2206b6056993337277/suite-common/wallet-utils/src/localizePercentage.ts#L21) `NaN.toLocaleString()`), and the circular progress ring fails to render because `strokeDashoffset` becomes `NaN` ([`AssetShareIndicator.tsx:98`](https://github.com/trezor/trezor-suite/blob/1c60438a8b283515bb84ae2206b6056993337277/packages/product-components/src/components/AssetShareIndicator/AssetShareIndicator.tsx#L98)).
- **Native** — the circular progress animation and icon rotation both compute on `NaN` ([`CryptoIconWithPercentage.tsx:69`](https://github.com/trezor/trezor-suite/blob/1c60438a8b283515bb84ae2206b6056993337277/suite-native/icons/src/CryptoIconWithPercentage.tsx#L69), [`:95`](https://github.com/trezor/trezor-suite/blob/1c60438a8b283515bb84ae2206b6056993337277/suite-native/icons/src/CryptoIconWithPercentage.tsx#L95)), so the ring doesn't render and the icon rotation is wrong.

## Reachability — latent, not a confirmed live symptom

I traced whether a `NaN` `fiatBalance` can actually reach this function in normal operation. **Upstream is well-guarded, so in practice it does not:**
- `toFiatCurrency` returns `null` on a falsy rate — [`fiatConverterUtils.ts:19`](https://github.com/trezor/trezor-suite/blob/1c60438a8b283515bb84ae2206b6056993337277/suite-common/wallet-utils/src/fiatConverterUtils.ts#L19) (`!rate`, which catches `NaN` since `NaN` is falsy) — **and** on a `NaN` result — [`:29`](https://github.com/trezor/trezor-suite/blob/1c60438a8b283515bb84ae2206b6056993337277/suite-common/wallet-utils/src/fiatConverterUtils.ts#L29) (`localAmount.isNaN()`). So a missing/`NaN` **rate** cannot produce a `NaN` balance.
- `null` balances are fine: `Number(null) === 0`, so they contribute 0.
- Desktop additionally falls back to `BASE_CURRENCY_ZERO` — [`AssetsView.tsx:87`](https://github.com/trezor/trezor-suite/blob/1c60438a8b283515bb84ae2206b6056993337277/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx#L87).

The only theoretical entry point is a **corrupted `account.formattedBalance`** (a non-numeric string like `'abc'`) flowing into `new BigNumber(formattedBalance).times(rate)` → `NaN`; that isn't validated at that layer, but doesn't arise from valid data.

**Verdict:** this is a **defense-in-depth / correctness fix**, not a "users currently see NaN%" fix. It is still worth landing because (a) the guard on line 21 is **objectively dead code** — it can never catch a `NaN` as written — and (b) the failure mode it protects against is severe and platform-wide (the whole portfolio ring breaks, not just one asset).

## The fix

Both parts — [`utils.ts:19` / `:25`](https://github.com/trezor/trezor-suite/blob/5ba59e05eb26fcbb6b18680c848ce0bcca857fba/suite-common/assets/src/utils.ts#L19):
```js
// skip NaN in the total so one bad asset can't poison it
const fiatTotal = assetsData.reduce((sum, next) => {
    const value = Number(next.fiatBalance);
    return sum + (Number.isNaN(value) ? 0 : value);
}, 0);
// guard the converted number, not the BigNumber object
if (fiatTotal === 0 || Number.isNaN(fiatBalance) || fiatBalance === 0) { ... }
```
Result: a `NaN` asset contributes 0 and reports 0%, and every other asset gets a correct percentage. Adds a fixture (`assetsFixtureWithNaNBalance`) and a regression test ("NaN balance does not poison other assets").

Split out from the continuously-improve sweep #29735.

## Notes for QA

No specific QA needed — no normal-operation path produces a `NaN` fiat balance (upstream `toFiatCurrency` guards it), so the dashboard allocation ring/percentages are unchanged for real data. This is a robustness fix that prevents a single malformed balance from breaking the entire allocation view (desktop + mobile).

## Related Issue

Part of the split-out series from #29735.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to suite-common/assets — a utility module and its unit tests/fixtures. The utils.ts file maps to 113 E2E tests, indicating it is a broadly imported utility. Since two of the three changed files are unit test files (assets.test.ts and fixtures/assets.ts), the primary risk is in utils.ts itself. The unit tests provide direct coverage of the utility logic. For E2E, only tests that specifically exercise asset-related UI flows (dashboard assets display, coin activation) warrant running; the vast majority of the 113 mapped tests use assets transitively and are unlikely to be affected. The recommended strategy is to rely heavily on the unit tests and run a small number of asset-focused E2E tests for confidence.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/assets/src/tests/assets.test.ts`
- `suite-common/assets/src/tests/fixtures/assets.ts`
- `suite-common/assets/src/utils.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test directly exercises the Assets section on the dashboard, including enabling coins and verifying asset display in grid/table views. Changes to suite-common/assets/src/utils.ts could affect how assets are resolved, displayed, or activated in the dashboard UI.
- `suite/e2e/tests/settings/coins.test.ts` — This test covers activating/deactivating coin networks and verifying asset activation via the 'Activate Assets' modal on the dashboard. The assets utility module likely powers the network/asset resolution logic that this test validates end-to-end.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test enables cryptocurrency assets and configures backends. While assets/utils.ts is a dependency, the test focuses more on backend configuration than asset utility logic. Including as low priority since asset enablement is a precondition.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/assets/src/tests/assets.test.ts`
- `suite-common/assets/src/tests/fixtures/assets.ts`

_Updated: 2026-07-13T13:54:54.566Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-assets-nan-percentage/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-assets-nan-percentage/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-assets-nan-percentage&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-assets-nan-percentage&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fix-assets-nan-percentage&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-13T13:58:24.488Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-13T13:58:14.119Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->