### PR TITLE
refactor(suite-common): reduce stablecoin yield type expansion

### DIFF
--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -190,11 +190,14 @@ const withSession = (
     updater(session);
 };
 
-export const stablecoinYieldSlice = createSlice({
+const stablecoinYieldSlice = createSlice({
     name: STABLECOIN_YIELD_PREFIX,
     initialState: initialStablecoinYieldState,
     reducers: {
-        initSession(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
+        initSession(
+            state: StablecoinYieldState,
+            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+        ) {
             const { flowType, flowKey } = action.payload;
 
             if (!isSafeObjectKey(flowKey)) {
@@ -207,7 +210,10 @@ export const stablecoinYieldSlice = createSlice({
                 state[flowType][sessionKey] = createInitialStablecoinYieldSessionState(flowType);
             }
         },
-        disposeSession(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
+        disposeSession(
+            state: StablecoinYieldState,
+            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+        ) {
             const { flowType, flowKey } = action.payload;
 
             if (!isSafeObjectKey(flowKey)) {
@@ -216,7 +222,10 @@ export const stablecoinYieldSlice = createSlice({
 
             delete state[flowType][getStablecoinYieldSessionKey(flowKey)];
         },
-        resetSession(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
+        resetSession(
+            state: StablecoinYieldState,
+            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+        ) {
             const { flowType, flowKey } = action.payload;
 
             if (!isSafeObjectKey(flowKey)) {
@@ -227,7 +236,7 @@ export const stablecoinYieldSlice = createSlice({
                 createInitialStablecoinYieldSessionState(flowType);
         },
         setError(
-            state,
+            state: StablecoinYieldState,
             action: PayloadAction<
                 StablecoinYieldSessionActionPayload & {
                     error: StablecoinYieldTranslationKey;
@@ -238,13 +247,16 @@ export const stablecoinYieldSlice = createSlice({
                 session.error = action.payload.error;
             });
         },
-        clearError(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
+        clearError(
+            state: StablecoinYieldState,
+            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+        ) {
             withSession(state, action.payload, session => {
                 session.error = null;
             });
         },
         openApprovalModal(
-            state,
+            state: StablecoinYieldState,
             action: PayloadAction<
                 StablecoinYieldSessionActionPayload & {
                     modalState: YieldApproveModalState;
@@ -255,18 +267,27 @@ export const stablecoinYieldSlice = createSlice({
                 session.approval.modalState = action.payload.modalState;
             });
         },
-        closeApprovalModal(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
+        closeApprovalModal(
+            state: StablecoinYieldState,
+            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+        ) {
             withSession(state, action.payload, session => {
                 session.approval.modalState = null;
                 session.error = null;
             });
         },
-        setRevokeRequired(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
+        setRevokeRequired(
+            state: StablecoinYieldState,
+            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+        ) {
             withSession(state, action.payload, session => {
                 session.approval.isRevokeRequired = true;
             });
         },
-        startSubmittingApproval(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
+        startSubmittingApproval(
+            state: StablecoinYieldState,
+            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+        ) {
             withSession(state, action.payload, session => {
                 session.approval.isSubmitting = true;
                 session.approval.modalState = null;
@@ -275,7 +296,7 @@ export const stablecoinYieldSlice = createSlice({
             });
         },
         finishSubmittingApproval(
-            state,
+            state: StablecoinYieldState,
             action: PayloadAction<StablecoinYieldSessionActionPayload>,
         ) {
             withSession(state, action.payload, session => {
@@ -283,7 +304,7 @@ export const stablecoinYieldSlice = createSlice({
             });
         },
         startInitializingAllowance(
-            state,
+            state: StablecoinYieldState,
             action: PayloadAction<StablecoinYieldSessionActionPayload>,
         ) {
             withSession(state, action.payload, session => {
@@ -291,7 +312,7 @@ export const stablecoinYieldSlice = createSlice({
             });
         },
         setInitializedAllowance(
-            state,
+            state: StablecoinYieldState,
             action: PayloadAction<StablecoinYieldSessionActionPayload & { amount: string }>,
         ) {
             withSession(state, action.payload, session => {
@@ -299,19 +320,25 @@ export const stablecoinYieldSlice = createSlice({
                 session.approval.allowanceStatus = 'loaded';
             });
         },
-        setAllowanceError(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
+        setAllowanceError(
+            state: StablecoinYieldState,
+            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+        ) {
             withSession(state, action.payload, session => {
                 session.approval.allowanceAmount = null;
                 session.approval.allowanceStatus = 'error';
             });
         },
-        invalidateAllowance(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
+        invalidateAllowance(
+            state: StablecoinYieldState,
+            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+        ) {
             withSession(state, action.payload, session => {
                 session.approval.allowanceStatus = 'idle';
             });
         },
         enterModifyMode(
-            state,
+            state: StablecoinYieldState,
             action: PayloadAction<StablecoinYieldSessionActionPayload & { amount?: string }>,
         ) {
             withSession(state, action.payload, session => {
@@ -326,7 +353,7 @@ export const stablecoinYieldSlice = createSlice({
             });
         },
         completeApproval(
-            state,
+            state: StablecoinYieldState,
             action: PayloadAction<
                 StablecoinYieldSessionActionPayload & {
                     amount: string;
@@ -343,12 +370,18 @@ export const stablecoinYieldSlice = createSlice({
                 session.step = getNextYieldFlowStep(action.payload.flowType, 'approve');
             });
         },
-        skipApprovalStep(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
+        skipApprovalStep(
+            state: StablecoinYieldState,
+            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+        ) {
             withSession(state, action.payload, session => {
                 session.step = getNextYieldFlowStep(action.payload.flowType, 'approve');
             });
         },
-        revokeSuccess(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
+        revokeSuccess(
+            state: StablecoinYieldState,
+            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+        ) {
             withSession(state, action.payload, session => {
                 session.approval.isModifyMode = false;
                 session.approval.allowanceAmount = '0';
@@ -358,7 +391,7 @@ export const stablecoinYieldSlice = createSlice({
             });
         },
         startSubmittingAction(
-            state,
+            state: StablecoinYieldState,
             action: PayloadAction<
                 StablecoinYieldSessionActionPayload & {
                     amount: string;
@@ -372,13 +405,16 @@ export const stablecoinYieldSlice = createSlice({
                 session.error = null;
             });
         },
-        finishSubmittingAction(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
+        finishSubmittingAction(
+            state: StablecoinYieldState,
+            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+        ) {
             withSession(state, action.payload, session => {
                 session.action.isSubmitting = false;
             });
         },
         storeActionReviewData(
-            state,
+            state: StablecoinYieldState,
             action: PayloadAction<StablecoinYieldStoreActionReviewDataPayload>,
         ) {
             withSession(state, action.payload, session => {
@@ -402,7 +438,7 @@ export const stablecoinYieldSlice = createSlice({
             });
         },
         setPendingTx(
-            state,
+            state: StablecoinYieldState,
             action: PayloadAction<
                 StablecoinYieldSessionActionPayload & {
                     tx: YieldPendingTransactionState;
@@ -417,7 +453,7 @@ export const stablecoinYieldSlice = createSlice({
             });
         },
         completeAction(
-            state,
+            state: StablecoinYieldState,
             action: PayloadAction<
                 StablecoinYieldSessionActionPayload & {
                     amount: string;
@@ -437,14 +473,17 @@ export const stablecoinYieldSlice = createSlice({
                 session.step = getNextYieldFlowStep(action.payload.flowType, 'action');
             });
         },
-        transactionFailed(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
+        transactionFailed(
+            state: StablecoinYieldState,
+            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+        ) {
             withSession(state, action.payload, session => {
                 session.action.pendingTransaction = null;
                 session.error = 'TR_EARN_YIELD_ERROR_TRANSACTION_FAILED';
             });
         },
         storePrecomposedTransaction(
-            state,
+            state: StablecoinYieldState,
             action: PayloadAction<
                 StablecoinYieldSessionActionPayload & {
                     precomposedTx: PrecomposedTransactionFinal;
@@ -464,12 +503,12 @@ export const stablecoinYieldSlice = createSlice({
             state.txReview.serializedTx = undefined;
         },
         storeSignedTransaction(
-            state,
+            state: StablecoinYieldState,
             action: PayloadAction<{ serializedTx: StablecoinYieldSerializedTx }>,
         ) {
             state.txReview.serializedTx = action.payload.serializedTx;
         },
-        discardTransaction(state) {
+        discardTransaction(state: StablecoinYieldState) {
             state.txReview.precomposedTx = undefined;
             state.txReview.precomposedForm = undefined;
             state.txReview.availableRewards = undefined;


### PR DESCRIPTION
## Description

18 KB source → 3.0 MB type declaration :scream:



Code improvement to reduce type-declarations to speedup the type-check

Nothing to manually test, only code improvement.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`, which is a Redux reducer for stablecoin yield functionality. It maps to 131 tests via static coverage, meaning it is a broadly imported global dependency (likely re-exported from the wallet-core barrel). None of the 131 analyzed E2E tests exercise stablecoin yield behavior — they cover analytics, backup, onboarding, metadata, staking (ETH/ADA/SOL), trading, settings, and general wallet operations. There is no E2E test whose behaviors, assertions, or source hints relate to stablecoin yield. Therefore, no E2E tests need to be run for this change; the risk of user-facing regression detectable by these tests is negligible.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`

_Updated: 2026-07-14T12:10:21.001Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ts-speedup/web/](https://dev.suite.sldev.cz/suite-web/ts-speedup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ts-speedup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ts-speedup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ts-speedup&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-14T12:13:36.132Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-14T12:13:24.860Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->