### PR TITLE
fix(e2e): reduce Invity fixture declaration size

### DIFF
--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -21,7 +21,6 @@ const FILES_EXPECTED_TO_GROW = new Set<string>([
 ]);
 
 const KNOWN_OVERSIZED_DECLARATIONS: string[] = [
-    'suite/e2e/libDev/fixtures/invity/index.d.ts',
     'packages/suite/libDev/src/utils/suite/notification.d.ts',
     'packages/suite/libDev/src/hooks/wallet/useRbfForm.d.ts',
 ];

--- a/suite/e2e/fixtures/invity/index.ts
+++ b/suite/e2e/fixtures/invity/index.ts
@@ -62,7 +62,7 @@ export const invityEndpoint = {
     sellQuotes: `${invityUrl}/api/v3/sell/fiat/quotes`,
     sellTrade: `${invityUrl}/api/v3/sell/fiat/trade`,
     sellWatch: `${invityUrl}/api/v3/sell/fiat/watch/*`,
-};
+} as const;
 
 export const invityRequest = {
     buyTradeBTCPayload,
@@ -72,7 +72,13 @@ export const invityRequest = {
     sellWatchPayload,
 };
 
-export const invityGeneralResponses = {
+/**
+ * `unknown` keeps the heterogeneous JSON payload types out of this aggregate's declaration.
+ * The individual fixture exports below retain their inferred types for direct use.
+ */
+export const invityGeneralResponses: Partial<
+    Record<(typeof invityEndpoint)[keyof typeof invityEndpoint], unknown>
+> = {
     [invityEndpoint.swapList]: swapList,
     [invityEndpoint.swapWatch]: swapWatch,
     [invityEndpoint.info]: info,

--- a/suite/e2e/support/mocks/tradingMock.ts
+++ b/suite/e2e/support/mocks/tradingMock.ts
@@ -1,6 +1,8 @@
 import { Page } from '@playwright/test';
 import { cloneDeep } from 'lodash';
 
+import { typedObjectEntries } from '@trezor/utils';
+
 import { invityEndpoint, invityGeneralResponses } from '../../fixtures/invity';
 import {
     SellTradeResponse,
@@ -26,7 +28,7 @@ export class TradingMock {
     // Common responses for all trading tests.
     @step()
     async routeInvityGeneralEndpoints() {
-        for (const [url, response] of Object.entries(invityGeneralResponses)) {
+        for (const [url, response] of typedObjectEntries(invityGeneralResponses)) {
             await this.page.route(url, async route => {
                 await route.fulfill({ json: response });
             });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prevents TypeScript from expanding all Invity JSON fixtures into `invityGeneralResponses.d.ts`. The response map now exposes only its endpoint keys and `unknown` JSON values, while individual fixtures remain fully typed.

Also switches to `typedObjectEntries` and preserves endpoint literal types.

Declaration size reduced from **757,236 bytes to 8,121 bytes (98.93%)**. No runtime behavior change.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ix-oversized-type-declarations-6/web/](https://dev.suite.sldev.cz/suite-web/ix-oversized-type-declarations-6/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ix-oversized-type-declarations-6&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ix-oversized-type-declarations-6&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ix-oversized-type-declarations-6&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-16T10:11:27.451Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-16T10:11:31.927Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->