### PR TITLE
fix(suite-native): show asset balance in yield account picker

### DIFF
--- a/suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts
+++ b/suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts
@@ -25,6 +25,7 @@ import {
     type StablecoinYieldClaimSummariesState,
     useStablecoinYieldClaimSummaries,
 } from './useStablecoinYieldClaimSummaries';
+import { hasPositiveContractTokenBalance } from '../utils/contractTokenBalanceUtils';
 
 export const MORPHO_PROVIDER_LIST_ITEM = {
     id: 'morpho-provider',
@@ -107,16 +108,12 @@ export const useStablecoinYieldListData = () => {
                 : null;
             const outputTokenAddress = receiptTokenContract?.toLowerCase();
 
-            const accountsWithPosition = outputTokenAddress
-                ? accounts.filter(account => {
-                      if (account.symbol !== network.symbol) {
-                          return false;
-                      }
-
-                      return account.tokens?.some(
-                          token => token.contract.toLowerCase() === outputTokenAddress,
-                      );
-                  })
+            const accountsWithPosition = receiptTokenContract
+                ? accounts.filter(
+                      account =>
+                          account.symbol === network.symbol &&
+                          hasPositiveContractTokenBalance(account, receiptTokenContract),
+                  )
                 : [];
 
             const defaultYieldItem: StablecoinYieldEarnItem = {

--- a/suite-native/module-earn/src/hooks/useStablecoinYieldPromoNavigation.ts
+++ b/suite-native/module-earn/src/hooks/useStablecoinYieldPromoNavigation.ts
@@ -63,10 +63,6 @@ export const useStablecoinYieldPromoNavigation = (): UseStablecoinYieldPromoNavi
         ? {
               tokenContractAddress: chosenYieldItem.underlyingTokenContract,
               tokenSymbol: chosenYieldItem.tokenSymbol,
-              receiptTokenContract: chosenYieldItem.receiptTokenContract,
-              token: chosenYieldItem.token,
-              outputToken: chosenYieldItem.outputToken,
-              pricePerShareState: chosenYieldItem.pricePerShareState,
           }
         : undefined;
 

--- a/suite-native/module-earn/src/types.ts
+++ b/suite-native/module-earn/src/types.ts
@@ -75,18 +75,11 @@ export type StablecoinYieldNavigationItem = Pick<
 >;
 
 export type StablecoinYieldPromoNavigationItem = StablecoinYieldNavigationItem &
-    Pick<
-        StablecoinYieldEarnItem,
-        'networkSymbol' | 'tokenSymbol' | 'token' | 'outputToken' | 'pricePerShareState'
-    >;
+    Pick<StablecoinYieldEarnItem, 'networkSymbol' | 'tokenSymbol'>;
 
 export type ChooseAccountTokenBalance = {
     tokenContractAddress: TokenAddress;
     tokenSymbol: TokenSymbol;
-    receiptTokenContract?: TokenAddress | null;
-    token?: StablecoinYieldEarnItem['token'];
-    outputToken?: StablecoinYieldEarnItem['outputToken'];
-    pricePerShareState?: StablecoinYieldEarnItem['pricePerShareState'];
 };
 
 export type EarnPromoItem = StakingEarnItem | StablecoinYieldEarnItem;

--- a/suite-native/module-earn/src/utils/chooseAccountBalanceUtils.ts
+++ b/suite-native/module-earn/src/utils/chooseAccountBalanceUtils.ts
@@ -1,5 +1,4 @@
-import { getConvertedOutputTokenBalanceToInputTokenAmount } from '@suite-common/wallet-core';
-import { type Account } from '@suite-common/wallet-types';
+import { type Account, toTokenAddress } from '@suite-common/wallet-types';
 
 import { type ChooseAccountTokenBalance } from '../types';
 import { getAccountTokenByContract } from './contractTokenBalanceUtils';
@@ -28,30 +27,13 @@ export const getChooseAccountBalanceData = (
     }
 
     const token = getAccountTokenByContract(account, tokenBalance.tokenContractAddress);
-    const receiptToken = getAccountTokenByContract(
-        account,
-        tokenBalance.receiptTokenContract ?? null,
-    );
-
-    if (receiptToken && tokenBalance.token) {
-        return {
-            type: 'token',
-            value: getConvertedOutputTokenBalanceToInputTokenAmount({
-                networkSymbol: account.symbol,
-                token: tokenBalance.token,
-                outputToken: tokenBalance.outputToken,
-                outputTokenBalance: receiptToken.balance,
-                pricePerShareState: tokenBalance.pricePerShareState,
-            }),
-            tokenContractAddress: tokenBalance.tokenContractAddress,
-            tokenSymbol: tokenBalance.tokenSymbol,
-        };
-    }
 
     return {
         type: 'token',
         value: token?.balance ?? '0',
-        tokenContractAddress: tokenBalance.tokenContractAddress,
+        tokenContractAddress: token
+            ? toTokenAddress(token.contract)
+            : tokenBalance.tokenContractAddress,
         tokenSymbol: tokenBalance.tokenSymbol,
     };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Show the underlying asset balance instead of the vault position in the Start Yielding account picker, and use the account token's contract for the fiat rate lookup so the fiat value doesn't load forever.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #29788

## Screenshots:

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/14738443-8daa-4364-8c37-12f01390eb4c" />

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/8d892865-01b4-483d-adc2-a549e0e75af8" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/29788-yield-account-picker-asset-balance&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->