### PR TITLE
feat(suite): do not show approved amount when zero

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
@@ -66,7 +66,6 @@ export const YieldApproveStep = ({
     onPendingTxClick,
 }: YieldApproveStepProps) => {
     const approveButtonId = getApproveButtonTranslationId(approvalAction);
-    const approvedAmountValue = approvedAmount ?? '0';
     const shouldEnableRevoke =
         canRevokeAllowance && !isApprovedAmountLoading && !hasApprovedAmountError && !isLoading;
     const onRevokeClick = shouldEnableRevoke ? onRevoke : undefined;
@@ -75,7 +74,7 @@ export const YieldApproveStep = ({
         <Column gap={16}>
             <YieldApprovedAmountCard
                 token={token}
-                amount={approvedAmountValue}
+                amount={approvedAmount}
                 isLoading={isApprovedAmountLoading}
                 hasError={hasApprovedAmountError}
                 onRevoke={onRevokeClick}

--- a/packages/suite/src/components/earn/yield/common/YieldApprovedAmountCard.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApprovedAmountCard.tsx
@@ -8,7 +8,7 @@ import { ApprovedAmountValue } from './ApprovedAmountValue';
 
 type YieldApprovedAmountCardProps = {
     token: YieldFlowDisplayToken;
-    amount: string;
+    amount?: string;
     isLoading?: boolean;
     hasError?: boolean;
     onRevoke?: () => void;
@@ -20,38 +20,42 @@ export const YieldApprovedAmountCard = ({
     isLoading = false,
     hasError = false,
     onRevoke,
-}: YieldApprovedAmountCardProps) => (
-    <Card type="contrast" paddingType="small">
-        <Row justifyContent="space-between" alignItems="center" width="100%">
-            <Text typographyStyle="body-md">
-                <Translation id="TR_EARN_YIELD_APPROVED_AMOUNT" />
-            </Text>
-            <Row alignItems="center" gap={8}>
-                <AssetLogo
-                    size={20}
-                    symbol={token.networkSymbol}
-                    contractAddress={token.contractAddress ?? null}
-                    placeholder={token.symbol}
-                    showNetworkIcon
-                    isBordered={false}
-                />
-                <ApprovedAmountValue
-                    amount={amount}
-                    token={token}
-                    isLoading={isLoading}
-                    hasError={hasError}
-                />
-                {onRevoke && (
-                    <IconButton
-                        icon={XIcon}
-                        size="small"
-                        intent="neutral"
-                        priority="secondary"
-                        onClick={onRevoke}
-                        tooltip={{ content: <Translation id="TR_REVOKE_DATA_TITLE" /> }}
+}: YieldApprovedAmountCardProps) => {
+    if (!amount || amount.trim() === '' || amount === '0') return null;
+
+    return (
+        <Card type="contrast" paddingType="small">
+            <Row justifyContent="space-between" alignItems="center" width="100%">
+                <Text typographyStyle="body-md">
+                    <Translation id="TR_EARN_YIELD_APPROVED_AMOUNT" />
+                </Text>
+                <Row alignItems="center" gap={8}>
+                    <AssetLogo
+                        size={20}
+                        symbol={token.networkSymbol}
+                        contractAddress={token.contractAddress ?? null}
+                        placeholder={token.symbol}
+                        showNetworkIcon
+                        isBordered={false}
                     />
-                )}
+                    <ApprovedAmountValue
+                        amount={amount}
+                        token={token}
+                        isLoading={isLoading}
+                        hasError={hasError}
+                    />
+                    {onRevoke && (
+                        <IconButton
+                            icon={XIcon}
+                            size="small"
+                            intent="neutral"
+                            priority="secondary"
+                            onClick={onRevoke}
+                            tooltip={{ content: <Translation id="TR_REVOKE_DATA_TITLE" /> }}
+                        />
+                    )}
+                </Row>
             </Row>
-        </Row>
-    </Card>
-);
+        </Card>
+    );
+};

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -230,7 +230,7 @@ export const YieldDepositForm = () => {
                                 inactiveContent: () => (
                                     <YieldApprovedAmountCard
                                         token={token}
-                                        amount={allowanceAmount || '0'}
+                                        amount={allowanceAmount}
                                         isLoading={allowanceStatus === 'loading'}
                                         hasError={allowanceStatus === 'error'}
                                     />


### PR DESCRIPTION
## Description

Do not show approved amount in yield deposit flow when it is zero.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29736

## Screenshots:

<img width="100%" alt="Screenshot 2026-07-15 at 15 42 48" src="https://github.com/user-attachments/assets/7cdcc2ff-0e1a-4799-8b2a-48654d6619e1" />

On mobile, the user is redirected to step 1 (approval step) when approved amount is zero and no row is shown. Otherwise the user is redirected to step 2 (deposit step) where the non-zero approval is displayed.

https://github.com/user-attachments/assets/b24141d6-70b5-47ce-8151-f5ab11392e09


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are scoped to three earn/yield staking components: YieldDepositForm (the deposit/staking form), YieldApproveStep (the approval step in staking flow), and YieldApprovedAmountCard (display of approved amounts). Despite static coverage mapping these to 131 tests (indicating they are transitively imported as part of the app bundle), only ETH and SOL staking tests actually exercise these components' functionality. The risk is concentrated in the staking deposit and approval flows — ETH staking tests are highest priority since the components are named with "Yield" which maps to the ETH staking infrastructure, while SOL staking tests are medium priority as they may share the same form infrastructure. ADA staking uses a different (Cardano-specific) flow and is unlikely to be affected.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx`
- `packages/suite/src/components/earn/yield/common/YieldApprovedAmountCard.tsx`
- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the ETH staking deposit flow end-to-end, which directly uses the YieldDepositForm component and likely the YieldApproveStep/YieldApprovedAmountCard components during the staking confirmation process. Changes to deposit form logic or approval steps could break transaction initiation and confirmation.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test covers staking additional ETH on an already-staked account, which exercises the yield deposit form for subsequent deposits. The YieldApproveStep and YieldApprovedAmountCard components are likely involved in the approval/confirmation flow for additional stakes.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates the ETH staking form input behavior including amount validation, percentage buttons, max amount calculation, and crypto/fiat switching — all of which are core behaviors of the YieldDepositForm component. Any changes to the deposit form would directly impact these validations.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — While primarily testing unstaking, this test starts from a staking dashboard context and verifies the full staking lifecycle. Changes to yield components could affect how the staking dashboard renders staked amounts and status indicators that are preconditions for the unstake flow.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL staking uses the same earn/yield infrastructure as ETH. The staking form, approval step, and amount card components may be shared across different staking networks. Changes could affect SOL staking deposit flow.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — SOL stake-more flow exercises the deposit form for adding additional SOL stakes. The yield deposit form and approval components may be used across staking networks, so changes could impact the SOL staking flow.

</details>

_Updated: 2026-07-15T13:48:31.970Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/yield-deposit-zero-approval/web/](https://dev.suite.sldev.cz/suite-web/feat/yield-deposit-zero-approval/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/yield-deposit-zero-approval&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/yield-deposit-zero-approval&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-15T13:51:35.910Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-15T13:51:27.140Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->