### PR TITLE
fix(suite-common): move native tokens first

### DIFF
--- a/suite-common/wallet-config/src/representativeAssets.ts
+++ b/suite-common/wallet-config/src/representativeAssets.ts
@@ -29,8 +29,8 @@ const representativeAssets: Partial<Record<NetworkSymbol, readonly Representativ
         { symbol: 'USDC', contract: '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d' },
     ],
     arb: [
-        { symbol: 'ARB', contract: '0x912ce59144191c1204e64559fe8253a0e49e6548' },
         { symbol: 'ETH' },
+        { symbol: 'ARB', contract: '0x912ce59144191c1204e64559fe8253a0e49e6548' },
         { symbol: 'USDC', contract: '0xaf88d065e77c8cc2239327c5edb3a432268e5831' },
         { symbol: 'GMX', contract: '0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a' },
         { symbol: 'LINK', contract: '0xf97f4df75117a78c1a5a0dbb814af92458539fb4' },
@@ -43,8 +43,8 @@ const representativeAssets: Partial<Record<NetworkSymbol, readonly Representativ
         { symbol: 'USDT', contract: '0xfde4c96c8593536e31f229ea8f37b2ada2699bb2' },
     ],
     op: [
-        { symbol: 'OP', contract: '0x4200000000000000000000000000000000000042' },
         { symbol: 'ETH' },
+        { symbol: 'OP', contract: '0x4200000000000000000000000000000000000042' },
         { symbol: 'USDC', contract: '0x0b2c639c533813f4aa9d7837caf62653d097ff85' },
         { symbol: 'SNX', contract: '0x8700daec35af8ff88c16bdf0418774cb3d7599b4' },
         { symbol: 'VELO', contract: '0x9560e827af36c94d2ac33a39bce1fe78631088db' },


### PR DESCRIPTION
## Description

Native tokens shown first.

## Related Issue

Follow-up for #29752.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to representativeAssets.ts in wallet-config, which is a broadly imported module (131 tests map to it statically). However, "representative assets" is a specific concept most likely used for asset display, preselection, and suggestion logic in dashboards, trading flows, and coin activation modals — not in backup, onboarding, analytics, or device settings flows. The recommended strategy focuses on the small subset of tests that directly exercise asset listing, asset picking, and coin activation UI where representative asset changes would manifest. Most of the 131 statically-mapped tests are false positives due to transitive imports.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/wallet-config/src/representativeAssets.ts`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — representativeAssets.ts likely defines which assets are shown as representative/default on the dashboard. This test exercises the Assets section including enabling coins, viewing asset contents in grid/table views, and activating assets via modal — all of which could be affected by changes to representative asset definitions.
- `suite/e2e/tests/trading/navigation.test.ts` — Trading navigation tests verify that the correct cryptocurrency is preselected when opening buy/sell/swap forms from various entry points (dashboard asset cards, account pages, global header). Representative assets configuration could affect which assets appear and are preselected in these flows.
- `suite/e2e/tests/settings/coins.test.ts` — This test verifies coin activation flows including the 'Activate Assets' modal from the dashboard empty state, which may use representative assets to determine which networks to show. Changes to representative asset definitions could affect the default/suggested coin list.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-inputs.test.ts` — Swap input tests exercise the asset picker for selecting sell/buy assets including token selection across networks. Representative assets could influence which assets appear in the asset picker dropdown or how they are categorized.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test selects a specific SPL token (Jupiter/JUP) from the asset picker when buying crypto. If representative assets affect which tokens are surfaced or how token selection works in the buy flow, this test could catch regressions.

</details>

_Updated: 2026-07-14T07:10:45.143Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/common/representative-assets-order/web/](https://dev.suite.sldev.cz/suite-web/fix/common/representative-assets-order/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/common/representative-assets-order&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/common/representative-assets-order&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/common/representative-assets-order&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-14T07:13:39.626Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-14T07:13:37.588Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->