### PR TITLE
feat(suite): enhance OutlineHighlight with offset support and update SectionItem integration

### DIFF
--- a/packages/product-components/src/components/Settings/OutlineHighlight.tsx
+++ b/packages/product-components/src/components/Settings/OutlineHighlight.tsx
@@ -2,39 +2,64 @@ import { type ReactNode } from 'react';
 
 import styled from 'styled-components';
 
-import { borders, spacingsPx } from '@trezor/theme';
+import { type SpacingValuesNew, borders } from '@trezor/theme';
 
-const Wrapper = styled.div<{ $shouldHighlight?: boolean }>`
+export type Offset =
+    | {
+          top?: SpacingValuesNew;
+          bottom?: SpacingValuesNew;
+          left?: SpacingValuesNew;
+          right?: SpacingValuesNew;
+          horizontal?: SpacingValuesNew;
+          vertical?: SpacingValuesNew;
+      }
+    | SpacingValuesNew;
+
+const mapOffsetToInset = (offset: Offset) => {
+    if (typeof offset === 'object') {
+        const top = offset.top ?? offset.vertical ?? 0;
+        const right = offset.right ?? offset.horizontal ?? 0;
+        const bottom = offset.bottom ?? offset.vertical ?? 0;
+        const left = offset.left ?? offset.horizontal ?? 0;
+
+        return `${-top}px ${-right}px ${-bottom}px ${-left}px`;
+    }
+
+    return `-${offset}px`;
+};
+
+const Wrapper = styled.div<{ $shouldHighlight?: boolean; $offset: Offset }>`
     position: relative;
 
     &::before {
         content: '';
         position: absolute;
-        inset: -${spacingsPx.lg};
-        outline: solid ${borders.widths.large} ${({ theme }) => theme.elementFillWarningBold};
-        background: ${({ theme }) => theme.elementFillWarningSoft};
+        inset: ${({ $offset }) => mapOffsetToInset($offset)};
+        outline: solid ${borders.widths.large} ${({ theme }) => theme.elementBorderWarningSofter};
+        background: ${({ theme }) => theme.elementFillWarningSofter};
         transition: opacity 0.6s ease-in;
         transition-delay: 0.3s;
         opacity: 0;
-        z-index: 0;
         border-radius: ${borders.radii.md};
         outline-offset: -${borders.widths.large};
+        pointer-events: none;
 
         ${({ $shouldHighlight }) => $shouldHighlight && 'opacity: 1;'};
     }
 `;
 
-const Content = styled.div`
-    position: relative;
-`;
-
 type OutlineHighlightProps = {
     shouldHighlight?: boolean;
+    offset?: Offset;
     children: ReactNode;
 };
 
-export const OutlineHighlight = ({ shouldHighlight, children }: OutlineHighlightProps) => (
-    <Wrapper $shouldHighlight={shouldHighlight}>
-        <Content>{children}</Content>
+export const OutlineHighlight = ({
+    shouldHighlight,
+    offset = 0,
+    children,
+}: OutlineHighlightProps) => (
+    <Wrapper $shouldHighlight={shouldHighlight} $offset={offset}>
+        {children}
     </Wrapper>
 );

--- a/packages/product-components/src/components/Settings/SectionItem.tsx
+++ b/packages/product-components/src/components/Settings/SectionItem.tsx
@@ -1,4 +1,4 @@
-import { type HTMLAttributes, forwardRef } from 'react';
+import { type HTMLAttributes, type Ref } from 'react';
 
 import styled from 'styled-components';
 
@@ -17,16 +17,18 @@ const ResponsiveFlex = styled.div`
     }
 `;
 
-interface SectionItemProps extends HTMLAttributes<HTMLDivElement> {
+type SectionItemProps = HTMLAttributes<HTMLDivElement> & {
     shouldHighlight?: boolean;
-}
+    ref?: Ref<HTMLDivElement>;
+};
 
-export const SectionItem = forwardRef<HTMLDivElement, SectionItemProps>(
-    ({ children, shouldHighlight, ...rest }, ref) => (
-        <div ref={ref} {...rest}>
-            <OutlineHighlight shouldHighlight={shouldHighlight}>
-                <ResponsiveFlex>{children}</ResponsiveFlex>
-            </OutlineHighlight>
-        </div>
-    ),
+export const SectionItem = ({ children, shouldHighlight, ref, ...rest }: SectionItemProps) => (
+    <div ref={ref} {...rest}>
+        <OutlineHighlight
+            shouldHighlight={shouldHighlight}
+            offset={{ vertical: 16, horizontal: 20 }}
+        >
+            <ResponsiveFlex>{children}</ResponsiveFlex>
+        </OutlineHighlight>
+    </div>
 );

--- a/packages/product-components/src/index.ts
+++ b/packages/product-components/src/index.ts
@@ -43,7 +43,7 @@ export type { TransactionNotificationType } from './components/Notifications/not
 export { ActionButton } from './components/Settings/ActionButton';
 export { ActionColumn } from './components/Settings/ActionColumn';
 export { ActionSelect } from './components/Settings/ActionSelect';
-export { OutlineHighlight } from './components/Settings/OutlineHighlight';
+export { OutlineHighlight, type Offset } from './components/Settings/OutlineHighlight';
 export { SectionItem } from './components/Settings/SectionItem';
 export { SettingsRequirementBanner } from './components/Settings/SettingsRequirementBanner';
 export { SettingsSection } from './components/Settings/SettingsSection';

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingTable.tsx
@@ -10,9 +10,9 @@ import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 
 import { EarnStakingAccountRow } from './EarnStakingAccountRow';
 import { EarnStakingActivateRow } from './EarnStakingActivateRow';
+import { useStakingTableData } from './hooks/useStakingTableData';
 import { EarnProviderInfoBadge } from '../../providers/EarnProviderInfoBadge';
 import { EarnDashboardTableHeader } from '../common/EarnDashboardTableHeader';
-import { useStakingTableData } from './hooks/useStakingTableData';
 
 export const EarnStakingTable = () => {
     const { anchorRef, shouldHighlight } = useAnchor(EarnAnchor.Staking);

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -9,7 +9,6 @@ import { selectFlags } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { ContextMessage } from '@suite/message-system';
 import { openModal } from '@suite/modal';
-import { Anchor, SettingsAnchor } from '@suite/router';
 import { selectIsTestnetNetworksEnabled } from '@suite/settings';
 import { useServices } from '@suite-common/dependency-injection';
 import { Context } from '@suite-common/message-system';
@@ -24,7 +23,7 @@ import {
 import { Box, Button, Column, Switch, Text, Tooltip, motionEasing } from '@trezor/components';
 import { hasBitcoinOnlyFirmware, isBitcoinOnlyDevice } from '@trezor/device-utils';
 import { CoinIcon } from '@trezor/icons';
-import { OutlineHighlight, SectionItem, SettingsSection } from '@trezor/product-components';
+import { SettingsSection } from '@trezor/product-components';
 import { breakpoints } from '@trezor/theme';
 
 import { SettingsLayout } from 'src/components/settings/SettingsLayout';
@@ -204,105 +203,49 @@ export const SettingsCoins = () => {
                 icon={CoinIcon}
                 hasContainer={false}
             >
-                <Anchor anchorId={SettingsAnchor.Crypto}>
-                    {({ anchorId, anchorRef, shouldHighlight }) => (
-                        <SectionItem
-                            data-testid={anchorId}
-                            ref={anchorRef}
-                            shouldHighlight={shouldHighlight}
-                        >
-                            <Column gap={24} width="100%">
-                                <NetworkSettingsSearchInput
-                                    searchQuery={searchQuery}
-                                    onSearchChange={handleSearchChange}
-                                    onSearchClear={handleSearchClear}
-                                />
-                                {hasNoSearchResults ? (
-                                    <NoNetworkSearchResults />
-                                ) : (
-                                    <Column gap={32} width="100%">
-                                        {showSupportedMainnets &&
-                                            renderNetworkList(filteredSupportedMainnets)}
+                <Column gap={24} width="100%">
+                    <NetworkSettingsSearchInput
+                        searchQuery={searchQuery}
+                        onSearchChange={handleSearchChange}
+                        onSearchClear={handleSearchClear}
+                    />
+                    {hasNoSearchResults ? (
+                        <NoNetworkSearchResults />
+                    ) : (
+                        <Column gap={32} width="100%">
+                            {showSupportedMainnets && renderNetworkList(filteredSupportedMainnets)}
 
-                                        {showSupportedTestnetsSection && (
-                                            <Anchor anchorId={SettingsAnchor.TestnetCrypto}>
-                                                {({
-                                                    anchorId: testnetAnchorId,
-                                                    anchorRef: testnetAnchorRef,
-                                                    shouldHighlight: testnetShouldHighlight,
-                                                }) => (
-                                                    <OutlineHighlight
-                                                        shouldHighlight={testnetShouldHighlight}
-                                                    >
-                                                        <Box
-                                                            ref={testnetAnchorRef}
-                                                            data-testid={testnetAnchorId}
-                                                            width="100%"
-                                                        >
-                                                            <Column gap={12} width="100%">
-                                                                <Text typographyStyle="body-md">
-                                                                    <Translation id="TR_TESTNET_COINS" />
-                                                                </Text>
-                                                                {renderNetworkList(
-                                                                    filteredSupportedTestnets,
-                                                                )}
-                                                            </Column>
-                                                        </Box>
-                                                    </OutlineHighlight>
-                                                )}
-                                            </Anchor>
-                                        )}
+                            {showSupportedTestnetsSection && (
+                                <Column gap={12} width="100%">
+                                    <Text typographyStyle="body-md">
+                                        <Translation id="TR_TESTNET_COINS" />
+                                    </Text>
+                                    {renderNetworkList(filteredSupportedTestnets)}
+                                </Column>
+                            )}
 
-                                        {showUnsupportedSection && (
-                                            <Anchor anchorId={SettingsAnchor.UnsupportedCrypto}>
-                                                {({
-                                                    anchorId: unsupportedAnchorId,
-                                                    anchorRef: unsupportedAnchorRef,
-                                                    shouldHighlight: unsupportedShouldHighlight,
-                                                }) => (
-                                                    <OutlineHighlight
-                                                        shouldHighlight={unsupportedShouldHighlight}
-                                                    >
-                                                        <Box
-                                                            ref={unsupportedAnchorRef}
-                                                            data-testid={unsupportedAnchorId}
-                                                            width="100%"
-                                                        >
-                                                            <Column gap={12} width="100%">
-                                                                <Text typographyStyle="headline-sm">
-                                                                    <Translation id="TR_UNSUPPORTED_COINS" />
-                                                                </Text>
-                                                                <Column gap={24} width="100%">
-                                                                    {showUnsupportedMainnets &&
-                                                                        renderNetworkList(
-                                                                            filteredUnsupportedMainnets,
-                                                                        )}
-                                                                    {showUnsupportedTestnets && (
-                                                                        <Column
-                                                                            gap={12}
-                                                                            width="100%"
-                                                                        >
-                                                                            <Text typographyStyle="body-md">
-                                                                                <Translation id="TR_TESTNET_COINS" />
-                                                                            </Text>
-                                                                            {renderNetworkList(
-                                                                                filteredUnsupportedTestnets,
-                                                                            )}
-                                                                        </Column>
-                                                                    )}
-                                                                </Column>
-                                                            </Column>
-                                                        </Box>
-                                                    </OutlineHighlight>
-                                                )}
-                                            </Anchor>
+                            {showUnsupportedSection && (
+                                <Column gap={12} width="100%">
+                                    <Text typographyStyle="headline-sm">
+                                        <Translation id="TR_UNSUPPORTED_COINS" />
+                                    </Text>
+                                    <Column gap={24} width="100%">
+                                        {showUnsupportedMainnets &&
+                                            renderNetworkList(filteredUnsupportedMainnets)}
+                                        {showUnsupportedTestnets && (
+                                            <Column gap={12} width="100%">
+                                                <Text typographyStyle="body-md">
+                                                    <Translation id="TR_TESTNET_COINS" />
+                                                </Text>
+                                                {renderNetworkList(filteredUnsupportedTestnets)}
+                                            </Column>
                                         )}
                                     </Column>
-                                )}
-                            </Column>
-                        </SectionItem>
+                                </Column>
+                            )}
+                        </Column>
                     )}
-                </Anchor>
+                </Column>
             </SettingsSection>
 
             <Box position={{ type: 'fixed', bottom: 16 }}>


### PR DESCRIPTION
## Notes for QA
- fixes unnecessary horizontal scrolling in network settings and earn section

## Screenshots:

### Before
<img width="687" height="192" alt="image" src="https://github.com/user-attachments/assets/bdb658de-88dd-4a2d-8a74-0ca421b61f89" />

### After
<img width="642" height="201" alt="image" src="https://github.com/user-attachments/assets/15720655-dc68-4886-957b-030ce90ce88e" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies shared Settings UI components (SectionItem, OutlineHighlight) used across all settings pages, the SettingsCoins view for coin network configuration, and the EarnStakingTable dashboard component. The highest risk is in the SettingsCoins view and the Settings UI primitives, as they directly affect user-facing settings interactions. The staking table change has moderate risk for staking dashboard rendering. The recommended strategy focuses on settings-related tests that directly exercise the coins settings page and general settings UI, plus staking tests that validate the dashboard table component.

<details><summary><b>Changed files (5)</b></summary>

- `packages/product-components/src/components/Settings/OutlineHighlight.tsx`
- `packages/product-components/src/components/Settings/SectionItem.tsx`
- `packages/product-components/src/index.ts`
- `packages/suite/src/components/earn/dashboard/staking/EarnStakingTable.tsx`
- `packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — This test directly exercises the SettingsCoins view (SettingsCoins.tsx), navigating to the coins settings page, enabling/disabling networks, toggling testnets, and configuring custom backends. Changes to SettingsCoins.tsx could break coin network toggling and custom backend UI.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test directly interacts with the Coins settings tab to enable networks and configure custom blockbook backends. The SettingsCoins.tsx change could affect the network enable/disable toggles and backend configuration UI that this test validates.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — The general settings page uses SectionItem components for settings rows (fiat, theme, language, analytics toggle). Changes to SectionItem.tsx or OutlineHighlight.tsx could affect the layout or interactability of these settings controls.
- `suite/e2e/tests/settings/passphrase.test.ts` — The device settings page renders passphrase toggle using SectionItem. Changes to SectionItem.tsx could affect the passphrase switch rendering and interaction.
- `suite/e2e/tests/settings/safety-checks.test.ts` — Safety checks settings modal is rendered within the device settings page that uses SectionItem components. Changes to SectionItem or OutlineHighlight could affect the button rendering or modal trigger behavior.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — Device settings page uses SectionItem for settings rows (device name, rotation, firmware, wipe, homescreen). Changes to SectionItem.tsx could break these interactive settings elements.
- `suite/e2e/tests/analytics/staking-events.test.ts` — This test navigates to staking from the dashboard assets section, which involves the EarnStakingTable component. Changes to EarnStakingTable.tsx could affect the staking navigation entry point from the dashboard.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the ETH staking dashboard which uses EarnStakingTable for displaying staking state. Changes to EarnStakingTable.tsx could affect how staking amounts, buttons, and progress indicators are rendered.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — The stake-more flow shows the staking dashboard with staked/pending/rewards amounts rendered via EarnStakingTable. Changes could affect the dashboard display and stakeMore button visibility.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — The unstake test verifies the staking dashboard displays correct amounts and button states, which are rendered through EarnStakingTable. Changes could break the unstake/claim button rendering or amount displays.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL staking dashboard uses EarnStakingTable to display staking state (empty card, staked amounts). Changes could affect initial empty state or post-stake dashboard rendering.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom backends through the coins settings tab which renders using SettingsCoins.tsx. However, its primary assertions are about discovery completion and dashboard graph visibility, not settings UI itself.
- `suite/e2e/tests/settings/t1b1-device-settings.test.ts` — Device settings page for T1B1 uses SectionItem for PIN and homescreen settings rows. A regression in SectionItem rendering could affect the PIN switch interaction.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/product-components/src/index.ts`

_Updated: 2026-07-14T11:19:28.046Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/outline-highlight/web/](https://dev.suite.sldev.cz/suite-web/fix/outline-highlight/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/outline-highlight&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->