### PR TITLE
refactor(networks): move XRP flag and Solana memo limit into network packages

### DIFF
--- a/networks/ripple/network-ripple/src/constants/index.ts
+++ b/networks/ripple/network-ripple/src/constants/index.ts
@@ -16,3 +16,6 @@ export const getUnixTimestamp = (xrplTimestamp?: number): number => {
 
     return xrplTimestamp + RIPPLE_EPOCH_OFFSET;
 };
+
+// tfFullyCanonicalSig — XRPL universal transaction flag
+export const XRP_FLAG = 0x80000000;

--- a/networks/solana/network-solana/src/constants/common.ts
+++ b/networks/solana/network-solana/src/constants/common.ts
@@ -29,6 +29,9 @@ export const MAX_CLAIM_ACCOUNTS = 16;
 
 export const MIN_STAKE_DELEGATION = 1_000_000_000n;
 
+// https://www.solana-program.com/docs/memo
+export const SOLANA_MEMO_MAX_BYTES = 566;
+
 export const tokenProgramNames = ['spl-token', 'spl-token-2022'] as const;
 
 export const tokenProgramsInfo = {

--- a/networks/solana/network-solana/src/runtime/connect.ts
+++ b/networks/solana/network-solana/src/runtime/connect.ts
@@ -36,7 +36,7 @@ import * as splToken2022 from '@solana-program/token-2022';
 
 import { BigNumber } from '@trezor/utils';
 
-import { SYSTEM_PROGRAM_PUBLIC_KEY, tokenProgramsInfo } from '../constants';
+import { SOLANA_MEMO_MAX_BYTES, SYSTEM_PROGRAM_PUBLIC_KEY, tokenProgramsInfo } from '../constants';
 import type {
     Blockhash,
     SolanaAPI,
@@ -48,8 +48,6 @@ import { createTransactionShim } from './shim';
 
 const getTokenLib = (tokenProgramName: TokenProgramName) =>
     tokenProgramName === 'spl-token' ? splToken : splToken2022;
-
-const SOLANA_MEMO_MAX_BYTES = 566; // https://www.solana-program.com/docs/memo
 
 const validateMemo = (memo: string) => {
     const byteLength = Buffer.from(memo, 'utf8').length;

--- a/suite-common/validators/package.json
+++ b/suite-common/validators/package.json
@@ -16,6 +16,7 @@
         "@suite-common/address": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
+        "@trezor/network-solana": "workspace:*",
         "@trezor/utils": "workspace:*",
         "yup": "1.7.1"
     }

--- a/suite-common/validators/src/inputsLengthConfig.ts
+++ b/suite-common/validators/src/inputsLengthConfig.ts
@@ -1,3 +1,5 @@
+import { SOLANA_MEMO_MAX_BYTES } from '@trezor/network-solana/constants';
+
 export const formInputsMaxLength = {
     pin: 50,
     passphrase: 50,
@@ -20,5 +22,5 @@ export const formInputsMaxLength = {
     ethereumNonce: 20, // max uint64: 18446744073709551615
 
     stellarTextMemo: 28, // https://developers.stellar.org/docs/learn/encyclopedia/transactions-specialized/memos
-    solanaMemo: 566, // https://www.solana-program.com/docs/memo
+    solanaMemo: SOLANA_MEMO_MAX_BYTES,
 } as const;

--- a/suite-common/validators/tsconfig.json
+++ b/suite-common/validators/tsconfig.json
@@ -5,6 +5,9 @@
         { "path": "../address" },
         { "path": "../wallet-config" },
         { "path": "../wallet-utils" },
+        {
+            "path": "../../networks/solana/network-solana"
+        },
         { "path": "../../packages/utils" }
     ]
 }

--- a/suite-common/wallet-constants/src/sendForm.ts
+++ b/suite-common/wallet-constants/src/sendForm.ts
@@ -7,7 +7,6 @@ export const BTC_RBF_SEQUENCE = 0xffffffff - 2;
 export const BTC_LOCKTIME_SEQUENCE = 0xffffffff - 1;
 
 export const BTC_LOCKTIME_VALUE = 500000000; // if locktime is equal/greater than this then it's a timestamp
-export const XRP_FLAG = 0x80000000;
 export const U_INT_32 = 0xffffffff;
 
 export const ETH_SPEED_UP_TX_MULTIPLIER = '1.2'; // multiply max fee and max priority fee per gas when speeding up tx

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -46,6 +46,7 @@
         "@trezor/connect-common": "workspace:^",
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
+        "@trezor/network-ripple": "workspace:*",
         "@trezor/network-solana": "workspace:*",
         "@trezor/network-stellar": "workspace:*",
         "@trezor/network-tron": "workspace:*",

--- a/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
@@ -1,6 +1,5 @@
 import { createThunk } from '@suite-common/redux-utils';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
-import { XRP_FLAG } from '@suite-common/wallet-constants';
 import {
     AddressDisplayOptions,
     type ExternalOutput,
@@ -18,6 +17,7 @@ import {
     unitsToSubunits,
 } from '@suite-common/wallet-utils';
 import TrezorConnect, { type FeeLevel, type RipplePayment, type TokenInfo } from '@trezor/connect';
+import { XRP_FLAG } from '@trezor/network-ripple/constants';
 import stellar from '@trezor/network-stellar/runtime';
 import { StellarAssetType } from '@trezor/protobuf/src/definitions';
 import { BigNumber } from '@trezor/utils';

--- a/suite-common/wallet-core/tsconfig.json
+++ b/suite-common/wallet-core/tsconfig.json
@@ -44,6 +44,9 @@
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/env-utils" },
         {
+            "path": "../../networks/ripple/network-ripple"
+        },
+        {
             "path": "../../networks/solana/network-solana"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11175,6 +11175,7 @@ __metadata:
     "@suite-common/address": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
+    "@trezor/network-solana": "workspace:*"
     "@trezor/utils": "workspace:*"
     yup: "npm:1.7.1"
   languageName: unknown
@@ -11243,6 +11244,7 @@ __metadata:
     "@trezor/connect-common": "workspace:^"
     "@trezor/device-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"
+    "@trezor/network-ripple": "workspace:*"
     "@trezor/network-solana": "workspace:*"
     "@trezor/network-stellar": "workspace:*"
     "@trezor/network-tron": "workspace:*"


### PR DESCRIPTION
## Description

Follow-up in the networks-modularization series (#29908, #29928, #29933). Centralizes two more chain-protocol constants into their `@trezor/network-*` packages.

- **`XRP_FLAG`** (`tfFullyCanonicalSig`, `0x80000000`) moves out of the generic `@suite-common/wallet-constants` `sendForm` bucket — where it sat among unrelated BTC/ETH constants — into `@trezor/network-ripple/constants`, next to the other ripple protocol constants. Its single consumer (`sendFormRippleStellarThunks`) now imports it from there.
- **`SOLANA_MEMO_MAX_BYTES`** (`566`) was duplicated: a private `const` inside the `network-solana` runtime (`validateMemo`) **and** an inlined literal in `@suite-common/validators` (`inputsLengthConfig`). It now lives once in `@trezor/network-solana/constants`; the runtime validator and the form-length config both import the single source, so the enforced limit and the UI input limit can no longer drift.

Dependency note: this adds `@trezor/network-ripple` to `wallet-core` and `@trezor/network-solana` to `validators` (both constants-only static subpaths). Project references + lockfile updated via `yarn update-project-references` + `yarn dedupe`.

## Related

- Follows #29908, #29928, #29933

## Notes for QA

No QA needed. No-effect refactor: both constants keep their exact previous values (`XRP_FLAG`=0x80000000, `SOLANA_MEMO_MAX_BYTES`=566). Solana memo-length validation (device signing path) and the send-form memo input limit are unchanged; XRP transaction flags are unchanged. Lint + prettier pass locally; type-check confirmed no errors in the changed files (remaining local errors are the pre-existing missing-`trezor-common`-submodule / unbuilt-`libDev` environment noise, unrelated to this diff).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes primarily affect three areas: (1) Solana network constants and connection runtime, (2) Ripple/Stellar send form thunks, and (3) shared validators/send form constants. The Solana changes carry the highest risk for SOL-specific flows (send, stake, swap), while sendForm.ts and inputsLengthConfig.ts are broadly imported but only materially affect tests that exercise send form input validation or transaction composition. The Ripple/Stellar send form thunk changes have no dedicated E2E test coverage. Testing strategy should prioritize Solana transaction flows and send form validation tests while avoiding running the 131 tests that transitively import the shared constants.

<details><summary><b>Changed files (10)</b></summary>

- `networks/ripple/network-ripple/src/constants/index.ts`
- `networks/solana/network-solana/src/constants/common.ts`
- `networks/solana/network-solana/src/runtime/connect.ts`
- `suite-common/validators/package.json`
- `suite-common/validators/src/inputsLengthConfig.ts`
- `suite-common/validators/tsconfig.json`
- `suite-common/wallet-constants/src/sendForm.ts`
- `suite-common/wallet-core/package.json`
- `suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts`
- `suite-common/wallet-core/tsconfig.json`

</details>

**Recommended tests (18)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/send-sol.test.ts` — Changes to networks/solana/network-solana/src/constants/common.ts and runtime/connect.ts directly affect Solana transaction handling. This test exercises the full Solana send flow including amount calculation, fee handling, and device confirmation — the exact code path where Solana constants and connection logic are used.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Changes to suite-common/wallet-constants/src/sendForm.ts and suite-common/validators/src/inputsLengthConfig.ts directly impact send form behavior including input validation and form constants. This test exercises adding/removing outputs, filling amounts, locktime, OP_RETURN data, and unit switching — all of which depend on send form constants and input validation.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Solana staking involves Solana constants (rent, fees) and connection logic from the changed Solana network files. This test covers the full initial SOL staking flow including amount/fee calculations and transaction confirmation, directly exercising the Solana constants and connect modules.

</details>

<details><summary>🟡 <b>Medium priority (12)</b></summary>

- `suite/e2e/tests/trading/sell-solana.test.ts` — The sell Solana flow exercises Solana send transaction logic and fee calculations. Changes to Solana constants and connection runtime could affect how SOL transactions are composed and sent during the sell flow.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test validates sell form input validation including decimal limits, insufficient funds errors, and percentage/max calculations for both BTC and SOL. Changes to inputsLengthConfig.ts and sendForm.ts constants directly affect these validations, and SOL-specific fee calculations use the changed Solana constants.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test swaps SOL to BTC, exercising Solana transaction sending and fee calculation logic. Changes to Solana constants and connection runtime could affect how the SOL send transaction is composed during the swap.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstaking and claiming involves Solana transaction composition and fee calculations that depend on Solana constants. The test verifies amounts, fees, and transaction confirmation on-device.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Staking additional SOL uses Solana transaction composition including rent and fee constants from the changed Solana constants file, and the connection runtime for transaction submission.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — SOL staking rewards display relies on Solana account balance calculations which may reference Solana constants. While less directly affected than transaction-sending tests, reward amounts and staked balances could be impacted.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Changes to sendForm.ts constants affect send form behavior across all networks. This test specifically validates sending large amounts and checking device prompt output formatting, which relies on send form constants.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Changes to sendForm.ts constants and inputsLengthConfig.ts affect Ethereum send form behavior including fee parameter inputs. This test exercises custom gas fees and amount/address input validation.
- `suite/e2e/tests/staking/staking-form.test.ts` — The ETH staking form validates input amounts (min, max, decimals, insufficient funds) and uses percentage/max calculations. Changes to inputsLengthConfig.ts and sendForm.ts could affect these validation rules.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Swapping SOL to USDC exercises Solana transaction sending which depends on the changed Solana constants and connection runtime.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Swapping Solana SPL tokens (USDT to USDC) exercises Solana transaction composition and sending, relying on Solana constants for fee/rent calculations.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swapping USDT on Solana to BTC involves Solana transaction sending which depends on the changed Solana network constants and connect runtime.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/wallet/send-base.test.ts` — While Base uses EVM send form logic (not Ripple/Stellar), changes to sendForm.ts constants could affect shared send form infrastructure used across all networks including Base.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Swap form input validation (exceeding balance, decimal limits) may be affected by changes to inputsLengthConfig.ts. The test also exercises SOL-related swap flows.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Changes to sendForm.ts constants could affect shared send form behavior. This test exercises the LTC send form with broadcast mode and max amount, which share infrastructure with the changed constants.

</details>

⚠️ **Changes with no test coverage (6)**
- `networks/ripple/network-ripple/src/constants/index.ts`
- `suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts`
- `suite-common/validators/package.json`
- `suite-common/validators/tsconfig.json`
- `suite-common/wallet-core/package.json`
- `suite-common/wallet-core/tsconfig.json`

_Updated: 2026-07-16T13:22:56.474Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/networks-flag-memo-constants/web/](https://dev.suite.sldev.cz/suite-web/mroz22/networks-flag-memo-constants/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/networks-flag-memo-constants&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/networks-flag-memo-constants&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/networks-flag-memo-constants&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| TrezorConnect > Error screen | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.signTransaction > TrezorConnect.signTransaction | 🤖 auto |
| TrezorConnect.ethereumSignMessage > TrezorConnect.ethereumSignMessage | 🤖 auto |
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-22T07:54:14.424Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-22T07:54:47.617Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->