### PR TITLE
fix(connect): skip input reference txs for Zcash v5 in validateReferencedTransactions

### DIFF
--- a/packages/connect/src/api/bitcoin/__tests__/refTx.test.ts
+++ b/packages/connect/src/api/bitcoin/__tests__/refTx.test.ts
@@ -49,6 +49,52 @@ describe('core/methods/tx/refTx', () => {
         ).toEqual(false);
     });
 
+    it('validateReferencedTransactions applies the ZEC v5 exemption for input reference txs', () => {
+        // A valid provided refTx, unrelated to the spent input below.
+        const providedRefTx = {
+            hash: '43d273d3caf41759ad843474f960fbf80ff2ec961135d018b61e9fab3ad1fc06',
+            version: 1,
+            lock_time: 1287124,
+            inputs: [
+                {
+                    prev_hash: 'e294c4c172c3d87991b0369e45d6af8584be92914d01e3060fad1ed31d12ff00',
+                    prev_index: 0,
+                    script_sig: '',
+                    sequence: 4294967293,
+                },
+            ],
+            bin_outputs: [
+                {
+                    amount: 10000000,
+                    script_pubkey: 'a914051877a0cc43165e48975c1e62bdef3b6c942a3887',
+                },
+            ],
+        };
+        // The input references a tx that is NOT provided, so a strict validation would throw.
+        const params = {
+            transactions: [providedRefTx],
+            inputs: [
+                {
+                    prev_hash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                    prev_index: 0,
+                },
+            ],
+            outputs: [],
+            coinInfo: { shortcut: 'ZEC' },
+        };
+
+        // Zcash NU5 (v5) transactions don't need input reference txs (matches the authoritative
+        // requireReferencedTransactions check in signTransaction) — validation must not throw.
+        expect(() =>
+            validateReferencedTransactions({ ...params, version: 5 } as any),
+        ).not.toThrow();
+
+        // Older Zcash versions still require them.
+        expect(() => validateReferencedTransactions({ ...params, version: 4 } as any)).toThrow(
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa not provided',
+        );
+    });
+
     it('getReferencedTransactions', () => {
         const inputs = [
             { prev_hash: 'abcd' },

--- a/packages/connect/src/api/bitcoin/refTx.ts
+++ b/packages/connect/src/api/bitcoin/refTx.ts
@@ -255,16 +255,22 @@ export const validateReferencedTransactions = ({
     outputs,
     addresses,
     coinInfo,
+    version,
 }: {
     transactions?: (RefTransaction | AccountTransaction)[];
     inputs: PROTO.TxInputType[];
     outputs: PROTO.TxOutputType[];
     addresses?: AccountAddresses;
     coinInfo: BitcoinNetworkInfo;
+    version?: number;
 }): RefTransaction[] | undefined => {
     if (!Array.isArray(transactions) || transactions.length === 0) return; // allow empty, they will be downloaded later...
-    // collect sets of transactions defined by inputs/outputs
-    const refTxs = requireReferencedTransactions(inputs) ? getReferencedTransactions(inputs) : [];
+    // collect sets of transactions defined by inputs/outputs. Pass coinInfo/version so the
+    // ZEC/TAZ v5 exemption matches the authoritative fetch path (requireReferencedTransactions
+    // in signTransaction); otherwise a v5 tx would spuriously demand input reference txs here.
+    const refTxs = requireReferencedTransactions(inputs, { version }, coinInfo)
+        ? getReferencedTransactions(inputs)
+        : [];
     const origTxs = getOrigTransactions(inputs, outputs); // NOTE: origTxs are used in RBF
     const transformedTxs: RefTransaction[] = transactions.map(tx => {
         // transform AccountTransaction to RefTransaction

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -113,12 +113,30 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
                 'two sources of referential transactions were passed. payload.refTxs have precedence',
             );
         }
+        const options = enhanceSignTx(
+            {
+                lock_time: payload.locktime,
+                timestamp: payload.timestamp,
+                version: payload.version,
+                expiry: payload.expiry,
+                overwintered: payload.overwintered,
+                version_group_id: payload.versionGroupId,
+                branch_id: payload.branchId,
+                amount_unit: payload.amountUnit,
+                serialize: payload.serialize,
+                coinjoin_request: payload.coinjoinRequest,
+                chunkify: typeof payload.chunkify === 'boolean' ? payload.chunkify : false,
+            },
+            coinInfo,
+        );
+
         const refTxs = validateReferencedTransactions({
             transactions: payload.refTxs || payload.account?.transactions,
             inputs,
             outputs,
             coinInfo,
             addresses: payload.account?.addresses,
+            version: options.version,
         });
 
         const outputsWithAmount = outputs.filter(
@@ -149,22 +167,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             paymentRequests,
             refTxs,
             addresses: payload.account ? payload.account.addresses : undefined,
-            options: enhanceSignTx(
-                {
-                    lock_time: payload.locktime,
-                    timestamp: payload.timestamp,
-                    version: payload.version,
-                    expiry: payload.expiry,
-                    overwintered: payload.overwintered,
-                    version_group_id: payload.versionGroupId,
-                    branch_id: payload.branchId,
-                    amount_unit: payload.amountUnit,
-                    serialize: payload.serialize,
-                    coinjoin_request: payload.coinjoinRequest,
-                    chunkify: typeof payload.chunkify === 'boolean' ? payload.chunkify : false,
-                },
-                coinInfo,
-            ),
+            options,
             coinInfo,
             identity: payload.identity,
             push: typeof payload.push === 'boolean' ? payload.push : false,


### PR DESCRIPTION
## Description

`validateReferencedTransactions` decides which input reference transactions a sign request must supply. It called `requireReferencedTransactions(inputs)` **without** `coinInfo`/`version`, so it missed the Zcash NU5 (v5) exemption and demanded input reference txs that v5 does not need — turning a valid Zcash v5 sign into a hard failure.

[`refTx.ts:267`](https://github.com/trezor/trezor-suite/blob/5ca2988a146d1c644a4f1e07ee7c12abc926c261/packages/connect/src/api/bitcoin/refTx.ts#L267):
```diff
- const refTxs = requireReferencedTransactions(inputs) ? getReferencedTransactions(inputs) : [];
+ const refTxs = requireReferencedTransactions(inputs, { version }, coinInfo)
+     ? getReferencedTransactions(inputs)
+     : [];
```

`requireReferencedTransactions` exempts Zcash v5 only when it gets `coinInfo`/`version` ([`refTx.ts:34-35`](https://github.com/trezor/trezor-suite/blob/5ca2988a146d1c644a4f1e07ee7c12abc926c261/packages/connect/src/api/bitcoin/refTx.ts#L34): `if (coinInfo.shortcut === 'ZEC' || 'TAZ') return !(version >= 5)`). Without them it falls through to the generic branch, returns `true` for normal inputs, and `validateReferencedTransactions` then requires every input `prev_hash` to be present — throwing [`refTx: {hash} not provided` (refTx.ts:352)](https://github.com/trezor/trezor-suite/blob/5ca2988a146d1c644a4f1e07ee7c12abc926c261/packages/connect/src/api/bitcoin/refTx.ts#L352) for any that isn't, even though v5 firmware doesn't use them. The **download** path already called `requireReferencedTransactions` correctly (with `coinInfo`/`version`); this aligns the **validation** path with it.

The fix also moves `enhanceSignTx` (which defaults ZEC/TAZ to [`version: 5` — enhanceSignTx.ts:19](https://github.com/trezor/trezor-suite/blob/5ca2988a146d1c644a4f1e07ee7c12abc926c261/packages/connect/src/api/bitcoin/enhanceSignTx.ts#L19)) ahead of `validateReferencedTransactions`, so the resolved version is available to thread through.

## Who is affected (honest)

- **Suite is not affected.** For a normal Zcash send Suite passes no `refTxs`/`account.transactions` — it only sets `refTxs` in the bitcoin-RBF-of-coinjoin/taproot case ([sendFormBitcoinThunks.ts:284-298](https://github.com/trezor/trezor-suite/blob/5ca2988a146d1c644a4f1e07ee7c12abc926c261/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts#L284)), which Zcash never hits. With no transactions passed, `validateReferencedTransactions` early-returns and the bug never fires. (That's why this hasn't surfaced as a Suite bug.)
- **Direct `@trezor/connect` SDK consumers are.** `@trezor/connect` is a public SDK; a third-party integration that signs a Zcash v5 transaction while supplying `payload.refTxs` or `payload.account.transactions` that don't already contain every input's previous tx gets a **hard signing failure** (`refTx: {hash} not provided`) — despite v5 not needing those references. Zcash v5 is the default version for all ZEC/TAZ transactions, so this is the normal case for that API path, not an edge coin version.

## Tests

Adds a `refTx.test.ts` case asserting `validateReferencedTransactions` does not require input reference txs for a Zcash v5 transaction (previously it threw), alongside the existing non-v5 behavior.

Split out from the continuously-improve sweep #29735.

## Notes for QA

No Suite-side QA needed (Suite doesn't exercise this path for Zcash sends). If verifying at the SDK level: a `TrezorConnect.signTransaction` for a ZEC v5 tx with `account.transactions`/`refTxs` supplied that omit the input previous transactions should now succeed instead of failing with `refTx: … not provided`. Note the repo currently has no Zcash-send e2e coverage — worth adding separately.

## Related Issue

Part of the split-out series from #29735.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in Bitcoin transaction signing infrastructure: refTx.ts (reference transaction handling) and signTransaction.ts (the signTransaction API method). refTx.ts maps to 131 tests but is a broad dependency — only tests that actually sign Bitcoin-like transactions are meaningfully affected. The five statically-mapped tests for signTransaction.ts are all high priority since they directly exercise BTC/DOGE/LTC transaction signing. The unit test file (refTx.test.ts) has no E2E coverage but is itself a test. The risk is moderate: any regression in reference transaction parsing or signing flow would break all Bitcoin-family send operations.

<details><summary><b>Changed files (3)</b></summary>

- `packages/connect/src/api/bitcoin/__tests__/refTx.test.ts`
- `packages/connect/src/api/bitcoin/refTx.ts`
- `packages/connect/src/api/signTransaction.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test exercises Bitcoin transaction signing on regtest including multiple outputs, locktime, and OP_RETURN — all paths that directly use signTransaction.ts and refTx.ts for reference transaction handling during the signing flow.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test sends a DOGE transaction with an amount exceeding MAX_SAFE_INTEGER, directly exercising signTransaction.ts. Changes to refTx.ts reference transaction processing could affect how the transaction inputs are resolved before signing.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test sends LTC with a MimbleWimble peg-out transaction output, directly using signTransaction.ts. RefTx changes could affect how LTC reference transactions are fetched and validated.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test initiates a BTC sell transaction that goes through the device signing flow, directly exercising signTransaction.ts and the reference transaction resolution in refTx.ts for Bitcoin inputs.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test performs a BTC-to-ETH swap with custom fee settings, exercising BTC transaction composition and signing through signTransaction.ts. It verifies fee rate display on device, which depends on correct transaction construction using refTx.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — This test calls TrezorConnect.signTransaction directly with Bitcoin inputs, which exercises signTransaction.ts and reference transaction resolution. Although not in the static mapping (it uses the desktop coreMode path), it's the most direct API-level test of the changed signing logic.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test sends multiple Bitcoin transactions on regtest and verifies pending/confirmed states. While not in static mapping, it exercises BTC transaction signing flows that depend on signTransaction.ts and refTx.ts.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/connect/src/api/bitcoin/__tests__/refTx.test.ts`

_Updated: 2026-07-15T09:58:47.020Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-zcash-v5-reftx/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-zcash-v5-reftx/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-zcash-v5-reftx&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-zcash-v5-reftx&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fix-zcash-v5-reftx&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-15T10:01:35.137Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-15T10:01:09.701Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->