### PR TITLE
fix(suite-native): skip backend server address validation for default server type

### DIFF
--- a/suite-native/module-settings/src/hooks/useBackendServersForm.ts
+++ b/suite-native/module-settings/src/hooks/useBackendServersForm.ts
@@ -80,9 +80,14 @@ export const useBackendServersForm = ({ symbol, backendOptions }: Network) => {
                 .test(
                     'format',
                     translate('moduleSettings.networkBackends.servers.invalidFormat'),
-                    (value, context) =>
-                        !!value &&
-                        validateServerAddress(context.resolve(yup.ref('serverType')), value),
+                    (value, context) => {
+                        const serverType = context.resolve(yup.ref<ServerType>('serverType'));
+                        if (serverType === 'default') {
+                            return true;
+                        }
+
+                        return !!value && validateServerAddress(serverType, value);
+                    },
                 ),
         }),
         defaultValues,


### PR DESCRIPTION
## Description

Backend server address validation skipped for `default` server type.

## Related Issue

Resolve #29927

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/backend-server-address-validation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->