### PR TITLE
refactor(connect): tighten coin resolution — narrow resolver params, dedupe unknown-coin guard

### DIFF
--- a/packages/connect-common/src/types/api/bitcoin/authorizeCoinjoin.ts
+++ b/packages/connect-common/src/types/api/bitcoin/authorizeCoinjoin.ts
@@ -2,6 +2,7 @@ import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import type { Static } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
 
+import { CoinSymbolParam } from '../../coinInfo';
 import type { Params, Response } from '../../params';
 import { DerivationPath } from '../../params';
 
@@ -12,7 +13,7 @@ export const AuthorizeCoinjoin = Type.Object({
     maxRounds: Type.Number(),
     maxCoordinatorFeeRate: Type.Number(),
     maxFeePerKvbyte: Type.Number(),
-    coin: Type.Optional(Type.String()),
+    coin: Type.Optional(CoinSymbolParam()),
     scriptType: Type.Optional(PROTO.InternalInputScriptType),
     amountUnit: Type.Optional(PROTO.EnumAmountUnit),
     preauthorized: Type.Optional(Type.Boolean()),

--- a/packages/connect/src/api/blockchainDisconnect.ts
+++ b/packages/connect/src/api/blockchainDisconnect.ts
@@ -2,13 +2,12 @@
 
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
 import { CoinObj } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import { findBackend, isBackendSupported } from '../backend/BlockchainLink';
 import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
     coinInfo: CoinInfo;
@@ -22,10 +21,7 @@ export default class BlockchainDisconnect extends AbstractMethod<'blockchainDisc
         // validate incoming parameters
         Assert(CoinObj, payload);
 
-        const coinInfo = getCoinInfo(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
         isBackendSupported(coinInfo);
 

--- a/packages/connect/src/api/blockchainEstimateFee.ts
+++ b/packages/connect/src/api/blockchainEstimateFee.ts
@@ -1,7 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainEstimateFee.js
 
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import type {
     MethodContext,
@@ -13,7 +12,7 @@ import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
 import { getOrInitFeeLevels } from '../backend/fees';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
     coinInfo: CoinInfo;
@@ -51,11 +50,7 @@ export default class BlockchainEstimateFee extends AbstractMethod<'blockchainEst
                 ]);
             }
         }
-        const coinInfo = getCoinInfo(payload.coin);
-
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
         isBackendSupported(coinInfo);
 

--- a/packages/connect/src/api/blockchainEvmRpcCall.ts
+++ b/packages/connect/src/api/blockchainEvmRpcCall.ts
@@ -1,11 +1,10 @@
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
     coinInfo: CoinInfo;
@@ -26,11 +25,7 @@ export default class BlockchainEvmRpcCall extends AbstractMethod<'blockchainEvmR
             { name: 'data', type: 'string', required: true },
         ]);
 
-        const coinInfo = getCoinInfo(payload.coin);
-
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
         isBackendSupported(coinInfo);
 

--- a/packages/connect/src/api/blockchainGetAccountBalanceHistory.ts
+++ b/packages/connect/src/api/blockchainGetAccountBalanceHistory.ts
@@ -1,13 +1,12 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainGetAccountBalanceHistory.js
 
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
     coinInfo: CoinInfo;
@@ -33,10 +32,7 @@ export default class BlockchainGetAccountBalanceHistory extends AbstractMethod<
             { name: 'currencies', type: 'array' },
         ]);
 
-        const coinInfo = getCoinInfo(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
         isBackendSupported(coinInfo);
 

--- a/packages/connect/src/api/blockchainGetContractInfo.ts
+++ b/packages/connect/src/api/blockchainGetContractInfo.ts
@@ -1,10 +1,9 @@
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 import { validateParams } from './common/paramsValidator';
 
 type Params = {
@@ -26,11 +25,7 @@ export default class BlockchainGetContractInfo extends AbstractMethod<
             { name: 'identity', type: 'string' },
         ]);
 
-        const coinInfo = getCoinInfo(payload.coin);
-
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getCoinInfoOrThrow(payload.coin);
 
         isBackendSupported(coinInfo);
 

--- a/packages/connect/src/api/blockchainGetCurrentFiatRates.ts
+++ b/packages/connect/src/api/blockchainGetCurrentFiatRates.ts
@@ -1,13 +1,12 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainGetCurrentFiatRates.js
 
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
     coinInfo: CoinInfo;
@@ -31,10 +30,7 @@ export default class BlockchainGetCurrentFiatRates extends AbstractMethod<
             { name: 'identity', type: 'string' },
         ]);
 
-        const coinInfo = getCoinInfo(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
         isBackendSupported(coinInfo);
 

--- a/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
+++ b/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
@@ -1,13 +1,12 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainGetFiatRatesForTimestamps.js
 
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
     coinInfo: CoinInfo;
@@ -33,10 +32,7 @@ export default class BlockchainGetFiatRatesForTimestamps extends AbstractMethod<
             { name: 'identity', type: 'string' },
         ]);
 
-        const coinInfo = getCoinInfo(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
         isBackendSupported(coinInfo);
 

--- a/packages/connect/src/api/blockchainGetInfo.ts
+++ b/packages/connect/src/api/blockchainGetInfo.ts
@@ -1,11 +1,10 @@
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
     coinInfo: CoinInfo;
@@ -22,10 +21,7 @@ export default class BlockchainGetInfo extends AbstractMethod<'blockchainGetInfo
             { name: 'identity', type: 'string' },
         ]);
 
-        const coinInfo = getCoinInfo(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
         isBackendSupported(coinInfo);
 

--- a/packages/connect/src/api/blockchainGetTransactions.ts
+++ b/packages/connect/src/api/blockchainGetTransactions.ts
@@ -1,13 +1,12 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainGetTransactions.js
 
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
     txs: string[];
@@ -31,10 +30,7 @@ export default class BlockchainGetTransactions extends AbstractMethod<
             { name: 'descriptor', type: 'string' },
         ]);
 
-        const coinInfo = getCoinInfo(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
         isBackendSupported(coinInfo);
 

--- a/packages/connect/src/api/blockchainSetCustomBackend.ts
+++ b/packages/connect/src/api/blockchainSetCustomBackend.ts
@@ -1,13 +1,12 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainSetCustomBackend.js
 
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { reconnectAllBackends, setCustomBackend } from '../backend/BlockchainLink';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
     coinInfo: CoinInfo;
@@ -30,10 +29,7 @@ export default class BlockchainSetCustomBackend extends AbstractMethod<
             { name: 'blockchainLink', type: 'object' },
         ]);
 
-        const coinInfo = getCoinInfo(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getCoinInfoOrThrow(payload.coin);
 
         const { blockchainLink } = payload;
 

--- a/packages/connect/src/api/blockchainSubscribe.ts
+++ b/packages/connect/src/api/blockchainSubscribe.ts
@@ -1,13 +1,12 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainSubscribe.js
 
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
     accounts: Payload<'blockchainSubscribe'>['accounts'];
@@ -34,10 +33,7 @@ export default class BlockchainSubscribe extends AbstractMethod<'blockchainSubsc
             });
         }
 
-        const coinInfo = getCoinInfo(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
         isBackendSupported(coinInfo);
 

--- a/packages/connect/src/api/blockchainSubscribeFiatRates.ts
+++ b/packages/connect/src/api/blockchainSubscribeFiatRates.ts
@@ -1,13 +1,12 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainSubscribeFiatRates.js
 
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
     currency: Payload<'blockchainSubscribeFiatRates'>['currency'];
@@ -29,10 +28,7 @@ export default class BlockchainSubscribeFiatRates extends AbstractMethod<
             { name: 'identity', type: 'string' },
         ]);
 
-        const coinInfo = getCoinInfo(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
         isBackendSupported(coinInfo);
 

--- a/packages/connect/src/api/blockchainUnsubscribe.ts
+++ b/packages/connect/src/api/blockchainUnsubscribe.ts
@@ -1,13 +1,12 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainUnsubscribe.js
 
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
     accounts: Payload<'blockchainUnsubscribe'>['accounts'];
@@ -34,10 +33,7 @@ export default class BlockchainUnsubscribe extends AbstractMethod<'blockchainUns
             });
         }
 
-        const coinInfo = getCoinInfo(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
         isBackendSupported(coinInfo);
 

--- a/packages/connect/src/api/blockchainUnsubscribeFiatRates.ts
+++ b/packages/connect/src/api/blockchainUnsubscribeFiatRates.ts
@@ -1,13 +1,12 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainUnsubscribeFiatRates.js
 
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
     coinInfo: CoinInfo;
@@ -27,10 +26,7 @@ export default class BlockchainUnsubscribeFiatRates extends AbstractMethod<
             { name: 'identity', type: 'string' },
         ]);
 
-        const coinInfo = getCoinInfo(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
         isBackendSupported(coinInfo);
 

--- a/packages/connect/src/api/discoverAccounts.ts
+++ b/packages/connect/src/api/discoverAccounts.ts
@@ -8,7 +8,6 @@ import {
     CARDANO_DERIVATIONS,
     type CoinInfo,
     type DiscoverAccountsProgress,
-    ERRORS,
     type EntropyCheckResult,
     type FirmwareRange,
     PAGING,
@@ -21,7 +20,7 @@ import { arrayPartition, getSynchronize, versionUtils } from '@trezor/utils';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 import type { AccountDescriptor } from '../device/DeviceCommands';
 import { isUtxoBased } from '../utils/accountUtils';
 import { validatePath } from '../utils/pathUtils';
@@ -106,10 +105,7 @@ export default class DiscoverAccounts extends AbstractMethod<
             const { symbol, known: knownAccs, knownOnly, ...rest } = coin;
 
             // validate coin info
-            const coinInfo = getCoinInfo(symbol);
-            if (!coinInfo) {
-                throw ERRORS.TypedError('Method_UnknownCoin');
-            }
+            const coinInfo = getCoinInfoOrThrow(symbol);
 
             // validate backend
             isBackendSupported(coinInfo);

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -15,7 +15,7 @@ import { fromHardenedPathPart } from '@trezor/crypto-utils';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage, MethodReturnType } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 import { bundlify, validateParams } from './common/paramsValidator';
 import { getAccountLabel, isUtxoBased } from '../utils/accountUtils';
 import { buildOutputDescriptor } from '../utils/buildOutputDescriptor';
@@ -61,10 +61,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
             ]);
 
             // validate coin info
-            const coinInfo = getCoinInfo(batch.coin);
-            if (!coinInfo) {
-                throw ERRORS.TypedError('Method_UnknownCoin');
-            }
+            const coinInfo = getCoinInfoOrThrow(batch.coin);
             // validate backend
             isBackendSupported(coinInfo);
             // validate path if exists

--- a/packages/connect/src/api/getCoinInfo.ts
+++ b/packages/connect/src/api/getCoinInfo.ts
@@ -2,12 +2,11 @@
 
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
 import { CoinObj } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
     coinInfo: CoinInfo;
@@ -19,10 +18,7 @@ export default class GetCoinInfo extends AbstractMethod<'getCoinInfo', Params> {
 
         Assert(CoinObj, payload);
 
-        const coinInfo = getCoinInfo(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getCoinInfoOrThrow(payload.coin);
 
         const params = { coinInfo };
 

--- a/packages/connect/src/api/nostr/nostrGetPublicKey.ts
+++ b/packages/connect/src/api/nostr/nostrGetPublicKey.ts
@@ -25,7 +25,7 @@ export default class NostrGetPublicKey extends AbstractMethod<
         };
 
         super(message, params);
-        this.requiredFirmwareCoins = [getMiscNetwork('Nostr')];
+        this.requiredFirmwareCoins = [getMiscNetwork('nostr')];
     }
 
     get requiredPermissions() {

--- a/packages/connect/src/api/nostr/nostrSignEvent.ts
+++ b/packages/connect/src/api/nostr/nostrSignEvent.ts
@@ -26,7 +26,7 @@ export default class NostrSignEvent extends AbstractMethod<'nostrSignEvent', PRO
         };
 
         super(message, params);
-        this.requiredFirmwareCoins = [getMiscNetwork('Nostr')];
+        this.requiredFirmwareCoins = [getMiscNetwork('nostr')];
     }
 
     get requiredPermissions() {

--- a/packages/connect/src/api/pushTransaction.ts
+++ b/packages/connect/src/api/pushTransaction.ts
@@ -8,7 +8,7 @@ import { Assert } from '@trezor/schema-utils';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
     tx: PushTransactionSchema['tx'];
@@ -23,10 +23,7 @@ export default class PushTransaction extends AbstractMethod<'pushTransaction', P
         // validate incoming parameters
         Assert(PushTransactionSchema, payload);
 
-        const coinInfo = getCoinInfo(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
         isBackendSupported(coinInfo);
 

--- a/packages/connect/src/api/selectAccount.ts
+++ b/packages/connect/src/api/selectAccount.ts
@@ -1,5 +1,4 @@
 import { type CoinInfo, type PermissionRequest } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 import {
     type AddressSelection,
     SelectAccount as SelectAccountSchema,
@@ -8,7 +7,7 @@ import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage, MethodReturnType } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getCoinInfo } from '../data/coinInfo';
+import { getCoinInfoOrThrow } from '../data/coinInfo';
 import { isUtxoBased } from '../utils/accountUtils';
 import { getLabel } from '../utils/pathUtils';
 
@@ -23,10 +22,7 @@ export default class SelectAccount extends AbstractMethod<'selectAccount', Param
 
         Assert(SelectAccountSchema, payload);
 
-        const coinInfo = getCoinInfo(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getCoinInfoOrThrow(payload.coin);
 
         super(message, { coinInfo, addressSelection: payload.addressSelection });
 

--- a/packages/connect/src/api/solana/api/solanaComposeTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaComposeTransaction.ts
@@ -8,7 +8,7 @@ import { Assert } from '@trezor/schema-utils';
 import { initBlockchain, isBackendSupported } from '../../../backend/BlockchainLink';
 import type { MethodContext, MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
-import { getCoinInfo } from '../../../data/coinInfo';
+import { getCoinInfoOrThrow } from '../../../data/coinInfo';
 
 type SolanaComposeTransactionParams = SolanaComposeTransactionSchema & {
     coinInfo: CoinInfo;
@@ -24,10 +24,7 @@ export default class SolanaComposeTransaction extends AbstractMethod<
         // validate bundle type
         Assert(SolanaComposeTransactionSchema, payload);
 
-        const coinInfo = getCoinInfo(payload.coin || 'sol');
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getCoinInfoOrThrow(payload.coin || 'sol');
         // validate backend
         isBackendSupported(coinInfo);
 

--- a/packages/connect/src/data/__tests__/coinInfo.test.ts
+++ b/packages/connect/src/data/__tests__/coinInfo.test.ts
@@ -1,19 +1,19 @@
 import type { CoinSymbol } from '@trezor/connect-common/src/types/coinInfo';
 
-import { getAllNetworks, getCoinInfo, getMiscNetwork, getUniqueNetworks } from '../coinInfo';
+import { getAllNetworks, getCoinInfoOrThrow, getMiscNetwork, getUniqueNetworks } from '../coinInfo';
 
 describe('data/coinInfo', () => {
     it('resolves a coin string by shortcut only (network name / label no longer accepted)', () => {
         // the lowercase shortcut resolves, case-insensitively, across all families
-        expect(getCoinInfo('btc')?.shortcut).toBe('BTC');
-        expect(getCoinInfo('BTC')?.shortcut).toBe('BTC');
-        expect(getCoinInfo('ada')?.shortcut).toBe('ADA');
-        expect(getCoinInfo('eth')?.shortcut).toBe('ETH');
+        expect(getCoinInfoOrThrow('btc').shortcut).toBe('BTC');
+        expect(getCoinInfoOrThrow('BTC').shortcut).toBe('BTC');
+        expect(getCoinInfoOrThrow('ada').shortcut).toBe('ADA');
+        expect(getCoinInfoOrThrow('eth').shortcut).toBe('ETH');
 
         // the network name and label forms are no longer accepted (D2/D3)
-        expect(getCoinInfo('bitcoin')).toBeUndefined();
-        expect(getCoinInfo('Bitcoin Cash')).toBeUndefined();
-        expect(getCoinInfo('cardano')).toBeUndefined();
+        expect(() => getCoinInfoOrThrow('bitcoin')).toThrow('Coin not found');
+        expect(() => getCoinInfoOrThrow('Bitcoin Cash')).toThrow('Coin not found');
+        expect(() => getCoinInfoOrThrow('cardano')).toThrow('Coin not found');
     });
 
     it('resolves every misc firmware-gating shortcut (requiredFirmwareCoins is never [undefined])', () => {
@@ -45,13 +45,13 @@ describe('data/coinInfo', () => {
 
     it('getUniqueNetworks', () => {
         const inputs = [
-            getCoinInfo('btc'),
-            getCoinInfo('ltc'),
-            getCoinInfo('btc'),
-            getCoinInfo('ltc'),
-            getCoinInfo('ltc'),
+            getCoinInfoOrThrow('btc'),
+            getCoinInfoOrThrow('ltc'),
+            getCoinInfoOrThrow('btc'),
+            getCoinInfoOrThrow('ltc'),
+            getCoinInfoOrThrow('ltc'),
         ];
-        const result = [getCoinInfo('btc'), getCoinInfo('ltc')];
+        const result = [getCoinInfoOrThrow('btc'), getCoinInfoOrThrow('ltc')];
         expect(getUniqueNetworks(inputs)).toEqual(result);
     });
 

--- a/packages/connect/src/data/__tests__/coinInfo.test.ts
+++ b/packages/connect/src/data/__tests__/coinInfo.test.ts
@@ -1,3 +1,5 @@
+import type { CoinSymbol } from '@trezor/connect-common/src/types/coinInfo';
+
 import { getAllNetworks, getCoinInfo, getMiscNetwork, getUniqueNetworks } from '../coinInfo';
 
 describe('data/coinInfo', () => {
@@ -17,7 +19,8 @@ describe('data/coinInfo', () => {
     it('resolves every misc firmware-gating shortcut (requiredFirmwareCoins is never [undefined])', () => {
         // the shortcut forms the misc api methods pass to getMiscNetwork() to build
         // requiredFirmwareCoins — a wrong form would silently become [undefined] (D1)
-        ['ada', 'xrp', 'xmr', 'trx', 'xlm', 'sol', 'xtz', 'nostr'].forEach(shortcut => {
+        const shortcuts: CoinSymbol[] = ['ada', 'xrp', 'xmr', 'trx', 'xlm', 'sol', 'xtz', 'nostr'];
+        shortcuts.forEach(shortcut => {
             expect(getMiscNetwork(shortcut)).toBeDefined();
         });
     });

--- a/packages/connect/src/data/coinInfo.ts
+++ b/packages/connect/src/data/coinInfo.ts
@@ -1,10 +1,10 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/data/CoinInfo.js
 import type {
     BitcoinNetworkInfo,
+    CoinSymbol,
     EthereumNetworkInfo,
     MiscNetworkInfo,
 } from '@trezor/connect-common/src/types/coinInfo';
-import type { DerivationPath } from '@trezor/connect-common/src/types/params';
 import coinsEth from '@trezor/connect-data/files/coins-eth.json';
 import coins from '@trezor/connect-data/files/coins.json';
 import { fromHardenedPathPart, toHardenedPathPart } from '@trezor/crypto-utils';
@@ -17,46 +17,46 @@ const ethereumNetworks: EthereumNetworkInfo[] = [];
 const miscNetworks: MiscNetworkInfo[] = [];
 
 export const getBitcoinNetwork = (
-    pathOrName: DerivationPath,
+    symbolOrPath: CoinSymbol | number[],
 ): Readonly<BitcoinNetworkInfo> | undefined => {
-    if (typeof pathOrName === 'string') {
-        const shortcut = pathOrName.toLowerCase();
+    if (typeof symbolOrPath === 'string') {
+        const shortcut = symbolOrPath.toLowerCase();
 
         return bitcoinNetworks.find(n => n.shortcut.toLowerCase() === shortcut);
     }
     // @ts-expect-error: indexing with noUncheckedIndexedAccess
-    const pathElement: number = pathOrName[1];
+    const pathElement: number = symbolOrPath[1];
     const slip44 = fromHardenedPathPart(pathElement);
 
     return bitcoinNetworks.find(n => n.slip44 === slip44);
 };
 
 export const getEthereumNetwork = (
-    pathOrNetworkSymbol: DerivationPath,
+    symbolOrPath: CoinSymbol | number[],
 ): Readonly<EthereumNetworkInfo> | undefined => {
-    if (typeof pathOrNetworkSymbol === 'string') {
-        const networkSymbol = pathOrNetworkSymbol.toLowerCase();
+    if (typeof symbolOrPath === 'string') {
+        const networkSymbol = symbolOrPath.toLowerCase();
 
         return ethereumNetworks.find(network => network.shortcut.toLowerCase() === networkSymbol);
     }
 
     // @ts-expect-error: indexing with noUncheckedIndexedAccess
-    const ethPathElement: number = pathOrNetworkSymbol[1];
+    const ethPathElement: number = symbolOrPath[1];
     const slip44 = fromHardenedPathPart(ethPathElement);
 
     return ethereumNetworks.find(n => n.slip44 === slip44);
 };
 
 export const getMiscNetwork = (
-    pathOrName: DerivationPath,
+    symbolOrPath: CoinSymbol | number[],
 ): Readonly<MiscNetworkInfo> | undefined => {
-    if (typeof pathOrName === 'string') {
-        const shortcut = pathOrName.toLowerCase();
+    if (typeof symbolOrPath === 'string') {
+        const shortcut = symbolOrPath.toLowerCase();
 
         return miscNetworks.find(n => n.shortcut.toLowerCase() === shortcut);
     }
     // @ts-expect-error: indexing with noUncheckedIndexedAccess
-    const miscPathElement: number = pathOrName[1];
+    const miscPathElement: number = symbolOrPath[1];
     const slip44 = fromHardenedPathPart(miscPathElement);
 
     return miscNetworks.find(n => n.slip44 === slip44);
@@ -114,8 +114,15 @@ export const fixCoinInfoNetwork = (ci: BitcoinNetworkInfo, path: number[]) => {
     return coinInfo;
 };
 
-export const getCoinInfo = (currency: string) =>
-    getBitcoinNetwork(currency) || getEthereumNetwork(currency) || getMiscNetwork(currency);
+// The single untrusted-string boundary: `currency` comes from the public
+// `getCoinInfo` param and may not be a real shortcut. The resolvers match by
+// shortcut and return undefined for anything that isn't one, so the cast only
+// asserts "treat this as a candidate shortcut", never a derivation path.
+export const getCoinInfo = (currency: string) => {
+    const coin = currency as CoinSymbol;
+
+    return getBitcoinNetwork(coin) || getEthereumNetwork(coin) || getMiscNetwork(coin);
+};
 
 export const getCoinName = (path: number[]) => {
     // @ts-expect-error: indexing with noUncheckedIndexedAccess

--- a/packages/connect/src/data/coinInfo.ts
+++ b/packages/connect/src/data/coinInfo.ts
@@ -1,4 +1,5 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/data/CoinInfo.js
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import type {
     BitcoinNetworkInfo,
     CoinSymbol,
@@ -114,14 +115,17 @@ export const fixCoinInfoNetwork = (ci: BitcoinNetworkInfo, path: number[]) => {
     return coinInfo;
 };
 
-// The single untrusted-string boundary: `currency` comes from the public
-// `getCoinInfo` param and may not be a real shortcut. The resolvers match by
-// shortcut and return undefined for anything that isn't one, so the cast only
-// asserts "treat this as a candidate shortcut", never a derivation path.
-export const getCoinInfo = (currency: string) => {
-    const coin = currency as CoinSymbol;
+const getCoinInfo = (coin: CoinSymbol) =>
+    getBitcoinNetwork(coin) || getEthereumNetwork(coin) || getMiscNetwork(coin);
 
-    return getBitcoinNetwork(coin) || getEthereumNetwork(coin) || getMiscNetwork(coin);
+export const getCoinInfoOrThrow = (coin: string) => {
+    // `coin` is unvalidated caller input; a non-shortcut resolves to undefined below
+    const coinInfo = getCoinInfo(coin as CoinSymbol);
+    if (!coinInfo) {
+        throw ERRORS.TypedError('Method_UnknownCoin');
+    }
+
+    return coinInfo;
 };
 
 export const getCoinName = (path: number[]) => {

--- a/packages/connect/src/utils/__tests__/addressUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/addressUtils.test.ts
@@ -1,3 +1,5 @@
+import type { CoinSymbol } from '@trezor/connect-common/src/types/coinInfo';
+
 import { getBitcoinNetwork } from '../../data/coinInfo';
 import * as fixtures from '../__fixtures__/addressUtils';
 import * as utils from '../addressUtils';
@@ -6,13 +8,17 @@ describe('utils/addressUtils', () => {
     describe('isValidAddress', () => {
         fixtures.validAddresses.forEach(f => {
             it(`${f.description} ${f.address}`, () => {
-                expect(utils.isValidAddress(f.address, getBitcoinNetwork(f.coin)!)).toEqual(true);
+                expect(
+                    utils.isValidAddress(f.address, getBitcoinNetwork(f.coin as CoinSymbol)!),
+                ).toEqual(true);
             });
         });
 
         fixtures.invalidAddresses.forEach(f => {
             it(`Invalid ${f.coin} ${f.address}`, () => {
-                expect(utils.isValidAddress(f.address, getBitcoinNetwork(f.coin)!)).toEqual(false);
+                expect(
+                    utils.isValidAddress(f.address, getBitcoinNetwork(f.coin as CoinSymbol)!),
+                ).toEqual(false);
             });
         });
     });


### PR DESCRIPTION
## Description

Follow-up to #29729, cleaning up coin resolution in `@trezor/connect`. Two independent commits.

### 1. Narrow the coin resolver params to `CoinSymbol | number[]`

Addresses the review thread [on `coinInfo.ts`](https://github.com/trezor/trezor-suite/pull/29729#discussion_r3577163188): `getBitcoinNetwork` / `getEthereumNetwork` / `getMiscNetwork` took `DerivationPath` (`string | number[]`), which conflated a **coin-shortcut string** with a **derivation-path string**. The param is now `symbolOrPath: CoinSymbol | number[]` so the two string kinds can no longer be confused at compile time — a lighter alternative to the branded types the reviewer floated (a derivation path here is always the `address_n` `number[]`, never a path string, so `number[]` alone already distinguishes it).

The narrower type surfaced two latent spots the parent PR's shortcut-only migration did not cover:

- **`nostrGetPublicKey` / `nostrSignEvent` passed the network name `'Nostr'`** to `getMiscNetwork`, not the `'nostr'` shortcut. It resolved at runtime only because the resolver lowercases its input; the narrowed type rejects it, and both call sites now pass `'nostr'`.
- **`authorizeCoinjoin`'s public `coin` param was still `Type.String()`** — the one coin param the parent PR's D3 narrowing missed. It's now `CoinSymbolParam()`, consistent with every other method.

`getCoinInfo` deliberately keeps accepting an arbitrary `string` (it's the untrusted public entry point that must still resolve case-insensitively and reject name/label forms), delegating to the resolvers through a single documented cast at that boundary.

### 2. Dedupe the `Method_UnknownCoin` guard into `getCoinInfoOrThrow`

All 20 `getCoinInfo` call sites repeated the same three-line guard — resolve, then `throw Method_UnknownCoin` on `undefined`. A new `getCoinInfoOrThrow` folds the throw into the lookup; every call site collapses to a single line and the now-unused `ERRORS` imports are dropped. The `-OrThrow` suffix keeps the throwing behavior explicit at each call site rather than hiding control flow inside a plain getter.

With every production caller now going through `getCoinInfoOrThrow`, the plain `getCoinInfo` became internal-only, so it is no longer exported and is typed `(coin: CoinSymbol)` — the untrusted-string boundary (and the one `as CoinSymbol` cast for an unvalidated public input) now lives in `getCoinInfoOrThrow`, where it belongs. The `coinInfo` unit test exercises that boundary through `getCoinInfoOrThrow` accordingly.

## Notes for QA

No runtime behavior change — this is a compile-time type narrowing plus two equivalent-at-runtime corrections:

- Nostr `getPublicKey` / `signEvent` already resolved `'Nostr'` → the nostr network via `toLowerCase`; they now pass `'nostr'` directly and resolve identically. Worth a smoke test that Nostr public-key export and event signing still work and gate on the correct firmware.
- `authorizeCoinjoin`'s `coin` is optional and BTC-only; no in-repo caller passes it, so the schema type change has no runtime effect. Coinjoin authorization flows are unaffected.
- No `suite` / `suite-common` / `suite-native` change is needed — the narrowing is internal to `@trezor/connect` and its call sites.
- The `getCoinInfoOrThrow` dedup is behavior-preserving: it throws the same `Method_UnknownCoin` on the same input as the 20 inlined guards it replaces. Any method that takes a `coin` and errors on an unknown one (blockchain*, getAccountInfo, selectAccount, pushTransaction, discoverAccounts, solanaComposeTransaction, the public getCoinInfo) is worth a quick "unknown coin still errors, known coin still works" check.

`@trezor/connect` unit tests (incl. the `coinInfo` resolution + new `getCoinInfoOrThrow` assertions) pass; `type-check` is green.

## Team
- **Product owner:** mroz22
- **Reviewer:** marekrjpolak (raised the original thread)

Follow-up to #29729 (merged).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies numerous @trezor/connect API method implementations (blockchain*, getAccountInfo, getCoinInfo, discoverAccounts, pushTransaction, selectAccount, solanaComposeTransaction) and the core coinInfo data module. Most files map to 60-130+ tests via transitive imports, but the actual risk is concentrated in: (1) coin info resolution affecting network parameters, (2) account discovery and blockchain interaction APIs, (3) Solana transaction composition, and (4) the selectAccount API. The recommended strategy focuses on tests that directly exercise the changed API methods (TrezorConnect API tests, wallet discovery, send/swap flows for affected chains) rather than tests that merely import these broadly-shared modules.

<details><summary><b>Changed files (26)</b></summary>

- `packages/connect-common/src/types/api/bitcoin/authorizeCoinjoin.ts`
- `packages/connect/src/api/blockchainDisconnect.ts`
- `packages/connect/src/api/blockchainEstimateFee.ts`
- `packages/connect/src/api/blockchainEvmRpcCall.ts`
- `packages/connect/src/api/blockchainGetAccountBalanceHistory.ts`
- `packages/connect/src/api/blockchainGetContractInfo.ts`
- `packages/connect/src/api/blockchainGetCurrentFiatRates.ts`
- `packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts`
- `packages/connect/src/api/blockchainGetInfo.ts`
- `packages/connect/src/api/blockchainGetTransactions.ts`
- `packages/connect/src/api/blockchainSetCustomBackend.ts`
- `packages/connect/src/api/blockchainSubscribe.ts`
- `packages/connect/src/api/blockchainSubscribeFiatRates.ts`
- `packages/connect/src/api/blockchainUnsubscribe.ts`
- `packages/connect/src/api/blockchainUnsubscribeFiatRates.ts`
- `packages/connect/src/api/discoverAccounts.ts`
- `packages/connect/src/api/getAccountInfo.ts`
- `packages/connect/src/api/getCoinInfo.ts`
- `packages/connect/src/api/nostr/nostrGetPublicKey.ts`
- `packages/connect/src/api/nostr/nostrSignEvent.ts`
- `packages/connect/src/api/pushTransaction.ts`
- `packages/connect/src/api/selectAccount.ts`
- `packages/connect/src/api/solana/api/solanaComposeTransaction.ts`
- `packages/connect/src/data/__tests__/coinInfo.test.ts`
- `packages/connect/src/data/coinInfo.ts`
- `packages/connect/src/utils/__tests__/addressUtils.test.ts`

</details>

**Recommended tests (23)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Directly exercises TrezorConnect.getAccountInfo which is one of the changed files (packages/connect/src/api/getAccountInfo.ts). Changes to the API method could break account info retrieval, permissions flow, and account selection.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — Directly exercises TrezorConnect.selectAccount which corresponds to the changed file packages/connect/src/api/selectAccount.ts. This test validates multi/single selection, cancellation, and privacy properties of the API.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Directly tests custom backend configuration which exercises blockchainSetCustomBackend and getCoinInfo - both changed files. It also validates discovery with custom backends, testing the full chain from coin info resolution to account loading.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Tests custom Blockbook backend setup for BTC and LTC and validates that discovery completes. This directly exercises getCoinInfo and blockchainSetCustomBackend, both of which are changed.
- `suite/e2e/tests/wallet/discovery.test.ts` — Tests multi-coin account discovery with page reload resilience. Discovery directly uses discoverAccounts, getAccountInfo, blockchainSubscribe, and coinInfo - all changed. A regression here would break the core wallet loading experience.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Directly tests Solana send flow which exercises solanaComposeTransaction (changed) and blockchainGetInfo (changed). Validates amount calculation, fee display, and device confirmation for SOL transactions.

</details>

<details><summary>🟡 <b>Medium priority (14)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Tests TrezorConnect.getAddress and cardanoGetAddress through the web popup flow. While getAddress itself isn't changed, the test relies on coinInfo resolution and the connect API infrastructure that has multiple changed files.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Tests Bitcoin transaction signing via TrezorConnect which relies on coinInfo for BTC coin data. Changes to coinInfo.ts could affect how coin parameters are resolved during signing.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Tests DOGE send flow with large amounts, exercising getCoinInfo for DOGE parameters and pushTransaction for broadcasting. Changes to coin info resolution could affect DOGE-specific parameters like decimals or amount validation.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Tests LTC send with MimbleWimble peg-out transactions, using getCoinInfo for LTC parameters and a custom blockbook backend. Changes to coinInfo or getCoinInfo could affect LTC-specific handling.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Tests Bitcoin regtest send form with multiple outputs, locktime, OP_RETURN, and unit switching. Uses pushTransaction (changed) for broadcasting and coinInfo for regtest coin parameters.
- `suite/e2e/tests/settings/coins.test.ts` — Tests enabling/disabling coin networks and setting custom backends, directly exercising getCoinInfo and blockchainSetCustomBackend. Validates that network activation and backend configuration work correctly.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Tests SOL-to-BTC swap which exercises solanaComposeTransaction, blockchainGetInfo, pushTransaction, and blockchainUnsubscribe - all changed files. Validates the full swap transaction flow including Solana-specific composition.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests selling SOL which uses solanaComposeTransaction (changed) for transaction composition and blockchainGetInfo (changed) for Solana network info. End-to-end flow includes device confirmation and transaction broadcasting.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Tests first-time ETH staking which exercises blockchainEstimateFee, pushTransaction, and getCoinInfo - all changed. Validates fee estimation and transaction broadcast for staking.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Tests first-time SOL staking which uses solanaComposeTransaction, getCoinInfo, pushTransaction, and blockchainEstimateFee - multiple changed files in the transaction composition and broadcasting path.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Tests DEX swap on ETH which exercises blockchainEstimateFee for gas estimation, pushTransaction for broadcasting, and getCoinInfo for ETH parameters - all changed files.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Tests ETH send with custom gas fees. While the primary changed files are connect API methods, the send flow relies on blockchainEstimateFee and coinInfo for ETH-specific parameters like gas handling.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests TrezorConnect permissions granting and revoking. The flow calls getAddress which depends on coinInfo resolution. Changes to the connect API infrastructure could affect the permissions flow.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Tests wallet discovery after ejecting and re-adding a wallet. Exercises discoverAccounts, blockchainDisconnect, and blockchainSubscribe - all changed files involved in the discovery lifecycle.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/wallet/send-base.test.ts` — Tests Base network (EVM L2) send flow with custom gas fees, which uses blockchainEstimateFee for fee estimation and coinInfo for network parameters. Changes to these could affect EVM fee calculation.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests SOL-to-USDC swap using solanaComposeTransaction and pushTransaction, both changed. Provides additional Solana transaction composition coverage beyond swap-coins test.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Tests ETH unstaking and claiming which exercises blockchainEvmRpcCall (only test mapped to this changed file), pushTransaction, and blockchainEstimateFee.

</details>

⚠️ **Changes with no test coverage (8)**
- `packages/connect/src/api/blockchainGetContractInfo.ts`
- `packages/connect/src/api/blockchainGetTransactions.ts`
- `packages/connect/src/api/blockchainSubscribeFiatRates.ts`
- `packages/connect/src/api/nostr/nostrGetPublicKey.ts`
- `packages/connect/src/api/nostr/nostrSignEvent.ts`
- `packages/connect/src/data/__tests__/coinInfo.test.ts`
- `packages/connect/src/utils/__tests__/addressUtils.test.ts`
- `packages/connect-common/src/types/api/bitcoin/authorizeCoinjoin.ts`

_Updated: 2026-07-14T10:32:21.863Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/conveyor/29669-coin-symbol-path-type/web/](https://dev.suite.sldev.cz/suite-web/conveyor/29669-coin-symbol-path-type/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=conveyor/29669-coin-symbol-path-type&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=conveyor/29669-coin-symbol-path-type&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=conveyor/29669-coin-symbol-path-type&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-14T10:34:51.628Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-14T10:34:26.804Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->