### PR TITLE
test(e2e): expand guide tests

### DIFF
--- a/packages/suite/src/components/guide/GuideImage.tsx
+++ b/packages/suite/src/components/guide/GuideImage.tsx
@@ -55,17 +55,28 @@ export const GuideImage = ({ src, alt }: GuideImageProps) => {
 
     return (
         <>
-            <ThumbnailImage src={resolvedSrc} alt={alt} onClick={() => setIsOpen(true)} />
+            <ThumbnailImage
+                src={resolvedSrc}
+                alt={alt}
+                onClick={() => setIsOpen(true)}
+                data-testid="@guide/article/image"
+            />
             {isOpen &&
                 createPortal(
                     <Modal.Backdrop onClick={close} zIndex={zIndices.modalGuide}>
-                        <FullSizeImage src={resolvedSrc} alt={alt} onClick={close} />
+                        <FullSizeImage
+                            src={resolvedSrc}
+                            alt={alt}
+                            onClick={close}
+                            data-testid="@guide/article/image-modal"
+                        />
                         <CloseButtonWrapper>
                             <Button
                                 iconLeft={XIcon}
                                 intent="neutral"
                                 priority="secondary"
                                 onClick={close}
+                                data-testid="@guide/article/image-close"
                             >
                                 <Translation id="TR_CLOSE" />
                             </Button>

--- a/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
+++ b/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
@@ -264,6 +264,7 @@ export const SupportFeedbackSelection = () => {
                                         priority="secondary"
                                         as="div"
                                         maxWidth="100%"
+                                        data-testid="@guide/support/app-version"
                                     >
                                         <Translation
                                             id="TR_YOUR_CURRENT_VERSION"
@@ -286,6 +287,7 @@ export const SupportFeedbackSelection = () => {
                                         priority="secondary"
                                         as="div"
                                         maxWidth="100%"
+                                        data-testid="@guide/support/firmware-version"
                                     >
                                         {getFirmwareVersionLabel()}
                                     </Text>

--- a/suite/e2e/support/pageObjects/guidePanel.ts
+++ b/suite/e2e/support/pageObjects/guidePanel.ts
@@ -16,7 +16,7 @@ export class GuidePanel {
     readonly bugLocationDropdownInput: Locator;
     readonly bugLocationDropdownOption = (location: FeedbackCategory) =>
         this.page.getByTestId(`@guide/feedback/suggestion-dropdown/select/option/${location}`);
-    readonly bugInputTextField: Locator;
+    readonly inputTextField: Locator;
     readonly submitButton: Locator;
     readonly closeButton: Locator;
     readonly guidePanel: Locator;
@@ -29,6 +29,18 @@ export class GuidePanel {
     readonly guideNodes: Locator;
     readonly guideLabel: Locator;
     readonly searchNoResults: Locator;
+    readonly backButton: Locator;
+    readonly article: Locator;
+    readonly articleImage: Locator;
+    readonly articleImageModal: Locator;
+    readonly articleImageCloseButton: Locator;
+    readonly supportAppVersion: Locator;
+    readonly supportFirmwareVersion: Locator;
+    readonly category = (categoryId: string) =>
+        this.page.getByTestId(`@guide/category/${categoryId}`);
+    readonly node = (nodePath: string) => this.page.getByTestId(`@guide/node/${nodePath}`);
+    readonly feedbackRating = (rating: number) =>
+        this.page.getByTestId(`@guide/feedback/suggestion/${rating}`);
 
     constructor(private readonly page: Page) {
         this.guideButton = this.page.getByTestId('@guide/button-open');
@@ -39,7 +51,7 @@ export class GuidePanel {
         this.bugLocationDropdownInput = this.page.getByTestId(
             '@guide/feedback/suggestion-dropdown/select/input',
         );
-        this.bugInputTextField = this.page.getByTestId('@guide/feedback/suggestion-form');
+        this.inputTextField = this.page.getByTestId('@guide/feedback/suggestion-form');
         this.submitButton = this.page.getByTestId('@guide/feedback/submit-button');
         this.closeButton = this.page.getByTestId('@guide/button-close');
         this.guidePanel = this.page.getByTestId('@guide/panel');
@@ -50,6 +62,13 @@ export class GuidePanel {
         this.guideNodes = this.page.getByTestId('@guide/nodes');
         this.guideLabel = this.page.getByTestId('@guide/label');
         this.searchNoResults = this.page.getByTestId('@guide/search/no-results');
+        this.backButton = this.page.getByTestId('@guide/button-back');
+        this.article = this.page.getByTestId('@guide/article');
+        this.articleImage = this.page.getByTestId('@guide/article/image');
+        this.articleImageModal = this.page.getByTestId('@guide/article/image-modal');
+        this.articleImageCloseButton = this.page.getByTestId('@guide/article/image-close');
+        this.supportAppVersion = this.page.getByTestId('@guide/support/app-version');
+        this.supportFirmwareVersion = this.page.getByTestId('@guide/support/firmware-version');
     }
 
     @step()
@@ -71,7 +90,7 @@ export class GuidePanel {
         await this.selectBugLocation(args.location);
         // stability necessity
         await this.page.waitForTimeout(250);
-        await this.bugInputTextField.fill(args.report);
+        await this.inputTextField.fill(args.report);
         await this.submitButton.click();
     }
 
@@ -79,7 +98,7 @@ export class GuidePanel {
     async closeAllToastNotifications() {
         for (const toast of await this.toastNotifications.all()) {
             await toast.locator(anyTestIdEndingWithClose).click();
-            await toast.waitFor({ state: 'detached' });
+            await expect(toast).toBeHidden();
         }
     }
 
@@ -88,7 +107,7 @@ export class GuidePanel {
         //Toasts may obstruct Guide panel close button
         await this.closeAllToastNotifications();
         await this.closeButton.click();
-        await this.guidePanel.waitFor({ state: 'detached' });
+        await expect(this.guidePanel).toBeHidden();
     }
 
     @step()
@@ -96,5 +115,27 @@ export class GuidePanel {
         await this.searchInput.fill(article);
         await expect(this.searchResults).toBeVisible();
         await this.articleWithText(article).click();
+    }
+
+    @step()
+    async sendFeedback(args: { rating: number; report: string }) {
+        await this.feedbackFormButton.click();
+        await this.feedbackRating(args.rating).click();
+        await this.inputTextField.fill(args.report);
+        await this.submitButton.click();
+    }
+
+    @step()
+    async openArticleImageModal(locator: Locator) {
+        await expect(locator).toHaveJSProperty('complete', true);
+        await expect(locator).not.toHaveJSProperty('naturalWidth', 0);
+        await locator.click();
+        await expect(this.articleImageModal).toBeVisible();
+    }
+
+    @step()
+    async closeArticleImageModal() {
+        await this.articleImageCloseButton.click();
+        await expect(this.articleImageModal).toBeHidden();
     }
 }

--- a/suite/e2e/tests/general/suite-guide.test.ts
+++ b/suite/e2e/tests/general/suite-guide.test.ts
@@ -1,37 +1,113 @@
+import { Locator } from '@playwright/test';
+
 import { expect, test } from '../../support/fixtures';
+
+const APP_VERSION_REGEX = /^Current version \d+\.\d+\.\d+(-dev)?$/;
+const FIRMWARE_VERSION_REGEX = /^Current version \d+\.\d+\.\d+$/;
+const FIRMWARE_VERSION_NO_DEVICE = '-/-';
+
+// This can possibly break by a change of GITBOOK_REVISION in docs/features/guide.md
+const CATEGORY_WITH_IMAGE = '2_dashboard-and-coins';
+const ARTICLE_WITH_IMAGE = '2_dashboard-and-coins/5_show-public-key.md';
 
 test.describe('Suite Guide', { tag: ['@noDevice'] }, () => {
     test.use({ startEmulator: false });
 
-    /**
-     * Test case:
-     * 1. Go to Bug section in Suite Guide
-     * 2. Select Dashboard
-     * 3. Write into feedback field
-     * 4. Submit bug report (reporttext)
-     */
-    test('Send a bug report', async ({ guidePanel }) => {
+    test.beforeEach(async ({ guidePanel }) => {
         await guidePanel.openPanel();
+    });
+
+    test('Send a bug report', async ({ guidePanel }) => {
         await guidePanel.supportAndFeedbackButton.click();
+        await expect.soft(guidePanel.supportAppVersion).toHaveText(APP_VERSION_REGEX);
+        await expect.soft(guidePanel.supportFirmwareVersion).toHaveText(FIRMWARE_VERSION_NO_DEVICE);
         await guidePanel.sendBugReport({
             location: 'account',
             report: 'Henlo this is testy test writing hangry test user report',
         });
-        await expect(guidePanel.feedbackSuccessToast).toBeVisible();
+        await expect(guidePanel.feedbackSuccessToast).toHaveTranslation('TR_GUIDE_FEEDBACK_SENT');
         await guidePanel.closeGuide();
     });
 
-    /**
-     * Test case:
-     * 1. Go to Suggestion section in Suite Guide
-     * 2. Look up an article
-     * 3. Verify that the article is displayed
-     */
-    test('Look up an article', async ({ guidePanel }) => {
+    test('Send feedback', async ({ guidePanel }) => {
+        await guidePanel.supportAndFeedbackButton.click();
+        await guidePanel.sendFeedback({
+            rating: 5,
+            report: 'Henlo this is testy test writing happy feedback',
+        });
+        await expect(guidePanel.feedbackSuccessToast).toHaveTranslation('TR_GUIDE_FEEDBACK_SENT');
+        await guidePanel.closeGuide();
+    });
+
+    test('Open an article from search', async ({ guidePanel }) => {
         const article = 'Install firmware';
-        await guidePanel.openPanel();
         await guidePanel.lookupArticle(article);
         await expect(guidePanel.guideLabel).toHaveText(article);
+        await expect(guidePanel.article).not.toBeEmpty();
         await guidePanel.closeGuide();
+    });
+
+    test('Open an article and view its screenshot', async ({ guidePanel }) => {
+        await guidePanel.category(CATEGORY_WITH_IMAGE).click();
+
+        const node = guidePanel.node(ARTICLE_WITH_IMAGE);
+        const articleTitle = await node.innerText();
+        await node.click();
+
+        await expect(guidePanel.guideLabel).toHaveText(articleTitle);
+        await expect(guidePanel.article).not.toBeEmpty();
+
+        await guidePanel.openArticleImageModal(guidePanel.articleImage.first());
+        await guidePanel.closeArticleImageModal();
+
+        await guidePanel.closeGuide();
+    });
+});
+
+test.describe('Suite Guide with device', { tag: ['@T3W1'] }, () => {
+    test('Navigate the guide and verify versions with a device', async ({
+        guidePanel,
+        onboardingPage,
+        page,
+    }) => {
+        await onboardingPage.completeOnboarding();
+        await guidePanel.openPanel();
+
+        let category: Locator;
+        let node: Locator;
+        let categoryTitle: string;
+
+        await test.step('Navigate to a category', async () => {
+            category = guidePanel.category(CATEGORY_WITH_IMAGE);
+            categoryTitle = await category.innerText();
+            await category.click();
+            await expect(guidePanel.guideLabel).toHaveText(categoryTitle);
+        });
+
+        await test.step('Navigate to an article', async () => {
+            node = guidePanel.node(ARTICLE_WITH_IMAGE);
+            const articleTitle = await node.innerText();
+            await node.click();
+            await expect(guidePanel.guideLabel).toHaveText(articleTitle);
+            await expect(guidePanel.article).not.toBeEmpty();
+        });
+
+        await test.step('Navigate back to the home', async () => {
+            await guidePanel.backButton.click();
+            await expect(guidePanel.guideLabel).toHaveText(categoryTitle!);
+            await guidePanel.backButton.click();
+            await expect(guidePanel.category(CATEGORY_WITH_IMAGE)).toBeVisible();
+        });
+
+        await test.step('Verify versions with device connected', async () => {
+            await guidePanel.supportAndFeedbackButton.click();
+            await expect.soft(guidePanel.supportAppVersion).toHaveText(APP_VERSION_REGEX);
+            await expect.soft(guidePanel.supportFirmwareVersion).toHaveText(FIRMWARE_VERSION_REGEX);
+        });
+
+        await test.step('Close the guide with Escape key', async () => {
+            await page.keyboard.press('Escape');
+            await expect(guidePanel.guidePanel).toBeHidden();
+        });
     });
 });

--- a/suite/e2e/tests/suite/guide.test.ts
+++ b/suite/e2e/tests/suite/guide.test.ts
@@ -33,7 +33,7 @@ test.describe('Guide without device', { tag: ['@webOnly', '@noDevice'] }, () => 
             await guidePanel.supportAndFeedbackButton.click();
             await guidePanel.feedbackFormButton.click();
             await page.getByTestId('@guide/feedback/suggestion/5').click();
-            await guidePanel.bugInputTextField.fill('Hello!');
+            await guidePanel.inputTextField.fill('Hello!');
             await guidePanel.submitButton.click();
             await expect(guidePanel.feedbackSuccessToast).toBeVisible();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Expands test coverage of suite Guide panel.

### Pull request overview
Expands end-to-end coverage of the Suite “Guide” panel by adding new navigation, feedback, and media-modal assertions, and by exposing stable data-testid hooks in the Guide UI for version labels and article images.

Changes:

Extend Guide E2E coverage with new tests for feedback, article rendering, image modal behavior, navigation, and version labels (with/without device).
Enhance the Guide E2E page object with additional locators and helper methods to support the new flows.
Add data-testid attributes to Guide UI elements (support version labels and guide images) to make E2E selectors stable.


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/guide-tests/web/](https://dev.suite.sldev.cz/suite-web/guide-tests/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=guide-tests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=guide-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-14T11:13:14.629Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-14T11:12:53.257Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->