### PR TITLE
fix(trading): keep exchange quote-selection errors on form

### DIFF
--- a/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
@@ -389,7 +389,7 @@ describe('confirmExchangeTradeThunk', () => {
         });
     });
 
-    it('should route a failed trade with orderId to the detail page instead of a toast', async () => {
+    it('should route a failed submitted trade with orderId to the detail page instead of a toast', async () => {
         const {
             store,
             returnUrl,
@@ -420,6 +420,7 @@ describe('confirmExchangeTradeThunk', () => {
                     receiveAddress,
                     account,
                     trade,
+                    isTradeSubmitted: true,
                     nextStep: mockNextStep,
                     triggerAnalyticsTradeConfirmation: mockTriggerAnalyticsTradeConfirmation,
                     processResponseData: mockProcessResponseData,
@@ -446,7 +447,7 @@ describe('confirmExchangeTradeThunk', () => {
         expect(!!response).toBeFalsy();
     });
 
-    it('should keep a failed approvalFlow trade with orderId on the form instead of routing to detail', async () => {
+    it('should keep a failed trade with orderId on the form instead of routing to detail when it is not submitted', async () => {
         const {
             store,
             returnUrl,
@@ -474,7 +475,6 @@ describe('confirmExchangeTradeThunk', () => {
                     receiveAddress,
                     account,
                     trade,
-                    approvalFlow: true,
                     nextStep: mockNextStep,
                     triggerAnalyticsTradeConfirmation: mockTriggerAnalyticsTradeConfirmation,
                     processResponseData: mockProcessResponseData,

--- a/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
@@ -24,6 +24,7 @@ export type ConfirmExchangeTradeThunkProps = {
     extraField?: string;
     trade?: ExchangeTrade;
     approvalFlow?: boolean;
+    isTradeSubmitted?: boolean;
 
     triggerAnalyticsTradeConfirmation: () => void;
     processResponseData: (response: ExchangeTrade) => void;
@@ -40,6 +41,7 @@ export const confirmExchangeTradeThunk = createThunk(
             account,
             extraField,
             approvalFlow = false,
+            isTradeSubmitted = false,
             triggerAnalyticsTradeConfirmation,
             processResponseData,
             nextStep,
@@ -114,7 +116,7 @@ export const confirmExchangeTradeThunk = createThunk(
             dispatch(tradingExchangeActions.saveSelectedQuote(response));
 
             const shouldRouteFailedTradeToDetail =
-                !approvalFlow && response.status === 'ERROR' && !!response.orderId;
+                isTradeSubmitted && response.status === 'ERROR' && !!response.orderId;
 
             if (shouldRouteFailedTradeToDetail) {
                 dispatch(

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -162,6 +162,7 @@ export const sendDexTransactionThunk = createThunk<
                 returnUrl,
                 receiveAddress: trade.receiveAddress,
                 account,
+                isTradeSubmitted: true,
                 triggerAnalyticsTradeConfirmation,
                 processResponseData,
                 nextStep: isSwapTx ? undefined : nextStep,

--- a/suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts
@@ -137,6 +137,7 @@ export const signDataAndConfirmThunk = createThunk<
                 returnUrl,
                 receiveAddress: trade.receiveAddress,
                 account,
+                isTradeSubmitted: true,
                 triggerAnalyticsTradeConfirmation,
                 processResponseData,
                 nextStep,


### PR DESCRIPTION
## Description

Swap form-phase errors (e.g. ETH→AVAX `invalid_address`) wrongly routed to the "Transaction failed" detail page, because partners return an `orderId` even on early quote-selection errors and the old `orderId`-based heuristic treated that as a terminal failure.

Fix: explicit `isTradeSubmitted` flag on `confirmExchangeTradeThunk`. Default = stay on form + toast; only the submission thunks (DEX broadcast, EIP-712 confirm) route failures to detail.

## Notes for QA

- Swap ETH→AVAX with an invalid address → toast, form stays open (not Transaction failed).
- Failed terminal confirm after submit (DEX + 1inch Fusion+) → still lands on Transaction failed.

## Related Issue

Related to #29691

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on the trading exchange thunks: confirmExchangeTradeThunk, sendDexTransactionThunk, and signDataAndConfirmThunk, plus a unit test file. These thunks are core to the swap/exchange trading flow — confirming trades, sending DEX transactions, and signing data. Despite mapping to 131 tests via static analysis (indicating they are bundled as part of the broad trading module), only the swap/exchange-related E2E tests directly exercise this functionality. The recommended strategy focuses on the ~14 swap-related tests that validate the end-to-end exchange flows (CEX and DEX), with high priority on tests that complete full swap transactions and medium priority on supporting tests (fees, inputs, history). The unit test file has no E2E coverage but is self-contained.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts`
- `suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts`
- `suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts`
- `suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This test directly exercises the DEX swap flow including sendDexTransactionThunk (sending a DEX transaction) and confirmExchangeTradeThunk (confirming the swap trade). It verifies gas limit, fees, device confirmation, broadcast, and status transitions — all core paths through the changed thunks.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test covers the full CEX swap flow (SOL→BTC) including confirming the exchange trade, sending crypto, and watching status transitions (CONFIRMING→CONVERTING→SUCCESS). It directly exercises confirmExchangeTradeThunk for trade confirmation and the swap send path.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests swapping SOL to USDC token, exercising the exchange trade confirmation flow and send confirmation. Directly validates the confirmExchangeTradeThunk path for cross-chain token swaps.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping USDT token to BTC, covering the exchange trade confirm and send paths including token confirmation flow. Directly exercises confirmExchangeTradeThunk for token-to-coin swaps.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests swapping SPL tokens (USDT→USDC) on Solana, exercising the exchange trade confirmation and send flow for token-to-token swaps. Directly validates confirmExchangeTradeThunk behavior.
- `suite/e2e/tests/trading-poc/passthru-swap-eth-to-btc.test.ts` — This passthrough test uses live swap quotes for ETH→BTC and exercises the full confirmExchangeTradeThunk path including composed transaction info validation, device confirmation, and broadcast. It also validates Redux state for composedTransactionInfo which is populated by the exchange thunks.
- `suite/e2e/tests/trading-poc/passthru-swap-sol-to-btc.test.ts` — Passthrough swap test for SOL→BTC exercising the exchange trade confirmation flow, device signing, broadcast blocking, and status transitions. Directly tests the confirmExchangeTradeThunk and swap send paths.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests swap BTC→ETH with custom fees, validating Redux state 'wallet.trading.composedTransactionInfo' which is populated during the exchange confirmation flow. Changes to confirmExchangeTradeThunk could affect transaction composition.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests swap ETH→BTC with custom Ethereum gas fees, validating composedTransactionInfo Redux state. The exchange thunks are responsible for populating this state during swap confirmation.
- `suite/e2e/tests/trading/swap-history.test.ts` — Tests viewing swap trade history and detail status. Changes to confirmExchangeTradeThunk could affect how trade records are stored and displayed, including status transitions shown in the history view.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests the swap form inputs, provider selection, and quote display. While primarily a form/UI test, it validates that quotes sync correctly and providers are displayed, which feeds into the exchange confirmation thunk flow.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swap form behavior when the buy asset is on a disabled network. While it doesn't complete a trade, it exercises the swap quote/provider display infrastructure that precedes confirmExchangeTradeThunk.
- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — Live swap test (SOL→USDC across chains) that exercises the full exchange trade flow with real providers. Changes to the exchange thunks could break the live swap confirmation and send paths.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Live swap test (USDT→SOL via CEX) exercising exchange trade confirmation and send flow with real providers. Changes to confirmExchangeTradeThunk or signDataAndConfirmThunk could affect this path.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts`

_Updated: 2026-07-16T11:22:15.990Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/exchange-quote-selection-error-form/web/](https://dev.suite.sldev.cz/suite-web/fix/exchange-quote-selection-error-form/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/exchange-quote-selection-error-form&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/exchange-quote-selection-error-form&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/exchange-quote-selection-error-form&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-16T11:25:05.139Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-16T11:24:57.498Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->