### PR TITLE
Mobile - Stablecoin Yield Fixes

### DIFF
--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -21,6 +21,7 @@ import {
 import {
     fetchTransactionsRates,
     groupTokensTransactionsByContractAddress,
+    isErc4626,
     isTestnet,
 } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
@@ -116,6 +117,56 @@ const fetchErc4626FiatRate = async ({
     return { rate: vaultRate, lastTickerTimestamp: underlyingAssetRate.lastTickerTimestamp };
 };
 
+interface FetchErc4626TransactionsRatesProps {
+    symbol: NetworkSymbol;
+    contract: TokenAddress;
+    timestamps: Timestamp[];
+    baseCurrencyCode: BaseCurrencyCode;
+    isElectrumBackend: boolean;
+    rates: TickerResult[];
+}
+
+const fetchErc4626TransactionsRates = async ({
+    symbol,
+    contract,
+    timestamps,
+    baseCurrencyCode,
+    isElectrumBackend,
+    rates,
+}: FetchErc4626TransactionsRatesProps) => {
+    try {
+        const erc4626 = await fetchErc4626Data({ coin: symbol, contract });
+
+        if (!erc4626.asset || !erc4626.convertToAssets1Share) return;
+
+        const underlyingRates: TickerResult[] = [];
+        await fetchTransactionsRates(
+            { symbol, tokenAddress: toTokenAddress(erc4626.asset.contract) },
+            timestamps,
+            baseCurrencyCode,
+            isElectrumBackend,
+            underlyingRates,
+        );
+
+        const exchangeRate = new BigNumber(erc4626.convertToAssets1Share).shiftedBy(
+            -erc4626.asset.decimals,
+        );
+
+        underlyingRates.forEach(({ localCurrency, rates: underlyingTokenRates }) => {
+            rates.push({
+                tickerId: { symbol, tokenAddress: contract },
+                localCurrency,
+                rates: underlyingTokenRates.map(({ rate, lastTickerTimestamp }) => ({
+                    rate: rate === undefined ? rate : exchangeRate.multipliedBy(rate).toNumber(),
+                    lastTickerTimestamp,
+                })),
+            });
+        });
+    } catch (error) {
+        console.error(error);
+    }
+};
+
 type UpdateTxsFiatRatesThunkPayload = {
     accountKey: AccountKey;
     txs: WalletAccountTransaction[];
@@ -149,6 +200,29 @@ export const updateTxsFiatRatesThunk = createThunk(
         const groupedTokensTxs = groupTokensTransactionsByContractAddress(txs);
 
         for (const token of typedObjectKeys(groupedTokensTxs)) {
+            // @ts-expect-error: indexing with noUncheckedIndexedAccess
+            const tokenTransactions: WalletAccountTransaction[] = groupedTokensTxs[token];
+            const tokenTimestamps = tokenTransactions
+                .map(tx => (tx.blockTime !== undefined ? asTimestamp(tx.blockTime) : undefined))
+                .filter(isNotUndefined);
+
+            const accountToken = account.tokens?.find(
+                accountTokenInfo => accountTokenInfo.contract === token,
+            );
+
+            if (accountToken && isErc4626(accountToken)) {
+                await fetchErc4626TransactionsRates({
+                    symbol: account.symbol,
+                    contract: toTokenAddress(token),
+                    timestamps: tokenTimestamps,
+                    baseCurrencyCode,
+                    isElectrumBackend,
+                    rates,
+                });
+
+                continue;
+            }
+
             const hasCoinDefinitions = getNetworkFeatures(account.symbol).includes(
                 'coin-definitions',
             );
@@ -164,12 +238,6 @@ export const updateTxsFiatRatesThunk = createThunk(
                     continue;
                 }
             }
-
-            // @ts-expect-error: indexing with noUncheckedIndexedAccess
-            const tokenTransactions: WalletAccountTransaction[] = groupedTokensTxs[token];
-            const tokenTimestamps = tokenTransactions
-                .map(tx => (tx.blockTime !== undefined ? asTimestamp(tx.blockTime) : undefined))
-                .filter(isNotUndefined);
 
             await fetchTransactionsRates(
                 {

--- a/suite-native/atoms/src/Card/TimelineDetailsCard.tsx
+++ b/suite-native/atoms/src/Card/TimelineDetailsCard.tsx
@@ -1,19 +1,22 @@
 import { type ReactNode } from 'react';
+import { Pressable } from 'react-native';
 
 import { Icon, type IconName } from '@suite-native/icons';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+import { type NativeStyle, prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { Box } from '../Box';
-import { Card } from './Card';
 import { OrderedListIcon } from '../OrderedListIcon';
 import { HStack, VStack } from '../Stack';
 import { Text } from '../Text';
+import { Card } from './Card';
 
 export type TimelineDetailsCardItem = {
     id: string;
     title: ReactNode;
     description?: ReactNode;
     icon?: ReactNode;
+    style?: NativeStyle<any>;
+    onPress?: () => void;
 };
 
 type TimelineDetailsCardProps = {
@@ -88,35 +91,43 @@ export const TimelineDetailsCard = ({
                 <Box style={applyStyle(separatorStyle)} />
                 <VStack spacing="sp16" padding="sp16">
                     {items.map((item, index) => (
-                        <HStack
-                            key={item.id}
-                            spacing="sp8"
-                            alignItems="flex-start"
-                            style={applyStyle(itemRowStyle)}
-                        >
+                        <Pressable key={item.id} onPress={item.onPress}>
                             <HStack
-                                spacing="sp12"
+                                spacing="sp8"
                                 alignItems="flex-start"
-                                style={applyStyle(itemTitleContainerStyle)}
+                                style={applyStyle(itemRowStyle)}
                             >
-                                {item.icon ??
-                                    renderItemIcon?.({ item, index }) ??
-                                    renderDefaultItemIcon(index)}
-                                <Text variant="body-sm-strong" style={applyStyle(itemTitleStyle)}>
-                                    {item.title}
-                                </Text>
-                            </HStack>
-                            {item.description && (
-                                <Text
-                                    variant="body-sm"
-                                    color="contentSecondary"
-                                    numberOfLines={1}
-                                    style={applyStyle(itemDescriptionStyle)}
+                                <HStack
+                                    spacing="sp12"
+                                    alignItems="flex-start"
+                                    style={applyStyle(itemTitleContainerStyle)}
                                 >
-                                    {item.description}
-                                </Text>
-                            )}
-                        </HStack>
+                                    {item.icon ??
+                                        renderItemIcon?.({ item, index }) ??
+                                        renderDefaultItemIcon(index)}
+                                    <Text
+                                        variant="body-sm-strong"
+                                        style={applyStyle(itemTitleStyle)}
+                                    >
+                                        {item.title}
+                                    </Text>
+                                </HStack>
+                                {item.description && (
+                                    <Text
+                                        variant="body-sm"
+                                        color="contentSecondary"
+                                        numberOfLines={1}
+                                        style={applyStyle(
+                                            item.style
+                                                ? [itemDescriptionStyle, item.style]
+                                                : itemDescriptionStyle,
+                                        )}
+                                    >
+                                        {item.description}
+                                    </Text>
+                                )}
+                            </HStack>
+                        </Pressable>
                     ))}
                 </VStack>
             </VStack>

--- a/suite-native/formatters/src/components/TokenToFiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/TokenToFiatAmountFormatter.tsx
@@ -4,11 +4,11 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { Box, type TextProps } from '@suite-native/atoms';
 
+import { useFiatFromCryptoValue } from '../hooks/useFiatFromCryptoValue';
 import { type FormatterProps } from '../types';
 import { AmountText } from './AmountText';
 import { EmptyAmountSkeleton } from './EmptyAmountSkeleton';
 import { SignValueFormatter } from './SignValueFormatter';
-import { useFiatFromCryptoValue } from '../hooks/useFiatFromCryptoValue';
 
 type TokenToFiatAmountFormatterProps = {
     symbol: NetworkSymbol;

--- a/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
+++ b/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
@@ -37,9 +37,10 @@ import {
 } from '@suite-native/navigation';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
-const abbrStyle = prepareNativeStyle(() => ({
+const abbrStyle = prepareNativeStyle(({ colors }) => ({
     borderStyle: 'dotted',
     borderBottomWidth: 1,
+    borderColor: colors.contentSecondary,
 }));
 
 type StablecoinYieldTokenOverviewProps = {

--- a/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
+++ b/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
@@ -10,7 +10,6 @@ import {
     toTokenSymbol,
 } from '@suite-common/wallet-types';
 import { isApyAvailable } from '@suite-common/wallet-utils';
-import { useAlert } from '@suite-native/alerts';
 import {
     Box,
     Button,
@@ -23,9 +22,9 @@ import {
 } from '@suite-native/atoms';
 import { TokenAmountFormatter } from '@suite-native/formatters';
 import { CryptoIconWithNetwork, Icon } from '@suite-native/icons';
-import { Translation, useTranslate } from '@suite-native/intl';
+import { Translation } from '@suite-native/intl';
 import {
-    StablecoinYieldApyBreakdown,
+    useApyBreakdownAlert,
     useResolvedYieldFlowData,
     useStablecoinYieldFirmwareUpdateAlert,
 } from '@suite-native/module-earn';
@@ -55,8 +54,6 @@ export const StablecoinYieldTokenOverview = ({
     tokenContract,
 }: StablecoinYieldTokenOverviewProps) => {
     const navigation = useNavigation<NavigationProps>();
-    const { showAlert } = useAlert();
-    const { translate } = useTranslate();
     const { applyStyle } = useNativeStyles();
     const { isFirmwareSupported, showFirmwareUpdateAlert } =
         useStablecoinYieldFirmwareUpdateAlert();
@@ -68,31 +65,7 @@ export const StablecoinYieldTokenOverview = ({
         });
     const apyValueText = apy && isApyAvailable(apy) ? `~${apy.toFixed(2)}%` : null;
 
-    const handleOpenApyAlert = useCallback(() => {
-        if (!account || !vault) {
-            return;
-        }
-
-        showAlert({
-            title: vault.outputToken?.name ?? '',
-            description: translate(
-                'moduleAccounts.accountDetail.stablecoinYield.apyBreakdown.apyLabel',
-                { apy: apyValueText },
-            ),
-            appendix: (
-                <StablecoinYieldApyBreakdown
-                    networkSymbol={account.symbol}
-                    rewards={vault.rewardRate.components}
-                    underlyingToken={vault.token}
-                    tokenSymbol={vault.token.symbol}
-                />
-            ),
-            textAlign: 'center',
-            titleSpacing: 'sp4',
-            primaryButtonTitle: translate('generic.buttons.close'),
-            testID: '@account-detail/stablecoin-yield/apy-breakdown-alert',
-        });
-    }, [account, apyValueText, showAlert, translate, vault]);
+    const apyBreakdownAlert = useApyBreakdownAlert({ account, vault, apy });
 
     const handleDepositMorePress = useCallback(() => {
         if (!vault?.token.address) {
@@ -176,7 +149,7 @@ export const StablecoinYieldTokenOverview = ({
                     </HStack>
                     <CardDivider />
                     <PressableOpacity
-                        onPress={handleOpenApyAlert}
+                        onPress={apyBreakdownAlert.onPress}
                         disabled={isApyRowDisabled}
                         testID="@account-detail/stablecoin-yield/apy-row"
                     >

--- a/suite-native/module-earn/src/components/YieldDepositInfoBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/YieldDepositInfoBottomSheet.tsx
@@ -1,9 +1,5 @@
-import { useCallback } from 'react';
-
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type Account } from '@suite-common/wallet-types';
-import { isApyAvailable } from '@suite-common/wallet-utils';
-import { useAlert } from '@suite-native/alerts';
 import {
     BottomSheetModal,
     type BottomSheetModalRef,
@@ -13,11 +9,11 @@ import {
     TimelineDetailsCard,
     VStack,
 } from '@suite-native/atoms';
-import { Translation, useTranslate } from '@suite-native/intl';
+import { Translation } from '@suite-native/intl';
 
+import { useApyBreakdownAlert } from '../hooks/useApyBreakdownAlert';
 import { HowEarnWorksBenefitsSection } from './HowEarnWorks/HowEarnWorksBenefitsSection';
 import { HowEarnWorksTimelineCard } from './HowEarnWorks/HowEarnWorksTimelineCard';
-import { StablecoinYieldApyBreakdown } from './StablecoinYieldApyBreakdown';
 import { createHowYieldWorksPreset } from '../presets/HowEarnWorks/yieldPresets';
 
 type YieldDepositInfoBottomSheetProps = {
@@ -41,40 +37,11 @@ export const YieldDepositInfoBottomSheet = ({
     account,
     vault,
 }: YieldDepositInfoBottomSheetProps) => {
-    const { showAlert } = useAlert();
-    const { translate } = useTranslate();
-
-    const apyValueText = apy && isApyAvailable(apy) ? `~${apy.toFixed(2)}%` : null;
-
-    const onApyPress = useCallback(() => {
-        if (!account || !vault) {
-            return;
-        }
-
-        showAlert({
-            title: vault.outputToken?.name ?? '',
-            description: translate(
-                'moduleAccounts.accountDetail.stablecoinYield.apyBreakdown.apyLabel',
-                { apy: apyValueText },
-            ),
-            appendix: (
-                <StablecoinYieldApyBreakdown
-                    networkSymbol={account.symbol}
-                    rewards={vault.rewardRate.components}
-                    underlyingToken={vault.token}
-                    tokenSymbol={vault.token.symbol}
-                />
-            ),
-            textAlign: 'center',
-            titleSpacing: 'sp4',
-            primaryButtonTitle: translate('generic.buttons.close'),
-            testID: '@account-detail/stablecoin-yield/apy-breakdown-alert',
-        });
-    }, [account, apyValueText, showAlert, translate, vault]);
+    const apyBreakdownAlert = useApyBreakdownAlert({ account, vault, apy });
 
     const { benefitItems, timelineSections } = createHowYieldWorksPreset({
         apy,
-        onApyPress,
+        onApyPress: apyBreakdownAlert.onPress,
         bonusRewardTokenName,
         tokenSymbol,
         vaultTokenSymbol,

--- a/suite-native/module-earn/src/components/YieldDepositInfoBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/YieldDepositInfoBottomSheet.tsx
@@ -1,3 +1,9 @@
+import { useCallback } from 'react';
+
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import { type Account } from '@suite-common/wallet-types';
+import { isApyAvailable } from '@suite-common/wallet-utils';
+import { useAlert } from '@suite-native/alerts';
 import {
     BottomSheetModal,
     type BottomSheetModalRef,
@@ -7,10 +13,11 @@ import {
     TimelineDetailsCard,
     VStack,
 } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
+import { Translation, useTranslate } from '@suite-native/intl';
 
 import { HowEarnWorksBenefitsSection } from './HowEarnWorks/HowEarnWorksBenefitsSection';
 import { HowEarnWorksTimelineCard } from './HowEarnWorks/HowEarnWorksTimelineCard';
+import { StablecoinYieldApyBreakdown } from './StablecoinYieldApyBreakdown';
 import { createHowYieldWorksPreset } from '../presets/HowEarnWorks/yieldPresets';
 
 type YieldDepositInfoBottomSheetProps = {
@@ -20,6 +27,8 @@ type YieldDepositInfoBottomSheetProps = {
     ref: BottomSheetModalRef;
     tokenSymbol: string;
     vaultTokenSymbol: string;
+    account: Account;
+    vault: YieldDtoV2;
 };
 
 export const YieldDepositInfoBottomSheet = ({
@@ -29,9 +38,43 @@ export const YieldDepositInfoBottomSheet = ({
     ref,
     tokenSymbol,
     vaultTokenSymbol,
+    account,
+    vault,
 }: YieldDepositInfoBottomSheetProps) => {
+    const { showAlert } = useAlert();
+    const { translate } = useTranslate();
+
+    const apyValueText = apy && isApyAvailable(apy) ? `~${apy.toFixed(2)}%` : null;
+
+    const onApyPress = useCallback(() => {
+        if (!account || !vault) {
+            return;
+        }
+
+        showAlert({
+            title: vault.outputToken?.name ?? '',
+            description: translate(
+                'moduleAccounts.accountDetail.stablecoinYield.apyBreakdown.apyLabel',
+                { apy: apyValueText },
+            ),
+            appendix: (
+                <StablecoinYieldApyBreakdown
+                    networkSymbol={account.symbol}
+                    rewards={vault.rewardRate.components}
+                    underlyingToken={vault.token}
+                    tokenSymbol={vault.token.symbol}
+                />
+            ),
+            textAlign: 'center',
+            titleSpacing: 'sp4',
+            primaryButtonTitle: translate('generic.buttons.close'),
+            testID: '@account-detail/stablecoin-yield/apy-breakdown-alert',
+        });
+    }, [account, apyValueText, showAlert, translate, vault]);
+
     const { benefitItems, timelineSections } = createHowYieldWorksPreset({
         apy,
+        onApyPress,
         bonusRewardTokenName,
         tokenSymbol,
         vaultTokenSymbol,

--- a/suite-native/module-earn/src/hooks/useApyBreakdownAlert.tsx
+++ b/suite-native/module-earn/src/hooks/useApyBreakdownAlert.tsx
@@ -1,0 +1,49 @@
+import { useCallback } from 'react';
+
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import { type Account } from '@suite-common/wallet-types';
+import { isApyAvailable } from '@suite-common/wallet-utils';
+import { useAlert } from '@suite-native/alerts';
+import { useTranslate } from '@suite-native/intl';
+
+import { StablecoinYieldApyBreakdown } from '../components/StablecoinYieldApyBreakdown';
+
+interface UseApyBreakdownAlertProps {
+    account?: Account | null;
+    vault?: YieldDtoV2 | null;
+    apy: number | null;
+}
+
+export const useApyBreakdownAlert = ({ account, vault, apy }: UseApyBreakdownAlertProps) => {
+    const { showAlert } = useAlert();
+    const { translate } = useTranslate();
+
+    const apyValue = apy && isApyAvailable(apy) ? `~${apy.toFixed(2)}%` : null;
+
+    const onPress = useCallback(() => {
+        if (!account || !vault) {
+            return;
+        }
+
+        showAlert({
+            title: vault.outputToken?.name ?? '',
+            description: translate(
+                'moduleAccounts.accountDetail.stablecoinYield.apyBreakdown.apyLabel',
+                { apy: apyValue },
+            ),
+            appendix: (
+                <StablecoinYieldApyBreakdown
+                    networkSymbol={account.symbol}
+                    rewards={vault.rewardRate.components}
+                    underlyingToken={vault.token}
+                    tokenSymbol={vault.token.symbol}
+                />
+            ),
+            textAlign: 'center',
+            titleSpacing: 'sp4',
+            primaryButtonTitle: translate('generic.buttons.close'),
+        });
+    }, [account, vault, showAlert, translate, apyValue]);
+
+    return { onPress };
+};

--- a/suite-native/module-earn/src/index.ts
+++ b/suite-native/module-earn/src/index.ts
@@ -1,5 +1,6 @@
 export { FiveBinariesHomeBanner } from './components/FiveBinariesHomeBanner';
 export { StablecoinYieldApyBreakdown } from './components/StablecoinYieldApyBreakdown';
+export { useApyBreakdownAlert } from './hooks/useApyBreakdownAlert';
 export { useResolvedYieldFlowData } from './hooks/useResolvedYieldFlowData';
 export { useStablecoinYieldFirmwareUpdateAlert } from './hooks/useStablecoinYieldFirmwareUpdateAlert';
 export { useStakingDetailNavigation } from './hooks/useStakingDetailNavigation';

--- a/suite-native/module-earn/src/presets/HowEarnWorks/yieldPresets.tsx
+++ b/suite-native/module-earn/src/presets/HowEarnWorks/yieldPresets.tsx
@@ -1,11 +1,19 @@
 import { Translation } from '@suite-native/intl';
+import { prepareNativeStyle } from '@trezor/styles-native';
 
 import { type HowEarnWorksScreenPreset } from './types';
+
+const abbrStyle = prepareNativeStyle(({ colors }) => ({
+    borderStyle: 'dotted',
+    borderBottomWidth: 1,
+    borderColor: colors.contentSecondary,
+}));
 
 type CreateHowYieldWorksPresetProps = {
     tokenSymbol: string;
     vaultTokenSymbol: string;
     apy: number | null;
+    onApyPress: () => void;
     bonusRewardTokenName?: string | null;
 };
 
@@ -13,6 +21,7 @@ export const createHowYieldWorksPreset = ({
     tokenSymbol,
     vaultTokenSymbol,
     apy,
+    onApyPress,
     bonusRewardTokenName,
 }: CreateHowYieldWorksPresetProps): HowEarnWorksScreenPreset => ({
     benefitItems: [
@@ -103,6 +112,8 @@ export const createHowYieldWorksPreset = ({
                         ) : (
                             <Translation id="earn.notAvailableShort" />
                         ),
+                    style: abbrStyle,
+                    onPress: onApyPress,
                 },
             ],
         },

--- a/suite-native/module-earn/src/screens/HowYieldWorksScreen.tsx
+++ b/suite-native/module-earn/src/screens/HowYieldWorksScreen.tsx
@@ -1,7 +1,11 @@
+import { useCallback } from 'react';
+
 import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 
+import { isApyAvailable } from '@suite-common/wallet-utils';
+import { useAlert } from '@suite-native/alerts';
 import { Button, TimelineDetailsCard, VStack } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
+import { Translation, useTranslate } from '@suite-native/intl';
 import {
     Screen,
     ScreenHeader,
@@ -13,6 +17,7 @@ import {
 import { HowEarnWorksBenefitsSection } from '../components/HowEarnWorks/HowEarnWorksBenefitsSection';
 import { HowEarnWorksHeaderSection } from '../components/HowEarnWorks/HowEarnWorksHeaderSection';
 import { HowEarnWorksTimelineCard } from '../components/HowEarnWorks/HowEarnWorksTimelineCard';
+import { StablecoinYieldApyBreakdown } from '../components/StablecoinYieldApyBreakdown';
 import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
 import { createHowYieldWorksPreset } from '../presets/HowEarnWorks/yieldPresets';
 
@@ -21,12 +26,49 @@ type NavigationProps = StackNavigationProps<YieldStackParamList, YieldStackRoute
 export const HowYieldWorksScreen = () => {
     const navigation = useNavigation<NavigationProps>();
     const route = useRoute<RouteProp<YieldStackParamList, YieldStackRoutes.HowYieldWorks>>();
-    const { apy, tokenSymbol, vaultTokenSymbol, bonusRewardTokenName, resolutionStatus } =
-        useResolvedYieldFlowData(route.params);
+    const { showAlert } = useAlert();
+    const { translate } = useTranslate();
+    const {
+        account,
+        apy,
+        vault,
+        tokenSymbol,
+        vaultTokenSymbol,
+        bonusRewardTokenName,
+        resolutionStatus,
+    } = useResolvedYieldFlowData(route.params);
+
+    const apyValueText = apy && isApyAvailable(apy) ? `~${apy.toFixed(2)}%` : null;
 
     const handleNavigateToYieldConsents = () => {
         navigation.navigate(YieldStackRoutes.YieldConsents, route.params);
     };
+
+    const onApyPress = useCallback(() => {
+        if (!account || !vault) {
+            return;
+        }
+
+        showAlert({
+            title: vault.outputToken?.name ?? '',
+            description: translate(
+                'moduleAccounts.accountDetail.stablecoinYield.apyBreakdown.apyLabel',
+                { apy: apyValueText },
+            ),
+            appendix: (
+                <StablecoinYieldApyBreakdown
+                    networkSymbol={account.symbol}
+                    rewards={vault.rewardRate.components}
+                    underlyingToken={vault.token}
+                    tokenSymbol={vault.token.symbol}
+                />
+            ),
+            textAlign: 'center',
+            titleSpacing: 'sp4',
+            primaryButtonTitle: translate('generic.buttons.close'),
+            testID: '@account-detail/stablecoin-yield/apy-breakdown-alert',
+        });
+    }, [account, apyValueText, showAlert, translate, vault]);
 
     if (resolutionStatus !== 'resolved') {
         return null;
@@ -36,6 +78,7 @@ export const HowYieldWorksScreen = () => {
         tokenSymbol,
         vaultTokenSymbol,
         apy,
+        onApyPress,
         bonusRewardTokenName,
     });
 

--- a/suite-native/module-earn/src/screens/HowYieldWorksScreen.tsx
+++ b/suite-native/module-earn/src/screens/HowYieldWorksScreen.tsx
@@ -1,11 +1,7 @@
-import { useCallback } from 'react';
-
 import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 
-import { isApyAvailable } from '@suite-common/wallet-utils';
-import { useAlert } from '@suite-native/alerts';
 import { Button, TimelineDetailsCard, VStack } from '@suite-native/atoms';
-import { Translation, useTranslate } from '@suite-native/intl';
+import { Translation } from '@suite-native/intl';
 import {
     Screen,
     ScreenHeader,
@@ -17,7 +13,7 @@ import {
 import { HowEarnWorksBenefitsSection } from '../components/HowEarnWorks/HowEarnWorksBenefitsSection';
 import { HowEarnWorksHeaderSection } from '../components/HowEarnWorks/HowEarnWorksHeaderSection';
 import { HowEarnWorksTimelineCard } from '../components/HowEarnWorks/HowEarnWorksTimelineCard';
-import { StablecoinYieldApyBreakdown } from '../components/StablecoinYieldApyBreakdown';
+import { useApyBreakdownAlert } from '../hooks/useApyBreakdownAlert';
 import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
 import { createHowYieldWorksPreset } from '../presets/HowEarnWorks/yieldPresets';
 
@@ -26,8 +22,6 @@ type NavigationProps = StackNavigationProps<YieldStackParamList, YieldStackRoute
 export const HowYieldWorksScreen = () => {
     const navigation = useNavigation<NavigationProps>();
     const route = useRoute<RouteProp<YieldStackParamList, YieldStackRoutes.HowYieldWorks>>();
-    const { showAlert } = useAlert();
-    const { translate } = useTranslate();
     const {
         account,
         apy,
@@ -38,37 +32,11 @@ export const HowYieldWorksScreen = () => {
         resolutionStatus,
     } = useResolvedYieldFlowData(route.params);
 
-    const apyValueText = apy && isApyAvailable(apy) ? `~${apy.toFixed(2)}%` : null;
+    const apyBreakdownAlert = useApyBreakdownAlert({ account, vault, apy });
 
     const handleNavigateToYieldConsents = () => {
         navigation.navigate(YieldStackRoutes.YieldConsents, route.params);
     };
-
-    const onApyPress = useCallback(() => {
-        if (!account || !vault) {
-            return;
-        }
-
-        showAlert({
-            title: vault.outputToken?.name ?? '',
-            description: translate(
-                'moduleAccounts.accountDetail.stablecoinYield.apyBreakdown.apyLabel',
-                { apy: apyValueText },
-            ),
-            appendix: (
-                <StablecoinYieldApyBreakdown
-                    networkSymbol={account.symbol}
-                    rewards={vault.rewardRate.components}
-                    underlyingToken={vault.token}
-                    tokenSymbol={vault.token.symbol}
-                />
-            ),
-            textAlign: 'center',
-            titleSpacing: 'sp4',
-            primaryButtonTitle: translate('generic.buttons.close'),
-            testID: '@account-detail/stablecoin-yield/apy-breakdown-alert',
-        });
-    }, [account, apyValueText, showAlert, translate, vault]);
 
     if (resolutionStatus !== 'resolved') {
         return null;
@@ -78,7 +46,7 @@ export const HowYieldWorksScreen = () => {
         tokenSymbol,
         vaultTokenSymbol,
         apy,
-        onApyPress,
+        onApyPress: apyBreakdownAlert.onPress,
         bonusRewardTokenName,
     });
 

--- a/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
@@ -350,6 +350,8 @@ export const YieldDepositApprovalScreen = () => {
                 onClose={handleCloseInfoBottomSheet}
                 tokenSymbol={tokenSymbol}
                 vaultTokenSymbol={vaultTokenSymbol}
+                account={account}
+                vault={resolvedFlowData.vault}
             />
             <YieldDepositApprovalLimitBottomSheet
                 ref={approvalLimitBottomSheetRef}

--- a/suite-native/module-earn/src/screens/YieldDepositCompleteScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositCompleteScreen.tsx
@@ -28,9 +28,10 @@ import { YieldCompleteScreenContent } from '../components/YieldCompleteScreenCon
 import { getYieldDepositCompleteRows } from '../components/YieldCompleteScreenPresets';
 import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
 
-const abbrStyle = prepareNativeStyle(() => ({
+const abbrStyle = prepareNativeStyle(({ colors }) => ({
     borderStyle: 'dotted',
     borderBottomWidth: 1,
+    borderColor: colors.contentSecondary,
 }));
 
 type RouteProps = RouteProp<YieldStackParamList, YieldStackRoutes.YieldDepositComplete>;

--- a/suite-native/module-earn/src/screens/YieldDepositCompleteScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositCompleteScreen.tsx
@@ -10,9 +10,8 @@ import {
     stablecoinYieldActions,
 } from '@suite-common/wallet-core';
 import { toTokenSymbol } from '@suite-common/wallet-types';
-import { useAlert } from '@suite-native/alerts';
 import { Text } from '@suite-native/atoms';
-import { Translation, useTranslate } from '@suite-native/intl';
+import { Translation } from '@suite-native/intl';
 import {
     type StackNavigationProps,
     type YieldStackParamList,
@@ -23,9 +22,9 @@ import {
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { ApyValue } from '../components/ApyValue';
-import { StablecoinYieldApyBreakdown } from '../components/StablecoinYieldApyBreakdown';
 import { YieldCompleteScreenContent } from '../components/YieldCompleteScreenContent';
 import { getYieldDepositCompleteRows } from '../components/YieldCompleteScreenPresets';
+import { useApyBreakdownAlert } from '../hooks/useApyBreakdownAlert';
 import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
 
 const abbrStyle = prepareNativeStyle(({ colors }) => ({
@@ -44,8 +43,6 @@ export const YieldDepositCompleteScreen = () => {
     const route = useRoute<RouteProps>();
     const navigation = useNavigation<NavigationProps>();
     const { applyStyle } = useNativeStyles();
-    const { showAlert } = useAlert();
-    const { translate } = useTranslate();
     const dispatch = useDispatch();
     const navigateToInitialScreen = useNavigateToInitialScreen();
     const { CryptoAmountFormatter } = useFormatters();
@@ -54,6 +51,8 @@ export const YieldDepositCompleteScreen = () => {
     const session = useSelector((state: StablecoinYieldRootState) =>
         selectStablecoinYieldSessionByFlowKey(state, 'deposit', flowKey),
     );
+
+    const apyBreakdownAlert = useApyBreakdownAlert({ account, vault, apy });
 
     const handleExit = useCallback(() => {
         if (flowKey) {
@@ -80,31 +79,6 @@ export const YieldDepositCompleteScreen = () => {
             navigation.replace(YieldStackRoutes.YieldDeposit, route.params);
         }
     }, [navigation, navigateToInitialScreen, resolutionStatus, route.params, session]);
-
-    const onApyPress = useCallback(() => {
-        if (!account || !vault) {
-            return;
-        }
-
-        showAlert({
-            title: vault.outputToken?.name ?? '',
-            description: translate(
-                'moduleAccounts.accountDetail.stablecoinYield.apyBreakdown.apyLabel',
-                { apy },
-            ),
-            appendix: (
-                <StablecoinYieldApyBreakdown
-                    networkSymbol={account.symbol}
-                    rewards={vault.rewardRate.components}
-                    underlyingToken={vault.token}
-                    tokenSymbol={vault.token.symbol}
-                />
-            ),
-            textAlign: 'center',
-            titleSpacing: 'sp4',
-            primaryButtonTitle: translate('generic.buttons.close'),
-        });
-    }, [account, vault, showAlert, translate, apy]);
 
     const rows = useMemo(() => {
         if (resolutionStatus !== 'resolved' || !session) {
@@ -133,7 +107,7 @@ export const YieldDepositCompleteScreen = () => {
                     <ApyValue apy={apy} />
                 </Text>
             ),
-            onApyPress,
+            onApyPress: apyBreakdownAlert.onPress,
             receivedAmount,
             receivedTokenContract: flowData.receiptToken.contractAddress ?? undefined,
             sentAmount,
@@ -142,7 +116,7 @@ export const YieldDepositCompleteScreen = () => {
     }, [
         CryptoAmountFormatter,
         applyStyle,
-        onApyPress,
+        apyBreakdownAlert.onPress,
         account,
         apy,
         flowData,

--- a/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
@@ -362,6 +362,8 @@ export const YieldDepositScreen = () => {
                 onClose={handleCloseInfoBottomSheet}
                 tokenSymbol={tokenSymbol}
                 vaultTokenSymbol={vaultTokenSymbol}
+                account={account}
+                vault={resolvedFlowData.vault}
             />
             {simulationPreparedAction && (
                 <YieldTxSimulationBottomSheet

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -103,6 +103,8 @@ export const YieldWithdrawScreen = () => {
         openModal: openPendingBottomSheet,
     } = useBottomSheetModal();
 
+    const resolvedYieldFlowData = useResolvedYieldFlowData(route.params);
+
     const {
         account,
         apy,
@@ -114,7 +116,7 @@ export const YieldWithdrawScreen = () => {
         vault,
         vaultTokenSymbol: resolvedVaultTokenSymbol,
         vaultTokenName,
-    } = useResolvedYieldFlowData(route.params);
+    } = resolvedYieldFlowData;
 
     const activeInputToken = flowData
         ? getYieldWithdrawInputToken({ flowData, flowType })
@@ -588,6 +590,8 @@ export const YieldWithdrawScreen = () => {
                 onClose={handleCloseInfoBottomSheet}
                 tokenSymbol={underlyingTokenSymbol}
                 vaultTokenSymbol={resolvedVaultTokenSymbol}
+                account={account}
+                vault={vault}
             />
         </Screen>
     );

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -103,8 +103,6 @@ export const YieldWithdrawScreen = () => {
         openModal: openPendingBottomSheet,
     } = useBottomSheetModal();
 
-    const resolvedYieldFlowData = useResolvedYieldFlowData(route.params);
-
     const {
         account,
         apy,
@@ -116,7 +114,7 @@ export const YieldWithdrawScreen = () => {
         vault,
         vaultTokenSymbol: resolvedVaultTokenSymbol,
         vaultTokenName,
-    } = resolvedYieldFlowData;
+    } = useResolvedYieldFlowData(route.params);
 
     const activeInputToken = flowData
         ? getYieldWithdrawInputToken({ flowData, flowType })


### PR DESCRIPTION
## Description

This PR fixes three things:
- `APY` underline color should reflect current app theme
- add `APY` underline and alert to `How Yield Works` screen
- fetch `ERC4626` fiat rates for transactions

## Related issue

Resolve https://github.com/trezor/trezor-suite/issues/29790
Resolve https://github.com/trezor/trezor-suite/issues/29791

## Screenshots:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-14 at 13 06 43" src="https://github.com/user-attachments/assets/66e9dfc9-00f4-415e-a796-5d74207a5adf" />

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-14 at 13 06 48" src="https://github.com/user-attachments/assets/36e17b3b-0105-49ba-8d2f-5ca3781d26d7" />

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-14 at 13 06 51" src="https://github.com/user-attachments/assets/9f6eef4e-471d-48a0-8638-c8c7c0cf5605" />

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-14 at 13 46 41" src="https://github.com/user-attachments/assets/58c36177-dac3-44a2-ac6b-71b2c08e3159" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set is predominantly focused on suite-native (mobile) earn/yield screens and components, which have zero E2E test coverage in the Playwright suite (all 12 native files are uncovered). The only web-relevant change is to fiatRatesThunks.ts, which is a broadly imported utility mapping to 131+ tests. Since fiatRatesThunks.ts is a global dependency, only tests that specifically exercise fiat rate display, currency switching, or crypto-to-fiat conversion logic warrant running. The overall risk to the web Suite is low, concentrated in fiat display correctness.

<details><summary><b>Changed files (13)</b></summary>

- `suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts`
- `suite-native/atoms/src/Card/TimelineDetailsCard.tsx`
- `suite-native/formatters/src/components/TokenToFiatAmountFormatter.tsx`
- `suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx`
- `suite-native/module-earn/src/components/YieldDepositInfoBottomSheet.tsx`
- `suite-native/module-earn/src/hooks/useApyBreakdownAlert.tsx`
- `suite-native/module-earn/src/index.ts`
- `suite-native/module-earn/src/presets/HowEarnWorks/yieldPresets.tsx`
- `suite-native/module-earn/src/screens/HowYieldWorksScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositCompleteScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx`

</details>

**Recommended tests (4)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test verifies fiat balance display ($0.00) on the dashboard, which directly depends on fiat rate fetching and formatting from fiatRatesThunks.ts. Changes to fiat rate thunks could affect how balances are displayed or cause missing fiat values.
- `suite/e2e/tests/settings/general.test.ts` — This test changes fiat currency (USD→EUR) and asserts the dashboard displays the correct fiat-denominated value (€0.00). The fiatRatesThunks.ts change could affect how fiat currency switching triggers rate re-fetching and display updates.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test exercises crypto/fiat input switching and fiat conversion in the staking form, which relies on fiat rates. Changes to fiatRatesThunks.ts could break the fiat amount calculation or display when switching between crypto and fiat input modes.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies coin balance display after receiving BTC, which involves fiat rate calculations for the balance display. Changes to fiatRatesThunks.ts could affect balance rendering or cause fiat conversion failures.

</details>

⚠️ **Changes with no test coverage (12)**
- `suite-native/atoms/src/Card/TimelineDetailsCard.tsx`
- `suite-native/formatters/src/components/TokenToFiatAmountFormatter.tsx`
- `suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx`
- `suite-native/module-earn/src/components/YieldDepositInfoBottomSheet.tsx`
- `suite-native/module-earn/src/hooks/useApyBreakdownAlert.tsx`
- `suite-native/module-earn/src/index.ts`
- `suite-native/module-earn/src/presets/HowEarnWorks/yieldPresets.tsx`
- `suite-native/module-earn/src/screens/HowYieldWorksScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositCompleteScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx`

_Updated: 2026-07-14T13:02:53.202Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/native/yield/web/](https://dev.suite.sldev.cz/suite-web/fix/native/yield/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/yield&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/yield&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/yield&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-14T13:05:50.066Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-14T13:05:28.877Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->