### PR TITLE
refactor(logger): shrink redaction declarations

### DIFF
--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -23,7 +23,6 @@ const FILES_EXPECTED_TO_GROW = new Set<string>([
 const KNOWN_OVERSIZED_DECLARATION_LIMITS = new Map<string, number>([
     ['packages/connect-cli/libDev/src/transport.d.ts', kibToBytes(104)],
     ['suite/e2e/libDev/fixtures/invity/index.d.ts', kibToBytes(740)],
-    ['suite-common/logger/libDev/src/utils.d.ts', kibToBytes(600)],
     ['suite-common/device/libDev/src/deviceSelectors.d.ts', kibToBytes(520)],
     ['packages/suite/libDev/src/reducers/store.d.ts', kibToBytes(515)],
     ['packages/suite/libDev/src/utils/suite/notification.d.ts', kibToBytes(395)],

--- a/suite-common/logger/src/utils.ts
+++ b/suite-common/logger/src/utils.ts
@@ -26,7 +26,39 @@ export const startTime = new Date().toUTCString();
 
 export const prettifyLog = (json: Record<any, any>) => JSON.stringify(json, null, 2);
 
-export const redactAccount = (account: DeepPartial<Account> | undefined) => {
+/** Prevents redacted data from expanding complete account and device unions in declarations. */
+type RedactedAccount = Omit<
+    DeepPartial<Account>,
+    | 'descriptor'
+    | 'deviceState'
+    | 'addresses'
+    | 'balance'
+    | 'availableBalance'
+    | 'formattedBalance'
+    | 'history'
+    | 'tokens'
+    | 'utxo'
+    | 'metadata'
+    | 'key'
+    | 'misc'
+> & {
+    descriptor: string;
+    deviceState: string;
+    addresses: string;
+    balance: string;
+    availableBalance: string;
+    formattedBalance: string;
+    history: string;
+    tokens: object[] | undefined;
+    utxo: string;
+    metadata: string;
+    key: string;
+    misc: object | undefined;
+};
+
+export const redactAccount = (
+    account: DeepPartial<Account> | undefined,
+): RedactedAccount | undefined => {
     if (!account) return undefined;
 
     return {
@@ -62,7 +94,21 @@ export const redactAccount = (account: DeepPartial<Account> | undefined) => {
     };
 };
 
-export const redactDevice = (device: DeepPartial<TrezorDevice> | undefined) => {
+type RedactedDevice = Omit<
+    DeepPartial<TrezorDevice>,
+    'id' | 'label' | 'state' | 'firmwareReleaseConfigInfo' | 'features' | 'metadata'
+> & {
+    id: string;
+    label: string | undefined;
+    state: string;
+    firmwareReleaseConfigInfo: string | undefined;
+    features: object | undefined;
+    metadata: string | undefined;
+};
+
+export const redactDevice = (
+    device: DeepPartial<TrezorDevice> | undefined,
+): RedactedDevice | undefined => {
     if (!device) return undefined;
 
     return {
@@ -109,8 +155,8 @@ export const redactDiscovery = (
     };
 };
 
-export const redactAction = (action: LogEntry) => {
-    let payload;
+export const redactAction = (action: LogEntry): LogEntry => {
+    let payload: LogEntry['payload'];
 
     if (accountsActions.updateSelectedAccount.match(action)) {
         payload = {


### PR DESCRIPTION
## Description

Code improvement to reduce type-declarations to speedup the type-check

Nothing to manually test, only code improvement.

The `suite-common/logger/libDev/src/utils.d.ts` changed from **609,060 bytes** to **2,624 bytes**.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The two changed files pose very low risk to E2E test scenarios. `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts` is a build-time/static-analysis utility for enforcing type declaration file sizes — it has no runtime effect on the application and no test coverage. `suite-common/logger/src/utils.ts` is a broadly shared logger utility that maps to 131 of 133 tests, indicating it is a foundational dependency with no specific behavioral coupling to any individual test. Changes to logger utils (formatting, log levels, etc.) are extremely unlikely to alter user-facing behavior exercised by E2E tests. No E2E tests are recommended for this change set.

<details><summary><b>Changed files (2)</b></summary>

- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`
- `suite-common/logger/src/utils.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`

_Updated: 2026-07-15T19:47:18.226Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-oversized-type-declarations-3/web/](https://dev.suite.sldev.cz/suite-web/fix-oversized-type-declarations-3/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-oversized-type-declarations-3&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-oversized-type-declarations-3&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-oversized-type-declarations-3&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-15T19:50:54.313Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-15T19:50:09.740Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->