### PR TITLE
fix(suite-native): show merkl rewards after full vault exit

### DIFF
--- a/suite-native/module-earn/src/components/EarnScreenListHeader.tsx
+++ b/suite-native/module-earn/src/components/EarnScreenListHeader.tsx
@@ -29,7 +29,11 @@ export const EarnScreenListHeader = ({
     isStablecoinYieldLoading,
     isStablecoinYieldClaimSummariesLoading,
 }: EarnScreenListHeaderProps) => {
-    if (stakingActiveItems.length === 0 && stablecoinYieldActiveItems.length === 0) {
+    if (
+        stakingActiveItems.length === 0 &&
+        stablecoinYieldActiveItems.length === 0 &&
+        stablecoinYieldClaimSummaries.length === 0
+    ) {
         return null;
     }
 

--- a/suite-native/module-earn/src/hooks/useStablecoinYieldClaimSummaries.ts
+++ b/suite-native/module-earn/src/hooks/useStablecoinYieldClaimSummaries.ts
@@ -13,10 +13,9 @@ import {
 } from '@suite-common/wallet-core';
 import { type Account, type BaseCurrencyAmount } from '@suite-common/wallet-types';
 
-import { type StablecoinYieldClaimSummary, type StablecoinYieldEarnItem } from '../types';
+import { type StablecoinYieldClaimSummary } from '../types';
 import {
     buildStablecoinYieldClaimSummaries,
-    getActiveStablecoinYieldClaimAccounts,
     getTotalFiatClaimableAmount,
 } from '../utils/stablecoinYieldClaimSummaryUtils';
 
@@ -30,29 +29,16 @@ export type StablecoinYieldClaimSummariesState = {
 };
 
 type UseStablecoinYieldClaimSummariesProps = {
-    activeItems: StablecoinYieldEarnItem[];
     accounts: Account[];
 };
 
 export const useStablecoinYieldClaimSummaries = ({
-    activeItems,
     accounts,
 }: UseStablecoinYieldClaimSummariesProps): StablecoinYieldClaimSummariesState => {
     const currentFiatRates = useSelector(selectCurrentFiatRates);
     const fiatCurrency = useSelector(selectBaseCurrency);
 
-    const activeClaimAccounts = useMemo(
-        () =>
-            getActiveStablecoinYieldClaimAccounts({
-                activeItems,
-                accounts,
-            }),
-        [accounts, activeItems],
-    );
-
-    const merklRewardsQueryEntries = useGetMerklRewardsQueryEntries(activeClaimAccounts, {
-        skipEmptyAccountCheck: true,
-    });
+    const merklRewardsQueryEntries = useGetMerklRewardsQueryEntries(accounts);
 
     const {
         data: chainsRewards,
@@ -75,10 +61,10 @@ export const useStablecoinYieldClaimSummaries = ({
     const stablecoinYieldClaimSummaries = useMemo(
         () =>
             buildStablecoinYieldClaimSummaries({
-                activeAccounts: activeClaimAccounts,
+                accounts,
                 chainsRewardsWithFiat,
             }),
-        [activeClaimAccounts, chainsRewardsWithFiat],
+        [accounts, chainsRewardsWithFiat],
     );
     const totalFiatClaimableAmount = useMemo(
         () => getTotalFiatClaimableAmount(stablecoinYieldClaimSummaries),

--- a/suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts
+++ b/suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts
@@ -188,7 +188,6 @@ export const useStablecoinYieldListData = () => {
     }, [accounts, yieldOpportunities, isLoading, isError]);
 
     const stablecoinYieldClaimSummariesState = useStablecoinYieldClaimSummaries({
-        activeItems: listData.activeItems,
         accounts,
     });
 

--- a/suite-native/module-earn/src/utils/__tests__/stablecoinYieldClaimSummaryUtils.test.ts
+++ b/suite-native/module-earn/src/utils/__tests__/stablecoinYieldClaimSummaryUtils.test.ts
@@ -4,21 +4,17 @@ import {
     asAccountDescriptor,
     asBaseCurrencyAmount,
     toTokenAddress,
-    toTokenSymbol,
 } from '@suite-common/wallet-types';
 import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { BigNumber } from '@trezor/utils';
 
-import { type StablecoinYieldEarnItem } from '../../types';
 import {
     buildStablecoinYieldClaimSummaries,
-    getActiveStablecoinYieldClaimAccounts,
     getStablecoinYieldAccountRewards,
     getStablecoinYieldClaimRewardsSnapshot,
     getTotalFiatClaimableAmount,
 } from '../stablecoinYieldClaimSummaryUtils';
 
-const underlyingTokenContract = toTokenAddress('0x0000000000000000000000000000000000000001');
 const receiptTokenContract = toTokenAddress('0x0000000000000000000000000000000000000002');
 
 const ethereumAccount = mockWalletAccount({
@@ -49,29 +45,11 @@ const anotherEthereumAccount = mockWalletAccount({
     ],
 });
 
-const createStablecoinYieldEarnItem = ({
-    account,
-    id,
-    tokenBalance,
-}: {
-    account: Account;
-    id: string;
-    tokenBalance: string | null;
-}): StablecoinYieldEarnItem => ({
-    id,
-    type: 'stablecoin-yield',
-    yieldId: id,
-    vaultName: 'Steakhouse USDC',
-    tokenSymbol: toTokenSymbol('USDC'),
-    networkSymbol: account.symbol,
-    underlyingTokenContract,
-    receiptTokenContract,
-    contractAddress: receiptTokenContract,
-    tokenContractAddress: underlyingTokenContract,
-    accountKey: account.key,
-    accountLabel: account.accountLabel,
-    tokenBalance,
-    apy: 3.2,
+const exitedEthereumAccount = mockWalletAccount({
+    symbol: 'eth',
+    descriptor: asAccountDescriptor('0xbb6845f200000000000000000000000013fb4863'),
+    accountLabel: 'Ethereum #3',
+    tokens: [],
 });
 
 const createReward = ({
@@ -118,34 +96,9 @@ const createChainRewards = ({
 });
 
 describe('stablecoinYieldClaimSummaryUtils', () => {
-    it('returns unique active accounts using account receipt-token balances', () => {
-        const activeAccounts = getActiveStablecoinYieldClaimAccounts({
-            activeItems: [
-                createStablecoinYieldEarnItem({
-                    account: ethereumAccount,
-                    id: 'steakhouse-usdc-eth',
-                    tokenBalance: '0',
-                }),
-                createStablecoinYieldEarnItem({
-                    account: ethereumAccount,
-                    id: 'moonwell-usdc-eth',
-                    tokenBalance: null,
-                }),
-                createStablecoinYieldEarnItem({
-                    account: anotherEthereumAccount,
-                    id: 'empty-usdc-eth',
-                    tokenBalance: '8',
-                }),
-            ],
-            accounts: [ethereumAccount, anotherEthereumAccount],
-        });
-
-        expect(activeAccounts).toEqual([ethereumAccount]);
-    });
-
     it('keeps claimable summaries when fiat values are missing and ignores zero raw claimables', () => {
         const summaries = buildStablecoinYieldClaimSummaries({
-            activeAccounts: [ethereumAccount, anotherEthereumAccount],
+            accounts: [ethereumAccount, anotherEthereumAccount],
             chainsRewardsWithFiat: [
                 createChainRewards({
                     account: ethereumAccount,
@@ -172,6 +125,34 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
         expect(getTotalFiatClaimableAmount(summaries)).toBeNull();
     });
 
+    it('builds summaries for accounts without any receipt-token balance (fully exited vaults)', () => {
+        const summaries = buildStablecoinYieldClaimSummaries({
+            accounts: [anotherEthereumAccount, exitedEthereumAccount],
+            chainsRewardsWithFiat: [
+                createChainRewards({
+                    account: anotherEthereumAccount,
+                    rewards: [createReward({ claimable: '1000000', fiatClaimable: '1.25' })],
+                }),
+                createChainRewards({
+                    account: exitedEthereumAccount,
+                    rewards: [createReward({ claimable: '2000000', fiatClaimable: '2.5' })],
+                }),
+            ],
+        });
+
+        expect(summaries).toEqual([
+            expect.objectContaining({
+                accountKey: anotherEthereumAccount.key,
+                claimableRewardsCount: 1,
+            }),
+            expect.objectContaining({
+                accountKey: exitedEthereumAccount.key,
+                claimableRewardsCount: 1,
+            }),
+        ]);
+        expect(getTotalFiatClaimableAmount(summaries)?.toString()).toBe('3.75');
+    });
+
     it('sums fiat values only when all claimable rewards have fiat values', () => {
         const chainsRewardsWithFiat = [
             createChainRewards({
@@ -183,7 +164,7 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
             }),
         ];
         const summaries = buildStablecoinYieldClaimSummaries({
-            activeAccounts: [ethereumAccount],
+            accounts: [ethereumAccount],
             chainsRewardsWithFiat,
         });
         const accountRewards = getStablecoinYieldAccountRewards({

--- a/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts
+++ b/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts
@@ -13,16 +13,10 @@ import {
 import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
-import { type StablecoinYieldClaimSummary, type StablecoinYieldEarnItem } from '../types';
-import { hasPositiveContractTokenBalance } from './contractTokenBalanceUtils';
-
-type GetActiveStablecoinYieldClaimAccountsParams = {
-    activeItems: StablecoinYieldEarnItem[];
-    accounts: Account[];
-};
+import { type StablecoinYieldClaimSummary } from '../types';
 
 type BuildStablecoinYieldClaimSummariesParams = {
-    activeAccounts: Account[];
+    accounts: Account[];
     chainsRewardsWithFiat: ChainRewardsWithFiat[];
 };
 
@@ -113,34 +107,6 @@ const getStablecoinYieldAccountRewardsFromMap = (
     };
 };
 
-export const getActiveStablecoinYieldClaimAccounts = ({
-    activeItems,
-    accounts,
-}: GetActiveStablecoinYieldClaimAccountsParams): Account[] => {
-    const accountsByKey = new Map(accounts.map(account => [account.key, account]));
-    const activeAccountsByKey = new Map<Account['key'], Account>();
-
-    for (const item of activeItems) {
-        if (item.accountKey === null) {
-            continue;
-        }
-
-        const account = accountsByKey.get(item.accountKey);
-
-        if (!account) {
-            continue;
-        }
-
-        if (!hasPositiveContractTokenBalance(account, item.receiptTokenContract)) {
-            continue;
-        }
-
-        activeAccountsByKey.set(item.accountKey, account);
-    }
-
-    return Array.from(activeAccountsByKey.values());
-};
-
 export const getStablecoinYieldAccountRewards = ({
     account,
     chainsRewardsWithFiat,
@@ -172,12 +138,12 @@ export const getStablecoinYieldClaimRewardsSnapshot = ({
     }));
 
 export const buildStablecoinYieldClaimSummaries = ({
-    activeAccounts,
+    accounts,
     chainsRewardsWithFiat,
 }: BuildStablecoinYieldClaimSummariesParams): StablecoinYieldClaimSummary[] => {
     const chainsRewardsByAccountKey = getChainsRewardsByAccountKey(chainsRewardsWithFiat);
 
-    return activeAccounts.flatMap(account => {
+    return accounts.flatMap(account => {
         const accountRewards = getStablecoinYieldAccountRewardsFromMap(
             account,
             chainsRewardsByAccountKey,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Mobile Earn queried Merkl rewards only for accounts that currently hold a positive receipt-token balance (`getActiveStablecoinYieldClaimAccounts` + `hasPositiveContractTokenBalance`). After a full vault exit the balance drops to zero, the query stopped running, and accrued-but-unclaimed rewards disappeared from the Earn screen with no recovery path on mobile.

This aligns mobile with desktop (`useMerklRewards`):

- `useStablecoinYieldClaimSummaries` now builds Merkl query entries from all visible accounts, using the same empty-account nonce heuristic as desktop instead of the receipt-token balance filter.
- Claim summaries are built from all queried accounts — `buildStablecoinYieldClaimSummaries` already emits summaries only for accounts with `claimable > 0`.
- `EarnScreenListHeader` renders the deposits card also when there are claim summaries but no active positions, so users with only exited positions can see and claim their rewards.
- Removed the now-unused `getActiveStablecoinYieldClaimAccounts`.

## Notes for QA

- Deposit into a stablecoin vault, let Merkl rewards accrue, then withdraw the whole position — the claim rewards card must stay visible on the Earn tab and claiming must work end to end.
- Same address opened in desktop Suite must show the same claimable rewards as mobile.
- Fresh accounts with no outgoing transactions must not trigger any request to `/merkl/v1/users/rewards`.
- Accounts with an active position must behave exactly as before (deposits card, amounts, claim flow).

## Related Issue

Resolve #29538

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native-merkl-rewards-after-vault-exit&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->