### PR TITLE
fix: withdraw max from vault via redeem to avoid dust balance

### DIFF
--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -35,7 +35,8 @@ export const YieldWithdrawForm = () => {
         flowType,
         completedInput,
         completedOutput,
-        setAmountInput,
+        selectMaxWithdraw,
+        isMaxWithdrawInfoVisible,
         toggleWithdrawFlowType,
         submitAction,
         openPendingTransaction,
@@ -113,7 +114,29 @@ export const YieldWithdrawForm = () => {
             },
         });
 
-        setAmountInput(maxAmount);
+        selectMaxWithdraw();
+    };
+
+    const getWithdrawWarning = () => {
+        if (!isAmountInvalidDecimals && isAmountTooHigh) {
+            return <YieldActionStepWarning isInsufficientFunds={isAmountTooHigh} />;
+        }
+
+        if (isMaxWithdrawInfoVisible) {
+            return (
+                <Banner
+                    intent="info"
+                    description={
+                        <Translation
+                            id="TR_EARN_YIELD_MAX_WITHDRAW_INFO"
+                            values={{ receiptTokenSymbol: receiptToken.symbol }}
+                        />
+                    }
+                />
+            );
+        }
+
+        return undefined;
     };
 
     return (
@@ -150,13 +173,7 @@ export const YieldWithdrawForm = () => {
                                             symbol={inputTokenSymbol}
                                         />
                                     }
-                                    warning={
-                                        !isAmountInvalidDecimals && isAmountTooHigh ? (
-                                            <YieldActionStepWarning
-                                                isInsufficientFunds={isAmountTooHigh}
-                                            />
-                                        ) : undefined
-                                    }
+                                    warning={getWithdrawWarning()}
                                     isDisabled={
                                         isAmountEmpty ||
                                         isAmountTooHigh ||

--- a/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
+++ b/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { type EarnParams } from '@suite/router';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
@@ -22,6 +22,8 @@ export type YieldWithdrawContextValues = Omit<YieldFlowContextValues, 'flowType'
     completedInput: YieldFlowCompleteValue;
     completedOutput?: YieldFlowCompleteValue;
     toggleWithdrawFlowType: () => void;
+    selectMaxWithdraw: () => void;
+    isMaxWithdrawInfoVisible: boolean;
 };
 
 export const useYieldWithdraw = ({
@@ -30,6 +32,8 @@ export const useYieldWithdraw = ({
     vault,
 }: UseYieldWithdrawProps): YieldWithdrawContextValues | null => {
     const [flowType, setFlowType] = useState<YieldWithdrawFlowType>('withdraw');
+    const [isMaxWithdrawSelectionPending, setIsMaxWithdrawSelectionPending] = useState(false);
+    const [maxWithdrawInfoAmount, setMaxWithdrawInfoAmount] = useState<string | null>(null);
 
     const flowResult = useYieldFlow({
         account,
@@ -37,11 +41,52 @@ export const useYieldWithdraw = ({
         vault,
         flowType,
     });
-    const { token, receiptToken } = flowResult;
+    const { token, receiptToken, depositedSharesAmount, setAmountInput, liveAmount, flow } =
+        flowResult;
 
     const toggleWithdrawFlowType = useCallback(() => {
+        setIsMaxWithdrawSelectionPending(false);
+        setMaxWithdrawInfoAmount(null);
         setFlowType(prev => (prev === 'redeem' ? 'withdraw' : 'redeem'));
     }, []);
+
+    const selectMaxWithdraw = useCallback(() => {
+        if (flowType === 'redeem') {
+            setAmountInput(depositedSharesAmount);
+
+            return;
+        }
+
+        setIsMaxWithdrawSelectionPending(true);
+        setFlowType('redeem');
+    }, [depositedSharesAmount, flowType, setAmountInput]);
+
+    // The flow resets the form while switching units, so fill it only after redeem is ready.
+    useEffect(() => {
+        if (
+            !isMaxWithdrawSelectionPending ||
+            flowType !== 'redeem' ||
+            flow.currentStep !== 'action'
+        ) {
+            return;
+        }
+
+        setAmountInput(depositedSharesAmount);
+        setMaxWithdrawInfoAmount(depositedSharesAmount);
+        setIsMaxWithdrawSelectionPending(false);
+    }, [
+        depositedSharesAmount,
+        flow.currentStep,
+        flowType,
+        isMaxWithdrawSelectionPending,
+        setAmountInput,
+    ]);
+
+    useEffect(() => {
+        if (maxWithdrawInfoAmount !== null && liveAmount !== maxWithdrawInfoAmount) {
+            setMaxWithdrawInfoAmount(null);
+        }
+    }, [liveAmount, maxWithdrawInfoAmount]);
 
     if (!token || !receiptToken) {
         return null;
@@ -78,5 +123,7 @@ export const useYieldWithdraw = ({
         completedInput,
         completedOutput,
         toggleWithdrawFlowType,
+        selectMaxWithdraw,
+        isMaxWithdrawInfoVisible: maxWithdrawInfoAmount !== null,
     };
 };

--- a/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleInput.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleInput.tsx
@@ -20,6 +20,7 @@ export type AnimatedDoubleInputProps = {
     renderSecondary: (props: RenderInputProps) => ReactNode;
     onInputSwitch?: (activeView: ActiveView) => void;
     switchLabel?: string;
+    activeView?: ActiveView;
 };
 
 export const AnimatedDoubleInput = ({
@@ -27,6 +28,7 @@ export const AnimatedDoubleInput = ({
     renderSecondary,
     onInputSwitch = noop,
     switchLabel,
+    activeView,
 }: AnimatedDoubleInputProps) => {
     const primaryInputRef = useRef<InputType | null>(null);
     const secondaryInputRef = useRef<InputType | null>(null);
@@ -50,9 +52,9 @@ export const AnimatedDoubleInput = ({
     );
 
     const focusInput = useCallback(
-        (activeView: ActiveView) => {
-            setActiveInputRef(activeView === 'primary' ? primaryInputRef : secondaryInputRef);
-            onInputSwitch(activeView);
+        (nextActiveView: ActiveView) => {
+            setActiveInputRef(nextActiveView === 'primary' ? primaryInputRef : secondaryInputRef);
+            onInputSwitch(nextActiveView);
         },
         [onInputSwitch],
     );
@@ -73,6 +75,7 @@ export const AnimatedDoubleInput = ({
             }
             onViewSwitch={focusInput}
             switchLabel={switchLabel}
+            activeView={activeView}
         />
     );
 };

--- a/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleView.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleView.tsx
@@ -20,6 +20,7 @@ export type AnimatedDoubleViewProps = {
     renderSecondary: AnimatedViewWrapperProps['renderView'];
     onViewSwitch?: (activeView: ActiveView) => void;
     switchLabel?: string;
+    activeView?: ActiveView;
 };
 
 export const ANIMATED_DOUBLE_VIEW_SWITCH_ANIMATION_DURATION = ANIMATION_DURATION;
@@ -35,17 +36,22 @@ export const AnimatedDoubleView = ({
     renderSecondary,
     onViewSwitch = noop,
     switchLabel,
+    activeView: controlledActiveView,
 }: AnimatedDoubleViewProps) => {
     const { applyStyle } = useNativeStyles();
 
-    const [activeView, setActiveView] = useState<ActiveView>('primary');
+    const [internalActiveView, setInternalActiveView] = useState<ActiveView>('primary');
+    const activeView = controlledActiveView ?? internalActiveView;
 
     const handleViewSwitch = useCallback(() => {
         const nextActiveView = activeView === 'primary' ? 'secondary' : 'primary';
 
-        setActiveView(nextActiveView);
+        if (controlledActiveView === undefined) {
+            setInternalActiveView(nextActiveView);
+        }
+
         onViewSwitch(nextActiveView);
-    }, [onViewSwitch, activeView]);
+    }, [activeView, controlledActiveView, onViewSwitch]);
 
     return (
         <Animated.View layout={LinearTransition} style={applyStyle(viewsWrapperStyle)}>

--- a/suite-native/atoms/src/AnimatedDoubleView/__tests__/AnimatedDoubleInput.test.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/__tests__/AnimatedDoubleInput.test.tsx
@@ -40,6 +40,20 @@ describe('AnimatedDoubleInput', () => {
         expect(onInputSwitch).toHaveBeenCalledWith('secondary');
     });
 
+    it('should derive the next view from the controlled activeView', async () => {
+        const onInputSwitch = jest.fn();
+        const { getByLabelText } = renderAnimatedDoubleInput({
+            onInputSwitch,
+            activeView: 'secondary',
+        });
+
+        const switchButton = getByLabelText('Switch');
+        await userEvent.press(switchButton);
+
+        expect(onInputSwitch).toHaveBeenCalledTimes(1);
+        expect(onInputSwitch).toHaveBeenCalledWith('primary');
+    });
+
     it('should propagate switch label', () => {
         const switchLabel = 'Custom Switch Label';
         const { getByLabelText, queryByLabelText } = renderAnimatedDoubleInput({ switchLabel });

--- a/suite-native/atoms/src/AnimatedDoubleView/__tests__/AnimatedDoubleView.test.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/__tests__/AnimatedDoubleView.test.tsx
@@ -34,6 +34,25 @@ describe('AnimatedDoubleView', () => {
         expect(onViewSwitch).toHaveBeenNthCalledWith(2, 'primary');
     });
 
+    it('should display the controlled active view', () => {
+        const { getByLabelText } = renderWithBasicProvider(
+            <AnimatedDoubleView
+                activeView="secondary"
+                renderPrimary={({ isDisabled }) => (
+                    <Box accessibilityLabel={isDisabled ? 'PRIMARY_DISABLED' : 'PRIMARY_ACTIVE'} />
+                )}
+                renderSecondary={({ isDisabled }) => (
+                    <Box
+                        accessibilityLabel={isDisabled ? 'SECONDARY_DISABLED' : 'SECONDARY_ACTIVE'}
+                    />
+                )}
+            />,
+        );
+
+        expect(getByLabelText('PRIMARY_DISABLED')).toBeOnTheScreen();
+        expect(getByLabelText('SECONDARY_ACTIVE')).toBeOnTheScreen();
+    });
+
     it('should propagate switch label', () => {
         const switchLabel = 'Custom Switch Label';
         const { getByLabelText, queryByLabelText } = renderAnimatedDoubleView({ switchLabel });

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2965,6 +2965,8 @@ export const messages = {
             amountExceedsDeposited: 'The amount exceeds your deposited balance.',
             networkFeeWarning:
                 'Network fees may exceed this amount. Your balance may decrease. Enter higher amount.',
+            maxWithdrawInfo:
+                'Amount switched to {vaultTokenSymbol} to withdraw your entire balance, including yield earned up to the moment the transaction is processed.',
             title: 'Withdraw',
             supplied: 'Supplied:',
             maximumFee: 'Maximum fee',

--- a/suite-native/module-earn/src/components/YieldWithdrawWarning.tsx
+++ b/suite-native/module-earn/src/components/YieldWithdrawWarning.tsx
@@ -1,14 +1,18 @@
-import { InlineAlertBox } from '@suite-native/atoms';
+import { InlineAlertBox, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
 type YieldWithdrawWarningProps = {
     isAmountTooHigh: boolean;
+    isMaxWithdrawInfoVisible: boolean;
     shouldShowNetworkFeeWarning: boolean;
+    vaultTokenSymbol: string;
 };
 
 export const YieldWithdrawWarning = ({
     isAmountTooHigh,
+    isMaxWithdrawInfoVisible,
     shouldShowNetworkFeeWarning,
+    vaultTokenSymbol,
 }: YieldWithdrawWarningProps) => {
     if (isAmountTooHigh) {
         return (
@@ -19,14 +23,29 @@ export const YieldWithdrawWarning = ({
         );
     }
 
-    if (shouldShowNetworkFeeWarning) {
-        return (
-            <InlineAlertBox
-                intent="warning"
-                title={<Translation id="earn.yieldWithdrawFlowScreen.networkFeeWarning" />}
-            />
-        );
+    if (!shouldShowNetworkFeeWarning && !isMaxWithdrawInfoVisible) {
+        return null;
     }
 
-    return null;
+    return (
+        <VStack spacing="sp16">
+            {shouldShowNetworkFeeWarning && (
+                <InlineAlertBox
+                    intent="warning"
+                    title={<Translation id="earn.yieldWithdrawFlowScreen.networkFeeWarning" />}
+                />
+            )}
+            {isMaxWithdrawInfoVisible && (
+                <InlineAlertBox
+                    intent="info"
+                    title={
+                        <Translation
+                            id="earn.yieldWithdrawFlowScreen.maxWithdrawInfo"
+                            values={{ vaultTokenSymbol }}
+                        />
+                    }
+                />
+            )}
+        </VStack>
+    );
 };

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -87,9 +87,12 @@ export const YieldWithdrawScreen = () => {
     const [assetAmount, setAssetAmount] = useState('');
     const [sharesAmount, setSharesAmount] = useState('');
     const [isMaxSelected, setIsMaxSelected] = useState(false);
-    const [flowType, setFlowType] = useState<YieldWithdrawFlowType>(
+    const [selectedFlowType, setSelectedFlowType] = useState<YieldWithdrawFlowType>(
         route.params.withdrawFlowType ?? 'withdraw',
     );
+    // Redeeming the exact shares balance prevents leaving yield dust behind.
+    const flowType: YieldWithdrawFlowType = isMaxSelected ? 'redeem' : selectedFlowType;
+    const isMaxWithdrawInfoVisible = isMaxSelected && selectedFlowType === 'withdraw';
     const isSharesInput = flowType === 'redeem';
     const amount = isSharesInput ? sharesAmount : assetAmount;
     const {
@@ -365,7 +368,8 @@ export const YieldWithdrawScreen = () => {
     }, [closeInfoBottomSheet, isWithdrawPending, openPendingBottomSheet]);
 
     const handleInputSwitch = useCallback((activeView: 'primary' | 'secondary') => {
-        setFlowType(getYieldWithdrawFlowTypeByInputView(activeView));
+        setIsMaxSelected(false);
+        setSelectedFlowType(getYieldWithdrawFlowTypeByInputView(activeView));
     }, []);
 
     const handleContinue = useCallback(() => {
@@ -469,6 +473,7 @@ export const YieldWithdrawScreen = () => {
                         </HStack>
 
                         <AnimatedDoubleInput
+                            activeView={isSharesInput ? 'secondary' : 'primary'}
                             onInputSwitch={handleInputSwitch}
                             renderPrimary={({ inputRef, isDisabled, onPress }) => (
                                 <Input
@@ -557,9 +562,11 @@ export const YieldWithdrawScreen = () => {
 
                 <YieldWithdrawWarning
                     isAmountTooHigh={!amountValidationError && isAmountTooHigh}
+                    isMaxWithdrawInfoVisible={isMaxWithdrawInfoVisible}
                     shouldShowNetworkFeeWarning={
                         !amountValidationError && shouldShowNetworkFeeWarning
                     }
+                    vaultTokenSymbol={vaultTokenSymbol}
                 />
             </VStack>
             {actionPendingTransaction && (

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10153,6 +10153,11 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_WITHDRAW_DISABLED',
         defaultMessage: 'Withdrawal is currently disabled.',
     },
+    TR_EARN_YIELD_MAX_WITHDRAW_INFO: {
+        id: 'TR_EARN_YIELD_MAX_WITHDRAW_INFO',
+        defaultMessage:
+            'Amount switched to {receiptTokenSymbol} to withdraw your entire balance, including yield earned up to the moment the transaction is processed.',
+    },
     TR_EARN_YIELD_CLAIM_DISABLED: {
         id: 'TR_EARN_YIELD_CLAIM_DISABLED',
         defaultMessage: 'Claim is currently disabled.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Max withdrawal used `withdraw(assets)` with a converted USDC amount, and since the USDC↔shares rate changes every block, dust always stayed in the vault. Clicking Max now switches the input to the vault token, fills the exact shares balance and submits `redeem(shares)`, so nothing is left behind. An info banner explains the switch — shown only when Max is clicked from the asset input, hidden on any input change. Desktop + mobile.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29786

## Screenshots:


https://github.com/user-attachments/assets/e4b320ed-2c10-42b6-b05d-4dae133788a1


https://github.com/user-attachments/assets/d2f809e9-73e1-43cd-86a7-86f27abd7ad1


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes primarily affect the yield/earn withdrawal flow (YieldWithdrawForm.tsx, useYieldWithdraw.ts) and translation messages. The suite-native changes (AnimatedDoubleView, YieldWithdrawScreen, etc.) are mobile-only and have no web E2E test coverage. The two changed suite files (YieldWithdrawForm.tsx and useYieldWithdraw.ts) map to 131 tests each via static analysis, but this is because they are bundled into the main Suite app — only staking/earn tests actually exercise this functionality. The ETH unstake test is the most critical since it directly validates the withdrawal flow being modified. Other staking tests provide supplementary coverage for shared UI and intl changes.

<details><summary><b>Changed files (10)</b></summary>

- `packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx`
- `packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts`
- `suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleInput.tsx`
- `suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleView.tsx`
- `suite-native/atoms/src/AnimatedDoubleView/__tests__/AnimatedDoubleInput.test.tsx`
- `suite-native/atoms/src/AnimatedDoubleView/__tests__/AnimatedDoubleView.test.tsx`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-earn/src/components/YieldWithdrawWarning.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test directly exercises the ETH unstaking/withdrawal flow end-to-end, including the unstake form, device confirmation, and claiming. The changed YieldWithdrawForm.tsx and useYieldWithdraw.ts are the core components powering the yield withdrawal UI that this test validates.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/staking/eth/stake-more.test.ts` — The stake-more flow shares the staking dashboard UI with the unstaking flow and validates staking amounts, progress indicators, and button states that could be affected by changes to the earn/yield withdraw components or intl messages used across staking views.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — The initial stake test validates the full staking lifecycle including the staking dashboard state where unstake/claim buttons are disabled until activation. Changes to the withdraw form or related intl messages could affect these shared staking UI elements.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates staking form input validation, amount calculations, and crypto/fiat switching — form patterns shared with the yield withdraw form. Changes to useYieldWithdraw.ts or the withdraw form component could affect shared validation logic or UI patterns.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstaking tests the unstake flow on a different chain. While SOL uses different staking mechanics, the yield withdraw UI components and intl messages are shared across chains, so changes could affect SOL unstaking behavior.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/ada/unstake.test.ts` — ADA unstaking uses Cardano-specific staking mechanics but shares some earn/yield UI components and intl translation keys. Changes to the withdraw form or messages could have cross-chain impact.
- `suite/e2e/tests/staking/ada/claim.test.ts` — ADA claim flow exercises reward claiming which is related to the withdrawal/unstaking path. Translation key changes in messages.ts could affect claim-related UI text shown in this test.

</details>

⚠️ **Changes with no test coverage (7)**
- `suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleInput.tsx`
- `suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleView.tsx`
- `suite-native/atoms/src/AnimatedDoubleView/__tests__/AnimatedDoubleInput.test.tsx`
- `suite-native/atoms/src/AnimatedDoubleView/__tests__/AnimatedDoubleView.test.tsx`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-earn/src/components/YieldWithdrawWarning.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx`

_Updated: 2026-07-15T15:16:35.149Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-withdraw-max-dust&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-withdraw-max-dust&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/yield-withdraw-max-dust&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-15T15:19:23.452Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-15T15:18:25.471Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-withdraw-max-dust/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-withdraw-max-dust/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->