### PR TITLE
fix(suite): hide historic fiat rates for ERC4626 tokens

### DIFF
--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Storage changelog
 
+## 26.8.0
+
+- remove inaccurate historic ERC4626 fiat rates from storage
+
 ## 26.6.0
 
 - purge desktop trading form draft keys (`trading-buy/*`, `trading-sell/`, `trading-exchange/`) from `formDrafts`

--- a/packages/suite/src/storage/migrations/versions/26.8.0.ts
+++ b/packages/suite/src/storage/migrations/versions/26.8.0.ts
@@ -1,0 +1,32 @@
+import { createMigration } from '@suite/idb-migration-utils';
+
+import { type SuiteDBSchema } from 'src/storage/definitions';
+
+import { updateAll } from '../utils';
+
+// Remove inaccurate ERC4626 rates calculated with current share-to-asset ratios.
+export default createMigration<SuiteDBSchema>('26.8.0', async (_db, tx) => {
+    const accounts = await tx.objectStore('accounts').getAll();
+
+    const erc4626RateKeyPrefixes = accounts.flatMap(account =>
+        (account.tokens ?? [])
+            .filter(token => token.protocols?.includes('erc4626'))
+            .map(token => `${account.symbol}-${token.contract}-`.toLowerCase()),
+    );
+
+    if (!erc4626RateKeyPrefixes.length) return;
+
+    await updateAll(tx, 'historicRates', rates => {
+        const keysToRemove = Object.keys(rates).filter(fiatRateKey =>
+            erc4626RateKeyPrefixes.some(prefix => fiatRateKey.toLowerCase().startsWith(prefix)),
+        );
+
+        if (!keysToRemove.length) return;
+
+        keysToRemove.forEach(fiatRateKey => {
+            delete rates[fiatRateKey as keyof typeof rates];
+        });
+
+        return rates;
+    });
+});

--- a/packages/suite/src/storage/migrations/versions/__tests__/26.8.0.test.ts
+++ b/packages/suite/src/storage/migrations/versions/__tests__/26.8.0.test.ts
@@ -1,0 +1,73 @@
+import '@suite-common/test-utils/src/globalOverrides';
+import { type IDBPDatabase, deleteDB, openDB } from 'idb';
+
+import { type SuiteDBSchema } from 'src/storage/definitions';
+
+import migration from '../26.8.0';
+
+const DB_NAME = 'suite-idb-test-26.8.0';
+const INITIAL_VERSION = 1;
+
+const VAULT_CONTRACT = '0xBeEF69b8FeA9a16Fb98a661860F6D78d94E1B000';
+const USDT_CONTRACT = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
+
+const runMigration = () =>
+    openDB(DB_NAME, INITIAL_VERSION + 1, {
+        upgrade(db: IDBPDatabase<SuiteDBSchema>, _oldVersion, _newVersion, tx) {
+            migration.migrate(db, tx);
+        },
+    });
+
+const createSeedDb = async () => {
+    const db = await openDB(DB_NAME, INITIAL_VERSION, {
+        upgrade(upgradeDb) {
+            upgradeDb.createObjectStore('accounts');
+            upgradeDb.createObjectStore('historicRates');
+        },
+    });
+
+    await db.put(
+        'accounts',
+        {
+            key: 'account-1',
+            symbol: 'eth',
+            tokens: [
+                { contract: USDT_CONTRACT, decimals: 6 },
+                { contract: VAULT_CONTRACT, decimals: 6, protocols: ['erc4626'] },
+            ],
+        },
+        'account-1',
+    );
+
+    return db;
+};
+
+describe('migration 26.8.0', () => {
+    beforeEach(async () => {
+        await deleteDB(DB_NAME);
+    });
+
+    test('removes historic rates of ERC4626 tokens and keeps the rest', async () => {
+        const db = await createSeedDb();
+        await db.put(
+            'historicRates',
+            {
+                'eth-usd': { 1700000000: 2000 },
+                [`eth-${USDT_CONTRACT}-usd`]: { 1700000000: 1 },
+                [`eth-${VAULT_CONTRACT.toLowerCase()}-usd`]: { 1700000000: 1.05 },
+                [`eth-${VAULT_CONTRACT}-eur`]: { 1700000000: 0.95 },
+            },
+            'account-1',
+        );
+        db.close();
+
+        const migratedDb = await runMigration();
+
+        expect(await migratedDb.get('historicRates', 'account-1')).toEqual({
+            'eth-usd': { 1700000000: 2000 },
+            [`eth-${USDT_CONTRACT}-usd`]: { 1700000000: 1 },
+        });
+
+        migratedDb.close();
+    });
+});

--- a/packages/suite/src/storage/migrations/versions/index.ts
+++ b/packages/suite/src/storage/migrations/versions/index.ts
@@ -27,3 +27,4 @@ export { default as m26_6_0_2 } from './26.6.0.2';
 export { default as m26_7_0 } from './26.7.0';
 export { default as m26_7_0_1 } from './26.7.0.1';
 export { default as m26_7_0_2 } from './26.7.0.2';
+export { default as m26_8_0 } from './26.8.0';

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionGroupedList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionGroupedList.tsx
@@ -37,6 +37,7 @@ export const TransactionGroupedList = ({
             key={dateKey}
             dateKey={dateKey}
             symbol={symbol}
+            account={account}
             transactions={value}
             baseCurrencyCode={baseCurrencyCode}
             isPending={isPending}

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx
@@ -5,6 +5,7 @@ import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { selectHistoricFiatRates } from '@suite-common/wallet-core';
 import { type Timestamp, type TokenAddress } from '@suite-common/wallet-types';
 import {
+    getErc4626Contracts,
     getFiatRateKey,
     isNftTokenTransfer,
     roundTimestampToNearestPastHour,
@@ -15,7 +16,7 @@ import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { Column } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
-import { type WalletAccountTransaction } from 'src/types/wallet';
+import { type Account, type WalletAccountTransaction } from 'src/types/wallet';
 
 import { DayHeader } from './DayHeader';
 
@@ -24,6 +25,7 @@ type TransactionsGroupProps = {
     transactions: WalletAccountTransaction[];
     children?: ReactNode;
     symbol: NetworkSymbol;
+    account: Account;
     baseCurrencyCode: BaseCurrencyCode;
     index: number;
     isPending: boolean;
@@ -32,6 +34,7 @@ type TransactionsGroupProps = {
 export const TransactionsGroup = ({
     dateKey,
     symbol,
+    account,
     transactions,
     baseCurrencyCode,
     isPending,
@@ -46,13 +49,18 @@ export const TransactionsGroup = ({
         baseCurrencyCode,
         historicFiatRates,
     );
+    const erc4626Contracts = getErc4626Contracts(account.tokens);
     const isMissingFiatRates = transactions.some(tx => {
         const fiatRateKey = getFiatRateKey(tx.symbol, baseCurrencyCode);
         const roundedTimestamp = roundTimestampToNearestPastHour(tx.blockTime as Timestamp);
         const historicCryptoRate = historicFiatRates?.[fiatRateKey]?.[roundedTimestamp];
 
         const isMissingTokenRate = tx.tokens
-            .filter(token => !isNftTokenTransfer(token))
+            .filter(
+                token =>
+                    !isNftTokenTransfer(token) &&
+                    !erc4626Contracts.has(token.contract.toLowerCase()),
+            )
             .some(token => {
                 const isTokenKnown = isTokenDefinitionKnown(
                     tokenDefinitions?.data,

--- a/suite-common/wallet-core/src/fiat-rates/__tests__/fiatRatesThunks.test.ts
+++ b/suite-common/wallet-core/src/fiat-rates/__tests__/fiatRatesThunks.test.ts
@@ -1,0 +1,91 @@
+import { getFiatRatesForTimestamps } from '@suite-common/fiat-services';
+import { configureMockStore } from '@suite-common/test-utils';
+import {
+    type Account,
+    type AccountKey,
+    type TickerResult,
+    type TokenAddress,
+    type WalletAccountTransaction,
+} from '@suite-common/wallet-types';
+import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
+
+import { blockchainInitialState } from '../../blockchain/blockchainReducer';
+import { updateTxsFiatRatesThunk } from '../fiatRatesThunks';
+
+jest.mock('@suite-common/fiat-services', () => ({
+    getFiatRatesForTimestamps: jest.fn(),
+}));
+
+const ACCOUNT_KEY = 'descriptor-eth-device' as AccountKey;
+const LOCAL_CURRENCY = 'usd' as BaseCurrencyCode;
+
+const USDT_CONTRACT = '0xdac17f958d2ee523a2206206994597c13d831ec7' as TokenAddress;
+const VAULT_CONTRACT = '0xbeef69b8fea9a16fb98a661860f6d78d94e1b000' as TokenAddress;
+
+const ethAccount = {
+    key: ACCOUNT_KEY,
+    symbol: 'eth',
+    tokens: [
+        { contract: USDT_CONTRACT, decimals: 6 },
+        { contract: VAULT_CONTRACT, decimals: 6, protocols: ['erc4626'] },
+    ],
+} as unknown as Account;
+
+const tokenTransaction = (contract: TokenAddress): WalletAccountTransaction =>
+    ({
+        txid: `tx-${contract}`,
+        symbol: 'eth',
+        blockTime: 1700002800,
+        tokens: [{ contract, standard: 'ERC20', amount: '1000000', decimals: 6 }],
+    }) as unknown as WalletAccountTransaction;
+
+const initStore = () =>
+    configureMockStore({
+        preloadedState: {
+            wallet: {
+                accounts: [ethAccount],
+                blockchain: blockchainInitialState,
+            },
+            tokenDefinitions: {
+                eth: {
+                    coin: {
+                        data: [USDT_CONTRACT, VAULT_CONTRACT],
+                        error: false,
+                        isLoading: false,
+                    },
+                },
+            },
+        },
+    });
+
+describe('updateTxsFiatRatesThunk', () => {
+    beforeEach(() => {
+        jest.mocked(getFiatRatesForTimestamps).mockImplementation((_tickerId, timestamps) =>
+            Promise.resolve({
+                ts: 0,
+                symbol: 'eth',
+                tickers: timestamps.map(ts => ({ ts, rates: { usd: 1 } })),
+            }),
+        );
+    });
+
+    it('fetches historic rates of regular tokens, but not of ERC4626 tokens', async () => {
+        const store = initStore();
+
+        const response = await store.dispatch(
+            updateTxsFiatRatesThunk({
+                accountKey: ACCOUNT_KEY,
+                txs: [tokenTransaction(USDT_CONTRACT), tokenTransaction(VAULT_CONTRACT)],
+                baseCurrencyCode: LOCAL_CURRENCY,
+            }),
+        );
+
+        expect(response.meta.requestStatus).toBe('fulfilled');
+
+        const { rates } = response.payload as { rates: TickerResult[] };
+        const tokenAddresses = rates.map(({ tickerId }) => tickerId.tokenAddress);
+
+        expect(tokenAddresses).toContain(USDT_CONTRACT);
+        expect(tokenAddresses).not.toContain(VAULT_CONTRACT);
+    });
+});

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -20,8 +20,8 @@ import {
 } from '@suite-common/wallet-types';
 import {
     fetchTransactionsRates,
+    getErc4626Contracts,
     groupTokensTransactionsByContractAddress,
-    isErc4626,
     isTestnet,
 } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
@@ -117,56 +117,6 @@ const fetchErc4626FiatRate = async ({
     return { rate: vaultRate, lastTickerTimestamp: underlyingAssetRate.lastTickerTimestamp };
 };
 
-interface FetchErc4626TransactionsRatesProps {
-    symbol: NetworkSymbol;
-    contract: TokenAddress;
-    timestamps: Timestamp[];
-    baseCurrencyCode: BaseCurrencyCode;
-    isElectrumBackend: boolean;
-    rates: TickerResult[];
-}
-
-const fetchErc4626TransactionsRates = async ({
-    symbol,
-    contract,
-    timestamps,
-    baseCurrencyCode,
-    isElectrumBackend,
-    rates,
-}: FetchErc4626TransactionsRatesProps) => {
-    try {
-        const erc4626 = await fetchErc4626Data({ coin: symbol, contract });
-
-        if (!erc4626.asset || !erc4626.convertToAssets1Share) return;
-
-        const underlyingRates: TickerResult[] = [];
-        await fetchTransactionsRates(
-            { symbol, tokenAddress: toTokenAddress(erc4626.asset.contract) },
-            timestamps,
-            baseCurrencyCode,
-            isElectrumBackend,
-            underlyingRates,
-        );
-
-        const exchangeRate = new BigNumber(erc4626.convertToAssets1Share).shiftedBy(
-            -erc4626.asset.decimals,
-        );
-
-        underlyingRates.forEach(({ localCurrency, rates: underlyingTokenRates }) => {
-            rates.push({
-                tickerId: { symbol, tokenAddress: contract },
-                localCurrency,
-                rates: underlyingTokenRates.map(({ rate, lastTickerTimestamp }) => ({
-                    rate: rate === undefined ? rate : exchangeRate.multipliedBy(rate).toNumber(),
-                    lastTickerTimestamp,
-                })),
-            });
-        });
-    } catch (error) {
-        console.error(error);
-    }
-};
-
 type UpdateTxsFiatRatesThunkPayload = {
     accountKey: AccountKey;
     txs: WalletAccountTransaction[];
@@ -198,6 +148,7 @@ export const updateTxsFiatRatesThunk = createThunk(
         );
 
         const groupedTokensTxs = groupTokensTransactionsByContractAddress(txs);
+        const erc4626Contracts = getErc4626Contracts(account.tokens);
 
         for (const token of typedObjectKeys(groupedTokensTxs)) {
             // @ts-expect-error: indexing with noUncheckedIndexedAccess
@@ -206,20 +157,8 @@ export const updateTxsFiatRatesThunk = createThunk(
                 .map(tx => (tx.blockTime !== undefined ? asTimestamp(tx.blockTime) : undefined))
                 .filter(isNotUndefined);
 
-            const accountToken = account.tokens?.find(
-                accountTokenInfo => accountTokenInfo.contract === token,
-            );
-
-            if (accountToken && isErc4626(accountToken)) {
-                await fetchErc4626TransactionsRates({
-                    symbol: account.symbol,
-                    contract: toTokenAddress(token),
-                    timestamps: tokenTimestamps,
-                    baseCurrencyCode,
-                    isElectrumBackend,
-                    rates,
-                });
-
+            // Historical ERC4626 rates cannot be calculated without historical share-to-asset ratios.
+            if (erc4626Contracts.has(token.toLowerCase())) {
                 continue;
             }
 

--- a/suite-common/wallet-core/src/transactions/__tests__/transactionsSelectors.test.ts
+++ b/suite-common/wallet-core/src/transactions/__tests__/transactionsSelectors.test.ts
@@ -1,0 +1,74 @@
+import {
+    type Account,
+    type AccountKey,
+    type TokenAddress,
+    type WalletAccountTransaction,
+} from '@suite-common/wallet-types';
+import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
+
+import { type AccountsRootState } from '../../accounts/accountsReducer';
+import { type FiatRatesRootState } from '../../fiat-rates/fiatRatesTypes';
+import { type TransactionsRootState } from '../transactionsReducerTypes';
+import { selectTransactionsWithMissingRates } from '../transactionsSelectors';
+
+const ACCOUNT_KEY = 'descriptor-eth-device' as AccountKey;
+const LOCAL_CURRENCY = 'usd' as BaseCurrencyCode;
+
+const USDT_CONTRACT = '0xdac17f958d2ee523a2206206994597c13d831ec7' as TokenAddress;
+const VAULT_CONTRACT = '0xbeef69b8fea9a16fb98a661860f6d78d94e1b000' as TokenAddress;
+
+const HOUR_ALIGNED_TIMESTAMP = 1700002800;
+
+const ethAccount = {
+    key: ACCOUNT_KEY,
+    symbol: 'eth',
+    tokens: [
+        { contract: USDT_CONTRACT, decimals: 6 },
+        { contract: VAULT_CONTRACT, decimals: 6, protocols: ['erc4626'] },
+    ],
+} as unknown as Account;
+
+const tokenTransaction = (contract: TokenAddress): WalletAccountTransaction =>
+    ({
+        txid: `tx-${contract}`,
+        symbol: 'eth',
+        blockTime: HOUR_ALIGNED_TIMESTAMP,
+        tokens: [{ contract, standard: 'ERC20', amount: '1000000', decimals: 6 }],
+    }) as unknown as WalletAccountTransaction;
+
+type State = TransactionsRootState & FiatRatesRootState & AccountsRootState;
+
+const getState = (transactions: WalletAccountTransaction[]): State =>
+    ({
+        wallet: {
+            transactions: { transactions: { [ACCOUNT_KEY]: transactions } },
+            fiat: {
+                historic: {
+                    // Rate of the native coin is always present, so only token rates decide.
+                    'eth-usd': { [HOUR_ALIGNED_TIMESTAMP]: 2000 },
+                },
+            },
+            accounts: [ethAccount],
+        },
+    }) as unknown as State;
+
+describe('selectTransactionsWithMissingRates', () => {
+    it('reports a transaction with a missing token rate', () => {
+        const result = selectTransactionsWithMissingRates(
+            getState([tokenTransaction(USDT_CONTRACT)]),
+            LOCAL_CURRENCY,
+        );
+
+        expect(result).toHaveLength(1);
+        expect(result[0]?.txs.map(tx => tx.txid)).toEqual([`tx-${USDT_CONTRACT}`]);
+    });
+
+    it('does not report a transaction whose only rateless transfer is an ERC4626 token', () => {
+        const result = selectTransactionsWithMissingRates(
+            getState([tokenTransaction(VAULT_CONTRACT)]),
+            LOCAL_CURRENCY,
+        );
+
+        expect(result).toHaveLength(0);
+    });
+});

--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
@@ -17,6 +17,7 @@ import type {
 } from '@suite-common/wallet-types';
 import {
     getConfirmations,
+    getErc4626Contracts,
     getFiatRateKey,
     isCardanoStakingTx,
     isClaimTx,
@@ -360,30 +361,41 @@ export const selectTransactionsWithMissingRates = (
 
     return pipe(
         scopedTransactions,
-        D.mapWithKey((key, txs) => ({
-            account: selectAccountByKey(state, key as AccountKey),
-            txs: txs.filter(tx => {
-                const fiatRateKey = getFiatRateKey(tx.symbol, localCurrency);
-                const roundedTimestamp = roundTimestampToNearestPastHour(tx.blockTime as Timestamp);
-                const historicRate = historicFiatRates?.[fiatRateKey]?.[roundedTimestamp];
+        D.mapWithKey((key, txs) => {
+            const account = selectAccountByKey(state, key as AccountKey);
+            const erc4626Contracts = getErc4626Contracts(account?.tokens);
 
-                const isMissingTokenRate = tx.tokens
-                    .filter(token => !isNftTokenTransfer(token))
-                    .some(token => {
-                        const tokenFiatRateKey = getFiatRateKey(
-                            tx.symbol,
-                            localCurrency,
-                            token.contract as TokenAddress,
-                        );
-                        const historicTokenRate =
-                            historicFiatRates?.[tokenFiatRateKey]?.[roundedTimestamp];
+            return {
+                account,
+                txs: txs.filter(tx => {
+                    const fiatRateKey = getFiatRateKey(tx.symbol, localCurrency);
+                    const roundedTimestamp = roundTimestampToNearestPastHour(
+                        tx.blockTime as Timestamp,
+                    );
+                    const historicRate = historicFiatRates?.[fiatRateKey]?.[roundedTimestamp];
 
-                        return historicTokenRate === undefined || historicTokenRate === 0;
-                    });
+                    const isMissingTokenRate = tx.tokens
+                        .filter(
+                            token =>
+                                !isNftTokenTransfer(token) &&
+                                !erc4626Contracts.has(token.contract.toLowerCase()),
+                        )
+                        .some(token => {
+                            const tokenFiatRateKey = getFiatRateKey(
+                                tx.symbol,
+                                localCurrency,
+                                token.contract as TokenAddress,
+                            );
+                            const historicTokenRate =
+                                historicFiatRates?.[tokenFiatRateKey]?.[roundedTimestamp];
 
-                return historicRate === undefined || historicRate === 0 || isMissingTokenRate;
-            }),
-        })),
+                            return historicTokenRate === undefined || historicTokenRate === 0;
+                        });
+
+                    return historicRate === undefined || historicRate === 0 || isMissingTokenRate;
+                }),
+            };
+        }),
         D.filter(({ account, txs }) => !!account && !!txs.length),
         D.values,
         A.filter(value => !!value),

--- a/suite-common/wallet-utils/src/__tests__/tokenUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/tokenUtils.test.ts
@@ -1,7 +1,10 @@
+import type { TokenInfo } from '@trezor/blockchain-link-types';
+
 import { getContractAddressForNetworkSymbolFixtures } from '../__fixtures__/tokenUtils';
 import {
     getAssetLogoContractAddresses,
     getContractAddressForNetworkSymbol,
+    getErc4626Contracts,
     sortTokensByName,
 } from '../tokenUtils';
 
@@ -40,6 +43,29 @@ describe('getAssetLogoContractAddresses', () => {
         await expect(getAssetLogoContractAddresses('eth', contract)).resolves.toEqual([
             contract.toLowerCase(),
         ]);
+    });
+});
+
+describe('getErc4626Contracts', () => {
+    const vaultToken: TokenInfo = {
+        standard: 'ERC20',
+        contract: '0xVault',
+        decimals: 6,
+        protocols: ['erc4626'],
+    };
+
+    const plainToken: TokenInfo = {
+        standard: 'ERC20',
+        contract: '0xPlain',
+        decimals: 6,
+    };
+
+    it('returns normalized contracts of ERC4626 tokens', () => {
+        expect(getErc4626Contracts([plainToken, vaultToken])).toEqual(new Set(['0xvault']));
+    });
+
+    it('returns an empty set when tokens are undefined', () => {
+        expect(getErc4626Contracts(undefined)).toEqual(new Set());
     });
 });
 

--- a/suite-common/wallet-utils/src/tokenUtils.ts
+++ b/suite-common/wallet-utils/src/tokenUtils.ts
@@ -137,5 +137,8 @@ export const shouldUppercaseTokenSymbol = (token: TokenInfo) =>
 
 export const isErc4626 = (token: TokenInfo) => !!token.protocols?.includes('erc4626');
 
+export const getErc4626Contracts = (tokens: TokenInfo[] | undefined) =>
+    new Set(tokens?.filter(isErc4626).map(token => token.contract.toLowerCase()));
+
 export const sortTokensByName = (a: Pick<TokenInfo, 'name'>, b: Pick<TokenInfo, 'name'>) =>
     (a.name ?? '').localeCompare(b.name ?? '');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Historic fiat rates for ERC4626 tokens were computed from the historic rate of the underlying asset × the **current** share-to-asset conversion ratio, which overstates past values (the ratio grows with yield). Accurate historic ratios are not available, so these rates are now hidden instead:

- `updateTxsFiatRatesThunk` no longer fetches historic rates for ERC4626 tokens
- ERC4626 transfers are excluded from "missing rates" checks (no endless refetch, day headers keep showing totals)
- IDB migration 26.8.0 removes previously stored inaccurate entries from `historicRates`

Desktop scope; mobile UI follow-up separately.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #29811

## Screenshots:

<img width="799" height="625" alt="image" src="https://github.com/user-attachments/assets/ade486d5-64b0-43d9-93db-cf04bd939aa5" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set touches three distinct areas: (1) storage migration logic (new 26.8.0 migration version), (2) transaction list UI components (TransactionGroupedList, TransactionsGroup), and (3) core wallet utilities (transactionsSelectors, fiatRatesThunks, tokenUtils). The highest risk is in the transaction display components and selectors, which directly affect how users see their transaction history. The storage migration is also high risk since incorrect migrations can corrupt user data. The wallet utility changes (fiatRates, tokenUtils) are broadly imported but primarily affect balance/fiat display and token handling. Testing strategy focuses on transaction list rendering, pagination, pending transactions, and DB migration tests as highest priority, with balance display and trading form tests as secondary coverage.

<details><summary><b>Changed files (11)</b></summary>

- `packages/suite/src/storage/migrations/versions/26.8.0.ts`
- `packages/suite/src/storage/migrations/versions/__tests__/26.8.0.test.ts`
- `packages/suite/src/storage/migrations/versions/index.ts`
- `packages/suite/src/views/wallet/transactions/TransactionList/TransactionGroupedList.tsx`
- `packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx`
- `suite-common/wallet-core/src/fiat-rates/__tests__/fiatRatesThunks.test.ts`
- `suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts`
- `suite-common/wallet-core/src/transactions/__tests__/transactionsSelectors.test.ts`
- `suite-common/wallet-core/src/transactions/transactionsSelectors.ts`
- `suite-common/wallet-utils/src/__tests__/tokenUtils.test.ts`
- `suite-common/wallet-utils/src/tokenUtils.ts`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly exercises the transaction list UI (TransactionGroupedList, TransactionsGroup) and transaction selectors. Changes to TransactionGroupedList.tsx, TransactionsGroup.tsx, and transactionsSelectors.ts directly affect how transactions are displayed, filtered by time range, and searched.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test validates pending and confirmed transaction groups, transaction labels, and transaction detail display — all of which rely on TransactionGroupedList, TransactionsGroup, and transactionsSelectors. Changes to grouping/rendering logic or transaction selection could break pending/confirmed group display.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — Exporting transactions (PDF/CSV/JSON) depends on transaction data flowing through transactionsSelectors and being rendered in the transaction list view. Changes to selectors or the transaction list components could affect what data is available for export.
- `suite/e2e/tests/wallet/pagination.test.ts` — Pagination navigates through transaction pages and verifies correct transactions are displayed on each page. This directly relies on transactionsSelectors for data and TransactionGroupedList/TransactionsGroup for rendering the paginated results.
- `suite/e2e/tests/suite/db-migration.test.ts` — This test validates database migration from an older Suite version to a newer one, verifying settings persistence through IndexedDB schema changes. The new storage migration version 26.8.0 and migration index changes directly affect this test's migration path.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/suite/db-locale-migration.test.ts` — This test validates database migration between Suite versions preserving user settings. While it tests a different migration path (25.7→develop), changes to the migration index and new migration version could affect the overall migration chain.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test labels transaction outputs and exports transactions as CSV with labels. It directly interacts with the transaction list where TransactionsGroup renders output labels, and uses transactionsSelectors for transaction data.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Discreet mode hides fiat values across the dashboard. Changes to fiatRatesThunks could affect how fiat rates are fetched and displayed, and tokenUtils changes could affect token balance display in the asset cards.
- `suite/e2e/tests/dashboard/assets.test.ts` — The assets dashboard test verifies asset display in grid/table views and enabling new coins. tokenUtils changes could affect how token balances are computed for display, and fiatRatesThunks changes could affect fiat value calculations.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies account balance display and formatting. Changes to fiatRatesThunks (which provides fiat conversion) and tokenUtils (which handles token balance computation) could affect balance rendering.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test verifies swap form token balance display and fraction button calculations. tokenUtils changes directly affect how token balances (e.g., USDC sell balance of 58.72333) are computed, and the test verifies precise fractional calculations.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test sends transactions and verifies OP_RETURN pending transaction display. It exercises the transaction list components (TransactionGroupedList/TransactionsGroup) when checking that sent transactions appear in the pending list.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — The staking form validates ETH amounts and uses crypto/fiat conversion which depends on fiatRatesThunks. The test explicitly verifies fiat conversion ratios (0.5 mocked rate), which could be affected by changes to fiat rate fetching logic.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Sell inputs test validates percentage-of-balance calculations for BTC and SOL. tokenUtils changes could affect how balances are computed for the fraction button calculations that this test verifies precisely.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/suite/src/storage/migrations/versions/__tests__/26.8.0.test.ts`
- `suite-common/wallet-core/src/fiat-rates/__tests__/fiatRatesThunks.test.ts`
- `suite-common/wallet-core/src/transactions/__tests__/transactionsSelectors.test.ts`
- `suite-common/wallet-utils/src/__tests__/tokenUtils.test.ts`

_Updated: 2026-07-17T09:52:17.142Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/29811-erc4626-historic-rates/web/](https://dev.suite.sldev.cz/suite-web/fix/29811-erc4626-historic-rates/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/29811-erc4626-historic-rates&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/29811-erc4626-historic-rates&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/29811-erc4626-historic-rates&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-17T09:55:01.975Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-17T09:55:04.930Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->