### PR TITLE
fix(trading): show missing swap network badges

### DIFF
--- a/packages/product-components/src/components/CoinLogo/CoinLogo.tsx
+++ b/packages/product-components/src/components/CoinLogo/CoinLogo.tsx
@@ -79,12 +79,17 @@ export const CoinLogo = ({
 
     if (type === 'tokenWithNetwork') {
         const network = getNetworkOptional(symbol);
-        const networkSymbol = network?.settlementLayer ?? symbol;
-        const displaySymbol = networkSymbol !== symbol ? networkSymbol : symbol;
-        const src = cryptoIcons[displaySymbol];
+        const coinSymbol = network?.settlementLayer ?? symbol;
+        const src = cryptoIcons[coinSymbol];
         const coin = <CoinSvg src={src} size={size} data-testid={dataTestId} />;
 
-        if (networkSymbol !== symbol && isNetworkIconSymbol(symbol)) {
+        const isNetworkDistinctFromCoin =
+            coinSymbol !== symbol ||
+            (network !== undefined &&
+                !network.testnet &&
+                network.displaySymbol.toLowerCase() !== symbol);
+
+        if (isNetworkDistinctFromCoin && isNetworkIconSymbol(symbol)) {
             return (
                 <NetworkIconBadge networkSymbol={symbol} parentSize={size} data-testid={dataTestId}>
                     {coin}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputContent.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputContent.tsx
@@ -6,7 +6,7 @@ import {
     type TradingAssetSellOption,
 } from '@suite-common/trading';
 import { Column, Row, Text } from '@trezor/components';
-import { AssetLogo, CoinLogo } from '@trezor/product-components';
+import { AssetLogo, CoinLogo, shouldShowNetworkIcon } from '@trezor/product-components';
 
 export type AssetPickerInputContentProps = {} & (
     | {
@@ -44,7 +44,7 @@ export function AssetPickerInputContent({ value }: AssetPickerInputContentProps)
                     symbol={networkSymbol}
                     contractAddress={contractAddress}
                     placeholder={displaySymbol}
-                    showNetworkIcon={showNetwork}
+                    showNetworkIcon={shouldShowNetworkIcon(networkSymbol, contractAddress)}
                 />
             )}
             <Column alignItems="start">

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
@@ -7,7 +7,7 @@ import { cryptoIdToNetworkSymbolAndContractAddress, useTradingAssets } from '@su
 import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { Card, Column, Row, Skeleton, Text } from '@trezor/components';
-import { AssetLogo, CoinLogo } from '@trezor/product-components';
+import { AssetLogo, CoinLogo, shouldShowNetworkIcon } from '@trezor/product-components';
 
 import { BaseCurrencyValue } from 'src/components/suite';
 import { type TradingPayGetLabelType } from 'src/types/trading/trading';
@@ -106,7 +106,10 @@ export const TradingInfoItem = ({
                                     symbol={networkSymbol}
                                     contractAddress={contractAddress}
                                     placeholder={displaySymbol}
-                                    showNetworkIcon={showNetwork}
+                                    showNetworkIcon={shouldShowNetworkIcon(
+                                        networkSymbol,
+                                        contractAddress,
+                                    )}
                                 />
                             )}
                             <Column alignItems="start">


### PR DESCRIPTION
## Description

- show network badges for swap native coins when the network display symbol differs from the internal symbol
- use the shared `shouldShowNetworkIcon` helper for swap token logos in the asset picker input
- use the shared `shouldShowNetworkIcon` helper for swap token logos in the selected offer details

## Notes for QA

- In Trading > Swap, select native coins on Arbitrum One, Base, Optimism, Polygon, and BNB Smart Chain, and verify the coin logo shows the correct network badge.
- In Trading > Swap, select the OP token on Optimism and verify the token logo keeps its Optimism network badge in the asset picker and selected offer details.

## Related Issue

Resolve #29033

## Screenshots:

<img width="492" height="612" alt="image" src="https://github.com/user-attachments/assets/7a20ecdd-5f38-40f7-8761-42d040d65946" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch three components: CoinLogo (a broadly used icon component mapped to 131 tests), AssetPickerInputContent (the asset display within trading forms), and TradingInfoItem (info rows in trading confirmation/detail views). CoinLogo is a global UI primitive, so only trading tests where it's directly visible in assertions are relevant. The primary risk lies in the two trading-specific components — AssetPickerInputContent affects how selected assets are displayed in buy/sell/swap forms, and TradingInfoItem affects confirmation screen details. The recommended strategy focuses on trading flow tests that directly exercise asset selection and trade confirmation, with a representative sample across buy, sell, and swap flows.

<details><summary><b>Changed files (3)</b></summary>

- `packages/product-components/src/components/CoinLogo/CoinLogo.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputContent.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx`

</details>

**Recommended tests (15)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test exercises the full buy flow including the asset picker (AssetPickerInputContent) and trade confirmation details (TradingInfoItem). It verifies best offer display, provider info, fiat/crypto amounts, and trade payload — all areas where the changed components render content.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test covers the full swap flow from form filling (using AssetPickerInputContent for sell/buy asset selection) through confirmation details (TradingInfoItem for exchange type, provider, amounts). Both changed components are directly exercised.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test directly interacts with the asset picker component (selecting sell/buy assets, verifying currency tickers) and swap form inputs. AssetPickerInputContent is the component rendering the selected asset display that this test validates.
- `suite/e2e/tests/trading/navigation.test.ts` — This test verifies that navigating to buy/sell/swap forms from various entry points shows the correct cryptocurrency name in the form. AssetPickerInputContent is responsible for rendering the selected asset label that these assertions check (verifyBuyFormOpened, verifySellFormOpened, verifySwapFormOpened).

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Tests the sell flow confirmation screen which uses TradingInfoItem to display fiat amount, crypto amount, provider, and payment method. Changes to TradingInfoItem rendering could break these assertions.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests the buy flow for ETH including asset picker search/selection and confirmation screen details (fiat amount, crypto amount, provider). Both changed components are exercised.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests the sell flow for SOL with confirmation details (provider, amounts, payment method) rendered by TradingInfoItem, and the sell form uses AssetPickerInputContent for asset display.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Tests DEX swap confirmation details (exchange type, slippage, minimum received, provider, amounts) rendered by TradingInfoItem. Changes to this component could break the detailed confirmation assertions.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests the buy form validation states including the asset picker modal interaction. AssetPickerInputContent changes could affect how the form loads and displays the selected asset.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation and the currency ticker display (e.g., SOL ticker assertion). AssetPickerInputContent renders the ticker/asset display that this test checks.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests swapping SOL to USDC token, exercising both the asset picker for token selection and TradingInfoItem for confirmation details (exchange type, provider, amounts).
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Tests buying a Solana SPL token (Jupiter), exercising the asset picker for token selection and TradingInfoItem for confirmation screen display of fiat/crypto amounts and provider.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping USDT token to BTC, exercising both changed components. Lower priority as the core swap flow is already covered by swap-coins and swap-coin-to-token tests.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests selling ETH with confirmation details rendered by TradingInfoItem. Lower priority since sell flow is already covered by sell-bitcoin and sell-solana tests.
- `suite/e2e/tests/trading/swap-history.test.ts` — Tests swap trade history display which uses TradingInfoItem in the transaction detail sidebar for amounts and provider. Lower priority as it tests historical data display rather than active form interaction.

</details>

_Updated: 2026-07-15T08:58:49.438Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/29033-swap-network-badges&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/29033-swap-network-badges&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/29033-swap-network-badges/web/](https://dev.suite.sldev.cz/suite-web/fix/29033-swap-network-badges/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-15T09:01:47.871Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-15T09:00:38.894Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->