### PR TITLE
docs(transport-bridge): remove outdated binary build instructions

### DIFF
--- a/packages/transport-bridge/README.md
+++ b/packages/transport-bridge/README.md
@@ -9,8 +9,3 @@
 
 Javascript build has 2 phases - node, using esbuild, and web, using webpack. It still can be used without the `build:lib` script. But to have
 also bridge status page available you need to build.
-
-## Build and run binary
-
-- `yarn workspace @trezor/transport-bridge build`
-- `./packages/transport-bridge/build/\@trezor/transport-bridge-<your-platform>`


### PR DESCRIPTION
## Description

The transport-bridge README's "Build and run binary" section is outdated. It instructed:

```
yarn workspace @trezor/transport-bridge build
./packages/transport-bridge/build/@trezor/transport-bridge-<your-platform>
```

But no standalone binary is produced anymore. The `build` script is now just an alias for `build:js` (esbuild for node + webpack for the UI, output to `dist/`), there's no `pkg`/`nexe` packaging step, and the `build/@trezor/transport-bridge-<platform>` executable is never generated.

This PR removes the stale section. The remaining "Build and run using node" section documents the actual, working way to run the bridge.

## Notes for QA

No QA needed — documentation-only change, no code or runtime behavior affected.