### PR TITLE
refactor(networks): centralize more chain constants in network packages

### DIFF
--- a/networks/ripple/network-ripple/src/constants/index.ts
+++ b/networks/ripple/network-ripple/src/constants/index.ts
@@ -3,3 +3,16 @@ export const RIPPLE_DECIMALS = 6;
 // Network default reserves in drops, overwritten at runtime from `server_info`.
 export const RIPPLE_BASE_RESERVE_DEFAULT = '10000000'; // 10 XRP
 export const RIPPLE_OWNER_RESERVE_DEFAULT = '2000000'; // 2 XRP
+
+// XRPL timestamps are based on the Ripple Epoch (2000-01-01T00:00:00Z).
+// To convert to a standard Unix timestamp, add this offset.
+// https://xrpl.org/docs/references/protocol/data-types/basic-data-types#specifying-time
+const RIPPLE_EPOCH_OFFSET = 946684800;
+
+export const getUnixTimestamp = (xrplTimestamp?: number): number => {
+    if (!xrplTimestamp || xrplTimestamp <= 0) {
+        return 0;
+    }
+
+    return xrplTimestamp + RIPPLE_EPOCH_OFFSET;
+};

--- a/networks/solana/network-solana/src/constants/common.ts
+++ b/networks/solana/network-solana/src/constants/common.ts
@@ -18,6 +18,11 @@ export const SERUM_ASSET_OWNER_PHANTOM_DEPLOYMENT_PROGRAM_ID =
 export const MEMO_PROGRAM_PUBLIC_KEY = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr';
 export const MEMO_PROGRAM_PUBLIC_KEY_V1 = 'Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo';
 
+export const SOLANA_DECIMALS = 9;
+
+// genesisHash is a reliable identifier of the network.
+export const SOLANA_MAINNET_GENESIS_HASH = '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d';
+
 export const MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT = 16;
 export const MAX_DEACTIVATE_ACCOUNTS = 22;
 export const MAX_CLAIM_ACCOUNTS = 16;

--- a/packages/blockchain-link-utils/src/ripple.ts
+++ b/packages/blockchain-link-utils/src/ripple.ts
@@ -1,5 +1,5 @@
 import type { ServerInfo, Transaction } from '@trezor/blockchain-link-types';
-import { RIPPLE_DECIMALS } from '@trezor/network-ripple/constants';
+import { RIPPLE_DECIMALS, getUnixTimestamp } from '@trezor/network-ripple/constants';
 import type { AccountTxTransaction, ServerInfoResponse } from '@trezor/network-ripple/types';
 
 export const transformServerInfo = (payload: ServerInfoResponse): Omit<ServerInfo, 'url'> => ({
@@ -12,19 +12,6 @@ export const transformServerInfo = (payload: ServerInfoResponse): Omit<ServerInf
     blockHeight: payload.result.info.validated_ledger?.seq ?? 0,
     blockHash: payload.result.info.validated_ledger?.hash ?? '',
 });
-
-// XRPL timestamps are based on the Ripple Epoch (2000-01-01T00:00:00Z).
-// To convert to a standard Unix timestamp, add this offset.
-// https://xrpl.org/docs/references/protocol/data-types/basic-data-types#specifying-time
-const BLOCKTIME_OFFSET = 946684800;
-
-const getUnixTimestamp = (xrplTimestamp?: number): number => {
-    if (!xrplTimestamp || xrplTimestamp <= 0) {
-        return 0;
-    }
-
-    return xrplTimestamp + BLOCKTIME_OFFSET;
-};
 
 export const transformTransaction = (
     hash: string | undefined,

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -10,7 +10,11 @@ import type {
 import { CustomError, MESSAGES, RESPONSES } from '@trezor/blockchain-link-types';
 import { solanaUtils } from '@trezor/blockchain-link-utils';
 import { getSuiteVersion } from '@trezor/env-utils';
-import { tokenProgramsInfo } from '@trezor/network-solana/constants';
+import {
+    SOLANA_DECIMALS,
+    SOLANA_MAINNET_GENESIS_HASH,
+    tokenProgramsInfo,
+} from '@trezor/network-solana/constants';
 import solana from '@trezor/network-solana/runtime';
 import type {
     AccountInfoBase,
@@ -389,7 +393,7 @@ const getInfo = async (request: Request<MessageTypes.GetInfo>, isTestnet: boolea
         url: api.clusterUrl,
         name: 'Solana',
         version: '1', // saving request api.rpc.getVersion().send(), version is not used anyways
-        decimals: 9,
+        decimals: SOLANA_DECIMALS,
     };
 
     return {
@@ -705,10 +709,7 @@ class SolanaWorker extends BaseWorker<SolanaAPI> {
         const { getApi } = await solana();
         const api = getApi(url, `Trezor Suite ${getSuiteVersion()}`);
 
-        // genesisHash is reliable identifier of the network, for mainnet the genesis hash is 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
-        this.isTestnet =
-            (await api.rpc.getGenesisHash().send()) !==
-            '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d';
+        this.isTestnet = (await api.rpc.getGenesisHash().send()) !== SOLANA_MAINNET_GENESIS_HASH;
 
         this.post({ id: -1, type: RESPONSES.CONNECTED });
 


### PR DESCRIPTION
## Description

Follow-up to #29908, continuing to pull chain-domain magic values out of the blockchain-link workers/utils and into the corresponding `@trezor/network-*` packages.

- **network-solana**: adds `SOLANA_DECIMALS` and `SOLANA_MAINNET_GENESIS_HASH` to the constants barrel. The solana worker now imports them instead of hardcoding `decimals: 9` and the mainnet genesis-hash base58 literal used for network (mainnet/testnet) detection.
- **network-ripple**: moves the Ripple-epoch `getUnixTimestamp` helper (and its `946684800` offset) from `blockchain-link-utils` into the `network-ripple` constants barrel. Same statically-importable placement as `toStroops` / the ripple reserves from #29908 (the barrel is pure, no heavy SDK deps, so it stays out of the lazily-loaded `runtime`).

Scope note: worker-infrastructure constants (timeouts, ping/poll intervals, page-size query defaults) were intentionally left in place — they are worker tuning, not chain-protocol values.

Pure refactor — no behavioral change; extracted values are identical to the previous literals.

## Related

- Follows up on #29908

## Notes for QA

No QA needed. No-effect refactor: the centralized constants and the moved `getUnixTimestamp` helper are byte-for-byte equivalent to the previous inline values/implementation. Solana network detection and XRP transaction timestamps are unchanged. Existing blockchain-link fixtures/mocks keep their own literal expectations (independent verification) and still pass.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies Solana and Ripple constants and worker logic. The Solana changes (network-solana constants and blockchain-link Solana worker) carry the highest risk since they affect transaction composition, fee calculation, balance fetching, and broadcasting for all Solana-related E2E flows. The Ripple changes (constants and blockchain-link-utils) have no direct E2E test coverage. Testing should focus first on core Solana wallet operations (send, receive, staking) and then on trading flows that compose Solana transactions.

<details><summary><b>Changed files (4)</b></summary>

- `networks/ripple/network-ripple/src/constants/index.ts`
- `networks/solana/network-solana/src/constants/common.ts`
- `packages/blockchain-link-utils/src/ripple.ts`
- `packages/blockchain-link/src/workers/solana/index.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/send-sol.test.ts` — This test exercises the full Solana send flow including fee calculation and transaction signing. Changes to network-solana constants and the Solana blockchain-link worker directly affect how Solana transactions are composed, fees are computed, and transactions are broadcast — all core behaviors of this test.
- `suite/e2e/tests/wallet/receive.test.ts` — This test verifies receiving addresses for SOL (among other coins). The Solana blockchain-link worker handles address derivation and account discovery for SOL accounts, meaning changes there could affect whether the SOL receive flow works correctly.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Initial SOL staking depends on the Solana blockchain-link worker for account balance fetching, transaction simulation, and broadcasting. Changes to Solana constants (e.g., rent exemption, fees) directly impact staking amount calculations verified by this test.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/staking/sol/unstake.test.ts` — Unstaking SOL involves transaction composition and broadcasting through the Solana blockchain-link worker. Changes to constants affecting fees or rent could alter the amounts displayed during unstake/claim flows.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Staking more SOL relies on the Solana worker for transaction simulation and fee calculation. Constant changes could affect the displayed stake amounts, rent values, or fee computations verified in this test's assertions.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — SOL staking rewards display depends on the Solana worker for fetching account state and balances. Changes to the worker or Solana constants could affect how staked amounts and rewards are retrieved and displayed.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Selling SOL requires composing a Solana transaction through the blockchain-link worker and verifying fee amounts on the device prompt. Changes to Solana constants or the worker could affect fee calculation and transaction composition.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test swaps SOL to BTC, which requires composing and sending a Solana transaction. The test explicitly reads the Solana fee from the form and verifies it on the device prompt, making it sensitive to changes in the Solana worker and constants.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test calculates percentage-based SOL amounts using balance data fetched via the Solana worker, and retrieves Solana fees. Changes to constants or worker logic could affect balance reporting or fee computation for the SOL sell form.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Swapping SOL to USDC token sends a Solana transaction, which uses the blockchain-link worker for broadcasting. The test verifies fee > 0 on the device prompt, which could be affected by constant changes.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swapping USDT (SPL token) to BTC requires Solana transaction handling through the worker. While using mocked backends, the transaction composition path through the worker could be affected.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Swapping SPL tokens (USDT to USDC) on Solana uses the blockchain-link worker for transaction sending. Changes to the worker's send handling could affect this flow.

</details>

⚠️ **Changes with no test coverage (2)**
- `networks/ripple/network-ripple/src/constants/index.ts`
- `packages/blockchain-link-utils/src/ripple.ts`

_Updated: 2026-07-16T12:21:32.129Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/networks-constants-followup/web/](https://dev.suite.sldev.cz/suite-web/mroz22/networks-constants-followup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/networks-constants-followup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/networks-constants-followup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-16T12:24:30.727Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-16T12:24:17.863Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->