### PR TITLE
chore(requirements): check declaration output sizes

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -61,6 +61,8 @@ jobs:
         uses: ./.github/actions/minimal-yarn-install
       - name: Type Check
         run: yarn type-check --output-style=stream
+      - name: Check Type Declaration Sizes
+        run: yarn requirements:verify --only=type-declaration-size
 
   lint:
     name: Linting and formatting

--- a/packages/requirements/README.md
+++ b/packages/requirements/README.md
@@ -25,4 +25,8 @@ yarn workspace @trezor/requirements requirements:verify --only=package-json
 
 # Limit to affected workspaces containing the given text
 yarn workspace @trezor/requirements requirements:verify --filter=@trezor/connect
+
+# Report oversized declarations after checking every TypeScript workspace
+yarn type-check:all --no-tui
+yarn workspace @trezor/requirements requirements:verify --only=type-declaration-size
 ```

--- a/packages/requirements/src/__tests__/runRequirements.test.ts
+++ b/packages/requirements/src/__tests__/runRequirements.test.ts
@@ -176,6 +176,30 @@ describe('runRequirements', () => {
     });
 
     describe('filtering', () => {
+        it('skips requirements that do not run by default', async () => {
+            const results = await runRequirements({
+                requirements: [
+                    createRepoRequirement({ name: 'default' }),
+                    createRepoRequirement({ name: 'opt-in', runByDefault: false }),
+                ],
+                repoRoot: '/repo',
+                mode: 'verify',
+            });
+
+            expect(results.map(result => result.requirement)).toEqual(['default']);
+        });
+
+        it('runs an opt-in requirement when selected by name', async () => {
+            const results = await runRequirements({
+                requirements: [createRepoRequirement({ name: 'opt-in', runByDefault: false })],
+                repoRoot: '/repo',
+                filter: 'opt-in',
+                mode: 'verify',
+            });
+
+            expect(results.map(result => result.requirement)).toEqual(['opt-in']);
+        });
+
         it('runs only the requirement matching the filter', async () => {
             const results = await runRequirements({
                 requirements: [

--- a/packages/requirements/src/requirements/Requirement.ts
+++ b/packages/requirements/src/requirements/Requirement.ts
@@ -16,7 +16,21 @@ export type RequirementContext = RepoContext | WorkspaceContext;
 
 export type Requirement<T extends RequirementScope> = {
     readonly name: string;
+
+    /**
+     * Controls whether the requirement runs once for the repository
+     * or for each affected workspace.
+     **/
     readonly scope: T;
+
+    /**
+     * Controls whether the requirement runs without an explicit
+     * `--only` selection. Defaults to `true`.
+     *
+     * Useful for cases when the requirements needs to be run at some
+     * specific point int the CI (for example after type-check).
+     **/
+    readonly runByDefault?: boolean;
 
     readonly applies?: (context: WorkspaceContext) => boolean;
 

--- a/packages/requirements/src/requirements/allRequirements.ts
+++ b/packages/requirements/src/requirements/allRequirements.ts
@@ -7,6 +7,7 @@ import { requireForbiddenDeps } from './forbidden-deps/requireForbiddenDeps';
 import { requirePackageJsonScripts } from './package-json/requirePackageJsonScripts';
 import { requirePublishConfig } from './package-json/requirePublishConfig';
 import { requireConnectPublicDependencies } from './public-package-dependencies/requireConnectPublicDependencies';
+import { requireTypeDeclarationSize } from './type-declarations/requireTypeDeclarationSize';
 
 export const requirements: ReadonlyArray<Requirement<RequirementScope>> = [
     requireAgentsSkills,
@@ -17,4 +18,5 @@ export const requirements: ReadonlyArray<Requirement<RequirementScope>> = [
     requireForbiddenDeps,
     requirePackageJsonScripts,
     requirePublishConfig,
+    requireTypeDeclarationSize,
 ];

--- a/packages/requirements/src/requirements/type-declarations/__tests__/requireTypeDeclarationSize.test.ts
+++ b/packages/requirements/src/requirements/type-declarations/__tests__/requireTypeDeclarationSize.test.ts
@@ -1,0 +1,160 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { listAllWorkspaces } from '../../../workspaces';
+import type { RepoContext } from '../../Requirement';
+import {
+    MAX_DECLARATION_SIZE_BYTES,
+    requireTypeDeclarationSize,
+} from '../requireTypeDeclarationSize';
+
+jest.mock('../../../workspaces');
+
+const mockListAllWorkspaces = jest.mocked(listAllWorkspaces);
+
+describe(requireTypeDeclarationSize.name, () => {
+    let repoRoot: string;
+    let libDevDirectory: string;
+    let context: RepoContext;
+
+    beforeEach(() => {
+        repoRoot = mkdtempSync(join(tmpdir(), 'type-declarations-'));
+        libDevDirectory = join(repoRoot, 'packages', 'example', 'libDev');
+        context = { repoRoot };
+
+        mkdirSync(join(libDevDirectory, 'src'), { recursive: true });
+        mockListAllWorkspaces.mockReturnValue([
+            {
+                dir: join(repoRoot, 'packages', 'example'),
+                name: '@trezor/example',
+            },
+        ]);
+    });
+
+    afterEach(() => {
+        rmSync(repoRoot, { recursive: true, force: true });
+    });
+
+    it('passes when emitted declarations are within the size limit', async () => {
+        writeFileSync(
+            join(libDevDirectory, 'src', 'small.d.ts'),
+            'export declare const small = 1;',
+        );
+
+        const errors = await requireTypeDeclarationSize.verify(context);
+
+        expect(errors).toEqual([]);
+    });
+
+    it('reports emitted declarations that exceed the size limit', async () => {
+        writeFileSync(
+            join(libDevDirectory, 'src', 'large.d.ts'),
+            `export declare const large: "${'x'.repeat(MAX_DECLARATION_SIZE_BYTES)}";`,
+        );
+
+        const errors = await requireTypeDeclarationSize.verify(context);
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toMatch(
+            /^packages\/example\/libDev\/src\/large\.d\.ts is \d+(?:\.\d+)? KiB; maximum is 100 KiB\.$/,
+        );
+    });
+
+    it('scans declaration outputs recursively', async () => {
+        const nestedDirectory = join(libDevDirectory, 'src', 'nested');
+        mkdirSync(nestedDirectory);
+        writeFileSync(
+            join(nestedDirectory, 'large.d.mts'),
+            'x'.repeat(MAX_DECLARATION_SIZE_BYTES + 1),
+        );
+
+        const errors = await requireTypeDeclarationSize.verify(context);
+
+        expect(errors[0]).toContain('packages/example/libDev/src/nested/large.d.mts');
+    });
+
+    it('allows known oversized declarations up to their legacy limit', async () => {
+        const knownWorkspaceDirectory = join(repoRoot, 'packages', 'icons');
+        const knownDeclarationDirectory = join(
+            knownWorkspaceDirectory,
+            'libDev',
+            'src',
+            'generated',
+            'icons',
+        );
+        mkdirSync(knownDeclarationDirectory, { recursive: true });
+        writeFileSync(join(knownDeclarationDirectory, 'index.d.ts'), 'x'.repeat(180 * 1024));
+        mockListAllWorkspaces.mockReturnValue([
+            { dir: knownWorkspaceDirectory, name: '@trezor/icons' },
+        ]);
+
+        const errors = await requireTypeDeclarationSize.verify(context);
+
+        expect(errors).toEqual([]);
+    });
+
+    it('reports legacy limits that can be removed', async () => {
+        const knownWorkspaceDirectory = join(repoRoot, 'packages', 'icons');
+        const knownDeclarationDirectory = join(
+            knownWorkspaceDirectory,
+            'libDev',
+            'src',
+            'generated',
+            'icons',
+        );
+        mkdirSync(knownDeclarationDirectory, { recursive: true });
+        writeFileSync(join(knownDeclarationDirectory, 'index.d.ts'), 'x'.repeat(90 * 1024));
+        mockListAllWorkspaces.mockReturnValue([
+            { dir: knownWorkspaceDirectory, name: '@trezor/icons' },
+        ]);
+
+        const errors = await requireTypeDeclarationSize.verify(context);
+
+        expect(errors).toEqual([
+            'packages/icons/libDev/src/generated/icons/index.d.ts is now 90 KiB; remove its legacy declaration-size limit.',
+        ]);
+    });
+
+    it('reports legacy limits for declarations missing from built workspaces', async () => {
+        const knownWorkspaceDirectory = join(repoRoot, 'packages', 'icons');
+        mkdirSync(join(knownWorkspaceDirectory, 'libDev'), { recursive: true });
+        mockListAllWorkspaces.mockReturnValue([
+            { dir: knownWorkspaceDirectory, name: '@trezor/icons' },
+        ]);
+
+        const errors = await requireTypeDeclarationSize.verify(context);
+
+        expect(errors).toEqual([
+            'packages/icons/libDev/src/generated/icons/index.d.ts no longer exists; remove or update its legacy declaration-size limit.',
+        ]);
+    });
+
+    it('does not validate legacy limits for workspaces without declaration output', async () => {
+        const knownWorkspaceDirectory = join(repoRoot, 'suite-native', 'intl');
+        mkdirSync(knownWorkspaceDirectory, { recursive: true });
+        mockListAllWorkspaces.mockReturnValue([
+            { dir: knownWorkspaceDirectory, name: '@suite-native/intl' },
+        ]);
+
+        const errors = await requireTypeDeclarationSize.verify(context);
+
+        expect(errors).toEqual([]);
+    });
+
+    it('ignores workspaces without declaration output', async () => {
+        rmSync(libDevDirectory, { recursive: true, force: true });
+
+        const errors = await requireTypeDeclarationSize.verify(context);
+
+        expect(errors).toEqual([]);
+    });
+
+    it('has repo scope', () => {
+        expect(requireTypeDeclarationSize.scope).toBe('repo');
+    });
+
+    it('only runs when selected explicitly', () => {
+        expect(requireTypeDeclarationSize.runByDefault).toBe(false);
+    });
+});

--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -1,0 +1,131 @@
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+import { listAllWorkspaces } from '../../workspaces';
+import type { Requirement } from '../Requirement';
+
+const kibToBytes = (sizeKib: number) => sizeKib * 1024;
+
+export const MAX_DECLARATION_SIZE_BYTES = kibToBytes(100);
+
+const KNOWN_OVERSIZED_DECLARATION_LIMITS = new Map<string, number>([
+    ['suite-common/wallet-core/libDev/src/stake/tron/tronStakeReducer.d.ts', kibToBytes(1670)],
+    ['suite/e2e/libDev/fixtures/invity/index.d.ts', kibToBytes(740)],
+    ['suite-common/earn-stablecoin-defs/libDev/src/api/index.d.ts', kibToBytes(625)],
+    ['suite-common/logger/libDev/src/utils.d.ts', kibToBytes(600)],
+    ['suite/intl/libDev/src/messages.d.ts', kibToBytes(550)],
+    ['suite-common/device/libDev/src/deviceSelectors.d.ts', kibToBytes(520)],
+    ['packages/suite/libDev/src/reducers/store.d.ts', kibToBytes(515)],
+    ['packages/suite/libDev/src/utils/suite/notification.d.ts', kibToBytes(395)],
+    ['packages/suite/libDev/src/reducers/suite/index.d.ts', kibToBytes(340)],
+    ['packages/transport/libDev/src/transports/bridge.d.ts', kibToBytes(235)],
+    ['packages/transport-common/libDev/src/transports/abstractApi.d.ts', kibToBytes(230)],
+    ['packages/protobuf/libDev/src/definitions/index.d.ts', kibToBytes(210)],
+    [
+        'packages/suite-desktop-ui/libDev/src/createSuiteDesktopCompositionRoot.d.ts',
+        kibToBytes(190),
+    ],
+    ['packages/suite-web/libDev/src/createSuiteWebCompositionRoot.d.ts', kibToBytes(190)],
+    ['packages/icons/libDev/src/generated/icons/index.d.ts', kibToBytes(185)],
+    ['suite/test-utils/libDev/src/initStoreForTests.d.ts', kibToBytes(185)],
+    [
+        'suite-common/wallet-core/libDev/src/transactions/transactionsSelectors.d.ts',
+        kibToBytes(180),
+    ],
+    ['suite-native/intl/libDev/src/Translate.d.ts', kibToBytes(155)],
+    ['packages/suite/libDev/src/actions/device/deviceSlice.d.ts', kibToBytes(150)],
+    ['suite-common/message-system/libDev/files/config.v1.d.ts', kibToBytes(135)],
+    ['suite-common/trading/libDev/src/selectors/tradingSelectors.d.ts', kibToBytes(130)],
+    [
+        'packages/suite/libDev/src/views/settings/SettingsDevice/ForgetDevice/useForgetDevice.d.ts',
+        kibToBytes(130),
+    ],
+    [
+        'packages/suite/libDev/src/selectors/suite/selectAccountLabelsForSearch.d.ts',
+        kibToBytes(130),
+    ],
+    ['suite-common/message-system/libDev/src/messageSystemSelectors.d.ts', kibToBytes(115)],
+    ['packages/protobuf/libDev/src/definitions/messages-bitcoin.d.ts', kibToBytes(115)],
+    ['packages/suite/libDev/src/hooks/wallet/useRbfForm.d.ts', kibToBytes(115)],
+    ['suite-native/intl/libDev/src/messages.d.ts', kibToBytes(115)],
+]);
+
+const normalizePath = (filePath: string) => filePath.split(sep).join('/');
+
+const isDeclarationFile = (fileName: string) => /\.d\.[cm]?ts$/.test(fileName);
+
+const listDeclarationFiles = (directory: string): ReadonlyArray<string> => {
+    const declarations: string[] = [];
+
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+        const entryPath = join(directory, entry.name);
+
+        if (entry.isDirectory()) {
+            declarations.push(...listDeclarationFiles(entryPath));
+        } else if (entry.isFile() && isDeclarationFile(entry.name)) {
+            declarations.push(entryPath);
+        }
+    }
+
+    return declarations;
+};
+
+const formatSize = (sizeBytes: number) => {
+    const sizeKib = sizeBytes / 1024;
+
+    return `${Number.isInteger(sizeKib) ? sizeKib : sizeKib.toFixed(1)} KiB`;
+};
+
+const verifyDeclarationFile = (repoRoot: string, declarationFile: string) => {
+    const declarationPath = normalizePath(relative(repoRoot, declarationFile));
+    const sizeBytes = statSync(declarationFile).size;
+    const knownLimit = KNOWN_OVERSIZED_DECLARATION_LIMITS.get(declarationPath);
+    const maximumSize = knownLimit ?? MAX_DECLARATION_SIZE_BYTES;
+
+    if (knownLimit !== undefined && sizeBytes <= MAX_DECLARATION_SIZE_BYTES) {
+        return `${declarationPath} is now ${formatSize(
+            sizeBytes,
+        )}; remove its legacy declaration-size limit.`;
+    }
+
+    if (sizeBytes <= maximumSize) return undefined;
+
+    return `${declarationPath} is ${formatSize(sizeBytes)}; maximum is ${formatSize(maximumSize)}.`;
+};
+
+export const requireTypeDeclarationSize: Requirement<'repo'> = {
+    name: 'type-declaration-size',
+    scope: 'repo',
+    runByDefault: false,
+    verify: ({ repoRoot }) => {
+        const declarationOutputDirectories = listAllWorkspaces(repoRoot)
+            .map(workspace => join(workspace.dir, 'libDev'))
+            .filter(existsSync);
+        const declarationFiles = declarationOutputDirectories.flatMap(listDeclarationFiles);
+        const declarationPaths = new Set(
+            declarationFiles.map(declarationFile =>
+                normalizePath(relative(repoRoot, declarationFile)),
+            ),
+        );
+        const builtDeclarationOutputPaths = declarationOutputDirectories.map(directory =>
+            normalizePath(relative(repoRoot, directory)),
+        );
+        const errors = declarationFiles
+            .map(declarationFile => verifyDeclarationFile(repoRoot, declarationFile))
+            .filter(error => error !== undefined);
+
+        for (const declarationPath of KNOWN_OVERSIZED_DECLARATION_LIMITS.keys()) {
+            const isWorkspaceBuilt = builtDeclarationOutputPaths.some(outputPath =>
+                declarationPath.startsWith(`${outputPath}/`),
+            );
+
+            if (isWorkspaceBuilt && !declarationPaths.has(declarationPath)) {
+                errors.push(
+                    `${declarationPath} no longer exists; remove or update its legacy declaration-size limit.`,
+                );
+            }
+        }
+
+        return Promise.resolve(errors.sort());
+    },
+};

--- a/packages/requirements/src/runRequirements.ts
+++ b/packages/requirements/src/runRequirements.ts
@@ -49,8 +49,9 @@ export const runRequirements = async ({
     filter,
     mode,
 }: RunRequirementsProps): Promise<ReadonlyArray<RequirementResult>> => {
-    const filtered =
-        filter !== undefined ? requirements.filter(r => r.name === filter) : requirements;
+    const filtered = requirements.filter(requirement =>
+        filter !== undefined ? requirement.name === filter : requirement.runByDefault !== false,
+    );
 
     const results: RequirementResult[] = [];
 


### PR DESCRIPTION
## Description

- Add a requirement limiting emitted TypeScript declarations to 100 KiB.
- Reuse `libDev` outputs from the existing type-check.
- Preserve current oversized files with per-file limits.
- Run the check after type-check in CI.

## Testing

- Nothing to manually test, only code improvement

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/requirements-check-type-declartion/web/](https://dev.suite.sldev.cz/suite-web/requirements-check-type-declartion/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=requirements-check-type-declartion&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=requirements-check-type-declartion&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-15T09:23:10.691Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-15T09:23:02.480Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->