### PR TITLE
refactor(suite): shrink RBF form declaration

### DIFF
--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -20,9 +20,7 @@ const FILES_EXPECTED_TO_GROW = new Set<string>([
     'packages/protobuf/libDev/src/definitions/messages-bitcoin.d.ts',
 ]);
 
-const KNOWN_OVERSIZED_DECLARATIONS: string[] = [
-    'packages/suite/libDev/src/hooks/wallet/useRbfForm.d.ts',
-];
+const KNOWN_OVERSIZED_DECLARATIONS: string[] = [];
 
 const normalizePath = (filePath: string) => filePath.split(sep).join('/');
 

--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -1,8 +1,8 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { type UseFormReturn, useForm } from 'react-hook-form';
 
 import { selectCurrentTargetAnonymity } from '@suite/coinjoin';
-import { getNetwork } from '@suite-common/wallet-config';
+import { type Network, getNetwork } from '@suite-common/wallet-config';
 import {
     DEFAULT_OPRETURN,
     DEFAULT_PAYMENT,
@@ -16,6 +16,9 @@ import {
     type FeeInfo,
     type FormOptions,
     type FormState,
+    type Output,
+    type PrecomposedLevels,
+    type PrecomposedLevelsCardano,
     type RbfTransactionParams,
     type RbfTransactionParamsBitcoin,
     type RbfTransactionParamsEthereum,
@@ -25,6 +28,7 @@ import {
     getConvertedOrDefaultFeeInfo,
     isEip1559,
 } from '@suite-common/wallet-utils';
+import { type AccountUtxo, type FeeLevel } from '@trezor/connect';
 import { BigNumber, throwError } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
@@ -42,6 +46,34 @@ export type UseRbfProps = {
     rbfParams: RbfTransactionParams;
     chainedTxs?: ChainedTransactions;
 };
+
+type RbfState = {
+    account: Account;
+    network: Network;
+    feeInfo: FeeInfo;
+    coinjoinRegisteredUtxos: AccountUtxo[];
+    chainedTxs?: ChainedTransactions;
+    shouldSendInSats?: boolean;
+    formValues: Omit<FormState, 'outputs' | 'selectedUtxos'> & {
+        outputs: Array<Omit<Output, 'token'> & { token?: string | null }>;
+    };
+};
+
+type RbfFormMethods = Pick<
+    UseFormReturn<FormState>,
+    'control' | 'formState' | 'getValues' | 'register' | 'setValue' | 'trigger'
+>;
+
+export type RbfContextValues = RbfState &
+    RbfFormMethods & {
+        methods: UseFormReturn<FormState>;
+        isLoading: boolean;
+        showDecreasedOutputs: boolean;
+        composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
+        changeFeeLevel: (level: FeeLevel['label']) => void;
+        composeRequest: (field?: string) => Promise<void>;
+        signTransaction: () => Promise<boolean | undefined>;
+    };
 
 const getBitcoinFeeInfo = (info: FeeInfo, rbfParams: RbfTransactionParamsBitcoin) => {
     const { feeRate } = rbfParams;
@@ -140,7 +172,7 @@ const getRbfFeeInfo = (info: FeeInfo, rbfParams: RbfTransactionParams) => {
     return info;
 };
 
-const useRbfState = ({ account, rbfParams, chainedTxs }: UseRbfProps) => {
+const useRbfState = ({ account, rbfParams, chainedTxs }: UseRbfProps): RbfState => {
     const networkFees = useSelector(state => selectRawNetworkFeeInfo(state, account.symbol));
     const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
     const coinjoinRegisteredUtxos = useCoinjoinRegisteredUtxos({ account });
@@ -244,7 +276,7 @@ const useRbfState = ({ account, rbfParams, chainedTxs }: UseRbfProps) => {
     ]);
 };
 
-export const useRbf = (props: UseRbfProps) => {
+export const useRbf = (props: UseRbfProps): RbfContextValues => {
     // local state
     const state = useRbfState(props);
     const { formValues, feeInfo, account } = state;
@@ -338,10 +370,6 @@ export const useRbf = (props: UseRbfProps) => {
         trigger,
     };
 };
-
-// context accepts only valid state (non-nullable account)
-export type RbfContextValues = ReturnType<typeof useRbf> &
-    NonNullable<ReturnType<typeof useRbfState>>;
 
 export const RbfContext = createContext<RbfContextValues | null>(null);
 RbfContext.displayName = 'RbfContext';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Code improvement to reduce type-declarations to speedup the type-check

Nothing to manually test, only code improvement.

-------

The fix is effective: [`useRbfForm.d.ts`](/home/user/workstation/trezor/trezor-suite3/packages/suite/src/hooks/wallet/useRbfForm.ts:47) dropped from **115,724 bytes to 1,681 bytes**, saving **114,043 bytes (111.4 KiB / 98.55%)**. The explicit contract covers all returned fields and all current consumers.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The two changed files pose minimal E2E risk. `requireTypeDeclarationSize.ts` is a build-time/static-analysis requirement check with no runtime behavior exercised by any E2E test. `useRbfForm.ts` is a React hook for Replace-By-Fee (RBF) transaction form logic, which maps to 131 tests only because it is transitively bundled into the main Suite application — none of the 133 candidate E2E tests specifically exercise RBF functionality (speed-up/bump-fee flows). Since no test directly covers RBF form behavior and the broad static mapping is purely incidental, no E2E tests are recommended. Unit or integration tests for the RBF hook would be more appropriate for validating this change.

<details><summary><b>Changed files (2)</b></summary>

- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`
- `packages/suite/src/hooks/wallet/useRbfForm.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`
- `packages/suite/src/hooks/wallet/useRbfForm.ts`

_Updated: 2026-07-17T14:26:36.566Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-oversized-type-declarations-8-rbf/web/](https://dev.suite.sldev.cz/suite-web/fix-oversized-type-declarations-8-rbf/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-oversized-type-declarations-8-rbf&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-oversized-type-declarations-8-rbf&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-17T14:29:47.955Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-17T14:30:09.846Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->