### PR TITLE
Tron Staking Message System

### DIFF
--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
@@ -63,8 +63,14 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
     const isClaimPending = useSelector(state =>
         selectAccountClaimTransactions(state, account.key).some(tx => isPending(tx)),
     );
-    const { isStakingDisabled, stakingMessageContent, isClaimingDisabled, claimingMessageContent } =
-        useMessageSystemStaking(account.symbol);
+    const {
+        isStakingDisabled,
+        stakingMessageContent,
+        isClaimingDisabled,
+        claimingMessageContent,
+        isVotingDisabled,
+        votingMessageContent,
+    } = useMessageSystemStaking(account.symbol);
 
     const { canClaim = false } = getStakingDataForNetwork(account) ?? {};
     const isClaimButtonDisabled = isClaimingDisabled || isClaimPending;
@@ -233,6 +239,10 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
     );
 
     const onTronStake = (event: React.MouseEvent<HTMLButtonElement>) => {
+        if (isStakingDisabled) {
+            return;
+        }
+
         event.stopPropagation();
 
         dispatch(
@@ -257,6 +267,10 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
     };
 
     const onTronVote = (event: React.MouseEvent<HTMLButtonElement>) => {
+        if (isVotingDisabled) {
+            return;
+        }
+
         event.stopPropagation();
 
         dispatch(
@@ -288,6 +302,8 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
         stakingStatus,
         isStakingDisabled,
         stakingMessageContent,
+        isVotingDisabled,
+        votingMessageContent,
         canClaim,
         isClaimButtonDisabled,
         claimingMessageContent,

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingActionButtons.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingActionButtons.tsx
@@ -10,6 +10,8 @@ type EarnStakingActionButtonsProps = {
     stakingStatus: StakingAccountStatus;
     isStakingDisabled: boolean | undefined;
     stakingMessageContent: ReactNode;
+    isVotingDisabled: boolean | undefined;
+    votingMessageContent: ReactNode;
     canClaim: boolean;
     isClaimButtonDisabled: boolean | undefined;
     claimingMessageContent: ReactNode;
@@ -25,6 +27,8 @@ export const EarnStakingActionButtons = ({
     stakingStatus,
     isStakingDisabled,
     stakingMessageContent,
+    isVotingDisabled,
+    votingMessageContent,
     canClaim,
     isClaimButtonDisabled,
     claimingMessageContent,
@@ -101,12 +105,12 @@ export const EarnStakingActionButtons = ({
         )}
 
         {stakingStatus === 'staking-remaining-votes' && (
-            <Tooltip content={stakingMessageContent}>
+            <Tooltip content={votingMessageContent}>
                 <Button
                     intent="brand"
                     size="small"
-                    isDisabled={isStakingDisabled}
-                    iconLeft={isStakingDisabled ? InfoIcon : undefined}
+                    isDisabled={isVotingDisabled}
+                    iconLeft={isVotingDisabled ? InfoIcon : undefined}
                     onClick={onVote}
                 >
                     <Translation id="TR_EARN_TRON_VOTE" />

--- a/packages/suite/src/components/earn/staking/tron/claim/TronClaimForm.tsx
+++ b/packages/suite/src/components/earn/staking/tron/claim/TronClaimForm.tsx
@@ -3,6 +3,8 @@ import { FormProvider } from 'react-hook-form';
 import { Translation } from '@suite/intl';
 import { Banner, Column, Text } from '@trezor/components';
 
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
+
 import { useTronStakeContext } from '../TronStakeContext';
 import { TronStakeFees } from '../TronStakeFees';
 import { TronStakePendingTransaction } from '../TronStakePendingTransaction';
@@ -10,8 +12,10 @@ import { TronClaimAmount } from './TronClaimAmount';
 import { TronClaimSubmitButton } from './TronClaimSubmitButton';
 
 export const TronClaimForm = () => {
-    const { form, actions } = useTronStakeContext();
+    const { form, actions, account } = useTronStakeContext();
     const { error } = actions;
+
+    const { isClaimingDisabled, claimingMessageContent } = useMessageSystemStaking(account.symbol);
 
     return (
         <FormProvider {...form.methods}>
@@ -19,6 +23,10 @@ export const TronClaimForm = () => {
                 <Text typographyStyle="headline-md">
                     <Translation id="TR_EARN_TRON_CLAIM_TITLE" />
                 </Text>
+
+                {isClaimingDisabled && (
+                    <Banner intent="warning" description={claimingMessageContent} />
+                )}
 
                 <TronClaimAmount />
 

--- a/packages/suite/src/components/earn/staking/tron/claim/TronClaimSubmitButton.tsx
+++ b/packages/suite/src/components/earn/staking/tron/claim/TronClaimSubmitButton.tsx
@@ -5,11 +5,12 @@ import { Translation, useTranslation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { getTronStakingRewards, isTronClaimSupported } from '@suite-common/wallet-utils';
-import { Button } from '@trezor/components';
+import { Button, Tooltip } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
 import { useFirmwareUpgradeModal } from 'src/hooks/suite/useFirmwareUpgradeModal';
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
 import { useTronStakeContext } from '../TronStakeContext';
 
@@ -23,14 +24,21 @@ export const TronClaimSubmitButton = () => {
     const { isFirmwareModalOpen, openFirmwareModal, closeFirmwareModal, updateFirmware } =
         useFirmwareUpgradeModal();
 
+    const { isClaimingDisabled, claimingMessageContent } = useMessageSystemStaking(account.symbol);
+
     const hasReward = new BigNumber(getTronStakingRewards(account)).gt(0);
     const isDeviceLocked = !!device?.connected && !!device?.available && isLocked();
     const isClaimFirmwareOutdated = !isTronClaimSupported(device);
 
-    const isDisabled = !hasReward || isSubmitting || isDeviceLocked || !!pendingTxid;
+    const isDisabled =
+        isClaimingDisabled || !hasReward || isSubmitting || isDeviceLocked || !!pendingTxid;
     const isLoading = isSubmitting || isDiscoveryRunning;
 
     const handleClick = () => {
+        if (isClaimingDisabled) {
+            return;
+        }
+
         if (isClaimFirmwareOutdated) {
             openFirmwareModal();
 
@@ -62,15 +70,18 @@ export const TronClaimSubmitButton = () => {
                     featureName={translationString('TR_EARN_TRON_CLAIM_TITLE')}
                 />
             )}
-            <Button
-                size="large"
-                width="100%"
-                onClick={handleClick}
-                isDisabled={isDisabled}
-                isLoading={isLoading}
-            >
-                <Translation id="TR_CONTINUE" />
-            </Button>
+
+            <Tooltip content={claimingMessageContent}>
+                <Button
+                    size="large"
+                    width="100%"
+                    onClick={handleClick}
+                    isDisabled={isDisabled}
+                    isLoading={isLoading}
+                >
+                    <Translation id="TR_CONTINUE" />
+                </Button>
+            </Tooltip>
         </>
     );
 };

--- a/packages/suite/src/components/earn/staking/tron/freeze/TronFreezeStep.tsx
+++ b/packages/suite/src/components/earn/staking/tron/freeze/TronFreezeStep.tsx
@@ -3,6 +3,8 @@ import { FormProvider } from 'react-hook-form';
 import { Translation } from '@suite/intl';
 import { Banner, Card, Column, Divider } from '@trezor/components';
 
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
+
 import { useTronStakeContext } from '../TronStakeContext';
 import { TronStakeFees } from '../TronStakeFees';
 import { TronStakePendingTransaction } from '../TronStakePendingTransaction';
@@ -11,12 +13,18 @@ import { TronFreezeResourceSelect } from './TronFreezeResourceSelect';
 import { TronFreezeSubmitButton } from './TronFreezeSubmitButton';
 
 export const TronFreezeStep = () => {
-    const { form, actions } = useTronStakeContext();
+    const { form, actions, account } = useTronStakeContext();
     const { error } = actions;
+
+    const { isStakingDisabled, stakingMessageContent } = useMessageSystemStaking(account.symbol);
 
     return (
         <FormProvider {...form.methods}>
             <Column gap={16}>
+                {isStakingDisabled && (
+                    <Banner intent="warning" description={stakingMessageContent} />
+                )}
+
                 <Card paddingType="none">
                     <Column gap={16} padding={{ vertical: 16, horizontal: 20 }}>
                         <TronFreezeAmount />

--- a/packages/suite/src/components/earn/staking/tron/freeze/TronFreezeSubmitButton.tsx
+++ b/packages/suite/src/components/earn/staking/tron/freeze/TronFreezeSubmitButton.tsx
@@ -5,9 +5,10 @@ import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
-import { Button } from '@trezor/components';
+import { Button, Tooltip } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
 import { useTronStakeContext } from '../TronStakeContext';
 
@@ -19,9 +20,15 @@ export const TronFreezeSubmitButton = () => {
     const { isSubmitting, pendingTxid, submitAction } = actions;
     const { isValid } = useFormState({ control: form.methods.control });
 
+    const { isStakingDisabled, stakingMessageContent } = useMessageSystemStaking(account.symbol);
+
     const isDeviceLocked = !!device?.connected && !!device?.available && isLocked();
 
     const handleClick = () => {
+        if (isStakingDisabled) {
+            return;
+        }
+
         submitAction();
 
         if (!device?.connected || !device?.available) {
@@ -41,14 +48,18 @@ export const TronFreezeSubmitButton = () => {
     };
 
     return (
-        <Button
-            size="large"
-            width="100%"
-            onClick={handleClick}
-            isDisabled={!isValid || isSubmitting || isDeviceLocked || !!pendingTxid}
-            isLoading={isSubmitting || isDiscoveryRunning}
-        >
-            <Translation id="TR_CONTINUE" />
-        </Button>
+        <Tooltip content={stakingMessageContent}>
+            <Button
+                size="large"
+                width="100%"
+                onClick={handleClick}
+                isDisabled={
+                    isStakingDisabled || !isValid || isSubmitting || isDeviceLocked || !!pendingTxid
+                }
+                isLoading={isSubmitting || isDiscoveryRunning}
+            >
+                <Translation id="TR_CONTINUE" />
+            </Button>
+        </Tooltip>
     );
 };

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
@@ -22,6 +22,7 @@ import { exhaustive } from '@trezor/type-utils';
 
 import { setConnectionModal, setConnectionMode } from 'src/actions/device/deviceSlice';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
 import { resolveVotedRepresentativeAddress } from '../voteUtils';
 import { type useTronStakeForm } from './useTronStakeForm';
@@ -54,6 +55,14 @@ export const useTronStakeActions = ({
         selectTronStakeSession(state, account.key, flow),
     );
 
+    const {
+        isStakingDisabled,
+        isUnstakingDisabled,
+        isClaimingDisabled,
+        isVotingDisabled,
+        isWithdrawingDisabled,
+    } = useMessageSystemStaking(account.symbol);
+
     const goToStep = (nextStep: TronStakeStepId) =>
         dispatch(tronStakeActions.goToStep({ accountKey: account.key, flow, step: nextStep }));
 
@@ -75,6 +84,8 @@ export const useTronStakeActions = ({
 
         switch (step) {
             case 'freeze': {
+                if (isStakingDisabled) break;
+
                 const { amount, resourceType } = form.methods.getValues();
                 dispatch(
                     submitTronFreezeThunk({
@@ -93,6 +104,8 @@ export const useTronStakeActions = ({
                 break;
             }
             case 'vote': {
+                if (isVotingDisabled) break;
+
                 const representativeAddress = resolveVotedRepresentativeAddress(
                     form.methods.getValues(),
                 );
@@ -151,6 +164,8 @@ export const useTronStakeActions = ({
                 break;
             }
             case 'unstake': {
+                if (isUnstakingDisabled) break;
+
                 const { amount, resourceType } = form.methods.getValues();
                 dispatch(
                     submitTronUnstakeThunk({
@@ -169,6 +184,8 @@ export const useTronStakeActions = ({
                 break;
             }
             case 'withdraw':
+                if (isWithdrawingDisabled) break;
+
                 form.methods.setValue('amount', getTronWithdrawableBalance(account));
                 dispatch(
                     submitTronWithdrawThunk({
@@ -184,6 +201,8 @@ export const useTronStakeActions = ({
                 );
                 break;
             case 'claim':
+                if (isClaimingDisabled) break;
+
                 form.methods.setValue('amount', getTronStakingRewards(account));
                 dispatch(
                     submitTronClaimThunk({

--- a/packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeForm.tsx
+++ b/packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeForm.tsx
@@ -4,6 +4,8 @@ import { Translation } from '@suite/intl';
 import { Banner, Card, Column, Divider, Text } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
+
 import { useTronStakeContext } from '../TronStakeContext';
 import { TronStakeFees } from '../TronStakeFees';
 import { TronStakePendingTransaction } from '../TronStakePendingTransaction';
@@ -13,8 +15,12 @@ import { TronUnstakeResourceSelect } from './TronUnstakeResourceSelect';
 import { TronUnstakeSubmitButton } from './TronUnstakeSubmitButton';
 
 export const TronUnstakeForm = () => {
-    const { form, actions } = useTronStakeContext();
+    const { form, actions, account } = useTronStakeContext();
     const { error } = actions;
+
+    const { isUnstakingDisabled, unstakingMessageContent } = useMessageSystemStaking(
+        account.symbol,
+    );
 
     const amount = useWatch({ control: form.methods.control, name: 'amount' });
     const showReduction = new BigNumber(amount || 0).gt(0);
@@ -30,6 +36,10 @@ export const TronUnstakeForm = () => {
                         <Translation id="TR_EARN_TRON_UNSTAKE_DESCRIPTION" />
                     </Text>
                 </Column>
+
+                {isUnstakingDisabled && (
+                    <Banner intent="warning" description={unstakingMessageContent} />
+                )}
 
                 <Card paddingType="none">
                     <Column gap={16} padding={{ vertical: 16 }}>

--- a/packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeSubmitButton.tsx
+++ b/packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeSubmitButton.tsx
@@ -5,9 +5,10 @@ import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
-import { Button } from '@trezor/components';
+import { Button, Tooltip } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
 import { useTronStakeContext } from '../TronStakeContext';
 
@@ -19,9 +20,17 @@ export const TronUnstakeSubmitButton = () => {
     const { isSubmitting, pendingTxid, submitAction } = actions;
     const { isValid } = useFormState({ control: form.methods.control });
 
+    const { isUnstakingDisabled, unstakingMessageContent } = useMessageSystemStaking(
+        account.symbol,
+    );
+
     const isDeviceLocked = !!device?.connected && !!device?.available && isLocked();
 
     const handleClick = () => {
+        if (isUnstakingDisabled) {
+            return;
+        }
+
         submitAction();
 
         if (!device?.connected || !device?.available) {
@@ -41,14 +50,22 @@ export const TronUnstakeSubmitButton = () => {
     };
 
     return (
-        <Button
-            size="large"
-            width="100%"
-            onClick={handleClick}
-            isDisabled={!isValid || isSubmitting || isDeviceLocked || !!pendingTxid}
-            isLoading={isSubmitting || isDiscoveryRunning}
-        >
-            <Translation id="TR_CONTINUE" />
-        </Button>
+        <Tooltip content={unstakingMessageContent}>
+            <Button
+                size="large"
+                width="100%"
+                onClick={handleClick}
+                isDisabled={
+                    isUnstakingDisabled ||
+                    !isValid ||
+                    isSubmitting ||
+                    isDeviceLocked ||
+                    !!pendingTxid
+                }
+                isLoading={isSubmitting || isDiscoveryRunning}
+            >
+                <Translation id="TR_CONTINUE" />
+            </Button>
+        </Tooltip>
     );
 };

--- a/packages/suite/src/components/earn/staking/tron/vote/TronVoteForm.tsx
+++ b/packages/suite/src/components/earn/staking/tron/vote/TronVoteForm.tsx
@@ -4,6 +4,8 @@ import { Translation } from '@suite/intl';
 import { Banner, Card, Column, Text } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
+
 import { useTronStakeContext } from '../TronStakeContext';
 import { TronStakeFees } from '../TronStakeFees';
 import { TronStakeInfoRow } from '../TronStakeInfoRow';
@@ -15,6 +17,8 @@ import { TronVoteSubmitButton } from './TronVoteSubmitButton';
 export const TronVoteForm = () => {
     const { account, form, actions } = useTronStakeContext();
     const { error } = actions;
+
+    const { isVotingDisabled, votingMessageContent } = useMessageSystemStaking(account.symbol);
 
     const totalVotingPower =
         account.networkType === 'tron'
@@ -28,6 +32,8 @@ export const TronVoteForm = () => {
                 <Text typographyStyle="headline-md">
                     <Translation id="TR_EARN_TRON_CHANGE_REPRESENTATIVE" />
                 </Text>
+
+                {isVotingDisabled && <Banner intent="warning" description={votingMessageContent} />}
 
                 <Card type="contrast" paddingType="none">
                     <TronStakeInfoRow label={<Translation id="TR_TRON_VOTES" />}>

--- a/packages/suite/src/components/earn/staking/tron/vote/TronVoteStep.tsx
+++ b/packages/suite/src/components/earn/staking/tron/vote/TronVoteStep.tsx
@@ -3,6 +3,8 @@ import { FormProvider } from 'react-hook-form';
 import { Translation } from '@suite/intl';
 import { Banner, Column } from '@trezor/components';
 
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
+
 import { useTronStakeContext } from '../TronStakeContext';
 import { TronStakeFees } from '../TronStakeFees';
 import { TronStakePendingTransaction } from '../TronStakePendingTransaction';
@@ -11,12 +13,16 @@ import { TronVoteRepresentativeSelect } from './TronVoteRepresentativeSelect';
 import { TronVoteSubmitButton } from './TronVoteSubmitButton';
 
 export const TronVoteStep = () => {
-    const { form, actions } = useTronStakeContext();
+    const { form, actions, account } = useTronStakeContext();
     const { error } = actions;
+
+    const { isVotingDisabled, votingMessageContent } = useMessageSystemStaking(account.symbol);
 
     return (
         <FormProvider {...form.methods}>
             <Column gap={16}>
+                {isVotingDisabled && <Banner intent="warning" description={votingMessageContent} />}
+
                 <TronVoteRepresentativeSelect />
 
                 <TronVoteApr />

--- a/packages/suite/src/components/earn/staking/tron/vote/TronVoteSubmitButton.tsx
+++ b/packages/suite/src/components/earn/staking/tron/vote/TronVoteSubmitButton.tsx
@@ -5,9 +5,10 @@ import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
-import { Button } from '@trezor/components';
+import { Button, Tooltip } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
 import { useTronStakeContext } from '../TronStakeContext';
 import { CUSTOM_REPRESENTATIVE } from './constants';
@@ -19,6 +20,8 @@ export const TronVoteSubmitButton = () => {
     const { account, form, actions } = useTronStakeContext();
     const { isSubmitting, pendingTxid, submitAction } = actions;
     const { control } = form.methods;
+
+    const { isVotingDisabled, votingMessageContent } = useMessageSystemStaking(account.symbol);
 
     const representative = useWatch({ control, name: 'representative' });
     const customRepresentativeAddress = useWatch({ control, name: 'customRepresentativeAddress' });
@@ -32,6 +35,10 @@ export const TronVoteSubmitButton = () => {
     const isDeviceLocked = !!device?.connected && !!device?.available && isLocked();
 
     const handleClick = () => {
+        if (isVotingDisabled) {
+            return;
+        }
+
         submitAction();
 
         if (!device?.connected || !device?.available) {
@@ -50,16 +57,22 @@ export const TronVoteSubmitButton = () => {
     };
 
     return (
-        <Button
-            size="large"
-            width="100%"
-            onClick={handleClick}
-            isDisabled={
-                !isRepresentativeSelected || isSubmitting || isDeviceLocked || !!pendingTxid
-            }
-            isLoading={isSubmitting || isDiscoveryRunning}
-        >
-            <Translation id="TR_CONTINUE" />
-        </Button>
+        <Tooltip content={votingMessageContent}>
+            <Button
+                size="large"
+                width="100%"
+                onClick={handleClick}
+                isDisabled={
+                    isVotingDisabled ||
+                    !isRepresentativeSelected ||
+                    isSubmitting ||
+                    isDeviceLocked ||
+                    !!pendingTxid
+                }
+                isLoading={isSubmitting || isDiscoveryRunning}
+            >
+                <Translation id="TR_CONTINUE" />
+            </Button>
+        </Tooltip>
     );
 };

--- a/packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawForm.tsx
@@ -3,6 +3,8 @@ import { FormProvider } from 'react-hook-form';
 import { Translation } from '@suite/intl';
 import { Banner, Column, Text } from '@trezor/components';
 
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
+
 import { useTronStakeContext } from '../TronStakeContext';
 import { TronStakeFees } from '../TronStakeFees';
 import { TronStakePendingTransaction } from '../TronStakePendingTransaction';
@@ -10,8 +12,12 @@ import { TronWithdrawAmount } from './TronWithdrawAmount';
 import { TronWithdrawSubmitButton } from './TronWithdrawSubmitButton';
 
 export const TronWithdrawForm = () => {
-    const { form, actions } = useTronStakeContext();
+    const { form, actions, account } = useTronStakeContext();
     const { error } = actions;
+
+    const { isWithdrawingDisabled, withdrawingMessageContent } = useMessageSystemStaking(
+        account.symbol,
+    );
 
     return (
         <FormProvider {...form.methods}>
@@ -19,6 +25,10 @@ export const TronWithdrawForm = () => {
                 <Text typographyStyle="headline-md">
                     <Translation id="TR_EARN_TRON_WITHDRAW_TITLE" />
                 </Text>
+
+                {isWithdrawingDisabled && (
+                    <Banner intent="warning" description={withdrawingMessageContent} />
+                )}
 
                 <TronWithdrawAmount />
 

--- a/packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawSubmitButton.tsx
+++ b/packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawSubmitButton.tsx
@@ -4,10 +4,11 @@ import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { getTronWithdrawableBalance } from '@suite-common/wallet-utils';
-import { Button } from '@trezor/components';
+import { Button, Tooltip } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
 import { useTronStakeContext } from '../TronStakeContext';
 
@@ -18,10 +19,18 @@ export const TronWithdrawSubmitButton = () => {
     const { account, actions } = useTronStakeContext();
     const { isSubmitting, pendingTxid, submitAction } = actions;
 
+    const { isWithdrawingDisabled, withdrawingMessageContent } = useMessageSystemStaking(
+        account.symbol,
+    );
+
     const hasWithdrawableAmount = new BigNumber(getTronWithdrawableBalance(account)).gt(0);
     const isDeviceUnavailable = !!device?.connected && !!device?.available && isLocked();
 
     const handleClick = () => {
+        if (isWithdrawingDisabled) {
+            return;
+        }
+
         submitAction();
 
         if (!device?.connected || !device?.available) {
@@ -39,16 +48,22 @@ export const TronWithdrawSubmitButton = () => {
     };
 
     return (
-        <Button
-            size="large"
-            width="100%"
-            onClick={handleClick}
-            isDisabled={
-                !hasWithdrawableAmount || isSubmitting || isDeviceUnavailable || !!pendingTxid
-            }
-            isLoading={isSubmitting || isDiscoveryRunning}
-        >
-            <Translation id="TR_CONTINUE" />
-        </Button>
+        <Tooltip content={withdrawingMessageContent}>
+            <Button
+                size="large"
+                width="100%"
+                onClick={handleClick}
+                isDisabled={
+                    isWithdrawingDisabled ||
+                    !hasWithdrawableAmount ||
+                    isSubmitting ||
+                    isDeviceUnavailable ||
+                    !!pendingTxid
+                }
+                isLoading={isSubmitting || isDiscoveryRunning}
+            >
+                <Translation id="TR_CONTINUE" />
+            </Button>
+        </Tooltip>
     );
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx
@@ -1,6 +1,7 @@
 import { ContextMessage } from '@suite/message-system';
 import { Context } from '@suite-common/message-system';
 import {
+    isSupportedAdaStakingNetworkSymbol,
     isSupportedEthStakingNetworkSymbol,
     isSupportedSolStakingNetworkSymbol,
     isSupportedTronStakingNetworkSymbol,
@@ -45,6 +46,11 @@ export const AccountBanners = ({ account }: AccountBannersProps) => {
                 isSupportedTronStakingNetworkSymbol(account.symbol) &&
                 route?.name === 'wallet-staking' && (
                     <ContextMessage context={Context.getStaking('trx')} />
+                )}
+            {account?.symbol &&
+                isSupportedAdaStakingNetworkSymbol(account.symbol) &&
+                route?.name === 'wallet-staking' && (
+                    <ContextMessage context={Context.getStaking('ada')} />
                 )}
             <BackendDisconnected />
             <DeviceUnavailable />

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx
@@ -3,6 +3,7 @@ import { Context } from '@suite-common/message-system';
 import {
     isSupportedEthStakingNetworkSymbol,
     isSupportedSolStakingNetworkSymbol,
+    isSupportedTronStakingNetworkSymbol,
 } from '@suite-common/wallet-utils';
 import { Column } from '@trezor/components';
 
@@ -39,6 +40,11 @@ export const AccountBanners = ({ account }: AccountBannersProps) => {
                 isSupportedSolStakingNetworkSymbol(account.symbol) &&
                 route?.name === 'wallet-staking' && (
                     <ContextMessage context={Context.getStaking('sol')} />
+                )}
+            {account?.symbol &&
+                isSupportedTronStakingNetworkSymbol(account.symbol) &&
+                route?.name === 'wallet-staking' && (
+                    <ContextMessage context={Context.getStaking('trx')} />
                 )}
             <BackendDisconnected />
             <DeviceUnavailable />

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourceModal.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourceModal.tsx
@@ -9,10 +9,11 @@ import {
     getTronStakingInfo,
     sunToTrx,
 } from '@suite-common/wallet-utils';
-import { Button, Card, Column, Divider, Icon, Modal, Row, Text } from '@trezor/components';
+import { Button, Card, Column, Divider, Icon, Modal, Row, Text, Tooltip } from '@trezor/components';
 import { InfoIcon } from '@trezor/icons';
 
 import { useDispatch } from 'src/hooks/suite';
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
 import {
     TronResourceBreakdownRow,
@@ -31,6 +32,8 @@ export const TronResourceModal = ({ account, resourceType, onClose }: TronResour
     const resources = getTronResources(account);
     const stakingInfo = getTronStakingInfo(account);
     const isEnergy = resourceType === 'energy';
+
+    const { isStakingDisabled, stakingMessageContent } = useMessageSystemStaking(account.symbol);
 
     const freeBandwidth = resources?.totalFreeBandwidth ?? 0;
     const stakedBandwidth = resources?.totalStakedBandwidth ?? 0;
@@ -83,6 +86,10 @@ export const TronResourceModal = ({ account, resourceType, onClose }: TronResour
         : formatBandwidthValue(availableFreeBandwidth, availableStakedBandwidth);
 
     const goToFreeze = () => {
+        if (isStakingDisabled) {
+            return;
+        }
+
         dispatch(
             goto({
                 routeName: 'earn-tron-stake',
@@ -116,9 +123,17 @@ export const TronResourceModal = ({ account, resourceType, onClose }: TronResour
             onCancel={onClose}
             bottomContent={
                 <Row gap={8}>
-                    <Button intent="brand" priority="primary" onClick={goToFreeze}>
-                        <Translation id="TR_EARN_TRON_GET_MORE" />
-                    </Button>
+                    <Tooltip content={stakingMessageContent}>
+                        <Button
+                            intent="brand"
+                            priority="primary"
+                            onClick={goToFreeze}
+                            isDisabled={isStakingDisabled}
+                        >
+                            <Translation id="TR_EARN_TRON_GET_MORE" />
+                        </Button>
+                    </Tooltip>
+
                     <Button intent="neutral" priority="secondary" onClick={onClose}>
                         <Translation id="TR_CLOSE" />
                     </Button>

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx
@@ -6,10 +6,11 @@ import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { type Account, type TronResourceType } from '@suite-common/wallet-types';
 import { getTronResources } from '@suite-common/wallet-utils';
-import { Button, Card, Column, Icon, Row, Text } from '@trezor/components';
+import { Button, Card, Column, Icon, Row, Text, Tooltip } from '@trezor/components';
 import { LightningIcon } from '@trezor/icons';
 
 import { useDispatch } from 'src/hooks/suite';
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
 import { TronResourceModal } from '../TronResourceModal';
 import { TronResourceRow } from './TronResourceRow';
@@ -24,6 +25,8 @@ export const TronResourcesCard = ({ account }: TronResourcesCardProps) => {
     const [openResource, setOpenResource] = useState<TronResourceType | null>(null);
     const resources = getTronResources(account);
 
+    const { isStakingDisabled, stakingMessageContent } = useMessageSystemStaking(account.symbol);
+
     const bandwidthAvailable =
         (resources?.availableStakedBandwidth ?? 0) + (resources?.availableFreeBandwidth ?? 0);
     const bandwidthTotal =
@@ -32,6 +35,10 @@ export const TronResourcesCard = ({ account }: TronResourcesCardProps) => {
     const energyTotal = resources?.totalEnergy ?? 0;
 
     const goToFreeze = () => {
+        if (isStakingDisabled) {
+            return;
+        }
+
         dispatch(
             goto({
                 routeName: 'earn-tron-stake',
@@ -65,9 +72,16 @@ export const TronResourcesCard = ({ account }: TronResourcesCardProps) => {
                 </Row>
             }
             footer={
-                <Button intent="neutral" priority="secondary" onClick={goToFreeze}>
-                    <Translation id="TR_EARN_TRON_GET_MORE" />
-                </Button>
+                <Tooltip content={stakingMessageContent}>
+                    <Button
+                        intent="neutral"
+                        priority="secondary"
+                        onClick={goToFreeze}
+                        isDisabled={isStakingDisabled}
+                    >
+                        <Translation id="TR_EARN_TRON_GET_MORE" />
+                    </Button>
+                </Tooltip>
             }
         >
             <Column gap={16} alignItems="stretch">

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx
@@ -28,6 +28,7 @@ import { BigNumber } from '@trezor/utils';
 import { formatApr } from 'src/components/earn/staking/tron/voteUtils';
 import { BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
 import { TronVoteAllocationModal } from './TronVoteAllocationModal/TronVoteAllocationModal';
 
@@ -41,6 +42,15 @@ export const TronStakedCard = ({ account }: TronStakedCardProps) => {
     const [isVoteAllocationOpen, setIsVoteAllocationOpen] = useState(false);
     const { stats, maxApr } = useTronStakingStats();
 
+    const {
+        isStakingDisabled,
+        stakingMessageContent,
+        isUnstakingDisabled,
+        unstakingMessageContent,
+        isVotingDisabled,
+        votingMessageContent,
+    } = useMessageSystemStaking(account.symbol);
+
     const stakedBalance = getTronAccountTotalStakingBalance(account) ?? '0';
     const hasStake = new BigNumber(stakedBalance).gt(0);
     const votedAddresses = getTronVotes(account).map(vote => vote.address);
@@ -51,6 +61,18 @@ export const TronStakedCard = ({ account }: TronStakedCardProps) => {
     const shouldShowRemainingVotes = new BigNumber(remainingVotes).plus(totalVotes).gt(0);
 
     const goToFlow = (routeName: 'earn-tron-stake' | 'earn-tron-unstake' | 'earn-tron-vote') => {
+        if (isStakingDisabled && routeName === 'earn-tron-stake') {
+            return;
+        }
+
+        if (isUnstakingDisabled && routeName === 'earn-tron-unstake') {
+            return;
+        }
+
+        if (isVotingDisabled && routeName === 'earn-tron-vote') {
+            return;
+        }
+
         dispatch(
             goto({
                 routeName,
@@ -100,36 +122,47 @@ export const TronStakedCard = ({ account }: TronStakedCardProps) => {
             }
             footer={
                 <Row gap={8}>
-                    <Button
-                        intent="brand"
-                        priority="primary"
-                        onClick={() => goToFlow('earn-tron-stake')}
-                    >
-                        <Translation
-                            id={
-                                hasStake
-                                    ? 'TR_EARN_STAKING_DASHBOARD_STAKE_MORE'
-                                    : 'TR_EARN_STAKING_DASHBOARD_STAKE_NOW'
-                            }
-                        />
-                    </Button>
-                    {hasStake && (
+                    <Tooltip content={stakingMessageContent}>
                         <Button
-                            intent="neutral"
-                            priority="secondary"
-                            onClick={() => goToFlow('earn-tron-unstake')}
+                            intent="brand"
+                            priority="primary"
+                            onClick={() => goToFlow('earn-tron-stake')}
+                            isDisabled={isStakingDisabled}
                         >
-                            <Translation id="TR_EARN_TRON_UNSTAKE_TITLE" />
+                            <Translation
+                                id={
+                                    hasStake
+                                        ? 'TR_EARN_STAKING_DASHBOARD_STAKE_MORE'
+                                        : 'TR_EARN_STAKING_DASHBOARD_STAKE_NOW'
+                                }
+                            />
                         </Button>
+                    </Tooltip>
+
+                    {hasStake && (
+                        <Tooltip content={unstakingMessageContent}>
+                            <Button
+                                intent="neutral"
+                                priority="secondary"
+                                onClick={() => goToFlow('earn-tron-unstake')}
+                                isDisabled={isUnstakingDisabled}
+                            >
+                                <Translation id="TR_EARN_TRON_UNSTAKE_TITLE" />
+                            </Button>
+                        </Tooltip>
                     )}
+
                     {hasStake && (
-                        <Button
-                            intent="neutral"
-                            priority="secondary"
-                            onClick={() => goToFlow('earn-tron-vote')}
-                        >
-                            <Translation id="TR_EARN_TRON_VOTE" />
-                        </Button>
+                        <Tooltip content={votingMessageContent}>
+                            <Button
+                                intent="neutral"
+                                priority="secondary"
+                                onClick={() => goToFlow('earn-tron-vote')}
+                                isDisabled={isVotingDisabled}
+                            >
+                                <Translation id="TR_EARN_TRON_VOTE" />
+                            </Button>
+                        </Tooltip>
                     )}
                 </Row>
             }

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVoteAllocationModal/TronVoteAllocationModal.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVoteAllocationModal/TronVoteAllocationModal.tsx
@@ -19,11 +19,13 @@ import {
     Row,
     Table,
     Text,
+    Tooltip,
 } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
 import { TronStakeInfoRow } from 'src/components/earn/staking/tron/TronStakeInfoRow';
 import { useDispatch } from 'src/hooks/suite';
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
 import { TronVoteAllocationRow } from './TronVoteAllocationRow';
 
@@ -37,6 +39,8 @@ export const TronVoteAllocationModal = ({ account, onClose }: TronVoteAllocation
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { stats } = useTronStakingStats();
 
+    const { isVotingDisabled, votingMessageContent } = useMessageSystemStaking(account.symbol);
+
     const remainingVotes = getTronAvailableVotingPower(account);
     const totalVotes = getTronTotalVotingPower(account);
     const hasRemainingVotes = new BigNumber(remainingVotes).gt(0);
@@ -44,6 +48,10 @@ export const TronVoteAllocationModal = ({ account, onClose }: TronVoteAllocation
     const hasVotes = votes.length > 0;
 
     const goToVote = () => {
+        if (isVotingDisabled) {
+            return;
+        }
+
         dispatch(
             goto({
                 routeName: 'earn-tron-vote',
@@ -89,9 +97,11 @@ export const TronVoteAllocationModal = ({ account, onClose }: TronVoteAllocation
                         icon
                         description={<Translation id="TR_EARN_TRON_ASSIGN_VOTES_BANNER" />}
                         rightContent={
-                            <Banner.Button onClick={goToVote}>
-                                <Translation id="TR_EARN_TRON_VOTE" />
-                            </Banner.Button>
+                            <Tooltip content={votingMessageContent}>
+                                <Banner.Button onClick={goToVote} isDisabled={isVotingDisabled}>
+                                    <Translation id="TR_EARN_TRON_VOTE" />
+                                </Banner.Button>
+                            </Tooltip>
                         }
                     />
                 )}
@@ -139,9 +149,16 @@ export const TronVoteAllocationModal = ({ account, onClose }: TronVoteAllocation
 
                 {hasVotes && (
                     <Row>
-                        <Button intent="neutral" priority="secondary" onClick={goToVote}>
-                            <Translation id="TR_EARN_TRON_CHANGE_VOTES" />
-                        </Button>
+                        <Tooltip content={votingMessageContent}>
+                            <Button
+                                intent="neutral"
+                                priority="secondary"
+                                onClick={goToVote}
+                                isDisabled={isVotingDisabled}
+                            >
+                                <Translation id="TR_EARN_TRON_CHANGE_VOTES" />
+                            </Button>
+                        </Tooltip>
                     </Row>
                 )}
             </Column>

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx
@@ -26,6 +26,7 @@ import { BigNumber } from '@trezor/utils';
 import { BaseCurrencyValue, CountdownTimer, FormattedCryptoAmount } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
 import { useFirmwareUpgradeModal } from 'src/hooks/suite/useFirmwareUpgradeModal';
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
 interface TronVotingRewardsCardProps {
     account: Account;
@@ -44,11 +45,17 @@ export const TronVotingRewardsCard = ({ account }: TronVotingRewardsCardProps) =
     const claimCooldownEndsAt = getTronRewardClaimCooldownEndsAt(account);
     const isClaimFirmwareOutdated = !isTronClaimSupported(device);
 
+    const { isClaimingDisabled, claimingMessageContent } = useMessageSystemStaking(account.symbol);
+
     if (new BigNumber(rewards).lte(0)) {
         return null;
     }
 
     const goToClaim = () => {
+        if (isClaimingDisabled) {
+            return;
+        }
+
         if (isClaimFirmwareOutdated) {
             openFirmwareModal();
 
@@ -75,6 +82,24 @@ export const TronVotingRewardsCard = ({ account }: TronVotingRewardsCardProps) =
             },
         });
     };
+
+    const claimButtonTooltipProps = isClaimingDisabled
+        ? ({ content: claimingMessageContent } as const)
+        : ({
+              isActive: isClaimOnCooldown,
+              tooltipMaxWidth: 220,
+              content: claimCooldownEndsAt !== null && (
+                  <CountdownTimer
+                      deadline={claimCooldownEndsAt * 1000}
+                      message="TR_EARN_TRON_CLAIM_COOLDOWN"
+                      minUnit="minute"
+                      unitDisplay="narrow"
+                  />
+              ),
+              placement: 'top',
+              cursor: 'not-allowed',
+              delayShow: TOOLTIP_DELAY_NONE,
+          } as const);
 
     return (
         <>
@@ -111,28 +136,13 @@ export const TronVotingRewardsCard = ({ account }: TronVotingRewardsCardProps) =
                                     />
                                 </Text>
                             </Column>
-                            <Tooltip
-                                isActive={isClaimOnCooldown}
-                                tooltipMaxWidth={220}
-                                content={
-                                    claimCooldownEndsAt !== null && (
-                                        <CountdownTimer
-                                            deadline={claimCooldownEndsAt * 1000}
-                                            message="TR_EARN_TRON_CLAIM_COOLDOWN"
-                                            minUnit="minute"
-                                            unitDisplay="narrow"
-                                        />
-                                    )
-                                }
-                                placement="top"
-                                cursor="not-allowed"
-                                delayShow={TOOLTIP_DELAY_NONE}
-                            >
+
+                            <Tooltip {...claimButtonTooltipProps}>
                                 <Button
                                     intent="neutral"
                                     priority="secondary"
                                     onClick={goToClaim}
-                                    isDisabled={isClaimOnCooldown}
+                                    isDisabled={isClaimOnCooldown || isClaimingDisabled}
                                 >
                                     <Translation id="TR_STAKE_CLAIM" />
                                 </Button>

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronWithdrawReadyBanner.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronWithdrawReadyBanner.tsx
@@ -4,11 +4,12 @@ import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { type Account } from '@suite-common/wallet-types';
 import { getTronWithdrawableBalance } from '@suite-common/wallet-utils';
-import { Banner } from '@trezor/components';
+import { Banner, Tooltip } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
 import { FormattedCryptoAmount } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
 interface TronWithdrawReadyBannerProps {
     account: Account;
@@ -18,6 +19,10 @@ export const TronWithdrawReadyBanner = ({ account }: TronWithdrawReadyBannerProp
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const withdrawableAmount = getTronWithdrawableBalance(account);
+
+    const { isWithdrawingDisabled, withdrawingMessageContent } = useMessageSystemStaking(
+        account.symbol,
+    );
 
     if (new BigNumber(withdrawableAmount).lte(0)) {
         return null;
@@ -50,9 +55,11 @@ export const TronWithdrawReadyBanner = ({ account }: TronWithdrawReadyBannerProp
             icon
             intent="info"
             rightContent={
-                <Banner.Button onClick={goToWithdraw}>
-                    <Translation id="TR_EARN_TRON_WITHDRAW_TITLE" />
-                </Banner.Button>
+                <Tooltip content={withdrawingMessageContent}>
+                    <Banner.Button onClick={goToWithdraw} isDisabled={isWithdrawingDisabled}>
+                        <Translation id="TR_EARN_TRON_WITHDRAW_TITLE" />
+                    </Banner.Button>
+                </Tooltip>
             }
             description={
                 <Translation

--- a/suite-common/message-system/src/__tests__/messageSystemTypes.test.ts
+++ b/suite-common/message-system/src/__tests__/messageSystemTypes.test.ts
@@ -37,6 +37,7 @@ describe('Message system types', () => {
             it.each([
                 ['eth', 'accounts.eth.staking'],
                 ['sol', 'accounts.sol.staking'],
+                ['trx', 'accounts.trx.staking'],
             ] as const satisfies [StakingNetworkSymbol, string][])(
                 'getStaking(%s) → %s',
                 (symbol, expected) => {

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -40,16 +40,25 @@ export const Feature = {
         eth: 'eth.staking.stake',
         sol: 'sol.staking.stake',
         ada: 'ada.staking.stake',
+        trx: 'trx.staking.stake',
     },
     unstake: {
         eth: 'eth.staking.unstake',
         sol: 'sol.staking.unstake',
         ada: 'ada.staking.unstake',
+        trx: 'trx.staking.unstake',
     },
     claim: {
         eth: 'eth.staking.claim',
         sol: 'sol.staking.claim',
         ada: 'ada.staking.claim',
+        trx: 'trx.staking.claim',
+    },
+    vote: {
+        trx: 'trx.staking.vote',
+    },
+    withdraw: {
+        trx: 'trx.staking.withdraw',
     },
 
     banners: {

--- a/suite-common/message-system/src/useMessageSystemStaking.ts
+++ b/suite-common/message-system/src/useMessageSystemStaking.ts
@@ -9,15 +9,19 @@ const availableNetworks = [
     ...Object.keys(Feature.stake),
     ...Object.keys(Feature.unstake),
     ...Object.keys(Feature.claim),
+    ...Object.keys(Feature.vote),
+    ...Object.keys(Feature.withdraw),
 ] as NetworkSymbol[];
+
+interface UseMessageSystemStakingProps {
+    networkSymbol?: NetworkSymbol | null;
+    locale: string;
+}
 
 export const useMessageSystemStaking = ({
     networkSymbol,
     locale,
-}: {
-    networkSymbol?: NetworkSymbol | null;
-    locale: string;
-}) => {
+}: UseMessageSystemStakingProps) => {
     const isAvailable = networkSymbol != null && availableNetworks.includes(networkSymbol);
     const isStaking = isAvailable && networkSymbol in Feature.stake;
     const key = networkSymbol as keyof typeof Feature.stake;
@@ -25,6 +29,8 @@ export const useMessageSystemStaking = ({
     const stake = isStaking ? Feature.stake[key] : undefined;
     const unstake = isStaking ? Feature.unstake[key] : undefined;
     const claim = isStaking ? Feature.claim[key] : undefined;
+    const vote = isStaking && key === 'trx' ? Feature.vote[key] : undefined;
+    const withdraw = isStaking && key === 'trx' ? Feature.withdraw[key] : undefined;
 
     const isStakingDisabled = useSelector((state: MessageSystemRootState) =>
         stake ? selectIsFeatureDisabled(state, stake) : undefined,
@@ -36,6 +42,13 @@ export const useMessageSystemStaking = ({
         claim ? selectIsFeatureDisabled(state, claim) : undefined,
     );
 
+    const isVotingDisabled = useSelector((state: MessageSystemRootState) =>
+        vote ? selectIsFeatureDisabled(state, vote) : undefined,
+    );
+    const isWithdrawingDisabled = useSelector((state: MessageSystemRootState) =>
+        withdraw ? selectIsFeatureDisabled(state, withdraw) : undefined,
+    );
+
     const stakingMessageContent = useSelector((state: MessageSystemRootState) =>
         stake ? selectFeatureMessageContent(state, stake, locale) : undefined,
     );
@@ -45,13 +58,23 @@ export const useMessageSystemStaking = ({
     const claimingMessageContent = useSelector((state: MessageSystemRootState) =>
         claim ? selectFeatureMessageContent(state, claim, locale) : undefined,
     );
+    const votingMessageContent = useSelector((state: MessageSystemRootState) =>
+        vote ? selectFeatureMessageContent(state, vote, locale) : undefined,
+    );
+    const withdrawingMessageContent = useSelector((state: MessageSystemRootState) =>
+        withdraw ? selectFeatureMessageContent(state, withdraw, locale) : undefined,
+    );
 
     return {
         isStakingDisabled,
         isUnstakingDisabled,
         isClaimingDisabled,
+        isVotingDisabled,
+        isWithdrawingDisabled,
         stakingMessageContent,
         unstakingMessageContent,
         claimingMessageContent,
+        votingMessageContent,
+        withdrawingMessageContent,
     };
 };


### PR DESCRIPTION
## Description

Add message system guards to Tron staking.

Additionally, this PR adds a context banner to Cardano staking.

## Notes for QA

Useful message system messages for testing:

```
[
    {
        "conditions": [],
        "message": {
            "id": "351edcf5-c2b3-4f26-bfec-29ccd235ff44",
            "priority": 1,
            "dismissible": false,
            "variant": "info",
            "category": "feature",
            "content": {
                "en": "Staking TRX is temporarily unavailable. Please try again later.",
                "es": "El staking de TRX no está disponible temporalmente. Inténtalo de nuevo más tarde.",
                "cs": "Staking TRX je dočasně nedostupný. Zkuste to prosím později.",
                "de": "Das Staking von TRX ist vorübergehend nicht verfügbar. Bitte versuchen Sie es später erneut.",
                "fr": "Le staking de TRX est temporairement indisponible. Veuillez réessayer plus tard.",
                "pt": "O staking de TRX está temporariamente indisponível. Tente novamente mais tarde."
            },
            "feature": [
                {
                    "domain": "trx.staking.stake",
                    "flag": false
                }
            ]
        }
    },
    {
        "conditions": [],
        "message": {
            "id": "fe15ae83-4bde-4323-a80c-3d34157efa7f",
            "priority": 1,
            "dismissible": false,
            "variant": "info",
            "category": "feature",
            "content": {
                "en": "Voting for Tron witnesses is temporarily unavailable. Please try again later.",
                "es": "La votación de testigos de Tron no está disponible temporalmente. Inténtalo de nuevo más tarde.",
                "cs": "Hlasování pro Tron witnesses je dočasně nedostupné. Zkuste to prosím později.",
                "de": "Die Abstimmung für Tron-Witnesses ist vorübergehend nicht verfügbar. Bitte versuchen Sie es später erneut.",
                "fr": "Le vote pour les témoins Tron est temporairement indisponible. Veuillez réessayer plus tard.",
                "pt": "A votação para testemunhas da Tron está temporariamente indisponível. Tente novamente mais tarde."
            },
            "feature": [
                {
                    "domain": "trx.staking.vote",
                    "flag": false
                }
            ]
        }
    },
    {
        "conditions": [],
        "message": {
            "id": "e800b8e3-34a3-4cfd-a12d-6136bb36d490",
            "priority": 1,
            "dismissible": false,
            "variant": "info",
            "category": "feature",
            "content": {
                "en": "Unstaking TRX is temporarily unavailable. Please try again later.",
                "es": "El unstaking de TRX no está disponible temporalmente. Inténtalo de nuevo más tarde.",
                "cs": "Unstaking TRX je dočasně nedostupný. Zkuste to prosím později.",
                "de": "Das Unstaking von TRX ist vorübergehend nicht verfügbar. Bitte versuchen Sie es später erneut.",
                "fr": "L'unstaking de TRX est temporairement indisponible. Veuillez réessayer plus tard.",
                "pt": "O unstaking de TRX está temporariamente indisponível. Tente novamente mais tarde."
            },
            "feature": [
                {
                    "domain": "trx.staking.unstake",
                    "flag": false
                }
            ]
        }
    },
    {
        "conditions": [],
        "message": {
            "id": "445eae36-caa2-40c9-82a2-e0560ecb46cf",
            "priority": 1,
            "dismissible": false,
            "variant": "info",
            "category": "feature",
            "content": {
                "en": "Withdrawing unstaked TRX is temporarily unavailable. Please try again later.",
                "es": "El retiro de TRX liberados no está disponible temporalmente. Inténtalo de nuevo más tarde.",
                "cs": "Výběr odstakovaných TRX je dočasně nedostupný. Zkuste to prosím později.",
                "de": "Die Abhebung von freigegebenen TRX ist vorübergehend nicht verfügbar. Bitte versuchen Sie es später erneut.",
                "fr": "Le retrait des TRX libérés est temporairement indisponible. Veuillez réessayer plus tard.",
                "pt": "A retirada de TRX liberados está temporariamente indisponível. Tente novamente mais tarde."
            },
            "feature": [
                {
                    "domain": "trx.staking.withdraw",
                    "flag": false
                }
            ]
        }
    },
    {
        "conditions": [],
        "message": {
            "id": "b7c057f2-ff92-4fdd-bbe7-c223adf3fa60",
            "priority": 1,
            "dismissible": false,
            "variant": "info",
            "category": "feature",
            "content": {
                "en": "Claiming TRX voting rewards is temporarily unavailable. Please try again later.",
                "es": "La reclamación de recompensas de votación de TRX no está disponible temporalmente. Inténtalo de nuevo más tarde.",
                "cs": "Vyzvednutí odměn za hlasování TRX je dočasně nedostupné. Zkuste to prosím později.",
                "de": "Das Einfordern von TRX-Abstimmungsbelohnungen ist vorübergehend nicht verfügbar. Bitte versuchen Sie es später erneut.",
                "fr": "La réclamation des récompenses de vote TRX est temporairement indisponible. Veuillez réessayer plus tard.",
                "pt": "A reivindicação de recompensas de votação TRX está temporariamente indisponível. Tente novamente mais tarde."
            },
            "feature": [
                {
                    "domain": "trx.staking.claim",
                    "flag": false
                }
            ]
        }
    },
    {
        "conditions": [],
        "message": {
            "id": "616d5d3b-4dea-495b-b602-85d573811408",
            "priority": 1,
            "dismissible": false,
            "variant": "info",
            "category": "feature",
            "content": {
                "en": "Tron staking is under maintenance. All staking actions are temporarily unavailable.",
                "es": "El staking de Tron está en mantenimiento. Todas las acciones de staking no están disponibles temporalmente.",
                "cs": "Tron staking je v údržbě. Všechny stakingové akce jsou dočasně nedostupné.",
                "de": "Das Tron-Staking wird gewartet. Alle Staking-Aktionen sind vorübergehend nicht verfügbar.",
                "fr": "Le staking Tron est en maintenance. Toutes les actions de staking sont temporairement indisponibles.",
                "pt": "O staking de Tron está em manutenção. Todas as ações de staking estão temporariamente indisponíveis."
            },
            "feature": [
                {
                    "domain": "trx.staking.stake",
                    "flag": false
                },
                {
                    "domain": "trx.staking.vote",
                    "flag": false
                },
                {
                    "domain": "trx.staking.unstake",
                    "flag": false
                },
                {
                    "domain": "trx.staking.withdraw",
                    "flag": false
                },
                {
                    "domain": "trx.staking.claim",
                    "flag": false
                }
            ]
        }
    },
    {
        "conditions": [],
        "message": {
            "id": "9d062a18-1f06-45f7-9e5d-ecfee8df56d2",
            "priority": 90,
            "dismissible": true,
            "variant": "warning",
            "category": "context",
            "content": {
                "en": "Some Tron staking actions may be temporarily unavailable.",
                "es": "Algunas acciones de staking de Tron pueden no estar disponibles temporalmente.",
                "cs": "Některé akce Tron stakingu mohou být dočasně nedostupné.",
                "de": "Einige Tron-Staking-Aktionen sind möglicherweise vorübergehend nicht verfügbar.",
                "fr": "Certaines actions de staking Tron peuvent être temporairement indisponibles.",
                "pt": "Algumas ações de staking da Tron podem estar temporariamente indisponíveis."
            },
            "cta": {
                "action": "external-link",
                "link": "https://trezor.io/support",
                "label": {
                    "en": "Learn more",
                    "es": "Más información",
                    "cs": "Zjistit více",
                    "de": "Mehr erfahren",
                    "fr": "En savoir plus",
                    "pt": "Saiba mais"
                }
            },
            "context": {
                "domain": "accounts.trx.staking"
            }
        }
    }
]
```

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29907
Resolve https://github.com/trezor/trezor-suite/issues/29914

## Screenshots:

Staking:

<img width="1512" height="845" alt="Screenshot 2026-07-16 at 13 25 23" src="https://github.com/user-attachments/assets/5b9bed20-3724-403d-aa9a-95682c13d366" />

<img width="1512" height="845" alt="Screenshot 2026-07-16 at 13 25 27" src="https://github.com/user-attachments/assets/61dbf1c9-78b7-484e-a4ec-4482f8711eb9" />

<img width="1512" height="845" alt="Screenshot 2026-07-16 at 13 25 40" src="https://github.com/user-attachments/assets/80fe956b-1b7a-4a8c-8668-7713505cfc80" />

<img width="1512" height="845" alt="Screenshot 2026-07-16 at 13 25 55" src="https://github.com/user-attachments/assets/67ba6c64-3db9-4f0d-9de6-d841e4a0ffe4" />

<img width="1512" height="845" alt="Screenshot 2026-07-16 at 13 37 05" src="https://github.com/user-attachments/assets/5cfb5627-e7cf-4673-be11-b220fd62c995" />

Voting:

<img width="1512" height="845" alt="Screenshot 2026-07-16 at 13 28 12" src="https://github.com/user-attachments/assets/85d325b0-a2cc-439c-94d6-c0da856b662a" />

<img width="1512" height="845" alt="Screenshot 2026-07-16 at 13 28 17" src="https://github.com/user-attachments/assets/cc0ad5cc-35ed-4f55-97b6-6e42d219dd91" />

<img width="1512" height="845" alt="Screenshot 2026-07-16 at 13 28 25" src="https://github.com/user-attachments/assets/321719f0-705b-42f3-8fb3-a8fd07d1af2e" />

<img width="1512" height="845" alt="Screenshot 2026-07-16 at 13 39 02" src="https://github.com/user-attachments/assets/f5f1a2da-fde2-410c-81d3-c912517988da" />

Unstaking:

<img width="1512" height="845" alt="Screenshot 2026-07-16 at 13 28 53" src="https://github.com/user-attachments/assets/622fd9d6-1237-4cef-85b2-8aa306f89252" />

<img width="1512" height="845" alt="Screenshot 2026-07-16 at 13 39 41" src="https://github.com/user-attachments/assets/51ad03df-c1be-41fb-b81f-de0f38f4abe8" />

Withdrawing:

<img width="1512" height="845" alt="Screenshot 2026-07-16 at 13 29 43" src="https://github.com/user-attachments/assets/33b0e8a4-de03-4b2e-aec7-60d4f3bed7d2" />

<img width="1512" height="845" alt="Screenshot 2026-07-16 at 13 40 18" src="https://github.com/user-attachments/assets/a82352e6-2e75-40d4-8795-8440807fe662" />

Claiming:

<img width="1512" height="845" alt="Screenshot 2026-07-16 at 13 30 26" src="https://github.com/user-attachments/assets/85b5b4c0-841a-4ba4-9d72-e1d7488a89db" />

I couldn't get to claim screen so no screenshot here.

All disabled:

<img width="1512" height="845" alt="Screenshot 2026-07-16 at 13 31 05" src="https://github.com/user-attachments/assets/fb939d59-d500-4937-9ee8-d9ee8c2ef2bb" />

<img width="1512" height="845" alt="Screenshot 2026-07-16 at 13 35 45" src="https://github.com/user-attachments/assets/8043c432-139f-4f4d-92b3-95ad2d8de3b9" />

Cardano staking context banner:

<img width="1512" height="845" alt="Screenshot 2026-07-16 at 13 49 04" src="https://github.com/user-attachments/assets/02a19136-a728-4fe5-9938-257ae35aa313" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily modifies Tron staking UI components (freeze, vote, unstake, claim, withdraw forms and dashboard cards), shared staking dashboard components (EarnStakingAccountRow, EarnStakingActionButtons), the AccountBanners component, and message-system staking types/hooks. There are no existing E2E tests for Tron-specific staking flows, so the main risk is regression in the shared staking components (action buttons, account rows) that affect ETH, SOL, and ADA staking tests. The message-system type changes and useMessageSystemStaking hook are broadly imported but unlikely to cause test-visible regressions unless they break at build time. The recommended strategy focuses on running all existing staking tests at medium priority to ensure the shared earn components still render correctly across all supported staking networks.

<details><summary><b>Changed files (24)</b></summary>

- `packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx`
- `packages/suite/src/components/earn/dashboard/staking/EarnStakingActionButtons.tsx`
- `packages/suite/src/components/earn/staking/tron/claim/TronClaimForm.tsx`
- `packages/suite/src/components/earn/staking/tron/claim/TronClaimSubmitButton.tsx`
- `packages/suite/src/components/earn/staking/tron/freeze/TronFreezeStep.tsx`
- `packages/suite/src/components/earn/staking/tron/freeze/TronFreezeSubmitButton.tsx`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts`
- `packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeForm.tsx`
- `packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeSubmitButton.tsx`
- `packages/suite/src/components/earn/staking/tron/vote/TronVoteForm.tsx`
- `packages/suite/src/components/earn/staking/tron/vote/TronVoteStep.tsx`
- `packages/suite/src/components/earn/staking/tron/vote/TronVoteSubmitButton.tsx`
- `packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawForm.tsx`
- `packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawSubmitButton.tsx`
- `packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourceModal.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVoteAllocationModal/TronVoteAllocationModal.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronWithdrawReadyBanner.tsx`
- `suite-common/message-system/src/__tests__/messageSystemTypes.test.ts`
- `suite-common/message-system/src/messageSystemTypes.ts`
- `suite-common/message-system/src/useMessageSystemStaking.ts`

</details>

**Recommended tests (13)**

<details><summary>🟡 <b>Medium priority (12)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test navigates to staking from the account menu and dashboard for ETH and ADA, exercising the EarnStakingAccountRow and EarnStakingActionButtons components that were changed. Changes to the staking dashboard row/action button components could affect staking navigation analytics.
- `suite/e2e/tests/staking/ada/claim.test.ts` — ADA claim staking test exercises the staking dashboard UI which shares the staking view layer where TronStakingDashboard components (TronStakedCard, TronVotingRewardsCard, etc.) are co-located. Changes to the staking view components or useMessageSystemStaking hook could affect the rendering of staking pages for all coins.
- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA stake test exercises the staking tab and staking dashboard components. The changed useMessageSystemStaking hook and TronStakingDashboard components are siblings in the staking view, and a broken import or export could affect the entire staking view routing.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — ADA unstake test uses the staking dashboard view where TronStakingDashboard components are registered. Changes to TronWithdrawReadyBanner or TronStakedCard could introduce build errors affecting the entire staking route.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH initial stake test navigates to the staking tab and interacts with the staking dashboard. The EarnStakingActionButtons component (changed) renders stake/unstake action buttons used across all staking dashboards including ETH.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — ETH stake-more test displays the staking dashboard with staked amounts and action buttons. EarnStakingActionButtons and EarnStakingAccountRow changes directly affect the dashboard layout that this test verifies.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstake test verifies staking dashboard amounts and the unstake/claim flow. Changes to EarnStakingActionButtons could affect the unstake button enablement logic tested here.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL initial stake test checks staking dashboard empty state and action buttons. EarnStakingActionButtons changes could affect the stake-more/unstake button visibility and enablement logic.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — SOL rewards test verifies staking dashboard display including staked amounts and action button states. EarnStakingAccountRow and EarnStakingActionButtons changes directly affect these UI elements.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — SOL stake-more test verifies the staking dashboard action buttons (stake more, unstake) which are rendered by the changed EarnStakingActionButtons component.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstake test verifies unstake/claim flow and staking dashboard state transitions. EarnStakingActionButtons changes could affect button enablement logic tested throughout this flow.
- `suite/e2e/tests/staking/staking-form.test.ts` — Staking form test opens the ETH staking form via the stakeMoreButton which is rendered by EarnStakingActionButtons. Changes to action button rendering or state could prevent the form from opening.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test crawls all routes including /earn/tron/* paths. Changes to TronStakingDashboard components and Tron staking forms could introduce broken page renders that this link checker would catch on those specific routes.

</details>

⚠️ **Changes with no test coverage (22)**
- `packages/suite/src/components/earn/staking/tron/claim/TronClaimForm.tsx`
- `packages/suite/src/components/earn/staking/tron/claim/TronClaimSubmitButton.tsx`
- `packages/suite/src/components/earn/staking/tron/freeze/TronFreezeStep.tsx`
- `packages/suite/src/components/earn/staking/tron/freeze/TronFreezeSubmitButton.tsx`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts`
- `packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeForm.tsx`
- `packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeSubmitButton.tsx`
- `packages/suite/src/components/earn/staking/tron/vote/TronVoteForm.tsx`
- `packages/suite/src/components/earn/staking/tron/vote/TronVoteStep.tsx`
- `packages/suite/src/components/earn/staking/tron/vote/TronVoteSubmitButton.tsx`
- `packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawForm.tsx`
- `packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawSubmitButton.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourceModal.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVoteAllocationModal/TronVoteAllocationModal.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx`
- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronWithdrawReadyBanner.tsx`
- `suite-common/message-system/src/__tests__/messageSystemTypes.test.ts`
- `suite-common/message-system/src/messageSystemTypes.ts`
- `suite-common/message-system/src/useMessageSystemStaking.ts`
- `packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx`

_Updated: 2026-07-16T11:54:38.748Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-staking-message-system/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-staking-message-system/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-staking-message-system&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-staking-message-system&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-staking-message-system&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-16T11:57:43.577Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-16T11:57:33.899Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->