### PR TITLE
test(coinjoin): shrink account action fixture declaration

### DIFF
--- a/suite/coinjoin/src/__fixtures__/coinjoinAccountActions.ts
+++ b/suite/coinjoin/src/__fixtures__/coinjoinAccountActions.ts
@@ -1,10 +1,52 @@
 import { goto } from '@suite/router';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { accountsActions } from '@suite-common/wallet-core';
-import { type Account } from '@suite-common/wallet-types';
+import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
 import * as COINJOIN from '../coinjoinConstants';
+
+type FixtureResult = {
+    actions: string[];
+};
+
+type CreateCoinjoinAccountFixture = {
+    description: string;
+    connect?: unknown;
+    params: {
+        network: {
+            symbol: string;
+            networkType: string;
+        };
+        account: {
+            accountType: string;
+            bip43Path?: string;
+        };
+    };
+    result: FixtureResult;
+};
+
+type StartCoinjoinSessionFixture = {
+    description: string;
+    connect?: unknown;
+    state?: Record<string, unknown>;
+    params: Partial<Account>;
+    result: FixtureResult;
+};
+
+type CoinjoinSessionFixture = {
+    description: string;
+    client?: string;
+    state: Record<string, unknown>;
+    param: AccountKey;
+    result: FixtureResult;
+};
+
+type RestoreCoinjoinAccountsFixture = {
+    description: string;
+    state: Record<string, unknown>;
+    result: FixtureResult;
+};
 
 const ACCOUNT_KEY_12345 = mockAccountKey({ descriptor: '12345' });
 
@@ -23,7 +65,7 @@ const CJ_ACCOUNT = {
 
 const SESSION = { signedRounds: [] as string[], maxRounds: 10 };
 
-export const createCoinjoinAccount = [
+export const createCoinjoinAccount: CreateCoinjoinAccountFixture[] = [
     {
         description: 'unsupported coinjoin client',
         params: {
@@ -150,7 +192,7 @@ export const createCoinjoinAccount = [
     },
 ];
 
-export const startCoinjoinSession = [
+export const startCoinjoinSession: StartCoinjoinSessionFixture[] = [
     {
         description: 'client not found',
         params: {
@@ -215,7 +257,7 @@ export const startCoinjoinSession = [
     },
 ];
 
-export const stopCoinjoinSession = [
+export const stopCoinjoinSession: CoinjoinSessionFixture[] = [
     {
         description: 'client not found',
         state: {
@@ -245,7 +287,7 @@ export const stopCoinjoinSession = [
     },
 ];
 
-export const restoreCoinjoinAccounts = [
+export const restoreCoinjoinAccounts: RestoreCoinjoinAccountsFixture[] = [
     {
         description: 'four accounts, two networks, one success, one errored',
         state: {
@@ -277,7 +319,7 @@ export const restoreCoinjoinAccounts = [
     },
 ];
 
-export const restoreCoinjoinSession = [
+export const restoreCoinjoinSession: CoinjoinSessionFixture[] = [
     {
         description: 'restore one paused coinjoin session',
         client: 'btc',


### PR DESCRIPTION
## Description

The Coinjoin test fixture exported fully inferred heterogeneous arrays, causing TypeScript to expand large account and mock-state types into its declaration.

Explicit fixture contracts preserve test coverage while reducing `coinjoinAccountActions.d.ts` from **93,566 to 1,360 bytes**.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is a test fixture file (`suite/coinjoin/src/__fixtures__/coinjoinAccountActions.ts`) used for unit tests of coinjoin account actions. This file is not referenced by any of the 106 candidate E2E tests, and none of the E2E tests cover coinjoin account action logic based on their behavioral descriptions and source hints. The change is isolated to coinjoin unit test fixtures and poses negligible risk to any end-to-end user flows. No E2E tests need to be run for this change.

<details><summary><b>Changed files (1)</b></summary>

- `suite/coinjoin/src/__fixtures__/coinjoinAccountActions.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite/coinjoin/src/__fixtures__/coinjoinAccountActions.ts`

_Updated: 2026-07-16T10:48:47.883Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-oversized-type-declarations-coinjoin-account-actions/web/](https://dev.suite.sldev.cz/suite-web/fix-oversized-type-declarations-coinjoin-account-actions/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-oversized-type-declarations-coinjoin-account-actions&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-oversized-type-declarations-coinjoin-account-actions&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-16T10:52:08.372Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-16T10:51:49.202Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->