### PR TITLE
Fix app crashes by reverting expo-file-system update

### DIFF
--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -117,7 +117,7 @@
         "expo-camera": "~56.0.7",
         "expo-clipboard": "~56.0.3",
         "expo-dev-client": "~56.0.16",
-        "expo-file-system": "~56.0.8",
+        "expo-file-system": "~56.0.7",
         "expo-haptics": "~56.0.3",
         "expo-image": "~56.0.9",
         "expo-image-picker": "~56.0.14",

--- a/suite-native/bip329/package.json
+++ b/suite-native/bip329/package.json
@@ -27,7 +27,7 @@
         "@trezor/device-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "expo-file-system": "~56.0.8",
+        "expo-file-system": "~56.0.7",
         "expo-sharing": "~56.0.18",
         "react": "19.2.3",
         "react-native": "0.85.3",

--- a/suite-native/helpers/package.json
+++ b/suite-native/helpers/package.json
@@ -20,7 +20,7 @@
         "@trezor/theme": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "expo-file-system": "~56.0.8",
+        "expo-file-system": "~56.0.7",
         "expo-sharing": "~56.0.18",
         "react": "19.2.3",
         "react-native": "0.85.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11616,7 +11616,7 @@ __metadata:
     expo-camera: "npm:~56.0.7"
     expo-clipboard: "npm:~56.0.3"
     expo-dev-client: "npm:~56.0.16"
-    expo-file-system: "npm:~56.0.8"
+    expo-file-system: "npm:~56.0.7"
     expo-haptics: "npm:~56.0.3"
     expo-image: "npm:~56.0.9"
     expo-image-picker: "npm:~56.0.14"
@@ -11808,7 +11808,7 @@ __metadata:
     "@trezor/device-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    expo-file-system: "npm:~56.0.8"
+    expo-file-system: "npm:~56.0.7"
     expo-sharing: "npm:~56.0.18"
     react: "npm:19.2.3"
     react-native: "npm:0.85.3"
@@ -12350,7 +12350,7 @@ __metadata:
     "@trezor/theme": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    expo-file-system: "npm:~56.0.8"
+    expo-file-system: "npm:~56.0.7"
     expo-sharing: "npm:~56.0.18"
     react: "npm:19.2.3"
     react-native: "npm:0.85.3"
@@ -27042,13 +27042,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-file-system@npm:~56.0.7, expo-file-system@npm:~56.0.8":
-  version: 56.0.8
-  resolution: "expo-file-system@npm:56.0.8"
+"expo-file-system@npm:~56.0.7":
+  version: 56.0.7
+  resolution: "expo-file-system@npm:56.0.7"
   peerDependencies:
     expo: "*"
     react-native: "*"
-  checksum: 10/a5a930d2a43f32ffafba69f2d5d953c148d584aaf5091b7703c6465af5a3324713dc55020eae289307070352346ba403c5137daabcc76412a1f4ea275d2d2cc4
+  checksum: 10/c8074d7f7bd8c1c542eb4e3af20151f153d3ee684b80952402c3aef9a1a1f7c02b10f0b822e9ab6383217c90ec3beebaa02d567817126c31a79a5595f2cc1d96
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix app crashes on start introduced in https://github.com/trezor/trezor-suite/pull/29750

reported internally here: https://satoshilabs.slack.com/archives/C03H2Q5MX51/p1784041279203959

Adhoc build: https://github.com/trezor/trezor-suite/actions/runs/29404513021

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all package.json files within the suite-native/ directory (app, bip329, helpers), which is the React Native mobile application. All 91 candidate E2E tests are Playwright tests targeting the suite-web or suite-desktop (Electron) applications, not the native mobile app. There is no static coverage mapping between these native package changes and any of the available E2E tests, and the LLM analysis confirms that none of the tests exercise suite-native code paths. These changes likely involve dependency version bumps or configuration adjustments for the mobile app and pose no risk to the web/desktop test suite. No E2E tests need to be run.

<details><summary><b>Changed files (3)</b></summary>

- `suite-native/app/package.json`
- `suite-native/bip329/package.json`
- `suite-native/helpers/package.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `suite-native/app/package.json`
- `suite-native/bip329/package.json`
- `suite-native/helpers/package.json`

_Updated: 2026-07-15T09:28:58.508Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/app-crashing-expo-file-system/web/](https://dev.suite.sldev.cz/suite-web/fix/app-crashing-expo-file-system/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/app-crashing-expo-file-system&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/app-crashing-expo-file-system&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/app-crashing-expo-file-system&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-15T09:32:47.447Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-15T09:32:18.095Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->