### PR TITLE
Tron tx tracking changes

### DIFF
--- a/suite-common/wallet-core/src/stake/tron/actions/freeze/submitFreeze.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/freeze/submitFreeze.ts
@@ -9,7 +9,6 @@ import { type FreezeThunkArguments, composeTronFreezeFeeLevelsThunk } from './co
 import { buildFreezeContract, buildFreezeReviewForm } from './freezeContract';
 import { addFakePendingTronTxThunk } from '../../../../transactions/transactionsThunks';
 import { TRON_STAKE_MODULE } from '../../shared/constants';
-import { reportTronStakeTxId } from '../../shared/reportTronStakeTxId';
 import { signTronContract } from '../../shared/signTronContract';
 import { tronStakeActions } from '../../tronStakeReducer';
 import { type TronFlow } from '../../tronStakeTypes';
@@ -112,20 +111,6 @@ export const submitTronFreezeThunk = createThunk<void, SubmitFreezeThunkArgument
                         accountKey,
                         flow,
                         error: { kind: 'cancelled' },
-                    }),
-                );
-
-                return;
-            }
-
-            const isReported = await reportTronStakeTxId(signResult.txid, 'freeze');
-
-            if (!isReported) {
-                dispatch(
-                    tronStakeActions.submitFinished({
-                        accountKey,
-                        flow,
-                        error: { kind: 'report-failed' },
                     }),
                 );
 

--- a/suite-common/wallet-core/src/stake/tron/shared/reportTronStakeTxId.ts
+++ b/suite-common/wallet-core/src/stake/tron/shared/reportTronStakeTxId.ts
@@ -1,4 +1,10 @@
-import { type ReportStakingTxIdsKind, reportStakingTxIds } from '@suite-common/earn-staking-api';
+import { captureException, withScope } from '@sentry/core';
+
+import {
+    EARN_API_BASE_URL,
+    type ReportStakingTxIdsKind,
+    reportStakingTxIds,
+} from '@suite-common/earn-staking-api';
 
 export const reportTronStakeTxId = async (
     txid: string,
@@ -8,7 +14,15 @@ export const reportTronStakeTxId = async (
         await reportStakingTxIds({ body: { txid, network: 'tron', kind } });
 
         return true;
-    } catch {
+    } catch (error) {
+        withScope(scope => {
+            scope.setTag('error.code', 'tron_staking_txid_report_failed');
+            scope.setTag('error.source', EARN_API_BASE_URL);
+            scope.setTag('error.kind', kind);
+            scope.setExtra('errorMessage', error instanceof Error ? error.message : String(error));
+            captureException(new Error('Failed to report Tron staking txid to the Earn API.'));
+        });
+
         return false;
     }
 };

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -5588,7 +5588,7 @@ export const messages = defineMessages({
     TR_TRON_VOTE_CONSENT_MODAL_BANNER_2_TEXT: {
         id: 'TR_TRON_VOTE_CONSENT_MODAL_BANNER_2_TEXT',
         defaultMessage:
-            'Use Trezor Suite to securely delegate your voting rights to {representativeName}. Enjoy competitive rewards, rely on a trusted Super Representative, and keep full ownership of your TRX at all times.',
+            'Use Trezor Suite to securely delegate your voting rights to {representativeName}. Enjoy competitive rewards, rely on a trusted Super Representative, and keep full ownership of your TRX at all times. To process your staking and votes correctly, transaction IDs are shared with Trezor.',
     },
     TR_TRON_BANDWIDTH: {
         id: 'TR_TRON_BANDWIDTH',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Remove tracking on `freeze` tron tx
- Add Sentry logging for failed `vote` tron tx
- update "Vote" modal copy

Crowdin updated

Tested Sentry issue: https://satoshilabs.sentry.io/issues/7608294711/

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="618" height="488" alt="Screenshot 2026-07-13 at 17 28 07" src="https://github.com/user-attachments/assets/ed788870-a821-47db-823c-9b9d0b68def3" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies Tron staking freeze action logic (submitFreeze.ts), a shared Tron staking transaction reporting utility (reportTronStakeTxId.ts), and the global intl messages file (messages.ts). The Tron staking changes are narrow in scope but currently have no direct E2E test coverage — there are no Tron staking E2E tests in the test suite. The messages.ts file is a global dependency used by virtually all tests, but changes to it are typically additive (new translation keys) and unlikely to break existing tests. The primary risk is in the Tron-specific staking logic which is entirely uncovered by E2E tests. A few staking tests from other chains are recommended at medium/low priority to verify shared staking infrastructure isn't broken.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/wallet-core/src/stake/tron/actions/freeze/submitFreeze.ts`
- `suite-common/wallet-core/src/stake/tron/shared/reportTronStakeTxId.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test covers staking navigation analytics events. While it focuses on ETH/ADA staking navigation rather than Tron freeze actions, changes to the Tron staking module could affect shared staking infrastructure or analytics reporting paths.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking tests exercise the broader staking infrastructure that Tron staking shares. Changes to submitFreeze.ts and reportTronStakeTxId.ts could affect shared staking utilities or state management patterns used across all staking flows.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL staking shares the wallet-core staking infrastructure with Tron. While the specific Tron freeze action is unlikely to directly affect SOL staking, shared reporting or state management patterns in reportTronStakeTxId.ts could have cross-chain impact.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/wallet-core/src/stake/tron/actions/freeze/submitFreeze.ts`
- `suite-common/wallet-core/src/stake/tron/shared/reportTronStakeTxId.ts`
- `suite/intl/src/messages.ts`

_Updated: 2026-07-13T15:46:56.494Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-tx-tracking-changes/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-tx-tracking-changes/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-tx-tracking-changes&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-tx-tracking-changes&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-tx-tracking-changes&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-13T15:49:17.128Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-13T15:49:14.565Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->