### PR TITLE
fix(suite): don't compose yield txs with a fallback gas limit

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -52,7 +52,6 @@
         "@suite-common/platform-encryption": "workspace:*",
         "@suite-common/react-query": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
-        "@suite-common/schemas": "workspace:^",
         "@suite-common/sentry": "workspace:*",
         "@suite-common/staking": "workspace:*",
         "@suite-common/suite-config": "workspace:*",

--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -9,71 +9,29 @@ import {
 import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin/src/tx-simulation';
 import { type YieldAccountsRewards } from '@suite-common/earn-stablecoin-api';
 import { createThunk } from '@suite-common/redux-utils';
-import { type EvmHexString } from '@suite-common/schemas/src/evm';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import {
-    type NetworkSymbol,
-    getEarnYieldClaimContractAddress,
-    getNetwork,
-} from '@suite-common/wallet-config';
-import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
+import { getEarnYieldClaimContractAddress, getNetwork } from '@suite-common/wallet-config';
 import {
     STABLECOIN_YIELD_PREFIX,
+    type YieldEstimatedFeeLevel,
+    estimateYieldFeeLevel,
     selectAddressDisplayType,
     selectIsMevProtectionEnabled,
     stablecoinYieldActions,
     synchronizeSentTransactionThunk,
 } from '@suite-common/wallet-core';
 import { ethereumGetCurrentNonceThunk } from '@suite-common/wallet-core/src/send/sendFormEthereumThunks';
-import {
-    type Account,
-    type AccountDescriptor,
-    AddressDisplayOptions,
-} from '@suite-common/wallet-types';
+import { type Account, AddressDisplayOptions } from '@suite-common/wallet-types';
 import { getAccountIdentity, getMevProtectedTxData } from '@suite-common/wallet-utils';
-import TrezorConnect, { type StaticSessionId } from '@trezor/connect';
+import TrezorConnect from '@trezor/connect';
 
 import { getYieldErrorTranslationKey } from './signingHelpers';
 
 type ClaimMerklReward = YieldAccountsRewards[number]['rewards'][number];
 
-interface GetEstimatedClaimFeeParams {
-    networkSymbol: NetworkSymbol;
-    from: AccountDescriptor;
-    to: EvmHexString;
-    data: EvmHexString;
-    deviceState: StaticSessionId;
-    value?: EvmHexString;
-}
+const getClaimFee = (feeLevel: YieldEstimatedFeeLevel) => {
+    const gasLimit = feeLevel.feeLimit;
 
-async function getEstimatedFee({
-    networkSymbol,
-    from,
-    to,
-    data,
-    deviceState,
-    value = '0x0',
-}: GetEstimatedClaimFeeParams) {
-    const estimatedFee = await TrezorConnect.blockchainEstimateFee({
-        coin: networkSymbol,
-        identity: deviceState,
-        request: {
-            blocks: [2],
-            specific: { from, to, data, value },
-        },
-    });
-
-    if (!estimatedFee.success) {
-        throw new Error('Failed to estimate fee for claim transaction.');
-    }
-
-    const feeLevel = estimatedFee.payload.levels[0];
-
-    if (!feeLevel) {
-        throw new Error('No fee level available.');
-    }
-
-    const gasLimit = feeLevel.feeLimit ?? ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT;
     const eip1559MediumFee = feeLevel.eip1559?.medium;
 
     if (eip1559MediumFee?.maxFeePerGas && eip1559MediumFee?.maxPriorityFeePerGas) {
@@ -89,7 +47,7 @@ async function getEstimatedFee({
         gasPrice: feeLevel.feePerUnit,
         gasLimit,
     };
-}
+};
 
 type ClaimMerklRewardsParams = {
     account: Account;
@@ -126,6 +84,18 @@ export const claimMerklRewardsThunk = createThunk(
             throw new Error('Merkl.xyz contract address not found for network.');
         }
 
+        const reportSubmitError = (errorMessage = 'submit-failed') =>
+            asTypedDesktopAnalytics(extra.services.analytics).report({
+                type: events.yieldClaimEvent.name,
+                payload: {
+                    type: 'error',
+                    action: 'continue',
+                    networkSymbol: account.symbol,
+                    rewardCount: rewards.length,
+                    errorMessage,
+                },
+            });
+
         dispatch(
             stablecoinYieldActions.startSubmittingAction({
                 flowType: 'claim',
@@ -140,9 +110,9 @@ export const claimMerklRewardsThunk = createThunk(
                 rewards,
             });
 
-            const estimatedFeeTask = getEstimatedFee({
-                networkSymbol: account.symbol,
-                deviceState: account.deviceState,
+            const estimatedFeeLevelTask = estimateYieldFeeLevel({
+                coin: account.symbol,
+                identity: account.deviceState,
                 from: account.descriptor,
                 to: merklXyzContractAddress,
                 data: claimCalldata,
@@ -155,13 +125,29 @@ export const claimMerklRewardsThunk = createThunk(
                 }),
             ).unwrap();
 
-            const [estimatedFee, { nonce }] = await Promise.all([estimatedFeeTask, nonceTask]);
+            const [estimatedFeeLevel, { nonce }] = await Promise.all([
+                estimatedFeeLevelTask,
+                nonceTask,
+            ]);
+
+            if (!estimatedFeeLevel.success) {
+                reportSubmitError(estimatedFeeLevel.error);
+                dispatch(
+                    stablecoinYieldActions.setError({
+                        flowType: 'claim',
+                        flowKey,
+                        error: 'TR_EARN_YIELD_ERROR_FEE_ESTIMATION',
+                    }),
+                );
+
+                return;
+            }
 
             const unsignedClaimTx = buildUnsignedClaimTransaction({
                 contractAddress: merklXyzContractAddress,
                 data: claimCalldata,
                 chainId: network.chainId,
-                fee: estimatedFee,
+                fee: getClaimFee(estimatedFeeLevel.payload),
                 nonce,
             });
 
@@ -302,24 +288,12 @@ export const claimMerklRewardsThunk = createThunk(
                 );
 
                 return pushResponse.payload;
-                // eslint-disable-next-line no-useless-catch
-            } catch (error) {
-                throw error;
             } finally {
                 dispatch(stablecoinYieldActions.discardTransaction());
             }
         } catch (error) {
             console.error(error);
-            asTypedDesktopAnalytics(extra.services.analytics).report({
-                type: events.yieldClaimEvent.name,
-                payload: {
-                    type: 'error',
-                    action: 'continue',
-                    networkSymbol: account.symbol,
-                    rewardCount: rewards.length,
-                    errorMessage: 'submit-failed',
-                },
-            });
+            reportSubmitError();
             dispatch(
                 stablecoinYieldActions.setError({
                     flowType: 'claim',

--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -25,7 +25,11 @@ import { type Account, AddressDisplayOptions } from '@suite-common/wallet-types'
 import { getAccountIdentity, getMevProtectedTxData } from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
 
-import { getYieldErrorTranslationKey } from './signingHelpers';
+import {
+    PUSH_TRANSACTION_FAILED_CAUSE,
+    getYieldErrorTranslationKey,
+    getYieldSubmitErrorAnalyticsMessage,
+} from './signingHelpers';
 
 type ClaimMerklReward = YieldAccountsRewards[number]['rewards'][number];
 
@@ -254,7 +258,9 @@ export const claimMerklRewardsThunk = createThunk(
                 dispatch(closeModal());
 
                 if (!pushResponse.success) {
-                    throw new Error(pushResponse.error.message);
+                    throw new Error(pushResponse.error.message, {
+                        cause: PUSH_TRANSACTION_FAILED_CAUSE,
+                    });
                 }
 
                 dispatch(
@@ -293,7 +299,7 @@ export const claimMerklRewardsThunk = createThunk(
             }
         } catch (error) {
             console.error(error);
-            reportSubmitError();
+            reportSubmitError(getYieldSubmitErrorAnalyticsMessage(error));
             dispatch(
                 stablecoinYieldActions.setError({
                     flowType: 'claim',

--- a/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts
@@ -1,19 +1,19 @@
 import { asEvmAddress } from '@suite-common/calldata';
 import { getYieldVault } from '@suite-common/earn-stablecoin-api';
-import { notificationsActions } from '@suite-common/toast-notifications';
 import { getNetwork } from '@suite-common/wallet-config';
-import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import {
+    type YieldFeeEstimationError,
     type YieldFlowResolvedData,
     type YieldWithdrawFlowType,
     buildYieldUnsignedTransaction,
     buildYieldWithdrawCalldata,
+    estimateYieldFeeLevel,
     selectRawNetworkFeeInfo,
 } from '@suite-common/wallet-core';
 import { ethereumGetCurrentNonceThunk } from '@suite-common/wallet-core/src/send/sendFormEthereumThunks';
 import { type Account } from '@suite-common/wallet-types';
 import { getAccountIdentity, getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
-import TrezorConnect from '@trezor/connect';
+import { type Result, err, ok } from '@trezor/type-utils';
 
 import type { AppState, Dispatch } from 'src/types/suite';
 
@@ -33,7 +33,7 @@ export const composeYieldWithdrawTransaction = async ({
     flowType,
     dispatch,
     getState,
-}: ComposeYieldWithdrawTransactionParams): Promise<string> => {
+}: ComposeYieldWithdrawTransactionParams): Promise<Result<string, YieldFeeEstimationError>> => {
     const { vault } = flowData;
 
     const { address: vaultAddress } = await getYieldVault({
@@ -67,31 +67,21 @@ export const composeYieldWithdrawTransaction = async ({
         ethereumGetCurrentNonceThunk({ selectedAccount: account, fetchConfirmedNonce: true }),
     ).unwrap();
 
-    const estimatedFeeTask = TrezorConnect.blockchainEstimateFee({
+    const estimatedFeeTask = estimateYieldFeeLevel({
         coin: account.symbol,
         identity: getAccountIdentity(account),
-        request: {
-            blocks: [2],
-            specific: {
-                from: account.descriptor,
-                to: vaultAddress,
-                data: calldata,
-                value: '0x0',
-            },
-        },
+        from: account.descriptor,
+        to: vaultAddress,
+        data: calldata,
     });
 
-    const [{ nonce }, estimatedFee] = await Promise.all([nonceTask, estimatedFeeTask]);
+    const [{ nonce }, estimatedFeeLevel] = await Promise.all([nonceTask, estimatedFeeTask]);
 
-    const estimatedGasLimit = estimatedFee.success
-        ? estimatedFee.payload.levels[0]?.feeLimit
-        : undefined;
-
-    if (!estimatedGasLimit) {
-        dispatch(notificationsActions.addToast({ type: 'estimated-fee-error' }));
+    if (!estimatedFeeLevel.success) {
+        return err(estimatedFeeLevel.error);
     }
 
-    const gasLimit = estimatedGasLimit ?? ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT;
+    const gasLimit = estimatedFeeLevel.payload.feeLimit;
 
     const feeInfo = getConvertedOrDefaultFeeInfo({
         networkType: account.networkType,
@@ -113,5 +103,5 @@ export const composeYieldWithdrawTransaction = async ({
         to: vaultAddress,
     });
 
-    return JSON.stringify(unsignedTx);
+    return ok(JSON.stringify(unsignedTx));
 };

--- a/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
@@ -19,12 +19,20 @@ import TrezorConnect from '@trezor/connect';
 
 import type { AppState, Dispatch } from 'src/types/suite';
 
-export const getYieldErrorTranslationKey = (error: unknown) =>
-    error instanceof Error &&
-    (error.cause === 'Device_InvalidState' || // incorrect passphrase submitted
-        error.cause === 'Method_Interrupted') // passphrase modal closed
-        ? 'TR_EARN_YIELD_ERROR_PASSPHRASE_INCORRECT'
-        : 'TR_EARN_YIELD_ERROR_GENERIC';
+export const getYieldErrorTranslationKey = (error: unknown) => {
+    if (!(error instanceof Error)) {
+        return 'TR_EARN_YIELD_ERROR_GENERIC';
+    }
+
+    if (
+        error.cause === 'Device_InvalidState' || // incorrect passphrase submitted
+        error.cause === 'Method_Interrupted' // passphrase modal closed
+    ) {
+        return 'TR_EARN_YIELD_ERROR_PASSPHRASE_INCORRECT';
+    }
+
+    return 'TR_EARN_YIELD_ERROR_GENERIC';
+};
 
 export type SendYieldTransactionParams = {
     account: Account;

--- a/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
@@ -19,6 +19,10 @@ import TrezorConnect from '@trezor/connect';
 
 import type { AppState, Dispatch } from 'src/types/suite';
 
+// Marks failures of the final broadcast — the transaction is already signed at that point,
+// which deserves a more specific message than the generic one.
+export const PUSH_TRANSACTION_FAILED_CAUSE = 'PushTransactionFailed';
+
 export const getYieldErrorTranslationKey = (error: unknown) => {
     if (!(error instanceof Error)) {
         return 'TR_EARN_YIELD_ERROR_GENERIC';
@@ -31,8 +35,17 @@ export const getYieldErrorTranslationKey = (error: unknown) => {
         return 'TR_EARN_YIELD_ERROR_PASSPHRASE_INCORRECT';
     }
 
+    if (error.cause === PUSH_TRANSACTION_FAILED_CAUSE) {
+        return 'TR_EARN_YIELD_ERROR_PUSH_FAILED';
+    }
+
     return 'TR_EARN_YIELD_ERROR_GENERIC';
 };
+
+export const getYieldSubmitErrorAnalyticsMessage = (error: unknown) =>
+    error instanceof Error && error.cause === PUSH_TRANSACTION_FAILED_CAUSE
+        ? 'push-failed'
+        : 'submit-failed';
 
 export type SendYieldTransactionParams = {
     account: Account;
@@ -148,7 +161,9 @@ export const sendYieldTransaction = async ({
         dispatch(closeModal());
 
         if (!pushResponse.success) {
-            throw new Error(`${pushResponse.error.code}: ${pushResponse.error.message}`);
+            throw new Error(`${pushResponse.error.code}: ${pushResponse.error.message}`, {
+                cause: PUSH_TRANSACTION_FAILED_CAUSE,
+            });
         }
 
         dispatch(

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
@@ -13,7 +13,11 @@ import {
     stablecoinYieldActions,
 } from '@suite-common/wallet-core';
 
-import { getYieldErrorTranslationKey, sendYieldTransaction } from './signingHelpers';
+import {
+    getYieldErrorTranslationKey,
+    getYieldSubmitErrorAnalyticsMessage,
+    sendYieldTransaction,
+} from './signingHelpers';
 
 type SubmitYieldDepositPayload = {
     flowKey: string;
@@ -156,7 +160,7 @@ export const submitYieldDepositThunk = createThunk(
                     action: 'continue',
                     networkSymbol: flowData.account.symbol,
                     vaultId: flowData.vault.id,
-                    errorMessage: 'submit-failed',
+                    errorMessage: getYieldSubmitErrorAnalyticsMessage(error),
                 },
             });
             dispatch(

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
@@ -7,8 +7,9 @@ import {
     STABLECOIN_YIELD_PREFIX,
     type YieldFlowResolvedData,
     composeYieldDepositTransactionThunk,
+    getYieldDepositErrorTranslationKey,
     openYieldApproveModal,
-    setYieldGenericError,
+    setYieldError,
     stablecoinYieldActions,
 } from '@suite-common/wallet-core';
 
@@ -36,7 +37,12 @@ export const submitYieldDepositThunk = createThunk(
             ).unwrap();
 
             if (result.type === 'error') {
-                setYieldGenericError({ dispatch, flowType, flowKey });
+                setYieldError({
+                    dispatch,
+                    flowType,
+                    flowKey,
+                    error: getYieldDepositErrorTranslationKey(result.reason),
+                });
 
                 return;
             }

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
@@ -26,6 +26,19 @@ export const submitYieldWithdrawThunk = createThunk(
         { flowKey, flowData, amount, flowType }: SubmitYieldWithdrawPayload,
         { dispatch, getState, extra },
     ) => {
+        const reportSubmitError = (errorMessage = 'submit-failed') =>
+            asTypedDesktopAnalytics(extra.services.analytics).report({
+                type: events.yieldWithdrawEvent.name,
+                payload: {
+                    type: 'error',
+                    operation: flowType,
+                    action: 'continue',
+                    networkSymbol: flowData.account.symbol,
+                    vaultId: flowData.vault.id,
+                    errorMessage,
+                },
+            });
+
         try {
             if (flowData.account.networkType !== 'ethereum') {
                 throw new Error('Yield actions currently support only EVM accounts.');
@@ -35,7 +48,7 @@ export const submitYieldWithdrawThunk = createThunk(
 
             const { account } = flowData;
 
-            const unsignedTransaction = await composeYieldWithdrawTransaction({
+            const composeResult = await composeYieldWithdrawTransaction({
                 account,
                 flowData,
                 amount,
@@ -43,6 +56,21 @@ export const submitYieldWithdrawThunk = createThunk(
                 dispatch,
                 getState,
             });
+
+            if (!composeResult.success) {
+                reportSubmitError(composeResult.error);
+                dispatch(
+                    stablecoinYieldActions.setError({
+                        flowType,
+                        flowKey,
+                        error: 'TR_EARN_YIELD_ERROR_FEE_ESTIMATION',
+                    }),
+                );
+
+                return;
+            }
+
+            const unsignedTransaction = composeResult.payload;
 
             const userAcceptedTxSimulation = await dispatch(
                 openDeferredModal({
@@ -125,17 +153,7 @@ export const submitYieldWithdrawThunk = createThunk(
             );
         } catch (error) {
             console.error(error);
-            asTypedDesktopAnalytics(extra.services.analytics).report({
-                type: events.yieldWithdrawEvent.name,
-                payload: {
-                    type: 'error',
-                    operation: flowType,
-                    action: 'continue',
-                    networkSymbol: flowData.account.symbol,
-                    vaultId: flowData.vault.id,
-                    errorMessage: 'submit-failed',
-                },
-            });
+            reportSubmitError();
             dispatch(
                 stablecoinYieldActions.setError({
                     flowType,

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
@@ -11,7 +11,11 @@ import {
 } from '@suite-common/wallet-core';
 
 import { composeYieldWithdrawTransaction } from './composeYieldWithdrawTransaction';
-import { getYieldErrorTranslationKey, sendYieldTransaction } from './signingHelpers';
+import {
+    getYieldErrorTranslationKey,
+    getYieldSubmitErrorAnalyticsMessage,
+    sendYieldTransaction,
+} from './signingHelpers';
 
 type SubmitYieldWithdrawPayload = {
     flowKey: string;
@@ -153,7 +157,7 @@ export const submitYieldWithdrawThunk = createThunk(
             );
         } catch (error) {
             console.error(error);
-            reportSubmitError();
+            reportSubmitError(getYieldSubmitErrorAnalyticsMessage(error));
             dispatch(
                 stablecoinYieldActions.setError({
                     flowType,

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -88,7 +88,6 @@
         {
             "path": "../../suite-common/redux-utils"
         },
-        { "path": "../../suite-common/schemas" },
         { "path": "../../suite-common/sentry" },
         { "path": "../../suite-common/staking" },
         {

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -71,6 +71,7 @@ export * from './stablecoin-yield/stablecoinYieldApprovalThunks';
 export * from './stablecoin-yield/stablecoinYieldConstants';
 export * from './stablecoin-yield/stablecoinYieldDepositThunks';
 export * from './stablecoin-yield/stablecoinYieldDeviceUtils';
+export * from './stablecoin-yield/stablecoinYieldFeeEstimation';
 export * from './stablecoin-yield/stablecoinYieldTypes';
 export * from './stablecoin-yield/stablecoinYieldUtils';
 export * from './stake/tron/tronStakeReducer';

--- a/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldDepositThunks.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldDepositThunks.test.ts
@@ -1,0 +1,121 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { configureMockStore } from '@suite-common/test-utils';
+import { type FeeInfo, asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { BigNumber } from '@trezor/utils';
+
+import { fetchAllowance } from '../../allowance/fetchAllowance';
+import { feesReducer } from '../../fees/feesReducer';
+import { ethereumGetCurrentNonceThunk } from '../../send/sendFormEthereumThunks';
+import { composeYieldDepositTransactionThunk } from '../stablecoinYieldDepositThunks';
+import { estimateYieldFeeLevel } from '../stablecoinYieldFeeEstimation';
+import { type YieldFlowResolvedData } from '../stablecoinYieldTypes';
+
+jest.mock('../../allowance/fetchAllowance', () => ({
+    fetchAllowance: jest.fn(),
+}));
+
+jest.mock('../stablecoinYieldFeeEstimation', () => ({
+    estimateYieldFeeLevel: jest.fn(),
+}));
+
+jest.mock('../../send/sendFormEthereumThunks', () => ({
+    ethereumGetCurrentNonceThunk: jest.fn(() => () => {
+        const result = { nonce: '5', confirmedNonce: '5' };
+
+        return Object.assign(Promise.resolve(result), {
+            unwrap: () => Promise.resolve(result),
+        });
+    }),
+}));
+
+const OWNER_ADDRESS = '0x1f9090aaE28b8a3dCeaDf281B0F12828e676c326';
+const VAULT_ADDRESS = '0xd63070114470f685b75B74D60EEc7c1113d33a3D';
+
+const account = mockWalletAccount({
+    symbol: 'eth',
+    descriptor: asAccountDescriptor(OWNER_ADDRESS),
+    deviceState: 'mock@device:0',
+});
+
+const flowData = {
+    account,
+    vault: { id: `eth-${VAULT_ADDRESS}`, chainId: 1 },
+    token: {
+        networkSymbol: 'eth',
+        symbol: 'usdc',
+        decimals: 6,
+        contractAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        balance: '100',
+    },
+    receiptToken: {
+        networkSymbol: 'eth',
+        symbol: 'musdc',
+        decimals: 18,
+        contractAddress: VAULT_ADDRESS,
+    },
+} as unknown as YieldFlowResolvedData;
+
+const ethFeeInfo: FeeInfo = {
+    blockHeight: 100,
+    blockTime: 12,
+    minFee: 1,
+    maxFee: 100,
+    minPriorityFee: 1,
+    levels: [{ label: 'normal', feePerUnit: '1000000000', blocks: -1 }],
+};
+
+const initStore = () =>
+    configureMockStore({
+        reducer: combineReducers({
+            wallet: combineReducers({ fees: feesReducer }),
+        }),
+        preloadedState: {
+            wallet: { fees: { eth: { status: 'loaded', data: ethFeeInfo } } },
+        },
+    });
+
+describe(composeYieldDepositTransactionThunk.name, () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (fetchAllowance as jest.Mock).mockResolvedValue(new BigNumber('1000000000000'));
+    });
+
+    it('fails with fee-estimation-failed when gas estimation fails', async () => {
+        (estimateYieldFeeLevel as jest.Mock).mockResolvedValue({
+            success: false,
+            error: 'Network error',
+        });
+
+        const store = initStore();
+        const result = await store
+            .dispatch(composeYieldDepositTransactionThunk({ flowData, amount: '1' }))
+            .unwrap();
+
+        expect(result).toEqual({ type: 'error', reason: 'fee-estimation-failed' });
+    });
+
+    it('uses the estimated gas limit when estimation succeeds', async () => {
+        (estimateYieldFeeLevel as jest.Mock).mockResolvedValue({
+            success: true,
+            payload: { feeLimit: '750000' },
+        });
+
+        const store = initStore();
+        const result = await store
+            .dispatch(composeYieldDepositTransactionThunk({ flowData, amount: '1' }))
+            .unwrap();
+
+        expect(result.type).toBe('action-ready');
+
+        if (result.type === 'action-ready') {
+            expect(JSON.parse(result.unsignedTransaction).gasLimit).toBe('0xb71b0');
+        }
+
+        expect(ethereumGetCurrentNonceThunk).toHaveBeenCalledWith({
+            selectedAccount: account,
+            fetchConfirmedNonce: true,
+        });
+    });
+});

--- a/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldFeeEstimation.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldFeeEstimation.test.ts
@@ -1,0 +1,65 @@
+import TrezorConnect from '@trezor/connect';
+
+import { estimateYieldFeeLevel } from '../stablecoinYieldFeeEstimation';
+
+jest.mock('@trezor/connect', () => ({
+    __esModule: true,
+    default: { blockchainEstimateFee: jest.fn() },
+}));
+
+const params = {
+    coin: 'eth',
+    identity: 'mock-identity',
+    from: '0xfrom',
+    to: '0xto',
+    data: '0xdata',
+} as const;
+
+const feeLevel = { feeLimit: '750000', feePerUnit: '1' };
+
+const mockEstimateFeeResponse = (response: unknown) => {
+    (TrezorConnect.blockchainEstimateFee as jest.Mock).mockResolvedValue(response);
+};
+
+describe(estimateYieldFeeLevel.name, () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('returns the estimated fee level on success', async () => {
+        mockEstimateFeeResponse({
+            success: true,
+            payload: { levels: [feeLevel] },
+        });
+
+        await expect(estimateYieldFeeLevel(params)).resolves.toEqual({
+            success: true,
+            payload: feeLevel,
+        });
+    });
+
+    it.each([
+        {
+            description: 'the estimate request fails',
+            response: {
+                success: false,
+                error: { message: 'Network error', code: 'Method_Discovery' },
+            },
+        },
+        {
+            description: 'the fee level is missing a gas limit',
+            response: { success: true, payload: { levels: [{ feePerUnit: '1' }] } },
+        },
+        {
+            description: 'no fee levels are returned',
+            response: { success: true, payload: { levels: [] } },
+        },
+    ])('fails when $description', async ({ response }) => {
+        mockEstimateFeeResponse(response);
+
+        await expect(estimateYieldFeeLevel(params)).resolves.toEqual({
+            success: false,
+            error: 'fee-estimation-failed',
+        });
+    });
+});

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
@@ -10,7 +10,10 @@ import {
 import { BigNumber } from '@trezor/utils';
 
 import { STABLECOIN_YIELD_PREFIX } from './stablecoinYieldConstants';
-import { stablecoinYieldActions } from './stablecoinYieldReducer';
+import {
+    type StablecoinYieldTranslationKey,
+    stablecoinYieldActions,
+} from './stablecoinYieldReducer';
 import { selectStablecoinYieldSession } from './stablecoinYieldSelectors';
 import type { YieldFlowResolvedData, YieldPositionFlowType } from './stablecoinYieldTypes';
 import { getAllowanceSpender, getWithdrawRequestAmount } from './stablecoinYieldUtils';
@@ -41,8 +44,9 @@ type InitYieldAllowancePayload = YieldSessionDataPayload & {
     shouldSkipApprovalStep?: boolean;
 };
 
-type SetYieldGenericErrorParams = YieldSessionPayload & {
+type SetYieldErrorParams = YieldSessionPayload & {
     dispatch: Dispatch;
+    error?: StablecoinYieldTranslationKey;
 };
 
 type GetApprovalContractAddressParams = {
@@ -69,16 +73,17 @@ type OpenYieldRevokeModalParams = YieldSessionDataPayload & {
     spender: string | null;
 };
 
-export const setYieldGenericError = ({
+export const setYieldError = ({
     dispatch,
     flowType,
     flowKey,
-}: SetYieldGenericErrorParams) => {
+    error = YIELD_GENERIC_ERROR,
+}: SetYieldErrorParams) => {
     dispatch(
         stablecoinYieldActions.setError({
             flowType,
             flowKey,
-            error: YIELD_GENERIC_ERROR,
+            error,
         }),
     );
 };
@@ -129,7 +134,7 @@ export const openYieldApproveModal = ({
     const contractAddress = getApprovalContractAddress({ flowType, flowData });
 
     if (!contractAddress) {
-        setYieldGenericError({ dispatch, flowType, flowKey });
+        setYieldError({ dispatch, flowType, flowKey });
 
         return false;
     }
@@ -161,7 +166,7 @@ export const openYieldRevokeModal = ({
     spender,
 }: OpenYieldRevokeModalParams) => {
     if (!spender) {
-        setYieldGenericError({ dispatch, flowType, flowKey });
+        setYieldError({ dispatch, flowType, flowKey });
 
         return false;
     }
@@ -305,7 +310,7 @@ export const submitYieldApproveThunk = createThunk(
         });
 
         if (!requestAmount) {
-            setYieldGenericError({ dispatch, flowType, flowKey });
+            setYieldError({ dispatch, flowType, flowKey });
 
             return;
         }
@@ -317,7 +322,7 @@ export const submitYieldApproveThunk = createThunk(
             const tokenContractAddress = flowData.token.contractAddress;
 
             if (!spender || !tokenContractAddress) {
-                setYieldGenericError({ dispatch, flowType, flowKey });
+                setYieldError({ dispatch, flowType, flowKey });
 
                 return;
             }
@@ -364,7 +369,7 @@ export const submitYieldApproveThunk = createThunk(
                 txType: 'approve',
             });
         } catch {
-            setYieldGenericError({ dispatch, flowType, flowKey });
+            setYieldError({ dispatch, flowType, flowKey });
         } finally {
             dispatch(stablecoinYieldActions.finishSubmittingApproval({ flowType, flowKey }));
         }

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.ts
@@ -1,7 +1,6 @@
 import { asEvmAddress } from '@suite-common/calldata';
 import { createThunk } from '@suite-common/redux-utils';
 import { getNetwork } from '@suite-common/wallet-config';
-import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import {
     asAmountUnit,
     getAccountIdentity,
@@ -9,12 +8,11 @@ import {
     tokenSupportsIncreasingAllowance,
     unitsToSubunits,
 } from '@suite-common/wallet-utils';
-import TrezorConnect from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
-import { getApprovalRequestAmount, setYieldGenericError } from './stablecoinYieldApprovalThunks';
+import { getApprovalRequestAmount } from './stablecoinYieldApprovalThunks';
 import { STABLECOIN_YIELD_PREFIX } from './stablecoinYieldConstants';
-import { stablecoinYieldActions } from './stablecoinYieldReducer';
+import { estimateYieldFeeLevel } from './stablecoinYieldFeeEstimation';
 import type { YieldFlowResolvedData } from './stablecoinYieldTypes';
 import {
     buildYieldDepositCalldata,
@@ -33,7 +31,13 @@ export type YieldDepositErrorReason =
     | 'missing-deposit-params'
     | 'vault-chain-mismatch'
     | 'missing-fee-level'
+    | 'fee-estimation-failed'
     | 'compose-failed';
+
+export const getYieldDepositErrorTranslationKey = (reason: YieldDepositErrorReason) =>
+    reason === 'fee-estimation-failed'
+        ? ('TR_EARN_YIELD_ERROR_FEE_ESTIMATION' as const)
+        : ('TR_EARN_YIELD_ERROR_GENERIC' as const);
 
 export type PrepareYieldDepositResult =
     | {
@@ -55,12 +59,6 @@ export type PrepareYieldDepositResult =
       };
 
 type ComposeYieldDepositTransactionPayload = {
-    flowData: YieldFlowResolvedData;
-    amount: string;
-};
-
-type PrepareYieldDepositPayload = {
-    flowKey: string;
     flowData: YieldFlowResolvedData;
     amount: string;
 };
@@ -124,30 +122,25 @@ export const composeYieldDepositTransactionThunk = createThunk<
             receiverAddress: ownerAddress,
         });
 
-        const [{ nonce }, estimatedFee] = await Promise.all([
+        const [{ nonce }, estimatedFeeLevel] = await Promise.all([
             dispatch(
                 ethereumGetCurrentNonceThunk({
                     selectedAccount: account,
                     fetchConfirmedNonce: true,
                 }),
             ).unwrap(),
-            TrezorConnect.blockchainEstimateFee({
+            estimateYieldFeeLevel({
                 coin: account.symbol,
                 identity: getAccountIdentity(account),
-                request: {
-                    blocks: [2],
-                    specific: {
-                        from: account.descriptor,
-                        to: spender,
-                        data: calldata,
-                        value: '0x0',
-                    },
-                },
+                from: account.descriptor,
+                to: spender,
+                data: calldata,
             }),
         ]);
-        const estimatedGasLimit = estimatedFee.success
-            ? estimatedFee.payload.levels[0]?.feeLimit
-            : undefined;
+
+        if (!estimatedFeeLevel.success) {
+            return { type: 'error', reason: 'fee-estimation-failed' } as const;
+        }
 
         const feeInfo = getConvertedOrDefaultFeeInfo({
             networkType: account.networkType,
@@ -166,7 +159,7 @@ export const composeYieldDepositTransactionThunk = createThunk<
                 data: calldata,
                 feeLevel: normalLevel,
                 from: account.descriptor,
-                gasLimit: estimatedGasLimit ?? ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT,
+                gasLimit: estimatedFeeLevel.payload.feeLimit,
                 nonce: Number(nonce),
                 to: spender,
             }),
@@ -186,36 +179,5 @@ export const composeYieldDepositTransactionThunk = createThunk<
             unsignedTransaction,
             receiptAmount,
         };
-    },
-);
-
-export const prepareYieldDepositThunk = createThunk<
-    PrepareYieldDepositResult,
-    PrepareYieldDepositPayload,
-    void
->(
-    `${YIELD_DEPOSIT_THUNK_PREFIX}/prepareDeposit`,
-    async ({ flowKey, flowData, amount }, { dispatch }) => {
-        const flowType = 'deposit' as const;
-
-        dispatch(stablecoinYieldActions.startSubmittingAction({ flowType, flowKey, amount }));
-
-        try {
-            const result = await dispatch(
-                composeYieldDepositTransactionThunk({ flowData, amount }),
-            ).unwrap();
-
-            if (result.type === 'error') {
-                setYieldGenericError({ dispatch, flowType, flowKey });
-            }
-
-            return result;
-        } catch {
-            setYieldGenericError({ dispatch, flowType, flowKey });
-
-            return { type: 'error', reason: 'compose-failed' } as const;
-        } finally {
-            dispatch(stablecoinYieldActions.finishSubmittingAction({ flowType, flowKey }));
-        }
     },
 );

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldFeeEstimation.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldFeeEstimation.ts
@@ -1,0 +1,53 @@
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+import TrezorConnect from '@trezor/connect';
+import type { BlockchainEstimatedFee } from '@trezor/connect-common/src/types/api/blockchain/blockchainEstimateFee';
+import { type Result, err, ok } from '@trezor/type-utils';
+
+export type YieldFeeEstimationError = 'fee-estimation-failed';
+export type YieldEstimatedFeeLevel = BlockchainEstimatedFee['levels'][number] & {
+    feeLimit: string;
+};
+
+type EstimateYieldFeeLevelParams = {
+    coin: NetworkSymbol;
+    identity?: string;
+    from: string;
+    to: string;
+    data: string;
+};
+
+export const estimateYieldFeeLevel = async ({
+    coin,
+    identity,
+    from,
+    to,
+    data,
+}: EstimateYieldFeeLevelParams): Promise<
+    Result<YieldEstimatedFeeLevel, YieldFeeEstimationError>
+> => {
+    const estimatedFee = await TrezorConnect.blockchainEstimateFee({
+        coin,
+        identity,
+        request: {
+            blocks: [2],
+            specific: {
+                from,
+                to,
+                data,
+                value: '0x0',
+            },
+        },
+    });
+
+    if (!estimatedFee.success) {
+        return err('fee-estimation-failed');
+    }
+
+    const feeLevel = estimatedFee.payload.levels[0];
+
+    if (!feeLevel?.feeLimit) {
+        return err('fee-estimation-failed');
+    }
+
+    return ok({ ...feeLevel, feeLimit: feeLevel.feeLimit });
+};

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -24,7 +24,8 @@ import { transactionsActions } from '../transactions/transactionsActions';
 
 // Message ids must exist in the desktop `suite/intl` messages — the desktop app renders
 // `session.error` directly via `<Translation>`.
-type StablecoinYieldTranslationKey =
+export type StablecoinYieldTranslationKey =
+    | 'TR_EARN_YIELD_ERROR_FEE_ESTIMATION'
     | 'TR_EARN_YIELD_ERROR_GENERIC'
     | 'TR_EARN_YIELD_ERROR_PASSPHRASE_INCORRECT'
     | 'TR_EARN_YIELD_ERROR_TRANSACTION_FAILED';

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -28,6 +28,7 @@ export type StablecoinYieldTranslationKey =
     | 'TR_EARN_YIELD_ERROR_FEE_ESTIMATION'
     | 'TR_EARN_YIELD_ERROR_GENERIC'
     | 'TR_EARN_YIELD_ERROR_PASSPHRASE_INCORRECT'
+    | 'TR_EARN_YIELD_ERROR_PUSH_FAILED'
     | 'TR_EARN_YIELD_ERROR_TRANSACTION_FAILED';
 
 type StablecoinYieldSerializedTx = {

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2505,6 +2505,8 @@ export const messages = {
         staking: 'Staking',
         stablecoinYield: 'Stablecoin yield',
         poweredBy: 'Powered by',
+        feeEstimationFailed:
+            "The network fee couldn't be estimated, so the transaction can't be prepared. Try again later.",
         stakingOperatedByProviders: 'Staking is operated by independent providers',
         portfolioTracker: {
             alert: {

--- a/suite-native/module-earn/src/components/YieldFeeEstimationErrorAlert.tsx
+++ b/suite-native/module-earn/src/components/YieldFeeEstimationErrorAlert.tsx
@@ -1,0 +1,15 @@
+import { InlineAlertBox } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+type YieldFeeEstimationErrorAlertProps = {
+    onRetry: () => void;
+};
+
+export const YieldFeeEstimationErrorAlert = ({ onRetry }: YieldFeeEstimationErrorAlertProps) => (
+    <InlineAlertBox
+        intent="critical"
+        title={<Translation id="earn.feeEstimationFailed" />}
+        buttonLabel={<Translation id="generic.buttons.tryAgain" />}
+        onButtonPress={onRetry}
+    />
+);

--- a/suite-native/module-earn/src/hooks/useYieldClaimFees.ts
+++ b/suite-native/module-earn/src/hooks/useYieldClaimFees.ts
@@ -8,10 +8,10 @@ import {
 import type { UnsignedClaimTransaction } from '@suite-common/earn-stablecoin/src/signing';
 import { type EvmHexString } from '@suite-common/schemas/src/evm';
 import { getEarnYieldClaimContractAddress, getNetwork } from '@suite-common/wallet-config';
-import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import {
     type FeesRootState,
     type FormDraftRootState,
+    estimateYieldFeeLevel,
     ethereumGetCurrentNonceThunk,
     formDraftActions,
     selectConvertedNetworkFeeInfo,
@@ -29,10 +29,10 @@ import {
     selectFeeLevels,
     transactionManagementActions,
 } from '@suite-native/transaction-management';
-import TrezorConnect from '@trezor/connect';
 import { useDebounce } from '@trezor/react-utils';
 
 import { buildEarnComposeFormState } from '../utils';
+import { useYieldFeeEstimationError } from './useYieldFeeEstimationError';
 import { type StablecoinYieldAccountRewards } from '../utils/stablecoinYieldClaimSummaryUtils';
 import { buildYieldClaimFeeLevels, getYieldClaimFee } from '../utils/yieldClaimFeeUtils';
 import {
@@ -68,36 +68,6 @@ type PrepareClaimFeeParams = {
     rewards: StablecoinYieldAccountRewards['rewards'];
 };
 
-const getEstimatedClaimGasLimit = async ({
-    account,
-    contractAddress,
-    data,
-}: {
-    account: AccountWithNetworkType<'ethereum'>;
-    contractAddress: EvmHexString;
-    data: EvmHexString;
-}) => {
-    const estimatedFee = await TrezorConnect.blockchainEstimateFee({
-        coin: account.symbol,
-        identity: account.deviceState,
-        request: {
-            blocks: [2],
-            specific: {
-                from: account.descriptor,
-                to: contractAddress,
-                data,
-                value: '0x0',
-            },
-        },
-    });
-
-    if (!estimatedFee.success) {
-        throw new Error('Failed to estimate fee for claim transaction.');
-    }
-
-    return estimatedFee.payload.levels[0]?.feeLimit ?? ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT;
-};
-
 const getClaimFormDraft = ({
     claimCalldata,
     contractAddress,
@@ -119,6 +89,12 @@ export const useYieldClaimFees = ({ accountRewards, isEnabled }: UseYieldClaimFe
     const requestIdRef = useRef(0);
     const [baseContext, setBaseContext] = useState<ClaimFeeBaseContext | null>(null);
     const [isPreparingClaimFee, setIsPreparingClaimFee] = useState(false);
+    const {
+        feeEstimationRetryKey,
+        hasFeeEstimationError,
+        retryFeeEstimation,
+        setHasFeeEstimationError,
+    } = useYieldFeeEstimationError();
     const account = accountRewards?.account;
     const accountKey = account?.key;
     const claimFormDraftKey = useMemo(
@@ -202,9 +178,11 @@ export const useYieldClaimFees = ({ accountRewards, isEnabled }: UseYieldClaimFe
             }
 
             try {
-                const gasLimitTask = getEstimatedClaimGasLimit({
-                    account: claimAccount,
-                    contractAddress,
+                const feeLevelTask = estimateYieldFeeLevel({
+                    coin: claimAccount.symbol,
+                    identity: claimAccount.deviceState,
+                    from: claimAccount.descriptor,
+                    to: contractAddress,
                     data: claimCalldata,
                 });
                 const nonceTask = dispatch(
@@ -214,9 +192,16 @@ export const useYieldClaimFees = ({ accountRewards, isEnabled }: UseYieldClaimFe
                     }),
                 ).unwrap();
 
-                const [gasLimit, { nonce }] = await Promise.all([gasLimitTask, nonceTask]);
+                const [feeLevel, { nonce }] = await Promise.all([feeLevelTask, nonceTask]);
 
                 if (requestId !== requestIdRef.current) {
+                    return;
+                }
+
+                if (!feeLevel.success) {
+                    setHasFeeEstimationError(true);
+                    clearClaimFeeState();
+
                     return;
                 }
 
@@ -229,7 +214,7 @@ export const useYieldClaimFees = ({ accountRewards, isEnabled }: UseYieldClaimFe
                     availableBalance: claimAccount.availableBalance,
                     feeInfo,
                     formDraft: claimFormDraft,
-                    gasLimit,
+                    gasLimit: feeLevel.payload.feeLimit,
                 });
 
                 dispatch(
@@ -256,12 +241,14 @@ export const useYieldClaimFees = ({ accountRewards, isEnabled }: UseYieldClaimFe
                 }
             }
         },
-        [claimFormDraftKey, clearClaimFeeState, dispatch, feeInfo],
+        [claimFormDraftKey, clearClaimFeeState, dispatch, feeInfo, setHasFeeEstimationError],
     );
 
     useEffect(() => {
         const requestId = requestIdRef.current + 1;
         requestIdRef.current = requestId;
+
+        setHasFeeEstimationError(false);
 
         if (!prepareClaimFeeParams) {
             clearClaimFeeState();
@@ -272,7 +259,14 @@ export const useYieldClaimFees = ({ accountRewards, isEnabled }: UseYieldClaimFe
         setBaseContext(null);
         setIsPreparingClaimFee(true);
         void debounce(() => void prepareClaimFee(prepareClaimFeeParams, requestId));
-    }, [clearClaimFeeState, debounce, prepareClaimFee, prepareClaimFeeParams]);
+    }, [
+        clearClaimFeeState,
+        debounce,
+        feeEstimationRetryKey,
+        prepareClaimFee,
+        prepareClaimFeeParams,
+        setHasFeeEstimationError,
+    ]);
 
     useEffect(
         () => () => {
@@ -309,9 +303,11 @@ export const useYieldClaimFees = ({ accountRewards, isEnabled }: UseYieldClaimFe
         feePreview,
         formDraft,
         formDraftKey: claimFormDraftKey,
+        hasFeeEstimationError,
         isFeeUnavailable,
         isPreparingClaimFee: !!prepareClaimFeeParams && isPreparingClaimFee,
         preparedAction,
+        retryFeeEstimation,
         selectedFee,
         updateFeeLevelThunk: updateYieldClaimSelectedFeeLevelThunk,
     };

--- a/suite-native/module-earn/src/hooks/useYieldDepositFees.ts
+++ b/suite-native/module-earn/src/hooks/useYieldDepositFees.ts
@@ -28,6 +28,7 @@ import { deepEqual } from '@trezor/utils';
 
 import { updateEarnSelectedFeeLevelThunk } from './useComposeEarnFees';
 import { type ResolvedYieldFlowData } from './useResolvedYieldFlowData';
+import { useYieldFeeEstimationError } from './useYieldFeeEstimationError';
 import { getYieldDepositFormDraftKey } from '../utils/yieldDepositUtils';
 import {
     buildYieldDepositFeeDraftState,
@@ -81,6 +82,12 @@ export const useYieldDepositFees = ({
     const [baseActionContext, setBaseActionContext] =
         useState<BaseYieldDepositActionContext | null>(null);
     const [isPreparingDepositFee, setIsPreparingDepositFee] = useState(false);
+    const {
+        feeEstimationRetryKey,
+        hasFeeEstimationError,
+        retryFeeEstimation,
+        setHasFeeEstimationError,
+    } = useYieldFeeEstimationError();
 
     const formDraftKey = useMemo(
         () => (flowKey ? getYieldDepositFormDraftKey(flowKey) : ''),
@@ -154,6 +161,10 @@ export const useYieldDepositFees = ({
                 }
 
                 if (result.type !== 'action-ready') {
+                    if (result.type === 'error' && result.reason === 'fee-estimation-failed') {
+                        setHasFeeEstimationError(true);
+                    }
+
                     clearDepositFeeState();
 
                     return;
@@ -182,7 +193,7 @@ export const useYieldDepositFees = ({
                 }
             }
         },
-        [clearDepositFeeState, dispatch],
+        [clearDepositFeeState, dispatch, setHasFeeEstimationError],
     );
 
     const depositFeeDraftState = useMemo(() => {
@@ -298,6 +309,8 @@ export const useYieldDepositFees = ({
         const requestId = requestIdRef.current + 1;
         requestIdRef.current = requestId;
 
+        setHasFeeEstimationError(false);
+
         if (!composeDepositBaseActionParams) {
             setBaseActionContext(null);
             setIsPreparingDepositFee(false);
@@ -318,8 +331,10 @@ export const useYieldDepositFees = ({
         clearDepositFeeStore,
         composeDepositBaseActionParams,
         debounce,
+        feeEstimationRetryKey,
         hasInvalidDepositContext,
         prepareDepositBaseAction,
+        setHasFeeEstimationError,
     ]);
 
     useEffect(
@@ -334,10 +349,12 @@ export const useYieldDepositFees = ({
         feePreview: preparedAction?.feePreview ?? null,
         formDraft,
         formDraftKey,
+        hasFeeEstimationError,
         isDepositFeeReady,
         isFeeUnavailable,
         isPreparingDepositFee: isCurrentDepositFeePreparing,
         preparedAction,
+        retryFeeEstimation,
         selectedFee,
         updateFeeLevelThunk: updateEarnSelectedFeeLevelThunk,
     };

--- a/suite-native/module-earn/src/hooks/useYieldFeeEstimationError.ts
+++ b/suite-native/module-earn/src/hooks/useYieldFeeEstimationError.ts
@@ -1,0 +1,18 @@
+import { useCallback, useState } from 'react';
+
+export const useYieldFeeEstimationError = () => {
+    const [hasFeeEstimationError, setHasFeeEstimationError] = useState(false);
+    const [feeEstimationRetryKey, setFeeEstimationRetryKey] = useState(0);
+
+    const retryFeeEstimation = useCallback(() => {
+        setHasFeeEstimationError(false);
+        setFeeEstimationRetryKey(currentKey => currentKey + 1);
+    }, []);
+
+    return {
+        feeEstimationRetryKey,
+        hasFeeEstimationError,
+        retryFeeEstimation,
+        setHasFeeEstimationError,
+    };
+};

--- a/suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts
+++ b/suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts
@@ -5,14 +5,15 @@ import { asEvmAddress } from '@suite-common/calldata';
 import { buildStablecoinYieldTransactionReview } from '@suite-common/earn-stablecoin/src/signing';
 import { createThunk } from '@suite-common/redux-utils';
 import { getNetwork } from '@suite-common/wallet-config';
-import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import {
     type FeesRootState,
     type FormDraftRootState,
+    type YieldFeeEstimationError,
     type YieldWithdrawFlowType,
     buildEvmSelectedFee,
     buildYieldUnsignedTransaction,
     buildYieldWithdrawCalldata,
+    estimateYieldFeeLevel,
     ethereumGetCurrentNonceThunk,
     formDraftActions,
     getYieldWithdrawInputToken,
@@ -36,11 +37,12 @@ import {
     selectFeeLevels,
     transactionManagementActions,
 } from '@suite-native/transaction-management';
-import TrezorConnect from '@trezor/connect';
 import { useDebounce } from '@trezor/react-utils';
+import { type Result, err, ok } from '@trezor/type-utils';
 
 import { EARN_MODULE_PREFIX } from '../constants';
 import { type ResolvedYieldFlowData } from './useResolvedYieldFlowData';
+import { useYieldFeeEstimationError } from './useYieldFeeEstimationError';
 import { getYieldWithdrawFormDraftKey } from '../utils/yieldWithdrawUtils';
 
 type UseYieldWithdrawFeesParams = Pick<ResolvedYieldFlowData, 'flowData' | 'flowKey'> & {
@@ -61,9 +63,11 @@ type UseYieldWithdrawFeesResult = {
     fee: string | null;
     formDraft: FormState | undefined;
     formDraftKey: string;
+    hasFeeEstimationError: boolean;
     isComposingWithdrawFee: boolean;
     isFeeUnavailable: boolean;
     preparedAction: PreparedYieldWithdrawAction | null;
+    retryFeeEstimation: () => void;
     selectedFee: FeeLevelLabel;
     updateFeeLevelThunk: typeof updateYieldWithdrawSelectedFeeLevelThunk;
 };
@@ -217,7 +221,7 @@ const composeYieldWithdrawTransaction = async ({
     feeInfo,
     flowData,
     flowType,
-}: ComposeYieldWithdrawTransactionParams) => {
+}: ComposeYieldWithdrawTransactionParams): Promise<Result<string, YieldFeeEstimationError>> => {
     const { account, receiptToken, vault } = flowData;
 
     if (account.networkType !== 'ethereum') {
@@ -240,27 +244,23 @@ const composeYieldWithdrawTransaction = async ({
         flowType,
     });
 
-    const [{ nonce }, estimatedFee] = await Promise.all([
+    const [{ nonce }, estimatedFeeLevel] = await Promise.all([
         dispatch(
             ethereumGetCurrentNonceThunk({ selectedAccount: account, fetchConfirmedNonce: true }),
         ).unwrap(),
-        TrezorConnect.blockchainEstimateFee({
+        estimateYieldFeeLevel({
             coin: account.symbol,
             identity: getAccountIdentity(account),
-            request: {
-                blocks: [2],
-                specific: {
-                    from: account.descriptor,
-                    to: vaultAddress,
-                    data: calldata,
-                    value: '0x0',
-                },
-            },
+            from: account.descriptor,
+            to: vaultAddress,
+            data: calldata,
         }),
     ]);
-    const estimatedGasLimit = estimatedFee.success
-        ? estimatedFee.payload.levels[0]?.feeLimit
-        : undefined;
+
+    if (!estimatedFeeLevel.success) {
+        return err(estimatedFeeLevel.error);
+    }
+
     const feeLevel = getFeeLevelForUnsignedTransaction(feeInfo);
 
     if (!feeLevel) {
@@ -272,12 +272,12 @@ const composeYieldWithdrawTransaction = async ({
         data: calldata,
         feeLevel,
         from: account.descriptor,
-        gasLimit: estimatedGasLimit ?? ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT,
+        gasLimit: estimatedFeeLevel.payload.feeLimit,
         nonce: Number(nonce),
         to: vaultAddress,
     });
 
-    return JSON.stringify(unsignedTransaction);
+    return ok(JSON.stringify(unsignedTransaction));
 };
 
 const buildYieldWithdrawFeeLevels = ({
@@ -316,6 +316,12 @@ export const useYieldWithdrawFees = ({
     const requestIdRef = useRef(0);
     const [preparedAction, setPreparedAction] = useState<PreparedYieldWithdrawAction | null>(null);
     const [isComposingWithdrawFee, setIsComposingWithdrawFee] = useState(false);
+    const {
+        feeEstimationRetryKey,
+        hasFeeEstimationError,
+        retryFeeEstimation,
+        setHasFeeEstimationError,
+    } = useYieldFeeEstimationError();
 
     const formDraftKey = useMemo(
         () => (flowKey ? getYieldWithdrawFormDraftKey(flowKey) : ''),
@@ -378,7 +384,7 @@ export const useYieldWithdrawFees = ({
                     return;
                 }
 
-                const unsignedTransaction = await composeYieldWithdrawTransaction({
+                const composeResult = await composeYieldWithdrawTransaction({
                     amount: withdrawAmount,
                     dispatch,
                     feeInfo: withdrawFeeInfo,
@@ -389,6 +395,16 @@ export const useYieldWithdrawFees = ({
                 if (requestId !== requestIdRef.current) {
                     return;
                 }
+
+                if (!composeResult.success) {
+                    setHasFeeEstimationError(true);
+                    dispatch(formDraftActions.removeDraft({ key: withdrawFormDraftKey }));
+                    setPreparedAction(null);
+
+                    return;
+                }
+
+                const unsignedTransaction = composeResult.payload;
 
                 const reviewToken = getYieldWithdrawInputToken({
                     flowData: withdrawFlowData,
@@ -468,12 +484,14 @@ export const useYieldWithdrawFees = ({
                 }
             }
         },
-        [dispatch],
+        [dispatch, setHasFeeEstimationError],
     );
 
     useEffect(() => {
         const requestId = requestIdRef.current + 1;
         requestIdRef.current = requestId;
+
+        setHasFeeEstimationError(false);
 
         if (!isEnabled || !amount || !formDraftKey || !hasFeeInfo) {
             setIsComposingWithdrawFee(false);
@@ -503,20 +521,24 @@ export const useYieldWithdrawFees = ({
         composeWithdrawFee,
         debounce,
         dispatch,
+        feeEstimationRetryKey,
         feeInfoRevision,
         flowType,
         formDraftKey,
         hasFeeInfo,
         isEnabled,
+        setHasFeeEstimationError,
     ]);
 
     return {
         fee,
         formDraft,
         formDraftKey,
+        hasFeeEstimationError,
         isComposingWithdrawFee,
         isFeeUnavailable,
         preparedAction,
+        retryFeeEstimation,
         selectedFee,
         updateFeeLevelThunk: updateYieldWithdrawSelectedFeeLevelThunk,
     };

--- a/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
@@ -23,6 +23,7 @@ import { FeeSelector } from '@suite-native/transaction-management';
 
 import { YieldClaimFlowFooter } from '../components/YieldClaimFlowFooter';
 import { YieldClaimRewardsCard } from '../components/YieldClaimRewardsCard';
+import { YieldFeeEstimationErrorAlert } from '../components/YieldFeeEstimationErrorAlert';
 import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
 import { YieldTxSimulationBottomSheet } from '../components/YieldTxSimulationBottomSheet';
 import { useShowYieldTransactionFailureAlert } from '../hooks/useShowYieldTransactionFailureAlert';
@@ -198,14 +199,18 @@ export const YieldClaimScreen = () => {
                         isLoading={isClaimRewardsLoading}
                     />
 
-                    <FeeSelector
-                        accountKey={account.key}
-                        updateThunk={claimFee.updateFeeLevelThunk}
-                        selectedFee={claimFee.selectedFee}
-                        selectedFeePerUnit={claimFee.formDraft?.feePerUnit}
-                        formDraft={claimFee.formDraft}
-                        formDraftKey={claimFee.formDraftKey}
-                    />
+                    {claimFee.hasFeeEstimationError ? (
+                        <YieldFeeEstimationErrorAlert onRetry={claimFee.retryFeeEstimation} />
+                    ) : (
+                        <FeeSelector
+                            accountKey={account.key}
+                            updateThunk={claimFee.updateFeeLevelThunk}
+                            selectedFee={claimFee.selectedFee}
+                            selectedFeePerUnit={claimFee.formDraft?.feePerUnit}
+                            formDraft={claimFee.formDraft}
+                            formDraftKey={claimFee.formDraftKey}
+                        />
+                    )}
 
                     {shouldShowFeeWarning && (
                         <FullAlertBox

--- a/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
@@ -30,6 +30,7 @@ import { YieldDepositFlowFooter } from '../components/YieldDepositFlowFooter';
 import { YieldDepositFlowScreenHeader } from '../components/YieldDepositFlowScreenHeader';
 import { YieldDepositInfoBottomSheet } from '../components/YieldDepositInfoBottomSheet';
 import { YieldDepositStepCard } from '../components/YieldDepositStepCard';
+import { YieldFeeEstimationErrorAlert } from '../components/YieldFeeEstimationErrorAlert';
 import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
 import { YieldTxSimulationBottomSheet } from '../components/YieldTxSimulationBottomSheet';
 import { useRefreshYieldDepositAllowanceOnIdle } from '../hooks/useRefreshYieldDepositAllowanceOnIdle';
@@ -322,15 +323,21 @@ export const YieldDepositScreen = () => {
 
                     {shouldShowDepositFee && (
                         <Box paddingHorizontal="sp16">
-                            <FeeSelector
-                                accountKey={account.key}
-                                tokenContract={route.params.tokenContract}
-                                updateThunk={depositFee.updateFeeLevelThunk}
-                                selectedFee={depositFee.selectedFee}
-                                selectedFeePerUnit={depositFee.formDraft?.feePerUnit}
-                                formDraft={depositFee.formDraft}
-                                formDraftKey={depositFee.formDraftKey}
-                            />
+                            {depositFee.hasFeeEstimationError ? (
+                                <YieldFeeEstimationErrorAlert
+                                    onRetry={depositFee.retryFeeEstimation}
+                                />
+                            ) : (
+                                <FeeSelector
+                                    accountKey={account.key}
+                                    tokenContract={route.params.tokenContract}
+                                    updateThunk={depositFee.updateFeeLevelThunk}
+                                    selectedFee={depositFee.selectedFee}
+                                    selectedFeePerUnit={depositFee.formDraft?.feePerUnit}
+                                    formDraft={depositFee.formDraft}
+                                    formDraftKey={depositFee.formDraftKey}
+                                />
+                            )}
                         </Box>
                     )}
                 </VStack>

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -44,6 +44,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { YieldDepositFlowScreenHeader } from '../components/YieldDepositFlowScreenHeader';
 import { YieldDepositInfoBottomSheet } from '../components/YieldDepositInfoBottomSheet';
+import { YieldFeeEstimationErrorAlert } from '../components/YieldFeeEstimationErrorAlert';
 import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
 import { YieldWithdrawWarning } from '../components/YieldWithdrawWarning';
 import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
@@ -154,9 +155,11 @@ export const YieldWithdrawScreen = () => {
         fee: withdrawFee,
         formDraft: withdrawFeeFormDraft,
         formDraftKey: withdrawFeeFormDraftKey,
+        hasFeeEstimationError,
         isComposingWithdrawFee,
         isFeeUnavailable,
         preparedAction,
+        retryFeeEstimation,
         selectedFee: selectedWithdrawFee,
         updateFeeLevelThunk: updateWithdrawFeeLevelThunk,
     } = useYieldWithdrawFees({
@@ -542,6 +545,10 @@ export const YieldWithdrawScreen = () => {
                         )}
                     </VStack>
                 </Card>
+
+                {hasFeeEstimationError && (
+                    <YieldFeeEstimationErrorAlert onRetry={retryFeeEstimation} />
+                )}
 
                 {isWithdrawReviewReady && (
                     <FeeSelector

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10202,6 +10202,11 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_DASHBOARD_DEPOSITED',
         defaultMessage: '{amount} {displaySymbol} deposited',
     },
+    TR_EARN_YIELD_ERROR_FEE_ESTIMATION: {
+        id: 'TR_EARN_YIELD_ERROR_FEE_ESTIMATION',
+        defaultMessage:
+            "We couldn't estimate the network fee, so the transaction wasn't created. Try again.",
+    },
     TR_EARN_YIELD_ERROR_GENERIC: {
         id: 'TR_EARN_YIELD_ERROR_GENERIC',
         defaultMessage: 'Something went wrong. Try again.',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10211,6 +10211,11 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_ERROR_GENERIC',
         defaultMessage: 'Something went wrong. Try again.',
     },
+    TR_EARN_YIELD_ERROR_PUSH_FAILED: {
+        id: 'TR_EARN_YIELD_ERROR_PUSH_FAILED',
+        defaultMessage:
+            "The transaction was signed but couldn't be sent to the network. Try again.",
+    },
     TR_EARN_YIELD_ERROR_PASSPHRASE_INCORRECT: {
         id: 'TR_EARN_YIELD_ERROR_PASSPHRASE_INCORRECT',
         defaultMessage: 'Passphrase is incorrect. Try again.',

--- a/yarn.lock
+++ b/yarn.lock
@@ -17037,7 +17037,6 @@ __metadata:
     "@suite-common/platform-encryption": "workspace:*"
     "@suite-common/react-query": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
-    "@suite-common/schemas": "workspace:^"
     "@suite-common/sentry": "workspace:*"
     "@suite-common/staking": "workspace:*"
     "@suite-common/suite-config": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When `blockchainEstimateFee` failed during yield deposit/withdraw/claim composition, we silently fell back to a fixed 250k gas limit — too low for some vaults (Morpho supply needs ~750k), so users signed transactions that reverted out of gas and burned fees. On mobile this was completely silent.

Yield flows no longer swallow failures:

- New `estimateYieldFeeLevel` helper is the single place calling
  `blockchainEstimateFee`; returns a typed `Result` and never falls back to a constant (a missing `feeLimit` counts as failure too)
- All 5 call sites (deposit, withdraw desktop/mobile, claim mobile, Merkl claim desktop) fail visibly instead of composing a doomed tx — desktop shows a blocking error, mobile shows an inline alert with retry and keeps the confirm button disabled
- Failed broadcast (`pushTransaction` — tx signed but not sent) gets its own message instead of the generic one; together with 14535a5eae this also covers
- Analytics distinguishes `fee-estimation-failed` and `push-failed` from the generic `submit-failed`

No fallback constant remains in any yield path (`ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT` stays only in the legacy send form, out of scope). Also removes the unused `prepareYieldDepositThunk`.


## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29536
Resolve #29537

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused entirely on stablecoin yield (deposit, withdraw, claim, fee estimation) functionality within the wallet-core package and suite actions, plus suite-native earn module screens and hooks. None of the 153 candidate E2E tests cover stablecoin yield flows — the closest tests are ETH/SOL/ADA staking tests, but those exercise a completely different staking feature (Everstake-based native staking), not ERC-20 stablecoin yield vaults. The changed files map to 131 tests only because they are re-exported through broad barrel files (wallet-core/src/index.ts, suite action bundles), making them global dependencies. There is no specific E2E test that exercises stablecoin yield deposit, withdraw, claim, or fee estimation. The suite-native changes are mobile-only (React Native) and have zero Playwright E2E test coverage. No E2E tests are recommended to run.

<details><summary><b>Changed files (24)</b></summary>

- `packages/suite/package.json`
- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts`
- `packages/suite/tsconfig.json`
- `suite-common/wallet-core/src/index.ts`
- `suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldDepositThunks.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldFeeEstimation.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldFeeEstimation.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-earn/src/components/YieldFeeEstimationErrorAlert.tsx`
- `suite-native/module-earn/src/hooks/useYieldClaimFees.ts`
- `suite-native/module-earn/src/hooks/useYieldDepositFees.ts`
- `suite-native/module-earn/src/hooks/useYieldFeeEstimationError.ts`
- `suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts`
- `suite-native/module-earn/src/screens/YieldClaimScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx`
- `suite/intl/src/messages.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (24)**
- `packages/suite/package.json`
- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts`
- `packages/suite/tsconfig.json`
- `suite-common/wallet-core/src/index.ts`
- `suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldDepositThunks.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldFeeEstimation.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldFeeEstimation.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-earn/src/components/YieldFeeEstimationErrorAlert.tsx`
- `suite-native/module-earn/src/hooks/useYieldClaimFees.ts`
- `suite-native/module-earn/src/hooks/useYieldDepositFees.ts`
- `suite-native/module-earn/src/hooks/useYieldFeeEstimationError.ts`
- `suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts`
- `suite-native/module-earn/src/screens/YieldClaimScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx`
- `suite/intl/src/messages.ts`

_Updated: 2026-07-15T15:30:55.736Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-fee-estimation-blocking/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-fee-estimation-blocking/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-fee-estimation-blocking&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/yield-fee-estimation-blocking&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-fee-estimation-blocking&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-15T15:34:26.920Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-15T15:33:53.271Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->