### PR TITLE
fix(suite-native): reduce tab routes declaration size

### DIFF
--- a/suite-native/app/src/navigation/routes.ts
+++ b/suite-native/app/src/navigation/routes.ts
@@ -1,4 +1,4 @@
-import { AccountsStackRoutes, AppTabsRoutes } from '@suite-native/navigation';
+import { AccountsStackRoutes, AppTabsRoutes, type TabsOptions } from '@suite-native/navigation';
 
 import { enhanceTabOption } from './enhanceTabOption';
 
@@ -35,14 +35,14 @@ const settings = enhanceTabOption({
     focusedIconName: 'gearFilled',
 });
 
-export const rootTabsOptionsWithoutEarn = {
+export const rootTabsOptionsWithoutEarn: TabsOptions = {
     ...homeStack,
     ...accountsStack,
     ...tradeStack,
     ...settings,
 };
 
-export const rootTabsOptions = {
+export const rootTabsOptions: TabsOptions = {
     ...rootTabsOptionsWithoutEarn,
     ...earnStack,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Code improvement to reduce type-declarations to speedup the type-check

Nothing to manually test, only code improvement

- Before: **54,813 bytes**
- After: **210 bytes**
- Saved: **54,603 bytes (53.3 KiB, 99.6%)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-native-tab-routes-declaration-size&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->