### PR TITLE
fix(suite-desktop): pending tx nonce fix

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -269,6 +269,8 @@ export const claimMerklRewardsThunk = createThunk(
                         precomposedTransaction,
                         precomposedForm: formState,
                         txid: pushResponse.payload.txid,
+                        // The decimal nonce the claim tx was built and signed with.
+                        ethereumNonce: nonce,
                     }),
                 );
 

--- a/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
@@ -172,6 +172,8 @@ export const sendYieldTransaction = async ({
                 precomposedTransaction,
                 precomposedForm: formState,
                 txid: pushResponse.payload.txid,
+                // transactionForSigning.nonce is hex; the fake pending tx expects a decimal string.
+                ethereumNonce: parseInt(transactionForSigning.nonce, 16).toString(),
             }),
         );
 

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -66,6 +66,7 @@ import {
 } from './sendFormRippleStellarThunks';
 import {
     selectPrecomposedSendForm,
+    selectResolvedEthereumNonce,
     selectSendFormDrafts,
     selectSendPrecomposedTx,
     selectSendSerializedTx,
@@ -259,11 +260,16 @@ export const synchronizeSentTransactionThunk = createThunk(
             precomposedTransaction,
             precomposedForm,
             txid,
+            ethereumNonce,
         }: {
             selectedAccount: Account;
             precomposedTransaction: GeneralPrecomposedTransactionFinal;
             precomposedForm?: FormState;
             txid: string;
+            // The nonce the EVM tx was actually signed with. Forwarded to the fake pending tx so it
+            // shows the true nonce instead of a value re-derived from the pending-inclusive
+            // account.misc.nonce (which reads one too high until the backend picks up the real tx).
+            ethereumNonce?: string;
         },
         { dispatch },
     ) => {
@@ -301,6 +307,7 @@ export const synchronizeSentTransactionThunk = createThunk(
                     precomposedForm,
                     txid,
                     account: selectedAccount,
+                    ethereumNonce,
                 }),
             );
             dispatch(accountsActions.updateAccount(selectedAccount));
@@ -351,6 +358,9 @@ export const pushSendFormTransactionThunk = createThunk<
         const serializedTx = selectSendSerializedTx(getState());
         const device = selectSelectedDevice(getState());
         const bitcoinAmountUnit = selectBitcoinAmountUnit(getState());
+        // Read the signed-with nonce before onModalCancel() so the fake pending tx (added in
+        // synchronizeSentTransactionThunk) shows the true nonce rather than a re-derived one.
+        const resolvedEthereumNonce = selectResolvedEthereumNonce(getState());
 
         if (!serializedTx || !precomposedTransaction)
             return rejectWithValue({
@@ -465,6 +475,7 @@ export const pushSendFormTransactionThunk = createThunk<
                     precomposedTransaction,
                     precomposedForm,
                     txid,
+                    ethereumNonce: resolvedEthereumNonce,
                 }),
             );
         } else {

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -357,11 +357,18 @@ export const addFakePendingEvmTxThunk = createThunk(
             precomposedForm,
             txid,
             account,
+            ethereumNonce,
         }: {
             precomposedTransaction: PrecomposedTransactionFinal;
             precomposedForm?: FormState;
             txid: string;
             account: Account;
+            // The nonce the tx was actually signed with. Preferred source: re-deriving it here from
+            // account.misc.nonce reads one too high while the just-broadcast tx sits in the mempool
+            // but isn't yet in the local tx list — blockbook's misc.nonce is pending-inclusive
+            // (trezor/blockbook#1562), so the lowestPendingNonce clamp in getEvmNonceInfo can't
+            // correct it yet.
+            ethereumNonce?: string;
         },
         { dispatch, getState },
     ) => {
@@ -373,12 +380,21 @@ export const addFakePendingEvmTxThunk = createThunk(
             return;
         }
 
-        // Display-only fake pending tx (rendered after the real tx was already pushed): a confirmed-
-        // nonce backend round-trip here is unwarranted, and any transient mismatch self-corrects once
-        // the backend picks up the real tx.
-        const { nonce } = await dispatch(
-            ethereumGetCurrentNonceThunk({ selectedAccount: account, fetchConfirmedNonce: false }),
-        ).unwrap();
+        // Prefer the nonce the tx was actually signed with. Fall back to deriving it from the
+        // account's (untrusted, pending-inclusive) nonce only when the caller can't supply it. This
+        // is a display-only fake pending tx rendered after the real tx was already pushed, so a
+        // confirmed-nonce backend round-trip is unwarranted, and any transient mismatch self-corrects
+        // once the backend picks up the real tx.
+        const nonce =
+            ethereumNonce ??
+            (
+                await dispatch(
+                    ethereumGetCurrentNonceThunk({
+                        selectedAccount: account,
+                        fetchConfirmedNonce: false,
+                    }),
+                ).unwrap()
+            ).nonce;
 
         const blockHeight = selectBlockchainHeightBySymbol(getState(), account.symbol);
         const rawFeeInfo = selectRawNetworkFeeInfo(getState(), account.symbol);

--- a/suite-common/wallet-core/tests/send/synchronizeSentTransactionThunk.test.ts
+++ b/suite-common/wallet-core/tests/send/synchronizeSentTransactionThunk.test.ts
@@ -59,3 +59,52 @@ describe('synchronizeSentTransactionThunk – RBF eviction (#28147)', () => {
         expect(removed).toHaveLength(0);
     });
 });
+
+describe('synchronizeSentTransactionThunk – EVM fake pending tx nonce', () => {
+    // account.misc.nonce is deliberately pending-inflated here: if the thunk re-derived the nonce
+    // (the old behaviour) the fake tx would read 9, not the true signed nonce 7.
+    const inflatedEthAccount = {
+        ...ethAccount,
+        misc: { ...(ethAccount as any).misc, nonce: '9' },
+    } as typeof ethAccount;
+
+    const preloadedState = {
+        wallet: {
+            fees: { eth: { data: { blockTime: 600 } } },
+            blockchain: { eth: { blockHeight: 100 } },
+            transactions: { transactions: {} },
+        },
+    };
+
+    const evmPrecomposed = () =>
+        precomposed({
+            outputs: [{ address: '0x1111111111111111111111111111111111111111', amount: '1000' }],
+            feeLimit: '21000',
+            maxFeePerGas: '20',
+            maxPriorityFeePerGas: '1',
+        });
+
+    const getAddedFakeTx = (store: ReturnType<typeof configureMockStore>) => {
+        const added = store
+            .getActions()
+            .filter(action => action.type === transactionsActions.addTransaction.type);
+
+        return added[0]?.payload.transactions[0];
+    };
+
+    it('stamps the fake pending tx with the signed nonce passed in, not the re-derived one', () => {
+        const store = configureMockStore({ preloadedState });
+
+        store.dispatch(
+            synchronizeSentTransactionThunk({
+                selectedAccount: inflatedEthAccount,
+                precomposedTransaction: evmPrecomposed(),
+                precomposedForm: { transactionData: '0x' } as any,
+                txid: 'NEW',
+                ethereumNonce: '7',
+            }),
+        );
+
+        expect(getAddedFakeTx(store)?.ethereumSpecific?.nonce).toBe(7);
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When tx is added with stub data to be displayed as pending the nonce is not being correctly resolved and needs to be externally passed. It resulted in issue with the user saw a warning for half of second before tx data was fetched. 

## Notes for QA

It does not happen on all the derivations and specific to some addresses. Was able to reproduce on a Eth#3 (see original issue)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29887

## Screenshots:

https://github.com/user-attachments/assets/9d2af8d2-96c1-4eb4-b8a1-f9e3f81ff1e5


https://github.com/user-attachments/assets/93ba1b1a-08d9-41e0-9300-78eb905eccb0




<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect stablecoin yield claiming (claimMerklRewardsThunk, signingHelpers), core send form transaction composition (sendFormThunks), transaction tracking (transactionsThunks), and a unit test for synchronizing sent transactions. All four source files map to 131 tests due to broad transitive imports, so most tests are irrelevant. The highest risk is in tests that actually compose, sign, and send transactions — particularly ETH/EVM sends and staking flows that exercise the modified sendFormThunks and transactionsThunks directly. The stablecoin yield claiming is not directly tested by any E2E test, but its signing infrastructure is shared with staking claim flows.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts`
- `suite-common/wallet-core/src/send/sendFormThunks.ts`
- `suite-common/wallet-core/src/transactions/transactionsThunks.ts`
- `suite-common/wallet-core/tests/send/synchronizeSentTransactionThunk.test.ts`

</details>

**Recommended tests (20)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test exercises the full ETH unstaking and claiming flow, which involves sendFormThunks (composing and sending transactions) and transactionsThunks (tracking transaction status changes). The claimMerklRewardsThunk and signingHelpers changes relate to stablecoin yield claiming, which shares signing infrastructure with staking claim flows.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test performs a full ETH staking transaction including device confirmation, transaction broadcasting, and status tracking (pending → confirmed → active). It directly exercises sendFormThunks for composing the stake transaction and transactionsThunks for tracking confirmation status.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Tests staking additional ETH with transaction composition, device confirmation, status tracking from pending to confirmed, and instant staking banner. Directly uses sendFormThunks for transaction composition and transactionsThunks for status transitions.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test fills an Ethereum send form with custom gas fees, confirms on the device, and verifies transaction details. It directly exercises sendFormThunks for composing the ETH transaction and the signing/fee calculation logic that signingHelpers may share infrastructure with.
- `suite/e2e/tests/wallet/send-base.test.ts` — Tests sending ETH on Base (EVM L2) with custom fees, device confirmation, and broadcast verification. Directly exercises sendFormThunks for transaction composition and transactionsThunks for post-send state (serializedTx, drafts cleanup).
- `suite/e2e/tests/wallet/send-sol.test.ts` — Tests sending max SOL amount with fee/reserve calculations, device confirmation, and transaction review. Directly exercises sendFormThunks for Solana transaction composition.

</details>

<details><summary>🟡 <b>Medium priority (12)</b></summary>

- `suite/e2e/tests/trading-poc/passthru-swap-eth-to-btc.test.ts` — This test performs a live ETH swap which involves composing and sending an Ethereum transaction via sendFormThunks, then tracking transaction status through transactionsThunks. The swap flow uses the same send infrastructure as direct sends.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — The sell BTC flow initiates a send transaction with fee calculation and device confirmation, exercising sendFormThunks for Bitcoin transaction composition. Changes to send thunks could affect the sell-and-send flow.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests the sell SOL flow including send transaction composition, device confirmation, and post-send status tracking. Uses sendFormThunks for composing the Solana send and transactionsThunks for status polling.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Tests SOL-to-BTC swap with transaction sending, status tracking through SENDING → CONFIRMING → CONVERTING → SUCCESS states. Exercises both sendFormThunks and transactionsThunks through the swap send flow.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Tests DEX swap on ETH with custom gas parameters, transaction signing, broadcasting, and status tracking. The DEX flow exercises sendFormThunks for composing the EVM transaction with adjusted gas limits and transactionsThunks for status transitions.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests custom Ethereum fee settings (gas limit, max fee, priority fee) in the swap flow. Directly verifies sendFormThunks' composedTransactionInfo Redux state and fee calculation logic.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Tests claiming Cardano staking rewards which involves transaction composition and sending. While the claimMerklRewardsThunk is specific to stablecoin yield, the claim flow shares transaction infrastructure via sendFormThunks and transactionsThunks.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Tests DOGE send with an amount exceeding MAX_SAFE_INTEGER, verifying error handling in the signing flow. Exercises sendFormThunks error paths which could be affected by changes to transaction composition logic.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Tests Bitcoin send form features including multiple outputs, locktime, OP_RETURN, and unit switching. Exercises sendFormThunks for Bitcoin transaction composition and various send form options.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — Tests pending transaction display, count tracking, and transition from pending to confirmed state. Directly exercises transactionsThunks for transaction status management and the synchronizeSentTransaction logic.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Tests LTC send with MimbleWimble peg-out transaction outputs and broadcast mode. Exercises sendFormThunks for Litecoin transaction composition.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Tests SOL unstaking and claiming flow with transaction composition, device confirmation, and epoch-based status tracking. Uses sendFormThunks and transactionsThunks for the unstake/claim transactions.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests custom Bitcoin fee rate in swap flow and verifies composedTransactionInfo Redux state from sendFormThunks. Less directly affected than Ethereum-based tests since the changed files focus on EVM signing helpers.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests selling ETH with custom gas fees and device confirmation. Exercises sendFormThunks for Ethereum transaction composition in the sell context.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `suite-common/wallet-core/tests/send/synchronizeSentTransactionThunk.test.ts`

_Updated: 2026-07-16T05:08:46.149Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/evm-pending-tx-nonce/web/](https://dev.suite.sldev.cz/suite-web/fix/evm-pending-tx-nonce/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/evm-pending-tx-nonce&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/evm-pending-tx-nonce&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/evm-pending-tx-nonce&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-16T05:11:16.818Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-16T05:11:04.750Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->