### PR TITLE
Fix oversized type declarations

### DIFF
--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -9,7 +9,6 @@ const kibToBytes = (sizeKib: number) => sizeKib * 1024;
 export const MAX_DECLARATION_SIZE_BYTES = kibToBytes(100);
 
 const KNOWN_OVERSIZED_DECLARATION_LIMITS = new Map<string, number>([
-    ['suite-common/wallet-core/libDev/src/stake/tron/tronStakeReducer.d.ts', kibToBytes(1670)],
     ['suite/e2e/libDev/fixtures/invity/index.d.ts', kibToBytes(740)],
     ['suite-common/earn-stablecoin-defs/libDev/src/api/index.d.ts', kibToBytes(625)],
     ['suite-common/logger/libDev/src/utils.d.ts', kibToBytes(600)],
@@ -33,8 +32,7 @@ const KNOWN_OVERSIZED_DECLARATION_LIMITS = new Map<string, number>([
         kibToBytes(180),
     ],
     ['suite-native/intl/libDev/src/Translate.d.ts', kibToBytes(155)],
-    ['packages/suite/libDev/src/actions/device/deviceSlice.d.ts', kibToBytes(150)],
-    ['suite-common/message-system/libDev/files/config.v1.d.ts', kibToBytes(135)],
+    ['suite-common/message-system/libDev/files/config.v1.d.ts', kibToBytes(140)],
     ['suite-common/trading/libDev/src/selectors/tradingSelectors.d.ts', kibToBytes(130)],
     [
         'packages/suite/libDev/src/views/settings/SettingsDevice/ForgetDevice/useForgetDevice.d.ts',

--- a/packages/suite/src/actions/device/deviceSlice.ts
+++ b/packages/suite/src/actions/device/deviceSlice.ts
@@ -4,7 +4,7 @@ import {
     type DeviceReducerState,
     deviceInitialState as commonInitialState,
     deviceActions,
-    prepareDeviceReducer,
+    prepareDeviceReducer as prepareCommonDeviceReducer,
 } from '@suite-common/device';
 import { type AnyAction, createSliceWithExtraDeps } from '@suite-common/redux-utils';
 
@@ -25,22 +25,25 @@ export type DesktopDeviceRootState = {
     device: DesktopDeviceState;
 };
 
-export const deviceSlice = createSliceWithExtraDeps({
+const deviceSlice = createSliceWithExtraDeps({
     name: 'device',
     initialState,
     reducers: {
-        toggleConnectionModal: state => {
+        toggleConnectionModal: (state: DesktopDeviceState) => {
             state.isConnectionModalOpen = !state.isConnectionModalOpen;
         },
-        setConnectionModal: (state, { payload }: PayloadAction<boolean>) => {
+        setConnectionModal: (state: DesktopDeviceState, { payload }: PayloadAction<boolean>) => {
             state.isConnectionModalOpen = payload;
         },
-        setConnectionMode: (state, { payload }: PayloadAction<ConnectionMode>) => {
+        setConnectionMode: (
+            state: DesktopDeviceState,
+            { payload }: PayloadAction<ConnectionMode>,
+        ) => {
             state.defaultConnectionMode = payload;
         },
     },
     extraReducers: (builder, extra) => {
-        const commonReducer = prepareDeviceReducer(extra);
+        const commonReducer = prepareCommonDeviceReducer(extra);
 
         builder
             .addMatcher(
@@ -57,3 +60,5 @@ export const deviceSlice = createSliceWithExtraDeps({
 });
 
 export const { toggleConnectionModal, setConnectionModal, setConnectionMode } = deviceSlice.actions;
+export const desktopDeviceActions = deviceSlice.actions;
+export const prepareDesktopDeviceReducer = deviceSlice.prepareReducer;

--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -24,7 +24,7 @@ import { mockAccountKey, mockWalletAccount } from '@suite-common/wallet-types/mo
 import { getAccountIdentifier, getAccountTransactions } from '@suite-common/wallet-utils';
 import { type StaticSessionId, asWalletDescriptor } from '@trezor/device-utils';
 
-import { deviceSlice } from 'src/actions/device/deviceSlice';
+import { prepareDesktopDeviceReducer } from 'src/actions/device/deviceSlice';
 import { suiteSyncQuotaManagerSlice } from 'src/actions/suiteSyncQuotaManager/suiteSyncQuotaManagerSlice';
 import { SETTINGS } from 'src/config/suite';
 import storageMiddleware from 'src/middlewares/wallet/storageMiddleware';
@@ -42,7 +42,7 @@ import * as storageActions from '../storageActions';
 const { getWalletTransaction } = testMocks;
 
 const discoveryReducer = prepareDiscoveryReducer(extraDependencies);
-const deviceReducer = deviceSlice.prepareReducer(extraDependencies);
+const deviceReducer = prepareDesktopDeviceReducer(extraDependencies);
 const flagsReducer = prepareFlagsReducer(extraDependencies);
 const sendFormReducer = prepareSendFormReducer(extraDependencies);
 const walletSettingsReducer = discoveryActions.prepareWalletSettingsReducer(extraDependencies);

--- a/packages/suite/src/actions/suite/__tests__/trezorConnectActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/trezorConnectActions.test.ts
@@ -7,12 +7,12 @@ import { messageSystemInitialState } from '@suite-common/message-system';
 import { testMocks } from '@suite-common/test-utils';
 import { BLOCKCHAIN_EVENT, DEVICE_EVENT, TRANSPORT_EVENT, UI_EVENT } from '@trezor/connect';
 
-import { deviceSlice } from 'src/actions/device/deviceSlice';
+import { prepareDesktopDeviceReducer } from 'src/actions/device/deviceSlice';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
 import { extraDependencies } from 'src/support/extraDependencies';
 import { configureStore } from 'src/support/tests/configureStore';
 
-const deviceReducer = deviceSlice.prepareReducer(extraDependencies);
+const deviceReducer = prepareDesktopDeviceReducer(extraDependencies);
 
 type SuiteState = ReturnType<typeof suiteReducer>;
 type DevicesState = ReturnType<typeof deviceReducer>;

--- a/packages/suite/src/reducers/suite/index.ts
+++ b/packages/suite/src/reducers/suite/index.ts
@@ -17,7 +17,7 @@ import { prepareMessageSystemReducer } from '@suite-common/message-system';
 import { createNotificationsReducer } from '@suite-common/toast-notifications';
 import { prepareWalletConnectReducer } from '@suite-common/walletconnect';
 
-import { deviceSlice } from 'src/actions/device/deviceSlice';
+import { prepareDesktopDeviceReducer } from 'src/actions/device/deviceSlice';
 import { extraDependencies } from 'src/support/extraDependencies';
 
 import guide from './guideReducer';
@@ -28,7 +28,7 @@ import window from './windowReducer';
 const analytics = prepareAnalyticsReducer(extraDependencies);
 // Type annotation as a workaround for type-check error "The inferred type of 'default' cannot be named..."
 const messageSystem = prepareMessageSystemReducer(extraDependencies);
-const device = deviceSlice.prepareReducer(extraDependencies);
+const device = prepareDesktopDeviceReducer(extraDependencies);
 const flags = prepareFlagsReducer(extraDependencies);
 const suiteSettings = prepareSuiteSettingsReducer(extraDependencies);
 const debug = prepareDebugReducer(extraDependencies);

--- a/packages/suite/src/reducers/wallet/accountSearchReducer.ts
+++ b/packages/suite/src/reducers/wallet/accountSearchReducer.ts
@@ -22,10 +22,10 @@ const accountSearchSlice = createSlice({
     name: ACCOUNT_SEARCH_PREFIX,
     initialState: accountSearchInitialState,
     reducers: {
-        setCoinFilter(state, action: PayloadAction<Array<NetworkSymbol>>) {
+        setCoinFilter(state: AccountSearchState, action: PayloadAction<Array<NetworkSymbol>>) {
             state.coinFilter = action.payload ?? [];
         },
-        toggleCoinFilter(state, action: PayloadAction<NetworkSymbol>) {
+        toggleCoinFilter(state: AccountSearchState, action: PayloadAction<NetworkSymbol>) {
             const symbol = action.payload;
             if (!symbol) return;
 
@@ -35,7 +35,7 @@ const accountSearchSlice = createSlice({
                 state.coinFilter.push(symbol);
             }
         },
-        setSearchString(state, action: PayloadAction<string | undefined>) {
+        setSearchString(state: AccountSearchState, action: PayloadAction<string | undefined>) {
             state.searchString = action.payload;
         },
     },

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -44,7 +44,7 @@ import {
 } from '@trezor/connect';
 import { type FilterOutFromUnionByTypeProperty } from '@trezor/type-utils';
 
-import { type deviceSlice } from 'src/actions/device/deviceSlice';
+import { type desktopDeviceActions } from 'src/actions/device/deviceSlice';
 import type { OnboardingAction } from 'src/actions/onboarding/onboardingActions';
 import type { BioAuthAction } from 'src/actions/suite/bioAuthActions';
 import type { GuideAction } from 'src/actions/suite/guideActions';
@@ -120,7 +120,7 @@ type FeatureFeedbackAction = ReturnType<
     (typeof featureFeedbackSlice.actions)[keyof typeof featureFeedbackSlice.actions]
 >;
 type DeviceActionDesktop = ReturnType<
-    (typeof deviceSlice.actions)[keyof typeof deviceSlice.actions]
+    (typeof desktopDeviceActions)[keyof typeof desktopDeviceActions]
 >;
 type ThpAction = ReturnType<(typeof thpActions)[keyof typeof thpActions]>;
 type GeolocationAction = ReturnType<(typeof geolocationActions)[keyof typeof geolocationActions]>;

--- a/suite-common/geolocation/src/geolocationReducer.ts
+++ b/suite-common/geolocation/src/geolocationReducer.ts
@@ -16,7 +16,7 @@ const geolocationSlice = createSlice({
     name: GEOLOCATION_PREFIX,
     initialState: geolocationInitialState,
     reducers: {
-        setCountryCode(state, action: PayloadAction<CountryCode>) {
+        setCountryCode(state: GeolocationState, action: PayloadAction<CountryCode>) {
             state.countryCode = action.payload;
         },
     },

--- a/suite-common/wallet-core/src/stake/tron/tronStakeReducer.ts
+++ b/suite-common/wallet-core/src/stake/tron/tronStakeReducer.ts
@@ -78,6 +78,14 @@ const getNextStep = (flow: TronFlow, step: TronStakeStepId): TronStakeStepId => 
 };
 
 type SessionPayload = { accountKey: AccountKey; flow: TronFlow };
+type GoToStepPayload = SessionPayload & { step: TronStakeStepId };
+type SubmitFinishedPayload = SessionPayload & { txid?: string; error?: TronStakeError };
+type StorePrecomposedTransactionPayload = {
+    precomposedTx: PrecomposedTransactionFinal;
+    precomposedForm: FormState;
+    accountKey: AccountKey;
+};
+type StoreSignedTransactionPayload = { serializedTx: SerializedTx };
 
 const getSession = (
     state: TronStakeReducerState,
@@ -94,15 +102,18 @@ const setSession = (
     state.sessions[accountKey] = { ...state.sessions[accountKey], [flow]: session };
 };
 
-export const tronStakeSlice = createSlice({
+const tronStakeSlice = createSlice({
     name: TRON_STAKE_PREFIX,
     initialState,
     reducers: {
-        goToStep(state, action: PayloadAction<SessionPayload & { step: TronStakeStepId }>) {
+        goToStep(state: TronStakeReducerState, action: PayloadAction<GoToStepPayload>) {
             const { accountKey, flow, step } = action.payload;
             setSession(state, accountKey, flow, { ...getSession(state, accountKey, flow), step });
         },
-        pendingTransactionConfirmed(state, action: PayloadAction<SessionPayload>) {
+        pendingTransactionConfirmed(
+            state: TronStakeReducerState,
+            action: PayloadAction<SessionPayload>,
+        ) {
             const { accountKey, flow } = action.payload;
             const session = getSession(state, accountKey, flow);
             setSession(state, accountKey, flow, {
@@ -111,7 +122,10 @@ export const tronStakeSlice = createSlice({
                 step: getNextStep(flow, session.step),
             });
         },
-        pendingTransactionFailed(state, action: PayloadAction<SessionPayload>) {
+        pendingTransactionFailed(
+            state: TronStakeReducerState,
+            action: PayloadAction<SessionPayload>,
+        ) {
             const { accountKey, flow } = action.payload;
             setSession(state, accountKey, flow, {
                 ...getSession(state, accountKey, flow),
@@ -119,11 +133,11 @@ export const tronStakeSlice = createSlice({
                 error: { kind: 'confirmation-failed' },
             });
         },
-        reset(state, action: PayloadAction<SessionPayload>) {
+        reset(state: TronStakeReducerState, action: PayloadAction<SessionPayload>) {
             const { accountKey, flow } = action.payload;
             setSession(state, accountKey, flow, createTronStakeSession(flow));
         },
-        submitStarted(state, action: PayloadAction<SessionPayload>) {
+        submitStarted(state: TronStakeReducerState, action: PayloadAction<SessionPayload>) {
             const { accountKey, flow } = action.payload;
             setSession(state, accountKey, flow, {
                 ...getSession(state, accountKey, flow),
@@ -131,10 +145,7 @@ export const tronStakeSlice = createSlice({
                 error: null,
             });
         },
-        submitFinished(
-            state,
-            action: PayloadAction<SessionPayload & { txid?: string; error?: TronStakeError }>,
-        ) {
+        submitFinished(state: TronStakeReducerState, action: PayloadAction<SubmitFinishedPayload>) {
             const { accountKey, flow, txid, error } = action.payload;
             setSession(state, accountKey, flow, {
                 ...getSession(state, accountKey, flow),
@@ -144,22 +155,21 @@ export const tronStakeSlice = createSlice({
             });
         },
         storePrecomposedTransaction(
-            state,
-            action: PayloadAction<{
-                precomposedTx: PrecomposedTransactionFinal;
-                precomposedForm: FormState;
-                accountKey: AccountKey;
-            }>,
+            state: TronStakeReducerState,
+            action: PayloadAction<StorePrecomposedTransactionPayload>,
         ) {
             state.txReview.precomposedTx = action.payload.precomposedTx;
             state.txReview.precomposedForm = action.payload.precomposedForm;
             state.txReview.accountKey = action.payload.accountKey;
             state.txReview.serializedTx = undefined;
         },
-        storeSignedTransaction(state, action: PayloadAction<{ serializedTx: SerializedTx }>) {
+        storeSignedTransaction(
+            state: TronStakeReducerState,
+            action: PayloadAction<StoreSignedTransactionPayload>,
+        ) {
             state.txReview.serializedTx = action.payload.serializedTx;
         },
-        discardTransaction(state) {
+        discardTransaction(state: TronStakeReducerState) {
             state.txReview = { ...initialTronStakeTxReview };
         },
     },

--- a/suite-native/graph/src/slice.ts
+++ b/suite-native/graph/src/slice.ts
@@ -42,13 +42,13 @@ const graphSlice = createSlice({
     initialState: graphInitialState,
     reducers: {
         setPortfolioGraphTimeframe: (
-            state,
+            state: GraphState,
             { payload: { timeframeHours } }: PayloadAction<{ timeframeHours: TimeframeHoursValue }>,
         ) => {
             state.portfolioGraphTimeframe = timeframeHours;
         },
         setAccountGraphTimeframe: (
-            state,
+            state: GraphState,
             {
                 payload: { accountKey, timeframeHours },
             }: PayloadAction<{ accountKey: AccountKey; timeframeHours: TimeframeHoursValue }>,

--- a/suite-native/intl/src/localeSlice.ts
+++ b/suite-native/intl/src/localeSlice.ts
@@ -32,13 +32,16 @@ const localeSlice = createSlice({
     name: 'locale',
     initialState: localeInitialState,
     reducers: {
-        setAppLocaleCode: (state, { payload }: PayloadAction<AppLocaleOption>) => {
+        setAppLocaleCode: (state: LocaleState, { payload }: PayloadAction<AppLocaleOption>) => {
             state.appLocaleCode = payload;
         },
-        setSystemLocaleCode: (state, { payload }: PayloadAction<LocaleCode>) => {
+        setSystemLocaleCode: (state: LocaleState, { payload }: PayloadAction<LocaleCode>) => {
             state.systemLocaleCode = payload;
         },
-        setAreDebugTranslationKeysDisplayed: (state, { payload }: PayloadAction<boolean>) => {
+        setAreDebugTranslationKeysDisplayed: (
+            state: LocaleState,
+            { payload }: PayloadAction<boolean>,
+        ) => {
             state.areDebugTranslationKeysDisplayed = payload;
         },
     },

--- a/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewScreenControls.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewScreenControls.test.ts
@@ -13,7 +13,10 @@ import {
 } from '@suite-native/test-utils-store';
 import { getWalletState } from '@suite-native/trading-fixtures';
 import { tradingSlice } from '@suite-native/trading-state';
-import { sendFormSlice, transactionManagementActions } from '@suite-native/transaction-management';
+import {
+    prepareSendFormReducer,
+    transactionManagementActions,
+} from '@suite-native/transaction-management';
 
 import { type TradingExchangeSignAndSendTransactionProps } from '../../exchange/useExchangeFlow';
 import { useTradingOutputsReviewScreenControls } from '../useTradingOutputsReviewScreenControls';
@@ -65,7 +68,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
         wallet: combineReducers({
             settings: createStaticReducer(initialWalletSettingsState),
             accounts: createStaticReducer(getWalletState({ tradeType: 'exchange' }).accounts),
-            send: sendFormSlice.prepareReducer(extraDependenciesCommonMock),
+            send: prepareSendFormReducer(extraDependenciesCommonMock),
             trading: tradingSlice.prepareReducer(extraDependenciesCommonMock),
         }),
     } as const;

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -74,7 +74,7 @@ import {
     walletStopPersistTransform,
 } from '@suite-native/storage';
 import { tradingInitialState, tradingSlice } from '@suite-native/trading-state';
-import { sendFormSlice } from '@suite-native/transaction-management';
+import { prepareSendFormReducer } from '@suite-native/transaction-management';
 
 import { appReducer } from './appSlice';
 import { extraDependencies } from './extraDependencies';
@@ -90,7 +90,7 @@ const messageSystemReducer = prepareMessageSystemReducer(extraDependencies);
 const deviceReducer = prepareDeviceReducer(extraDependencies);
 const discoveryReducer = prepareDiscoveryReducer(extraDependencies);
 const tokenDefinitionsReducer = prepareTokenDefinitionsReducer(extraDependencies);
-const sendFormReducer = sendFormSlice.prepareReducer(extraDependencies);
+const sendFormReducer = prepareSendFormReducer(extraDependencies);
 const tradingReducer = tradingSlice.prepareReducer(extraDependencies);
 const stakeReducer = prepareStakeReducer(extraDependencies);
 const firmwareReducer = prepareFirmwareReducer(extraDependencies);

--- a/suite-native/trading-browser-auth/src/hooks/__tests__/useProviderConfirmationStatus.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/__tests__/useProviderConfirmationStatus.test.ts
@@ -15,7 +15,7 @@ import {
     tradingActions,
     tradingSlice,
 } from '@suite-native/trading-state';
-import { sendFormSlice } from '@suite-native/transaction-management';
+import { prepareSendFormReducer } from '@suite-native/transaction-management';
 
 import { useProviderConfirmationStatus } from '../useProviderConfirmationStatus';
 
@@ -33,7 +33,7 @@ describe('useProviderConfirmationStatus', () => {
                 locale: localeReducer,
                 wallet: combineReducers({
                     settings: createStaticReducer(initialWalletSettingsState),
-                    send: sendFormSlice.prepareReducer(extraDependenciesCommonMock),
+                    send: prepareSendFormReducer(extraDependenciesCommonMock),
                     trading: tradingSlice.prepareReducer(extraDependenciesCommonMock),
                 }),
             },

--- a/suite-native/transaction-management/src/__tests__/sendFormSlice.test.ts
+++ b/suite-native/transaction-management/src/__tests__/sendFormSlice.test.ts
@@ -3,12 +3,12 @@ import { configureStore } from '@reduxjs/toolkit';
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 
 import { createFeeLevels } from '../__fixtures__/feeLevels';
-import { sendFormSlice, transactionManagementActions } from '../sendFormSlice';
+import { prepareSendFormReducer, transactionManagementActions } from '../sendFormSlice';
 
 describe('sendFormSlice', () => {
     // Create a test store with the prepared reducer
     const createTestStore = () => {
-        const reducer = sendFormSlice.prepareReducer(extraDependenciesCommonMock);
+        const reducer = prepareSendFormReducer(extraDependenciesCommonMock);
 
         return configureStore({
             reducer: { send: reducer },

--- a/suite-native/transaction-management/src/sendFormSlice.ts
+++ b/suite-native/transaction-management/src/sendFormSlice.ts
@@ -29,7 +29,7 @@ export const sendFormInitialState: NativeSendState = {
     feeLevels: {},
 };
 
-export const sendFormSlice = createSliceWithExtraDeps({
+const sendFormSlice = createSliceWithExtraDeps({
     name: 'send',
     initialState: sendFormInitialState,
     reducers: {
@@ -74,3 +74,4 @@ export const sendFormSlice = createSliceWithExtraDeps({
 });
 
 export const transactionManagementActions = sendFormSlice.actions;
+export const prepareSendFormReducer = sendFormSlice.prepareReducer;

--- a/suite/debug/src/debugSlice.ts
+++ b/suite/debug/src/debugSlice.ts
@@ -22,7 +22,7 @@ const debugSlice = createSliceWithExtraDeps({
     name: 'debug',
     initialState: debugInitialState,
     reducers: {
-        setShowDebugMenu: (state, { payload }: PayloadAction<boolean>) => {
+        setShowDebugMenu: (state: DebugState, { payload }: PayloadAction<boolean>) => {
             state.showDebugMenu = payload;
         },
     },

--- a/suite/desktop-update/src/desktopUpdateReducer.ts
+++ b/suite/desktop-update/src/desktopUpdateReducer.ts
@@ -57,50 +57,59 @@ const desktopUpdateSlice = createSlice({
     name: 'desktopUpdate',
     initialState,
     reducers: {
-        checking: state => {
+        checking: (state: DesktopUpdateState) => {
             state.state = UpdateState.Checking;
         },
-        available: (state, action: PayloadAction<UpdateInfo>) => {
+        available: (state: DesktopUpdateState, action: PayloadAction<UpdateInfo>) => {
             state.state = UpdateState.Available;
             state.latest = action.payload;
         },
-        notAvailable: (state, action: PayloadAction<UpdateInfo | undefined>) => {
+        notAvailable: (
+            state: DesktopUpdateState,
+            action: PayloadAction<UpdateInfo | undefined>,
+        ) => {
             state.state = UpdateState.NotAvailable;
             state.latest = action.payload;
         },
-        download: state => {
+        download: (state: DesktopUpdateState) => {
             state.state = UpdateState.Downloading;
         },
-        downloading: (state, action: PayloadAction<UpdateProgress>) => {
+        downloading: (state: DesktopUpdateState, action: PayloadAction<UpdateProgress>) => {
             state.progress = action.payload;
         },
-        ready: (state, action: PayloadAction<UpdateInfo>) => {
+        ready: (state: DesktopUpdateState, action: PayloadAction<UpdateInfo>) => {
             state.state = UpdateState.Ready;
             state.latest = action.payload;
         },
-        justUpdated: state => {
+        justUpdated: (state: DesktopUpdateState) => {
             state.state = UpdateState.JustUpdated;
             state.isModalVisible = true;
             state.justUpdatedInteractedWith = true;
         },
-        setIsUpdateModalVisible: (state, action: PayloadAction<boolean>) => {
+        setIsUpdateModalVisible: (state: DesktopUpdateState, action: PayloadAction<boolean>) => {
             state.isModalVisible = action.payload;
         },
-        setIsVersionInfoModalVisible: (state, action: PayloadAction<boolean>) => {
+        setIsVersionInfoModalVisible: (
+            state: DesktopUpdateState,
+            action: PayloadAction<boolean>,
+        ) => {
             state.isVersionInfoModalVisible = action.payload;
         },
-        openEarlyAccessEnable: state => {
+        openEarlyAccessEnable: (state: DesktopUpdateState) => {
             state.state = UpdateState.EarlyAccessEnable;
             state.isModalVisible = true;
         },
-        openEarlyAccessDisable: state => {
+        openEarlyAccessDisable: (state: DesktopUpdateState) => {
             state.state = UpdateState.EarlyAccessDisable;
             state.isModalVisible = true;
         },
-        allowPrerelease: (state, action: PayloadAction<boolean>) => {
+        allowPrerelease: (state: DesktopUpdateState, action: PayloadAction<boolean>) => {
             state.allowPrerelease = action.payload;
         },
-        setAutomaticUpdates: (state, action: PayloadAction<{ isEnabled: boolean }>) => {
+        setAutomaticUpdates: (
+            state: DesktopUpdateState,
+            action: PayloadAction<{ isEnabled: boolean }>,
+        ) => {
             state.isAutomaticUpdateEnabled = action.payload.isEnabled;
         },
     },

--- a/suite/flags/src/flagsSlice.ts
+++ b/suite/flags/src/flagsSlice.ts
@@ -71,7 +71,10 @@ const flagsSlice = createSliceWithExtraDeps({
     name: 'flags',
     initialState: flagsInitialState,
     reducers: {
-        setFlag: (state, { payload }: PayloadAction<{ key: keyof FlagsState; value: boolean }>) => {
+        setFlag: (
+            state: FlagsState,
+            { payload }: PayloadAction<{ key: keyof FlagsState; value: boolean }>,
+        ) => {
             state[payload.key] = payload.value;
         },
     },

--- a/suite/receive/src/receiveReducer.ts
+++ b/suite/receive/src/receiveReducer.ts
@@ -89,12 +89,12 @@ const markAddressUnverified = (draft: ReceiveAccountState, path: string, address
     draft.currentFreshAddress = undefined;
 };
 
-export const receiveSlice = createSlice({
+const receiveSlice = createSlice({
     name: 'receive',
     initialState: receiveInitialState,
     reducers: {
         showAddress: {
-            reducer: (state, action: PayloadAction<ReceiveActionPayload>) => {
+            reducer: (state: ReceiveState, action: PayloadAction<ReceiveActionPayload>) => {
                 const accountState = getReceiveAccountState(state, action.payload.accountKey);
 
                 markAddressVerified(accountState, action.payload.path, action.payload.address);
@@ -104,7 +104,7 @@ export const receiveSlice = createSlice({
             }),
         },
         showUnverifiedAddress: {
-            reducer: (state, action: PayloadAction<ReceiveActionPayload>) => {
+            reducer: (state: ReceiveState, action: PayloadAction<ReceiveActionPayload>) => {
                 const accountState = getReceiveAccountState(state, action.payload.accountKey);
 
                 markAddressUnverified(accountState, action.payload.path, action.payload.address);
@@ -113,7 +113,10 @@ export const receiveSlice = createSlice({
                 payload: { accountKey, path, address },
             }),
         },
-        setCurrentFreshAddress: (state, action: PayloadAction<SetCurrentFreshAddressPayload>) => {
+        setCurrentFreshAddress: (
+            state: ReceiveState,
+            action: PayloadAction<SetCurrentFreshAddressPayload>,
+        ) => {
             const accountState = getReceiveAccountState(state, action.payload.accountKey);
 
             accountState.currentFreshAddress = action.payload.currentFreshAddress;

--- a/suite/router/src/routerReducer.ts
+++ b/suite/router/src/routerReducer.ts
@@ -68,11 +68,14 @@ const routerSlice = createSlice({
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     initialState: initialState as RouterState,
     reducers: {
-        routerLocationChange: (state, action: PayloadAction<LocationChangePayload>) => {
+        routerLocationChange: (
+            state: RouterState,
+            action: PayloadAction<LocationChangePayload>,
+        ) => {
             state.loaded = true;
             Object.assign(state, action.payload);
         },
-        anchorChange: (state, action: PayloadAction<AnchorType | undefined>) => {
+        anchorChange: (state: RouterState, action: PayloadAction<AnchorType | undefined>) => {
             state.anchor = action.payload;
         },
     },

--- a/suite/settings/src/settingsSlice.ts
+++ b/suite/settings/src/settingsSlice.ts
@@ -99,55 +99,88 @@ const suiteSettingsSlice = createSliceWithExtraDeps({
     name: 'suiteSettings',
     initialState: suiteSettingsInitialState,
     reducers: {
-        setLanguage: (state, { payload }: PayloadAction<Locale>) => {
+        setLanguage: (state: SuiteSettingsState, { payload }: PayloadAction<Locale>) => {
             state.language = payload;
         },
-        setDebugMode: (state, { payload }: PayloadAction<Partial<DebugModeOptions>>) => {
+        setDebugMode: (
+            state: SuiteSettingsState,
+            { payload }: PayloadAction<Partial<DebugModeOptions>>,
+        ) => {
             state.debug = { ...state.debug, ...payload };
         },
         setExperimentalFeatures: (
-            state,
+            state: SuiteSettingsState,
             { payload }: PayloadAction<ExperimentalFeature[] | undefined>,
         ) => {
             state.experimental = payload;
         },
-        setIsTestnetNetworksEnabled: (state, { payload }: PayloadAction<boolean>) => {
+        setIsTestnetNetworksEnabled: (
+            state: SuiteSettingsState,
+            { payload }: PayloadAction<boolean>,
+        ) => {
             state.isTestnetNetworksEnabled = payload;
         },
-        setIsNftSectionEnabled: (state, { payload }: PayloadAction<boolean>) => {
+        setIsNftSectionEnabled: (
+            state: SuiteSettingsState,
+            { payload }: PayloadAction<boolean>,
+        ) => {
             state.isNftSectionEnabled = payload;
         },
-        setTheme: (state, { payload }: PayloadAction<SuiteSettingsState['theme']['variant']>) => {
+        setTheme: (
+            state: SuiteSettingsState,
+            { payload }: PayloadAction<SuiteSettingsState['theme']['variant']>,
+        ) => {
             state.theme.variant = payload;
         },
-        setAutodetect: (state, { payload }: PayloadAction<Partial<AutodetectSettings>>) => {
+        setAutodetect: (
+            state: SuiteSettingsState,
+            { payload }: PayloadAction<Partial<AutodetectSettings>>,
+        ) => {
             state.autodetect = { ...state.autodetect, ...payload };
         },
-        setSidebarWidth: (state, { payload }: PayloadAction<number>) => {
+        setSidebarWidth: (state: SuiteSettingsState, { payload }: PayloadAction<number>) => {
             state.sidebarWidth = payload;
         },
-        setIsCoinsFilterVisible: (state, { payload }: PayloadAction<boolean>) => {
+        setIsCoinsFilterVisible: (
+            state: SuiteSettingsState,
+            { payload }: PayloadAction<boolean>,
+        ) => {
             state.isCoinsFilterVisible = payload;
         },
-        setOnionLinks: (state, { payload }: PayloadAction<boolean>) => {
+        setOnionLinks: (state: SuiteSettingsState, { payload }: PayloadAction<boolean>) => {
             state.torOnionLinks = payload;
         },
-        setCoinjoinReceiveWarningHidden: (state, { payload }: PayloadAction<boolean>) => {
+        setCoinjoinReceiveWarningHidden: (
+            state: SuiteSettingsState,
+            { payload }: PayloadAction<boolean>,
+        ) => {
             state.isCoinjoinReceiveWarningHidden = payload;
         },
-        toggleDeviceAuthenticityCheck: (state, { payload }: PayloadAction<boolean>) => {
+        toggleDeviceAuthenticityCheck: (
+            state: SuiteSettingsState,
+            { payload }: PayloadAction<boolean>,
+        ) => {
             state.enabledSecurityChecks.deviceAuthenticity = payload;
         },
-        toggleFirmwareRevisionCheck: (state, { payload }: PayloadAction<boolean>) => {
+        toggleFirmwareRevisionCheck: (
+            state: SuiteSettingsState,
+            { payload }: PayloadAction<boolean>,
+        ) => {
             state.enabledSecurityChecks.firmwareRevision = payload;
         },
-        toggleFirmwareHashCheck: (state, { payload }: PayloadAction<boolean>) => {
+        toggleFirmwareHashCheck: (
+            state: SuiteSettingsState,
+            { payload }: PayloadAction<boolean>,
+        ) => {
             state.enabledSecurityChecks.firmwareHash = payload;
         },
-        toggleEntropyCheck: (state, { payload }: PayloadAction<boolean>) => {
+        toggleEntropyCheck: (state: SuiteSettingsState, { payload }: PayloadAction<boolean>) => {
             state.enabledSecurityChecks.entropy = payload;
         },
-        toggleDeviceMetaChecks: (state, { payload }: PayloadAction<boolean>) => {
+        toggleDeviceMetaChecks: (
+            state: SuiteSettingsState,
+            { payload }: PayloadAction<boolean>,
+        ) => {
             state.enabledSecurityChecks.deviceMeta = payload;
         },
     },

--- a/suite/tor/src/torSlice.ts
+++ b/suite/tor/src/torSlice.ts
@@ -29,10 +29,10 @@ const torSlice = createSlice({
     name: 'tor',
     initialState,
     reducers: {
-        setTorStatus: (state, { payload }: PayloadAction<TorStatus>) => {
+        setTorStatus: (state: TorState, { payload }: PayloadAction<TorStatus>) => {
             state.torStatus = payload;
         },
-        setTorBootstrap: (state, { payload }: PayloadAction<TorBootstrap | null>) => {
+        setTorBootstrap: (state: TorState, { payload }: PayloadAction<TorBootstrap | null>) => {
             state.torBootstrap = payload;
         },
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description


Code improvement to reduce type-declarations to speedup the type-check

Nothing to manually test, only code improvement.

<img width="607" height="335" alt="image" src="https://github.com/user-attachments/assets/65239cdd-c434-459d-b0dc-f6c1e2b50dd2" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-oversized-type-declarations&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-oversized-type-declarations&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-oversized-type-declarations&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily refactors Redux slices and reducers across the application — settingsSlice, flagsSlice, deviceSlice, receiveReducer, routerReducer, accountSearchReducer, debugSlice, torSlice, desktopUpdateReducer, and geolocationReducer. Most changes map to 131+ tests because they are global state dependencies, so broad testing is not warranted. The highest risk areas are: (1) settingsSlice changes affecting settings UI, autodetection, analytics defaults, and DB migration; (2) accountSearchReducer changes affecting wallet search/filter; (3) flagsSlice changes affecting initial run persistence; (4) receiveReducer changes affecting address reveal flows. Many changed files are suite-native (mobile) or unit test files with no E2E coverage. The recommended strategy focuses on tests that directly exercise the specific state managed by each changed slice.

<details><summary><b>Changed files (23)</b></summary>

- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`
- `packages/suite/src/actions/device/deviceSlice.ts`
- `packages/suite/src/actions/suite/__tests__/storageActions.test.ts`
- `packages/suite/src/actions/suite/__tests__/trezorConnectActions.test.ts`
- `packages/suite/src/reducers/suite/index.ts`
- `packages/suite/src/reducers/wallet/accountSearchReducer.ts`
- `packages/suite/src/types/suite/index.ts`
- `suite-common/geolocation/src/geolocationReducer.ts`
- `suite-common/wallet-core/src/stake/tron/tronStakeReducer.ts`
- `suite-native/graph/src/slice.ts`
- `suite-native/intl/src/localeSlice.ts`
- `suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewScreenControls.test.ts`
- `suite-native/state/src/reducers.ts`
- `suite-native/trading-browser-auth/src/hooks/__tests__/useProviderConfirmationStatus.test.ts`
- `suite-native/transaction-management/src/__tests__/sendFormSlice.test.ts`
- `suite-native/transaction-management/src/sendFormSlice.ts`
- `suite/debug/src/debugSlice.ts`
- `suite/desktop-update/src/desktopUpdateReducer.ts`
- `suite/flags/src/flagsSlice.ts`
- `suite/receive/src/receiveReducer.ts`
- `suite/router/src/routerReducer.ts`
- `suite/settings/src/settingsSlice.ts`
- `suite/tor/src/torSlice.ts`

</details>

**Recommended tests (16)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/wallet/account-search.test.ts` — The accountSearchReducer.ts was changed directly. This test specifically exercises account search/filter functionality — typing queries into the account search field, filtering accounts, and clearing search. A regression in the search reducer would be directly caught here.
- `suite/e2e/tests/settings/general.test.ts` — settingsSlice.ts was changed, and this test directly exercises changing fiat currency, theme, language, and analytics toggle in application settings — all managed by the settings slice. It also verifies analytics events tied to settings changes.
- `suite/e2e/tests/analytics/events.test.ts` — This test verifies SuiteReady event contains correct default application settings (language, currency, theme, discreetMode, autodetectTheme, autodetectLanguage) — all values managed by settingsSlice.ts. Changes to the settings slice could alter defaults or serialization of these values.
- `suite/e2e/tests/suite/initial-run.test.ts` — flagsSlice.ts was changed, and this test directly exercises the initialRun flag persistence — verifying that analytics consent persists/doesn't persist across reloads depending on onboarding completion state. The flags slice likely manages the initialRun flag.
- `suite/e2e/tests/settings/autodetect.test.ts` — settingsSlice.ts was changed, and this test verifies autodetect behavior for theme (color scheme) and language (locale). These autodetect settings are stored in the settings slice and directly affect how the onboarding page renders.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/analytics/toggle.test.ts` — This test exercises analytics enable/disable toggle which interacts with settings persistence (settingsSlice) and the initial run flow (flagsSlice). Changes to either slice could affect analytics consent state management.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — settingsSlice.ts was changed. This test verifies discreet mode toggle behavior and the corresponding analytics event. Discreet mode state is managed in the settings slice, so changes could affect the toggle or initial state.
- `suite/e2e/tests/suite/db-migration.test.ts` — settingsSlice.ts was changed. This test verifies database migration preserves user settings (autoEject) across Suite versions. Schema changes in settings or flags slices could break migration paths.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — settingsSlice.ts was changed. This test verifies language preference persistence during database migration between Suite versions. The language setting is stored in the settings slice.
- `suite/e2e/tests/wallet/receive.test.ts` — receiveReducer.ts was changed. This test exercises the receive address flow for multiple coin types (BTC, ETH, SOL, TRX), including address reveal and copy. Changes to the receive reducer could affect address display state management.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — receiveReducer.ts was changed. This test exercises the global receive flow including address reveal, device confirmation, and copy — all of which depend on receive state managed by the receive reducer.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — deviceSlice.ts was changed, and this test specifically exercises setSimulatedEntropyCheckFail action dispatched via the Redux store, which is defined in the device slice. Changes to the device slice actions could break this test's core behavior.
- `suite/e2e/tests/general/check-links.test.ts` — routerReducer.ts was changed. This test crawls all routes defined in router-config and validates links. Changes to the router reducer could affect route registration or navigation state.
- `suite/e2e/tests/settings/forget-device.test.ts` — deviceSlice.ts was changed. This test exercises the forget device flow which directly manipulates device state (disconnect detection, forget confirmation, device removal). The device slice manages this state.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — desktopUpdateReducer.ts and torSlice.ts were changed. This desktop-only test exercises bridge spawning in Electron, which interacts with desktop update and tor infrastructure. Changes to these slices could affect app initialization.
- `suite/e2e/tests/trading/navigation.test.ts` — geolocationReducer.ts was changed. Trading tests depend on geolocation for country selection in buy/sell forms. Navigation test verifies trading form opens correctly which could be affected by geolocation state initialization.

</details>

⚠️ **Changes with no test coverage (14)**
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`
- `packages/suite/src/actions/suite/__tests__/storageActions.test.ts`
- `packages/suite/src/actions/suite/__tests__/trezorConnectActions.test.ts`
- `packages/suite/src/types/suite/index.ts`
- `suite-native/graph/src/slice.ts`
- `suite-native/intl/src/localeSlice.ts`
- `suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewScreenControls.test.ts`
- `suite-native/state/src/reducers.ts`
- `suite-native/trading-browser-auth/src/hooks/__tests__/useProviderConfirmationStatus.test.ts`
- `suite-native/transaction-management/src/__tests__/sendFormSlice.test.ts`
- `suite-native/transaction-management/src/sendFormSlice.ts`
- `suite/debug/src/debugSlice.ts`
- `suite/desktop-update/src/desktopUpdateReducer.ts`
- `suite/tor/src/torSlice.ts`

_Updated: 2026-07-15T13:09:47.961Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-15T13:12:22.846Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-15T13:11:53.370Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-oversized-type-declarations/web/](https://dev.suite.sldev.cz/suite-web/fix-oversized-type-declarations/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->