### PR TITLE
fix(suite): buttons in onboarding

### DIFF
--- a/packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInitialStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInitialStep.tsx
@@ -27,7 +27,6 @@ const InstallButton = ({ children, ...rest }: ButtonProps) => (
     <Tooltip
         cursor="default"
         isActive={rest.isDisabled}
-        maxWidth={200}
         placement="bottom"
         content={<Translation id="TR_INSTALL_FW_DISABLED_MULTIPLE_DEVICES" />}
     >


### PR DESCRIPTION
## Notes for QA

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to FirmwareInitialStep.tsx, which is the firmware step component shown during the onboarding flow. This file maps to 131 tests because virtually every test passes through onboarding, but most tests use `completeOnboarding` as a black-box prerequisite and don't specifically exercise the firmware step UI. The highest risk tests are those in the onboarding directory that explicitly interact with the firmware step (continueThroughFirmware, expectFirmwareToBeReady, firmware hash check dismissal). Tests outside the onboarding flow that merely call `completeOnboarding` as setup are omitted since a regression in the firmware step would be caught by the targeted onboarding tests.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInitialStep.tsx`

</details>

**Recommended tests (15)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test directly exercises the firmware step during onboarding, which is the exact component changed (FirmwareInitialStep.tsx). It verifies firmware readiness detection after passing through the analytics step.
- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — This test navigates through the firmware setup step (onboardingPage.firmware) during onboarding wallet creation on T2T1, directly exercising the FirmwareInitialStep component.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — This test navigates through the firmware step (onboardingPage.firmware.continueThroughFirmware) during T3T1 wallet creation, directly exercising the changed FirmwareInitialStep component.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — This test passes through the firmware continuation step during T3W1 onboarding, directly exercising the FirmwareInitialStep component as part of the create wallet flow.
- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` — This test goes through the firmware step during T1B1 wallet creation onboarding, directly exercising the changed FirmwareInitialStep component.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts` — This test passes through the firmware step during T1B1 recovery onboarding, directly exercising the FirmwareInitialStep component before proceeding to recovery.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — This test navigates through the firmware step during T2T1 recovery, directly exercising the changed FirmwareInitialStep component.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test passes through the firmware continuation step during onboarding before testing entropy check failures, exercising the FirmwareInitialStep as part of its flow.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts` — This test navigates through the firmware step during T1B1 advanced recovery onboarding, exercising the FirmwareInitialStep component.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts` — This test passes through the firmware check step before testing recovery failure scenarios on T1B1, exercising the FirmwareInitialStep.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts` — This test passes through the firmware continuation step during T2T1 recovery before testing device disconnection, exercising the FirmwareInitialStep.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — This test validates recovery persistence through reload and reconnect scenarios, passing through the firmware step as part of the onboarding flow.
- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — This test disables firmware hash check and passes through the firmware step during onboarding before the authenticity check, exercising the FirmwareInitialStep component.
- `suite/e2e/tests/suite/initial-run.test.ts` — This test validates the initial run/onboarding persistence flow including firmware hash check error dismissal, which is part of the FirmwareInitialStep component's behavior.
- `suite/e2e/tests/settings/autodetect.test.ts` — This test starts from onboarding and optionally dismisses the firmware hash check error before proceeding to the analytics section, directly interacting with FirmwareInitialStep behavior.

</details>

_Updated: 2026-07-14T12:26:53.072Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/onboarding-buttons/web/](https://dev.suite.sldev.cz/suite-web/fix/onboarding-buttons/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/onboarding-buttons&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/onboarding-buttons&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-14T12:30:04.229Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-14T12:29:48.430Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->