### PR TITLE
fix(components): avoid rendering a stray "0" for empty arrays

### DIFF
--- a/packages/components/src/components/Menu/Menu.tsx
+++ b/packages/components/src/components/Menu/Menu.tsx
@@ -202,7 +202,7 @@ export const Menu = forwardRef<HTMLUListElement, MenuProps>(
             >
                 <Column gap={spacings.md}>
                     {content}
-                    {visibleItems?.length && (
+                    {!!visibleItems?.length && (
                         <MenuList ref={ref}>
                             {visibleItems?.map((item, index) => (
                                 <MenuItem

--- a/packages/components/src/components/buttons/Button/Button.tsx
+++ b/packages/components/src/components/buttons/Button/Button.tsx
@@ -130,7 +130,7 @@ export const Button = ({
                 {(iconRight || buttonProps.target === '_blank') && (
                     <Icon as={iconRight ?? ArrowLineUpRightIcon} {...iconProps} />
                 )}
-                {shortcut?.length && (
+                {!!shortcut?.length && (
                     <Text as="div" color={colorToken}>
                         <ShortcutBadge shortcut={shortcut} />
                     </Text>


### PR DESCRIPTION
## Description

Classic React footgun: `{arr?.length && <JSX/>}` renders a stray literal **"0"** when the array is empty, because `0 && <JSX/>` evaluates to `0` — and React renders the number `0` as text (unlike `false`, which renders nothing).

Fixed in two design-system components by coercing to boolean with `!!`:

- [`Menu.tsx:205`](https://github.com/trezor/trezor-suite/blob/92518697bd9d3725942d13184d5219fd299769c9/packages/components/src/components/Menu/Menu.tsx#L205) — `{visibleItems?.length && …}` → `{!!visibleItems?.length && …}`. Reachable when every menu item is hidden (`visibleItems` is an empty array), which would render a bare "0" where the list should be.
- [`Button.tsx:133`](https://github.com/trezor/trezor-suite/blob/92518697bd9d3725942d13184d5219fd299769c9/packages/components/src/components/buttons/Button/Button.tsx#L133) — `{shortcut?.length && …}` → `{!!shortcut?.length && …}`. Reachable when a `Button` is passed an empty `shortcut={[]}` array.

No behavior change other than not rendering the stray "0"; a non-empty array still renders the JSX as before.

Split out from the continuously-improve sweep #29735.

## Notes for QA

Trivial, low-risk. Anywhere a `Menu` ends up with all items hidden, or a `Button` receives an empty `shortcut` array, a stray "0" would previously appear next to the component — it no longer does. Non-empty cases are unchanged.

## Related Issue

Part of the split-out series from #29735.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Both changed files (Button.tsx and Menu.tsx) are foundational UI components used across virtually all 131 E2E tests, making them extremely broad dependencies. Since no specific behavioral change details are available, the risk is that a rendering or interaction regression in these components could surface anywhere. The recommended strategy is to run a small, diverse set of tests that exercise buttons and menus in distinct contexts (settings dropdowns, guide panel navigation, form submission, disabled state handling) rather than running the full suite. If the change is purely cosmetic (styling), risk is minimal; if it affects props, event handling, or rendering logic, the medium-priority tests should catch regressions.

<details><summary><b>Changed files (2)</b></summary>

- `packages/components/src/components/Menu/Menu.tsx`
- `packages/components/src/components/buttons/Button/Button.tsx`

</details>

**Recommended tests (7)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/browser/safari.test.ts` — This test explicitly verifies a 'Continue at my own risk' Button component on the unsupported browser page, and checks button text and click behavior. A change to Button.tsx could affect rendering or click handling of this prominent CTA button.
- `suite/e2e/tests/general/suite-guide.test.ts` — The Suite Guide test exercises button interactions for submitting bug reports and navigating guide content. The guide panel likely uses Menu.tsx for its navigation structure and Button.tsx for submit/action buttons, making it a reasonable smoke test for both changed components.
- `suite/e2e/tests/settings/general.test.ts` — Settings page contains multiple interactive buttons and dropdown menus (fiat selector, theme selector, language selector, analytics toggle). Changes to Button and Menu components could affect these core settings interactions.
- `suite/e2e/tests/suite/guide.test.ts` — This comprehensive guide test verifies feedback form submission buttons, guide navigation nodes, and search functionality — all of which rely on Button and potentially Menu components for their UI interactions.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — The assets test clicks buy buttons on asset cards and an 'Enable More Coins' button, directly exercising Button component rendering in both grid and table view contexts.
- `suite/e2e/tests/settings/safety-checks.test.ts` — This test explicitly checks that a confirm button is disabled/enabled based on state changes — a behavior directly tied to Button.tsx's disabled prop handling.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — The send form test uses header dropdown menus (likely rendered via Menu.tsx) to access locktime and OP_RETURN options, and Button components for send/submit actions.

</details>

_Updated: 2026-07-15T06:51:12.002Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-components-stray-zero/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-components-stray-zero/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-components-stray-zero&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-components-stray-zero&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-15T06:54:22.788Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-15T06:54:07.741Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->