### PR TITLE
fix(connect-web): recover the iframe after a transient init failure

### DIFF
--- a/packages/connect-web/src/popup/iframe.ts
+++ b/packages/connect-web/src/popup/iframe.ts
@@ -88,6 +88,9 @@ export const getIframeInstance = () => {
                 if (newInstance.parentNode) {
                     newInstance.parentNode.removeChild(newInstance);
                 }
+                // Clear the rejected deferred, otherwise the `if (initPromise)` guard above would
+                // keep returning this same rejected promise and the iframe would never be recreated.
+                initPromise = undefined;
                 // Propagate TypedError to caller.
                 throw error;
             });


### PR DESCRIPTION
## Description

The connect-web iframe manager never recovered from a transient iframe-load failure — one timeout or block left Trezor Connect permanently broken until a full page reload.

`getIframeInstance()` keeps its init state in a closure `initPromise`, and `create()` guards on it ([`iframe.ts:62`](https://github.com/trezor/trezor-suite/blob/39f84abb4f050cd7fa12d56b4e6e053efa3b5662/packages/connect-web/src/popup/iframe.ts#L62)):
```js
if (initPromise) {
    return initPromise.promise;   // reuse the in-flight init...
}
```

On failure the `.catch` removes the iframe DOM node but — the bug — never reset `initPromise`, so it stayed a **settled, rejected** deferred ([`iframe.ts:86-92`](https://github.com/trezor/trezor-suite/blob/39f84abb4f050cd7fa12d56b4e6e053efa3b5662/packages/connect-web/src/popup/iframe.ts#L87)):
```js
.catch(error => {
    if (newInstance.parentNode) newInstance.parentNode.removeChild(newInstance);
    // comment says "Reset state to allow initialization again" — but initPromise was NOT reset
    throw error;
});
```
So every subsequent `create()` hit the guard and returned that same rejected promise — the iframe was never recreated. The comment right above (*"Reset state to allow initialization again"*) states the intent; the reset was just incomplete.

## Reachability — real, not latent

Verified across the connect-web lifecycle:

1. **Singleton state.** `WebPopup` holds `private iframe = getIframeInstance()` ([`web.ts:14`](https://github.com/trezor/trezor-suite/blob/39f84abb4f050cd7fa12d56b4e6e053efa3b5662/packages/connect-web/src/popup/web.ts#L14)), and `CoreInSuiteWeb` creates the popup manager **once** and reuses it ([`core-in-suite-web.ts:56`](https://github.com/trezor/trezor-suite/blob/39f84abb4f050cd7fa12d56b4e6e053efa3b5662/packages/connect-web/src/impl/core-in-suite-web.ts#L56), `if (!this._popupManager)`). The `initPromise` closure therefore lives for the whole page session.
2. **`create()` is re-entered after a failure.** Each `TrezorConnect.<method>()` → `focusOrCreate()` → `open()` → `iframe.create()` ([`web.ts:46`](https://github.com/trezor/trezor-suite/blob/39f84abb4f050cd7fa12d56b4e6e053efa3b5662/packages/connect-web/src/popup/web.ts#L46)). After a failure `reset()` only clears `Popup.locked` ([`abstract.ts:142`](https://github.com/trezor/trezor-suite/blob/39f84abb4f050cd7fa12d56b4e6e053efa3b5662/packages/connect-web/src/popup/abstract.ts#L142)), not the iframe closure — so the next call re-enters `create()` and hits the stale promise.
3. **Transient triggers.** `iframe-timeout` (`IFRAME_TIMEOUT = 10000` ms — a slow WiFi/4G load) or `iframe-blocked` (cross-origin check fails: CSP, ad-blocker/extension, momentary block). Both are ordinary, recoverable-on-retry web conditions.

**No recovery path** other than a page reload: `TrezorConnect.dispose()` is a no-op for `CoreInSuiteWeb` (never clears `_popupManager`), and re-`init()` is guarded, so the singleton (and its poisoned `initPromise`) persists.

## Impact

After a single transient iframe failure, **every** subsequent Trezor Connect call fails instantly with the same `Handshake_Error` (or hangs) — the wallet integration is dead until the user manually reloads the page, even though the original condition (slow network / temporary block) would have succeeded on retry.

## The fix

Reset the closure before rethrowing ([`iframe.ts:93`](https://github.com/trezor/trezor-suite/blob/3cc445a24699802b291b0d21bf1d85bd7a38fbce/packages/connect-web/src/popup/iframe.ts#L93)):
```js
initPromise = undefined;   // so the next create() starts fresh and recreates the iframe
throw error;
```
This completes the "reset state to allow initialization again" the surrounding code already intended.

Split out from the continuously-improve sweep #29735.

## Notes for QA

Reproduce the transient failure and confirm self-recovery on a page using the connect-web (in-suite-web) popup manager:

1. Open a page that uses Trezor Connect via connect-web (e.g. Suite web / connect-explorer).
2. In DevTools → **Network**, force the iframe load to fail transiently — either block the request to the connect popup/iframe URL (`connect.trezor.io`), or set throttling so the load exceeds **10 s** (`IFRAME_TIMEOUT`), or toggle **Offline** briefly.
3. Trigger any Trezor Connect action → it fails with a handshake error (`iframe-timeout` / `iframe-blocked`).
4. **Remove the block / restore the network** (the transient condition is gone).
5. Trigger the same action again:
   - **Before the fix:** it still fails instantly with the same error — Connect is stuck until you reload the page.
   - **After the fix:** the iframe is recreated and the action proceeds normally.

Only affects the connect-web path; no device interaction needed to reproduce the recovery behaviour.

## Related Issue

Part of the split-out series from #29735.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to packages/connect-web/src/popup/iframe.ts, which is the core module managing the TrezorConnect iframe/popup lifecycle, message passing, and popup window management in web contexts. The highest risk is to tests that exercise the full web popup flow (connectPopupWeb and connectPopupWebextension), as they directly test popup opening, closing, cancellation, and popup-blocked scenarios. Tests using TrezorConnect in suite-desktop coreMode are lower risk since they may bypass parts of the web iframe path, but still initialize connect-web infrastructure. No static coverage mapping was available, so all recommendations are inferred from the LLM analysis of test behaviors and source hints.

<details><summary><b>Changed files (1)</b></summary>

- `packages/connect-web/src/popup/iframe.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises the TrezorConnect popup flow in a web context, which directly relies on the iframe/popup communication layer in packages/connect-web/src/popup/iframe.ts. Changes to iframe.ts could affect popup opening, closing, message passing, and popup-blocked detection — all of which are explicitly tested here.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test covers the TrezorConnect popup flow from a webextension context, which uses the same iframe/popup infrastructure from connect-web. It tests popup lifecycle, focusing existing popups, and cancellation — all behaviors that route through the changed iframe.ts module.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trezor-connect/permissions.test.ts` — This test exercises the TrezorConnect permissions modal flow which is rendered inside the connect popup/iframe. Changes to iframe.ts could affect how the permissions UI is initialized, displayed, and how permission state is communicated back to the calling app.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This test calls TrezorConnect.getAddress in suite-desktop coreMode which still initializes connect-web infrastructure including iframe/popup communication. Address confirmation UI rendering and device interaction flow could be affected by iframe.ts changes.
- `suite/e2e/tests/trezor-connect/error.test.ts` — This test verifies that TrezorConnect displays error modals when invalid parameters are passed. The error rendering pipeline uses the popup/iframe communication layer from connect-web, so changes to iframe.ts could affect error display behavior.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — This test exercises TrezorConnect.selectAccount which opens the connect popup/iframe for account selection, permission granting, and cancellation flows — all relying on the iframe communication layer being changed.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Silent mode controls whether the Suite popup/iframe is brought to the foreground. Changes to iframe.ts could affect how silent mode suppresses focus behavior and how the connect popup lifecycle is managed.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — This test uses TrezorConnect.ethereumSignMessage in suite-desktop coreMode. While it uses connect-web initialization which includes iframe.ts, the desktop coreMode may bypass the web popup/iframe path, making impact less likely but still plausible.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Similar to ethereumSignMessage, this test uses TrezorConnect in suite-desktop coreMode. The iframe.ts change could affect initialization or the permissions modal flow, though desktop coreMode may not exercise the full web iframe path.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — This test signs a Bitcoin transaction via TrezorConnect in desktop mode. It uses connect-web initialization and the permissions modal, which could be affected by iframe.ts changes, though the desktop coreMode reduces the likelihood.

</details>

_Updated: 2026-07-15T09:23:34.506Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-connectweb-iframe-recovery/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-connectweb-iframe-recovery/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-connectweb-iframe-recovery&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-connectweb-iframe-recovery&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-15T09:26:11.191Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-15T09:26:22.841Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->