### PR TITLE
refactor(networks): centralize constants in network packages

### DIFF
--- a/networks/ripple/network-ripple/src/constants/index.ts
+++ b/networks/ripple/network-ripple/src/constants/index.ts
@@ -1,1 +1,5 @@
-export {};
+export const RIPPLE_DECIMALS = 6;
+
+// Network default reserves in drops, overwritten at runtime from `server_info`.
+export const RIPPLE_BASE_RESERVE_DEFAULT = '10000000'; // 10 XRP
+export const RIPPLE_OWNER_RESERVE_DEFAULT = '2000000'; // 2 XRP

--- a/networks/ripple/network-ripple/src/index.ts
+++ b/networks/ripple/network-ripple/src/index.ts
@@ -1,3 +1,3 @@
-export {} from './constants';
+export * from './constants';
 export * from './runtime/exports';
 export type * from './types';

--- a/networks/stellar/network-stellar/src/constants/index.ts
+++ b/networks/stellar/network-stellar/src/constants/index.ts
@@ -1,4 +1,10 @@
+import { BigNumber } from '@trezor/utils';
+
 export const STELLAR_DECIMALS = 7;
 
 // 0.5 XLM, https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures/accounts#base-reserves
 export const STELLAR_BASE_RESERVE = '5000000';
+
+// Converts an amount from lumens (decimal) to stroops (integer base unit).
+export const toStroops = (value: number | string) =>
+    new BigNumber(10).pow(STELLAR_DECIMALS).times(new BigNumber(value));

--- a/networks/stellar/network-stellar/src/runtime/transactions/identify.ts
+++ b/networks/stellar/network-stellar/src/runtime/transactions/identify.ts
@@ -9,10 +9,7 @@ import {
 
 import { BigNumber } from '@trezor/utils';
 
-import { STELLAR_DECIMALS } from '../../constants';
-
-export const toStroops = (value: string) =>
-    new BigNumber(10).pow(STELLAR_DECIMALS).times(new BigNumber(value));
+import { toStroops } from '../../constants';
 
 const isoToTimestamp = (isoDate: string): number => {
     const timestamp = Date.parse(isoDate);

--- a/networks/stellar/network-stellar/src/runtime/transactions/transform.ts
+++ b/networks/stellar/network-stellar/src/runtime/transactions/transform.ts
@@ -12,7 +12,7 @@ import {
     type Transaction,
 } from '@stellar/stellar-sdk';
 
-import { BigNumber } from '@trezor/utils';
+import { toStroops } from '../../constants';
 
 /**
  * Transforms Signer to TrezorConnect.StellarTransaction.Signer
@@ -57,12 +57,6 @@ const transformAsset = (asset: Asset) => {
         issuer: asset.getIssuer(),
     };
 };
-
-/**
- * Transforms amount from decimals (lumens) to integer (stroop)
- */
-const transformAmount = (amount: number | string) =>
-    new BigNumber(amount).times(10000000).toString();
 
 /**
  * Transforms Memo to TrezorConnect.StellarTransaction.Memo
@@ -139,7 +133,7 @@ export const transformTransaction = (transaction: Transaction) => {
         // transform amounts
         amounts.forEach(field => {
             if (typeof operation[field] === 'string') {
-                operation[field] = transformAmount(operation[field]);
+                operation[field] = toStroops(operation[field]).toString();
             }
         });
 

--- a/networks/stellar/network-stellar/tests/transactions.test.ts
+++ b/networks/stellar/network-stellar/tests/transactions.test.ts
@@ -1,7 +1,8 @@
 import { BigNumber } from '@trezor/utils';
 
 import * as fixtures from './transactions.fixture';
-import { buildSendTransaction, toStroops, transformTransaction } from '../src/runtime/transactions';
+import { toStroops } from '../src/constants';
+import { buildSendTransaction, transformTransaction } from '../src/runtime/transactions';
 
 describe('transactions', () => {
     describe('toStroops', () => {

--- a/packages/blockchain-link-utils/src/ripple.ts
+++ b/packages/blockchain-link-utils/src/ripple.ts
@@ -1,4 +1,5 @@
 import type { ServerInfo, Transaction } from '@trezor/blockchain-link-types';
+import { RIPPLE_DECIMALS } from '@trezor/network-ripple/constants';
 import type { AccountTxTransaction, ServerInfoResponse } from '@trezor/network-ripple/types';
 
 export const transformServerInfo = (payload: ServerInfoResponse): Omit<ServerInfo, 'url'> => ({
@@ -7,7 +8,7 @@ export const transformServerInfo = (payload: ServerInfoResponse): Omit<ServerInf
     network: 'xrp',
     testnet: false,
     version: payload.result.info.build_version,
-    decimals: 6,
+    decimals: RIPPLE_DECIMALS,
     blockHeight: payload.result.info.validated_ledger?.seq ?? 0,
     blockHash: payload.result.info.validated_ledger?.hash ?? '',
 });

--- a/packages/blockchain-link/src/workers/ripple/index.ts
+++ b/packages/blockchain-link/src/workers/ripple/index.ts
@@ -8,6 +8,10 @@ import type {
 } from '@trezor/blockchain-link-types';
 import * as utils from '@trezor/blockchain-link-utils/src/ripple';
 import { getSuiteVersion } from '@trezor/env-utils';
+import {
+    RIPPLE_BASE_RESERVE_DEFAULT,
+    RIPPLE_OWNER_RESERVE_DEFAULT,
+} from '@trezor/network-ripple/constants';
 import xrpl from '@trezor/network-ripple/runtime';
 import type { LedgerStream, TransactionStream, XrplAPI } from '@trezor/network-ripple/types';
 import { type TimerId } from '@trezor/type-utils';
@@ -21,8 +25,8 @@ type Request<T> = T & Context;
 const DEFAULT_TIMEOUT = 20 * 1000;
 const DEFAULT_PING_TIMEOUT = 3 * 60 * 1000;
 const RESERVE = {
-    BASE: '10000000',
-    OWNER: '2000000',
+    BASE: RIPPLE_BASE_RESERVE_DEFAULT,
+    OWNER: RIPPLE_OWNER_RESERVE_DEFAULT,
 };
 
 const getInfo = async (request: Request<MessageTypes.GetInfo>) => {

--- a/packages/blockchain-link/src/workers/stellar/index.ts
+++ b/packages/blockchain-link/src/workers/stellar/index.ts
@@ -7,7 +7,11 @@ import type {
 } from '@trezor/blockchain-link-types';
 import * as utils from '@trezor/blockchain-link-utils/src/stellar';
 import { getSuiteVersion, isDesktop, isNative } from '@trezor/env-utils';
-import { STELLAR_BASE_RESERVE, STELLAR_DECIMALS } from '@trezor/network-stellar/constants';
+import {
+    STELLAR_BASE_RESERVE,
+    STELLAR_DECIMALS,
+    toStroops,
+} from '@trezor/network-stellar/constants';
 import stellar from '@trezor/network-stellar/runtime';
 import type { StellarAPI } from '@trezor/network-stellar/types';
 import { type IntervalId } from '@trezor/type-utils';
@@ -64,9 +68,6 @@ const getInfo = async (request: Request<MessageTypes.GetInfo>, isTestnet: boolea
         payload: { ...serverInfo },
     } as const;
 };
-
-const toStroops = (value: string) =>
-    new BigNumber(10).pow(STELLAR_DECIMALS).times(new BigNumber(value));
 
 const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => {
     const { payload } = request;


### PR DESCRIPTION
## Description

Follow-up cleanup to the networks modularization work. Network-specific magic values now live in the network packages and are consumed from the blockchain-link workers instead of being duplicated inline.

- `network-ripple`: adds `RIPPLE_DECIMALS`, `RIPPLE_BASE_RESERVE_DEFAULT` and `RIPPLE_OWNER_RESERVE_DEFAULT` to the constants barrel, and re-exports it via `export * from './constants'`. The ripple worker and `blockchain-link-utils` now import these instead of hardcoding `6` / `'10000000'` / `'2000000'`.
- `network-stellar`: the `toStroops` helper moves into the constants barrel (deduplicated between `identify.ts`, `transform.ts` and the stellar worker, which each carried their own copy). Consumers now import the single shared implementation.

Pure refactor — no behavioral change; the extracted values are identical to what was inlined.

## Notes for QA

No QA needed. This is a no-effect refactor: the centralized constants and the `toStroops` helper are byte-for-byte equivalent to the previous inline values/implementations. Covered by the existing `network-stellar` transactions unit tests (updated to import `toStroops` from its new location).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files affect Ripple (XRP) and Stellar (XLM) network layers — specifically constants, transaction identification/transformation logic, and blockchain-link workers for these two networks. None of the 117 candidate E2E tests exercise Ripple or Stellar functionality directly. The XRP-related test closest would be wallet discovery (which enables XRP among other coins), but the discovery test only checks that account balances are visible after discovery, and the changes to ripple constants/workers are unlikely to cause a discovery regression detectable by that test. The Stellar changes are even more isolated — no E2E test interacts with Stellar accounts or transactions. The swap-token-to-disabled-network test uses XLM as a disabled buy asset but only checks that provider info is displayed in quotes, never touching the Stellar blockchain-link worker or transaction logic. These are low-level network protocol changes best covered by unit tests (like the included transactions.test.ts for Stellar). No E2E tests are recommended as there is no concrete path from these changes to any E2E test's assertions.

<details><summary><b>Changed files (9)</b></summary>

- `networks/ripple/network-ripple/src/constants/index.ts`
- `networks/ripple/network-ripple/src/index.ts`
- `networks/stellar/network-stellar/src/constants/index.ts`
- `networks/stellar/network-stellar/src/runtime/transactions/identify.ts`
- `networks/stellar/network-stellar/src/runtime/transactions/transform.ts`
- `networks/stellar/network-stellar/tests/transactions.test.ts`
- `packages/blockchain-link-utils/src/ripple.ts`
- `packages/blockchain-link/src/workers/ripple/index.ts`
- `packages/blockchain-link/src/workers/stellar/index.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (9)**
- `networks/ripple/network-ripple/src/constants/index.ts`
- `networks/ripple/network-ripple/src/index.ts`
- `networks/stellar/network-stellar/src/constants/index.ts`
- `networks/stellar/network-stellar/src/runtime/transactions/identify.ts`
- `networks/stellar/network-stellar/src/runtime/transactions/transform.ts`
- `networks/stellar/network-stellar/tests/transactions.test.ts`
- `packages/blockchain-link-utils/src/ripple.ts`
- `packages/blockchain-link/src/workers/ripple/index.ts`
- `packages/blockchain-link/src/workers/stellar/index.ts`

_Updated: 2026-07-16T09:21:26.833Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/networks-modularization/web/](https://dev.suite.sldev.cz/suite-web/mroz22/networks-modularization/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/networks-modularization&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/networks-modularization&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-16T09:24:41.574Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-16T09:23:13.279Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->