### PR TITLE
fix(suite): reduce notification declaration size

### DIFF
--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -21,7 +21,6 @@ const FILES_EXPECTED_TO_GROW = new Set<string>([
 ]);
 
 const KNOWN_OVERSIZED_DECLARATIONS: string[] = [
-    'packages/suite/libDev/src/utils/suite/notification.d.ts',
     'packages/suite/libDev/src/hooks/wallet/useRbfForm.d.ts',
 ];
 

--- a/packages/suite/src/utils/suite/notification.ts
+++ b/packages/suite/src/utils/suite/notification.ts
@@ -1,8 +1,8 @@
 import { type TranslationKey } from '@suite/intl';
-import { type NotificationEntry } from '@suite-common/toast-notifications';
+import { type NotificationsState } from '@suite-common/toast-notifications';
 import { CheckIcon, InfoIcon, WarningIcon } from '@trezor/icons';
 
-import { type AppState, type ToastNotificationVariant } from 'src/types/suite';
+import { type ToastNotificationVariant } from 'src/types/suite';
 
 export const getNotificationIcon = (variant: ToastNotificationVariant) => {
     switch (variant) {
@@ -17,15 +17,22 @@ export const getNotificationIcon = (variant: ToastNotificationVariant) => {
     }
 };
 
-// filter notifications which should not be visible in notifications popup
-export const filterNonActivityNotifications = (notifications: AppState['notifications']) =>
+// Filters notifications which should not be visible in the notifications popup.
+export const filterNonActivityNotifications = (
+    notifications: NotificationsState<TranslationKey>,
+): NotificationsState<TranslationKey> =>
     notifications.filter(notification => notification.type !== 'coin-scheme-protocol');
 
-export const getSeenAndUnseenNotifications = (notifications: AppState['notifications']) => {
-    const seen: Array<NotificationEntry<TranslationKey>> = [];
-    const unseen: Array<NotificationEntry<TranslationKey>> = [];
+export const getSeenAndUnseenNotifications = (
+    notifications: NotificationsState<TranslationKey>,
+): {
+    seenNotifications: NotificationsState<TranslationKey>;
+    unseenNotifications: NotificationsState<TranslationKey>;
+} => {
+    const seen: NotificationsState<TranslationKey> = [];
+    const unseen: NotificationsState<TranslationKey> = [];
 
-    // loop over all notifications and check which of them there were seen or not
+    // Splits notifications based on whether they were seen.
     filterNonActivityNotifications(notifications).forEach(notification => {
         if (notification.seen) {
             seen.push(notification);


### PR DESCRIPTION
If of badly merged https://github.com/trezor/trezor-suite/pull/29894


## Description

Prevents TypeScript from expanding all Invity JSON fixtures into `invityGeneralResponses.d.ts`. The response map now exposes only its endpoint keys and `unknown` JSON values, while individual fixtures remain fully typed.

Also switches to `typedObjectEntries` and preserves endpoint literal types.

Declaration size reduced from **757,236 bytes to 8,121 bytes (98.93%)**. No runtime behavior change.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The two changed files present very low E2E risk. `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts` is a build-time/CI type-checking utility with no runtime impact and no test coverage. `packages/suite/src/utils/suite/notification.ts` is a globally-imported utility that maps to 131 tests, indicating it is a broad shared dependency. Without knowing the specific nature of the change to the notification utility (e.g., whether it changes toast rendering, notification formatting, or is a minor refactor), there is no evidence from the LLM test analysis that any particular test's code path would be uniquely affected — every test that shows toast notifications would be equally impacted. Given the broad-utility heuristic, no individual test can be singled out as high or medium priority without more specific change context. If the notification.ts change is substantive (e.g., altering how toast messages are displayed), a small representative sample of tests that heavily assert on toast notifications could be run, but the risk of false confidence from selecting arbitrary tests is high. Running zero targeted E2E tests is the appropriate recommendation for this change set; unit tests for the notification utility itself would provide better coverage.

<details><summary><b>Changed files (2)</b></summary>

- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`
- `packages/suite/src/utils/suite/notification.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`

_Updated: 2026-07-16T10:35:35.376Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-oversized-type-declarations-5/web/](https://dev.suite.sldev.cz/suite-web/fix-oversized-type-declarations-5/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-oversized-type-declarations-5&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-oversized-type-declarations-5&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-16T10:38:39.983Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-16T10:37:13.490Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->