### PR TITLE
fix(suite): disable tx data for evm tokens

### DIFF
--- a/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumOptions.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useWatch } from 'react-hook-form';
 
 import { formInputsMaxLength } from '@suite-common/validators';
@@ -11,8 +12,16 @@ import { EthereumNonce } from './EthereumNonce';
 import { TransactionData } from '../shared/TransactionData';
 
 export const EthereumOptions = () => {
-    const { getDefaultValue, toggleOption, composeTransaction, account, setValue, control } =
-        useSendFormContext();
+    const {
+        getDefaultValue,
+        toggleOption,
+        resetDefaultValue,
+        composeTransaction,
+        account,
+        setValue,
+        control,
+        watch,
+    } = useSendFormContext();
 
     // Nonce editing is toggled from the send-form header dropdown (EVM-only). useWatch keeps this in
     // sync with that cross-component toggle (getValues would not re-render here when it flips).
@@ -32,7 +41,15 @@ export const EthereumOptions = () => {
     const confirmedNonce = nonceInfo?.confirmedNonce.toString();
 
     const options = getDefaultValue('options', []);
-    const dataEnabled = options.includes('transactionData');
+    const isDataEnabled = options.includes('transactionData');
+    const token = watch('outputs.0.token');
+
+    useEffect(() => {
+        if (token && isDataEnabled) {
+            toggleOption('transactionData');
+            resetDefaultValue('transactionData');
+        }
+    }, [token, isDataEnabled, toggleOption, resetDefaultValue]);
 
     const toggle = (option: FormOptions) => {
         toggleOption(option);
@@ -48,7 +65,7 @@ export const EthereumOptions = () => {
 
     return (
         <Column gap={16}>
-            {dataEnabled && (
+            {isDataEnabled && !token && (
                 <TransactionData maxBytes={formInputsMaxLength.ethData} close={toggleData} />
             )}
 

--- a/packages/suite/src/views/wallet/send/SendHeader.tsx
+++ b/packages/suite/src/views/wallet/send/SendHeader.tsx
@@ -97,7 +97,7 @@ export const SendHeader = () => {
             },
             closeOnClick: true,
             label: <Translation id="DATA_ADD" />,
-            isDisabled: dataEnabled || (networkType === 'tron' && !!token),
+            isDisabled: dataEnabled || !!token,
             isHidden: networkType !== 'ethereum' && networkType !== 'tron',
         },
         {


### PR DESCRIPTION
## Description

Disable `Add data` for sending EVM tokens.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29722

## Screenshots:

https://github.com/user-attachments/assets/e2902bb4-8e55-4e44-95c1-afb0fc7c5038

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two send form components: EthereumOptions.tsx (Ethereum-specific fee options) and SendHeader.tsx (send form header with dropdown menu). The highest risk is to the Ethereum send flow which directly uses both components. Medium risk applies to tests that exercise the SendHeader dropdown features (CSV import, locktime/OP_RETURN, broadcast mode). Other tests that statically reference these files do so only through transitive imports and don't exercise the changed functionality directly.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumOptions.tsx`
- `packages/suite/src/views/wallet/send/SendHeader.tsx`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — This test directly exercises the Ethereum send form with custom gas fee parameters (gas limit, max fee per gas, max priority fee per gas), which are rendered by EthereumOptions.tsx. It also interacts with the send form header, which is rendered by SendHeader.tsx. Changes to either file could break the ETH send flow's UI and fee configuration.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — This test uses the send form header dropdown to import a CSV file (@send/header-dropdown), which is directly rendered by SendHeader.tsx. Changes to the header component could break the dropdown menu or the import option.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test interacts with the send form header dropdown for locktime and OP_RETURN options (@send/header-dropdown/locktime, @send/header-dropdown/opreturn), which are part of SendHeader.tsx. It also verifies the send form header is visible after unit switching. Changes to SendHeader could break these dropdown options.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test uses the send form header dropdown for broadcast mode (@send/header-dropdown/broadcast), which is rendered by SendHeader.tsx. Changes to the header could break the broadcast mode toggle.

</details>

_Updated: 2026-07-15T09:33:59.157Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/eth-send-token-data/web/](https://dev.suite.sldev.cz/suite-web/fix/eth-send-token-data/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/eth-send-token-data&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/eth-send-token-data&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-15T09:37:36.998Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-15T09:37:28.378Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->