### PR TITLE
chore(ci): bump autoupdate timeout to 90 minutes

### DIFF
--- a/.github/workflows/release-suite-desktop-web-staging.yml
+++ b/.github/workflows/release-suite-desktop-web-staging.yml
@@ -217,7 +217,7 @@ jobs:
       - suite-desktop-autoupdate-release
       - build-web
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

Bumping the autoupdate timeout to from 60 to 90 minutes.

## Notes for QA

Nothing to be tested actually.