### PR TITLE
fix(device): handle null vs. undefined in deviceInvariabilityCheck

### DIFF
--- a/suite-common/device/src/services/deviceInvariabilityCheck.ts
+++ b/suite-common/device/src/services/deviceInvariabilityCheck.ts
@@ -40,8 +40,9 @@ export const deviceInvariabilityCheck = ({
         return ok();
     }
 
-    const isModelMismatch = currentModel !== previousModel;
-    const isColorMismatch = currentColor !== previousColor;
+    // Loose equality, so that null and undefined are considered equal.
+    const isModelMismatch = currentModel != previousModel;
+    const isColorMismatch = currentColor != previousColor;
 
     if (isModelMismatch || isColorMismatch) {
         const error: DeviceInvariabilityCheckError = {

--- a/suite-common/device/tests/deviceInvariabilityCheck.test.ts
+++ b/suite-common/device/tests/deviceInvariabilityCheck.test.ts
@@ -50,6 +50,19 @@ describe(deviceInvariabilityCheck.name, () => {
         });
     });
 
+    it('returns success when device model differs only by null vs undefined', () => {
+        const result = deviceInvariabilityCheck({
+            isDeviceKnown: true,
+            isBootloaderMode: false,
+            hasPreviousRecord: true,
+            currentModel: undefined,
+            // @ts-expect-error real occurrences in Sentry
+            previousModel: null,
+        });
+
+        expect(result).toEqual({ success: true, payload: undefined });
+    });
+
     it('returns error when device changes its color', () => {
         const device = mockConnectDevice({ id: deviceId }, { ...defaultFeatures, unit_color: 2 });
         const previousData = {
@@ -66,6 +79,19 @@ describe(deviceInvariabilityCheck.name, () => {
                 currentColor: 2,
             },
         });
+    });
+
+    it('returns success when device color differs only by null vs undefined', () => {
+        const result = deviceInvariabilityCheck({
+            isDeviceKnown: true,
+            isBootloaderMode: false,
+            hasPreviousRecord: true,
+            currentColor: undefined,
+            // @ts-expect-error real occurrences in Sentry
+            previousColor: null,
+        });
+
+        expect(result).toEqual({ success: true, payload: undefined });
     });
 
     it('returns error when device changes both its model and color', () => {


### PR DESCRIPTION
## Description

Looser null vs undefined handling in `deviceInvariabilityCheck` to prevent false positives, see issues

## Notes for QA

N/A, it only makes the check more loose to fix Sentry issues.

## Related Issue

Many sentry issues which have `errorPayload: {previousColor: null }`, which necessarily means that `currentColor` is `undefined`  so it doesn't make it to serialization, because both values [are always reported](https://github.com/trezor/trezor-suite/blob/3a775b17b21dd520f354f555d4f32510837becb3/suite-common/device/src/services/deviceInvariabilityCheck.ts#L50).
https://satoshilabs.sentry.io/issues/7468252414/
https://satoshilabs.sentry.io/issues/7460141534/
https://satoshilabs.sentry.io/issues/7464277477/
and more...

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change modifies deviceInvariabilityCheck.ts (a service for device integrity/invariability verification) and its unit test. The source file maps to 131 E2E tests, indicating it is a broadly-imported dependency. However, the functional impact is narrowly scoped to device integrity verification flows: entropy checks during wallet creation, authenticity checks, and firmware hash/revision validation during onboarding. The unit test file has no E2E coverage (as expected). The recommended strategy focuses on the few tests that directly exercise device integrity verification paths rather than broadly running all tests that transitively import this module.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/device/src/services/deviceInvariabilityCheck.ts`
- `suite-common/device/tests/deviceInvariabilityCheck.test.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test directly exercises entropy check failure handling during wallet creation, which is closely related to device invariability/integrity checking. The test dispatches simulated entropy check failures via deviceActions and validates the device compromised modal behavior, which is the most directly relevant user-facing flow for device invariability checks.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — The authenticity check during onboarding involves device integrity verification (firmware hash check, firmware revision check), which shares the device invariability check infrastructure. Changes to deviceInvariabilityCheck could affect how authenticity verification proceeds.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test validates firmware readiness detection during onboarding after disabling firmware checks. The deviceInvariabilityCheck service likely participates in firmware hash/revision checking logic that this test exercises via disableNecessaryFirmwareChecks.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/suite/initial-run.test.ts` — This test optionally dismisses a firmware hash check error modal during the initial run flow. If deviceInvariabilityCheck changes affect when/how firmware hash check errors are surfaced, this test's flow could be impacted.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/device/tests/deviceInvariabilityCheck.test.ts`

_Updated: 2026-07-16T17:20:24.393Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/device-invariability-null-undefined/web/](https://dev.suite.sldev.cz/suite-web/fix/device-invariability-null-undefined/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/device-invariability-null-undefined&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/device-invariability-null-undefined&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-16T17:23:36.263Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-16T17:23:30.139Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->