### PR TITLE
fix(requirements): update type-declaration-size snapshot

### DIFF
--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -9,6 +9,7 @@ const kibToBytes = (sizeKib: number) => sizeKib * 1024;
 export const MAX_DECLARATION_SIZE_BYTES = kibToBytes(100);
 
 const KNOWN_OVERSIZED_DECLARATION_LIMITS = new Map<string, number>([
+    ['packages/connect-cli/libDev/src/transport.d.ts', kibToBytes(104)],
     ['suite/e2e/libDev/fixtures/invity/index.d.ts', kibToBytes(740)],
     ['suite-common/earn-stablecoin-defs/libDev/src/api/index.d.ts', kibToBytes(625)],
     ['suite-common/logger/libDev/src/utils.d.ts', kibToBytes(600)],


### PR DESCRIPTION
## Description

Update `type-declaration-size` snapshot to allow a file that was modified in the meantime (git soft conflicts).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file (packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts) is a build-time/compile-time type-declaration requirement check, not runtime application code. It has no static test coverage mapping, and none of the 35 candidate E2E tests touch or depend on type-declaration validation logic. This change carries negligible risk of causing any runtime regression in user-facing functionality, so no E2E tests are recommended.

<details><summary><b>Changed files (1)</b></summary>

- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`

_Updated: 2026-07-15T13:40:07.972Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/update-KNOWN_OVERSIZED_DECLARATION_LIMITS/web/](https://dev.suite.sldev.cz/suite-web/fix/update-KNOWN_OVERSIZED_DECLARATION_LIMITS/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/update-KNOWN_OVERSIZED_DECLARATION_LIMITS&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/update-KNOWN_OVERSIZED_DECLARATION_LIMITS&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-15T13:43:46.133Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-15T13:43:36.727Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->