### PR TITLE
fix(suite-native): yield claim review integrity, fee warning and config guard

### DIFF
--- a/suite-common/earn-stablecoin/src/signing/__tests__/claimSigningUtils.test.ts
+++ b/suite-common/earn-stablecoin/src/signing/__tests__/claimSigningUtils.test.ts
@@ -19,9 +19,14 @@ const createReward = (tokenAddress = TOKEN): ClaimReward => ({
     },
 });
 
+const CLAIM_CALLDATA = buildClaimCalldata({
+    senderAddress: SENDER,
+    rewards: [createReward()],
+});
+
 const unsignedTransaction = {
     to: CLAIM_CONTRACT,
-    data: '0xabc',
+    data: CLAIM_CALLDATA,
     chainId: 1,
     gasLimit: '21000',
     maxFeePerGas: '2000000000',
@@ -114,7 +119,7 @@ describe('claimSigningUtils', () => {
             maxFeePerGas: '2',
             maxPriorityFeePerGas: '1',
             baseFeePerGas: '1',
-            transactionData: '0xabc',
+            transactionData: CLAIM_CALLDATA,
         });
         expect(result.precomposedTransaction).toMatchObject({
             fee: '42000000000000',
@@ -130,7 +135,7 @@ describe('claimSigningUtils', () => {
             chainId: 1,
             value: '0x0',
             nonce: '0xa',
-            data: '0x0abc',
+            data: CLAIM_CALLDATA,
             gasLimit: '0x5208',
             maxFeePerGas: '0x77359400',
             maxPriorityFeePerGas: '0x3b9aca00',
@@ -166,10 +171,52 @@ describe('claimSigningUtils', () => {
             chainId: 1,
             value: '0x0',
             nonce: '0xa',
-            data: '0x0abc',
+            data: CLAIM_CALLDATA,
             gasLimit: '0x5208',
             gasPrice: '0x3b9aca00',
         });
+    });
+
+    it('throws when review rewards do not match the claim calldata', () => {
+        const selectedFee = {
+            type: 'eip1559',
+            gasLimit: '0x5208',
+            maxFeePerGas: '0x77359400',
+            maxPriorityFeePerGas: '0x3b9aca00',
+            baseFeePerGas: '0x3b9aca00',
+        } as const;
+
+        expect(() =>
+            buildClaimTransactionReview({
+                unsignedTransaction,
+                selectedFee,
+                rewards: [createReward('0x1111111111111111111111111111111111111111')],
+            }),
+        ).toThrow('Claim rewards do not match the claim transaction data.');
+
+        expect(() =>
+            buildClaimTransactionReview({
+                unsignedTransaction,
+                selectedFee,
+                rewards: [createReward(), createReward()],
+            }),
+        ).toThrow('Claim rewards do not match the claim transaction data.');
+    });
+
+    it('throws when the claim transaction data cannot be decoded', () => {
+        expect(() =>
+            buildClaimTransactionReview({
+                unsignedTransaction: { ...unsignedTransaction, data: '0xabc' },
+                selectedFee: {
+                    type: 'eip1559',
+                    gasLimit: '0x5208',
+                    maxFeePerGas: '0x77359400',
+                    maxPriorityFeePerGas: '0x3b9aca00',
+                    baseFeePerGas: '0x3b9aca00',
+                },
+                rewards: [createReward()],
+            }),
+        ).toThrow('Failed to decode claim transaction data.');
     });
 
     it('throws when selected fee data is missing or incomplete', () => {

--- a/suite-common/earn-stablecoin/src/signing/claimSigningUtils.ts
+++ b/suite-common/earn-stablecoin/src/signing/claimSigningUtils.ts
@@ -124,6 +124,31 @@ const getClaimFeeData = (fee: EvmFeeHex) => {
     };
 };
 
+const assertRewardsMatchClaimCalldata = ({
+    data,
+    rewards,
+}: {
+    data: EvmHexString;
+    rewards: ClaimReviewReward[];
+}) => {
+    const decodedClaim = Calldata.evm.distributor.claim.decode(data);
+
+    if (!decodedClaim) {
+        throw new Error('Failed to decode claim transaction data.');
+    }
+
+    const claimedTokens = decodedClaim.tokens;
+    const doRewardsMatchCalldata =
+        claimedTokens.length === rewards.length &&
+        rewards.every(
+            (reward, index) => reward.token.address.toLowerCase() === claimedTokens[index],
+        );
+
+    if (!doRewardsMatchCalldata) {
+        throw new Error('Claim rewards do not match the claim transaction data.');
+    }
+};
+
 export const buildClaimCalldata = ({ senderAddress, rewards }: BuildClaimCalldataParams) => {
     const sender = asEvmAddress(senderAddress);
     const claimResult = Calldata.evm.distributor.claim.encode(
@@ -269,6 +294,8 @@ export const buildClaimTransactionReview = ({
     if (!fee) {
         throw new Error('Fee information is missing for the transaction.');
     }
+
+    assertRewardsMatchClaimCalldata({ data: unsignedTransaction.data, rewards });
 
     return {
         ...buildClaimReviewState({

--- a/suite-common/earn-stablecoin/src/signing/claimSigningUtils.ts
+++ b/suite-common/earn-stablecoin/src/signing/claimSigningUtils.ts
@@ -42,6 +42,11 @@ type UnsignedClaimTransactionFee =
 
 export type UnsignedClaimTransaction = UnsignedClaimTransactionBase & UnsignedClaimTransactionFee;
 
+type AssertRewardsMatchClaimCalldataParams = {
+    data: EvmHexString;
+    rewards: ClaimReviewReward[];
+};
+
 type BuildClaimCalldataParams = {
     senderAddress: string;
     rewards: ClaimReward[];
@@ -127,10 +132,7 @@ const getClaimFeeData = (fee: EvmFeeHex) => {
 const assertRewardsMatchClaimCalldata = ({
     data,
     rewards,
-}: {
-    data: EvmHexString;
-    rewards: ClaimReviewReward[];
-}) => {
+}: AssertRewardsMatchClaimCalldataParams) => {
     const decodedClaim = Calldata.evm.distributor.claim.decode(data);
 
     if (!decodedClaim) {

--- a/suite-common/wallet-config/src/__tests__/earnRewardsProvider.test.ts
+++ b/suite-common/wallet-config/src/__tests__/earnRewardsProvider.test.ts
@@ -1,0 +1,34 @@
+import {
+    getEarnYieldClaimContractAddress,
+    isEarnYieldClaimSupported,
+} from '../earnRewardsProvider';
+import { getNetworkFeatures, networkSymbolCollection } from '../utils';
+
+describe(isEarnYieldClaimSupported.name, () => {
+    it('has a claim contract address for every network with the claim-rewards feature', () => {
+        const networkSymbolsWithClaimFeature = networkSymbolCollection.filter(networkSymbol =>
+            getNetworkFeatures(networkSymbol).includes('claim-rewards'),
+        );
+
+        expect(networkSymbolsWithClaimFeature.length).toBeGreaterThan(0);
+
+        networkSymbolsWithClaimFeature.forEach(networkSymbol => {
+            expect(getEarnYieldClaimContractAddress(networkSymbol)).toBeDefined();
+        });
+    });
+
+    it('does not support claim on a network without the claim-rewards feature', () => {
+        // Arbitrum has a claim contract address but the feature flag is not enabled.
+        expect(getNetworkFeatures('arb')).not.toContain('claim-rewards');
+        expect(isEarnYieldClaimSupported('arb')).toBe(false);
+    });
+
+    it('supports claim in debug mode on networks with a claim contract address', () => {
+        expect(isEarnYieldClaimSupported('arb', { isDebugMode: true })).toBe(true);
+        expect(isEarnYieldClaimSupported('btc', { isDebugMode: true })).toBe(false);
+    });
+
+    it('supports claim on networks with both the feature and a contract address', () => {
+        expect(isEarnYieldClaimSupported('eth')).toBe(true);
+    });
+});

--- a/suite-common/wallet-config/src/earnRewardsProvider.ts
+++ b/suite-common/wallet-config/src/earnRewardsProvider.ts
@@ -14,11 +14,13 @@ export const isEarnYieldClaimSupported = (
     networkSymbol: NetworkSymbol,
     { isDebugMode = false }: { isDebugMode?: boolean } = {},
 ) => {
+    const hasClaimContract = MERKL_XYZ_CONTRACT[networkSymbol] !== undefined;
+
     if (isDebugMode) {
-        return MERKL_XYZ_CONTRACT[networkSymbol] !== undefined;
+        return hasClaimContract;
     }
 
-    return getNetworkFeatures(networkSymbol).includes('claim-rewards');
+    return hasClaimContract && getNetworkFeatures(networkSymbol).includes('claim-rewards');
 };
 
 export const getEarnYieldClaimContractAddress = (networkSymbol: NetworkSymbol) =>

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -25,6 +25,7 @@ import { transactionsActions } from '../transactions/transactionsActions';
 // Message ids must exist in the desktop `suite/intl` messages — the desktop app renders
 // `session.error` directly via `<Translation>`.
 export type StablecoinYieldTranslationKey =
+    | 'TR_EARN_YIELD_ERROR_CLAIM_REVIEW_MISMATCH'
     | 'TR_EARN_YIELD_ERROR_FEE_ESTIMATION'
     | 'TR_EARN_YIELD_ERROR_GENERIC'
     | 'TR_EARN_YIELD_ERROR_PASSPHRASE_INCORRECT'

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2990,6 +2990,11 @@ export const messages = {
                 title: 'Network fees may exceed rewards.',
                 description: 'Consider waiting for your rewards to grow before claiming.',
             },
+            unverifiableFeeWarning: {
+                title: "Rewards value can't be verified.",
+                description:
+                    "We couldn't determine the value of your rewards. Make sure the network fee doesn't exceed the rewards you're claiming.",
+            },
             alerts: {
                 reviewMismatch: {
                     title: "Claim couldn't be verified",

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2990,6 +2990,13 @@ export const messages = {
                 title: 'Network fees may exceed rewards.',
                 description: 'Consider waiting for your rewards to grow before claiming.',
             },
+            alerts: {
+                reviewMismatch: {
+                    title: "Claim couldn't be verified",
+                    description:
+                        "The rewards to claim didn't match the transaction details, so nothing was signed and no funds moved. Tap Continue to try again with refreshed data. If the issue persists, contact Trezor Support.",
+                },
+            },
         },
         yieldDepositApprovalReviewScreen: {
             title: 'Review with Trezor',

--- a/suite-native/module-earn/src/hooks/useShowYieldTransactionFailureAlert.ts
+++ b/suite-native/module-earn/src/hooks/useShowYieldTransactionFailureAlert.ts
@@ -2,10 +2,25 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { type YieldFlowType, stablecoinYieldActions } from '@suite-common/wallet-core';
+import { type TxKeyPath } from '@suite-native/intl';
 
 import { useShowYieldAlert } from './useShowYieldAlert';
 
-const TRANSACTION_FAILED_ERROR = 'TR_EARN_YIELD_ERROR_TRANSACTION_FAILED';
+type FailureAlertContent = {
+    title: TxKeyPath;
+    description: TxKeyPath;
+};
+
+const FAILURE_ALERT_CONTENT: Record<string, FailureAlertContent> = {
+    TR_EARN_YIELD_ERROR_TRANSACTION_FAILED: {
+        title: 'earn.yieldDepositFlowScreen.alerts.transactionFailed.title',
+        description: 'earn.yieldDepositFlowScreen.alerts.transactionFailed.description',
+    },
+    TR_EARN_YIELD_ERROR_CLAIM_REVIEW_MISMATCH: {
+        title: 'earn.yieldClaimFlowScreen.alerts.reviewMismatch.title',
+        description: 'earn.yieldClaimFlowScreen.alerts.reviewMismatch.description',
+    },
+};
 
 type UseShowYieldTransactionFailureAlertParams = {
     flowKey: string | null;
@@ -24,13 +39,15 @@ export const useShowYieldTransactionFailureAlert = ({
     const showYieldAlert = useShowYieldAlert();
 
     useEffect(() => {
-        if (!isEnabled || !flowKey || error !== TRANSACTION_FAILED_ERROR) {
+        const alertContent = error ? FAILURE_ALERT_CONTENT[error] : undefined;
+
+        if (!isEnabled || !flowKey || !alertContent) {
             return;
         }
 
         showYieldAlert({
-            title: 'earn.yieldDepositFlowScreen.alerts.transactionFailed.title',
-            description: 'earn.yieldDepositFlowScreen.alerts.transactionFailed.description',
+            title: alertContent.title,
+            description: alertContent.description,
             onPressPrimaryButton: () =>
                 dispatch(stablecoinYieldActions.clearError({ flowType, flowKey })),
         });

--- a/suite-native/module-earn/src/screens/YieldClaimReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldClaimReviewScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 
@@ -9,6 +9,7 @@ import {
     type StablecoinYieldRootState,
     selectAccountByKey,
     selectStablecoinYieldSessionByFlowKey,
+    stablecoinYieldActions,
 } from '@suite-common/wallet-core';
 import {
     type StackNavigationProps,
@@ -25,6 +26,7 @@ type NavigationProps = StackNavigationProps<YieldStackParamList, YieldStackRoute
 export const YieldClaimReviewScreen = () => {
     const route = useRoute<RouteProps>();
     const navigation = useNavigation<NavigationProps>();
+    const dispatch = useDispatch();
     const { accountKey } = route.params;
     const device = useSelector(selectSelectedDevice);
     const account = useSelector((state: AccountsRootState) =>
@@ -54,9 +56,27 @@ export const YieldClaimReviewScreen = () => {
         }
 
         if (!review || session?.step !== 'action') {
-            navigation.navigate(YieldStackRoutes.YieldClaim, route.params);
+            navigation.popTo(YieldStackRoutes.YieldClaim, route.params);
+
+            return;
         }
-    }, [account, navigation, review, route.params, session?.step]);
+
+        if (!device || preview) {
+            return;
+        }
+
+        // The preview could not be built from the stored review data, so
+        // signing must not start; leave with the standard failure alert
+        // instead of an empty screen.
+        dispatch(
+            stablecoinYieldActions.setError({
+                flowKey: account.key,
+                flowType: 'claim',
+                error: 'TR_EARN_YIELD_ERROR_CLAIM_REVIEW_MISMATCH',
+            }),
+        );
+        navigation.popTo(YieldStackRoutes.YieldClaim, route.params);
+    }, [account, device, dispatch, navigation, preview, review, route.params, session?.step]);
 
     if (!account || !preview || !review) {
         return null;

--- a/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
@@ -33,7 +33,7 @@ import { useYieldPendingTransaction } from '../hooks/useYieldPendingTransaction'
 import { useYieldPendingTransactionTracking } from '../hooks/useYieldPendingTransactionTracking';
 import { useYieldSession } from '../hooks/useYieldSession';
 import { getStablecoinYieldClaimRewardsSnapshot } from '../utils/stablecoinYieldClaimSummaryUtils';
-import { shouldShowClaimFeeWarning } from '../utils/yieldClaimFeeWarningUtils';
+import { getClaimFeeWarning } from '../utils/yieldClaimFeeWarningUtils';
 
 type RouteProps = RouteProp<YieldStackParamList, YieldStackRoutes.YieldClaim>;
 type NavigationProps = StackNavigationProps<YieldStackParamList, YieldStackRoutes.YieldClaim>;
@@ -87,10 +87,29 @@ export const YieldClaimScreen = () => {
         isBalance: false,
     });
     const totalFiatClaimableAmount = accountRewards?.totalFiatClaimableAmount ?? null;
-    const shouldShowFeeWarning = shouldShowClaimFeeWarning({
+
+    const claimFeeWarning = getClaimFeeWarning({
         feeFiatAmount,
         totalFiatClaimableAmount,
     });
+    const [hasClaimBeenPrepared, setHasClaimBeenPrepared] = useState(false);
+    const isClaimPrepared =
+        !isClaimRewardsLoading &&
+        !isClaimRewardsFiatLoading &&
+        !claimFee.isPreparingClaimFee &&
+        !!claimFee.preparedAction;
+
+    useEffect(() => {
+        if (isClaimPrepared) {
+            setHasClaimBeenPrepared(true);
+        }
+    }, [isClaimPrepared]);
+
+    const shouldShowFeeWarning = claimFeeWarning === 'fee-exceeds-rewards';
+
+    const shouldShowUnverifiableFeeWarning =
+        claimFeeWarning === 'unverifiable-rewards-value' && hasClaimBeenPrepared;
+
     const isContinueDisabled =
         isClaimPending ||
         isClaimSubmitting ||
@@ -226,6 +245,18 @@ export const YieldClaimScreen = () => {
                             title={<Translation id="earn.yieldClaimFlowScreen.feeWarning.title" />}
                             description={
                                 <Translation id="earn.yieldClaimFlowScreen.feeWarning.description" />
+                            }
+                        />
+                    )}
+
+                    {shouldShowUnverifiableFeeWarning && (
+                        <FullAlertBox
+                            intent="info"
+                            title={
+                                <Translation id="earn.yieldClaimFlowScreen.unverifiableFeeWarning.title" />
+                            }
+                            description={
+                                <Translation id="earn.yieldClaimFlowScreen.unverifiableFeeWarning.description" />
                             }
                         />
                     )}

--- a/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
@@ -131,22 +131,30 @@ export const YieldClaimScreen = () => {
     }, [claimFee.preparedAction, isContinueDisabled, openSimulationBottomSheet]);
 
     const handleConfirmSimulation = useCallback(() => {
-        if (!flowKey || !accountRewards || !simulationPreparedAction) {
+        if (!account || !flowKey || !simulationPreparedAction) {
             return;
         }
+
+        // The snapshot is built from the same frozen rewards the claim
+        // calldata was built from, so the review cannot diverge from the
+        // signed transaction when Merkl data refreshes in the background.
+        const rewardsSnapshot = getStablecoinYieldClaimRewardsSnapshot({
+            account,
+            rewards: simulationPreparedAction.rewards,
+        });
 
         dispatch(
             stablecoinYieldActions.storeActionReviewData({
                 flowKey,
                 flowType: 'claim',
-                rewards: getStablecoinYieldClaimRewardsSnapshot(accountRewards),
+                rewards: rewardsSnapshot,
                 unsignedTransaction: simulationPreparedAction.unsignedTransaction,
             }),
         );
         closeSimulationBottomSheet();
         navigation.navigate(YieldStackRoutes.YieldClaimReview, route.params);
     }, [
-        accountRewards,
+        account,
         closeSimulationBottomSheet,
         dispatch,
         flowKey,

--- a/suite-native/module-earn/src/utils/__tests__/yieldClaimFeeWarningUtils.test.ts
+++ b/suite-native/module-earn/src/utils/__tests__/yieldClaimFeeWarningUtils.test.ts
@@ -1,47 +1,54 @@
 import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils';
 
-import { shouldShowClaimFeeWarning } from '../yieldClaimFeeWarningUtils';
+import { getClaimFeeWarning } from '../yieldClaimFeeWarningUtils';
 
 const fiatAmount = (amount: string) => asBaseCurrencyAmount(new BigNumber(amount));
 
-describe('shouldShowClaimFeeWarning', () => {
-    it('shows warning only when fee fiat exceeds rewards fiat', () => {
+describe('getClaimFeeWarning', () => {
+    it('warns only when fee fiat exceeds rewards fiat', () => {
         expect(
-            shouldShowClaimFeeWarning({
+            getClaimFeeWarning({
                 feeFiatAmount: fiatAmount('4.76'),
                 totalFiatClaimableAmount: fiatAmount('3.75'),
             }),
-        ).toBe(true);
+        ).toBe('fee-exceeds-rewards');
 
         expect(
-            shouldShowClaimFeeWarning({
+            getClaimFeeWarning({
                 feeFiatAmount: fiatAmount('3.75'),
                 totalFiatClaimableAmount: fiatAmount('3.75'),
             }),
-        ).toBe(false);
+        ).toBeNull();
 
         expect(
-            shouldShowClaimFeeWarning({
+            getClaimFeeWarning({
                 feeFiatAmount: fiatAmount('1.25'),
                 totalFiatClaimableAmount: fiatAmount('3.75'),
             }),
-        ).toBe(false);
+        ).toBeNull();
     });
 
-    it('hides warning when fiat data is incomplete', () => {
+    it('reports an unverifiable rewards value when fiat data is incomplete', () => {
         expect(
-            shouldShowClaimFeeWarning({
+            getClaimFeeWarning({
                 feeFiatAmount: null,
                 totalFiatClaimableAmount: fiatAmount('3.75'),
             }),
-        ).toBe(false);
+        ).toBe('unverifiable-rewards-value');
 
         expect(
-            shouldShowClaimFeeWarning({
+            getClaimFeeWarning({
                 feeFiatAmount: fiatAmount('4.76'),
                 totalFiatClaimableAmount: null,
             }),
-        ).toBe(false);
+        ).toBe('unverifiable-rewards-value');
+
+        expect(
+            getClaimFeeWarning({
+                feeFiatAmount: null,
+                totalFiatClaimableAmount: null,
+            }),
+        ).toBe('unverifiable-rewards-value');
     });
 });

--- a/suite-native/module-earn/src/utils/__tests__/yieldClaimReviewUtils.test.ts
+++ b/suite-native/module-earn/src/utils/__tests__/yieldClaimReviewUtils.test.ts
@@ -1,0 +1,65 @@
+import { type StablecoinYieldActionReviewState } from '@suite-common/wallet-core';
+
+import { buildYieldClaimRewards } from '../yieldClaimReviewUtils';
+
+type YieldClaimReview = Extract<StablecoinYieldActionReviewState, { type: 'claim' }>;
+
+const TOKEN_ADDRESS = '0x58d97b57bb95320f9a05dc918aef65434969c2b2';
+
+const createClaimReview = (
+    rewards: YieldClaimReview['rewards'][number]['token'][],
+): YieldClaimReview => ({
+    type: 'claim',
+    rewards: rewards.map(token => ({
+        token,
+        value: '0.848795999565318',
+        fiatValue: '1.25',
+    })),
+    unsignedTransaction: {
+        to: '0x3ef3d8ba38ebe18db133cec108f4d14ce00dd9ae',
+        data: '0x71ee95c0',
+        chainId: 1,
+        gasLimit: '21000',
+        maxFeePerGas: '2000000000',
+        maxPriorityFeePerGas: '1000000000',
+        nonce: '10',
+    },
+});
+
+describe('buildYieldClaimRewards', () => {
+    it('maps every reward to its token address and symbol', () => {
+        const review = createClaimReview([
+            {
+                networkSymbol: 'eth',
+                symbol: 'USDC',
+                decimals: 6,
+                contractAddress: TOKEN_ADDRESS,
+            },
+        ]);
+
+        expect(buildYieldClaimRewards(review)).toEqual([
+            { token: { address: TOKEN_ADDRESS, symbol: 'USDC' } },
+        ]);
+    });
+
+    it('throws when a reward is missing a token contract address', () => {
+        const review = createClaimReview([
+            {
+                networkSymbol: 'eth',
+                symbol: 'USDC',
+                decimals: 6,
+                contractAddress: TOKEN_ADDRESS,
+            },
+            {
+                networkSymbol: 'eth',
+                symbol: 'MORPHO',
+                decimals: 18,
+                contractAddress: null,
+            },
+        ]);
+
+        expect(() => buildYieldClaimRewards(review)).toThrow(
+            'Yield claim reward is missing a token contract address.',
+        );
+    });
+});

--- a/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts
+++ b/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts
@@ -122,7 +122,7 @@ export const getStablecoinYieldAccountRewards = ({
 export const getStablecoinYieldClaimRewardsSnapshot = ({
     account,
     rewards,
-}: StablecoinYieldAccountRewards): YieldFlowCompleteRewardItem[] =>
+}: Pick<StablecoinYieldAccountRewards, 'account' | 'rewards'>): YieldFlowCompleteRewardItem[] =>
     rewards.map(reward => ({
         token: {
             networkSymbol: account.symbol,

--- a/suite-native/module-earn/src/utils/yieldClaimFeeWarningUtils.ts
+++ b/suite-native/module-earn/src/utils/yieldClaimFeeWarningUtils.ts
@@ -1,14 +1,21 @@
 import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
 
-type ShouldShowClaimFeeWarningParams = {
+export type YieldClaimFeeWarning = 'fee-exceeds-rewards' | 'unverifiable-rewards-value';
+
+type GetClaimFeeWarningParams = {
     feeFiatAmount: BaseCurrencyAmount | null;
     totalFiatClaimableAmount: BaseCurrencyAmount | null;
 };
 
-export const shouldShowClaimFeeWarning = ({
+export const getClaimFeeWarning = ({
     feeFiatAmount,
     totalFiatClaimableAmount,
-}: ShouldShowClaimFeeWarningParams) =>
-    feeFiatAmount !== null &&
-    totalFiatClaimableAmount !== null &&
-    feeFiatAmount.gt(totalFiatClaimableAmount);
+}: GetClaimFeeWarningParams): YieldClaimFeeWarning | null => {
+    // Missing fiat data means the fee-vs-rewards check cannot run, which must
+    // surface to the user instead of silently suppressing the warning.
+    if (feeFiatAmount === null || totalFiatClaimableAmount === null) {
+        return 'unverifiable-rewards-value';
+    }
+
+    return feeFiatAmount.gt(totalFiatClaimableAmount) ? 'fee-exceeds-rewards' : null;
+};

--- a/suite-native/module-earn/src/utils/yieldClaimReviewUtils.ts
+++ b/suite-native/module-earn/src/utils/yieldClaimReviewUtils.ts
@@ -3,15 +3,15 @@ import { type StablecoinYieldActionReviewState } from '@suite-common/wallet-core
 type YieldClaimReview = Extract<StablecoinYieldActionReviewState, { type: 'claim' }>;
 
 export const buildYieldClaimRewards = (review: YieldClaimReview) =>
-    review.rewards.flatMap(reward =>
-        reward.token.contractAddress
-            ? [
-                  {
-                      token: {
-                          address: reward.token.contractAddress,
-                          symbol: reward.token.symbol,
-                      },
-                  },
-              ]
-            : [],
-    );
+    review.rewards.map(reward => {
+        if (!reward.token.contractAddress) {
+            throw new Error('Yield claim reward is missing a token contract address.');
+        }
+
+        return {
+            token: {
+                address: reward.token.contractAddress,
+                symbol: reward.token.symbol,
+            },
+        };
+    });

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10252,6 +10252,11 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_ERROR_TRANSACTION_FAILED',
         defaultMessage: 'Transaction failed',
     },
+    TR_EARN_YIELD_ERROR_CLAIM_REVIEW_MISMATCH: {
+        id: 'TR_EARN_YIELD_ERROR_CLAIM_REVIEW_MISMATCH',
+        defaultMessage:
+            "The rewards to claim didn't match the transaction details, so nothing was signed. Try again.",
+    },
     TR_EARN_YIELD_REVIEW_DEPOSIT_TITLE: {
         id: 'TR_EARN_YIELD_REVIEW_DEPOSIT_TITLE',
         defaultMessage: 'Deposit',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes three findings from the stablecoin-yield audit (claim flow, mobile):

1. **Review under-reporting** — claim review now fails instead of silently dropping rewards, and reviewed rewards are verified against the decoded claim calldata, so nothing can be signed that wasn't fully displayed. On failure the user gets a "Claim couldn't be verified" alert instead of a blank screen.
2. **Suppressed fee warning** — missing fiat rates no longer hide the fee-vs-rewards check; an informational "Rewards value can't be verified" alert is shown instead.
3. **Config drift** — claim support now requires both the `claim-rewards` feature and a `MERKL_XYZ_CONTRACT` entry; a new unit test enforces consistency in CI.

## Notes for QA

Claim flow on ETH: review must list all claimed tokens; with missing fiat rates an
info alert appears after fees load. Alert copy is new (not reviewed by copy team).

## Related Issue

Resolve #29540

## Screenshots:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-15 at 11 35 57" src="https://github.com/user-attachments/assets/a89af0c4-efaf-4b1f-939e-cce1e1289d41" />

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-14 at 18 52 18" src="https://github.com/user-attachments/assets/d026304c-100c-4706-bd82-687fa6618c36" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files fall into two categories: (1) suite-native mobile-only code (suite-native/module-earn, suite-native/intl) which has no E2E test coverage in the Playwright suite since these tests target the web/desktop app, and (2) shared libraries (suite-common/earn-stablecoin, suite-common/wallet-config/earnRewardsProvider, suite-common/wallet-core/stablecoinYieldReducer) that map to 131 tests each purely because they are broad transitive dependencies bundled into the app. The earn-stablecoin and stablecoin-yield changes relate to a yield/claim feature for stablecoins, which is distinct from the ETH/SOL/ADA staking flows tested in the E2E suite. The suite/intl/src/messages.ts change likely adds new translation keys for the stablecoin yield claim feature, which would not affect existing tests unless keys were removed or renamed. None of the 154 candidate E2E tests exercise stablecoin yield claiming, earn rewards provider configuration for stablecoins, or the stablecoinYieldReducer logic — they test traditional staking (ETH, SOL, ADA), trading, onboarding, and other unrelated features. No targeted E2E tests are recommended for this change set.

<details><summary><b>Changed files (15)</b></summary>

- `suite-common/earn-stablecoin/src/signing/__tests__/claimSigningUtils.test.ts`
- `suite-common/earn-stablecoin/src/signing/claimSigningUtils.ts`
- `suite-common/wallet-config/src/__tests__/earnRewardsProvider.test.ts`
- `suite-common/wallet-config/src/earnRewardsProvider.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-earn/src/hooks/useShowYieldTransactionFailureAlert.ts`
- `suite-native/module-earn/src/screens/YieldClaimReviewScreen.tsx`
- `suite-native/module-earn/src/screens/YieldClaimScreen.tsx`
- `suite-native/module-earn/src/utils/__tests__/yieldClaimFeeWarningUtils.test.ts`
- `suite-native/module-earn/src/utils/__tests__/yieldClaimReviewUtils.test.ts`
- `suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts`
- `suite-native/module-earn/src/utils/yieldClaimFeeWarningUtils.ts`
- `suite-native/module-earn/src/utils/yieldClaimReviewUtils.ts`
- `suite/intl/src/messages.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (15)**
- `suite-common/earn-stablecoin/src/signing/__tests__/claimSigningUtils.test.ts`
- `suite-common/earn-stablecoin/src/signing/claimSigningUtils.ts`
- `suite-common/wallet-config/src/__tests__/earnRewardsProvider.test.ts`
- `suite-common/wallet-config/src/earnRewardsProvider.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-earn/src/hooks/useShowYieldTransactionFailureAlert.ts`
- `suite-native/module-earn/src/screens/YieldClaimReviewScreen.tsx`
- `suite-native/module-earn/src/screens/YieldClaimScreen.tsx`
- `suite-native/module-earn/src/utils/__tests__/yieldClaimFeeWarningUtils.test.ts`
- `suite-native/module-earn/src/utils/__tests__/yieldClaimReviewUtils.test.ts`
- `suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts`
- `suite-native/module-earn/src/utils/yieldClaimFeeWarningUtils.ts`
- `suite-native/module-earn/src/utils/yieldClaimReviewUtils.ts`
- `suite/intl/src/messages.ts`

_Updated: 2026-07-17T11:28:44.605Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-claim-review-audit&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-claim-review-audit&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/yield-claim-review-audit&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-17T11:31:45.821Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-17T11:31:10.926Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-claim-review-audit/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-claim-review-audit/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->