### PR TITLE
test(request manager): fix testing scripts

### DIFF
--- a/.github/workflows/test-request-manager.yml
+++ b/.github/workflows/test-request-manager.yml
@@ -20,7 +20,9 @@ jobs:
     if: github.repository == 'trezor/trezor-suite'
     timeout-minutes: 60
     env:
-      TEST_SCRIPT: ${{ github.event_name == 'workflow_dispatch' && 'test:e2e' || 'test:all' }}
+      # Run the (unflagged) real-Tor e2e suite on manual dispatch AND on the nightly schedule, so the
+      # flaky-gated circuit-isolation suites are exercised at least daily; PRs still run test:all.
+      TEST_SCRIPT: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && 'test:e2e' || 'test:all' }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6

--- a/packages/request-manager/jest.config.e2e.cjs
+++ b/packages/request-manager/jest.config.e2e.cjs
@@ -2,5 +2,8 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    maxWorkers: 1, // runInBand
+    verbose: true,
     testEnvironment: '../../JestCustomEnv.js',
+    testMatch: ['**/e2e/**/*.test.ts'],
 };

--- a/packages/request-manager/jest.config.unit.cjs
+++ b/packages/request-manager/jest.config.unit.cjs
@@ -1,0 +1,8 @@
+const baseConfig = require('../../jest.config.base.swc');
+
+module.exports = {
+    ...baseConfig,
+    verbose: true,
+    testEnvironment: '../../JestCustomEnv.js',
+    testMatch: ['**/tests/**/*.test.ts'],
+};

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -6,9 +6,9 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "scripts": {
-        "test:all": "SKIP_FLAKY_TESTS=1 yarn g:jest",
-        "test:unit": "yarn g:jest --testPathIgnorePatterns e2e",
-        "test:e2e": "yarn g:jest --runInBand --testPathIgnorePatterns tests",
+        "test:all": "yarn test:unit && SKIP_FLAKY_TESTS=1 yarn test:e2e",
+        "test:unit": "yarn g:jest -c jest.config.unit.cjs",
+        "test:e2e": "yarn g:jest -c jest.config.e2e.cjs",
         "type-check": "yarn g:tsc --build tsconfig.json",
         "test:stress": "tsx ./e2e/identities-stress.ts",
         "depcheck": "yarn g:depcheck",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

cherrypicked from https://github.com/trezor/trezor-suite/pull/28538

test scripts are broken, there is no way to explicitly include test pattern when `--testPathIgnorePatterns` is used - actually it does the opposite and ignores them:

`yarn workspace @trezor/request-manager test:unit interceptor` should run 2 tests files (tests/interceptor-*) , but instead it runs the one i dont want (tests/torSimulator.test.ts)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/request-manager-test-scripts/web/](https://dev.suite.sldev.cz/suite-web/test/request-manager-test-scripts/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/request-manager-test-scripts&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/request-manager-test-scripts&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect.ethereumSignMessage > TrezorConnect.ethereumSignMessage | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect > Error screen | 🤖 auto |
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-21T14:25:15.654Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-21T14:25:40.915Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->