### PR TITLE
refactor(suite): simplify router test state overrides

### DIFF
--- a/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
@@ -3,6 +3,7 @@
 import { flagsInitialState, prepareFlagsReducer } from '@suite/flags';
 import { modalReducer } from '@suite/modal';
 import { routerReducer } from '@suite/router';
+import { type RouterStateOverrides, createRouterStateMock } from '@suite/router/mocks';
 import { torReducer } from '@suite/tor';
 import { connectInitThunk } from '@suite-common/connect-init';
 import { deviceActions, prepareDeviceReducer } from '@suite-common/device';
@@ -33,13 +34,12 @@ const flagsReducer = prepareFlagsReducer(extraDependencies);
 
 type SuiteState = ReturnType<typeof suiteReducer>;
 type DevicesState = ReturnType<typeof deviceReducer>;
-type RouterState = ReturnType<typeof routerReducer>;
 type FirmwareState = ReturnType<typeof firmwareReducer>;
 
 const getInitialState = (
     suite?: Partial<SuiteState>,
     device?: Partial<DevicesState>,
-    router?: RouterState,
+    router?: RouterStateOverrides,
     firmware?: Partial<FirmwareState>,
     suiteSyncData?: Partial<ReturnType<typeof suiteSyncReducer>>,
 ) => ({
@@ -54,10 +54,7 @@ const getInitialState = (
         ...deviceReducer(undefined, { type: 'foo' } as any),
         ...device,
     },
-    router: {
-        ...routerReducer(undefined, { type: 'foo' } as any),
-        ...router,
-    },
+    router: createRouterStateMock(router),
     modal: modalReducer(undefined, { type: 'foo' } as any),
     firmware: {
         ...firmwareReducer(undefined, { type: 'foo' } as any),

--- a/packages/suite/src/middlewares/onboarding/__tests__/onboardingMiddleware.test.ts
+++ b/packages/suite/src/middlewares/onboarding/__tests__/onboardingMiddleware.test.ts
@@ -1,5 +1,6 @@
 import { modalReducer } from '@suite/modal';
 import { routerAppChanged, routerReducer } from '@suite/router';
+import { type RouterStateOverrides, createRouterStateMock } from '@suite/router/mocks';
 
 import onboardingMiddlewares from 'src/middlewares/onboarding';
 import onboardingReducer from 'src/reducers/onboarding/index';
@@ -16,11 +17,10 @@ jest.mock('@trezor/suite-storage', () => ({
 jest.mock('src/actions/suite/storageActions', () => ({ __esModule: true }));
 
 type SuiteState = ReturnType<typeof suiteReducer>;
-type RouterState = ReturnType<typeof routerReducer>;
 type OnboardingState = ReturnType<typeof onboardingReducer>;
 
 const getInitialState = (
-    router?: RouterState,
+    router?: RouterStateOverrides,
     suite?: Partial<SuiteState>,
     onboarding?: Partial<OnboardingState>,
 ) => ({
@@ -28,10 +28,7 @@ const getInitialState = (
         ...suiteReducer(undefined, { type: 'foo' } as any),
         ...suite,
     },
-    router: {
-        ...routerReducer(undefined, { type: 'foo' } as any),
-        ...router,
-    },
+    router: createRouterStateMock(router),
     onboarding: {
         ...onboardingReducer(undefined, { type: 'foo' } as any),
         ...onboarding,

--- a/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
@@ -1,6 +1,7 @@
 import { locksInitialState, locksReducer } from '@suite/locks';
 import { modalReducer } from '@suite/modal';
 import { goto, routerReducer } from '@suite/router';
+import { type RouterStateOverrides, createRouterStateMock } from '@suite/router/mocks';
 import { deviceActions, prepareDeviceReducer } from '@suite-common/device';
 import { mockConnectDevice, mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
@@ -23,13 +24,12 @@ const deviceReducer = prepareDeviceReducer(extraDependencies);
 
 type SuiteState = ReturnType<typeof suiteReducer>;
 type DevicesState = ReturnType<typeof deviceReducer>;
-type RouterState = ReturnType<typeof routerReducer>;
 type ModalState = ReturnType<typeof modalReducer>;
 
 const getInitialState = (
     suite?: Partial<SuiteState>,
     device?: Partial<DevicesState>,
-    router?: Partial<RouterState>,
+    router?: RouterStateOverrides,
     modal?: Partial<ModalState>,
 ) => ({
     suite: {
@@ -41,10 +41,7 @@ const getInitialState = (
         ...deviceReducer(undefined, { type: 'foo' } as any),
         ...device,
     },
-    router: {
-        ...routerReducer(undefined, { type: 'foo' } as any),
-        ...router,
-    },
+    router: createRouterStateMock(router),
     modal: {
         ...modalReducer(undefined, { type: 'foo' } as any),
         ...modal,
@@ -63,7 +60,7 @@ const initStore = (state: State) => {
 
         const { suite, router, device, locks } = store.getState();
         store.getState().suite = suiteReducer(suite, action);
-        store.getState().router = routerReducer(router as RouterState, action);
+        store.getState().router = routerReducer(router, action);
         store.getState().device = deviceReducer(device, action);
         store.getState().locks = locksReducer(locks, action);
 

--- a/packages/type-utils/test/object.type-test.ts
+++ b/packages/type-utils/test/object.type-test.ts
@@ -1,4 +1,4 @@
-import { NullablePropsRecursive } from '../src';
+import { NullablePropsRecursive, type OptionalKey } from '../src';
 
 type X = {
     a: 'A';
@@ -21,7 +21,21 @@ const y4fail: Y = {};
 // @ts-expect-error This expects and error as b is missing
 const y3fail: Y = { a: null };
 
+type DiscriminatedUnion = { type: 'string'; value: string } | { type: 'number'; value: number };
+
+type PartialDiscriminatedUnion = OptionalKey<DiscriminatedUnion, keyof DiscriminatedUnion>;
+
+const nonDistributivePartial: PartialDiscriminatedUnion = {
+    type: 'string',
+    value: 1,
+};
+
+// @ts-expect-error The value remains constrained to the original property's value types.
+const invalidNonDistributivePartial: PartialDiscriminatedUnion = { value: false };
+
 void y1ok;
 void y2ok;
-void y4fail;
 void y3fail;
+void y4fail;
+void nonDistributivePartial;
+void invalidNonDistributivePartial;

--- a/skills/tests/SKILL.md
+++ b/skills/tests/SKILL.md
@@ -56,6 +56,21 @@ mock, keep it generic and non-opinionated.
 
 Simple test: change in shared mock SHALL NOT break existing tests (or make fixes trivial).
 
+## Type tests
+
+Keep type-test assertions module-local. Do not export test-only values or types, because exports
+pollute the generated declaration files. Use `void` statements to mark assertion values as used:
+
+```ts
+const valid: ExpectedType = value;
+
+// @ts-expect-error The value must not accept an incompatible type.
+const invalid: ExpectedType = incompatibleValue;
+
+void valid;
+void invalid;
+```
+
 ## Mocks (& Fixtures)
 
 ### Typing

--- a/suite/router/mocks/index.ts
+++ b/suite/router/mocks/index.ts
@@ -1,0 +1,22 @@
+import { type OptionalKey } from '@trezor/type-utils';
+
+import { type RouterState, routerReducer } from '../src/routerReducer';
+
+const TEST_INIT_ACTION = { type: '@tests/init' };
+
+export type RouterStateOverrides = OptionalKey<RouterState, keyof RouterState>;
+
+// RouterState is a large discriminated union. Letting object-spread inference merge its members
+// with overrides creates thousands of possible object types. Applying overrides after the initial
+// state is contextually typed preserves selective overrides while returning the original union.
+export const createRouterStateMock = (overrides?: RouterStateOverrides): RouterState => {
+    const state: RouterState = {
+        ...routerReducer(undefined, TEST_INIT_ACTION),
+    };
+
+    if (overrides) {
+        Object.assign(state, overrides);
+    }
+
+    return state;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Code improvement to reduce type-declarations to speedup the type-check

Nothing to manually test, only code improvement

<img width="884" height="505" alt="image" src="https://github.com/user-attachments/assets/2cf32881-b808-4121-a68f-d6dc481ad378" />


## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set consists entirely of unit test files and a router mock module — no production source code is modified. The risk is very low since the changes are to test infrastructure (__tests__ files and mocks), not to the actual suite actions, middlewares, or routing logic. However, the router mock change (suite/router/mocks/index.ts) could potentially affect E2E test infrastructure if it's consumed by E2E test setup. A minimal set of tests covering onboarding flow and routing behavior provides reasonable confidence without over-testing.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/actions/suite/__tests__/suiteActions.test.ts`
- `packages/suite/src/middlewares/onboarding/__tests__/onboardingMiddleware.test.ts`
- `packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts`
- `packages/type-utils/test/object.type-test.ts`
- `suite/router/mocks/index.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — The onboarding middleware test change could affect how onboarding redirects work. This test navigates directly to /accounts during onboarding and verifies the analytics consent dialog appears correctly, which exercises the onboarding middleware's redirect logic.
- `suite/e2e/tests/suite/initial-run.test.ts` — The redirect middleware and onboarding middleware changes could affect how the initial run flow persists across page reloads and how routing decisions are made. This test specifically validates that the analytics consent screen persists across reloads and that completing onboarding properly updates the initial run state, which are behaviors governed by suite actions and redirect middleware.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — The suite/router/mocks/index.ts change directly relates to router configuration mocking. This test imports router-config to validate all routes are covered and navigates to every defined route, so changes to router mocks could indicate router config changes that affect route coverage validation.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/suite/src/actions/suite/__tests__/suiteActions.test.ts`
- `packages/suite/src/middlewares/onboarding/__tests__/onboardingMiddleware.test.ts`
- `packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts`
- `packages/type-utils/test/object.type-test.ts`

_Updated: 2026-07-17T07:50:39.596Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/perf/router-state-type-expansion/web/](https://dev.suite.sldev.cz/suite-web/perf/router-state-type-expansion/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=perf/router-state-type-expansion&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=perf/router-state-type-expansion&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-17T07:54:01.521Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-17T07:53:29.049Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->