### PR TITLE
fix(suite): reduce store declaration size

### DIFF
--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -23,7 +23,6 @@ const FILES_EXPECTED_TO_GROW = new Set<string>([
 const KNOWN_OVERSIZED_DECLARATIONS: string[] = [
     'suite/e2e/libDev/fixtures/invity/index.d.ts',
     'suite-common/device/libDev/src/deviceSelectors.d.ts',
-    'packages/suite/libDev/src/reducers/store.d.ts',
     'packages/suite/libDev/src/utils/suite/notification.d.ts',
     'packages/suite/libDev/src/reducers/suite/index.d.ts',
     'packages/suite-desktop-ui/libDev/src/createSuiteDesktopCompositionRoot.d.ts',
@@ -31,7 +30,6 @@ const KNOWN_OVERSIZED_DECLARATIONS: string[] = [
     'suite/test-utils/libDev/src/initStoreForTests.d.ts',
     'suite-common/wallet-core/libDev/src/transactions/transactionsSelectors.d.ts',
     'suite-common/trading/libDev/src/selectors/tradingSelectors.d.ts',
-    'packages/suite/libDev/src/views/settings/SettingsDevice/ForgetDevice/useForgetDevice.d.ts',
     'packages/suite/libDev/src/selectors/suite/selectAccountLabelsForSearch.d.ts',
     'suite-common/message-system/libDev/src/messageSystemSelectors.d.ts',
     'packages/suite/libDev/src/hooks/wallet/useRbfForm.d.ts',

--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -24,13 +24,8 @@ const KNOWN_OVERSIZED_DECLARATIONS: string[] = [
     'suite/e2e/libDev/fixtures/invity/index.d.ts',
     'suite-common/device/libDev/src/deviceSelectors.d.ts',
     'packages/suite/libDev/src/utils/suite/notification.d.ts',
-    'packages/suite/libDev/src/reducers/suite/index.d.ts',
-    'packages/suite-desktop-ui/libDev/src/createSuiteDesktopCompositionRoot.d.ts',
-    'packages/suite-web/libDev/src/createSuiteWebCompositionRoot.d.ts',
-    'suite/test-utils/libDev/src/initStoreForTests.d.ts',
     'suite-common/wallet-core/libDev/src/transactions/transactionsSelectors.d.ts',
     'suite-common/trading/libDev/src/selectors/tradingSelectors.d.ts',
-    'packages/suite/libDev/src/selectors/suite/selectAccountLabelsForSearch.d.ts',
     'suite-common/message-system/libDev/src/messageSystemSelectors.d.ts',
     'packages/suite/libDev/src/hooks/wallet/useRbfForm.d.ts',
 ];

--- a/packages/suite/src/actions/suite/__tests__/initAction.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/initAction.test.ts
@@ -58,7 +58,7 @@ import { init } from 'src/actions/suite/initAction';
 import { prepareSuiteMiddleware } from 'src/middlewares/suite/suiteMiddleware';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
 import windowReducer from 'src/reducers/suite/windowReducer';
-import walletReducers from 'src/reducers/wallet';
+import { walletReducers } from 'src/reducers/wallet';
 import { extraDependencies } from 'src/support/extraDependencies';
 import { configureStore } from 'src/support/tests/configureStore';
 import type { AppState } from 'src/types/suite';

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/hooks/useNetworkFilter.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/hooks/useNetworkFilter.ts
@@ -6,7 +6,10 @@ import { selectEnabledNetworks } from '@suite-common/wallet-core';
 import { type GlobalSendReceiveType } from '@suite-common/wallet-types';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFilters';
+import {
+    globalSendReceiveFiltersActions,
+    globalSendReceiveFiltersSelectors,
+} from 'src/slices/wallet/globalSendReceiveFilters';
 
 export interface UseNetworkFilterProps {
     modal?: NonNullable<GlobalSendReceiveType>;
@@ -21,7 +24,7 @@ export function useNetworkFilter({ listRef, resetSearch, modal }: UseNetworkFilt
         [routerParams],
     );
 
-    const defaultNetwork = useSelector(globalSendReceiveFilters.selectors.selectNetworkSymbol);
+    const defaultNetwork = useSelector(globalSendReceiveFiltersSelectors.selectNetworkSymbol);
     const enabledNetworks = useSelector(selectEnabledNetworks);
     const [networkFilter, setNetworkFilter] = useState<NetworkSymbol | undefined>(defaultNetwork);
 
@@ -46,7 +49,7 @@ export function useNetworkFilter({ listRef, resetSearch, modal }: UseNetworkFilt
 
         resetSearch();
 
-        dispatch(globalSendReceiveFilters.actions.setNetworkSymbol(networkFilter));
+        dispatch(globalSendReceiveFiltersActions.setNetworkSymbol(networkFilter));
 
         dispatch(
             goto({

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/hooks/useSearchFilter.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/hooks/useSearchFilter.ts
@@ -2,17 +2,20 @@ import { useState } from 'react';
 import { useDebounce } from 'react-use';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFilters';
+import {
+    globalSendReceiveFiltersActions,
+    globalSendReceiveFiltersSelectors,
+} from 'src/slices/wallet/globalSendReceiveFilters';
 
 export function useSearchFilter() {
-    const defaultSearch = useSelector(globalSendReceiveFilters.selectors.selectSearch);
+    const defaultSearch = useSelector(globalSendReceiveFiltersSelectors.selectSearch);
     const [search, setSearch] = useState(defaultSearch);
     const dispatch = useDispatch();
 
     useDebounce(
         () => {
             if (search !== defaultSearch) {
-                dispatch(globalSendReceiveFilters.actions.setSearch(search));
+                dispatch(globalSendReceiveFiltersActions.setSearch(search));
             }
         },
         100,

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/GlobalReceiveModal.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/GlobalReceiveModal.tsx
@@ -12,7 +12,7 @@ import { HOW_TO_CHOOSE_RIGHT_NETWORK_URL } from '@trezor/urls';
 import { useModal } from 'src/components/suite/asset-picker/hooks/useModal';
 import { AddAccountModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal';
 import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
-import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFilters';
+import { globalSendReceiveFiltersSelectors } from 'src/slices/wallet/globalSendReceiveFilters';
 import { type Account, type AccountItemType } from 'src/types/wallet';
 
 import { GlobalReceiveAccountListItem } from './components/GlobalReceiveAccountListItem';
@@ -36,7 +36,7 @@ export const GlobalReceiveModal = ({ onCancel, onSubmit }: GlobalReceiveModalPro
     const listRef = useRef<HTMLDivElement>(null);
     const accountsOptions = useAccountsOptions();
     const filteredAccounts = useFilterAccounts(accountsOptions);
-    const filledSearch = useSelector(globalSendReceiveFilters.selectors.filledSearch);
+    const filledSearch = useSelector(globalSendReceiveFiltersSelectors.filledSearch);
 
     return (
         <>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/hooks/useFilterAccounts.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/hooks/useFilterAccounts.ts
@@ -3,12 +3,12 @@ import { useMemo } from 'react';
 import { accountSearchFn } from '@suite-common/wallet-utils';
 
 import { useSelector } from 'src/hooks/suite';
-import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFilters';
+import { globalSendReceiveFiltersSelectors } from 'src/slices/wallet/globalSendReceiveFilters';
 
 import { type AccountOption } from './useAccountsOptions';
 
 export function useFilterAccounts(accounts: AccountOption[]) {
-    const { search, networkSymbol } = useSelector(globalSendReceiveFilters.selectors.selectFilters);
+    const { search, networkSymbol } = useSelector(globalSendReceiveFiltersSelectors.selectFilters);
 
     return useMemo(
         () =>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx
@@ -25,7 +25,7 @@ import {
     useInsertGroupLabelsAndSpaces,
 } from 'src/components/suite/asset-picker/hooks';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFilters';
+import { globalSendReceiveFiltersSelectors } from 'src/slices/wallet/globalSendReceiveFilters';
 
 import { AssetSearchWithNetworkFilter } from '../AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter';
 import { useAccountWithTokensOptions } from './hooks/useAccountWithTokensOptions';
@@ -40,8 +40,8 @@ const LIST_HEIGHT = 480;
 export function GlobalSendModal({ onCancel, onSubmit }: GlobalSendModalProps) {
     const dispatch = useDispatch();
 
-    const networkSymbolFilter = useSelector(globalSendReceiveFilters.selectors.selectNetworkSymbol);
-    const searchFilter = useSelector(globalSendReceiveFilters.selectors.selectSearch);
+    const networkSymbolFilter = useSelector(globalSendReceiveFiltersSelectors.selectNetworkSymbol);
+    const searchFilter = useSelector(globalSendReceiveFiltersSelectors.selectSearch);
     const { expandedAccountTokensGroups, updateExpandableAccountGroups } =
         useExpandableAccountGroups();
     const device = useSelector(selectSelectedDevice);
@@ -60,7 +60,7 @@ export function GlobalSendModal({ onCancel, onSubmit }: GlobalSendModalProps) {
 
     const submitRef = useCurrentRef(onSubmit);
     const listRef = useRef<HTMLDivElement>(null);
-    const filledSearch = useSelector(globalSendReceiveFilters.selectors.filledSearch);
+    const filledSearch = useSelector(globalSendReceiveFiltersSelectors.filledSearch);
 
     const handleAccountClick = useCallback(
         (account: Account) => {

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceive.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceive.tsx
@@ -7,7 +7,7 @@ import { type Account } from '@suite-common/wallet-types';
 import { resetProtocol } from 'src/actions/suite/protocolActions';
 import { AppNavigationTooltip } from 'src/components/suite/AppNavigation/AppNavigationTooltip';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFilters';
+import { globalSendReceiveFiltersActions } from 'src/slices/wallet/globalSendReceiveFilters';
 import { type AccountItemType } from 'src/types/wallet';
 import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOverallStatus';
 
@@ -54,13 +54,13 @@ export const GlobalSendReceive = memo(function GlobalSendReceiveInner() {
         sendAnalytics.close(filledSearch);
         closeModal();
         dispatch(resetProtocol());
-        dispatch(globalSendReceiveFilters.actions.resetFilters());
+        dispatch(globalSendReceiveFiltersActions.resetFilters());
     };
 
     const handleReceiveCancel = (filledSearch: boolean) => {
         receiveAnalytics.close(filledSearch);
         closeModal();
-        dispatch(globalSendReceiveFilters.actions.resetFilters());
+        dispatch(globalSendReceiveFiltersActions.resetFilters());
     };
 
     return (

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx
@@ -18,7 +18,7 @@ import { BigNumber } from '@trezor/utils';
 import { fillSendForm, resetProtocol } from 'src/actions/suite/protocolActions';
 import type { NotificationRendererProps } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFilters';
+import { globalSendReceiveFiltersActions } from 'src/slices/wallet/globalSendReceiveFilters';
 
 import { ConditionalActionRenderer } from './ConditionalActionRenderer';
 
@@ -72,7 +72,7 @@ export const CoinProtocolRenderer = ({
                         }),
                     );
                 } else {
-                    dispatch(globalSendReceiveFilters.actions.setNetworkSymbol(networkSymbol));
+                    dispatch(globalSendReceiveFiltersActions.setNetworkSymbol(networkSymbol));
                     dispatch(
                         goto({
                             routeName: 'suite-index',

--- a/packages/suite/src/middlewares/suite/__tests__/messageSystemMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/messageSystemMiddleware.test.ts
@@ -14,7 +14,7 @@ import { configureMockStore } from '@suite-common/test-utils';
 
 import { type AppState } from 'src/reducers/store';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
-import WalletReducers from 'src/reducers/wallet';
+import { walletReducers } from 'src/reducers/wallet';
 import { extraDependencies } from 'src/support/extraDependencies';
 
 import messageSystemMiddleware from '../messageSystemMiddleware';
@@ -30,7 +30,7 @@ const messageSystemReducer: Reducer<
 > = prepareMessageSystemReducer(extraDependencies);
 const deviceReducer = prepareDeviceReducer(extraDependencies);
 
-type WalletsState = ReturnType<typeof WalletReducers>;
+type WalletsState = ReturnType<typeof walletReducers>;
 type MessageSystemState = ReturnType<typeof messageSystemReducer>;
 type SuiteState = ReturnType<typeof suiteReducer>;
 
@@ -40,7 +40,7 @@ const getInitialState = (
     suite?: Partial<SuiteState>,
 ): Partial<AppState> => ({
     wallet: {
-        ...WalletReducers(undefined, { type: 'foo' } as any),
+        ...walletReducers(undefined, { type: 'foo' } as any),
         ...wallet,
     },
     messageSystem: {
@@ -69,7 +69,7 @@ const makeTestAction = (id: string): Action => ({
 });
 
 const reducer = combineReducers({
-    wallet: WalletReducers,
+    wallet: walletReducers,
     messageSystem: messageSystemReducer,
     suite: suiteReducer,
     tor: torReducer,
@@ -93,7 +93,7 @@ const initStore = (preloadedState: State) => {
 
             store.getState().suite = suiteReducer(suite, action);
             store.getState().messageSystem = messageSystemReducer(messageSystem, action);
-            if (wallet) store.getState().wallet = WalletReducers(wallet, action);
+            if (wallet) store.getState().wallet = walletReducers(wallet, action);
 
             store.getActions().push(action);
         }

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -2,34 +2,41 @@
 import {
     type DevToolsEnhancerOptions,
     type Dispatch,
+    type EnhancedStore,
     type Middleware,
     type MiddlewareAPI,
     type Reducer,
+    type UnknownAction,
     combineReducers,
     configureStore,
 } from '@reduxjs/toolkit';
 import { createLogger } from 'redux-logger';
 
-import { backupMiddleware, backupReducer } from '@suite/backup';
+import { type BackupState, backupMiddleware, backupReducer } from '@suite/backup';
 import { MODAL_OPEN_USER_CONTEXT } from '@suite/modal';
-import { recoveryReducer } from '@suite/recovery';
+import { type RecoveryState, recoveryReducer } from '@suite/recovery';
 import { type HistoryDep } from '@suite/router';
-import { suiteSyncSlice } from '@suite/suite-sync';
-import { prepareFirmwareReducer } from '@suite-common/firmware';
-import { geolocationReducer } from '@suite-common/geolocation';
+import { type DesktopSuiteSyncState, suiteSyncSlice } from '@suite/suite-sync';
+import { type FirmwareUpdateState, prepareFirmwareReducer } from '@suite-common/firmware';
+import { type GeolocationState, geolocationReducer } from '@suite-common/geolocation';
 import { addLog } from '@suite-common/logger';
 import { type PlatformEncryptionDep } from '@suite-common/platform-encryption';
 import {
     type ExtraDependencies,
+    type ExtraDependenciesStatic,
     type GetTransportsFactoriesDep,
     type ThpHostNameDep,
     castExtraStore,
     createStoreWithExtraStoreMiddleware,
 } from '@suite-common/redux-utils';
-import { suiteSyncDataReducer } from '@suite-common/suite-sync';
+import { type SuiteSyncDataState, suiteSyncDataReducer } from '@suite-common/suite-sync';
+import { type SuiteSyncQuotaManagerState } from '@suite-common/suite-sync-quota-manager';
 import { type ReloadAppDep } from '@suite-common/suite-types';
-import { prepareThpReducer } from '@suite-common/thp';
-import { prepareTokenDefinitionsReducer } from '@suite-common/token-definitions';
+import { type ThpState, prepareThpReducer } from '@suite-common/thp';
+import {
+    type TokenDefinitionsState,
+    prepareTokenDefinitionsReducer,
+} from '@suite-common/token-definitions';
 import { accountsActions } from '@suite-common/wallet-core';
 import { isCodesignBuild } from '@trezor/env-utils';
 import { mergeDeepObject } from '@trezor/utils';
@@ -40,16 +47,24 @@ import { getSuiteMiddleware } from 'src/middlewares/suite';
 import { toastMiddleware } from 'src/middlewares/suite/toastMiddleware';
 import { getWalletMiddlewares } from 'src/middlewares/wallet';
 import onboardingReducers from 'src/reducers/onboarding';
-import suiteReducers from 'src/reducers/suite';
-import walletReducers from 'src/reducers/wallet';
-import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFilters';
+import suiteReducers, { type SuiteReducersState } from 'src/reducers/suite';
+import walletReducers, { type WalletState } from 'src/reducers/wallet';
+import {
+    type GlobalSendReceiveFiltersState,
+    globalSendReceiveFilters,
+} from 'src/slices/wallet/globalSendReceiveFilters';
 import type { PreloadStoreAction } from 'src/support/suite/preloadStore';
+import { type Action } from 'src/types/suite';
 
-import { prepareBioAuthReducer } from './bioAuth';
-import { desktopReducer } from './desktop';
-import { bluetoothSlice } from '../actions/bluetooth/desktopBluetoothReducer';
+import { type BioAuthState, prepareBioAuthReducer } from './bioAuth';
+import { type DesktopState, desktopReducer } from './desktop';
+import {
+    type DesktopBluetoothState,
+    bluetoothSlice,
+} from '../actions/bluetooth/desktopBluetoothReducer';
 import { type CreateConnectLoggerFactoryDep } from '../support/createConnectLoggerFactory';
 import {
+    type SuiteServices,
     createSuiteServicesCompositionRoot,
     extraDependencies,
 } from '../support/extraDependencies';
@@ -60,6 +75,24 @@ const bluetoothReducer = bluetoothSlice.prepareReducer(extraDependencies);
 const thpReducer = prepareThpReducer(extraDependencies);
 const suiteSyncReducer = suiteSyncSlice.prepareReducer(extraDependencies);
 const suiteSyncQuotaManagerReducer = suiteSyncQuotaManagerSlice.prepareReducer(extraDependencies);
+
+export type AppState = SuiteReducersState & {
+    onboarding: ReturnType<typeof onboardingReducers>;
+    wallet: WalletState;
+    recovery: RecoveryState;
+    firmware: FirmwareUpdateState;
+    backup: BackupState;
+    desktop: DesktopState;
+    bioAuth: BioAuthState;
+    tokenDefinitions: Partial<TokenDefinitionsState>;
+    bluetooth: DesktopBluetoothState;
+    thp: ThpState;
+    suiteSync: DesktopSuiteSyncState;
+    suiteSyncQuotaManager: SuiteSyncQuotaManagerState;
+    suiteSyncData: SuiteSyncDataState;
+    geolocation: GeolocationState;
+    globalSendReceiveFilters: GlobalSendReceiveFiltersState;
+};
 
 const rootReducer = combineReducers({
     ...suiteReducers,
@@ -79,8 +112,6 @@ const rootReducer = combineReducers({
     geolocation: geolocationReducer,
     globalSendReceiveFilters: globalSendReceiveFilters.reducer,
 });
-
-export type AppState = ReturnType<typeof rootReducer>;
 
 const loggerExcludedActions = [addLog.type, accountsActions.updateAccountRefreshTimestamp.type];
 
@@ -139,11 +170,19 @@ export type SuiteStoreDeps = HistoryDep &
     ThpHostNameDep &
     GetTransportsFactoriesDep;
 
+type SuiteExtra = ExtraDependenciesStatic & { services: SuiteServices };
+
+export type SuiteStore = ReturnType<
+    typeof castExtraStore<SuiteExtra, EnhancedStore<AppState, Action | UnknownAction>>
+> & {
+    services: SuiteServices;
+};
+
 export const initStore = (
     deps: SuiteStoreDeps,
     preloadStoreAction?: PreloadStoreAction,
     options: { statePatch?: Record<string, any> } = {},
-) => {
+): SuiteStore => {
     // get initial state by calling STORAGE.LOAD action with optional payload
     // payload will be processed in each reducer explicitly
     const preloadedState = preloadStoreAction

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -6,6 +6,7 @@ import {
     type Middleware,
     type MiddlewareAPI,
     type Reducer,
+    type ReducersMapObject,
     type UnknownAction,
     combineReducers,
     configureStore,
@@ -47,11 +48,12 @@ import { getSuiteMiddleware } from 'src/middlewares/suite';
 import { toastMiddleware } from 'src/middlewares/suite/toastMiddleware';
 import { getWalletMiddlewares } from 'src/middlewares/wallet';
 import onboardingReducers from 'src/reducers/onboarding';
-import suiteReducers, { type SuiteReducersState } from 'src/reducers/suite';
-import walletReducers, { type WalletState } from 'src/reducers/wallet';
+import { type OnboardingState } from 'src/reducers/onboarding/onboardingReducer';
+import { type SuiteReducersState, suiteReducers } from 'src/reducers/suite';
+import { type WalletState, walletReducers } from 'src/reducers/wallet';
 import {
     type GlobalSendReceiveFiltersState,
-    globalSendReceiveFilters,
+    globalSendReceiveFiltersReducer,
 } from 'src/slices/wallet/globalSendReceiveFilters';
 import type { PreloadStoreAction } from 'src/support/suite/preloadStore';
 import { type Action } from 'src/types/suite';
@@ -77,7 +79,7 @@ const suiteSyncReducer = suiteSyncSlice.prepareReducer(extraDependencies);
 const suiteSyncQuotaManagerReducer = suiteSyncQuotaManagerSlice.prepareReducer(extraDependencies);
 
 export type AppState = SuiteReducersState & {
-    onboarding: ReturnType<typeof onboardingReducers>;
+    onboarding: OnboardingState;
     wallet: WalletState;
     recovery: RecoveryState;
     firmware: FirmwareUpdateState;
@@ -110,8 +112,8 @@ const rootReducer = combineReducers({
     suiteSyncQuotaManager: suiteSyncQuotaManagerReducer,
     suiteSyncData: suiteSyncDataReducer,
     geolocation: geolocationReducer,
-    globalSendReceiveFilters: globalSendReceiveFilters.reducer,
-});
+    globalSendReceiveFilters: globalSendReceiveFiltersReducer,
+} satisfies ReducersMapObject<AppState, never, Record<keyof AppState, never>>);
 
 const loggerExcludedActions = [addLog.type, accountsActions.updateAccountRefreshTimestamp.type];
 

--- a/packages/suite/src/reducers/suite/guideReducer.ts
+++ b/packages/suite/src/reducers/suite/guideReducer.ts
@@ -5,7 +5,7 @@ import * as indexNodeJSON from '@trezor/suite-data/files/guide/index.json';
 import { GUIDE } from 'src/actions/suite/constants';
 import { type Action } from 'src/types/suite';
 
-export interface State {
+export interface GuideState {
     open: boolean;
     view: ActiveView;
     indexNode: GuideCategory | null;
@@ -15,7 +15,7 @@ export interface State {
 
 const indexNode = indexNodeJSON as GuideCategory;
 
-export const initialState: State = {
+export const initialState: GuideState = {
     open: false,
     view: 'GUIDE_DEFAULT',
     indexNode,
@@ -24,7 +24,7 @@ export const initialState: State = {
 };
 
 // NOTE: we cannot use immer in this reducer, because GuideCategory mimics the react node and immer uses Object.freeze()
-const guideReducer = (state: State = initialState, action: Action): State => {
+const guideReducer = (state: GuideState = initialState, action: Action): GuideState => {
     switch (action.type) {
         case GUIDE.OPEN:
             return {

--- a/packages/suite/src/reducers/suite/index.ts
+++ b/packages/suite/src/reducers/suite/index.ts
@@ -1,31 +1,41 @@
-import { type StateFromReducersMapObject } from '@reduxjs/toolkit';
+import { type ReducersMapObject, type UnknownAction } from '@reduxjs/toolkit';
 
-import { prepareDebugReducer } from '@suite/debug';
-import { desktopUpdateReducer } from '@suite/desktop-update';
+import { type DebugState, prepareDebugReducer } from '@suite/debug';
+import { type DesktopUpdateState, desktopUpdateReducer } from '@suite/desktop-update';
+import { type FeedbackFeatureName } from '@suite/experimental';
 import { featureFeedbackReducer } from '@suite/feature-feedback';
-import { prepareFlagsReducer } from '@suite/flags';
+import { type FlagsState, prepareFlagsReducer } from '@suite/flags';
 import { type TranslationKey } from '@suite/intl';
-import { locksReducer } from '@suite/locks';
+import { type LocksState, locksReducer } from '@suite/locks';
 import { metadataReducer } from '@suite/metadata';
-import { modalReducer as modal } from '@suite/modal';
-import { routerReducer } from '@suite/router';
-import { prepareSuiteSettingsReducer } from '@suite/settings';
-import { torReducer } from '@suite/tor';
-import { prepareAnalyticsReducer } from '@suite-common/analytics-redux';
-import { prepareConnectPopupReducer } from '@suite-common/connect-popup';
-import { discreetModeReducer } from '@suite-common/discreet-mode';
-import { logsSlice } from '@suite-common/logger';
-import { prepareMessageSystemReducer } from '@suite-common/message-system';
-import { createNotificationsReducer } from '@suite-common/toast-notifications';
-import { prepareWalletConnectReducer } from '@suite-common/walletconnect';
+import { type State as ModalState, modalReducer as modal } from '@suite/modal';
+import { type RouterState, routerReducer } from '@suite/router';
+import { type SuiteSettingsState, prepareSuiteSettingsReducer } from '@suite/settings';
+import { type TorState, torReducer } from '@suite/tor';
+import { type AnalyticsState, prepareAnalyticsReducer } from '@suite-common/analytics-redux';
+import { type ConnectPopupState, prepareConnectPopupReducer } from '@suite-common/connect-popup';
+import { type DiscreetModeState, discreetModeReducer } from '@suite-common/discreet-mode';
+import { type FeatureFeedbackState } from '@suite-common/feedback';
+import { type LogsSliceState, logsSlice } from '@suite-common/logger';
+import { type MessageSystemState, prepareMessageSystemReducer } from '@suite-common/message-system';
+import { type MetadataState } from '@suite-common/metadata-types';
+import {
+    type NotificationsState,
+    createNotificationsReducer,
+} from '@suite-common/toast-notifications';
+import { type WalletConnectState, prepareWalletConnectReducer } from '@suite-common/walletconnect';
 
-import { prepareDesktopDeviceReducer } from 'src/actions/device/deviceSlice';
+import {
+    type DesktopDeviceState,
+    prepareDesktopDeviceReducer,
+} from 'src/actions/device/deviceSlice';
 import { extraDependencies } from 'src/support/extraDependencies';
+import { type Action } from 'src/types/suite';
 
-import guide from './guideReducer';
-import protocol from './protocolReducer';
-import suite from './suiteReducer';
-import window from './windowReducer';
+import guide, { type GuideState } from './guideReducer';
+import protocol, { type ProtocolState } from './protocolReducer';
+import suite, { type SuiteState } from './suiteReducer';
+import window, { type WindowState } from './windowReducer';
 
 const analytics = prepareAnalyticsReducer(extraDependencies);
 // Type annotation as a workaround for type-check error "The inferred type of 'default' cannot be named..."
@@ -37,7 +47,32 @@ const debug = prepareDebugReducer(extraDependencies);
 const connectPopupReducer = prepareConnectPopupReducer(extraDependencies);
 const walletConnectReducer = prepareWalletConnectReducer(extraDependencies);
 
-const suiteReducers = {
+export type SuiteReducersState = {
+    suite: SuiteState;
+    discreetMode: DiscreetModeState;
+    tor: TorState;
+    suiteSettings: SuiteSettingsState;
+    debug: DebugState;
+    flags: FlagsState;
+    locks: LocksState;
+    router: RouterState;
+    modal: ModalState;
+    device: DesktopDeviceState;
+    logs: LogsSliceState;
+    notifications: NotificationsState<TranslationKey>;
+    window: WindowState;
+    analytics: AnalyticsState;
+    metadata: MetadataState;
+    desktopUpdate: DesktopUpdateState;
+    messageSystem: MessageSystemState;
+    guide: GuideState;
+    protocol: ProtocolState;
+    featureFeedback: FeatureFeedbackState<FeedbackFeatureName>;
+    connectPopup: ConnectPopupState;
+    walletConnect: WalletConnectState;
+};
+
+export const suiteReducers: ReducersMapObject<SuiteReducersState, Action & UnknownAction> = {
     suite,
     discreetMode: discreetModeReducer,
     tor: torReducer,
@@ -61,7 +96,3 @@ const suiteReducers = {
     connectPopup: connectPopupReducer,
     walletConnect: walletConnectReducer,
 };
-
-export type SuiteReducersState = StateFromReducersMapObject<typeof suiteReducers>;
-
-export default suiteReducers;

--- a/packages/suite/src/reducers/suite/index.ts
+++ b/packages/suite/src/reducers/suite/index.ts
@@ -1,3 +1,5 @@
+import { type StateFromReducersMapObject } from '@reduxjs/toolkit';
+
 import { prepareDebugReducer } from '@suite/debug';
 import { desktopUpdateReducer } from '@suite/desktop-update';
 import { featureFeedbackReducer } from '@suite/feature-feedback';
@@ -35,7 +37,7 @@ const debug = prepareDebugReducer(extraDependencies);
 const connectPopupReducer = prepareConnectPopupReducer(extraDependencies);
 const walletConnectReducer = prepareWalletConnectReducer(extraDependencies);
 
-export default {
+const suiteReducers = {
     suite,
     discreetMode: discreetModeReducer,
     tor: torReducer,
@@ -59,3 +61,7 @@ export default {
     connectPopup: connectPopupReducer,
     walletConnect: walletConnectReducer,
 };
+
+export type SuiteReducersState = StateFromReducersMapObject<typeof suiteReducers>;
+
+export default suiteReducers;

--- a/packages/suite/src/reducers/suite/windowReducer.ts
+++ b/packages/suite/src/reducers/suite/windowReducer.ts
@@ -5,20 +5,20 @@ import { type BreakpointFlags, initialBreakpointFlags } from '@trezor/theme';
 import { WINDOW } from 'src/actions/suite/constants';
 import { type Action } from 'src/types/suite';
 
-export interface State extends BreakpointFlags {
+export interface WindowState extends BreakpointFlags {
     isVisible: boolean;
 }
 
 interface WindowRootState {
-    window: State;
+    window: WindowState;
 }
 
-export const initialState: State = {
+export const initialState: WindowState = {
     ...initialBreakpointFlags,
     isVisible: true,
 };
 
-const windowReducer = (state: State = initialState, action: Action): State =>
+const windowReducer = (state: WindowState = initialState, action: Action): WindowState =>
     produce(state, draft => {
         switch (action.type) {
             case WINDOW.UPDATE_BREAKPOINTS:

--- a/packages/suite/src/reducers/wallet/graphReducer.ts
+++ b/packages/suite/src/reducers/wallet/graphReducer.ts
@@ -9,21 +9,21 @@ import { type Action as SuiteAction } from 'src/types/suite';
 import { type Account, type WalletAction } from 'src/types/wallet';
 import { type AccountIdentifier, type GraphData, type GraphRange } from 'src/types/wallet/graph';
 
-export interface State {
+export interface GraphState {
     data: GraphData[];
     error: null | AccountIdentifier[];
     isLoading: boolean;
     selectedRange: GraphRange;
 }
 
-const initialState: State = {
+const initialState: GraphState = {
     data: [],
     selectedRange: SETTINGS.DEFAULT_GRAPH_RANGE,
     error: null,
     isLoading: false,
 };
 
-const updateError = (draft: State) => {
+const updateError = (draft: GraphState) => {
     const failedGraphData = draft.data.filter(d => d.error);
     if (failedGraphData.length > 0) {
         draft.error = failedGraphData.map(a => a.account);
@@ -32,7 +32,7 @@ const updateError = (draft: State) => {
     }
 };
 
-const update = (draft: State, payload: GraphData) => {
+const update = (draft: GraphState, payload: GraphData) => {
     const { account, data, error, isLoading } = payload;
     const dataIndex = draft.data.findIndex(
         d =>
@@ -59,12 +59,12 @@ const update = (draft: State, payload: GraphData) => {
     updateError(draft);
 };
 
-const loadFromStorage = (draft: State, payload: GraphData[] = []) => {
+const loadFromStorage = (draft: GraphState, payload: GraphData[] = []) => {
     draft.data = payload;
     updateError(draft);
 };
 
-const remove = (draft: State, accounts: Account[]) => {
+const remove = (draft: GraphState, accounts: Account[]) => {
     accounts.forEach(account => {
         const affected = draft.data.filter(
             d =>
@@ -80,7 +80,10 @@ const remove = (draft: State, accounts: Account[]) => {
     updateError(draft);
 };
 
-const graphReducer = (state: State = initialState, action: WalletAction | SuiteAction): State =>
+const graphReducer = (
+    state: GraphState = initialState,
+    action: WalletAction | SuiteAction,
+): GraphState =>
     produce(state, draft => {
         switch (action.type) {
             case STORAGE.LOAD:

--- a/packages/suite/src/reducers/wallet/index.ts
+++ b/packages/suite/src/reducers/wallet/index.ts
@@ -61,4 +61,6 @@ const WalletReducers = combineReducers({
     tronStake: tronStakeReducer,
 });
 
+export type WalletState = ReturnType<typeof WalletReducers>;
+
 export default WalletReducers;

--- a/packages/suite/src/reducers/wallet/index.ts
+++ b/packages/suite/src/reducers/wallet/index.ts
@@ -1,10 +1,20 @@
-import { combineReducers } from 'redux';
+import { type Reducer, type UnknownAction, combineReducers } from 'redux';
 
 import { selectedAccountReducer } from '@suite/account';
-import { coinjoinReducer } from '@suite/coinjoin';
-import { receiveReducer } from '@suite/receive';
-import { prepareTradingReducer } from '@suite-common/trading';
+import { type CoinjoinAction, type CoinjoinState, coinjoinReducer } from '@suite/coinjoin';
+import { type ReceiveState, receiveReducer } from '@suite/receive';
+import { type TradingState, prepareTradingReducer } from '@suite-common/trading';
 import {
+    type AccountsState,
+    type ExplorerConfig,
+    type FiatRatesState,
+    type FormDraftState,
+    type PhishingState,
+    type SendState,
+    type StablecoinYieldState,
+    type StakeState,
+    type TransactionsState,
+    type TronStakeReducerState,
     feesReducer,
     prepareAccountsReducer,
     prepareBlockchainReducer,
@@ -19,12 +29,20 @@ import {
     stablecoinYieldReducer,
     tronStakeReducer,
 } from '@suite-common/wallet-core';
+import {
+    type BlockchainNetworks,
+    type Discovery,
+    type FeesState,
+    type SelectedAccountStatus,
+    type WalletSettings,
+} from '@suite-common/wallet-types';
 
 import { extraDependencies } from 'src/support/extraDependencies';
+import { type Action } from 'src/types/suite';
 
-import accountSearchReducer from './accountSearchReducer';
+import accountSearchReducer, { type AccountSearchState } from './accountSearchReducer';
 import formDraftReducer from './formDraftReducer';
-import graphReducer from './graphReducer';
+import graphReducer, { type GraphState } from './graphReducer';
 
 export const transactionsReducer = prepareTransactionsReducer(extraDependencies);
 export const phishingReducer = preparePhishingReducer(extraDependencies);
@@ -38,7 +56,34 @@ export const sendFormReducer = prepareSendFormReducer(extraDependencies);
 export const tradingReducer = prepareTradingReducer(extraDependencies);
 export const walletSettingsReducer = prepareWalletSettingsReducer(extraDependencies);
 
-const WalletReducers = combineReducers({
+export type WalletState = {
+    fiat: FiatRatesState;
+    graph: GraphState;
+    transactions: TransactionsState;
+    phishing: PhishingState;
+    discovery: Discovery;
+    accounts: AccountsState;
+    selectedAccount: SelectedAccountStatus;
+    receive: ReceiveState;
+    fees: FeesState;
+    blockchain: BlockchainNetworks;
+    explorer: ExplorerConfig;
+    trading: TradingState;
+    send: SendState;
+    accountSearch: AccountSearchState;
+    formDrafts: FormDraftState;
+    coinjoin: CoinjoinState;
+    stake: StakeState;
+    settings: WalletSettings;
+    stablecoinYield: StablecoinYieldState;
+    tronStake: TronStakeReducerState;
+};
+
+export const walletReducers: Reducer<
+    WalletState,
+    Action | UnknownAction | CoinjoinAction,
+    Partial<Omit<WalletState, 'graph' | 'coinjoin'>>
+> = combineReducers({
     fiat: fiatRatesReducer,
     graph: graphReducer,
     transactions: transactionsReducer,
@@ -60,7 +105,3 @@ const WalletReducers = combineReducers({
     stablecoinYield: stablecoinYieldReducer,
     tronStake: tronStakeReducer,
 });
-
-export type WalletState = ReturnType<typeof WalletReducers>;
-
-export default WalletReducers;

--- a/packages/suite/src/slices/wallet/globalSendReceiveFilters.ts
+++ b/packages/suite/src/slices/wallet/globalSendReceiveFilters.ts
@@ -12,20 +12,23 @@ const initialState: GlobalSendReceiveFiltersState = {
     networkSymbol: undefined,
 };
 
-export const globalSendReceiveFilters = createSlice({
+const globalSendReceiveFiltersSlice = createSlice({
     name: 'globalSendReceiveFilters',
     initialState,
     reducers: {
-        setSearch(state, action: PayloadAction<GlobalSendReceiveFiltersState['search']>) {
+        setSearch(
+            state: GlobalSendReceiveFiltersState,
+            action: PayloadAction<GlobalSendReceiveFiltersState['search']>,
+        ) {
             state.search = action.payload;
         },
         setNetworkSymbol(
-            state,
+            state: GlobalSendReceiveFiltersState,
             action: PayloadAction<GlobalSendReceiveFiltersState['networkSymbol']>,
         ) {
             state.networkSymbol = action.payload;
         },
-        resetFilters(state) {
+        resetFilters(state: GlobalSendReceiveFiltersState) {
             state.search = '';
             state.networkSymbol = undefined;
         },
@@ -41,6 +44,10 @@ export const globalSendReceiveFilters = createSlice({
     },
 });
 
+export const globalSendReceiveFiltersActions = globalSendReceiveFiltersSlice.actions;
+export const globalSendReceiveFiltersReducer = globalSendReceiveFiltersSlice.reducer;
+export const globalSendReceiveFiltersSelectors = globalSendReceiveFiltersSlice.selectors;
+
 export type GlobalSendReceiveAction = ReturnType<
-    (typeof globalSendReceiveFilters.actions)[keyof typeof globalSendReceiveFilters.actions]
+    (typeof globalSendReceiveFiltersActions)[keyof typeof globalSendReceiveFiltersActions]
 >;

--- a/packages/suite/src/slices/wallet/globalSendReceiveFilters.ts
+++ b/packages/suite/src/slices/wallet/globalSendReceiveFilters.ts
@@ -2,12 +2,12 @@ import { type PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 
-type State = {
+export type GlobalSendReceiveFiltersState = {
     search: string;
     networkSymbol: NetworkSymbol | undefined;
 };
 
-const initialState: State = {
+const initialState: GlobalSendReceiveFiltersState = {
     search: '',
     networkSymbol: undefined,
 };
@@ -16,10 +16,13 @@ export const globalSendReceiveFilters = createSlice({
     name: 'globalSendReceiveFilters',
     initialState,
     reducers: {
-        setSearch(state, action: PayloadAction<State['search']>) {
+        setSearch(state, action: PayloadAction<GlobalSendReceiveFiltersState['search']>) {
             state.search = action.payload;
         },
-        setNetworkSymbol(state, action: PayloadAction<State['networkSymbol']>) {
+        setNetworkSymbol(
+            state,
+            action: PayloadAction<GlobalSendReceiveFiltersState['networkSymbol']>,
+        ) {
             state.networkSymbol = action.payload;
         },
         resetFilters(state) {

--- a/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
+++ b/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
@@ -20,7 +20,7 @@ import { type OnboardingState } from 'src/reducers/onboarding/onboardingReducer'
 import { type AppState } from 'src/reducers/store';
 import { type ProtocolState } from 'src/reducers/suite/protocolReducer';
 import { suiteInitialState } from 'src/reducers/suite/suiteReducer';
-import type WalletReducers from 'src/reducers/wallet';
+import { type WalletState } from 'src/reducers/wallet';
 
 export const initialAppState: AppState = {
     suite: suiteInitialState,
@@ -78,7 +78,7 @@ export const initialAppState: AppState = {
             enabledNetworks: [] as NetworkSymbol[],
         },
         blockchain: {},
-    } as ReturnType<typeof WalletReducers>, // Todo: maybe one day, fix types
+    } as WalletState, // Todo: maybe one day, fix types
     desktopUpdate: desktopUpdateInitialState,
     router: {
         loaded: true,

--- a/packages/suite/src/utils/wallet/graph/utils.ts
+++ b/packages/suite/src/utils/wallet/graph/utils.ts
@@ -15,7 +15,7 @@ import type { BlockchainAccountBalanceHistory, StaticSessionId } from '@trezor/c
 import { BigNumber } from '@trezor/utils';
 
 import { type AppState } from 'src/reducers/store';
-import { type State as GraphState } from 'src/reducers/wallet/graphReducer';
+import { type GraphState } from 'src/reducers/wallet/graphReducer';
 import {
     type CommonAggregatedHistory,
     type GraphData,

--- a/packages/suite/src/utils/wallet/graph/utilsWorker.ts
+++ b/packages/suite/src/utils/wallet/graph/utilsWorker.ts
@@ -4,7 +4,7 @@ import { BASE_CURRENCY_ZERO, toFiatCurrency } from '@suite-common/wallet-utils';
 import type { FiatRatesBySymbol, StaticSessionId } from '@trezor/connect';
 import { BigNumber, typedObjectFromEntries, typedObjectKeys } from '@trezor/utils';
 
-import type { State as GraphState } from 'src/reducers/wallet/graphReducer';
+import type { GraphState } from 'src/reducers/wallet/graphReducer';
 import {
     type AggregatedAccountHistory,
     type AggregatedDashboardHistory,

--- a/skills/redux/SKILL.md
+++ b/skills/redux/SKILL.md
@@ -72,7 +72,7 @@ myPackageSelectors.ts;
 5. **Slice** - slice created using RTK `createSlice` function.
 
     ```tsx
-    export const appSettingsSlice = createSlice({
+    const appSettingsSlice = createSlice({
         name: 'appSettings',
         initialState,
         reducers: {
@@ -85,6 +85,34 @@ myPackageSelectors.ts;
 
 6. **Selectors and lookups**
 7. **Exports of actions and reducers**
+
+### Slice exports
+
+Keep the slice object private. Export its actions and reducer as named values. For slices created
+with `createSliceWithExtraDeps`, export `prepareReducer` instead of the prepared reducer. Define
+selectors as standalone exported functions so their declarations do not expose generated slice or
+Reselect implementation types.
+
+Explicitly type the `state` parameter of every case reducer. This keeps generated declaration files
+from exposing Redux Toolkit's inferred slice implementation types.
+
+```tsx
+const appSettingsSlice = createSlice({
+    name: 'appSettings',
+    initialState,
+    reducers: {
+        setColorScheme(state: AppSettingsState, action: PayloadAction<AppColorScheme>) {
+            state.colorScheme = action.payload;
+        },
+    },
+});
+
+export const appSettingsActions = appSettingsSlice.actions;
+export const appSettingsReducer = appSettingsSlice.reducer;
+export const selectColorScheme = (state: AppSettingsRootState) => state.appSettings.colorScheme;
+```
+
+Do not export `appSettingsSlice`. Consumers should not depend on the complete inferred slice API.
 
 Sources:
 

--- a/suite-common/logger/src/logsSlice.ts
+++ b/suite-common/logger/src/logsSlice.ts
@@ -2,7 +2,7 @@ import { type AnyAction, createSlice } from '@reduxjs/toolkit';
 
 import { type LogEntry } from './types';
 
-type LogsSliceState = {
+export type LogsSliceState = {
     logEntries: LogEntry[];
 };
 

--- a/suite-common/walletconnect/src/walletConnectReducer.ts
+++ b/suite-common/walletconnect/src/walletConnectReducer.ts
@@ -5,7 +5,7 @@ import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { walletConnectActions } from './walletConnectActions';
 import { type PendingConnectionProposal, type WalletConnectSession } from './walletConnectTypes';
 
-type WalletConnectState = {
+export type WalletConnectState = {
     sessions: WalletConnectSession[];
     pendingProposal: PendingConnectionProposal | undefined;
 };

--- a/suite/tor/src/index.ts
+++ b/suite/tor/src/index.ts
@@ -1,4 +1,4 @@
-export { type TorBootstrap, TorStatus } from './torSlice';
+export { type TorBootstrap, type TorState, TorStatus } from './torSlice';
 export { getIsTorDomain, getIsTorEnabled, getIsTorLoading, isOnionUrl } from './torUtils';
 export { selectIsTorEnabled, selectTorState } from './torSelectors';
 export { type TorAction, type TorRootState, torActions, torReducer } from './torSlice';

--- a/suite/tor/src/torSlice.ts
+++ b/suite/tor/src/torSlice.ts
@@ -15,7 +15,7 @@ export interface TorBootstrap {
     isSlow?: boolean;
 }
 
-type TorState = {
+export type TorState = {
     torStatus: TorStatus;
     torBootstrap: TorBootstrap | null;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Code improvement to reduce type-declarations to speedup the type-check

Nothing to manually test, only code improvement.

<img width="894" height="260" alt="image" src="https://github.com/user-attachments/assets/b2439f7c-19da-4a2e-96c5-c592caa1f856" />

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set primarily affects the Global Send/Receive flow (modals, filtering hooks, state slice) and several Redux reducer/slice restructurings (guide, graph, window, logs, walletConnect, store composition). The highest risk is in the Global Send/Receive feature where multiple components and hooks were modified — the dedicated E2E test for this flow is critical. The reducer changes span broadly across the app but are likely structural refactors; targeted tests for features that directly use the changed reducers (guide panel, graph/transactions, application logs, WalletConnect) provide focused coverage without running the full 131-test suite. Several changed files (unit tests, type declarations, tor module, test fixtures) have no E2E coverage and are best validated by unit tests or manual review.

<details><summary><b>Changed files (24)</b></summary>

- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`
- `packages/suite/src/actions/suite/__tests__/initAction.test.ts`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/hooks/useNetworkFilter.ts`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/hooks/useSearchFilter.ts`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/GlobalReceiveModal.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/hooks/useFilterAccounts.ts`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceive.tsx`
- `packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx`
- `packages/suite/src/middlewares/suite/__tests__/messageSystemMiddleware.test.ts`
- `packages/suite/src/reducers/store.ts`
- `packages/suite/src/reducers/suite/guideReducer.ts`
- `packages/suite/src/reducers/suite/index.ts`
- `packages/suite/src/reducers/suite/windowReducer.ts`
- `packages/suite/src/reducers/wallet/graphReducer.ts`
- `packages/suite/src/reducers/wallet/index.ts`
- `packages/suite/src/slices/wallet/globalSendReceiveFilters.ts`
- `packages/suite/src/support/tests/__fixtures__/defaultAppState.ts`
- `packages/suite/src/utils/wallet/graph/utils.ts`
- `packages/suite/src/utils/wallet/graph/utilsWorker.ts`
- `suite-common/logger/src/logsSlice.ts`
- `suite-common/walletconnect/src/walletConnectReducer.ts`
- `suite/tor/src/index.ts`
- `suite/tor/src/torSlice.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test directly exercises the Global Send/Receive modals, asset picker with filtering/search, and account selection — all of which are changed in GlobalReceiveModal.tsx, GlobalSendModal.tsx, GlobalSendReceive.tsx, useNetworkFilter.ts, useSearchFilter.ts, useFilterAccounts.ts, and globalSendReceiveFilters.ts. This is the primary feature-level test for the changed code.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/suite/guide.test.ts` — The guideReducer.ts was changed, and this test directly exercises the Guide panel UI including opening/closing, navigating content, submitting feedback, and searching articles. Changes to the guide reducer could break guide state management.
- `suite/e2e/tests/general/suite-guide.test.ts` — This test exercises the Suite Guide panel for bug reporting and article search. Changes to guideReducer.ts could affect guide panel state, article lookup, and feedback form behavior.
- `suite/e2e/tests/wallet/transactions.test.ts` — Changes to graphReducer.ts and graph/utils.ts directly affect the transaction overview graph with time range filtering (day/week/month/year/all). This test cycles through all graph range selectors and verifies correct label updates.
- `suite/e2e/tests/settings/application-log.test.ts` — The logsSlice.ts was changed which manages application log state. This test directly verifies viewing and exporting application logs from Settings, so changes to the logs slice could break log content display or export.
- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — The walletConnectReducer.ts was changed. This test exercises WalletConnect initialization, proposal approval/rejection, and verifies analytics events are emitted correctly — all dependent on WalletConnect state management.
- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates to Buy/Sell/Swap from global header buttons which are adjacent to the changed GlobalSendReceive component. Changes to GlobalSendReceive.tsx could affect the layout/rendering of the global trading buttons.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Changes to graphReducer.ts and windowReducer.ts could affect the dashboard portfolio graph display. This test verifies dashboard balance values and graph interactions which rely on these reducers.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test verifies that after discovery the dashboard graph is displayed. Changes to graphReducer.ts could affect graph rendering after wallet discovery completes.

</details>

⚠️ **Changes with no test coverage (7)**
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`
- `packages/suite/src/actions/suite/__tests__/initAction.test.ts`
- `packages/suite/src/middlewares/suite/__tests__/messageSystemMiddleware.test.ts`
- `packages/suite/src/support/tests/__fixtures__/defaultAppState.ts`
- `suite/tor/src/index.ts`
- `suite/tor/src/torSlice.ts`
- `packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx`

_Updated: 2026-07-16T08:55:56.589Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-oversized-type-declarations-4/web/](https://dev.suite.sldev.cz/suite-web/fix-oversized-type-declarations-4/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-oversized-type-declarations-4&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-oversized-type-declarations-4&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-oversized-type-declarations-4&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-16T08:58:43.464Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-16T08:59:04.862Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->