### PR TITLE
refactor(transport): shrink receive declaration

### DIFF
--- a/packages/transport-common/src/api/abstract.ts
+++ b/packages/transport-common/src/api/abstract.ts
@@ -23,6 +23,16 @@ type AccessLock = {
     read: boolean;
     write: boolean;
 };
+
+export type AbstractApiReadError =
+    | typeof ERRORS.DEVICE_NOT_FOUND
+    | typeof ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE
+    | typeof ERRORS.INTERFACE_DATA_TRANSFER
+    | typeof ERRORS.DEVICE_DISCONNECTED_DURING_ACTION
+    | typeof ERRORS.UNEXPECTED_ERROR
+    | typeof ERRORS.ABORTED_BY_TIMEOUT
+    | typeof ERRORS.ABORTED_BY_SIGNAL;
+
 /**
  * This class defines unifying shape for native communication interfaces such as
  * - navigator.bluetooth
@@ -71,16 +81,7 @@ export abstract class AbstractApi extends TypedEmitter<{
         options?: {
             signal?: AbortSignal;
         },
-    ): AsyncResultWithTypedError<
-        Buffer,
-        | typeof ERRORS.DEVICE_NOT_FOUND
-        | typeof ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE
-        | typeof ERRORS.INTERFACE_DATA_TRANSFER
-        | typeof ERRORS.DEVICE_DISCONNECTED_DURING_ACTION
-        | typeof ERRORS.UNEXPECTED_ERROR
-        | typeof ERRORS.ABORTED_BY_TIMEOUT
-        | typeof ERRORS.ABORTED_BY_SIGNAL
-    >;
+    ): AsyncResultWithTypedError<Buffer, AbstractApiReadError>;
 
     /**
      * write to device on path

--- a/packages/transport-common/src/utils/receive.ts
+++ b/packages/transport-common/src/utils/receive.ts
@@ -2,11 +2,24 @@ import { protobufManager } from '@trezor/protobuf';
 import { PROTOCOL_MALFORMED, type TransportProtocol } from '@trezor/protocol';
 
 import { error, success } from './result';
-import { type AbstractApi } from '../api/abstract';
+import { type AbstractApi, type AbstractApiReadError } from '../api/abstract';
+import { type AsyncResultWithTypedError, type MessageResponse } from '../types';
 
 type Receiver = () => ReturnType<AbstractApi['read']>;
 
-export async function receive<T extends Receiver>(receiver: T, protocol: TransportProtocol) {
+type ReceiveError = AbstractApiReadError | typeof PROTOCOL_MALFORMED;
+
+type ReceivePayload = {
+    messageType: number;
+    payload: Buffer;
+    header: Buffer;
+    length: number;
+};
+
+export async function receive<T extends Receiver>(
+    receiver: T,
+    protocol: TransportProtocol,
+): AsyncResultWithTypedError<ReceivePayload, ReceiveError> {
     const readResult = await receiver();
     if (!readResult.success) {
         return readResult;
@@ -57,7 +70,7 @@ export async function receive<T extends Receiver>(receiver: T, protocol: Transpo
 export async function receiveAndParse<T extends Receiver>(
     receiver: T,
     protocol: TransportProtocol,
-) {
+): AsyncResultWithTypedError<MessageResponse, ReceiveError> {
     const readResult = await receive(receiver, protocol);
     if (!readResult.success) return readResult;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Code improvement to reduce type-declarations to speedup the type-check

Nothing to manually test, only code improvement.

<img width="768" height="187" alt="image" src="https://github.com/user-attachments/assets/b8c04407-7bf6-41c8-8d58-9eee64bee925" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect `packages/transport-common/src/api/abstract.ts` and `packages/transport-common/src/utils/receive.ts`, which are foundational transport layer components used by virtually all E2E tests (126 and 122 tests respectively). Since these are broad infrastructure files, the testing strategy focuses on tests that most directly exercise transport-specific behaviors: session management, device connect/disconnect handling, transport type reporting, message receiving from hardware devices, and discovery resilience across reconnections. Most tests are omitted because they only transitively depend on the transport layer without directly testing transport-specific behavior.

<details><summary><b>Changed files (2)</b></summary>

- `packages/transport-common/src/api/abstract.ts`
- `packages/transport-common/src/utils/receive.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test explicitly validates TransportType event reporting 'BridgeTransport' with a valid version. Changes to the abstract transport API or receive utilities could affect how transport type and version information is communicated, making this a direct regression risk.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test validates Bridge session acquisition, stealing, and reclamation — behaviors directly dependent on the abstract transport API layer. Changes to abstract.ts could break session management or enumeration logic.
- `suite/e2e/tests/suite/bridge.test.ts` — This test directly exercises the Bridge page and WebUSB transport selection flow, which relies on the abstract transport API. Changes to the transport abstraction could break device connection prompts or transport switching.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Wallet discovery depends on stable transport communication to enumerate and discover accounts. The receive utility handles incoming messages from the device during discovery, so changes could cause discovery failures.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test exercises multi-coin discovery with page reload resilience, which stresses the transport layer's ability to re-establish connections and receive responses. Changes to receive.ts or abstract.ts could cause discovery desync after reload.
- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test validates device disconnect/reconnect handling during backup, which directly exercises the transport layer's connection lifecycle. Changes to the abstract transport API could affect disconnect detection or reconnection behavior.
- `suite/e2e/tests/recovery/dry-run.test.ts` — This test validates recovery after bridge stop/restart (simulating disconnect/reconnect) and page reload during device communication. Transport receive and abstract API changes could break the reinitialize-after-reconnect flow.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — Tests persistence of recovery state across device disconnect/reconnect and page reload — scenarios that heavily exercise transport layer reconnection and message receiving logic.
- `suite/e2e/tests/wallet/receive.test.ts` — The receive address flow requires the transport layer to relay address data from the hardware device. Changes to receive.ts (message receiving utility) could directly impact whether addresses are correctly received and displayed.
- `suite/e2e/tests/wallet/public-keys.test.ts` — Public key retrieval from the device requires transport-level message exchange. Changes to the receive utility or abstract transport API could corrupt or drop the public key response from the device.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/wallet/without-device.test.ts` — Tests device disconnection detection and connection modal behavior, which depend on the transport layer's ability to signal device state changes. Changes to abstract.ts could affect disconnect detection.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Tests passphrase wallet behavior across device disconnect/reconnect cycles, exercising transport reconnection and passphrase caching logic that depends on stable transport communication.

</details>

_Updated: 2026-07-16T09:12:49.745Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-oversized-type-declarations-9-receive/web/](https://dev.suite.sldev.cz/suite-web/fix-oversized-type-declarations-9-receive/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-oversized-type-declarations-9-receive&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-oversized-type-declarations-9-receive&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-16T09:15:58.363Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-16T09:15:43.855Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->