### PR TITLE
chore(connect): tiny types improvement in buildOutputDescriptor helper

### DIFF
--- a/packages/connect/src/utils/__tests__/buildOutputDescriptor.test.ts
+++ b/packages/connect/src/utils/__tests__/buildOutputDescriptor.test.ts
@@ -173,6 +173,7 @@ describe('utils/buildOutputDescriptor', () => {
             expect(
                 buildOutputDescriptor({
                     account: 0,
+                    // @ts-expect-error testing invalid coin
                     coin: 'Ethereum',
                     scriptType: 'SPENDWITNESS',
                     xpub: XPUB,

--- a/packages/connect/src/utils/buildOutputDescriptor.ts
+++ b/packages/connect/src/utils/buildOutputDescriptor.ts
@@ -23,7 +23,7 @@ const PURPOSE_TO_SCRIPT_TYPE: Record<number, PROTO.InternalInputScriptType> = {
 };
 
 type BuildOutputDescriptorBip380Params = {
-    coin?: string;
+    coin?: 'Bitcoin' | 'Testnet' | 'Regtest';
     account: number;
     purpose?: number;
     scriptType?: PROTO.InternalInputScriptType;
@@ -55,7 +55,7 @@ export const buildOutputDescriptor = ({
         return undefined;
     }
 
-    const COIN_TYPE: Record<string, number> = { Bitcoin: 0, Testnet: 1, Regtest: 1 };
+    const COIN_TYPE = { Bitcoin: 0, Testnet: 1, Regtest: 1 } as const;
     const coinType = COIN_TYPE[coin ?? 'Bitcoin'];
     if (coinType === undefined) {
         return undefined;


### PR DESCRIPTION

## Description

Little stronger type on buildOutputDescriptor input params.

## Notes for QA

Nothing to test, types only change

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to `packages/connect/src/utils/buildOutputDescriptor.ts` and its co-located unit test file. The `buildOutputDescriptor` utility is a low-level function within `@trezor/connect` used for constructing output descriptors during transaction operations. While the static coverage mapping shows 131 E2E tests transitively importing this file (indicating it is a deeply nested, broadly shared dependency), none of the 146 candidate E2E tests directly exercise output descriptor building logic in their behaviors, assertions, or entry points. The function is likely called internally during transaction signing flows, but the E2E tests for send/sign operations test at the UI and device-prompt level and would not catch regressions in descriptor formatting — those are properly covered by the co-located unit test. No E2E tests are recommended; the unit test (`buildOutputDescriptor.test.ts`) provides the appropriate level of coverage for this change.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect/src/utils/__tests__/buildOutputDescriptor.test.ts`
- `packages/connect/src/utils/buildOutputDescriptor.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/connect/src/utils/__tests__/buildOutputDescriptor.test.ts`

_Updated: 2026-07-14T06:44:40.693Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/connect-tiny-types-impromvenet/web/](https://dev.suite.sldev.cz/suite-web/connect-tiny-types-impromvenet/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-tiny-types-impromvenet&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-tiny-types-impromvenet&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=connect-tiny-types-impromvenet&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-14T06:48:07.971Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-14T06:47:42.993Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->