### PR TITLE
fix(suite): don't treat a pending RBF-replaced tx as mined in replaceByFeeErrorMiddleware

### DIFF
--- a/packages/suite/src/middlewares/wallet/replaceByFeeErrorMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/replaceByFeeErrorMiddleware.ts
@@ -1,7 +1,7 @@
 import { type MiddlewareAPI } from 'redux';
 
 import { transactionsActions } from '@suite-common/wallet-core/';
-import { isRbfTransaction } from '@suite-common/wallet-utils';
+import { isPending, isRbfTransaction } from '@suite-common/wallet-utils';
 
 import { type Action, type AppState, type Dispatch } from 'src/types/suite';
 
@@ -30,7 +30,10 @@ export const replaceByFeeErrorMiddleware =
 
         const addedTransaction = transactions.find(tx => tx.txid === precomposedTx.prevTxid);
 
-        if (addedTransaction?.blockHeight !== undefined) {
+        // Fire only when the previous transaction was actually mined. A pending re-add of the same
+        // transaction (blockbook reports pending txs with blockHeight -1, so blockHeight !== undefined
+        // was true for those too) must not trigger the "already mined" error.
+        if (addedTransaction && !isPending(addedTransaction)) {
             api.dispatch(replaceByFeeErrorThunk());
         }
 


### PR DESCRIPTION
## Description

`replaceByFeeErrorMiddleware` decides whether the original (replaced) transaction of an in-progress RBF has been mined — and if so, aborts the bump-fee and shows a "previous transaction already mined" error. It used the wrong "mined" check.

Buggy ([`replaceByFeeErrorMiddleware.ts:33`](https://github.com/trezor/trezor-suite/blob/39f84abb4f050cd7fa12d56b4e6e053efa3b5662/packages/suite/src/middlewares/wallet/replaceByFeeErrorMiddleware.ts#L33)):
```js
if (addedTransaction?.blockHeight !== undefined) {
    api.dispatch(replaceByFeeErrorThunk());
}
```
Blockbook reports **pending / mempool** transactions with `blockHeight = -1` ([`blockbook.ts:362`](https://github.com/trezor/trezor-suite/blob/39f84abb4f050cd7fa12d56b4e6e053efa3b5662/packages/blockchain-link-utils/src/blockbook.ts#L362) passes it through), and `-1 !== undefined` is `true`. So a **pending re-add** of the original tx was treated as "mined" and spuriously fired the error, even though the transaction was still unconfirmed.

Fixed ([`replaceByFeeErrorMiddleware.ts:36`](https://github.com/trezor/trezor-suite/blob/de374473bcaa570f3baf379bd822dba36b618c5f/packages/suite/src/middlewares/wallet/replaceByFeeErrorMiddleware.ts#L36)) by using the codebase-wide pending convention ([`isPending`](https://github.com/trezor/trezor-suite/blob/39f84abb4f050cd7fa12d56b4e6e053efa3b5662/suite-common/wallet-utils/src/transactionUtils.ts#L65) = `!blockHeight || blockHeight < 0`):
```js
if (addedTransaction && !isPending(addedTransaction)) {
    api.dispatch(replaceByFeeErrorThunk());
}
```
Now the error fires only when the original tx is *actually* mined (`blockHeight > 0`).

## What the user experiences on a spurious fire

`replaceByFeeErrorThunk` ([`replaceByFeeErrorThunk.ts:12`](https://github.com/trezor/trezor-suite/blob/39f84abb4f050cd7fa12d56b4e6e053efa3b5662/packages/suite/src/actions/wallet/send/replaceByFeeErrorThunk.ts#L12)) **cancels the ongoing TrezorConnect signing** and opens an error modal titled *"The previous transaction has already been mined"* with only a **Close** button — the device-confirmation UI is hidden and the bump-fee is aborted. A false positive therefore kills a legitimate fee-bump on a still-stuck transaction with a misleading message.

## Reachability

Real, but a timing race. The middleware is active while `state.wallet.send.precomposedTx` carries `rbfType` — a window that opens at [`enhancePrecomposedTransactionThunk` (sendFormThunks.ts:217)](https://github.com/trezor/trezor-suite/blob/39f84abb4f050cd7fa12d56b4e6e053efa3b5662/packages/suite/src/actions/wallet/send/sendFormThunks.ts#L217) and stays open across [`signTransactionThunk` (:237)](https://github.com/trezor/trezor-suite/blob/39f84abb4f050cd7fa12d56b4e6e053efa3b5662/packages/suite/src/actions/wallet/send/sendFormThunks.ts#L237) — i.e. **during the on-device confirmation** — until the flow is cleared. If a blockbook notification (new block or a mempool/incoming tx for the account) re-adds the original pending tx (`blockHeight -1`) during that window — via [`fetchAndUpdateAccountThunk` (blockchainThunks.ts:255 / :373)](https://github.com/trezor/trezor-suite/blob/39f84abb4f050cd7fa12d56b4e6e053efa3b5662/suite-common/wallet-core/src/blockchain/blockchainThunks.ts#L255) → `addTransaction` — the middleware fires.

- **Non-EVM only** (BTC, XRP, XLM, ADA, SOL, TRX). EVM is unaffected: the send flow evicts the original tx immediately, so it can't re-add.
- In everyday use it is intermittent (the notification must land within the sign/push window), but the window can be **held open at the device-confirmation step**, which makes it deterministically reproducible (see QA below).

## Tests

Adds `replaceByFeeErrorMiddleware.test.ts` with 4 cases: mined (`blockHeight 100`) → fires; **pending re-add (`blockHeight -1`) → does NOT fire** (the regression); non-matching txid → no fire; non-RBF precomposedTx → no fire. This is a deterministic proof of the fix without a device.

Split out from the continuously-improve sweep #29735.

## Notes for QA — how to reproduce the bug on `develop` (before the fix)

The bug is deterministically reproducible by holding the RBF window open at the device-confirmation step and forcing a pending re-add. Easiest with a **Bitcoin regtest** account via `trezor/trezor-user-env` (you control mining), but testnet works too.

1. Use a **Bitcoin** account (non-EVM). Create a **pending, RBF-enabled** transaction: send a low-fee tx with *Replace-by-fee* enabled and **do not let it confirm** (on regtest simply don't mine it).
2. On that pending tx, open **Bump fee**, raise the fee, and click **Send/Sign**. Suite stores the RBF `precomposedTx` (window opens) and the device shows a **confirmation prompt** — **do NOT confirm yet** (this keeps the window open).
3. While the device prompt is waiting, trigger a blockchain notification for that account so Suite re-syncs and re-adds the original *pending* tx:
   - send an **incoming payment** to the account (from another wallet / `bitcoin-cli sendtoaddress`), **or**
   - (regtest) **mine one block**: `bitcoin-cli generatetoaddress 1 <any-address>`.
4. **Expected on `develop` (bug present):** an error modal *"The previous transaction has already been mined"* pops up and the bump-fee is cancelled — even though you never confirmed and the original transaction is still unconfirmed in the mempool.
5. **With this PR:** repeat the same steps — the error does **not** appear; you can confirm on the device and the bump-fee broadcasts normally.

If the false error does not appear on the first try (the sync must arrive while the prompt is open), retry step 3 a couple of times, or add a second incoming tx — the on-device wait gives you plenty of time. EVM (Ethereum) accounts will not reproduce it; use Bitcoin or another non-EVM coin.

related to #29747 

## Related Issue

Part of the split-out series from #29735.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-rbf-pending-already-mined/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-rbf-pending-already-mined/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-rbf-pending-already-mined&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-rbf-pending-already-mined&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-06T12:07:58.381Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-06T12:07:39.544Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a wallet-level replace-by-fee middleware that statically maps to nearly the whole suite, so it must be treated as a broad dependency. I focused on tests that explicitly trigger pending-transaction speed-up UI on Ethereum staking and Solana-based trading, because those are the concrete user flows the middleware is meant to support. Running these targeted tests should catch regressions in replace-by-fee error handling and pending state without resorting to the full suite.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/middlewares/wallet/replaceByFeeErrorMiddleware.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test explicitly exercises the speed-up button on a pending Ethereum staking transaction, which is the replace-by-fee user flow that replaceByFeeErrorMiddleware handles. A regression in the middleware would likely appear as a broken pending state or missing error notification here.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — The test clicks the speed-up button while an Ethereum staking transaction is confirming, directly using the replace-by-fee/speed-up path. It is a strong sentinel for middleware regressions that affect pending ETH transactions.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test verifies the pending unstaking transaction state, including an enabled speed-up button, on Ethereum. Changes to replace-by-fee error handling could alter the pending transaction UI or error toasts surfaced here.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trading/sell-solana.test.ts` — The test exercises a pending Solana sell transaction with a speed-up button, sharing the pending-transaction/replace infrastructure. If the middleware generically intercepts replace errors, a regression could affect the speed-up flow or status updates.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — This test drives a pending swap transaction through its status phases, including a speed-up button while confirming. It covers the cross-chain pending-transaction flow that relies on the same replace/speed-up plumbing as the changed middleware.

</details>

_Updated: 2026-08-06T12:06:22.482Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->