### PR TITLE
feat(suite): add tron staking analytics

### DIFF
--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
@@ -245,6 +245,15 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
                 },
             }),
         );
+
+        analytics.report({
+            type: events.stakingStakeEvent.name,
+            payload: {
+                action: 'continue',
+                step: 'staking-dashboard',
+                networkSymbol: account.symbol,
+            },
+        });
     };
 
     const onTronVote = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -260,6 +269,15 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
                 },
             }),
         );
+
+        analytics.report({
+            type: events.stakingUpdateProviderEvent.name,
+            payload: {
+                action: 'continue',
+                step: 'staking-dashboard',
+                networkSymbol: account.symbol,
+            },
+        });
     };
 
     const apyAvailable =

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/TronStakeInANutshellModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/TronStakeInANutshellModal.tsx
@@ -1,6 +1,9 @@
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { useTronStakingStats } from '@suite-common/earn-staking-api';
 import { type EarnModalAction } from '@suite-common/suite-types/src/staking';
+import { supportedTronNetworkSymbols } from '@suite-common/wallet-types';
 import { Divider, StepList } from '@trezor/components';
 import { CheckSquareOffsetIcon, LightningIcon, LockSimpleOpenIcon } from '@trezor/icons';
 
@@ -26,7 +29,21 @@ export const TronStakeInANutshellModal = ({
     onCancel,
     actionType = 'close',
 }: TronStakeInANutshellModalProps) => {
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { maxApr } = useTronStakingStats();
+
+    const handleCancel = () => {
+        onCancel();
+
+        analytics.report({
+            type: events.stakingStakeEvent.name,
+            payload: {
+                action: actionType,
+                step: 'stake-in-a-nutshell-modal',
+                networkSymbol: supportedTronNetworkSymbols[0],
+            },
+        });
+    };
 
     const networkFeeBadge = { text: <Translation id="TR_TRADING_NETWORK_FEE" />, isBadge: true };
 
@@ -90,9 +107,9 @@ export const TronStakeInANutshellModal = ({
     return (
         <EarnInANutshellModalLayout
             heading={<Translation id="TR_EARN_TRON_STAKING_IN_A_NUTSHELL" />}
-            onCancel={onCancel}
+            onCancel={handleCancel}
             actionType={actionType}
-            onAction={onCancel}
+            onAction={handleCancel}
         >
             <EarnInANutshellHighlights
                 items={[

--- a/packages/suite/src/components/earn/staking/tron/TronStakePageHeader.tsx
+++ b/packages/suite/src/components/earn/staking/tron/TronStakePageHeader.tsx
@@ -1,13 +1,18 @@
 import { AccountLabel } from '@suite/account';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { goto, selectSettingsBackRoute } from '@suite/router';
+import { goto, selectRouteName, selectSettingsBackRoute } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectTronStakeSession } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { Box, Button, Column, IconButton, Row, Text } from '@trezor/components';
 import { CaretLeftIcon, InfoIcon } from '@trezor/icons';
 import { CoinLogo } from '@trezor/product-components';
+import { exhaustive } from '@trezor/type-utils';
 
 import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
+import { TRON_FLOW_BY_ROUTE } from 'src/constants/suite/staking';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 
@@ -17,11 +22,62 @@ type TronStakePageHeaderProps = {
 
 export const TronStakePageHeader = ({ account }: TronStakePageHeaderProps) => {
     const dispatch = useDispatch();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { translationString } = useTranslation();
     const { isBelowMobile } = useLayoutSize();
     const previousRoute = useSelector(selectSettingsBackRoute);
+    const routeName = useSelector(selectRouteName);
+
+    const flow = routeName ? TRON_FLOW_BY_ROUTE[routeName] : undefined;
+    const flowStep = useSelector(state =>
+        account && flow ? selectTronStakeSession(state, account.key, flow).step : undefined,
+    );
+
+    const reportFlowClose = () => {
+        if (!account || !flow || flowStep === 'complete') {
+            return;
+        }
+
+        const payload = { action: 'close', networkSymbol: account.symbol } as const;
+
+        switch (flow) {
+            case 'stake':
+                analytics.report({
+                    type: events.stakingStakeEvent.name,
+                    payload: { ...payload, step: 'stake-form-modal' },
+                });
+                break;
+            case 'vote':
+                analytics.report({
+                    type: events.stakingUpdateProviderEvent.name,
+                    payload: { ...payload, step: 'stake-form-modal' },
+                });
+                break;
+            case 'unstake':
+                analytics.report({
+                    type: events.stakingUnstakeEvent.name,
+                    payload: { ...payload, step: 'unstake-form-modal' },
+                });
+                break;
+            case 'withdraw':
+                analytics.report({
+                    type: events.stakingUnstakeEvent.name,
+                    payload: { ...payload, step: 'withdraw-form-modal' },
+                });
+                break;
+            case 'claim':
+                analytics.report({
+                    type: events.stakingClaimEvent.name,
+                    payload: { ...payload, step: 'claim-form-modal' },
+                });
+                break;
+            default:
+                exhaustive(flow);
+        }
+    };
 
     const onBackClick = () => {
+        reportFlowClose();
         dispatch(goto({ routeName: previousRoute.name, params: previousRoute.params }));
     };
 

--- a/packages/suite/src/components/earn/staking/tron/claim/TronClaimSubmitButton.tsx
+++ b/packages/suite/src/components/earn/staking/tron/claim/TronClaimSubmitButton.tsx
@@ -1,6 +1,8 @@
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
 import { Translation, useTranslation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { getTronStakingRewards, isTronClaimSupported } from '@suite-common/wallet-utils';
 import { Button } from '@trezor/components';
@@ -13,6 +15,7 @@ import { useTronStakeContext } from '../TronStakeContext';
 
 export const TronClaimSubmitButton = () => {
     const { device, isLocked } = useDevice();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { translationString } = useTranslation();
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
     const { account, actions } = useTronStakeContext();
@@ -35,6 +38,19 @@ export const TronClaimSubmitButton = () => {
         }
 
         submitAction();
+
+        if (!device?.connected || !device?.available) {
+            return;
+        }
+
+        analytics.report({
+            type: events.stakingClaimEvent.name,
+            payload: {
+                action: 'continue',
+                step: 'claim-form-modal',
+                networkSymbol: account.symbol,
+            },
+        });
     };
 
     return (

--- a/packages/suite/src/components/earn/staking/tron/freeze/TronFreezeSubmitButton.tsx
+++ b/packages/suite/src/components/earn/staking/tron/freeze/TronFreezeSubmitButton.tsx
@@ -1,7 +1,9 @@
 import { useFormState } from 'react-hook-form';
 
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Button } from '@trezor/components';
 
@@ -11,18 +13,38 @@ import { useTronStakeContext } from '../TronStakeContext';
 
 export const TronFreezeSubmitButton = () => {
     const { device, isLocked } = useDevice();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
-    const { form, actions } = useTronStakeContext();
+    const { account, form, actions, amountInput } = useTronStakeContext();
     const { isSubmitting, pendingTxid, submitAction } = actions;
     const { isValid } = useFormState({ control: form.methods.control });
 
     const isDeviceLocked = !!device?.connected && !!device?.available && isLocked();
 
+    const handleClick = () => {
+        submitAction();
+
+        if (!device?.connected || !device?.available) {
+            return;
+        }
+
+        analytics.report({
+            type: events.stakingStakeEvent.name,
+            payload: {
+                action: 'continue',
+                step: 'stake-form-modal',
+                networkSymbol: account.symbol,
+                currency: amountInput.currency,
+                resource: form.methods.getValues().resourceType,
+            },
+        });
+    };
+
     return (
         <Button
             size="large"
             width="100%"
-            onClick={submitAction}
+            onClick={handleClick}
             isDisabled={!isValid || isSubmitting || isDeviceLocked || !!pendingTxid}
             isLoading={isSubmitting || isDiscoveryRunning}
         >

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
@@ -1,5 +1,7 @@
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { closeModal, openDeferredModal, preserveModal } from '@suite/modal';
+import { useServices } from '@suite-common/dependency-injection';
 import { useTronStakingStats } from '@suite-common/earn-staking-api';
 import { TRON_REPRESENTATIVE_TERMS_OF_SERVICE_URLS } from '@suite-common/wallet-constants';
 import {
@@ -46,6 +48,7 @@ export const useTronStakeActions = ({
 }: UseTronStakeActionsProps): TronStakeActions => {
     const dispatch = useDispatch();
     const { device } = useDevice();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { stats } = useTronStakingStats();
     const { step, isSubmitting, error, pendingTxid } = useSelector(state =>
         selectTronStakeSession(state, account.key, flow),
@@ -103,8 +106,8 @@ export const useTronStakeActions = ({
 
                 const requestVoteConsent =
                     representative && termsOfServiceUrl
-                        ? async () =>
-                              Boolean(
+                        ? async () => {
+                              const isConsentGiven = Boolean(
                                   await dispatch(
                                       openDeferredModal({
                                           type: 'tron-vote-consent',
@@ -112,7 +115,22 @@ export const useTronStakeActions = ({
                                           termsOfServiceUrl,
                                       }),
                                   ),
-                              )
+                              );
+
+                              if (!isConsentGiven) {
+                                  analytics.report({
+                                      type: events.stakingUpdateProviderEvent.name,
+                                      payload: {
+                                          action: 'cancel',
+                                          step: 'stake-form-modal',
+                                          networkSymbol: account.symbol,
+                                          votingDelegation: representativeAddress,
+                                      },
+                                  });
+                              }
+
+                              return isConsentGiven;
+                          }
                         : undefined;
 
                 dispatch(

--- a/packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeSubmitButton.tsx
+++ b/packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeSubmitButton.tsx
@@ -1,7 +1,9 @@
 import { useFormState } from 'react-hook-form';
 
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Button } from '@trezor/components';
 
@@ -11,18 +13,38 @@ import { useTronStakeContext } from '../TronStakeContext';
 
 export const TronUnstakeSubmitButton = () => {
     const { device, isLocked } = useDevice();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
-    const { form, actions } = useTronStakeContext();
+    const { account, form, actions, amountInput } = useTronStakeContext();
     const { isSubmitting, pendingTxid, submitAction } = actions;
     const { isValid } = useFormState({ control: form.methods.control });
 
     const isDeviceLocked = !!device?.connected && !!device?.available && isLocked();
 
+    const handleClick = () => {
+        submitAction();
+
+        if (!device?.connected || !device?.available) {
+            return;
+        }
+
+        analytics.report({
+            type: events.stakingUnstakeEvent.name,
+            payload: {
+                action: 'continue',
+                step: 'unstake-form-modal',
+                networkSymbol: account.symbol,
+                currency: amountInput.currency,
+                resource: form.methods.getValues().resourceType,
+            },
+        });
+    };
+
     return (
         <Button
             size="large"
             width="100%"
-            onClick={submitAction}
+            onClick={handleClick}
             isDisabled={!isValid || isSubmitting || isDeviceLocked || !!pendingTxid}
             isLoading={isSubmitting || isDiscoveryRunning}
         >

--- a/packages/suite/src/components/earn/staking/tron/vote/TronVoteSubmitButton.tsx
+++ b/packages/suite/src/components/earn/staking/tron/vote/TronVoteSubmitButton.tsx
@@ -1,7 +1,9 @@
 import { useFormState, useWatch } from 'react-hook-form';
 
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Button } from '@trezor/components';
 
@@ -12,8 +14,9 @@ import { CUSTOM_REPRESENTATIVE } from './constants';
 
 export const TronVoteSubmitButton = () => {
     const { device, isLocked } = useDevice();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
-    const { form, actions } = useTronStakeContext();
+    const { account, form, actions } = useTronStakeContext();
     const { isSubmitting, pendingTxid, submitAction } = actions;
     const { control } = form.methods;
 
@@ -28,11 +31,29 @@ export const TronVoteSubmitButton = () => {
 
     const isDeviceLocked = !!device?.connected && !!device?.available && isLocked();
 
+    const handleClick = () => {
+        submitAction();
+
+        if (!device?.connected || !device?.available) {
+            return;
+        }
+
+        analytics.report({
+            type: events.stakingUpdateProviderEvent.name,
+            payload: {
+                action: 'continue',
+                step: 'stake-form-modal',
+                networkSymbol: account.symbol,
+                votingDelegation: representative,
+            },
+        });
+    };
+
     return (
         <Button
             size="large"
             width="100%"
-            onClick={submitAction}
+            onClick={handleClick}
             isDisabled={
                 !isRepresentativeSelected || isSubmitting || isDeviceLocked || !!pendingTxid
             }

--- a/packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawSubmitButton.tsx
+++ b/packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawSubmitButton.tsx
@@ -1,5 +1,7 @@
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { getTronWithdrawableBalance } from '@suite-common/wallet-utils';
 import { Button } from '@trezor/components';
@@ -11,6 +13,7 @@ import { useTronStakeContext } from '../TronStakeContext';
 
 export const TronWithdrawSubmitButton = () => {
     const { device, isLocked } = useDevice();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
     const { account, actions } = useTronStakeContext();
     const { isSubmitting, pendingTxid, submitAction } = actions;
@@ -18,11 +21,28 @@ export const TronWithdrawSubmitButton = () => {
     const hasWithdrawableAmount = new BigNumber(getTronWithdrawableBalance(account)).gt(0);
     const isDeviceUnavailable = !!device?.connected && !!device?.available && isLocked();
 
+    const handleClick = () => {
+        submitAction();
+
+        if (!device?.connected || !device?.available) {
+            return;
+        }
+
+        analytics.report({
+            type: events.stakingUnstakeEvent.name,
+            payload: {
+                action: 'continue',
+                step: 'withdraw-form-modal',
+                networkSymbol: account.symbol,
+            },
+        });
+    };
+
     return (
         <Button
             size="large"
             width="100%"
-            onClick={submitAction}
+            onClick={handleClick}
             isDisabled={
                 !hasWithdrawableAmount || isSubmitting || isDeviceUnavailable || !!pendingTxid
             }

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalBottomContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalBottomContent.tsx
@@ -14,6 +14,7 @@ import {
     type FormState,
     type RbfTransactionType,
     type ReviewOutput,
+    type TronStakingFormState,
 } from '@suite-common/wallet-types';
 import {
     getTxValidityTimeoutInMs,
@@ -30,6 +31,17 @@ import { type TxInfoState, getTxType, hasTxValidityExpired } from '../utils';
 const mapRbfTypeToReporting: Record<RbfTransactionType, TransactionCreatedEventAction> = {
     'bump-fee': 'replaced',
     cancel: 'canceled',
+};
+
+const mapTronStakingKindToConfirmAction: Record<
+    TronStakingFormState['kind'],
+    'stake' | 'unstake' | 'claim' | 'change-delegate' | 'withdraw'
+> = {
+    freeze: 'stake',
+    vote: 'change-delegate',
+    unstake: 'unstake',
+    withdraw: 'withdraw',
+    claim: 'claim',
 };
 
 type TransactionReviewModalBottomContentProps = {
@@ -117,10 +129,15 @@ export const TransactionReviewModalBottomContent = ({
                     : 'sent',
             );
 
-            if (stakeType) {
+            const stakingConfirmAction =
+                stakeType ??
+                (precomposedForm.tronStaking &&
+                    mapTronStakingKindToConfirmAction[precomposedForm.tronStaking.kind]);
+
+            if (stakingConfirmAction) {
                 return analytics.report({
                     type: events.stakingConfirmEvent.name,
-                    payload: { action: stakeType, networkSymbol: symbol },
+                    payload: { action: stakingConfirmAction, networkSymbol: symbol },
                 });
             }
         }

--- a/packages/suite/src/constants/suite/staking.ts
+++ b/packages/suite/src/constants/suite/staking.ts
@@ -1,7 +1,16 @@
 import { events } from '@suite/analytics';
 import { EarnFlow } from '@suite-common/suite-types/src/staking';
+import { type TronFlow } from '@suite-common/wallet-core';
 
 export const earnFlowToEventTypeMap = {
     [EarnFlow.Stake]: events.stakingStakeEvent.name,
     [EarnFlow.UpdateProvider]: events.stakingUpdateProviderEvent.name,
 } as const satisfies Record<Exclude<EarnFlow, EarnFlow.Yield>, string>;
+
+export const TRON_FLOW_BY_ROUTE: Partial<Record<string, TronFlow>> = {
+    'earn-tron-stake': 'stake',
+    'earn-tron-vote': 'vote',
+    'earn-tron-unstake': 'unstake',
+    'earn-tron-withdraw': 'withdraw',
+    'earn-tron-claim': 'claim',
+};

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard/useEmptyStakingCardContent.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard/useEmptyStakingCardContent.tsx
@@ -1,8 +1,10 @@
 import { type ReactNode } from 'react';
 
+import { type DesktopAnalyticsDep, events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { goto } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
 import { EarnFlow, EarnProvider } from '@suite-common/suite-types/src/staking';
 import { type Account } from '@suite-common/wallet-types';
 import { type IconComponent, Tooltip } from '@trezor/components';
@@ -49,7 +51,13 @@ interface UseNetworkContentProps {
     dispatch: ReturnType<typeof useDispatch>;
 }
 
-const getTronContent = ({ data, dispatch }: UseNetworkContentProps): EmptyStakingCardContent => {
+const getTronContent = ({
+    data,
+    dispatch,
+    analytics,
+}: UseNetworkContentProps & {
+    analytics: DesktopAnalyticsDep['analytics'];
+}): EmptyStakingCardContent => {
     const rate = formatApyValue(data.rate);
     const { displaySymbol, isStartStakingDisabled, account } = data;
 
@@ -93,6 +101,15 @@ const getTronContent = ({ data, dispatch }: UseNetworkContentProps): EmptyStakin
                 },
             }),
         );
+
+        analytics.report({
+            type: events.stakingStakeEvent.name,
+            payload: {
+                action: 'continue',
+                step: 'staking-dashboard',
+                networkSymbol: account.symbol,
+            },
+        });
     };
 
     return { title, text, features, onStartStakingClick };
@@ -274,10 +291,11 @@ export const useStakingCardContent = ({
     data,
 }: UseStakingCardContentProps): EmptyStakingCardContent => {
     const dispatch = useDispatch();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     switch (variant) {
         case 'tron':
-            return getTronContent({ data, dispatch });
+            return getTronContent({ data, dispatch, analytics });
         case 'cardano':
             return getCardanoContent({ data, dispatch });
         case 'default':

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourceModal.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourceModal.tsx
@@ -1,5 +1,7 @@
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
 import { type Account, type TronResourceType } from '@suite-common/wallet-types';
 import {
     getResourceGain,
@@ -25,6 +27,7 @@ interface TronResourceModalProps {
 
 export const TronResourceModal = ({ account, resourceType, onClose }: TronResourceModalProps) => {
     const dispatch = useDispatch();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const resources = getTronResources(account);
     const stakingInfo = getTronStakingInfo(account);
     const isEnergy = resourceType === 'energy';
@@ -91,6 +94,15 @@ export const TronResourceModal = ({ account, resourceType, onClose }: TronResour
             }),
         );
         onClose();
+
+        analytics.report({
+            type: events.stakingStakeEvent.name,
+            payload: {
+                action: 'continue',
+                step: 'staking-dashboard',
+                networkSymbol: account.symbol,
+            },
+        });
     };
 
     return (

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
 import { type Account, type TronResourceType } from '@suite-common/wallet-types';
 import { getTronResources } from '@suite-common/wallet-utils';
 import { Button, Card, Column, Icon, Row, Text } from '@trezor/components';
@@ -18,6 +20,7 @@ interface TronResourcesCardProps {
 
 export const TronResourcesCard = ({ account }: TronResourcesCardProps) => {
     const dispatch = useDispatch();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const [openResource, setOpenResource] = useState<TronResourceType | null>(null);
     const resources = getTronResources(account);
 
@@ -28,7 +31,7 @@ export const TronResourcesCard = ({ account }: TronResourcesCardProps) => {
     const energyAvailable = resources?.availableEnergy ?? 0;
     const energyTotal = resources?.totalEnergy ?? 0;
 
-    const goToFreeze = () =>
+    const goToFreeze = () => {
         dispatch(
             goto({
                 routeName: 'earn-tron-stake',
@@ -39,6 +42,16 @@ export const TronResourcesCard = ({ account }: TronResourcesCardProps) => {
                 },
             }),
         );
+
+        analytics.report({
+            type: events.stakingStakeEvent.name,
+            payload: {
+                action: 'continue',
+                step: 'staking-dashboard',
+                networkSymbol: account.symbol,
+            },
+        });
+    };
 
     return (
         <Card

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
 import { getTronVotedApr, useTronStakingStats } from '@suite-common/earn-staking-api';
 import { type Account } from '@suite-common/wallet-types';
 import {
@@ -35,6 +37,7 @@ interface TronStakedCardProps {
 
 export const TronStakedCard = ({ account }: TronStakedCardProps) => {
     const dispatch = useDispatch();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const [isVoteAllocationOpen, setIsVoteAllocationOpen] = useState(false);
     const { stats, maxApr } = useTronStakingStats();
 
@@ -47,7 +50,7 @@ export const TronStakedCard = ({ account }: TronStakedCardProps) => {
     const hasRemainingVotes = new BigNumber(remainingVotes).gt(0);
     const shouldShowRemainingVotes = new BigNumber(remainingVotes).plus(totalVotes).gt(0);
 
-    const goToFlow = (routeName: 'earn-tron-stake' | 'earn-tron-unstake' | 'earn-tron-vote') =>
+    const goToFlow = (routeName: 'earn-tron-stake' | 'earn-tron-unstake' | 'earn-tron-vote') => {
         dispatch(
             goto({
                 routeName,
@@ -58,6 +61,22 @@ export const TronStakedCard = ({ account }: TronStakedCardProps) => {
                 },
             }),
         );
+
+        const eventTypeByRoute = {
+            'earn-tron-stake': events.stakingStakeEvent.name,
+            'earn-tron-unstake': events.stakingUnstakeEvent.name,
+            'earn-tron-vote': events.stakingUpdateProviderEvent.name,
+        } as const;
+
+        analytics.report({
+            type: eventTypeByRoute[routeName],
+            payload: {
+                action: 'continue',
+                step: 'staking-dashboard',
+                networkSymbol: account.symbol,
+            },
+        });
+    };
 
     return (
         <Card

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVoteAllocationModal/TronVoteAllocationModal.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVoteAllocationModal/TronVoteAllocationModal.tsx
@@ -1,5 +1,7 @@
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
 import { useTronStakingStats } from '@suite-common/earn-staking-api';
 import { type Account } from '@suite-common/wallet-types';
 import {
@@ -32,6 +34,7 @@ interface TronVoteAllocationModalProps {
 
 export const TronVoteAllocationModal = ({ account, onClose }: TronVoteAllocationModalProps) => {
     const dispatch = useDispatch();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { stats } = useTronStakingStats();
 
     const remainingVotes = getTronAvailableVotingPower(account);
@@ -52,6 +55,15 @@ export const TronVoteAllocationModal = ({ account, onClose }: TronVoteAllocation
             }),
         );
         onClose();
+
+        analytics.report({
+            type: events.stakingUpdateProviderEvent.name,
+            payload: {
+                action: 'continue',
+                step: 'staking-dashboard',
+                networkSymbol: account.symbol,
+            },
+        });
     };
 
     return (

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx
@@ -1,7 +1,9 @@
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
 import { Translation, useTranslation } from '@suite/intl';
 import { goto } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
 import { type Account } from '@suite-common/wallet-types';
 import {
     getTronRewardClaimCooldownEndsAt,
@@ -31,6 +33,7 @@ interface TronVotingRewardsCardProps {
 
 export const TronVotingRewardsCard = ({ account }: TronVotingRewardsCardProps) => {
     const dispatch = useDispatch();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { device } = useDevice();
     const { translationString } = useTranslation();
     const { isFirmwareModalOpen, openFirmwareModal, closeFirmwareModal, updateFirmware } =
@@ -62,6 +65,15 @@ export const TronVotingRewardsCard = ({ account }: TronVotingRewardsCardProps) =
                 },
             }),
         );
+
+        analytics.report({
+            type: events.stakingClaimEvent.name,
+            payload: {
+                action: 'continue',
+                step: 'staking-dashboard',
+                networkSymbol: account.symbol,
+            },
+        });
     };
 
     return (

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronWithdrawReadyBanner.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronWithdrawReadyBanner.tsx
@@ -1,5 +1,7 @@
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
 import { type Account } from '@suite-common/wallet-types';
 import { getTronWithdrawableBalance } from '@suite-common/wallet-utils';
 import { Banner } from '@trezor/components';
@@ -14,13 +16,14 @@ interface TronWithdrawReadyBannerProps {
 
 export const TronWithdrawReadyBanner = ({ account }: TronWithdrawReadyBannerProps) => {
     const dispatch = useDispatch();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const withdrawableAmount = getTronWithdrawableBalance(account);
 
     if (new BigNumber(withdrawableAmount).lte(0)) {
         return null;
     }
 
-    const goToWithdraw = () =>
+    const goToWithdraw = () => {
         dispatch(
             goto({
                 routeName: 'earn-tron-withdraw',
@@ -31,6 +34,16 @@ export const TronWithdrawReadyBanner = ({ account }: TronWithdrawReadyBannerProp
                 },
             }),
         );
+
+        analytics.report({
+            type: events.stakingUnstakeEvent.name,
+            payload: {
+                action: 'continue',
+                step: 'staking-dashboard',
+                networkSymbol: account.symbol,
+            },
+        });
+    };
 
     return (
         <Banner

--- a/suite-common/suite-types/src/staking.ts
+++ b/suite-common/suite-types/src/staking.ts
@@ -28,4 +28,5 @@ export type EarnAnalyticsStep =
     | 'staking-dashboard'
     | 'yield-deposit'
     | 'yield-withdraw'
-    | 'unstake-form-modal';
+    | 'unstake-form-modal'
+    | 'withdraw-form-modal';

--- a/suite/analytics/src/events/stakingConfirmEvent.ts
+++ b/suite/analytics/src/events/stakingConfirmEvent.ts
@@ -3,7 +3,7 @@ import type { AttributeDef, EventDef } from '@suite-common/analytics';
 import { EventType } from '../constants';
 
 type Attributes = {
-    action: AttributeDef<'stake' | 'unstake' | 'claim' | 'change-delegate'>;
+    action: AttributeDef<'stake' | 'unstake' | 'claim' | 'change-delegate' | 'withdraw'>;
     networkSymbol?: AttributeDef<string>;
 };
 
@@ -14,7 +14,13 @@ export const stakingConfirmEvent: EventDef<Attributes, EventType.StakingConfirm>
 
     attributes: {
         action: {
-            changelog: [{ version: '25.4.0', notes: 'added' }],
+            changelog: [
+                { version: '25.4.0', notes: 'added' },
+                {
+                    version: '26.7.0',
+                    notes: 'added `withdraw` value for withdrawing an expired Tron unstake; for Tron, `stake` is the freeze transaction and `change-delegate` the vote transaction',
+                },
+            ],
         },
         networkSymbol: {
             changelog: [{ version: '25.12.0', notes: 'added' }],

--- a/suite/analytics/src/events/stakingStakeEvent.ts
+++ b/suite/analytics/src/events/stakingStakeEvent.ts
@@ -17,6 +17,7 @@ type Attributes = {
     >;
     networkSymbol?: AttributeDef<string>;
     currency?: AttributeDef<'crypto' | 'fiat'>;
+    resource?: AttributeDef<'bandwidth' | 'energy'>;
 };
 
 export const stakingStakeEvent: EventDef<Attributes, EventType.StakingStake> = {
@@ -50,6 +51,11 @@ export const stakingStakeEvent: EventDef<Attributes, EventType.StakingStake> = {
             changelog: [{ version: '25.4.0', notes: 'added' }],
             description:
                 'The display currency format: `crypto` for cryptocurrency amounts, `fiat` for fiat currency conversion',
+        },
+        resource: {
+            changelog: [{ version: '26.7.0', notes: 'added' }],
+            description:
+                'The Tron resource the frozen balance provides: `bandwidth` or `energy`; only sent for Tron',
         },
     },
 };

--- a/suite/analytics/src/events/stakingUnstakeEvent.ts
+++ b/suite/analytics/src/events/stakingUnstakeEvent.ts
@@ -5,9 +5,15 @@ import { EventType } from '../constants';
 
 type Attributes = {
     action: AttributeDef<EarnModalAction>;
-    step: AttributeDef<Extract<EarnAnalyticsStep, 'staking-dashboard' | 'unstake-form-modal'>>;
+    step: AttributeDef<
+        Extract<
+            EarnAnalyticsStep,
+            'staking-dashboard' | 'unstake-form-modal' | 'withdraw-form-modal'
+        >
+    >;
     networkSymbol?: AttributeDef<string>;
     currency?: AttributeDef<'crypto' | 'fiat'>;
+    resource?: AttributeDef<'bandwidth' | 'energy'>;
 };
 
 export const stakingUnstakeEvent: EventDef<Attributes, EventType.StakingUnstake> = {
@@ -29,9 +35,15 @@ export const stakingUnstakeEvent: EventDef<Attributes, EventType.StakingUnstake>
                 'The action taken by the user: `continue` to proceed with unstaking, `cancel` to abort the process, `close` to dismiss the modal',
         },
         step: {
-            changelog: [{ version: '25.4.0', notes: 'added' }],
+            changelog: [
+                { version: '25.4.0', notes: 'added' },
+                {
+                    version: '26.7.0',
+                    notes: 'added `withdraw-form-modal` value for the Tron withdraw-expired-unstake form',
+                },
+            ],
             description:
-                'The current step in the unstaking flow: `staking-dashboard` when initiated from dashboard, `unstake-form-modal` when in the unstaking form',
+                'The current step in the unstaking flow: `staking-dashboard` when initiated from dashboard, `unstake-form-modal` when in the unstaking form, `withdraw-form-modal` when in the Tron withdraw form',
         },
         networkSymbol: {
             changelog: [{ version: '25.4.0', notes: 'added' }],
@@ -41,6 +53,11 @@ export const stakingUnstakeEvent: EventDef<Attributes, EventType.StakingUnstake>
             changelog: [{ version: '25.4.0', notes: 'added' }],
             description:
                 'The currency type used for amount display: `crypto` for cryptocurrency amounts, `fiat` for fiat currency amounts',
+        },
+        resource: {
+            changelog: [{ version: '26.7.0', notes: 'added' }],
+            description:
+                'The Tron resource the unfrozen balance was providing: `bandwidth` or `energy`; only sent for Tron',
         },
     },
 };

--- a/suite/analytics/src/events/stakingUpdateProviderEvent.ts
+++ b/suite/analytics/src/events/stakingUpdateProviderEvent.ts
@@ -16,7 +16,7 @@ type Attributes = {
     >;
     networkSymbol?: AttributeDef<string>;
     currency?: AttributeDef<'crypto' | 'fiat'>;
-    votingDelegation?: AttributeDef<'everstake' | 'another_drep'>;
+    votingDelegation?: AttributeDef<string>;
 };
 
 export const stakingUpdateProviderEvent: EventDef<Attributes, EventType.StakingUpdateProvider> = {
@@ -52,9 +52,15 @@ export const stakingUpdateProviderEvent: EventDef<Attributes, EventType.StakingU
                 'Currency type: `crypto` for cryptocurrency amount, `fiat` for fiat currency conversion',
         },
         votingDelegation: {
-            changelog: [{ version: '25.12.0', notes: 'added' }],
+            changelog: [
+                { version: '25.12.0', notes: 'added' },
+                {
+                    version: '26.7.0',
+                    notes: 'for Tron, carries the Super Representative address of a Suite-offered representative, or `custom` for a user-entered one',
+                },
+            ],
             description:
-                'Voting delegation provider: `everstake` for Everstake provider, `another_drep` for other delegation providers',
+                'Voting delegation provider: `everstake` for Everstake provider, `another_drep` for other delegation providers; for Tron, the Super Representative address or `custom`',
         },
     },
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Implements Tron staking analytics

## Analytics events

No new event types — Tron reuses the existing `staking/*` events with `networkSymbol: trx`.

### Schema extensions

- `staking/confirm` — added `withdraw` action value
- `staking/stake` — added `resource: bandwidth | energy` attribute
- `staking/unstake` — added `resource` attribute and `withdraw-form-modal` step value
- `staking/update-provider` — `votingDelegation` widened to string: carries the SR address for Suite-offered representatives, or the literal `custom` for a user-entered one
- `EarnAnalyticsStep` — added `withdraw-form-modal`

### Events fired for Tron

 Event | When | Steps used |
  | --- | --- | --- |
  | `staking/stake` | Stake CTAs, freeze form submit, nutshell modal, page close | `staking-dashboard`, `stake-form-modal` (+ `currency`, `resource`), `stake-in-a-nutshell-modal` |
  | `staking/update-provider` | Vote CTAs, vote form submit, ToS consent decline, page close | `staking-dashboard`, `stake-form-modal` (+ `votingDelegation`: SR address or `custom`) |
  | `staking/unstake` | Unstake/withdraw CTAs, both form submits, page close | `staking-dashboard`, `unstake-form-modal` (+ `currency`, `resource`), `withdraw-form-modal` |
  | `staking/claim` | Claim CTA, claim form submit, page close | `staking-dashboard`, `claim-form-modal` |
  | `staking/confirm` | Send click in tx review modal | `action` by tx: freeze → `stake`, vote → `change-delegate`, unstake, `withdraw`, claim |

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-15T08:12:41.810Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-15T08:13:49.364Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-analytics&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-analytics&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-analytics&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set is focused on Tron staking UI components (freeze, vote, claim, unstake, withdraw), shared staking infrastructure (constants, types, analytics events, EarnStakingAccountRow, EmptyStakingCard, TransactionReviewModalBottomContent), and Tron-specific dashboard views. There are no dedicated Tron staking E2E tests in the test suite, so the Tron-specific components have no direct test coverage. The risk is primarily in shared staking infrastructure changes (staking constants, empty card content hook, transaction review modal, EarnStakingAccountRow) that could affect ETH, SOL, and ADA staking flows. The recommended strategy is to run the existing staking tests for ETH, SOL, and ADA to verify that shared components haven't regressed.

<details><summary><b>Changed files (23)</b></summary>

- `packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx`
- `packages/suite/src/components/earn/modals/EarnInANutshell/TronStakeInANutshellModal.tsx`
- `packages/suite/src/components/earn/staking/tron/TronStakePageHeader.tsx`
- `packages/suite/src/components/earn/staking/tron/claim/TronClaimSubmitButton.tsx`
- `packages/suite/src/components/earn/staking/tron/freeze/TronFreezeSubmitButton.tsx`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts`
- `packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeSubmitButton.tsx`
- `packages/suite/src/components/earn/staking/tron/vote/TronVoteSubmitButton.tsx`
- `packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawSubmitButton.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalBottomContent.tsx`
- `packages/suite/src/constants/suite/staking.ts`
- `packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard/useEmptyStakingCardContent.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourceModal.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVoteAllocationModal/TronVoteAllocationModal.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronWithdrawReadyBanner.tsx`
- `suite-common/suite-types/src/staking.ts`
- `suite/analytics/src/events/stakingConfirmEvent.ts`
- `suite/analytics/src/events/stakingStakeEvent.ts`
- `suite/analytics/src/events/stakingUnstakeEvent.ts`
- `suite/analytics/src/events/stakingUpdateProviderEvent.ts`

</details>

**Recommended tests (12)**

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Changes to useEmptyStakingCardContent.tsx and staking constants could affect the empty staking card rendering and the staking flow entry point. This test verifies the empty-to-staked transition for ETH which shares staking dashboard infrastructure with the changed Tron components.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — EarnStakingAccountRow.tsx is changed and is used in the staking dashboard to display staked amounts. This test exercises the ETH staking dashboard view and staking flow which renders staking account rows.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — TransactionReviewModalBottomContent.tsx is changed, which renders the bottom section of the transaction review modal used when confirming unstake transactions. This test exercises the full unstake and claim flows including transaction confirmation.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Changes to staking constants and useEmptyStakingCardContent could affect how staking cards render across all networks including ADA. The claim flow also uses the transaction review modal whose bottom content was changed.
- `suite/e2e/tests/staking/ada/stake.test.ts` — The staking nutshell modal infrastructure is shared across networks; TronStakeInANutshellModal changes could indicate refactoring in the earn modals pattern. ADA staking also uses the empty staking card and transaction review modal.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — ADA unstake exercises the staking dashboard and transaction review modal bottom content. Changes to staking constants and the review modal component could affect the unstaking confirmation flow.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL initial staking uses the empty staking card (useEmptyStakingCardContent changed) and staking constants. Changes could affect how the empty-to-staked transition renders for Solana.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstake flow uses the transaction review modal (TransactionReviewModalBottomContent changed) and staking dashboard components. The staking constants change could also affect SOL staking UI.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — SOL stake-more exercises the staking dashboard with EarnStakingAccountRow and the transaction review modal. Both components were changed.
- `suite/e2e/tests/staking/staking-form.test.ts` — The staking form test validates ETH staking form behavior which uses the staking dashboard components and constants. Changes to staking constants could affect validation or display logic.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/sol/rewards.test.ts` — SOL rewards test displays the staking dashboard with EarnStakingAccountRow. Changes to the account row component could affect how staked amounts and rewards are displayed.
- `suite/e2e/tests/analytics/staking-events.test.ts` — Staking analytics events are changed (stakingStakeEvent, stakingUnstakeEvent, stakingConfirmEvent, stakingUpdateProviderEvent). This test verifies StakingNavigate events for ETH and ADA, which could be affected if the analytics event structure was refactored.

</details>

⚠️ **Changes with no test coverage (19)**
- `packages/suite/src/components/earn/staking/tron/TronStakePageHeader.tsx`
- `packages/suite/src/components/earn/staking/tron/claim/TronClaimSubmitButton.tsx`
- `packages/suite/src/components/earn/staking/tron/freeze/TronFreezeSubmitButton.tsx`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts`
- `packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeSubmitButton.tsx`
- `packages/suite/src/components/earn/staking/tron/vote/TronVoteSubmitButton.tsx`
- `packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawSubmitButton.tsx`
- `packages/suite/src/components/earn/modals/EarnInANutshell/TronStakeInANutshellModal.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourceModal.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVoteAllocationModal/TronVoteAllocationModal.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronWithdrawReadyBanner.tsx`
- `suite-common/suite-types/src/staking.ts`
- `suite/analytics/src/events/stakingConfirmEvent.ts`
- `suite/analytics/src/events/stakingStakeEvent.ts`
- `suite/analytics/src/events/stakingUnstakeEvent.ts`
- `suite/analytics/src/events/stakingUpdateProviderEvent.ts`

_Updated: 2026-07-15T08:10:02.566Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-analytics/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-analytics/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->