### PR TITLE
feat(trading): show trade fee experiment in swap confirm

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingTrezorFeeInfoItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingTrezorFeeInfoItem.tsx
@@ -1,0 +1,19 @@
+import { Translation } from '@suite/intl';
+import { InfoItem, Text, Tooltip } from '@trezor/components';
+
+export const TREZOR_FEE_PERCENTAGE = 2.3;
+
+export const TradingTrezorFeeInfoItem = () => (
+    <InfoItem
+        label={
+            <Tooltip content={<Translation id="TR_TRADING_TREZOR_FEE_TOOLTIP" />} hasIcon>
+                <Translation id="TR_TRADING_TREZOR_FEE" />
+            </Tooltip>
+        }
+        direction="row"
+    >
+        <Text typographyStyle="body-sm" data-testid="@trading/offer/info/trezor-fee">
+            {`${TREZOR_FEE_PERCENTAGE}%`}
+        </Text>
+    </InfoItem>
+);

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeDetails.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeDetails.tsx
@@ -1,6 +1,7 @@
 import { type ExchangeTrade } from 'invity-api';
 
 import { Translation } from '@suite/intl';
+import { ExperimentId, ExperimentWrapper } from '@suite-common/message-system';
 import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import {
     cryptoIdToNetwork,
@@ -30,6 +31,7 @@ import { TradingExchangeRateInfoItem } from '../TradingInfo/TradingExchangeRateI
 import { TradingExchangeSlippageInfoItem } from '../TradingInfo/TradingExchangeSlippageInfoItem';
 import { TradingNetworkFeeInfoItem } from '../TradingInfo/TradingNetworkFeeInfoItem';
 import { TradingProviderInfoItem } from '../TradingInfo/TradingProviderInfoItem';
+import { TradingTrezorFeeInfoItem } from '../TradingInfo/TradingTrezorFeeInfoItem';
 
 type TradingOfferExchangeDetailsProps = {
     account: Account;
@@ -91,6 +93,14 @@ export const TradingOfferExchangeDetails = ({
     return (
         <>
             <Column gap={8}>
+                <ExperimentWrapper
+                    id={ExperimentId.tradingShowTradeFee}
+                    components={[
+                        { variant: 'control', element: <></> },
+                        { variant: 'treatment', element: <TradingTrezorFeeInfoItem /> },
+                    ]}
+                />
+
                 {dexSlippage !== undefined && (
                     <>
                         <TradingExchangeSlippageInfoItem

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,6 +1,6 @@
 {
     "version": 1,
-    "timestamp": "2026-07-13T12:00:00+00:00",
+    "timestamp": "2026-07-14T12:00:00+00:00",
     "sequence": 148,
     "actions": [
         {
@@ -1834,6 +1834,30 @@
                     {
                         "variant": "B",
                         "percentage": 100
+                    }
+                ]
+            }
+        },
+        {
+            "conditions": [
+                {
+                    "environment": {
+                        "desktop": "*",
+                        "mobile": "!",
+                        "web": "*"
+                    }
+                }
+            ],
+            "experiment": {
+                "id": "eef0ff6f-95da-4a7e-aae6-ccd589c32998",
+                "groups": [
+                    {
+                        "variant": "control",
+                        "percentage": 90
+                    },
+                    {
+                        "variant": "treatment",
+                        "percentage": 10
                     }
                 ]
             }

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -187,6 +187,7 @@ export type ContextDomain = FunctionContextReturnValues;
 export enum ExperimentId {
     tradingFeedbackForm = '092db279-98dc-418e-bbfa-ef70716fb211',
     tradingFiatValues = 'b73df44d-37ed-4b66-aba1-5c4164493bae',
+    tradingShowTradeFee = 'eef0ff6f-95da-4a7e-aae6-ccd589c32998',
 }
 
 export type ExperimentsItemType = Omit<ExperimentsItem, 'id'> & { id: ExperimentId };

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1201,6 +1201,15 @@ export const messages = defineMessages({
         defaultMessage: 'Network fee',
         id: 'TR_TRADING_NETWORK_FEE',
     },
+    TR_TRADING_TREZOR_FEE: {
+        defaultMessage: 'Trezor fee (incl.)',
+        id: 'TR_TRADING_TREZOR_FEE',
+    },
+    TR_TRADING_TREZOR_FEE_TOOLTIP: {
+        defaultMessage:
+            "This is Trezor's fee to facilitate your trade—already included in your offer.",
+        id: 'TR_TRADING_TREZOR_FEE_TOOLTIP',
+    },
     TR_TRADING_TRADE_HISTORY_COUNTER: {
         defaultMessage:
             '{totalBuys, plural, =0 {{totalBuys} buys} one {{totalBuys} buy} other {{totalBuys} buys} } • {totalSells, plural, =0 {{totalSells} sells} one {{totalSells} sell} other {{totalSells} sells} } • {totalSwaps, plural, =0 {{totalSwaps} swaps} one {{totalSwaps} swap} other {{totalSwaps} swaps} }',


### PR DESCRIPTION
## Description

- Adds a swap confirm details row for the Trezor trade fee.
- Shows the new fee row only in the `tradingShowTradeFee` treatment variant.
- Registers the experiment in message-system with a 90% control and 10% treatment split for web and desktop.
- Adds label and tooltip copy that explains the fee is already included in the offer.

## Notes for QA

- Open Wallet > Trading > Swap, reach the Confirm step, and verify that when the treatment variant is active the details include `Trezor fee (incl.)` with `2.3%`.
- Hover the fee tooltip on the Confirm step and verify it says the fee is already included in the offer; when the control variant is active, verify the fee row is hidden.

## Related Issue

Resolve #27358

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes primarily affect swap/exchange trading UI components (TradingOfferExchangeDetails and TradingTrezorFeeInfoItem) along with the global messages.ts and message system types. The trading component changes carry focused risk to swap confirmation flows where exchange type, provider, fees, and crypto amounts are displayed. The message-system types file maps to 131 tests but is likely a broad infrastructure type change with low regression risk for most tests. The recommended strategy prioritizes the mocked swap tests that directly assert on confirmation details, with medium priority for passthrough/fee-specific tests, and low priority for live tests.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingTrezorFeeInfoItem.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeDetails.tsx`
- `suite-common/message-system/config/config.v1.json`
- `suite-common/message-system/src/messageSystemTypes.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/swap-coins.test.ts` — This test verifies the full swap flow including exchange type, provider name, and transaction detail views — all rendered by TradingOfferExchangeDetails. It also checks confirmation crypto amounts and provider support links, which are directly affected by changes to TradingOfferExchangeDetails.tsx and TradingTrezorFeeInfoItem.tsx.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Directly asserts on confirmation exchange type (TR_EXCHANGE_FLOAT), provider name, and confirmation crypto amounts — all rendered by TradingOfferExchangeDetails. Changes to this component or its fee info sub-component could break these assertions.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This test extensively validates DEX swap details including exchange type (TR_EXCHANGE_DEX), slippage, minimum received, network fee, provider, and crypto amounts on the confirmation screen — all directly rendered by TradingOfferExchangeDetails. It also checks gas limit and fee info which relate to TradingTrezorFeeInfoItem.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Asserts on confirmation crypto amounts, exchange type (TR_EXCHANGE_FLOAT), and provider name — all rendered by TradingOfferExchangeDetails. Also verifies transaction detail status which flows through the same component hierarchy.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Validates exchange type, provider name, and confirmation crypto amounts for SPL token swaps, all rendered through TradingOfferExchangeDetails. A regression in the exchange details component would directly fail these assertions.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests custom Bitcoin fee display in the swap confirmation modal. While it primarily checks device prompt values, the fee rate and total amount flow through TradingTrezorFeeInfoItem and the confirmation UI rendered by TradingOfferExchangeDetails.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests custom Ethereum fee parameters (gas limit, max fee per gas, priority fee) in the swap confirmation flow. These values are displayed through TradingTrezorFeeInfoItem and the confirmation UI in TradingOfferExchangeDetails.
- `suite/e2e/tests/trading-poc/passthru-swap-eth-to-btc.test.ts` — Live passthrough swap test that verifies transaction detail crypto amounts, provider name, and status transitions through the exchange details view. Changes to TradingOfferExchangeDetails could affect these detail views.
- `suite/e2e/tests/trading-poc/passthru-swap-sol-to-btc.test.ts` — Similar to the ETH passthrough test, this validates transaction detail crypto amounts and provider info for SOL→BTC swaps, rendered through TradingOfferExchangeDetails.
- `suite/e2e/tests/trading/swap-history.test.ts` — Validates the swap transaction detail sidebar including send/receive amounts, provider, and status translations. The detail sidebar is rendered by TradingOfferExchangeDetails-related components, and translation key changes in messages.ts could affect status labels.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Live swap test that verifies swap detail sidebar (send/receive amounts, provider, exchange type) which is rendered by TradingOfferExchangeDetails. Lower priority as it's a live test with external dependencies.
- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — Live swap test verifying transaction detail status and trading transactions tab. TradingOfferExchangeDetails changes could affect the detail view, but this is a live test with external dependencies.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/message-system/config/config.v1.json`

_Updated: 2026-07-16T05:20:29.207Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/27358-show-trade-fee-ab-test/web/](https://dev.suite.sldev.cz/suite-web/feat/27358-show-trade-fee-ab-test/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/27358-show-trade-fee-ab-test&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/27358-show-trade-fee-ab-test&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/27358-show-trade-fee-ab-test&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-16T05:22:25.712Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-16T05:23:21.145Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->