### PR TITLE
fix(suite-native): localize auto-eject alert title

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1364,8 +1364,9 @@ export const messages = {
                     title: 'Auto-eject wallets',
                     description: 'Automatically eject all wallets when you disconnect your Trezor.',
                     alert: {
-                        titleNoConnectedTrezor: 'Enable auto-eject to hide your balances',
-                        titleConnectedTrezor: 'when you disconnect your Trezor',
+                        disconnectedTrezorTitle: 'Enable auto-eject to hide your balances',
+                        connectedTrezorTitle:
+                            'Enable auto-eject to hide your balances when you disconnect your Trezor',
                         primaryButtonTitle: 'Enable auto-eject',
                     },
                 },

--- a/suite-native/module-settings/src/components/EjectWallets/AutoEjectSwitch.tsx
+++ b/suite-native/module-settings/src/components/EjectWallets/AutoEjectSwitch.tsx
@@ -46,12 +46,13 @@ export const AutoEjectSwitch = () => {
         } else {
             showAlert({
                 title: (
-                    <>
-                        <Translation id="moduleSettings.viewOnly.autoEject.switch.alert.titleNoConnectedTrezor" />
-                        {!isNoPhysicalDeviceConnected && (
-                            <Translation id="moduleSettings.viewOnly.autoEject.switch.alert.titleConnectedTrezor" />
-                        )}
-                    </>
+                    <Translation
+                        id={
+                            isNoPhysicalDeviceConnected
+                                ? 'moduleSettings.viewOnly.autoEject.switch.alert.disconnectedTrezorTitle'
+                                : 'moduleSettings.viewOnly.autoEject.switch.alert.connectedTrezorTitle'
+                        }
+                    />
                 ),
                 primaryButtonTitle: (
                     <Translation id="moduleSettings.viewOnly.autoEject.switch.alert.primaryButtonTitle" />


### PR DESCRIPTION
## Description

Displays a complete translated auto-eject alert title for both connected and disconnected Trezor states.

## QA

Enable auto-eject with and without a Trezor connected and confirm that the alert title is a complete sentence in each supported language.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/fix-screenshot-issues&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->