### PR TITLE
fix(suite-native): passphrase confirm button & device-manager buttons during discovery

### DIFF
--- a/suite-native/device-manager/src/components/AddHiddenWalletButton.tsx
+++ b/suite-native/device-manager/src/components/AddHiddenWalletButton.tsx
@@ -24,7 +24,11 @@ type NavigationProp = StackToStackCompositeNavigationProps<
     RootStackParamList
 >;
 
-export const AddHiddenWalletButton = () => {
+type AddHiddenWalletButtonProps = {
+    isDisabled?: boolean;
+};
+
+export const AddHiddenWalletButton = ({ isDisabled }: AddHiddenWalletButtonProps) => {
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const dispatch = useDispatch();
 
@@ -58,6 +62,7 @@ export const AddHiddenWalletButton = () => {
             intent="neutral"
             priority="secondary"
             iconLeft="password"
+            isDisabled={isDisabled}
             onPress={handleAddHiddenWallet}
             testID="@device-manager/passphrase/add"
         >

--- a/suite-native/device-manager/src/components/ConnectButton.tsx
+++ b/suite-native/device-manager/src/components/ConnectButton.tsx
@@ -36,10 +36,6 @@ export const ConnectButton = ({ onSelectDevice }: ConnectButtonProps) => {
 
     const { onConnectDevicePress } = useConnectDeviceHandler();
 
-    if (hasDiscovery) {
-        return null;
-    }
-
     const handleConnectDevice = () => {
         if (device) {
             onSelectDevice(device);
@@ -67,6 +63,7 @@ export const ConnectButton = ({ onSelectDevice }: ConnectButtonProps) => {
                     intent="neutral"
                     priority="secondary"
                     isFullWidth
+                    isDisabled={hasDiscovery}
                     onPress={handleConnectDevice}
                 >
                     <Translation id="deviceManager.connectButton" />

--- a/suite-native/device-manager/src/components/DeviceManagerContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerContent.tsx
@@ -104,8 +104,9 @@ export const DeviceManagerContent = () => {
     const scrollViewTopOffset = insets.top + utils.spacings.sp24 + HEADER_HEIGHT;
     const scrollViewMaxHeight = CONTENT_MAX_HEIGHT - scrollViewTopOffset;
 
+    // Kept visible (but disabled) while discovery runs so the button doesn't vanish mid-discovery,
+    // mirroring the desktop switch-device behavior.
     const isAddHiddenWalletButtonVisible =
-        !hasRunningDiscovery &&
         isDeviceConnected &&
         isDeviceInitialized &&
         deviceStaticSessionId &&
@@ -144,7 +145,9 @@ export const DeviceManagerContent = () => {
                             )}
                             <VStack paddingHorizontal="sp16" paddingBottom="sp16" spacing="sp12">
                                 <DeviceSettingsButton />
-                                {isAddHiddenWalletButtonVisible && <AddHiddenWalletButton />}
+                                {isAddHiddenWalletButtonVisible && (
+                                    <AddHiddenWalletButton isDisabled={hasRunningDiscovery} />
+                                )}
                             </VStack>
                         </AnimatedVStack>
                     )}

--- a/suite-native/passphrase/src/components/PassphraseForm.tsx
+++ b/suite-native/passphrase/src/components/PassphraseForm.tsx
@@ -101,7 +101,7 @@ export const PassphraseForm = ({
                             onBlur={() => setIsInputFocused(false)}
                             testID="@passphrase/passphraseInput"
                         />
-                        {isInputFocused && (
+                        {(isInputFocused || isDirty) && (
                             <Animated.View entering={FadeIn} exiting={FadeOut}>
                                 <Button
                                     accessibilityRole="button"


### PR DESCRIPTION
## Description

- When discovery is running, `add passphrase` and `connect trezor` buttons should be visible but disabled.
- when passphrase input is not focused, it should still show `confirm` button

## Related Issue

Resolve #29153
Resolve #29150

## Screenshots:

**#29153 — before** (value typed, input blurred, no Confirm button):

<img width="300" alt="29153-before" src="https://github.com/user-attachments/assets/2d7385dc-63ee-4fb8-8742-c8dcb3b3b2ee" />

**#29150 — during discovery, before** (Open passphrase / Connect Trezor missing):

<img width="300" alt="29150-before" src="https://github.com/user-attachments/assets/f2e8435d-bd84-42f6-b6bd-bf6f780184b7" />

After:

<img width="427" height="716" alt="Screenshot 2026-07-14 at 11 30 42" src="https://github.com/user-attachments/assets/0a8a8bb8-5a92-4e6b-86bf-383d26fd65f2" />
<img width="402" height="402" alt="Screenshot 2026-07-14 at 10 49 40" src="https://github.com/user-attachments/assets/295334d7-8e4d-4d5f-8a98-2711cbca43ce" />

_After: on mobile both buttons stay visible (disabled) during discovery, matching desktop; and the passphrase Confirm button remains visible once a value is entered, even after the input loses focus._

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/29153-passphrase-confirm-missing&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->