### PR TITLE
fix(suite-native): translate biometric authentication prompt

### DIFF
--- a/suite-native/biometrics/src/__tests__/biometricsThunks.test.ts
+++ b/suite-native/biometrics/src/__tests__/biometricsThunks.test.ts
@@ -3,6 +3,7 @@ import * as LocalAuthentication from 'expo-local-authentication';
 
 import { events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
+import { getTranslation, localeInitialState, localeReducer } from '@suite-native/intl';
 
 import { biometricsSlice, biometricsSliceInitialState } from '../biometricsSlice';
 import {
@@ -40,9 +41,11 @@ const createBiometricsStore = (
     configureStore({
         reducer: {
             biometrics: biometricsSlice.reducer,
+            locale: localeReducer,
         },
         preloadedState: {
             biometrics: preloadedBiometricsState,
+            locale: localeInitialState,
         },
         middleware: getDefaultMiddleware =>
             getDefaultMiddleware({
@@ -103,6 +106,17 @@ describe('biometricsThunks', () => {
             expect(store.getState().biometrics.biometricsError).toBe(
                 AuthenticateError.AuthenticationFailed,
             );
+        });
+
+        it('should pass translated labels to the native prompt', async () => {
+            const store = createBiometricsStore();
+
+            await store.dispatch(authenticateUserThunk());
+
+            expect(LocalAuthentication.authenticateAsync).toHaveBeenCalledWith({
+                promptMessage: getTranslation('biometrics.prompt.title'),
+                cancelLabel: getTranslation('generic.buttons.cancel'),
+            });
         });
     });
 

--- a/suite-native/biometrics/src/biometricsThunks.ts
+++ b/suite-native/biometrics/src/biometricsThunks.ts
@@ -6,6 +6,7 @@ import type { LocalAuthenticationResult } from 'expo-local-authentication';
 
 import { createThunk } from '@suite-common/redux-utils';
 import { asTypedNativeAnalytics, events } from '@suite-native/analytics';
+import { getLocalizedMessage, selectSupportedLanguageLocale } from '@suite-native/intl';
 
 import {
     selectGoneToBackgroundAtTimestamp,
@@ -45,14 +46,21 @@ export const authenticateUserThunk = createThunk<
     LocalAuthenticationResult,
     void,
     { rejectValue: AuthenticateError }
->(`${BIOMETRICS_THUNK_PREFIX}/authenticate`, async (_, { rejectWithValue }) => {
+>(`${BIOMETRICS_THUNK_PREFIX}/authenticate`, async (_, { getState, rejectWithValue }) => {
     const isBiometricsAvailable = await getIsBiometricsFeatureAvailable();
 
     if (!isBiometricsAvailable) {
         return rejectWithValue(AuthenticateError.BiometricsNotAvailable);
     }
 
-    const result = await LocalAuthentication.authenticateAsync();
+    // Without explicit labels, the native prompt falls back to the untranslated defaults
+    // of expo-local-authentication, regardless of the app language.
+    const locale = selectSupportedLanguageLocale(getState());
+
+    const result = await LocalAuthentication.authenticateAsync({
+        promptMessage: getLocalizedMessage(locale, 'biometrics.prompt.title'),
+        cancelLabel: getLocalizedMessage(locale, 'generic.buttons.cancel'),
+    });
 
     if (!result.success) {
         return rejectWithValue(AuthenticateError.AuthenticationFailed);

--- a/suite-native/intl/src/getLocalizedMessage.ts
+++ b/suite-native/intl/src/getLocalizedMessage.ts
@@ -1,0 +1,32 @@
+import { type IntlShape, createIntl, createIntlCache } from 'react-intl';
+
+import { getMessagesForLocale } from './translationsMap';
+import { type SupportedLocaleCode, type TxKeyPath } from './types';
+
+const intlByLocale = new Map<SupportedLocaleCode, IntlShape>();
+
+const getIntlForLocale = (locale: SupportedLocaleCode): IntlShape => {
+    const cachedIntl = intlByLocale.get(locale);
+
+    if (cachedIntl) {
+        return cachedIntl;
+    }
+
+    const intl = createIntl({ locale, messages: getMessagesForLocale(locale) }, createIntlCache());
+    intlByLocale.set(locale, intl);
+
+    return intl;
+};
+
+/**
+ * Imperative counterpart of the `useTranslate` hook, for code that runs outside of React and
+ * therefore cannot use it, e.g. Redux thunks passing strings to native OS prompts.
+ *
+ * The locale has to be resolved by the caller, typically via `selectSupportedLanguageLocale`.
+ * Prefer `useTranslate` or the `Translation` component whenever React context is available.
+ */
+export const getLocalizedMessage = (
+    locale: SupportedLocaleCode,
+    id: TxKeyPath,
+    values?: Record<string, string | number>,
+): string => String(getIntlForLocale(locale).formatMessage({ id }, values));

--- a/suite-native/intl/src/hooks/useTranslatedMessages.ts
+++ b/suite-native/intl/src/hooks/useTranslatedMessages.ts
@@ -2,32 +2,14 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { selectSupportedLanguageLocale } from '../localeSlice';
-import { messages as defaultMessages } from '../messages';
-import { type SupportedLocaleCode } from '../types';
-import { flatten } from '../utils';
-
-const LANGUAGE_TRANSLATIONS_MAP = {
-    'en-US': require('../../translations/en-US.json'),
-    'cs-CZ': require('../../translations/cs-CZ.json'),
-    'de-DE': require('../../translations/de-DE.json'),
-    'es-ES': require('../../translations/es-ES.json'),
-    'fr-FR': require('../../translations/fr-FR.json'),
-    'pt-BR': require('../../translations/pt-BR.json'),
-    'ja-JP': require('../../translations/ja-JP.json'),
-    'zh-CN': require('../../translations/zh-CN.json'),
-} as const satisfies Record<SupportedLocaleCode, any>;
-
-// default values defined during the development.
-const englishFallback = flatten(defaultMessages);
+import { getMessagesForLocale } from '../translationsMap';
 
 export const useTranslatedMessages = () => {
     const [messages, setMessages] = useState<{ [key: string]: string }>({});
     const supportedLanguageLocale = useSelector(selectSupportedLanguageLocale);
 
     useEffect(() => {
-        const localizedMessages = LANGUAGE_TRANSLATIONS_MAP[supportedLanguageLocale];
-
-        setMessages({ ...englishFallback, ...localizedMessages });
+        setMessages(getMessagesForLocale(supportedLanguageLocale));
     }, [supportedLanguageLocale]);
 
     return messages;

--- a/suite-native/intl/src/index.ts
+++ b/suite-native/intl/src/index.ts
@@ -6,3 +6,4 @@ export * from './types';
 export * from './localeSlice';
 export * from './languages';
 export { getTranslation } from './getTranslation';
+export { getLocalizedMessage } from './getLocalizedMessage';

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -216,6 +216,9 @@ export const messages = {
     },
     biometrics: {
         biometricsButton: 'Unlock with biometrics',
+        prompt: {
+            title: 'Unlock Trezor Suite',
+        },
         biometricsUnavailableAlert: {
             title: 'Biometric authentication',
             description:

--- a/suite-native/intl/src/translationsMap.ts
+++ b/suite-native/intl/src/translationsMap.ts
@@ -1,0 +1,22 @@
+import { messages as defaultMessages } from './messages';
+import { type SupportedLocaleCode } from './types';
+import { flatten } from './utils';
+
+const LANGUAGE_TRANSLATIONS_MAP = {
+    'en-US': require('../translations/en-US.json'),
+    'cs-CZ': require('../translations/cs-CZ.json'),
+    'de-DE': require('../translations/de-DE.json'),
+    'es-ES': require('../translations/es-ES.json'),
+    'fr-FR': require('../translations/fr-FR.json'),
+    'pt-BR': require('../translations/pt-BR.json'),
+    'ja-JP': require('../translations/ja-JP.json'),
+    'zh-CN': require('../translations/zh-CN.json'),
+} as const satisfies Record<SupportedLocaleCode, any>;
+
+// Default values defined during the development.
+const englishFallback = flatten(defaultMessages);
+
+export const getMessagesForLocale = (locale: SupportedLocaleCode): Record<string, string> => ({
+    ...englishFallback,
+    ...LANGUAGE_TRANSLATIONS_MAP[locale],
+});


### PR DESCRIPTION
## Description

Opening the app with biometrics enabled showed an English "Authenticate" prompt, whatever the app language was set to.

`LocalAuthentication.authenticateAsync()` was called without any options, so `expo-local-authentication` fell back to its own untranslated defaults — the string never existed in the intl system at all.

The prompt now receives a translated `promptMessage` and `cancelLabel`. The locale is resolved from the store inside `authenticateUserThunk`, so all three call sites are covered at once:

- returning to the foreground after the keep-logged-in window (`handleBiometricsAppStateChangeThunk`)
- the biometrics toggle in settings (`toggleBiometricsSettingsThunk`)
- the manual "Unlock with biometrics" button (`BiometricOverlay`)

Since the thunk runs outside of React, `useTranslate` is not available, and `getTranslation` is English-only (`createIntl({ locale: 'en' })`) and documented as a test helper — using it would have silently kept the prompt in English. This PR therefore adds `getLocalizedMessage(locale, id, values?)` to `@suite-native/intl` as the imperative counterpart of the `useTranslate` hook, and extracts the language translations map into `translationsMap.ts` so that it and `useTranslatedMessages` share a single source.

One new key is added: `biometrics.prompt.title`. The cancel label reuses the existing `generic.buttons.cancel`, which is already translated — so the cancel button is localized right away, while the new title falls back to English until it lands in Crowdin.

## Notes for QA

Requires biometrics enrolled on the device, and the biometrics option enabled in the app.

Set the app language to a non-English one (e.g. Français), then check the native prompt in all three flows:

1. Send the app to the background, wait past the keep-logged-in window, return to the foreground.
2. Settings → toggle biometric authentication off and on.
3. On the lock overlay, tap "Unlock with biometrics".

Expected in each: the cancel button shows the translated label (e.g. "Annuler") instead of "Cancel", and the title reads "Unlock Trezor Suite" instead of "Authenticate". The title stays English until `biometrics.prompt.title` is translated in Crowdin.

Worth a regression pass in English too, and confirming that cancelling or failing the prompt still behaves as before (app stays locked, error state unchanged).

## Related Issue

None — found while testing the app in French.

## Screenshots: