### PR TITLE
fix(suite-native): keep yield review CTA visible after signing

### DIFF
--- a/suite-native/confirm-on-trezor/src/components/ConfirmOnTrezorContent.tsx
+++ b/suite-native/confirm-on-trezor/src/components/ConfirmOnTrezorContent.tsx
@@ -67,6 +67,7 @@ export type ConfirmOnTrezorWrapperProps = PropsWithChildren<{
     isManualControlEnabled?: boolean;
     defaultHeader?: React.ReactNode;
     isCloseButtonDisabled?: boolean;
+    shouldKeepScrolledToEnd?: boolean;
 }> &
     ScreenHeaderProps;
 
@@ -84,6 +85,7 @@ export const ConfirmOnTrezorContent = ({
     panGesture,
     children,
     defaultHeader,
+    shouldKeepScrolledToEnd,
 }: ConfirmOnTrezorContentProps) => {
     const { applyStyle, utils } = useNativeStyles();
     const colorVariant = useActiveColorScheme();
@@ -160,6 +162,7 @@ export const ConfirmOnTrezorContent = ({
                 <Screen
                     systemThemeStyle={!isFullscreen ? 'light' : undefined}
                     containerStyle={applyStyle(innerContainerStyle)}
+                    shouldKeepScrolledToEnd={shouldKeepScrolledToEnd}
                 >
                     {children}
                 </Screen>

--- a/suite-native/confirm-on-trezor/src/components/ConfirmOnTrezorWrapper.tsx
+++ b/suite-native/confirm-on-trezor/src/components/ConfirmOnTrezorWrapper.tsx
@@ -33,6 +33,7 @@ const ConfirmOnTrezor = ({
     controlRef,
     isManualControlEnabled = false,
     defaultHeader,
+    shouldKeepScrolledToEnd,
     ...headerProps
 }: ConfirmOnTrezorWrapperProps) => {
     const { applyStyle } = useNativeStyles();
@@ -93,6 +94,7 @@ const ConfirmOnTrezor = ({
                         snapPoints={snapPoints}
                         isFullscreen={isFullscreen}
                         defaultHeader={defaultHeader}
+                        shouldKeepScrolledToEnd={shouldKeepScrolledToEnd}
                     >
                         {children}
                     </ConfirmOnTrezorContent>

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2983,7 +2983,6 @@ export const messages = {
         },
         yieldDepositApprovalReviewScreen: {
             title: 'Review with Trezor',
-            successMessage: "You're all set",
             submitButton: 'Approve',
         },
         yieldDepositRevokeReviewScreen: {
@@ -2993,18 +2992,15 @@ export const messages = {
         },
         yieldDepositReviewScreen: {
             title: 'Review with Trezor',
-            successMessage: "You're all set",
             submitButton: 'Deposit',
         },
         yieldWithdrawReviewScreen: {
             title: 'Review with Trezor',
-            successMessage: "You're all set.",
             submitButton: 'Withdraw',
             redeemSubmitButton: 'Redeem',
         },
         yieldClaimReviewScreen: {
             title: 'Review with Trezor',
-            successMessage: "You're all set.",
             submitButton: 'Claim now',
         },
         yieldDepositCompleteScreen: {

--- a/suite-native/module-earn/src/components/EarnReviewSubmittedCard.tsx
+++ b/suite-native/module-earn/src/components/EarnReviewSubmittedCard.tsx
@@ -5,7 +5,7 @@ import { sendArrowsLottie } from '@suite-native/transaction-management';
 type EarnReviewSubmittedCardProps = {
     buttonTranslationId: TxKeyPath;
     isButtonLoading?: ButtonProps['isLoading'];
-    messageTranslationId: TxKeyPath;
+    messageTranslationId?: TxKeyPath;
     onButtonPress: ButtonProps['onPress'];
 };
 
@@ -24,9 +24,11 @@ export const EarnReviewSubmittedCard = ({
             spacing="sp24"
         >
             <LottieAnimation source={sendArrowsLottie} size="small" />
-            <Text variant="body-md-strong" textAlign="center">
-                <Translation id={messageTranslationId} />
-            </Text>
+            {messageTranslationId && (
+                <Text variant="body-md-strong" textAlign="center">
+                    <Translation id={messageTranslationId} />
+                </Text>
+            )}
         </VStack>
         <Button isLoading={isButtonLoading} onPress={onButtonPress}>
             <Translation id={buttonTranslationId} />

--- a/suite-native/module-earn/src/components/YieldClaimReviewContent.tsx
+++ b/suite-native/module-earn/src/components/YieldClaimReviewContent.tsx
@@ -58,7 +58,6 @@ export const YieldClaimReviewContent = ({
                     <EarnReviewSubmittedCard
                         buttonTranslationId="earn.yieldClaimReviewScreen.submitButton"
                         isButtonLoading={isSendingClaim}
-                        messageTranslationId="earn.yieldClaimReviewScreen.successMessage"
                         onButtonPress={handleClaimSubmitted}
                     />
                 ) : undefined

--- a/suite-native/module-earn/src/components/YieldDepositApprovalReviewContent.tsx
+++ b/suite-native/module-earn/src/components/YieldDepositApprovalReviewContent.tsx
@@ -50,7 +50,7 @@ export const YieldDepositApprovalReviewContent = ({
     const isRevokeReview = transactionType === 'revoke';
     const successMessageTranslationId = isRevokeReview
         ? 'earn.yieldDepositRevokeReviewScreen.successMessage'
-        : 'earn.yieldDepositApprovalReviewScreen.successMessage';
+        : undefined;
     const submitButtonTranslationId = isRevokeReview
         ? 'earn.yieldDepositRevokeReviewScreen.submitButton'
         : 'earn.yieldDepositApprovalReviewScreen.submitButton';

--- a/suite-native/module-earn/src/components/YieldDepositReviewContent.tsx
+++ b/suite-native/module-earn/src/components/YieldDepositReviewContent.tsx
@@ -62,7 +62,6 @@ export const YieldDepositReviewContent = ({
                     <EarnReviewSubmittedCard
                         buttonTranslationId="earn.yieldDepositReviewScreen.submitButton"
                         isButtonLoading={isSendingDeposit}
-                        messageTranslationId="earn.yieldDepositReviewScreen.successMessage"
                         onButtonPress={handleDepositSubmitted}
                     />
                 ) : undefined

--- a/suite-native/module-earn/src/components/YieldReviewScreenLayout.tsx
+++ b/suite-native/module-earn/src/components/YieldReviewScreenLayout.tsx
@@ -35,6 +35,7 @@ export const YieldReviewScreenLayout = ({
                 }
             />
         }
+        shouldKeepScrolledToEnd={!!submittedCard}
     >
         <VStack flex={1} justifyContent="space-between">
             {children}

--- a/suite-native/module-earn/src/components/YieldWithdrawReviewContent.tsx
+++ b/suite-native/module-earn/src/components/YieldWithdrawReviewContent.tsx
@@ -76,7 +76,6 @@ export const YieldWithdrawReviewContent = ({
                     <EarnReviewSubmittedCard
                         buttonTranslationId={submitButtonTranslationId}
                         isButtonLoading={isSendingWithdraw}
-                        messageTranslationId="earn.yieldWithdrawReviewScreen.successMessage"
                         onButtonPress={handleWithdrawSubmitted}
                     />
                 ) : undefined

--- a/suite-native/navigation/src/components/Screen.tsx
+++ b/suite-native/navigation/src/components/Screen.tsx
@@ -15,11 +15,11 @@ import { type Color } from '@trezor/theme';
 
 import { type DynamicScreenHeaderProps } from './DynamicHeader/DynamicScreenHeader';
 import { DynamicHeaderProvider } from './DynamicHeader/DynamicScreenHeaderContext';
+import { DynamicScrollableScreenContentHeader } from './DynamicHeader/DynamicScrollableScreenContentHeader';
+import { isScreenHeaderPropDynamic } from './DynamicHeader/dynamicHeaderUtils';
 import { ScreenContentWrapper } from './ScreenContentWrapper';
 import { useAndroidNavigationBarStyle } from '../hooks/useAndroidNavigationBarStyle';
 import { useIsKeyboardShown } from '../hooks/useIsKeyboardShown';
-import { DynamicScrollableScreenContentHeader } from './DynamicHeader/DynamicScrollableScreenContentHeader';
-import { isScreenHeaderPropDynamic } from './DynamicHeader/dynamicHeaderUtils';
 
 export type ScreenProps = {
     children: ReactNode;
@@ -34,6 +34,7 @@ export type ScreenProps = {
     hasBottomInset?: boolean;
     refreshControl?: ScrollViewProps['refreshControl'];
     containerStyle?: ViewProps['style'];
+    shouldKeepScrolledToEnd?: boolean;
 };
 
 const screenContainerStyle = prepareNativeStyle<{
@@ -93,6 +94,7 @@ export const Screen = ({
     noBottomPadding = false,
     focusedInputBottomOffset,
     hasBottomInset = true,
+    shouldKeepScrolledToEnd = false,
 }: ScreenProps) => {
     const {
         applyStyle,
@@ -146,6 +148,7 @@ export const Screen = ({
                     focusedInputBottomOffset={focusedInputBottomOffset}
                     refreshControl={refreshControl}
                     isDynamicHeader={isScreenHeaderPropDynamic(header)}
+                    shouldKeepScrolledToEnd={shouldKeepScrolledToEnd}
                 >
                     {shouldRenderDynamicScrollableHeader && (
                         <DynamicScrollableScreenContentHeader {...dynamicHeaderProps} />

--- a/suite-native/navigation/src/components/ScreenContentWrapper.tsx
+++ b/suite-native/navigation/src/components/ScreenContentWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode, useRef } from 'react';
+import React, { type ReactNode, useEffect, useRef } from 'react';
 import { type ScrollViewProps } from 'react-native';
 import {
     KeyboardAwareScrollView,
@@ -20,6 +20,7 @@ type ScreenContentProps = {
     focusedInputBottomOffset?: number;
     isDynamicHeader?: boolean;
     refreshControl?: ScrollViewProps['refreshControl'];
+    shouldKeepScrolledToEnd?: boolean;
 };
 
 const screenContentWrapperStyle = prepareNativeStyle(() => ({ flexGrow: 1 }));
@@ -31,12 +32,21 @@ export const ScreenContentWrapper = ({
     focusedInputBottomOffset,
     refreshControl,
     isDynamicHeader = false,
+    shouldKeepScrolledToEnd = false,
 }: ScreenContentProps) => {
     const scrollViewRef = useRef<KeyboardAwareScrollViewRef | null>(null);
     const { applyStyle } = useNativeStyles();
 
     const { scrollDivider, handleScroll } = useScrollDivider();
     const { handleDynamicHeaderScroll } = useDynamicHeader();
+
+    const scrollToEnd = () => scrollViewRef.current?.scrollToEnd({ animated: false });
+
+    useEffect(() => {
+        if (shouldKeepScrolledToEnd) {
+            scrollToEnd();
+        }
+    }, [shouldKeepScrolledToEnd]);
 
     const scrollHandler = (() => {
         if (hasHeader && isDynamicHeader) {
@@ -63,6 +73,9 @@ export const ScreenContentWrapper = ({
                 contentInsetAdjustmentBehavior="never"
                 contentContainerStyle={applyStyle(screenContentWrapperStyle)}
                 onScroll={scrollHandler}
+                // Keeps the end of the content visible even when its height settles in several
+                // layout passes (e.g. a review CTA appearing while output items collapse).
+                onContentSizeChange={shouldKeepScrolledToEnd ? scrollToEnd : undefined}
                 testID="@screen/mainScrollView"
             >
                 <ScrollViewContext.Provider value={scrollViewRef}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Keeps the yield review scroll pinned to the end after signing (new `Screen.shouldKeepScrolledToEnd` prop using `onContentSizeChange`), so the submit CTA is always visible. Also removes the misleading "You're all set" message from yield review flows.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29787

## Screenshots:


https://github.com/user-attachments/assets/658057c9-eda1-4112-83d0-d041c9aa3134


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/yield-review-cta-visibility&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->