### PR TITLE
fix(suite-native): hide fee approx sign when fee is not composed yet

### DIFF
--- a/suite-native/transaction-management/src/components/fees/FeeSummaryRow.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeSummaryRow.tsx
@@ -48,7 +48,7 @@ export const FeeSummaryRow = ({
                     testID="@transactionManagement/fee-crypto-amount"
                 />
                 <HStack spacing="sp2" alignItems="center" justifyContent="flex-end">
-                    {!areFeesLoading && (
+                    {!areFeesLoading && fee !== null && (
                         <Text variant="body-sm" color="contentSecondary">
                             ≈
                         </Text>


### PR DESCRIPTION
## Description

`FeeSummaryRow` hid the `≈` sign only while `areFeesLoading` was `true`, but the amount formatters also render skeletons when the fee value is `null` (before the transaction is composed). In that state the `≈` floated next to the skeletons. The sign is now also hidden while `fee` is `null`.

## Notes for QA

Open Earn → Claim SOL (or any fee summary row) and watch the Transaction fee row before the fee loads — only skeletons should be visible, no `≈` sign.

## Related Issue

Resolve #29775

## Screenshots:
Before
<img width="578" height="361" alt="Screenshot 2026-07-14 at 12 18 46" src="https://github.com/user-attachments/assets/f921b905-82a7-4c6c-892c-fe435535e90a" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/29775-fee-approx-sign&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->