### PR TITLE
refactor(connect): shrink core module declaration

### DIFF
--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -35,9 +35,12 @@ import { initCoreState } from '../core';
 export abstract class CoreInModule implements TrezorConnectCore<ConnectSettings> {
     private readonly eventEmitter = new ConnectEmitter();
 
-    public on = this.eventEmitter.on.bind(this.eventEmitter);
-    public off = this.eventEmitter.removeListener.bind(this.eventEmitter);
-    public removeAllListeners = this.eventEmitter.removeAllListeners.bind(this.eventEmitter);
+    public on: ConnectEmitter['on'] = this.eventEmitter.on.bind(this.eventEmitter);
+    public off: ConnectEmitter['removeListener'] = this.eventEmitter.removeListener.bind(
+        this.eventEmitter,
+    );
+    public removeAllListeners: ConnectEmitter['removeAllListeners'] =
+        this.eventEmitter.removeAllListeners.bind(this.eventEmitter);
 
     protected settings;
     private coreManager;


### PR DESCRIPTION
## Description

TypeScript expanded the complete `ConnectEmitter` event map three times for inferred `on`, `off`, and `removeAllListeners` declarations.

Explicit member types preserve the same API while reducing `core-in-module.d.ts` from **99,918 to 1,849 bytes**.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to packages/connect/src/impl/core-in-module.ts, which is the in-process implementation of the trezor-connect core — the fundamental bridge between the Suite application and the Trezor hardware device. This file maps to all 131 E2E tests because every device interaction flows through it. The risk profile is high because any regression could break device communication entirely. The recommended strategy focuses on tests that exercise distinct connect API paths (discovery, getAddress, getPublicKey, signMessage, applySettings, backupDevice) and stress session management (reconnection, multi-session, passphrase caching), rather than running all 131 tests.

<details><summary><b>Changed files (1)</b></summary>

- `packages/connect/src/impl/core-in-module.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — core-in-module.ts is the core implementation of trezor-connect used in-process. Wallet discovery is the fundamental flow that exercises the connect module's device communication pipeline end-to-end — discovering accounts via the transport layer. A regression here would break all wallet functionality.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coin networks and triggers full account discovery with a reload mid-discovery, directly stressing the connect core module's session management, device communication, and discovery lifecycle. It's the most comprehensive discovery stress test.
- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — The authenticity check flow requires direct device communication through trezor-connect's core module during onboarding. A regression in core-in-module.ts could break the device authentication handshake, which is a critical security feature.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test directly exercises Bridge session acquisition, theft, and reclamation — core-in-module.ts manages the transport/session lifecycle. Session management bugs would manifest here as device status failures.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — Receiving addresses requires getAddress calls through trezor-connect core to the device. This test verifies the connect module correctly relays device responses for multiple coin types (BTC, ETH, SOL, TRX).
- `suite/e2e/tests/wallet/public-keys.test.ts` — Displaying XPUBs requires getPublicKey calls through the connect core module. This test exercises the device communication path for multiple networks and verifies correct key derivation responses.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Sign and verify flows use signMessage/verifyMessage through the connect core module. These are distinct API calls that exercise the core module's method dispatch and device interaction differently than discovery or address flows.
- `suite/e2e/tests/backup/t2t1-success.test.ts` — Backup creation requires multi-step device communication (resetDevice/backupDevice calls) through the connect core module. A regression could silently break the backup flow.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test exercises device disconnect/reconnect with passphrase caching — core-in-module.ts manages device state and session persistence. Passphrase caching across reconnections is handled at the connect core level.
- `suite/e2e/tests/recovery/dry-run.test.ts` — Recovery dry run tests device reconnection during an active connect call, and page reload recovery — both directly stress the core module's error handling and session reinitialization logic.
- `suite/e2e/tests/settings/passphrase.test.ts` — Enabling passphrase protection requires applySettings device call through the connect core module. This is a simple but critical device settings mutation path.

</details>

_Updated: 2026-07-16T10:40:05.735Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-oversized-type-declarations-core-in-module/web/](https://dev.suite.sldev.cz/suite-web/fix-oversized-type-declarations-core-in-module/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-oversized-type-declarations-core-in-module&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-oversized-type-declarations-core-in-module&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-oversized-type-declarations-core-in-module&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-16T10:43:17.102Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-16T10:42:55.341Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->