### PR TITLE
fix(connect): use a valid two-argument sort comparator in thpHandshake

### DIFF
--- a/packages/connect/src/device/thp/handshake.ts
+++ b/packages/connect/src/device/thp/handshake.ts
@@ -75,8 +75,8 @@ export const thpHandshake = async (device: IDevice, unlockPin = false) => {
 
     const settings = settingsStore.get('thp');
     // sort credentials by autoconnect field
-    const knownCredentials = (settings?.knownCredentials || []).sort(cre =>
-        cre.autoconnect ? -1 : 1,
+    const knownCredentials = (settings?.knownCredentials || []).sort(
+        (a, b) => (a.autoconnect ? -1 : 1) - (b.autoconnect ? -1 : 1),
     );
     const tryToUnlock = unlockPin ? 1 : 0;
 


### PR DESCRIPTION
## Description

The THP handshake sorts known pairing credentials so that `autoconnect` ones come first, but the comparator was **single-argument** — it ignored the second element, so it is not a valid `Array.prototype.sort` comparator.

[`handshake.ts:78`](https://github.com/trezor/trezor-suite/blob/5ca2988a146d1c644a4f1e07ee7c12abc926c261/packages/connect/src/device/thp/handshake.ts#L78):
```diff
- const knownCredentials = (settings?.knownCredentials || []).sort(cre =>
-     cre.autoconnect ? -1 : 1,
- );
+ const knownCredentials = (settings?.knownCredentials || []).sort(
+     (a, b) => (a.autoconnect ? -1 : 1) - (b.autoconnect ? -1 : 1),
+ );
```

The sorted list feeds `handleHandshakeInit` → `findKnownPairingCredentials` (a `.filter`, which preserves order) → `credentials = allCredentials[0]` ([`pairing.ts:127`](https://github.com/trezor/trezor-suite/blob/5ca2988a146d1c644a4f1e07ee7c12abc926c261/packages/protocol/src/protocol-thp/crypto/pairing.ts#L127)), so the intent is that the first credential offered to the device is the `autoconnect` one.

## Honest severity: robustness / spec-compliance, not a live bug

I want to be precise: **this is behaviorally benign in the current code — it is not a bug users hit.** The fix is worth landing as a spec-compliance and robustness improvement on a live feature, not because it fixes an observable failure.

Why it is benign today: the malformed comparator's **cross-group** comparisons are still consistent — `compareFn(autoconnect, non-autoconnect)` always returns `-1` and `compareFn(non-autoconnect, autoconnect)` always returns `+1`. So no sort algorithm in any real engine (V8 insertion/TimSort, SpiderMonkey, JavaScriptCore, Hermes) can place a non-autoconnect credential ahead of an available autoconnect one — the autoconnect-first *partition* holds. The inconsistency only scrambles order *within* each group, which does not matter because `allCredentials[0]` just needs *some* autoconnect credential first. (Verified by formal argument and by testing 228 permutations; no failing input exists.)

Why it is still worth fixing:
- It violates the ECMAScript `sort` contract (a comparator must define a total order); the fixed arithmetic form `(a ? -1 : 1) - (b ? -1 : 1)` yields a proper `-2 / 0 / +2` total order.
- THP is a **live, shipped** feature (Trezor Safe 7 / T3W1 pairing over Bluetooth), and `@trezor/connect` runs across many runtimes (Node, browsers, WebExtension, React Native/Hermes). A comparator that only works "by luck of consistent cross-group comparisons" is fragile against future engine or code changes (e.g. if the `allCredentials[0]` selection logic ever changes).
- Two-line, zero-risk change with no observable behavior difference.

The precondition where ordering matters at all — a single device with both an `autoconnect` and a non-`autoconnect` matching credential — is uncommon but real (initial pairing stores a non-autoconnect credential; a later `thpGetCredentials` can add an autoconnect one; the connect THP e2e suite exercises this).

## Notes for QA

No QA needed — no observable behavior change. THP autoconnect pairing selects the same (autoconnect) credential before and after this change; the fix only makes the comparator spec-compliant.

## Related Issue

Part of the split-out series from #29735.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to the THP (Trezor Host Protocol) handshake module, which handles the cryptographic handshake when establishing communication with newer Trezor devices (T3W1, T3T1). While this file is statically imported across 131 tests (indicating it's part of the broad @trezor/connect dependency tree), only a handful of tests actually exercise the THP-specific handshake flow. The highest risk is to onboarding flows for THP-capable devices (especially T3W1 which explicitly uses THP pairing codes) and the initial-run test which validates THP pairing. Most other tests use older device models or don't trigger THP-specific code paths.

<details><summary><b>Changed files (1)</b></summary>

- `packages/connect/src/device/thp/handshake.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — The THP (Trezor Host Protocol) handshake is directly exercised during T3W1 onboarding, which explicitly handles THP pairing code entry and device connection prompts. Changes to handshake.ts could break the THP pairing flow that this test validates.
- `suite/e2e/tests/suite/initial-run.test.ts` — This test explicitly validates THP pairing code flow during initial run — 'If the device uses THP, the user is prompted to allow connection and enter a THP pairing code during onboarding.' A handshake change directly affects this flow.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — T3T1 onboarding involves device connection and firmware steps that may use THP handshake for newer firmware versions. While not as explicitly THP-focused as T3W1, it exercises the device connection path that handshake.ts supports.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — This test explicitly mentions 'THP pairing code flow is handled for devices that support THP' as a behavior, directly exercising the THP handshake during the onboarding consent flow.
- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — Authenticity check during onboarding for T3B1/T3T1 devices requires an established device connection that goes through the THP handshake layer. A handshake regression could prevent the authenticity check from completing.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Multiple sessions test exercises Bridge session acquisition and device connection management. THP handshake changes could affect how sessions are established and reclaimed across competing tabs.

</details>

_Updated: 2026-07-15T09:21:29.772Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-thp-sort-comparator&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-thp-sort-comparator&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fix-thp-sort-comparator&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-thp-sort-comparator/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-thp-sort-comparator/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-15T09:24:41.509Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-15T09:24:34.695Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->