### PR TITLE
refactor(connect): split backend support into isSupported predicate + assertBackendSupported

### DIFF
--- a/packages/connect/src/api/blockchainDisconnect.ts
+++ b/packages/connect/src/api/blockchainDisconnect.ts
@@ -4,7 +4,7 @@ import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
 import { CoinObj } from '@trezor/connect-common';
 import { Assert } from '@trezor/schema-utils';
 
-import { findBackend, isBackendSupported } from '../backend/BlockchainLink';
+import { assertBackendSupported, findBackend } from '../backend/BlockchainLink';
 import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfoOrThrow } from '../data/coinInfo';
@@ -23,7 +23,7 @@ export default class BlockchainDisconnect extends AbstractMethod<'blockchainDisc
 
         const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
-        isBackendSupported(coinInfo);
+        assertBackendSupported(coinInfo);
 
         const params = {
             coinInfo,

--- a/packages/connect/src/api/blockchainEstimateFee.ts
+++ b/packages/connect/src/api/blockchainEstimateFee.ts
@@ -10,7 +10,7 @@ import type {
 } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
-import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import { getOrInitFeeLevels } from '../backend/fees';
 import { getCoinInfoOrThrow } from '../data/coinInfo';
 
@@ -52,7 +52,7 @@ export default class BlockchainEstimateFee extends AbstractMethod<'blockchainEst
         }
         const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
-        isBackendSupported(coinInfo);
+        assertBackendSupported(coinInfo);
 
         const params = {
             coinInfo,

--- a/packages/connect/src/api/blockchainEvmRpcCall.ts
+++ b/packages/connect/src/api/blockchainEvmRpcCall.ts
@@ -1,6 +1,6 @@
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
 
-import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
@@ -27,7 +27,7 @@ export default class BlockchainEvmRpcCall extends AbstractMethod<'blockchainEvmR
 
         const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
-        isBackendSupported(coinInfo);
+        assertBackendSupported(coinInfo);
 
         const params = {
             coinInfo,

--- a/packages/connect/src/api/blockchainGetAccountBalanceHistory.ts
+++ b/packages/connect/src/api/blockchainGetAccountBalanceHistory.ts
@@ -5,7 +5,7 @@ import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
 import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
-import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
@@ -34,7 +34,7 @@ export default class BlockchainGetAccountBalanceHistory extends AbstractMethod<
 
         const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
-        isBackendSupported(coinInfo);
+        assertBackendSupported(coinInfo);
 
         const params = {
             coinInfo,

--- a/packages/connect/src/api/blockchainGetContractInfo.ts
+++ b/packages/connect/src/api/blockchainGetContractInfo.ts
@@ -1,6 +1,6 @@
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
 
-import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfoOrThrow } from '../data/coinInfo';
@@ -27,7 +27,7 @@ export default class BlockchainGetContractInfo extends AbstractMethod<
 
         const coinInfo = getCoinInfoOrThrow(payload.coin);
 
-        isBackendSupported(coinInfo);
+        assertBackendSupported(coinInfo);
 
         const request = {
             contract: payload.contract,

--- a/packages/connect/src/api/blockchainGetCurrentFiatRates.ts
+++ b/packages/connect/src/api/blockchainGetCurrentFiatRates.ts
@@ -5,7 +5,7 @@ import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
 import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
-import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
@@ -32,7 +32,7 @@ export default class BlockchainGetCurrentFiatRates extends AbstractMethod<
 
         const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
-        isBackendSupported(coinInfo);
+        assertBackendSupported(coinInfo);
 
         const params = {
             currencies: payload.currencies,

--- a/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
+++ b/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
@@ -5,7 +5,7 @@ import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
 import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
-import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
@@ -34,7 +34,7 @@ export default class BlockchainGetFiatRatesForTimestamps extends AbstractMethod<
 
         const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
-        isBackendSupported(coinInfo);
+        assertBackendSupported(coinInfo);
 
         const params = {
             currencies: payload.currencies,

--- a/packages/connect/src/api/blockchainGetInfo.ts
+++ b/packages/connect/src/api/blockchainGetInfo.ts
@@ -3,7 +3,7 @@ import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
 import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
-import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
@@ -23,7 +23,7 @@ export default class BlockchainGetInfo extends AbstractMethod<'blockchainGetInfo
 
         const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
-        isBackendSupported(coinInfo);
+        assertBackendSupported(coinInfo);
 
         const params = {
             coinInfo,

--- a/packages/connect/src/api/blockchainGetTransactions.ts
+++ b/packages/connect/src/api/blockchainGetTransactions.ts
@@ -5,7 +5,7 @@ import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
 import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
-import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
@@ -32,7 +32,7 @@ export default class BlockchainGetTransactions extends AbstractMethod<
 
         const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
-        isBackendSupported(coinInfo);
+        assertBackendSupported(coinInfo);
 
         const params = {
             txs: payload.txs,

--- a/packages/connect/src/api/blockchainSubscribe.ts
+++ b/packages/connect/src/api/blockchainSubscribe.ts
@@ -5,7 +5,7 @@ import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
 import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
-import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
@@ -35,7 +35,7 @@ export default class BlockchainSubscribe extends AbstractMethod<'blockchainSubsc
 
         const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
-        isBackendSupported(coinInfo);
+        assertBackendSupported(coinInfo);
 
         const params = {
             accounts: payload.accounts,

--- a/packages/connect/src/api/blockchainSubscribeFiatRates.ts
+++ b/packages/connect/src/api/blockchainSubscribeFiatRates.ts
@@ -5,7 +5,7 @@ import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
 import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
-import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
@@ -30,7 +30,7 @@ export default class BlockchainSubscribeFiatRates extends AbstractMethod<
 
         const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
-        isBackendSupported(coinInfo);
+        assertBackendSupported(coinInfo);
 
         const params = {
             currency: payload.currency,

--- a/packages/connect/src/api/blockchainUnsubscribe.ts
+++ b/packages/connect/src/api/blockchainUnsubscribe.ts
@@ -5,7 +5,7 @@ import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
 import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
-import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
@@ -35,7 +35,7 @@ export default class BlockchainUnsubscribe extends AbstractMethod<'blockchainUns
 
         const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
-        isBackendSupported(coinInfo);
+        assertBackendSupported(coinInfo);
 
         const params = {
             accounts: payload.accounts,

--- a/packages/connect/src/api/blockchainUnsubscribeFiatRates.ts
+++ b/packages/connect/src/api/blockchainUnsubscribeFiatRates.ts
@@ -5,7 +5,7 @@ import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
 import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
-import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import { getCoinInfoOrThrow } from '../data/coinInfo';
 
 type Params = {
@@ -28,7 +28,7 @@ export default class BlockchainUnsubscribeFiatRates extends AbstractMethod<
 
         const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
-        isBackendSupported(coinInfo);
+        assertBackendSupported(coinInfo);
 
         const params = {
             coinInfo,

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -22,7 +22,7 @@ import { resolveAfter } from '@trezor/utils/src/resolveAfter';
 import { unique } from '@trezor/utils/src/unique';
 import type { ComposeOutput, TransactionInputOutputSortingStrategy } from '@trezor/utxo-lib';
 
-import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { requestExistingAccounts } from './common/requestExistingAccounts';
@@ -79,7 +79,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             throw ERRORS.TypedError('Method_UnknownCoin');
         }
         // validate backend
-        isBackendSupported(coinInfo);
+        assertBackendSupported(coinInfo);
 
         // validate each output and transform into @trezor/utxo-lib/compose format
         const outputs: ComposeOutput[] = [];

--- a/packages/connect/src/api/discoverAccounts.ts
+++ b/packages/connect/src/api/discoverAccounts.ts
@@ -17,7 +17,7 @@ import {
 } from '@trezor/connect-common';
 import { arrayPartition, getSynchronize, versionUtils } from '@trezor/utils';
 
-import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfoOrThrow } from '../data/coinInfo';
@@ -108,7 +108,7 @@ export default class DiscoverAccounts extends AbstractMethod<
             const coinInfo = getCoinInfoOrThrow(symbol);
 
             // validate backend
-            isBackendSupported(coinInfo);
+            assertBackendSupported(coinInfo);
 
             const firmwareRange = getFirmwareRange([payload.method], [coinInfo]);
 

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -12,7 +12,7 @@ import type {
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { fromHardenedPathPart } from '@trezor/crypto-utils';
 
-import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage, MethodReturnType } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfoOrThrow } from '../data/coinInfo';
@@ -63,7 +63,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
             // validate coin info
             const coinInfo = getCoinInfoOrThrow(batch.coin);
             // validate backend
-            isBackendSupported(coinInfo);
+            assertBackendSupported(coinInfo);
             // validate path if exists
             let address_n: number[] = [];
             if (batch.path) {

--- a/packages/connect/src/api/pushTransaction.ts
+++ b/packages/connect/src/api/pushTransaction.ts
@@ -5,7 +5,7 @@ import { PushTransaction as PushTransactionSchema } from '@trezor/connect-common
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfoOrThrow } from '../data/coinInfo';
@@ -25,7 +25,7 @@ export default class PushTransaction extends AbstractMethod<'pushTransaction', P
 
         const coinInfo = getCoinInfoOrThrow(payload.coin);
         // validate backend
-        isBackendSupported(coinInfo);
+        assertBackendSupported(coinInfo);
 
         if (
             coinInfo.type === 'bitcoin' &&

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -30,7 +30,7 @@ import {
     verifyTx,
 } from './bitcoin';
 import type { Blockchain } from '../backend/BlockchainLink';
-import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getBitcoinNetwork } from '../data/coinInfo';
@@ -283,7 +283,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
         }
 
         // validate and initialize backend
-        isBackendSupported(coinInfo);
+        assertBackendSupported(coinInfo);
         const blockchain = await initBlockchain(coinInfo, sendCoreMessage, identity);
 
         const refTxs = !refTxsIds.length
@@ -379,7 +379,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
 
         if (params.push) {
             // validate backend
-            isBackendSupported(coinInfo);
+            assertBackendSupported(coinInfo);
             const blockchain = await initBlockchain(coinInfo, sendCoreMessage, params.identity);
             const txid = await blockchain.pushTransaction(response.serializedTx);
 

--- a/packages/connect/src/api/solana/api/solanaComposeTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaComposeTransaction.ts
@@ -5,7 +5,7 @@ import { SolanaComposeTransaction as SolanaComposeTransactionSchema } from '@tre
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { initBlockchain, isBackendSupported } from '../../../backend/BlockchainLink';
+import { assertBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import type { MethodContext, MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getCoinInfoOrThrow } from '../../../data/coinInfo';
@@ -26,7 +26,7 @@ export default class SolanaComposeTransaction extends AbstractMethod<
 
         const coinInfo = getCoinInfoOrThrow(payload.coin || 'sol');
         // validate backend
-        isBackendSupported(coinInfo);
+        assertBackendSupported(coinInfo);
 
         const params = { coinInfo, ...payload };
 

--- a/packages/connect/src/backend/BackendManager.ts
+++ b/packages/connect/src/backend/BackendManager.ts
@@ -1,6 +1,5 @@
 import { BLOCKCHAIN, createBlockchainMessage } from '@trezor/connect-common';
 import type { BlockchainLink, CoinInfo, Proxy } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 import type { TimerId } from '@trezor/type-utils';
 import { deepEqual } from '@trezor/utils';
 
@@ -80,9 +79,8 @@ export class BackendManager {
 
     isSupported(coinInfo: CoinInfo) {
         const info = this.custom[coinInfo.shortcut] || coinInfo.blockchainLink;
-        if (!info) {
-            throw ERRORS.TypedError('Backend_NotSupported');
-        }
+
+        return !!info;
     }
 
     setCustom(shortcut: CoinShortcut, blockchainLink?: BlockchainLink) {

--- a/packages/connect/src/backend/BlockchainLink.ts
+++ b/packages/connect/src/backend/BlockchainLink.ts
@@ -1,4 +1,5 @@
 import type { CoinInfo, Proxy } from '@trezor/connect-common';
+import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import { BackendManager } from './BackendManager';
 import type { BlockchainOptions as Options } from './Blockchain';
@@ -15,7 +16,11 @@ export const setCustomBackend = (coinInfo: CoinInfo, blockchainLink: CoinInfo['b
         blockchainLink?.url.length ? blockchainLink : coinInfo.blockchainLink,
     );
 
-export const isBackendSupported = (coinInfo: CoinInfo) => backends.isSupported(coinInfo);
+export const assertBackendSupported = (coinInfo: CoinInfo) => {
+    if (!backends.isSupported(coinInfo)) {
+        throw ERRORS.TypedError('Backend_NotSupported');
+    }
+};
 
 export const initBlockchain = (
     coinInfo: CoinInfo,


### PR DESCRIPTION
## Description

Small terminology follow-up to #29792 (merged), tidying the backend-support check into a predicate + assertion pair.

`#29792` split coin resolution into a plain getter plus a `getCoinInfoOrThrow` wrapper that keeps the throw explicit at each call site. The backend-support check had a similar shape but muddled ergonomics: `BackendManager.isSupported` returned nothing and threw `Backend_NotSupported` internally, and the exported `isBackendSupported` wrapper hid that control flow behind an `is…` name that reads like a boolean predicate.

This splits the two responsibilities cleanly:

- [`BackendManager.isSupported`](https://github.com/trezor/trezor-suite/blob/7e1e69df970/packages/connect/src/backend/BackendManager.ts#L80-L84) is now an honest boolean predicate — it returns `!!info` instead of throwing.
- The exported wrapper is renamed to [`assertBackendSupported`](https://github.com/trezor/trezor-suite/blob/7e1e69df970/packages/connect/src/backend/BlockchainLink.ts#L19-L23) and owns the `throw ERRORS.TypedError('Backend_NotSupported')`, so the throwing behavior is explicit at every call site.
- The now-unused `ERRORS` import is dropped from `BackendManager` and moved to `BlockchainLink`.

The `assert*` prefix (rather than `…OrThrow`) matches the function's shape: it returns `void` and exists purely to throw, like the existing `assertDeviceListConnected` / `assertReleaseVersion` in connect. Every `*OrThrow` in connect (`getCoinInfoOrThrow`, `getIndexOrThrow`) returns a value, so reusing that suffix here would have been misleading. Thanks @marekrjpolak for the naming nudge.

All 19 `api/**` call sites already used the wrapper purely as a throwing assertion (statement form, return value discarded), so they are a mechanical rename with no behavior change. `isSupported` had exactly one caller (the wrapper), so making it return a boolean is safe — and it is now also usable as a plain predicate where a caller only wants to know whether a backend exists, without a try/catch.

Rebased onto `develop` now that #29792 is merged; the diff stays limited to the backend-support rename.

## Notes for QA

No runtime behavior change — pure rename plus an equivalent-at-runtime relocation of the `Backend_NotSupported` throw from `BackendManager.isSupported` up into `assertBackendSupported`. Every method that gates on backend support (blockchain*, getAccountInfo, discoverAccounts, pushTransaction, composeTransaction, signTransaction, solanaComposeTransaction) throws the same error on the same input as before. No `suite` / `suite-common` / `suite-native` change is needed — the symbol is internal to `@trezor/connect`. No QA needed.

## Related

- Follow-up to #29792 (terminology unification: `getCoinInfoOrThrow`)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies 21 files in the @trezor/connect package, spanning blockchain API methods (subscribe, disconnect, fee estimation, transaction signing/pushing, account discovery), Solana transaction composition, and the core backend infrastructure (BackendManager, BlockchainLink). These are foundational components that underpin wallet discovery, transaction sending, staking, and trading across all supported blockchains. The highest risk areas are: (1) BackendManager/BlockchainLink changes that could break any blockchain connection, (2) signTransaction/composeTransaction/pushTransaction changes that affect all send flows, (3) solanaComposeTransaction changes affecting SOL-specific flows, and (4) discoverAccounts/getAccountInfo changes affecting wallet discovery. The recommended strategy prioritizes tests that directly exercise transaction composition, signing, and broadcasting across BTC/LTC/ETH/SOL, followed by discovery and backend connection tests, while avoiding the 90+ tests that only transitively depend on these broadly-shared modules.

<details><summary><b>Changed files (21)</b></summary>

- `packages/connect/src/api/blockchainDisconnect.ts`
- `packages/connect/src/api/blockchainEstimateFee.ts`
- `packages/connect/src/api/blockchainEvmRpcCall.ts`
- `packages/connect/src/api/blockchainGetAccountBalanceHistory.ts`
- `packages/connect/src/api/blockchainGetContractInfo.ts`
- `packages/connect/src/api/blockchainGetCurrentFiatRates.ts`
- `packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts`
- `packages/connect/src/api/blockchainGetInfo.ts`
- `packages/connect/src/api/blockchainGetTransactions.ts`
- `packages/connect/src/api/blockchainSubscribe.ts`
- `packages/connect/src/api/blockchainSubscribeFiatRates.ts`
- `packages/connect/src/api/blockchainUnsubscribe.ts`
- `packages/connect/src/api/blockchainUnsubscribeFiatRates.ts`
- `packages/connect/src/api/composeTransaction.ts`
- `packages/connect/src/api/discoverAccounts.ts`
- `packages/connect/src/api/getAccountInfo.ts`
- `packages/connect/src/api/pushTransaction.ts`
- `packages/connect/src/api/signTransaction.ts`
- `packages/connect/src/api/solana/api/solanaComposeTransaction.ts`
- `packages/connect/src/backend/BackendManager.ts`
- `packages/connect/src/backend/BlockchainLink.ts`

</details>

**Recommended tests (24)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — This test directly exercises the account discovery process across multiple coin networks (BTC, ETH, LTC, etc.), including page reload resilience. Changes to discoverAccounts.ts, BackendManager.ts, BlockchainLink.ts, blockchainSubscribe.ts, and getAccountInfo.ts are all core to the discovery pipeline this test validates.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test exercises Bitcoin transaction composition (composeTransaction.ts), signing (signTransaction.ts), and broadcasting (pushTransaction.ts) — three of the directly changed files. It covers multiple send scenarios including locktime, OP_RETURN, and unit switching.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test validates sending SOL with max amount calculation, fee handling, and device confirmation. It directly exercises solanaComposeTransaction.ts and blockchainGetInfo.ts (for Solana network info), both of which were changed.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test validates DOGE transaction composition and signing with an extremely large amount that triggers a sign error. It directly exercises composeTransaction.ts and signTransaction.ts, both changed in this PR.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Tests LTC send with MimbleWimble peg-out transaction using a custom blockbook backend. Directly exercises composeTransaction.ts, signTransaction.ts, and the backend infrastructure (BackendManager/BlockchainLink).
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test directly validates custom blockbook backend configuration, connection success/failure, and discovery with custom backends. Changes to BackendManager.ts and BlockchainLink.ts directly affect backend connection logic tested here.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends for BTC and LTC and verifies discovery completes successfully. It directly exercises BackendManager.ts (backend connection management) and BlockchainLink.ts (blockchain communication layer).
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Directly tests TrezorConnect.signTransaction API which maps to the changed signTransaction.ts file. Validates the multi-step device confirmation flow and error handling for invalid inputs.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Directly tests TrezorConnect.getAccountInfo API which maps to the changed getAccountInfo.ts file. Validates permissions modal, account type selection, and successful account info retrieval.

</details>

<details><summary>🟡 <b>Medium priority (12)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Tests the full ETH staking flow including transaction push (pushTransaction.ts), fee estimation (blockchainEstimateFee.ts), and EVM RPC calls. The staking flow relies on blockchain backend infrastructure that was changed.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test is the only one mapped to blockchainEvmRpcCall.ts, and also exercises pushTransaction.ts and blockchainEstimateFee.ts. The unstake+claim flow relies on EVM RPC calls for contract interaction.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Exercises SOL staking which uses solanaComposeTransaction.ts, pushTransaction.ts, and blockchainGetInfo.ts — all changed. Validates the full staking lifecycle from composition through broadcast.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Tests SOL→BTC swap including Solana transaction composition (solanaComposeTransaction.ts), broadcasting (pushTransaction.ts), and blockchain info retrieval (blockchainGetInfo.ts). Multiple changed files are directly in this flow.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Tests BTC sell flow which composes a Bitcoin transaction (composeTransaction.ts) and signs it (signTransaction.ts). Also exercises fee estimation via blockchainEstimateFee.ts.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests Bitcoin swap with custom fee settings, directly exercising composeTransaction.ts and signTransaction.ts. Validates fee rate calculation and display on device prompt.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests Solana sell flow using solanaComposeTransaction.ts, pushTransaction.ts, blockchainGetInfo.ts, and blockchainUnsubscribe.ts. Multiple changed files are directly in the critical path.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Tests DEX swap via LI.FI on Ethereum, exercising pushTransaction.ts for broadcast and blockchainEstimateFee.ts for gas estimation. The DEX flow is a distinct code path worth validating.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Tests wallet discovery after device ejection, exercising blockchainDisconnect.ts (only 2 tests map to this file) along with the general discovery pipeline. The disconnect API is a narrowly-scoped change worth testing.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Tests Ethereum send form with custom gas parameters. While it doesn't map to signTransaction directly, it exercises the ETH transaction flow which depends on blockchainEstimateFee.ts and the backend infrastructure.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation for BTC (using composeTransaction.ts for fee calculation and max amount) and SOL (using blockchainUnsubscribe.ts when switching accounts). Validates percentage buttons and custom fee interaction.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Tests Cardano staking flow that uses pushTransaction.ts for broadcast and getAccountInfo.ts for account data. Validates the full ADA staking lifecycle with device confirmation.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/wallet/without-device.test.ts` — Tests send flow behavior when device is disconnected, which exercises composeTransaction.ts for transaction preparation. The disconnection handling interacts with the backend infrastructure changes.
- `suite/e2e/tests/staking/staking-form.test.ts` — Tests ETH staking form validation (min/max amounts, percentage buttons, crypto/fiat switching). Uses blockchainEstimateFee.ts for fee estimation which was changed.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests Ethereum swap with custom gas parameters. Relies on blockchainEstimateFee.ts for fee calculation, which was changed.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/connect/src/api/blockchainGetContractInfo.ts`
- `packages/connect/src/api/blockchainGetTransactions.ts`
- `packages/connect/src/api/blockchainSubscribeFiatRates.ts`

_Updated: 2026-07-14T12:22:51.259Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/backend-supported-or-throw/web/](https://dev.suite.sldev.cz/suite-web/mroz22/backend-supported-or-throw/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/backend-supported-or-throw&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/backend-supported-or-throw&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-14T12:25:43.811Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-14T12:25:41.824Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->