### PR TITLE
test: reduce fixture declaration sizes

### DIFF
--- a/packages/connect/e2e/__fixtures__/applyFlags.ts
+++ b/packages/connect/e2e/__fixtures__/applyFlags.ts
@@ -1,4 +1,4 @@
-export default {
+const applyFlags: TestCase = {
     method: 'applyFlags',
     setup: {
         mnemonic: 'mnemonic_12',
@@ -14,4 +14,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default applyFlags;

--- a/packages/connect/e2e/__fixtures__/applySettings.ts
+++ b/packages/connect/e2e/__fixtures__/applySettings.ts
@@ -1,4 +1,4 @@
-export default {
+const applySettings: TestCase = {
     method: 'applySettings',
     setup: {
         mnemonic: 'mnemonic_12',
@@ -26,4 +26,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default applySettings;

--- a/packages/connect/e2e/__fixtures__/cardanoGetAddress.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoGetAddress.ts
@@ -11,7 +11,7 @@ const legacyResults = {
     },
 };
 
-export default {
+const cardanoGetAddress: TestCase = {
     method: 'cardanoGetAddress',
     enabledCoins: ['ada'] as const,
     setup: {
@@ -506,4 +506,6 @@ export default {
             result: false,
         },
     ].map(test => ({ ...test, legacyResults: [legacyResults.minConnectVersion] })),
-} satisfies TestCase;
+};
+
+export default cardanoGetAddress;

--- a/packages/connect/e2e/__fixtures__/cardanoGetAddressDerivations.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoGetAddressDerivations.ts
@@ -14,7 +14,7 @@ const legacyResults = {
     },
 };
 
-export default {
+const cardanoGetAddressDerivations: TestCase = {
     method: 'cardanoGetAddress',
     enabledCoins: ['ada'] as const,
     setup: {
@@ -39,4 +39,6 @@ export default {
         },
         legacyResults: [legacyResults.minConnectVersion],
     })),
-} satisfies TestCase;
+};
+
+export default cardanoGetAddressDerivations;

--- a/packages/connect/e2e/__fixtures__/cardanoGetNativeScriptHash.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoGetNativeScriptHash.ts
@@ -10,7 +10,7 @@ const legacyResults = {
     },
 };
 
-export default {
+const cardanoGetNativeScriptHash: TestCase = {
     method: 'cardanoGetNativeScriptHash',
     enabledCoins: ['ada'] as const,
     setup: {
@@ -316,4 +316,6 @@ export default {
             },
         },
     ].map(test => ({ ...test, legacyResults: [legacyResults.minConnectVersion] })),
-} satisfies TestCase;
+};
+
+export default cardanoGetNativeScriptHash;

--- a/packages/connect/e2e/__fixtures__/cardanoGetPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoGetPublicKey.ts
@@ -13,7 +13,7 @@ const showOnTrezorDisplayablePublicKey =
     'd507c8f866691bd96e131334c355188b1a1d0b2fa0ab11545075aab332d77d9eb19657ad13ee581b56b0f8d744d66ca356b93d42fe176b3de007d53e9c4c4e7a';
 const showOnTrezorDeviceScreen = showOnTrezorDisplayablePublicKey.slice(0, 40);
 
-export default {
+const cardanoGetPublicKey: TestCase = {
     method: 'cardanoGetPublicKey',
     enabledCoins: ['ada'] as const,
     setup: {
@@ -96,4 +96,6 @@ export default {
             deviceScreenSkip: ['1', '<2.7.0'],
         },
     ].map(t => ({ ...t, legacyResults: [legacyResults.minConnectVersion] })),
-} satisfies TestCase;
+};
+
+export default cardanoGetPublicKey;

--- a/packages/connect/e2e/__fixtures__/cardanoSignMessage.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoSignMessage.ts
@@ -21,7 +21,7 @@ const headerUnhashed = (address: string) => ({
 /** "HelloTrezor!" repeated 86 times (=1032 bytes) in hex */
 const HELLO_TREZOR_86 = '48656c6c6f5472657a6f7221'.repeat(86);
 
-export default {
+const cardanoSignMessage: TestCase = {
     method: 'cardanoSignMessage',
     enabledCoins: ['ada'] as const,
     setup: {
@@ -130,3 +130,5 @@ export default {
         },
     ],
 };
+
+export default cardanoSignMessage;

--- a/packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts
@@ -449,7 +449,7 @@ const legacyResults = {
     },
 };
 
-export default {
+const cardanoSignTransaction: TestCase = {
     method: 'cardanoSignTransaction',
     enabledCoins: ['ada'] as const,
     setup: {
@@ -2909,4 +2909,6 @@ export default {
 
         return { ...test, legacyResults: [legacyResults.minConnectVersion] };
     }),
-} satisfies TestCase;
+};
+
+export default cardanoSignTransaction;

--- a/packages/connect/e2e/__fixtures__/changeLanguage.ts
+++ b/packages/connect/e2e/__fixtures__/changeLanguage.ts
@@ -1,4 +1,4 @@
-export default {
+const changeLanguage: TestCase = {
     method: 'changeLanguage',
     setup: {
         mnemonic: 'mnemonic_12',
@@ -15,4 +15,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default changeLanguage;

--- a/packages/connect/e2e/__fixtures__/composeTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/composeTransaction.ts
@@ -64,7 +64,7 @@ const DOGE_FEE_LEVELS = [
     },
 ];
 
-export default {
+const composeTransaction: TestCase = {
     method: 'composeTransaction',
     setup: {
         mnemonic: undefined, // device is not used in this test case
@@ -440,4 +440,6 @@ export default {
             ],
         },
     ],
-} satisfies TestCase;
+};
+
+export default composeTransaction;

--- a/packages/connect/e2e/__fixtures__/ethereumGetAddress.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumGetAddress.ts
@@ -12,7 +12,7 @@ const legacyResults: Record<string, LegacyResult[]> = {
     ],
 };
 
-export default {
+const ethereumGetAddress: TestCase = {
     method: 'ethereumGetAddress',
     setup: {
         mnemonic: commonFixtures.setup.mnemonic,
@@ -55,4 +55,6 @@ export default {
             ],
         },
     ],
-} satisfies TestCase;
+};
+
+export default ethereumGetAddress;

--- a/packages/connect/e2e/__fixtures__/ethereumGetPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumGetPublicKey.ts
@@ -30,10 +30,12 @@ const firstShowOnTrezor = {
     deviceScreenSkip: ['1', '<2.7.0'],
 };
 
-export default {
+const ethereumGetPublicKey: TestCase = {
     method: 'ethereumGetPublicKey',
     setup: {
         mnemonic: commonFixtures.setup.mnemonic,
     },
     tests: [...generatedTests, firstShowOnTrezor],
-} satisfies TestCase;
+};
+
+export default ethereumGetPublicKey;

--- a/packages/connect/e2e/__fixtures__/ethereumSignMessage.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignMessage.ts
@@ -9,7 +9,7 @@ const [standardPathFixtures, nonstandardPathFixtures] = arrayPartition(
     ({ parameters }) => parameters.path.startsWith("m/44'/60'"),
 );
 
-export default {
+const ethereumSignMessage: TestCase = {
     method: 'ethereumSignMessage',
     setup: {
         mnemonic: commonFixtures.setup.mnemonic,
@@ -49,4 +49,6 @@ export default {
             ],
         })),
     ],
-} satisfies TestCase;
+};
+
+export default ethereumSignMessage;

--- a/packages/connect/e2e/__fixtures__/ethereumSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignTransaction.ts
@@ -25,7 +25,7 @@ const legacyResults: Record<string, LegacyResult[]> = {
     ],
 };
 
-export default {
+const ethereumSignTransaction: TestCase = {
     method: 'ethereumSignTransaction',
     setup: {
         mnemonic: commonFixtures.setup.mnemonic,
@@ -149,4 +149,6 @@ export default {
                 result: false,
             },
         ]),
-} satisfies TestCase;
+};
+
+export default ethereumSignTransaction;

--- a/packages/connect/e2e/__fixtures__/ethereumSignTransactionDefinitions.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignTransactionDefinitions.ts
@@ -1,4 +1,4 @@
-export default {
+const ethereumSignTransactionDefinitions: TestCase = {
     method: 'ethereumSignTransaction',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -27,4 +27,6 @@ export default {
             deviceScreenSkip: ['1', '<2.12.1'],
         },
     ],
-} satisfies TestCase;
+};
+
+export default ethereumSignTransactionDefinitions;

--- a/packages/connect/e2e/__fixtures__/ethereumSignTransactionEip155.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignTransactionEip155.ts
@@ -40,7 +40,7 @@ const legacyResults: Record<string, LegacyResult[]> = {
     ];
 });
 
-export default {
+const ethereumSignTransactionEip155: TestCase = {
     method: 'ethereumSignTransaction',
     setup: {
         mnemonic: commonFixtures.setup.mnemonic,
@@ -80,4 +80,6 @@ export default {
 
             return fixture;
         }),
-} satisfies TestCase;
+};
+
+export default ethereumSignTransactionEip155;

--- a/packages/connect/e2e/__fixtures__/ethereumSignTransactionEip1559.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignTransactionEip1559.ts
@@ -20,7 +20,7 @@ const legacyResultsCommon = [
     },
 ];
 
-export default {
+const ethereumSignTransactionEip1559: TestCase = {
     method: 'ethereumSignTransaction',
     setup: {
         mnemonic: commonFixtures.setup.mnemonic,
@@ -58,4 +58,6 @@ export default {
 
         return fixture;
     }),
-} satisfies TestCase;
+};
+
+export default ethereumSignTransactionEip1559;

--- a/packages/connect/e2e/__fixtures__/ethereumSignTypedData.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignTypedData.ts
@@ -113,10 +113,12 @@ const fixtures = [...ethereumDefinitionFixture, ...commonFixtures.tests]
         return [fixture, autoComputeFixture];
     });
 
-export default {
+const ethereumSignTypedData: TestCase = {
     method: 'ethereumSignTypedData',
     setup: {
         mnemonic: commonFixtures.setup.mnemonic,
     },
     tests: fixtures,
-} satisfies TestCase;
+};
+
+export default ethereumSignTypedData;

--- a/packages/connect/e2e/__fixtures__/ethereumVerifyMessage.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumVerifyMessage.ts
@@ -2,7 +2,7 @@
 // @ts-ignore
 import commonFixtures from '../../../../submodules/trezor-common/tests/fixtures/ethereum/verifymessage.json';
 
-export default {
+const ethereumVerifyMessage: TestCase = {
     method: 'ethereumVerifyMessage',
     setup: {
         mnemonic: commonFixtures.setup.mnemonic,
@@ -18,4 +18,6 @@ export default {
             message: 'Message verified',
         },
     })),
-} satisfies TestCase;
+};
+
+export default ethereumVerifyMessage;

--- a/packages/connect/e2e/__fixtures__/getAccountInfo.ts
+++ b/packages/connect/e2e/__fixtures__/getAccountInfo.ts
@@ -1,4 +1,4 @@
-export default {
+const getAccountInfo: TestCase = {
     method: 'getAccountInfo',
     setup: {
         mnemonic: 'mnemonic_12',
@@ -159,4 +159,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default getAccountInfo;

--- a/packages/connect/e2e/__fixtures__/getAddress.ts
+++ b/packages/connect/e2e/__fixtures__/getAddress.ts
@@ -1,4 +1,4 @@
-export default {
+const getAddress: TestCase = {
     method: 'getAddress',
     setup: {
         mnemonic: 'mnemonic_12',
@@ -132,4 +132,6 @@ export default {
             ],
         },
     ],
-} satisfies TestCase;
+};
+
+export default getAddress;

--- a/packages/connect/e2e/__fixtures__/getAddressMultisig.ts
+++ b/packages/connect/e2e/__fixtures__/getAddressMultisig.ts
@@ -17,7 +17,7 @@ const multisig = {
     m: 2,
 };
 
-export default {
+const getAddressMultisig: TestCase = {
     method: 'getAddress',
     setup: {
         mnemonic: 'mnemonic_12',
@@ -63,4 +63,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default getAddressMultisig;

--- a/packages/connect/e2e/__fixtures__/getAddressMultisigPubkeysOrder.ts
+++ b/packages/connect/e2e/__fixtures__/getAddressMultisigPubkeysOrder.ts
@@ -49,7 +49,7 @@ const addressUnsorted1 = '3DKeup4KhFpvJPpqnPRdZMte73YZC3v8dS';
 const addressUnsorted2 = '3DpiomhFpTzGJZNksqn67pW5AUV1xHBMG1';
 
 // trezorctl btc get-address -n m/45h/0/0/0 -m 2 -x xpub1 -x xpub2 --multisig-sort-pubkeys
-export default {
+const getAddressMultisigPubkeysOrder: TestCase = {
     method: 'getAddress',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -116,4 +116,6 @@ export default {
             ],
         },
     ],
-} satisfies TestCase;
+};
+
+export default getAddressMultisigPubkeysOrder;

--- a/packages/connect/e2e/__fixtures__/getAddressSegwit.ts
+++ b/packages/connect/e2e/__fixtures__/getAddressSegwit.ts
@@ -1,4 +1,4 @@
-export default {
+const getAddressSegwit: TestCase = {
     method: 'getAddress',
     setup: {
         mnemonic: 'mnemonic_12',
@@ -49,4 +49,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default getAddressSegwit;

--- a/packages/connect/e2e/__fixtures__/getFeatures.ts
+++ b/packages/connect/e2e/__fixtures__/getFeatures.ts
@@ -139,10 +139,12 @@ const tests = [
     },
 ];
 
-export default {
+const getFeatures: TestCase = {
     method: 'getFeatures',
     setup: {
         mnemonic: 'mnemonic_12',
     },
     tests,
-} satisfies TestCase;
+};
+
+export default getFeatures;

--- a/packages/connect/e2e/__fixtures__/getFirmwareHash.ts
+++ b/packages/connect/e2e/__fixtures__/getFirmwareHash.ts
@@ -1,4 +1,4 @@
-export default {
+const getFirmwareHash: TestCase = {
     method: 'getFirmwareHash',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -24,4 +24,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default getFirmwareHash;

--- a/packages/connect/e2e/__fixtures__/getOwnershipId.ts
+++ b/packages/connect/e2e/__fixtures__/getOwnershipId.ts
@@ -10,7 +10,7 @@ const legacyResults = [
     },
 ];
 
-export default {
+const getOwnershipId: TestCase = {
     method: 'getOwnershipId',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -69,4 +69,6 @@ export default {
             legacyResults,
         },
     ],
-} satisfies TestCase;
+};
+
+export default getOwnershipId;

--- a/packages/connect/e2e/__fixtures__/getOwnershipProof.ts
+++ b/packages/connect/e2e/__fixtures__/getOwnershipProof.ts
@@ -10,7 +10,7 @@ const legacyResults = [
     },
 ];
 
-export default {
+const getOwnershipProof: TestCase = {
     method: 'getOwnershipProof',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -104,4 +104,6 @@ export default {
             legacyResults,
         },
     ],
-} satisfies TestCase;
+};
+
+export default getOwnershipProof;

--- a/packages/connect/e2e/__fixtures__/getPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/getPublicKey.ts
@@ -15,7 +15,7 @@ const p2pkhDisplayablePublicKey =
     'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH';
 const p2pkhDeviceScreen = p2pkhDisplayablePublicKey.slice(0, 37);
 
-export default {
+const getPublicKey: TestCase = {
     method: 'getPublicKey',
     setup: {
         mnemonic: 'mnemonic_12',
@@ -206,4 +206,6 @@ export default {
             result: false,
         },
     ],
-} satisfies TestCase;
+};
+
+export default getPublicKey;

--- a/packages/connect/e2e/__fixtures__/getPublicKeyBip48.ts
+++ b/packages/connect/e2e/__fixtures__/getPublicKeyBip48.ts
@@ -1,4 +1,4 @@
-export default {
+const getPublicKeyBip48: TestCase = {
     method: 'getPublicKey',
     setup: {
         mnemonic: 'mnemonic_12',
@@ -39,4 +39,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default getPublicKeyBip48;

--- a/packages/connect/e2e/__fixtures__/loadDevice.ts
+++ b/packages/connect/e2e/__fixtures__/loadDevice.ts
@@ -1,4 +1,4 @@
-export default {
+const loadDevice: TestCase = {
     method: 'loadDevice',
     setup: {
         wiped: true,
@@ -15,4 +15,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default loadDevice;

--- a/packages/connect/e2e/__fixtures__/moneroGetAddress.ts
+++ b/packages/connect/e2e/__fixtures__/moneroGetAddress.ts
@@ -5,7 +5,7 @@ const legacyResults = [
     },
 ];
 
-export default {
+const moneroGetAddress: TestCase = {
     method: 'moneroGetAddress',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -200,4 +200,6 @@ export default {
             legacyResults,
         },
     ],
-} satisfies TestCase;
+};
+
+export default moneroGetAddress;

--- a/packages/connect/e2e/__fixtures__/moneroGetWatchKey.ts
+++ b/packages/connect/e2e/__fixtures__/moneroGetWatchKey.ts
@@ -5,7 +5,7 @@ const legacyResults = [
     },
 ];
 
-export default {
+const moneroGetWatchKey: TestCase = {
     method: 'moneroGetWatchKey',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -85,4 +85,6 @@ export default {
             legacyResults,
         },
     ],
-} satisfies TestCase;
+};
+
+export default moneroGetWatchKey;

--- a/packages/connect/e2e/__fixtures__/moneroKeyImageSync.ts
+++ b/packages/connect/e2e/__fixtures__/moneroKeyImageSync.ts
@@ -5,7 +5,7 @@ const legacyResults = [
     },
 ];
 
-export default {
+const moneroKeyImageSync: TestCase = {
     method: 'moneroKeyImageSync',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -202,4 +202,6 @@ export default {
             legacyResults,
         },
     ],
-} satisfies TestCase;
+};
+
+export default moneroKeyImageSync;

--- a/packages/connect/e2e/__fixtures__/moneroSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/moneroSignTransaction.ts
@@ -5,7 +5,7 @@ const legacyResults = [
     },
 ];
 
-export default {
+const moneroSignTransaction: TestCase = {
     method: 'moneroSignTransaction',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -1015,4 +1015,6 @@ export default {
             legacyResults,
         },
     ],
-} satisfies TestCase;
+};
+
+export default moneroSignTransaction;

--- a/packages/connect/e2e/__fixtures__/nostrGetPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/nostrGetPublicKey.ts
@@ -3,7 +3,7 @@
 const skip = ['1', '<2.9.3'];
 
 // Expected x-only (BIP-340) public keys derived per NIP-06 (m/44'/1237'/<account>'/0/0).
-export default {
+const nostrGetPublicKey: TestCase = {
     method: 'nostrGetPublicKey',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -52,4 +52,6 @@ export default {
             skip,
         },
     ],
-} satisfies TestCase;
+};
+
+export default nostrGetPublicKey;

--- a/packages/connect/e2e/__fixtures__/nostrSignEvent.ts
+++ b/packages/connect/e2e/__fixtures__/nostrSignEvent.ts
@@ -6,7 +6,7 @@ const skip = ['1', '<2.9.3'];
 // id is the NIP-01 event id (sha256 of the serialized event). The BIP-340
 // signature is not asserted because it is not deterministic, so only the
 // deterministic fields are checked (matchObject ignores the extra signature).
-export default {
+const nostrSignEvent: TestCase = {
     method: 'nostrSignEvent',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -42,4 +42,6 @@ export default {
             skip,
         },
     ],
-} satisfies TestCase;
+};
+
+export default nostrSignEvent;

--- a/packages/connect/e2e/__fixtures__/rippleGetAddress.ts
+++ b/packages/connect/e2e/__fixtures__/rippleGetAddress.ts
@@ -6,7 +6,7 @@ const legacyResults = [
     },
 ];
 
-export default {
+const rippleGetAddress: TestCase = {
     method: 'rippleGetAddress',
     setup: {
         mnemonic: 'mnemonic_12',
@@ -48,4 +48,6 @@ export default {
             },
         },
     ].map(fixture => ({ ...fixture, legacyResults })),
-} satisfies TestCase;
+};
+
+export default rippleGetAddress;

--- a/packages/connect/e2e/__fixtures__/rippleSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/rippleSignTransaction.ts
@@ -6,7 +6,7 @@ const legacyResults = [
     },
 ];
 
-export default {
+const rippleSignTransaction: TestCase = {
     method: 'rippleSignTransaction',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -93,4 +93,6 @@ export default {
             result: false,
         },
     ].map(fixture => ({ ...fixture, legacyResults })),
-} satisfies TestCase;
+};
+
+export default rippleSignTransaction;

--- a/packages/connect/e2e/__fixtures__/signMessage.ts
+++ b/packages/connect/e2e/__fixtures__/signMessage.ts
@@ -8,7 +8,7 @@ const legacyResults = [
     },
 ];
 
-export default {
+const signMessage: TestCase = {
     method: 'signMessage',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -261,4 +261,6 @@ export default {
             ],
         },
     ],
-} satisfies TestCase;
+};
+
+export default signMessage;

--- a/packages/connect/e2e/__fixtures__/signTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/signTransaction.ts
@@ -21,7 +21,7 @@ serializedTx += 'd91b0000000000001976a9145a9452b8db22e7fb606adafc731f5d4b482f9e8
 );
 serializedTx += '00000000';
 
-export default {
+const signTransaction: TestCase = {
     method: 'signTransaction',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -454,4 +454,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default signTransaction;

--- a/packages/connect/e2e/__fixtures__/signTransactionBcash.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionBcash.ts
@@ -1,6 +1,6 @@
 const { TX_CACHE } = global.TestUtils;
 
-export default {
+const signTransactionBcash: TestCase = {
     method: 'signTransaction',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -116,4 +116,6 @@ export default {
             result: false,
         },
     ],
-} satisfies TestCase;
+};
+
+export default signTransactionBcash;

--- a/packages/connect/e2e/__fixtures__/signTransactionBech32.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionBech32.ts
@@ -1,6 +1,6 @@
 const { TX_CACHE } = global.TestUtils;
 
-export default {
+const signTransactionBech32: TestCase = {
     method: 'signTransaction',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -140,4 +140,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default signTransactionBech32;

--- a/packages/connect/e2e/__fixtures__/signTransactionBgold.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionBgold.ts
@@ -8,7 +8,7 @@ const legacyResults = [
     },
 ];
 
-export default {
+const signTransactionBgold: TestCase = {
     method: 'signTransaction',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -207,4 +207,6 @@ export default {
             legacyResults,
         },
     ],
-} satisfies TestCase;
+};
+
+export default signTransactionBgold;

--- a/packages/connect/e2e/__fixtures__/signTransactionDoge.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionDoge.ts
@@ -1,6 +1,6 @@
 const { TX_CACHE } = global.TestUtils;
 
-export default {
+const signTransactionDoge: TestCase = {
     method: 'signTransaction',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -45,4 +45,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default signTransactionDoge;

--- a/packages/connect/e2e/__fixtures__/signTransactionExternal.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionExternal.ts
@@ -2,7 +2,7 @@
 
 const { TX_CACHE } = global.TestUtils;
 
-export default {
+const signTransactionExternal: TestCase = {
     method: 'signTransaction',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -394,4 +394,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default signTransactionExternal;

--- a/packages/connect/e2e/__fixtures__/signTransactionMultisig.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionMultisig.ts
@@ -34,7 +34,7 @@ const SIGNATURES_2_OF_3 = [
     '304502210089153ad97c0d69656cd9bd9eb2056552acaec91365dd7ab31250f3f707123baa02200f884de63041d73bd20fbe8804c6036968d8149b7f46963a82b561cd8211ab08',
 ];
 
-export default {
+const signTransactionMultisig: TestCase = {
     method: 'signTransaction',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -279,4 +279,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default signTransactionMultisig;

--- a/packages/connect/e2e/__fixtures__/signTransactionMultisigChange.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionMultisigChange.ts
@@ -61,7 +61,7 @@ const input2 = {
     multisig: multisig2,
 };
 
-export default {
+const signTransactionMultisigChange: TestCase = {
     method: 'signTransaction',
     setup: {
         mnemonic: 'mnemonic_12',
@@ -167,4 +167,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default signTransactionMultisigChange;

--- a/packages/connect/e2e/__fixtures__/signTransactionMultisigPubkeysOrder.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionMultisigPubkeysOrder.ts
@@ -21,7 +21,7 @@ const PUBKEYS_2_OF_3 = [
     },
 ];
 
-export default {
+const signTransactionMultisigPubkeysOrder: TestCase = {
     method: 'signTransaction',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -105,4 +105,6 @@ export default {
             ],
         },
     ],
-} satisfies TestCase;
+};
+
+export default signTransactionMultisigPubkeysOrder;

--- a/packages/connect/e2e/__fixtures__/signTransactionPaymentRequest.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionPaymentRequest.ts
@@ -2,7 +2,7 @@
 
 const { TX_CACHE } = global.TestUtils;
 
-export default {
+const signTransactionPaymentRequest: TestCase = {
     method: 'signTransaction',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -63,4 +63,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default signTransactionPaymentRequest;

--- a/packages/connect/e2e/__fixtures__/signTransactionReplace.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionReplace.ts
@@ -1,6 +1,6 @@
 const { TX_CACHE } = global.TestUtils;
 
-export default {
+const signTransactionReplace: TestCase = {
     method: 'signTransaction',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -394,4 +394,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default signTransactionReplace;

--- a/packages/connect/e2e/__fixtures__/signTransactionSegwit.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionSegwit.ts
@@ -1,6 +1,6 @@
 const { TX_CACHE } = global.TestUtils;
 
-export default {
+const signTransactionSegwit: TestCase = {
     method: 'signTransaction',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -119,4 +119,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default signTransactionSegwit;

--- a/packages/connect/e2e/__fixtures__/signTransactionTaproot.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionTaproot.ts
@@ -2,7 +2,7 @@
 
 const { TX_CACHE } = global.TestUtils;
 
-export default {
+const signTransactionTaproot: TestCase = {
     method: 'signTransaction',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -155,4 +155,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default signTransactionTaproot;

--- a/packages/connect/e2e/__fixtures__/signTransactionZcash.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionZcash.ts
@@ -1,6 +1,6 @@
 const { TX_CACHE } = global.TestUtils;
 
-export default {
+const signTransactionZcash: TestCase = {
     method: 'signTransaction',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -424,4 +424,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default signTransactionZcash;

--- a/packages/connect/e2e/__fixtures__/solanaComposeTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/solanaComposeTransaction.ts
@@ -1,4 +1,4 @@
-export default {
+const solanaComposeTransaction: TestCase = {
     method: 'solanaComposeTransaction',
     setup: {
         mnemonic: undefined, // device is not used in this test case
@@ -90,4 +90,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default solanaComposeTransaction;

--- a/packages/connect/e2e/__fixtures__/solanaGetAddress.ts
+++ b/packages/connect/e2e/__fixtures__/solanaGetAddress.ts
@@ -7,7 +7,7 @@ const legacyResults = [
     },
 ];
 
-export default {
+const solanaGetAddress: TestCase = {
     method: 'solanaGetAddress',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -44,4 +44,6 @@ export default {
             legacyResults,
         },
     ],
-} satisfies TestCase;
+};
+
+export default solanaGetAddress;

--- a/packages/connect/e2e/__fixtures__/solanaGetPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/solanaGetPublicKey.ts
@@ -13,7 +13,7 @@ const legacyResults = [
 const showOnTrezorDisplayablePublicKey = '4UR47Kp4FxGJiJZZGSPAzXqRgMmZ27oVfGhHoLmcHakE';
 const showOnTrezorDeviceScreen = showOnTrezorDisplayablePublicKey.slice(0, 34);
 
-export default {
+const solanaGetPublicKey: TestCase = {
     method: 'solanaGetPublicKey',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -71,4 +71,6 @@ export default {
             legacyResults,
         },
     ],
-} satisfies TestCase;
+};
+
+export default solanaGetPublicKey;

--- a/packages/connect/e2e/__fixtures__/solanaSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/solanaSignTransaction.ts
@@ -7,7 +7,7 @@ const legacyResults = [
     },
 ];
 
-export default {
+const solanaSignTransaction: TestCase = {
     method: 'solanaSignTransaction',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -40,4 +40,6 @@ export default {
             legacyResults,
         },
     ],
-} satisfies TestCase;
+};
+
+export default solanaSignTransaction;

--- a/packages/connect/e2e/__fixtures__/stellarGetAddress.ts
+++ b/packages/connect/e2e/__fixtures__/stellarGetAddress.ts
@@ -1,6 +1,6 @@
 // https://github.com/trezor/trezor-firmware/blob/main/tests/device_tests/test_msg_stellar_get_address.py
 
-export default {
+const stellarGetAddress: TestCase = {
     method: 'stellarGetAddress',
     setup: {
         mnemonic: 'illness spike retreat truth genius clock brain pass fit cave bargain toe',
@@ -39,4 +39,6 @@ export default {
             result: false,
         },
     ],
-} satisfies TestCase;
+};
+
+export default stellarGetAddress;

--- a/packages/connect/e2e/__fixtures__/stellarSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/stellarSignTransaction.ts
@@ -183,7 +183,7 @@ const legacyResultsMap: Record<string, LegacyResult[]> = {
     ],
 };
 
-export default {
+const stellarSignTransaction: TestCase = {
     method: 'stellarSignTransaction',
     setup: {
         mnemonic: commonFixtures.setup.mnemonic,
@@ -294,4 +294,6 @@ export default {
             ],
         },
     ],
-} satisfies TestCase;
+};
+
+export default stellarSignTransaction;

--- a/packages/connect/e2e/__fixtures__/telemetryGet.ts
+++ b/packages/connect/e2e/__fixtures__/telemetryGet.ts
@@ -1,4 +1,4 @@
-export default {
+const telemetryGet: TestCase = {
     method: 'telemetryGet',
     setup: {
         mnemonic: 'mnemonic_12',
@@ -21,4 +21,6 @@ export default {
             ],
         },
     ],
-} satisfies TestCase;
+};
+
+export default telemetryGet;

--- a/packages/connect/e2e/__fixtures__/tezosGetAddress.ts
+++ b/packages/connect/e2e/__fixtures__/tezosGetAddress.ts
@@ -6,7 +6,7 @@ const legacyResults = [
     },
 ];
 
-export default {
+const tezosGetAddress: TestCase = {
     method: 'tezosGetAddress',
     setup: {
         mnemonic: 'mnemonic_12',
@@ -49,4 +49,6 @@ export default {
             result: false,
         },
     ].map(fixture => ({ ...fixture, legacyResults })),
-} satisfies TestCase;
+};
+
+export default tezosGetAddress;

--- a/packages/connect/e2e/__fixtures__/tezosGetPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/tezosGetPublicKey.ts
@@ -12,7 +12,7 @@ const legacyResults = [
 const showOnTrezorDisplayablePublicKey = 'edpkuxZ5W8c2jmcaGuCFZxRDSWxS7hp98zcwj2YpUZkJWs5F7UMuF6';
 const showOnTrezorDeviceScreen = showOnTrezorDisplayablePublicKey.slice(0, 39);
 
-export default {
+const tezosGetPublicKey: TestCase = {
     method: 'tezosGetPublicKey',
     setup: {
         mnemonic: 'mnemonic_12',
@@ -70,4 +70,6 @@ export default {
             deviceScreenSkip: ['1', '<2.7.0'],
         },
     ].map(fixture => ({ ...fixture, legacyResults })),
-} satisfies TestCase;
+};
+
+export default tezosGetPublicKey;

--- a/packages/connect/e2e/__fixtures__/tezosSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/tezosSignTransaction.ts
@@ -6,7 +6,7 @@ const legacyResults = [
     },
 ];
 
-export default {
+const tezosSignTransaction: TestCase = {
     method: 'tezosSignTransaction',
     setup: {
         mnemonic: 'mnemonic_12',
@@ -169,4 +169,6 @@ export default {
             },
         },
     ].map(fixture => ({ ...fixture, legacyResults })),
-} satisfies TestCase;
+};
+
+export default tezosSignTransaction;

--- a/packages/connect/e2e/__fixtures__/tronGetAddress.ts
+++ b/packages/connect/e2e/__fixtures__/tronGetAddress.ts
@@ -5,7 +5,7 @@ const legacyResults = [
     },
 ];
 
-export default {
+const tronGetAddress: TestCase = {
     method: 'tronGetAddress',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -32,4 +32,6 @@ export default {
             legacyResults,
         },
     ],
-} satisfies TestCase;
+};
+
+export default tronGetAddress;

--- a/packages/connect/e2e/__fixtures__/tronSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/tronSignTransaction.ts
@@ -5,7 +5,7 @@ const legacyResults = [
     },
 ];
 
-export default {
+const tronSignTransaction: TestCase = {
     method: 'tronSignTransaction',
     setup: {
         mnemonic: 'mnemonic_all',
@@ -196,4 +196,6 @@ export default {
             legacyResults,
         },
     ],
-} satisfies TestCase;
+};
+
+export default tronSignTransaction;

--- a/packages/connect/e2e/__fixtures__/verifyMessage.ts
+++ b/packages/connect/e2e/__fixtures__/verifyMessage.ts
@@ -1,4 +1,4 @@
-export default {
+const verifyMessage: TestCase = {
     method: 'verifyMessage',
     setup: {
         mnemonic: 'mnemonic_12',
@@ -138,4 +138,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default verifyMessage;

--- a/packages/connect/e2e/__fixtures__/verifyMessageSegwit.ts
+++ b/packages/connect/e2e/__fixtures__/verifyMessageSegwit.ts
@@ -1,4 +1,4 @@
-export default {
+const verifyMessageSegwit: TestCase = {
     method: 'verifyMessage',
     setup: {
         mnemonic: 'mnemonic_12',
@@ -76,4 +76,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default verifyMessageSegwit;

--- a/packages/connect/e2e/__fixtures__/verifyMessageSegwitNative.ts
+++ b/packages/connect/e2e/__fixtures__/verifyMessageSegwitNative.ts
@@ -1,4 +1,4 @@
-export default {
+const verifyMessageSegwitNative: TestCase = {
     method: 'verifyMessage',
     setup: {
         mnemonic: 'mnemonic_12',
@@ -76,4 +76,6 @@ export default {
             },
         },
     ],
-} satisfies TestCase;
+};
+
+export default verifyMessageSegwitNative;

--- a/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
@@ -1,5 +1,3 @@
-import { type DeepPartial } from 'react-hook-form';
-
 import { type AnyAction } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
@@ -11,6 +9,8 @@ import {
     transactionsActions,
 } from '@suite-common/wallet-core';
 import { analyzeTransactions } from '@suite-common/wallet-utils/src/__fixtures__/transactionUtils';
+import { type BlockchainBlock, type BlockchainNotification } from '@trezor/connect-common';
+import { type DeepPartial } from '@trezor/type-utils';
 
 const DEFAULT_ACCOUNT = {
     deviceState: '1stTestnetAddress@device_id:0',
@@ -228,8 +228,61 @@ const analyzeTransactionsExtended = [
     },
 ];
 
+/** Partial state passed directly to the test store initializer. */
+type FixtureState = unknown;
+
+/** Opaque mock responses passed directly to setTrezorConnectFixtures. */
+type ConnectFixtures = unknown;
+
+type OnBlockFixture = {
+    description: string;
+    connect?: ConnectFixtures;
+    block: DeepPartial<BlockchainBlock>;
+    state: FixtureState;
+    result?: string[];
+    resultTxs?: {
+        'xpub-btc-deviceState': Array<{
+            blockHeight: number | undefined;
+            blockHash: string | undefined;
+            txid: string;
+        }>;
+    };
+};
+
+type OnConnectFixture = {
+    description: string;
+    connect?: ConnectFixtures;
+    initialState?: FixtureState;
+    symbol: string;
+    actions: AnyAction[];
+    blockchainEstimateFee: number;
+    blockchainSubscribe: number;
+};
+
+type OnDisconnectFixture = {
+    description: string;
+    initialState?: FixtureState;
+    symbol: string;
+    actions: AnyAction[];
+};
+
+type OnNotificationFixture = {
+    description: string;
+    initialState?: FixtureState;
+    params: DeepPartial<BlockchainNotification>;
+    actions: AnyAction[];
+    getAccountInfo: number;
+};
+
+type CustomBackendFixture = {
+    description: string;
+    initialState: FixtureState;
+    symbol: 'btc';
+    blockchainSetCustomBackend: number;
+};
+
 // A little bit crazy test to avoid fixtures duplication
-export const onBlock = analyzeTransactions
+export const onBlock: OnBlockFixture[] = analyzeTransactions
     // extend @wallet-utils/__fixtures__/transactionUtils
     .map((f, i) => ({
         description: f.description,
@@ -426,7 +479,7 @@ export const init: InitFixture[] = [
     },
 ];
 
-export const onConnect = [
+export const onConnect: OnConnectFixture[] = [
     {
         description: 'unknown coin',
         symbol: 'btc-invalid',
@@ -524,7 +577,7 @@ export const onConnect = [
     },
 ];
 
-export const onDisconnect = [
+export const onDisconnect: OnDisconnectFixture[] = [
     {
         description: 'unknown coin',
         symbol: 'btc-invalid',
@@ -561,7 +614,7 @@ export const onDisconnect = [
     },
 ];
 
-export const onNotification = [
+export const onNotification: OnNotificationFixture[] = [
     {
         description: 'no accounts',
         initialState: {
@@ -660,7 +713,7 @@ export const onNotification = [
     },
 ];
 
-export const customBackend = [
+export const customBackend: CustomBackendFixture[] = [
     {
         description: 'enable coin with custom backend',
         initialState: {

--- a/packages/suite/src/actions/wallet/__fixtures__/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/selectedAccountActions.ts
@@ -1,6 +1,8 @@
 import { routerLocationChange } from '@suite/router';
+import { type SelectedAccountStatus, type WalletParams } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { type StaticSessionId } from '@trezor/connect';
+import { type DeepPartial } from '@trezor/type-utils';
 
 const DEVICE_STATE: StaticSessionId = '1stTestnetAddress@device_id:0';
 const DEVICE_PATH = '1';
@@ -10,7 +12,7 @@ const device = {
     state: { staticSessionId: DEVICE_STATE },
 };
 
-const walletParams = {
+const walletParams: WalletParams = {
     symbol: 'btc',
     accountIndex: 0,
     accountType: 'normal',
@@ -28,7 +30,20 @@ const btcFailedAccount = {
     error: 'discovery error',
 };
 
-export default [
+/** Partial state passed directly to the test store initializer. */
+type FixtureState = unknown;
+
+/** Partial action passed directly to syncSelectedAccount by the test. */
+type FixtureAction = unknown;
+
+type SelectedAccountFixture = {
+    description: string;
+    initialState: FixtureState;
+    action: FixtureAction;
+    result: DeepPartial<SelectedAccountStatus>;
+};
+
+const selectedAccountFixtures: SelectedAccountFixture[] = [
     {
         description: 'Action ignored',
         initialState: {},
@@ -110,4 +125,6 @@ export default [
             params: walletParams,
         },
     },
-] as const;
+];
+
+export default selectedAccountFixtures;

--- a/suite/coinjoin/src/__fixtures__/coinjoinAccountActions.ts
+++ b/suite/coinjoin/src/__fixtures__/coinjoinAccountActions.ts
@@ -1,10 +1,58 @@
 import { goto } from '@suite/router';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { accountsActions } from '@suite-common/wallet-core';
-import { type Account } from '@suite-common/wallet-types';
+import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
 import * as COINJOIN from '../coinjoinConstants';
+
+type FixtureResult = {
+    actions: string[];
+};
+
+/** Partial state passed directly to the test store initializer. */
+type FixtureState = unknown;
+
+/** Opaque mock responses passed directly to setTrezorConnectFixtures. */
+type ConnectFixtures = unknown;
+
+type CreateCoinjoinAccountFixture = {
+    description: string;
+    connect?: ConnectFixtures;
+    params: {
+        network: {
+            symbol: string;
+            networkType: string;
+        };
+        account: {
+            accountType: string;
+            bip43Path?: string;
+        };
+    };
+    result: FixtureResult;
+};
+
+type StartCoinjoinSessionFixture = {
+    description: string;
+    connect?: ConnectFixtures;
+    state?: FixtureState;
+    params: Partial<Account>;
+    result: FixtureResult;
+};
+
+type CoinjoinSessionFixture = {
+    description: string;
+    client?: string;
+    state: FixtureState;
+    param: AccountKey;
+    result: FixtureResult;
+};
+
+type RestoreCoinjoinAccountsFixture = {
+    description: string;
+    state: FixtureState;
+    result: FixtureResult;
+};
 
 const ACCOUNT_KEY_12345 = mockAccountKey({ descriptor: '12345' });
 
@@ -23,7 +71,7 @@ const CJ_ACCOUNT = {
 
 const SESSION = { signedRounds: [] as string[], maxRounds: 10 };
 
-export const createCoinjoinAccount = [
+export const createCoinjoinAccount: CreateCoinjoinAccountFixture[] = [
     {
         description: 'unsupported coinjoin client',
         params: {
@@ -150,7 +198,7 @@ export const createCoinjoinAccount = [
     },
 ];
 
-export const startCoinjoinSession = [
+export const startCoinjoinSession: StartCoinjoinSessionFixture[] = [
     {
         description: 'client not found',
         params: {
@@ -215,7 +263,7 @@ export const startCoinjoinSession = [
     },
 ];
 
-export const stopCoinjoinSession = [
+export const stopCoinjoinSession: CoinjoinSessionFixture[] = [
     {
         description: 'client not found',
         state: {
@@ -245,7 +293,7 @@ export const stopCoinjoinSession = [
     },
 ];
 
-export const restoreCoinjoinAccounts = [
+export const restoreCoinjoinAccounts: RestoreCoinjoinAccountsFixture[] = [
     {
         description: 'four accounts, two networks, one success, one errored',
         state: {
@@ -277,7 +325,7 @@ export const restoreCoinjoinAccounts = [
     },
 ];
 
-export const restoreCoinjoinSession = [
+export const restoreCoinjoinSession: CoinjoinSessionFixture[] = [
     {
         description: 'restore one paused coinjoin session',
         client: 'btc',

--- a/suite/coinjoin/src/__fixtures__/coinjoinClientActions.ts
+++ b/suite/coinjoin/src/__fixtures__/coinjoinClientActions.ts
@@ -1,9 +1,77 @@
 import { MODAL_CLOSE, MODAL_OPEN_USER_CONTEXT } from '@suite/modal';
+import { type TrezorDevice } from '@suite-common/suite-types';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import {
+    type CoinjoinClientEvents,
+    type CoinjoinRequestOwnershipEvent,
+    type CoinjoinRequestSignatureEvent,
+    type CoinjoinResponseOwnershipEvent,
+    type CoinjoinResponseSignatureEvent,
+    type SerializedCoinjoinRound,
+} from '@trezor/coinjoin';
+import type TrezorConnect from '@trezor/connect';
+import { type DeepPartial } from '@trezor/type-utils';
 
 import * as COINJOIN from '../coinjoinConstants';
+import { type CoinjoinState } from '../coinjoinTypes';
 
-export const DEVICE = mockSuiteDevice({
+/** Partial state passed directly to the test store initializer. */
+type FixtureState = unknown;
+
+/** Opaque mock responses passed directly to setTrezorConnectFixtures. */
+type ConnectFixtures = unknown;
+
+type OnCoinjoinRoundChangedFixture = {
+    description: string;
+    connect?: ConnectFixtures;
+    state: FixtureState;
+    params: DeepPartial<SerializedCoinjoinRound> | Array<DeepPartial<SerializedCoinjoinRound>>;
+    result: {
+        actions: string[];
+        trezorConnectCalledTimes: number;
+        trezorConnectCallsWith?: DeepPartial<Parameters<typeof TrezorConnect.setBusy>[0]>;
+    };
+};
+
+type GetOwnershipProofFixture = {
+    description: string;
+    connect?: ConnectFixtures;
+    state: FixtureState;
+    params: Array<DeepPartial<CoinjoinRequestOwnershipEvent>>;
+    result: {
+        response: Array<DeepPartial<CoinjoinResponseOwnershipEvent>>;
+        trezorConnectCalledTimes: number;
+    };
+};
+
+type SignCoinjoinTxFixture = {
+    description: string;
+    connect?: ConnectFixtures;
+    state: FixtureState;
+    params: DeepPartial<CoinjoinRequestSignatureEvent>;
+    result: {
+        actions: string[];
+        response: DeepPartial<CoinjoinResponseSignatureEvent>;
+        trezorConnectCalledTimes: number;
+        trezorConnectCalledWith: Array<
+            DeepPartial<Parameters<typeof TrezorConnect.signTransaction>[0]>
+        >;
+    };
+};
+
+type TestedClientEvent = 'status' | 'prison' | 'round' | 'session-phase';
+
+type ClientEventFixture = {
+    [Event in TestedClientEvent]: {
+        description: string;
+        event: Event;
+        state: FixtureState;
+        params: DeepPartial<CoinjoinClientEvents[Event]>;
+        result: DeepPartial<CoinjoinState>;
+    };
+}[TestedClientEvent];
+
+export const DEVICE: TrezorDevice = mockSuiteDevice({
     state: { staticSessionId: '1stTestnetAddress@device_id:0' },
     connected: true,
     available: true,
@@ -12,7 +80,7 @@ export const DEVICE = mockSuiteDevice({
 
 const SESSION = { signedRounds: [] as string[], sessionPhaseQueue: [], maxRounds: 10 };
 
-export const onCoinjoinRoundChanged = [
+export const onCoinjoinRoundChanged: OnCoinjoinRoundChangedFixture[] = [
     {
         description: 'Phase 0. No associated coinjoin accounts',
         connect: undefined,
@@ -327,7 +395,7 @@ export const onCoinjoinRoundChanged = [
     },
 ];
 
-export const getOwnershipProof = [
+export const getOwnershipProof: GetOwnershipProofFixture[] = [
     {
         description: 'getOwnershipProof success with 3 accounts, 2 passphrases, 2 physical devices',
         connect: [
@@ -540,7 +608,7 @@ export const getOwnershipProof = [
     },
 ];
 
-export const signCoinjoinTx = [
+export const signCoinjoinTx: SignCoinjoinTxFixture[] = [
     {
         description: 'signCoinjoinTx success with 3 accounts, 2 passphrases, 2 physical devices',
         connect: [
@@ -1039,7 +1107,7 @@ export const signCoinjoinTx = [
     },
 ];
 
-export const clientEvents = [
+export const clientEvents: ClientEventFixture[] = [
     {
         description: 'StatusEvent updates client values',
         event: 'status',


### PR DESCRIPTION
## Description

Adds explicit types to large test fixtures to prevent TypeScript from emitting their fully inferred structures.

<img width="835" height="328" alt="image" src="https://github.com/user-attachments/assets/68df2df0-dc08-4f70-99b9-14bf1bed900e" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All 73 changed files are test fixtures (under `__fixtures__` directories) used by unit tests or Connect-level e2e tests in `packages/connect/e2e/`, `packages/suite/src/actions/wallet/`, and `suite/coinjoin/src/`. These fixtures define test data (expected inputs/outputs, mock parameters) for unit and integration tests — they are not consumed by any of the 141 Playwright Suite E2E tests analyzed. The Suite E2E tests exercise the application through UI interactions with page objects and device emulators, and none of them import or reference these fixture files. The risk of regression in the Suite E2E layer is negligible since the changes are isolated to test data for lower-level test suites. No Suite E2E tests are recommended.

<details><summary><b>Changed files (73)</b></summary>

- `packages/connect/e2e/__fixtures__/applyFlags.ts`
- `packages/connect/e2e/__fixtures__/applySettings.ts`
- `packages/connect/e2e/__fixtures__/cardanoGetAddress.ts`
- `packages/connect/e2e/__fixtures__/cardanoGetAddressDerivations.ts`
- `packages/connect/e2e/__fixtures__/cardanoGetNativeScriptHash.ts`
- `packages/connect/e2e/__fixtures__/cardanoGetPublicKey.ts`
- `packages/connect/e2e/__fixtures__/cardanoSignMessage.ts`
- `packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts`
- `packages/connect/e2e/__fixtures__/changeLanguage.ts`
- `packages/connect/e2e/__fixtures__/composeTransaction.ts`
- `packages/connect/e2e/__fixtures__/ethereumGetAddress.ts`
- `packages/connect/e2e/__fixtures__/ethereumGetPublicKey.ts`
- `packages/connect/e2e/__fixtures__/ethereumSignMessage.ts`
- `packages/connect/e2e/__fixtures__/ethereumSignTransaction.ts`
- `packages/connect/e2e/__fixtures__/ethereumSignTransactionDefinitions.ts`
- `packages/connect/e2e/__fixtures__/ethereumSignTransactionEip155.ts`
- `packages/connect/e2e/__fixtures__/ethereumSignTransactionEip1559.ts`
- `packages/connect/e2e/__fixtures__/ethereumSignTypedData.ts`
- `packages/connect/e2e/__fixtures__/ethereumVerifyMessage.ts`
- `packages/connect/e2e/__fixtures__/getAccountInfo.ts`
- `packages/connect/e2e/__fixtures__/getAddress.ts`
- `packages/connect/e2e/__fixtures__/getAddressMultisig.ts`
- `packages/connect/e2e/__fixtures__/getAddressMultisigPubkeysOrder.ts`
- `packages/connect/e2e/__fixtures__/getAddressSegwit.ts`
- `packages/connect/e2e/__fixtures__/getFeatures.ts`
- `packages/connect/e2e/__fixtures__/getFirmwareHash.ts`
- `packages/connect/e2e/__fixtures__/getOwnershipId.ts`
- `packages/connect/e2e/__fixtures__/getOwnershipProof.ts`
- `packages/connect/e2e/__fixtures__/getPublicKey.ts`
- `packages/connect/e2e/__fixtures__/getPublicKeyBip48.ts`
- `packages/connect/e2e/__fixtures__/loadDevice.ts`
- `packages/connect/e2e/__fixtures__/moneroGetAddress.ts`
- `packages/connect/e2e/__fixtures__/moneroGetWatchKey.ts`
- `packages/connect/e2e/__fixtures__/moneroKeyImageSync.ts`
- `packages/connect/e2e/__fixtures__/moneroSignTransaction.ts`
- `packages/connect/e2e/__fixtures__/nostrGetPublicKey.ts`
- `packages/connect/e2e/__fixtures__/nostrSignEvent.ts`
- `packages/connect/e2e/__fixtures__/rippleGetAddress.ts`
- `packages/connect/e2e/__fixtures__/rippleSignTransaction.ts`
- `packages/connect/e2e/__fixtures__/signMessage.ts`
- `packages/connect/e2e/__fixtures__/signTransaction.ts`
- `packages/connect/e2e/__fixtures__/signTransactionBcash.ts`
- `packages/connect/e2e/__fixtures__/signTransactionBech32.ts`
- `packages/connect/e2e/__fixtures__/signTransactionBgold.ts`
- `packages/connect/e2e/__fixtures__/signTransactionDoge.ts`
- `packages/connect/e2e/__fixtures__/signTransactionExternal.ts`
- `packages/connect/e2e/__fixtures__/signTransactionMultisig.ts`
- `packages/connect/e2e/__fixtures__/signTransactionMultisigChange.ts`
- `packages/connect/e2e/__fixtures__/signTransactionMultisigPubkeysOrder.ts`
- `packages/connect/e2e/__fixtures__/signTransactionPaymentRequest.ts`
- `packages/connect/e2e/__fixtures__/signTransactionReplace.ts`
- `packages/connect/e2e/__fixtures__/signTransactionSegwit.ts`
- `packages/connect/e2e/__fixtures__/signTransactionTaproot.ts`
- `packages/connect/e2e/__fixtures__/signTransactionZcash.ts`
- `packages/connect/e2e/__fixtures__/solanaComposeTransaction.ts`
- `packages/connect/e2e/__fixtures__/solanaGetAddress.ts`
- `packages/connect/e2e/__fixtures__/solanaGetPublicKey.ts`
- `packages/connect/e2e/__fixtures__/solanaSignTransaction.ts`
- `packages/connect/e2e/__fixtures__/stellarGetAddress.ts`
- `packages/connect/e2e/__fixtures__/stellarSignTransaction.ts`
- `packages/connect/e2e/__fixtures__/telemetryGet.ts`
- `packages/connect/e2e/__fixtures__/tezosGetAddress.ts`
- `packages/connect/e2e/__fixtures__/tezosGetPublicKey.ts`
- `packages/connect/e2e/__fixtures__/tezosSignTransaction.ts`
- `packages/connect/e2e/__fixtures__/tronGetAddress.ts`
- `packages/connect/e2e/__fixtures__/tronSignTransaction.ts`
- `packages/connect/e2e/__fixtures__/verifyMessage.ts`
- `packages/connect/e2e/__fixtures__/verifyMessageSegwit.ts`
- `packages/connect/e2e/__fixtures__/verifyMessageSegwitNative.ts`
- `packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts`
- `packages/suite/src/actions/wallet/__fixtures__/selectedAccountActions.ts`
- `suite/coinjoin/src/__fixtures__/coinjoinAccountActions.ts`
- `suite/coinjoin/src/__fixtures__/coinjoinClientActions.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (73)**
- `packages/connect/e2e/__fixtures__/applyFlags.ts`
- `packages/connect/e2e/__fixtures__/applySettings.ts`
- `packages/connect/e2e/__fixtures__/cardanoGetAddress.ts`
- `packages/connect/e2e/__fixtures__/cardanoGetAddressDerivations.ts`
- `packages/connect/e2e/__fixtures__/cardanoGetNativeScriptHash.ts`
- `packages/connect/e2e/__fixtures__/cardanoGetPublicKey.ts`
- `packages/connect/e2e/__fixtures__/cardanoSignMessage.ts`
- `packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts`
- `packages/connect/e2e/__fixtures__/changeLanguage.ts`
- `packages/connect/e2e/__fixtures__/composeTransaction.ts`
- `packages/connect/e2e/__fixtures__/ethereumGetAddress.ts`
- `packages/connect/e2e/__fixtures__/ethereumGetPublicKey.ts`
- `packages/connect/e2e/__fixtures__/ethereumSignMessage.ts`
- `packages/connect/e2e/__fixtures__/ethereumSignTransaction.ts`
- `packages/connect/e2e/__fixtures__/ethereumSignTransactionDefinitions.ts`
- `packages/connect/e2e/__fixtures__/ethereumSignTransactionEip155.ts`
- `packages/connect/e2e/__fixtures__/ethereumSignTransactionEip1559.ts`
- `packages/connect/e2e/__fixtures__/ethereumSignTypedData.ts`
- `packages/connect/e2e/__fixtures__/ethereumVerifyMessage.ts`
- `packages/connect/e2e/__fixtures__/getAccountInfo.ts`
- `packages/connect/e2e/__fixtures__/getAddress.ts`
- `packages/connect/e2e/__fixtures__/getAddressMultisig.ts`
- `packages/connect/e2e/__fixtures__/getAddressMultisigPubkeysOrder.ts`
- `packages/connect/e2e/__fixtures__/getAddressSegwit.ts`
- `packages/connect/e2e/__fixtures__/getFeatures.ts`
- `packages/connect/e2e/__fixtures__/getFirmwareHash.ts`
- `packages/connect/e2e/__fixtures__/getOwnershipId.ts`
- `packages/connect/e2e/__fixtures__/getOwnershipProof.ts`
- `packages/connect/e2e/__fixtures__/getPublicKey.ts`
- `packages/connect/e2e/__fixtures__/getPublicKeyBip48.ts`
- `packages/connect/e2e/__fixtures__/loadDevice.ts`
- `packages/connect/e2e/__fixtures__/moneroGetAddress.ts`
- `packages/connect/e2e/__fixtures__/moneroGetWatchKey.ts`
- `packages/connect/e2e/__fixtures__/moneroKeyImageSync.ts`
- `packages/connect/e2e/__fixtures__/moneroSignTransaction.ts`
- `packages/connect/e2e/__fixtures__/nostrGetPublicKey.ts`
- `packages/connect/e2e/__fixtures__/nostrSignEvent.ts`
- `packages/connect/e2e/__fixtures__/rippleGetAddress.ts`
- `packages/connect/e2e/__fixtures__/rippleSignTransaction.ts`
- `packages/connect/e2e/__fixtures__/signMessage.ts`
- `packages/connect/e2e/__fixtures__/signTransaction.ts`
- `packages/connect/e2e/__fixtures__/signTransactionBcash.ts`
- `packages/connect/e2e/__fixtures__/signTransactionBech32.ts`
- `packages/connect/e2e/__fixtures__/signTransactionBgold.ts`
- `packages/connect/e2e/__fixtures__/signTransactionDoge.ts`
- `packages/connect/e2e/__fixtures__/signTransactionExternal.ts`
- `packages/connect/e2e/__fixtures__/signTransactionMultisig.ts`
- `packages/connect/e2e/__fixtures__/signTransactionMultisigChange.ts`
- `packages/connect/e2e/__fixtures__/signTransactionMultisigPubkeysOrder.ts`
- `packages/connect/e2e/__fixtures__/signTransactionPaymentRequest.ts`
- `packages/connect/e2e/__fixtures__/signTransactionReplace.ts`
- `packages/connect/e2e/__fixtures__/signTransactionSegwit.ts`
- `packages/connect/e2e/__fixtures__/signTransactionTaproot.ts`
- `packages/connect/e2e/__fixtures__/signTransactionZcash.ts`
- `packages/connect/e2e/__fixtures__/solanaComposeTransaction.ts`
- `packages/connect/e2e/__fixtures__/solanaGetAddress.ts`
- `packages/connect/e2e/__fixtures__/solanaGetPublicKey.ts`
- `packages/connect/e2e/__fixtures__/solanaSignTransaction.ts`
- `packages/connect/e2e/__fixtures__/stellarGetAddress.ts`
- `packages/connect/e2e/__fixtures__/stellarSignTransaction.ts`
- `packages/connect/e2e/__fixtures__/telemetryGet.ts`
- `packages/connect/e2e/__fixtures__/tezosGetAddress.ts`
- `packages/connect/e2e/__fixtures__/tezosGetPublicKey.ts`
- `packages/connect/e2e/__fixtures__/tezosSignTransaction.ts`
- `packages/connect/e2e/__fixtures__/tronGetAddress.ts`
- `packages/connect/e2e/__fixtures__/tronSignTransaction.ts`
- `packages/connect/e2e/__fixtures__/verifyMessage.ts`
- `packages/connect/e2e/__fixtures__/verifyMessageSegwit.ts`
- `packages/connect/e2e/__fixtures__/verifyMessageSegwitNative.ts`
- `packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts`
- `packages/suite/src/actions/wallet/__fixtures__/selectedAccountActions.ts`
- `suite/coinjoin/src/__fixtures__/coinjoinAccountActions.ts`
- `suite/coinjoin/src/__fixtures__/coinjoinClientActions.ts`

_Updated: 2026-07-16T12:08:05.183Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-fixture-declaration-types&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-fixture-declaration-types&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-fixture-declaration-types&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-16T12:11:20.916Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-16T12:10:59.334Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-fixture-declaration-types/web/](https://dev.suite.sldev.cz/suite-web/fix-fixture-declaration-types/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->