### PR TITLE
fix(blockchain-link): derive EIP-1559 fee from effectiveGasPrice

### DIFF
--- a/packages/blockchain-link/src/workers/evm-rpc/mappers/transaction.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/mappers/transaction.ts
@@ -34,9 +34,11 @@ export const mapGetTransactionResponse = ({
     block,
     userAddress,
 }: MapTransactionParams): Responses.GetTransaction => {
-    const { value, gasPrice } = tx;
-    const { gasUsed } = receipt;
-    const fee = (gasUsed * (gasPrice ?? 0n)).toString(10);
+    const { value } = tx;
+    const { gasUsed, effectiveGasPrice } = receipt;
+    // `tx.gasPrice` is undefined for EIP-1559 (type-2) transactions, so the actual price paid must
+    // be read from the receipt's `effectiveGasPrice` — otherwise the fee would be 0 for every type-2 tx.
+    const fee = (gasUsed * effectiveGasPrice).toString(10);
 
     const blockTime = block ? Number(block.timestamp) : 0;
     const blockHash = tx.blockHash || '';
@@ -102,7 +104,7 @@ export const mapGetTransactionResponse = ({
                 nonce: tx.nonce,
                 gasLimit: Number(tx.gas),
                 gasUsed: Number(receipt.gasUsed),
-                gasPrice: gasPrice?.toString(),
+                gasPrice: effectiveGasPrice.toString(),
                 data: tx.input,
             },
         },

--- a/packages/blockchain-link/tests/unit/evmRpcTransactionMapper.test.ts
+++ b/packages/blockchain-link/tests/unit/evmRpcTransactionMapper.test.ts
@@ -1,0 +1,44 @@
+import type { Block, Transaction, TransactionReceipt } from 'viem';
+
+import { mapGetTransactionResponse } from '../../src/workers/evm-rpc/mappers/transaction';
+
+const baseTx = {
+    hash: '0xdeadbeef',
+    from: '0xfrom',
+    to: '0xto',
+    value: 1000n,
+    nonce: 7,
+    gas: 21000n,
+    input: '0x',
+    blockHash: '0xblock',
+    blockNumber: 123n,
+} as unknown as Transaction;
+
+const baseReceipt = {
+    status: 'success',
+    gasUsed: 21000n,
+    effectiveGasPrice: 5n,
+} as unknown as TransactionReceipt;
+
+const block = { timestamp: 42n } as unknown as Block;
+
+describe('mapGetTransactionResponse fee', () => {
+    // Regression: EIP-1559 (type-2) transactions have `tx.gasPrice === undefined`; the actual price
+    // paid lives in the receipt's `effectiveGasPrice`. Deriving the fee from `tx.gasPrice` produced 0.
+    it('derives the fee from receipt.effectiveGasPrice for an EIP-1559 tx', () => {
+        const tx = { ...baseTx, gasPrice: undefined } as unknown as Transaction;
+
+        const { payload } = mapGetTransactionResponse({ tx, receipt: baseReceipt, block });
+
+        expect(payload.fee).toBe('105000'); // 21000 * 5
+        expect(payload.ethereumSpecific?.gasPrice).toBe('5');
+    });
+
+    it('still uses effectiveGasPrice for a legacy tx', () => {
+        const tx = { ...baseTx, gasPrice: 5n } as unknown as Transaction;
+
+        const { payload } = mapGetTransactionResponse({ tx, receipt: baseReceipt, block });
+
+        expect(payload.fee).toBe('105000');
+    });
+});


### PR DESCRIPTION
## Description

The evm-rpc worker's transaction mapper derived the fee from `tx.gasPrice`, which is **`undefined` for EIP-1559 (type-2) transactions** — so every type-2 tx reported a fee of `0`.

Buggy ([`transaction.ts`](https://github.com/trezor/trezor-suite/blob/1c60438a8b283515bb84ae2206b6056993337277/packages/blockchain-link/src/workers/evm-rpc/mappers/transaction.ts#L37)):
```js
const { value, gasPrice } = tx;
const { gasUsed } = receipt;
const fee = (gasUsed * (gasPrice ?? 0n)).toString(10);   // gasPrice undefined for type-2 → fee = gasUsed * 0 = 0
```

In EIP-1559, a transaction carries `maxFeePerGas` / `maxPriorityFeePerGas`, not a fixed `gasPrice` — the actual price paid is computed at execution and lives on the **receipt** as `effectiveGasPrice`. That field is populated for **both** legacy (where it equals `gasPrice`) and type-2 transactions, so switching to it fixes type-2 without changing legacy.

Fixed ([`transaction.ts:41`](https://github.com/trezor/trezor-suite/blob/e5bbce14662cdc748e89ea20bfd27ae1942249bd/packages/blockchain-link/src/workers/evm-rpc/mappers/transaction.ts#L41), [`:107`](https://github.com/trezor/trezor-suite/blob/e5bbce14662cdc748e89ea20bfd27ae1942249bd/packages/blockchain-link/src/workers/evm-rpc/mappers/transaction.ts#L107)):
```js
const { gasUsed, effectiveGasPrice } = receipt;
const fee = (gasUsed * effectiveGasPrice).toString(10);
...
gasPrice: effectiveGasPrice.toString(),
```

## Reachability — behind an opt-in backend, but real

The evm-rpc worker is **not** a default backend. Every EVM network defaults to blockbook ([`backendUtils.ts:16`](https://github.com/trezor/trezor-suite/blob/1c60438a8b283515bb84ae2206b6056993337277/suite-common/wallet-utils/src/backendUtils.ts#L16)). evm-rpc is a supported, opt-in alternative offered for 8 production networks (ETH, POL, BSC, ARB, BASE, OP, AVAX, ETC) and 2 testnets — it is the second entry in each network's `backendOptions` ([`networksConfig.ts:68`](https://github.com/trezor/trezor-suite/blob/1c60438a8b283515bb84ae2206b6056993337277/suite-common/wallet-config/src/networksConfig.ts#L68)). A user activates it by configuring a custom backend (their own RPC URL) for that coin.

So this is **conditional, not latent**: it does not affect the blockbook default, but for any user who switches an EVM coin to a custom evm-rpc backend it fires for **essentially every transaction** — EIP-1559 has been the network default since August 2021, so virtually all modern txs are type-2.

## Impact when active

The `fee` (and `ethereumSpecific.gasPrice`) flow into every fee display, all showing `0`:
- Transaction detail modal fee row ([`AmountDetails.tsx:320`](https://github.com/trezor/trezor-suite/blob/1c60438a8b283515bb84ae2206b6056993337277/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx#L320)) → "Fee: 0 ETH"
- Transaction history list fee
- CSV / PDF / JSON exports (`fee` column = `0`)

## Not fixed here (sibling, different fix)

The same symptom exists one file over in [`block.ts:35`](https://github.com/trezor/trezor-suite/blob/1c60438a8b283515bb84ae2206b6056993337277/packages/blockchain-link/src/workers/evm-rpc/mappers/block.ts#L35): `fees: tx.gas && tx.gasPrice ? (tx.gas * tx.gasPrice).toString(10) : '0'` also yields `0` for type-2. It is **intentionally left out** because it maps block-level (typically pending, pre-receipt) transactions where `effectiveGasPrice` is not yet available — the correct fix there is a `gas × maxFeePerGas` estimate, a different change. Flagging it as a follow-up.

## Tests

Adds `evmRpcTransactionMapper.test.ts`: asserts the fee is derived from `receipt.effectiveGasPrice` for an EIP-1559 tx (`tx.gasPrice === undefined` → `21000 * 5 = 105000`, previously `0`), and that a legacy tx still resolves correctly.

Split out from the continuously-improve sweep #29735.

## Notes for QA

Only affects EVM accounts using a **custom evm-rpc backend** — the default blockbook path is unchanged, so no regression risk there. To reproduce / verify the fix:

1. Add an EVM account (e.g. **Ethereum**) that has at least one normal outgoing transaction in its history (any recent ETH tx is EIP-1559 / type-2).
2. Switch that coin's backend to evm-rpc: **Settings → Cryptocurrencies (Coins) → Ethereum → gear/Advanced → backend**, choose a custom backend and enter an Ethereum JSON-RPC URL (any public RPC node, or your own).
3. Reload the account and open a transaction's detail (and the history row / a CSV export).
   - **Before the fix:** the fee shows **`0 ETH`** for type-2 txs.
   - **After the fix:** the fee shows the real amount (`gasUsed × effectiveGasPrice`).

Deterministic proof without a device is the added unit test (`yarn workspace @trezor/blockchain-link test:unit evmRpcTransactionMapper`). No effect on the default (blockbook) backend, so users who never set a custom RPC are unaffected.

## Related Issue

Part of the split-out series from #29735.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to the EVM RPC transaction mapper in blockchain-link and its unit test. The mapper is responsible for transforming raw EVM RPC transaction data into the internal transaction format used by Suite. Since no static coverage mapping exists for these files, all recommendations are inferred. The primary risk is that changes to transaction mapping could affect how Ethereum transaction data (amounts, fees, statuses) is displayed or processed in wallet and trading flows. The unit test file change carries no E2E risk. The recommended strategy is to run a focused set of ETH-centric E2E tests covering send, staking, and swap flows that rely on EVM transaction data.

<details><summary><b>Changed files (2)</b></summary>

- `packages/blockchain-link/src/workers/evm-rpc/mappers/transaction.ts`
- `packages/blockchain-link/tests/unit/evmRpcTransactionMapper.test.ts`

</details>

**Recommended tests (7)**

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — This test exercises Ethereum transaction sending with detailed fee verification (gas limit, max fee per gas, priority fee). The changed EVM RPC transaction mapper handles how EVM transactions are parsed and mapped, which could affect how sent ETH transactions are displayed or processed in the wallet UI.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test involves ETH staking transactions with pending/confirmed status transitions and balance updates. The EVM RPC transaction mapper directly affects how Ethereum transaction data is parsed from the RPC layer, which could impact how staking transaction statuses and amounts are displayed.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test covers ETH unstaking and claiming flows with transaction status tracking (pending → confirmed). Changes to the EVM RPC transaction mapper could affect how these Ethereum transaction states and amounts are parsed and displayed in the staking dashboard.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This test performs a DEX swap on Ethereum with detailed gas limit and fee verification against the device prompt. The EVM RPC transaction mapper processes Ethereum transaction data which feeds into the composed transaction info used in the swap confirmation flow.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test specifically verifies Ethereum custom fee parameters (gas limit, max fee per gas, max priority fee per gas) in the swap flow. Changes to the EVM RPC transaction mapper could affect how fee data is parsed and presented to the user.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test involves selling ETH with custom gas fee settings and device confirmation. The EVM transaction mapper changes could affect how Ethereum transaction data is processed during the sell flow, though the sell flow primarily depends on higher-level transaction composition.
- `suite/e2e/tests/trading-poc/passthru-swap-eth-to-btc.test.ts` — This test performs a live ETH-to-BTC swap with Ethereum transaction verification on the device. The EVM RPC transaction mapper is in the data pipeline for Ethereum transactions, though this test primarily exercises the trading/swap orchestration layer.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/blockchain-link/tests/unit/evmRpcTransactionMapper.test.ts`

_Updated: 2026-07-13T14:16:34.420Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-evmrpc-eip1559-fee/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-evmrpc-eip1559-fee/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-evmrpc-eip1559-fee&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-evmrpc-eip1559-fee&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-13T14:19:54.473Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-13T14:19:42.003Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->