### PR TITLE
test: reduce type-test declaration sizes

### DIFF
--- a/packages/connect-common/src/types/api/__tests__/tiers.type-test.ts
+++ b/packages/connect-common/src/types/api/__tests__/tiers.type-test.ts
@@ -8,16 +8,20 @@ type AssertNever<T extends never> = T;
 
 type PublicApiKeys = keyof TrezorConnectPublicAPI<Record<string, any>>;
 
-export type PublicApiHasNoManagementMethods = AssertNever<
+declare const publicApiHasNoManagementMethods: AssertNever<
     Extract<PublicApiKeys, keyof TrezorConnectManagement>
 >;
-export type PublicApiHasNoInternalMembers = AssertNever<
+declare const publicApiHasNoInternalMembers: AssertNever<
     Extract<PublicApiKeys, keyof TrezorConnectInternal>
 >;
 
 // The privileged tier keeps both groups.
-export const privileged = (api: TrezorConnectPrivilegedAPI) => {
+const privileged = (api: TrezorConnectPrivilegedAPI) => {
     const { on, off, removeAllListeners, uiResponse, updateConnectSettings, wipeDevice } = api;
 
     return { on, off, removeAllListeners, uiResponse, updateConnectSettings, wipeDevice };
 };
+
+void publicApiHasNoManagementMethods;
+void publicApiHasNoInternalMembers;
+void privileged;

--- a/packages/connect/tests/typedCall.type-test.ts
+++ b/packages/connect/tests/typedCall.type-test.ts
@@ -21,25 +21,30 @@ declare const wireOut: Messages.WireOutMessage;
 const { typedCall } = DeviceCommands(provider);
 
 // Valid: GetFeatures (wire_in) request -> Features (wire_out) response.
-export const valid = typedCall('GetFeatures', 'Features');
+const valid = typedCall('GetFeatures', 'Features');
 
 // Valid: the Monero stateful signing requests are sent host -> device and are tagged wire_in.
-export const validMoneroRequest = typedCall(
-    'MoneroTransactionInitRequest',
-    'MoneroTransactionInitAck',
-);
+const validMoneroRequest = typedCall('MoneroTransactionInitRequest', 'MoneroTransactionInitAck');
 
 // @ts-expect-error request must be a host -> device message; 'PublicKey' is wire_out.
-export const badRequestDirection = typedCall('PublicKey', wireOut);
+const badRequestDirection = typedCall('PublicKey', wireOut);
 
 // @ts-expect-error expected response must be a device -> host message; 'GetPublicKey' is wire_in.
-export const badResponseDirection = typedCall('GetPublicKey', 'GetPublicKey');
+const badResponseDirection = typedCall('GetPublicKey', 'GetPublicKey');
 
 // Valid: the array-response overload (R extends WireOutMessage[]) accepts a list of wire_out messages.
-export const validArrayResponse = typedCall('SignTx', ['TxRequest', 'ButtonRequest']);
+const validArrayResponse = typedCall('SignTx', ['TxRequest', 'ButtonRequest']);
 
 // @ts-expect-error every array response must be a device -> host message; 'GetPublicKey' is wire_in.
-export const badArrayResponseDirection = typedCall('SignTx', ['TxRequest', 'GetPublicKey']);
+const badArrayResponseDirection = typedCall('SignTx', ['TxRequest', 'GetPublicKey']);
 
 // @ts-expect-error 'NotAMessage' is not a known protobuf message.
-export const badMessageName = typedCall('NotAMessage', wireOut);
+const badMessageName = typedCall('NotAMessage', wireOut);
+
+void valid;
+void validMoneroRequest;
+void badRequestDirection;
+void badResponseDirection;
+void validArrayResponse;
+void badArrayResponseDirection;
+void badMessageName;

--- a/packages/type-utils/test/object.type-test.ts
+++ b/packages/type-utils/test/object.type-test.ts
@@ -12,11 +12,16 @@ type X = {
 
 type Y = NullablePropsRecursive<X>;
 
-export const y1ok: Y = { a: 'A', b: null };
-export const y2ok: Y = { a: 'A', b: { c: 'C', d: { e: null } } };
+const y1ok: Y = { a: 'A', b: null };
+const y2ok: Y = { a: 'A', b: { c: 'C', d: { e: null } } };
 
 // @ts-expect-error This expects and error as a, b is missing
-export const y4fail: Y = {};
+const y4fail: Y = {};
 
 // @ts-expect-error This expects and error as b is missing
-export const y3fail: Y = { a: null };
+const y3fail: Y = { a: null };
+
+void y1ok;
+void y2ok;
+void y4fail;
+void y3fail;

--- a/packages/utils/tests/typedObjectFromEntries.type-test.ts
+++ b/packages/utils/tests/typedObjectFromEntries.type-test.ts
@@ -5,21 +5,26 @@ const map = {
     b: 2,
 };
 
-export const _test: { [K in keyof typeof map]: number } = typedObjectFromEntries([
+const _test: { [K in keyof typeof map]: number } = typedObjectFromEntries([
     ['a', 10],
     ['b', 20],
 ] as const);
 
-export const _test2: { [K in keyof typeof map]: number } = typedObjectFromEntries(
+const _test2: { [K in keyof typeof map]: number } = typedObjectFromEntries(
     typedObjectKeys(map).map(k => [k, map[k] * 2]),
 );
 
 const multiplyValues = <T extends Record<string, number>>(input: T) =>
     typedObjectFromEntries(typedObjectEntries(input).map(([key, value]) => [key, value * 2]));
 
-export const _test3: { [K in keyof typeof map]: number } = multiplyValues(map);
+const _test3: { [K in keyof typeof map]: number } = multiplyValues(map);
 
 // @ts-expect-error String cannot be assigned to number as map-value
-export const _test4: { [K in keyof typeof map]: number } = typedObjectFromEntries(
+const _test4: { [K in keyof typeof map]: number } = typedObjectFromEntries(
     typedObjectKeys(map).map(k => [k, '']),
 );
+
+void _test;
+void _test2;
+void _test3;
+void _test4;

--- a/packages/utils/tests/typedObjectKeys.type-test.ts
+++ b/packages/utils/tests/typedObjectKeys.type-test.ts
@@ -11,5 +11,4 @@ _assertExpectedType = test1;
 const test2 = typedObjectKeys({ a: 'A', b: 'B' } satisfies AB);
 _assertExpectedType = test2;
 
-// eslint-disable-next-line no-self-assign
-_assertExpectedType = _assertExpectedType;
+void _assertExpectedType;

--- a/packages/utils/tests/typedObjectValues.type-test.ts
+++ b/packages/utils/tests/typedObjectValues.type-test.ts
@@ -11,5 +11,4 @@ _assertExpectedType = test1;
 const test2 = typedObjectValues({ a: 'A', b: 'B' } satisfies AB);
 _assertExpectedType = test2;
 
-// eslint-disable-next-line no-self-assign
-_assertExpectedType = _assertExpectedType;
+void _assertExpectedType;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Code improvement to reduce type-declarations to speedup the type-check

Nothing to manually test, only code improvement

<img width="784" height="240" alt="image" src="https://github.com/user-attachments/assets/075392b8-fc46-4f88-a645-cb03c0fbe050" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All 6 changed files are TypeScript type-level test files (`.type-test.ts`) that validate compile-time type constraints only. They do not contain runtime logic, do not affect application behavior, and are not executed by Playwright E2E tests. These files are verified by the TypeScript compiler (e.g., via `tsc --noEmit` or `@ts-expect-error` annotations) rather than by any runtime test runner. No E2E tests are needed for this change set.

<details><summary><b>Changed files (6)</b></summary>

- `packages/connect-common/src/types/api/__tests__/tiers.type-test.ts`
- `packages/connect/tests/typedCall.type-test.ts`
- `packages/type-utils/test/object.type-test.ts`
- `packages/utils/tests/typedObjectFromEntries.type-test.ts`
- `packages/utils/tests/typedObjectKeys.type-test.ts`
- `packages/utils/tests/typedObjectValues.type-test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (6)**
- `packages/connect-common/src/types/api/__tests__/tiers.type-test.ts`
- `packages/connect/tests/typedCall.type-test.ts`
- `packages/type-utils/test/object.type-test.ts`
- `packages/utils/tests/typedObjectFromEntries.type-test.ts`
- `packages/utils/tests/typedObjectKeys.type-test.ts`
- `packages/utils/tests/typedObjectValues.type-test.ts`

_Updated: 2026-07-16T12:31:40.008Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-type-test-declaration-sizes/web/](https://dev.suite.sldev.cz/suite-web/fix-type-test-declaration-sizes/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-type-test-declaration-sizes&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-type-test-declaration-sizes&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-type-test-declaration-sizes&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-16T12:35:18.360Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-16T12:35:07.422Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->