### PR TITLE
refactor(transport): shrink transport declarations

### DIFF
--- a/packages/requirements/src/requirements/type-declarations/__tests__/requireTypeDeclarationSize.test.ts
+++ b/packages/requirements/src/requirements/type-declarations/__tests__/requireTypeDeclarationSize.test.ts
@@ -74,50 +74,6 @@ describe(requireTypeDeclarationSize.name, () => {
         expect(errors[0]).toContain('packages/example/libDev/src/nested/large.d.mts');
     });
 
-    it('allows known oversized declarations up to their legacy limit', async () => {
-        const knownWorkspaceDirectory = join(repoRoot, 'packages', 'connect-cli');
-        const knownDeclarationDirectory = join(knownWorkspaceDirectory, 'libDev', 'src');
-        mkdirSync(knownDeclarationDirectory, { recursive: true });
-        writeFileSync(join(knownDeclarationDirectory, 'transport.d.ts'), 'x'.repeat(103 * 1024));
-        mockListAllWorkspaces.mockReturnValue([
-            { dir: knownWorkspaceDirectory, name: '@trezor/connect-cli' },
-        ]);
-
-        const errors = await requireTypeDeclarationSize.verify(context);
-
-        expect(errors).toEqual([]);
-    });
-
-    it('reports legacy limits that can be removed', async () => {
-        const knownWorkspaceDirectory = join(repoRoot, 'packages', 'connect-cli');
-        const knownDeclarationDirectory = join(knownWorkspaceDirectory, 'libDev', 'src');
-        mkdirSync(knownDeclarationDirectory, { recursive: true });
-        writeFileSync(join(knownDeclarationDirectory, 'transport.d.ts'), 'x'.repeat(90 * 1024));
-        mockListAllWorkspaces.mockReturnValue([
-            { dir: knownWorkspaceDirectory, name: '@trezor/connect-cli' },
-        ]);
-
-        const errors = await requireTypeDeclarationSize.verify(context);
-
-        expect(errors).toEqual([
-            'packages/connect-cli/libDev/src/transport.d.ts is now 90 KiB; remove its legacy declaration-size limit.',
-        ]);
-    });
-
-    it('reports legacy limits for declarations missing from built workspaces', async () => {
-        const knownWorkspaceDirectory = join(repoRoot, 'packages', 'connect-cli');
-        mkdirSync(join(knownWorkspaceDirectory, 'libDev'), { recursive: true });
-        mockListAllWorkspaces.mockReturnValue([
-            { dir: knownWorkspaceDirectory, name: '@trezor/connect-cli' },
-        ]);
-
-        const errors = await requireTypeDeclarationSize.verify(context);
-
-        expect(errors).toEqual([
-            'packages/connect-cli/libDev/src/transport.d.ts no longer exists; remove or update its legacy declaration-size limit.',
-        ]);
-    });
-
     it('ignores emitted declarations that are expected to grow', async () => {
         const knownWorkspaceDirectory = join(repoRoot, 'suite-native', 'intl');
         const knownDeclarationDirectory = join(knownWorkspaceDirectory, 'libDev', 'src');

--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -20,37 +20,22 @@ const FILES_EXPECTED_TO_GROW = new Set<string>([
     'packages/protobuf/libDev/src/definitions/messages-bitcoin.d.ts',
 ]);
 
-const KNOWN_OVERSIZED_DECLARATION_LIMITS = new Map<string, number>([
-    ['packages/connect-cli/libDev/src/transport.d.ts', kibToBytes(104)],
-    ['suite/e2e/libDev/fixtures/invity/index.d.ts', kibToBytes(740)],
-    ['suite-common/device/libDev/src/deviceSelectors.d.ts', kibToBytes(520)],
-    ['packages/suite/libDev/src/reducers/store.d.ts', kibToBytes(515)],
-    ['packages/suite/libDev/src/utils/suite/notification.d.ts', kibToBytes(395)],
-    ['packages/suite/libDev/src/reducers/suite/index.d.ts', kibToBytes(340)],
-    ['packages/transport/libDev/src/transports/bridge.d.ts', kibToBytes(235)],
-    ['packages/transport-common/libDev/src/transports/abstractApi.d.ts', kibToBytes(230)],
-    [
-        'packages/suite-desktop-ui/libDev/src/createSuiteDesktopCompositionRoot.d.ts',
-        kibToBytes(190),
-    ],
-    ['packages/suite-web/libDev/src/createSuiteWebCompositionRoot.d.ts', kibToBytes(190)],
-    ['suite/test-utils/libDev/src/initStoreForTests.d.ts', kibToBytes(185)],
-    [
-        'suite-common/wallet-core/libDev/src/transactions/transactionsSelectors.d.ts',
-        kibToBytes(180),
-    ],
-    ['suite-common/trading/libDev/src/selectors/tradingSelectors.d.ts', kibToBytes(130)],
-    [
-        'packages/suite/libDev/src/views/settings/SettingsDevice/ForgetDevice/useForgetDevice.d.ts',
-        kibToBytes(130),
-    ],
-    [
-        'packages/suite/libDev/src/selectors/suite/selectAccountLabelsForSearch.d.ts',
-        kibToBytes(130),
-    ],
-    ['suite-common/message-system/libDev/src/messageSystemSelectors.d.ts', kibToBytes(115)],
-    ['packages/suite/libDev/src/hooks/wallet/useRbfForm.d.ts', kibToBytes(115)],
-]);
+const KNOWN_OVERSIZED_DECLARATIONS: string[] = [
+    'suite/e2e/libDev/fixtures/invity/index.d.ts',
+    'suite-common/device/libDev/src/deviceSelectors.d.ts',
+    'packages/suite/libDev/src/reducers/store.d.ts',
+    'packages/suite/libDev/src/utils/suite/notification.d.ts',
+    'packages/suite/libDev/src/reducers/suite/index.d.ts',
+    'packages/suite-desktop-ui/libDev/src/createSuiteDesktopCompositionRoot.d.ts',
+    'packages/suite-web/libDev/src/createSuiteWebCompositionRoot.d.ts',
+    'suite/test-utils/libDev/src/initStoreForTests.d.ts',
+    'suite-common/wallet-core/libDev/src/transactions/transactionsSelectors.d.ts',
+    'suite-common/trading/libDev/src/selectors/tradingSelectors.d.ts',
+    'packages/suite/libDev/src/views/settings/SettingsDevice/ForgetDevice/useForgetDevice.d.ts',
+    'packages/suite/libDev/src/selectors/suite/selectAccountLabelsForSearch.d.ts',
+    'suite-common/message-system/libDev/src/messageSystemSelectors.d.ts',
+    'packages/suite/libDev/src/hooks/wallet/useRbfForm.d.ts',
+];
 
 const normalizePath = (filePath: string) => filePath.split(sep).join('/');
 
@@ -84,18 +69,19 @@ const verifyDeclarationFile = (repoRoot: string, declarationFile: string) => {
     if (FILES_EXPECTED_TO_GROW.has(declarationPath)) return undefined;
 
     const sizeBytes = statSync(declarationFile).size;
-    const knownLimit = KNOWN_OVERSIZED_DECLARATION_LIMITS.get(declarationPath);
-    const maximumSize = knownLimit ?? MAX_DECLARATION_SIZE_BYTES;
+    const isKnownOversized = KNOWN_OVERSIZED_DECLARATIONS.includes(declarationPath);
 
-    if (knownLimit !== undefined && sizeBytes <= MAX_DECLARATION_SIZE_BYTES) {
+    if (isKnownOversized && sizeBytes <= MAX_DECLARATION_SIZE_BYTES) {
         return `${declarationPath} is now ${formatSize(
             sizeBytes,
-        )}; remove its legacy declaration-size limit.`;
+        )}; remove it from known oversized declarations.`;
     }
 
-    if (sizeBytes <= maximumSize) return undefined;
+    if (isKnownOversized || sizeBytes <= MAX_DECLARATION_SIZE_BYTES) return undefined;
 
-    return `${declarationPath} is ${formatSize(sizeBytes)}; maximum is ${formatSize(maximumSize)}.`;
+    return `${declarationPath} is ${formatSize(sizeBytes)}; maximum is ${formatSize(
+        MAX_DECLARATION_SIZE_BYTES,
+    )}.`;
 };
 
 export const requireTypeDeclarationSize: Requirement<'repo'> = {
@@ -119,14 +105,14 @@ export const requireTypeDeclarationSize: Requirement<'repo'> = {
             .map(declarationFile => verifyDeclarationFile(repoRoot, declarationFile))
             .filter(error => error !== undefined);
 
-        for (const declarationPath of KNOWN_OVERSIZED_DECLARATION_LIMITS.keys()) {
+        for (const declarationPath of KNOWN_OVERSIZED_DECLARATIONS) {
             const isWorkspaceBuilt = builtDeclarationOutputPaths.some(outputPath =>
                 declarationPath.startsWith(`${outputPath}/`),
             );
 
             if (isWorkspaceBuilt && !declarationPaths.has(declarationPath)) {
                 errors.push(
-                    `${declarationPath} no longer exists; remove or update its legacy declaration-size limit.`,
+                    `${declarationPath} no longer exists; remove or update it in known oversized declarations.`,
                 );
             }
         }

--- a/packages/transport-common/src/transports/abstractApi.ts
+++ b/packages/transport-common/src/transports/abstractApi.ts
@@ -4,6 +4,7 @@ import {
     AbstractTransport,
     type AbstractTransportMethodParams,
     type AbstractTransportParams,
+    type ReadWriteError,
 } from './abstract';
 import {
     type AbstractApi,
@@ -16,7 +17,7 @@ import { SessionsBackground } from '../sessions/background';
 import { SessionsClient } from '../sessions/client';
 import { type SessionsBackgroundInterface } from '../sessions/types';
 import { callThpMessage, parseThpMessage, receiveThpMessage, sendThpMessage } from '../thp';
-import { type Session } from '../types';
+import { type AsyncResultWithTypedError, type MessageResponse, type Session } from '../types';
 import { receiveAndParse } from '../utils/receive';
 import { error, success } from '../utils/result';
 import { buildMessage, createChunks, sendChunks } from '../utils/send';
@@ -225,7 +226,10 @@ export abstract class AbstractApiTransport extends AbstractTransport {
         thpState,
         signal,
         timeout,
-    }: AbstractTransportMethodParams<'call'>) {
+    }: AbstractTransportMethodParams<'call'>): AsyncResultWithTypedError<
+        MessageResponse,
+        ReadWriteError
+    > {
         return this.scheduleAction(
             async signal => {
                 const handleError = (error: string) => {
@@ -334,7 +338,10 @@ export abstract class AbstractApiTransport extends AbstractTransport {
         thpState,
         signal,
         timeout,
-    }: AbstractTransportMethodParams<'send'>) {
+    }: AbstractTransportMethodParams<'send'>): AsyncResultWithTypedError<
+        undefined,
+        ReadWriteError
+    > {
         return this.scheduleAction(
             async signal => {
                 const getPathBySessionResponse = await this.sessionsClient.getPathBySession({
@@ -413,7 +420,10 @@ export abstract class AbstractApiTransport extends AbstractTransport {
         thpState,
         signal,
         timeout,
-    }: AbstractTransportMethodParams<'receive'>) {
+    }: AbstractTransportMethodParams<'receive'>): AsyncResultWithTypedError<
+        MessageResponse,
+        ReadWriteError
+    > {
         return this.scheduleAction(
             async signal => {
                 const getPathBySessionResponse = await this.sessionsClient.getPathBySession({

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -13,6 +13,7 @@ import {
     type BridgeCommonErrors,
     type Descriptor,
     TRANSPORT_ERROR as ERRORS,
+    type MessageResponse,
     type Session,
     TRANSPORT,
     buildMessage,
@@ -61,6 +62,17 @@ type IncompleteRequestOptions = {
 };
 
 type BridgeConstructorParameters = AbstractTransportParams & { port?: number };
+
+type BridgeReadWriteError =
+    | BridgeCommonErrors
+    | typeof ERRORS.ABORTED_BY_SIGNAL
+    | typeof ERRORS.ABORTED_BY_TIMEOUT
+    | typeof ERRORS.DEVICE_DISCONNECTED_DURING_ACTION
+    | typeof ERRORS.DEVICE_NOT_FOUND
+    | typeof ERRORS.INTERFACE_DATA_TRANSFER
+    | typeof ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE
+    | typeof ERRORS.OTHER_CALL_IN_PROGRESS
+    | typeof PROTOCOL_MALFORMED;
 
 export class BridgeTransport extends AbstractTransport {
     private useAbortEndpoint: boolean = false;
@@ -213,7 +225,10 @@ export class BridgeTransport extends AbstractTransport {
         thpState,
         signal,
         timeout,
-    }: AbstractTransportMethodParams<'call'>) {
+    }: AbstractTransportMethodParams<'call'>): AsyncResultWithTypedError<
+        MessageResponse,
+        BridgeReadWriteError
+    > {
         return this.scheduleAction(
             async signal => {
                 const protocol = this.getProtocol(customProtocol);
@@ -271,7 +286,10 @@ export class BridgeTransport extends AbstractTransport {
         thpState,
         signal,
         timeout,
-    }: AbstractTransportMethodParams<'send'>) {
+    }: AbstractTransportMethodParams<'send'>): AsyncResultWithTypedError<
+        undefined,
+        BridgeReadWriteError
+    > {
         return this.scheduleAction(
             async signal => {
                 const protocol = this.getProtocol(customProtocol);
@@ -309,7 +327,10 @@ export class BridgeTransport extends AbstractTransport {
         thpState,
         signal,
         timeout,
-    }: AbstractTransportMethodParams<'receive'>) {
+    }: AbstractTransportMethodParams<'receive'>): AsyncResultWithTypedError<
+        MessageResponse,
+        BridgeReadWriteError
+    > {
         return this.scheduleAction(
             async signal => {
                 const protocol = this.getProtocol(customProtocol);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Code improvement to reduce type-declarations to speedup the type-check

Nothing to manually test, only code improvement.

<img width="854" height="261" alt="image" src="https://github.com/user-attachments/assets/4c9b894b-2b45-4f57-96b5-44ea4f35613e" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch two transport-layer files (bridge.ts and abstractApi.ts) which are foundational dependencies used by nearly all E2E tests, plus two files in the requirements package with no E2E test coverage. Since the transport files map to 126-131 tests, only tests that specifically exercise transport/bridge behavior (session management, bridge reconnection, transport type reporting) are recommended. The requirements package changes are purely unit-test-level with no E2E exposure.

<details><summary><b>Changed files (4)</b></summary>

- `packages/requirements/src/requirements/type-declarations/__tests__/requireTypeDeclarationSize.test.ts`
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`
- `packages/transport-common/src/transports/abstractApi.ts`
- `packages/transport/src/transports/bridge.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test explicitly asserts that TransportType event reports 'BridgeTransport' and a valid version. Changes to packages/transport/src/transports/bridge.ts directly affect BridgeTransport behavior and could change the transport type or version reporting.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test directly exercises Bridge session acquisition, enumeration, and stealing — core BridgeTransport functionality. Changes to bridge.ts or abstractApi.ts could break session management, 'Use Here' status detection, and session reclamation logic.
- `suite/e2e/tests/suite/bridge.test.ts` — This test navigates the Bridge page and exercises WebUSB transport switching. Changes to bridge.ts directly affect the Bridge page behavior and transport layer initialization.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/recovery/dry-run.test.ts` — This test explicitly stops and restarts the bridge (trezorUserEnv.stopBridge/startBridge) to simulate device disconnect/reconnect during recovery. Changes to bridge.ts or abstractApi.ts could affect bridge reconnection behavior.
- `suite/e2e/tests/recovery/t2t1-dry-run.test.ts` — Like dry-run.test.ts, this test stops and restarts the bridge to simulate disconnect/reconnect during a T2T1 recovery dry run. Bridge reconnection logic in the changed files is directly exercised.
- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test simulates device disconnect during backup by powering off the emulator and verifies proper error handling. Changes to the transport/bridge layer could affect how disconnection is detected and reported.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/suite/db-locale-migration.test.ts` — This test starts/stops the bridge explicitly (trezorUserEnv.stopBridge/startBridge) when switching between Suite versions. Changes to bridge.ts could affect bridge compatibility during version migration.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/requirements/src/requirements/type-declarations/__tests__/requireTypeDeclarationSize.test.ts`
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`

_Updated: 2026-07-16T08:25:13.058Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-oversized-type-declarations-7-connect/web/](https://dev.suite.sldev.cz/suite-web/fix-oversized-type-declarations-7-connect/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-oversized-type-declarations-7-connect&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-oversized-type-declarations-7-connect&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-16T08:29:11.760Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-16T08:28:31.868Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->