### PR TITLE
perf(suite): narrow sign verify account selector

### DIFF
--- a/packages/suite/src/views/wallet/sign-verify/index.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { type FieldError } from 'react-hook-form';
 
+import { selectSelectedAccountKey } from '@suite/account';
 import { useDevice } from '@suite/device';
 import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
 import { selectReceiveRevealedAddresses } from '@suite/receive';
@@ -41,8 +42,9 @@ const SignVerify = () => {
     const [isCompleted, setIsCompleted] = useState(false);
 
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const selectedAccountKey = useSelector(selectSelectedAccountKey);
     const revealedAddresses = useSelector(state =>
-        selectReceiveRevealedAddresses(state, selectedAccount.account?.key),
+        selectReceiveRevealedAddresses(state, selectedAccountKey),
     );
     const dispatch = useDispatch();
 


### PR DESCRIPTION
## Description

Uses `selectSelectedAccountKey` for the Sign/Verify receive-address selector instead of deriving the key from the full selected account object.

This addresses the review feedback about selecting only the account key where only the key is needed.

## Testing

- `yarn lint:js --no-tui`
- `yarn type-check --no-tui` failed before reaching Suite due to existing `@trezor/connect` fixture/submodule errors, including missing `submodules/trezor-common/tests/fixtures/...` files
- `yarn workspace @trezor/suite run type-check` also failed due to existing missing build outputs/submodule fixture state

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is the Sign & Verify view component, which is directly tested by exactly two E2E tests — one for Bitcoin and one for Ethereum. Both tests should be run at high priority since any change to this view could break signing, verification, address selection, or format toggling for either coin. There are no uncovered changes.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/sign-verify/index.tsx`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — This test directly exercises the Sign & Verify view component (index.tsx) for Bitcoin, covering standard and Electrum signature formats, address selection, signing, and verification flows. Any change to the view component could break these user-facing workflows.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — This test directly exercises the same Sign & Verify view component for Ethereum signing and verification. Since the changed file is the shared view for both BTC and ETH sign-and-verify flows, a regression in either coin's flow would be immediately user-visible.

</details>

_Updated: 2026-07-14T14:36:34.568Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/sign-verify-selected-account/web/](https://dev.suite.sldev.cz/suite-web/fix/sign-verify-selected-account/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sign-verify-selected-account&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sign-verify-selected-account&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-14T14:39:54.028Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-14T14:39:36.595Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->