### PR TITLE
fix(suite): apy breakdown tooltip colors

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
@@ -102,6 +102,7 @@ export const EarnYieldApyBreakdown = ({
                                     typographyStyle="body-sm"
                                     intent="neutral"
                                     priority="secondary"
+                                    isInverse
                                 >
                                     <Translation id={descriptionId} />
                                 </Text>
@@ -111,6 +112,7 @@ export const EarnYieldApyBreakdown = ({
                             typographyStyle="body-sm"
                             intent={hasRatePercent ? 'brand' : 'neutral'}
                             priority={hasRatePercent ? 'primary' : 'secondary'}
+                            isInverse
                         >
                             {rateNode}
                         </Text>
@@ -118,8 +120,14 @@ export const EarnYieldApyBreakdown = ({
                 );
             })}
             <Row gap={4} alignItems="center" margin={{ top: 4 }}>
-                <Icon as={ChartLineIcon} size={14} intent="neutral" priority="secondary" />
-                <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                <Icon
+                    as={ChartLineIcon}
+                    size={14}
+                    intent="neutral"
+                    priority="secondary"
+                    isInverse
+                />
+                <Text typographyStyle="body-sm" intent="neutral" priority="secondary" isInverse>
                     <Translation id={footerId} />
                 </Text>
             </Row>


### PR DESCRIPTION
## Description

Fix colors in APY breakdown tooltip.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29844

## Screenshots:

<img width="1507" height="826" alt="Screenshot 2026-07-15 at 13 09 20" src="https://github.com/user-attachments/assets/0073f522-4cbc-4f84-8470-3fc8d8934b5f" />

<img width="1507" height="826" alt="Screenshot 2026-07-15 at 13 09 36" src="https://github.com/user-attachments/assets/e8087815-2ad5-4a59-a034-06c2efbd96d4" />

<img width="1507" height="826" alt="Screenshot 2026-07-15 at 13 09 46" src="https://github.com/user-attachments/assets/8300ce9f-84b9-4c77-80a3-af6cd169e8b6" />

<img width="1507" height="826" alt="Screenshot 2026-07-15 at 13 09 52" src="https://github.com/user-attachments/assets/89f4d885-28ff-4eb5-8c0a-be29414e7160" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to a single UI component (EarnYieldApyBreakdown) within the earn/staking dashboard yield section. Despite static coverage mapping showing 131 tests (indicating this file is bundled into the broader app), the actual risk is narrow and limited to staking dashboard views where APY/yield information is displayed. The recommended strategy focuses on ETH and SOL staking tests that directly render the staking dashboard, with ETH initial-stake and stake-more tests being highest priority since they most thoroughly exercise the dashboard card where this component appears.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/staking/eth/stake-more.test.ts` — EarnYieldApyBreakdown is a component within the earn/staking dashboard UI. The ETH stake-more test directly exercises the staking dashboard view where staked amounts, rewards, and progress indicators are displayed — exactly the context where an APY breakdown component would render.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the full ETH staking flow including the staking dashboard card visibility and staking amount displays. The EarnYieldApyBreakdown component is part of the earn/dashboard/yield UI that renders after staking is active, making this a direct consumer of the changed component.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — The unstake test views the staking dashboard with staked/rewards/pending amounts before and after unstaking. The EarnYieldApyBreakdown component would be visible in the staking dashboard during the initial staked state verification.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test opens the ETH staking form from the staking dashboard and verifies balance displays and form validation. The yield APY breakdown component is part of the staking dashboard that the test navigates through.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — The SOL initial stake test exercises the staking dashboard empty and active states. If EarnYieldApyBreakdown is shared across coin staking dashboards (yield component), a regression could surface here.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — This test specifically verifies staking rewards display and reward list entries on the SOL staking dashboard. An APY breakdown component directly relates to how yield/rewards information is presented.

</details>

_Updated: 2026-07-16T09:55:25.660Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/apy-breakdown-tooltip-colors/web/](https://dev.suite.sldev.cz/suite-web/fix/apy-breakdown-tooltip-colors/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/apy-breakdown-tooltip-colors&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/apy-breakdown-tooltip-colors&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-16T09:59:17.903Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-16T10:01:27.842Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->