### PR TITLE
refactor(types): reduce inferred declaration surface

### DIFF
--- a/packages/components/src/config/colors.ts
+++ b/packages/components/src/config/colors.ts
@@ -1,18 +1,7 @@
-import { colorVariants, mapBoxShadowsToCSS } from '@trezor/theme';
+import { type BoxShadows, type Colors, colorVariants, mapBoxShadowsToCSS } from '@trezor/theme';
 
 // TODO: button hover color could be derived from its based color
 //       by applying something like opacity/darkening, same goes for gradients
-
-type LightThemeProps = typeof intermediaryTheme.light;
-type DarkThemeProps = typeof intermediaryTheme.dark;
-
-// Extracts values for common props (eg. NEUE_BG_GREEN: "#00854D" | "#e3ede0")
-type CommonThemeProps = {
-    [K in keyof LightThemeProps & keyof DarkThemeProps]: LightThemeProps[K] | DarkThemeProps[K];
-};
-
-type PropsOnlyInLightTheme = Omit<LightThemeProps, keyof DarkThemeProps>;
-type PropsOnlyInDarkTheme = Omit<DarkThemeProps, keyof LightThemeProps>;
 
 /**
  * IMPORTANT:
@@ -24,13 +13,15 @@ type PropsOnlyInDarkTheme = Omit<DarkThemeProps, keyof LightThemeProps>;
  *  See `suite` package for reference.
  */
 
-// All common theme props and their values are nicely listed,
-// props that are specific to given theme are marked optional.
-export type SuiteThemeColors = CommonThemeProps &
-    Partial<PropsOnlyInDarkTheme> &
-    Partial<PropsOnlyInLightTheme>;
+type ThemeMode = 'light' | 'dark';
 
-export const intermediaryTheme = {
+export type SuiteThemeColors = Colors & BoxShadows & { mode: ThemeMode };
+
+type IntermediaryTheme = {
+    [Mode in ThemeMode]: SuiteThemeColors & { mode: Mode };
+};
+
+export const intermediaryTheme: IntermediaryTheme = {
     light: {
         mode: 'light' as const,
         ...colorVariants.standard,

--- a/packages/suite/src/actions/bluetooth/__tests__/desktopBluetoothReducer.test.ts
+++ b/packages/suite/src/actions/bluetooth/__tests__/desktopBluetoothReducer.test.ts
@@ -7,8 +7,8 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { type DesktopBluetoothDevice } from '../DesktopBluetoothDevice';
 import {
-    bluetoothSlice,
     initialDesktopBluetoothState,
+    prepareDesktopBluetoothReducer,
     startConnectingBluetoothDevice,
     stopConnectingBluetoothDevice,
 } from '../desktopBluetoothReducer';
@@ -19,7 +19,7 @@ const manufacturerData: BluetoothManufacturerData = {
     filterPolicy: undefined,
 };
 
-const bluetoothReducer = bluetoothSlice.prepareReducer(extraDependenciesCommonMock);
+const bluetoothReducer = prepareDesktopBluetoothReducer(extraDependenciesCommonMock);
 
 const disconnectedDeviceB: DesktopBluetoothDevice = {
     id: asBluetoothDeviceId('B'),

--- a/packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts
+++ b/packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts
@@ -1,3 +1,5 @@
+import { type PayloadAction } from '@reduxjs/toolkit';
+
 import {
     type BluetoothState,
     prepareBluetoothReducerCreator,
@@ -38,20 +40,32 @@ export type WithBluetoothRootState = {
     bluetooth: DesktopBluetoothState;
 };
 
-export const bluetoothSlice = createSliceWithExtraDeps({
+const bluetoothSlice = createSliceWithExtraDeps({
     name: 'bluetooth',
     initialState: initialDesktopBluetoothState,
     reducers: {
-        startConnectingBluetoothDevice: (state, { payload: { deviceId } }) => {
+        startConnectingBluetoothDevice: (
+            state: DesktopBluetoothState,
+            { payload: { deviceId } }: PayloadAction<{ deviceId: string }>,
+        ) => {
             state.connectingDeviceIds.push(deviceId);
         },
-        stopConnectingBluetoothDevice: (state, { payload: { deviceId } }) => {
+        stopConnectingBluetoothDevice: (
+            state: DesktopBluetoothState,
+            { payload: { deviceId } }: PayloadAction<{ deviceId: string }>,
+        ) => {
             state.connectingDeviceIds = state.connectingDeviceIds.filter(id => id !== deviceId);
         },
-        setIsUnpairingDevice: (state, { payload: { isUnpairing } }) => {
+        setIsUnpairingDevice: (
+            state: DesktopBluetoothState,
+            { payload: { isUnpairing } }: PayloadAction<{ isUnpairing: boolean }>,
+        ) => {
             state.isUnpairingDevice = isUnpairing;
         },
-        setBluetoothDeviceNeedsManualPairing: (state, { payload }) => {
+        setBluetoothDeviceNeedsManualPairing: (
+            state: DesktopBluetoothState,
+            { payload }: PayloadAction<boolean>,
+        ) => {
             state.isManualPairingRequired = payload;
         },
     },
@@ -78,9 +92,12 @@ export const bluetoothSlice = createSliceWithExtraDeps({
     },
 });
 
+export const desktopBluetoothActions = bluetoothSlice.actions;
 export const {
     startConnectingBluetoothDevice,
     stopConnectingBluetoothDevice,
     setIsUnpairingDevice,
     setBluetoothDeviceNeedsManualPairing,
-} = bluetoothSlice.actions;
+} = desktopBluetoothActions;
+
+export const prepareDesktopBluetoothReducer = bluetoothSlice.prepareReducer;

--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -4,7 +4,7 @@ import { coinjoinReducer } from '@suite/coinjoin';
 import { initialRunCompleted, prepareFlagsReducer } from '@suite/flags';
 import { initialMetadataState, metadataReducer } from '@suite/metadata';
 import { suiteSettingsInitialState } from '@suite/settings';
-import { suiteSyncSlice } from '@suite/suite-sync';
+import { prepareSuiteSyncReducer } from '@suite/suite-sync';
 import { deviceActions, selectDevices, selectDevicesCount } from '@suite-common/device';
 import { asEncryptedHex } from '@suite-common/platform-encryption';
 import { prepareReceiveReducer } from '@suite-common/receive';
@@ -47,7 +47,7 @@ const flagsReducer = prepareFlagsReducer(extraDependencies);
 const sendFormReducer = prepareSendFormReducer(extraDependencies);
 const walletSettingsReducer = discoveryActions.prepareWalletSettingsReducer(extraDependencies);
 const quotaManagerSliceReducer = suiteSyncQuotaManagerSlice.prepareReducer(extraDependencies);
-const suiteSyncReducer = suiteSyncSlice.prepareReducer(extraDependencies);
+const suiteSyncReducer = prepareSuiteSyncReducer(extraDependencies);
 const receiveReducer = prepareReceiveReducer(extraDependencies);
 
 // TODO: add method in suite-storage for deleting all stored data (done as a static method on SuiteDB), call it after each test

--- a/packages/suite/src/components/suite/asset-picker/hooks/useAccountsWithTokenDisplayNames.ts
+++ b/packages/suite/src/components/suite/asset-picker/hooks/useAccountsWithTokenDisplayNames.ts
@@ -36,7 +36,7 @@ export const getTokenDisplayNameSources = (accountsWithTokens: AccountWithTokens
 export const getAccountsWithTokenDisplayNames = (
     accountsWithTokens: AccountWithTokensOption[],
     tokenDisplaySymbolNames: Map<CryptoId, string>,
-) =>
+): AccountWithTokensOption[] =>
     accountsWithTokens.map(item => {
         switch (item.type) {
             case 'account':
@@ -74,7 +74,7 @@ export const getAccountsWithTokenDisplayNames = (
 export const useAccountsWithTokenDisplayNames = (
     accountsWithTokens: AccountWithTokensOption[],
     assets?: TradingAssetOption[],
-) => {
+): AccountWithTokensOption[] => {
     const tokens = useMemo(
         () => getTokenDisplayNameSources(accountsWithTokens),
         [accountsWithTokens],

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -17,7 +17,7 @@ import { type BackupState, backupMiddleware, backupReducer } from '@suite/backup
 import { MODAL_OPEN_USER_CONTEXT } from '@suite/modal';
 import { type RecoveryState, recoveryReducer } from '@suite/recovery';
 import { type HistoryDep } from '@suite/router';
-import { type DesktopSuiteSyncState, suiteSyncSlice } from '@suite/suite-sync';
+import { type DesktopSuiteSyncState, prepareSuiteSyncReducer } from '@suite/suite-sync';
 import { type FirmwareUpdateState, prepareFirmwareReducer } from '@suite-common/firmware';
 import { type GeolocationState, geolocationReducer } from '@suite-common/geolocation';
 import { addLog } from '@suite-common/logger';
@@ -63,7 +63,7 @@ import { type BioAuthState, prepareBioAuthReducer } from './bioAuth';
 import { type DesktopState, desktopReducer } from './desktop';
 import {
     type DesktopBluetoothState,
-    bluetoothSlice,
+    prepareDesktopBluetoothReducer,
 } from '../actions/bluetooth/desktopBluetoothReducer';
 import { type CreateConnectLoggerFactoryDep } from '../support/createConnectLoggerFactory';
 import {
@@ -74,9 +74,9 @@ import {
 
 const firmwareReducer = prepareFirmwareReducer(extraDependencies);
 const tokenDefinitionsReducer = prepareTokenDefinitionsReducer(extraDependencies);
-const bluetoothReducer = bluetoothSlice.prepareReducer(extraDependencies);
+const bluetoothReducer = prepareDesktopBluetoothReducer(extraDependencies);
 const thpReducer = prepareThpReducer(extraDependencies);
-const suiteSyncReducer = suiteSyncSlice.prepareReducer(extraDependencies);
+const suiteSyncReducer = prepareSuiteSyncReducer(extraDependencies);
 const suiteSyncQuotaManagerReducer = suiteSyncQuotaManagerSlice.prepareReducer(extraDependencies);
 const receiveReducer = prepareReceiveReducer(extraDependencies);
 

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -4,7 +4,7 @@ import type { ThunkAction as TAction, ThunkDispatch } from 'redux-thunk';
 import type { backupActions } from '@suite/backup';
 import { type debugActions } from '@suite/debug';
 import type { desktopUpdateActions } from '@suite/desktop-update';
-import { type featureFeedbackSlice } from '@suite/feature-feedback';
+import { type featureFeedbackActions } from '@suite/feature-feedback';
 import type { flagsActions } from '@suite/flags';
 import type { LockAction } from '@suite/locks';
 import type { MetadataAction } from '@suite/metadata';
@@ -12,7 +12,7 @@ import type { ModalAction } from '@suite/modal';
 import type { recoveryActions } from '@suite/recovery';
 import { type Route, type RouterAction } from '@suite/router';
 import { type suiteSettingsActions } from '@suite/settings';
-import { type suiteSyncSlice } from '@suite/suite-sync';
+import { type desktopSuiteSyncActions } from '@suite/suite-sync';
 import { type TorAction } from '@suite/tor';
 import { type analyticsActions } from '@suite-common/analytics-redux';
 import { type bluetoothActions } from '@suite-common/bluetooth';
@@ -22,10 +22,7 @@ import { type firmwareActions } from '@suite-common/firmware';
 import { type geolocationActions } from '@suite-common/geolocation';
 import { type addLog } from '@suite-common/logger';
 import { type messageSystemActions } from '@suite-common/message-system';
-import {
-    type suiteSyncSlice as suiteSyncCommonSlice,
-    type suiteSyncDataSlice,
-} from '@suite-common/suite-sync';
+import { type suiteSyncActions, type suiteSyncDataActions } from '@suite-common/suite-sync';
 import { type suiteSyncQuotaManagerActions } from '@suite-common/suite-sync-quota-manager';
 import { type thpActions } from '@suite-common/thp';
 import { type notificationsActions } from '@suite-common/toast-notifications';
@@ -56,7 +53,7 @@ import type { AppState } from 'src/reducers/store';
 import { type GlobalSendReceiveAction } from 'src/slices/wallet/globalSendReceiveFilters';
 import type { WalletAction } from 'src/types/wallet';
 
-import { type bluetoothSlice } from '../../actions/bluetooth/desktopBluetoothReducer';
+import { type desktopBluetoothActions } from '../../actions/bluetooth/desktopBluetoothReducer';
 
 // reexport
 export type {
@@ -98,26 +95,21 @@ type FirmwareAction = ReturnType<(typeof firmwareActions)[keyof typeof firmwareA
 type DeviceAction = ReturnType<(typeof deviceActions)[keyof typeof deviceActions]>;
 type DiscoveryAction = ReturnType<(typeof discoveryActions)[keyof typeof discoveryActions]>;
 type BluetoothAction = ReturnType<(typeof bluetoothActions)[keyof typeof bluetoothActions]>;
-type BluetoothActionDesktop = ReturnType<
-    (typeof bluetoothSlice.actions)[keyof typeof bluetoothSlice.actions]
+type DesktopBluetoothAction = ReturnType<
+    (typeof desktopBluetoothActions)[keyof typeof desktopBluetoothActions]
 >;
-type SuiteSyncAction = ReturnType<
-    (typeof suiteSyncSlice.actions)[keyof typeof suiteSyncSlice.actions]
+type FeatureFeedbackAction = ReturnType<
+    (typeof featureFeedbackActions)[keyof typeof featureFeedbackActions]
 >;
-type SuiteSyncActionCommon = ReturnType<
-    (typeof suiteSyncCommonSlice.actions)[keyof typeof suiteSyncCommonSlice.actions]
+type SuiteSyncAction = ReturnType<(typeof suiteSyncActions)[keyof typeof suiteSyncActions]>;
+type DesktopSuiteSyncAction = ReturnType<
+    (typeof desktopSuiteSyncActions)[keyof typeof desktopSuiteSyncActions]
 >;
 type SuiteSyncDataAction = ReturnType<
-    (typeof suiteSyncDataSlice.actions)[keyof typeof suiteSyncDataSlice.actions]
->;
-type SuiteSyncActionDesktop = ReturnType<
-    (typeof suiteSyncSlice.actions)[keyof typeof suiteSyncSlice.actions]
+    (typeof suiteSyncDataActions)[keyof typeof suiteSyncDataActions]
 >;
 type SuiteSyncQuotaManagerAction = ReturnType<
     (typeof suiteSyncQuotaManagerActions)[keyof typeof suiteSyncQuotaManagerActions]
->;
-type FeatureFeedbackAction = ReturnType<
-    (typeof featureFeedbackSlice.actions)[keyof typeof featureFeedbackSlice.actions]
 >;
 type DeviceActionDesktop = ReturnType<
     (typeof desktopDeviceActions)[keyof typeof desktopDeviceActions]
@@ -147,7 +139,7 @@ export type Action =
     | DiscreetModeAction
     | BioAuthAction
     | BluetoothAction
-    | BluetoothActionDesktop
+    | DesktopBluetoothAction
     | DesktopUpdateAction
     | DeviceAction
     | FeatureFeedbackAction
@@ -172,9 +164,8 @@ export type Action =
     | SuiteAction
     | SuiteSettingsAction
     | SuiteSyncAction
-    | SuiteSyncActionCommon
+    | DesktopSuiteSyncAction
     | SuiteSyncDataAction
-    | SuiteSyncActionDesktop
     | SuiteSyncQuotaManagerAction
     | ThpAction
     | TorAction

--- a/packages/suite/src/utils/suite/theme.ts
+++ b/packages/suite/src/utils/suite/theme.ts
@@ -1,7 +1,7 @@
 import type { SuiteSettingsState } from '@suite/settings';
-import { intermediaryTheme } from '@trezor/components/src/config/colors';
+import { type SuiteThemeColors, intermediaryTheme } from '@trezor/components/src/config/colors';
 
-export const getThemeColors = (theme: SuiteSettingsState['theme']) => {
+export const getThemeColors = (theme: SuiteSettingsState['theme']): SuiteThemeColors => {
     switch (theme?.variant) {
         case 'light':
             return intermediaryTheme.light;

--- a/packages/suite/src/utils/wallet/graph/utils.ts
+++ b/packages/suite/src/utils/wallet/graph/utils.ts
@@ -177,7 +177,7 @@ export const getMinMaxValueFromData = <TType extends TypeName, TValue extends Bi
     return [minValue as TValue, maxValue as TValue];
 };
 
-export const sumFiatValueMap = (valueMap: FiatValueMap, obj: FiatValueMap) => {
+export const sumFiatValueMap = (valueMap: FiatValueMap, obj: FiatValueMap): FiatValueMap => {
     const newMap = { ...valueMap };
     sumFiatValueMapInPlace(newMap, obj);
 

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/useTradingReceiveAddressValues.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/useTradingReceiveAddressValues.ts
@@ -1,4 +1,4 @@
-import { type ExchangeTrade } from 'invity-api';
+import { type BuyTrade, type CoinExtraField, type CryptoId, type ExchangeTrade } from 'invity-api';
 
 import {
     TRADING_EXCHANGE_FORM,
@@ -7,8 +7,18 @@ import {
 } from '@suite-common/trading';
 
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { type useTradingReceiveAddress } from 'src/hooks/wallet/trading/form/useTradingReceiveAddress';
 import { isTradingExchangeContext } from 'src/utils/wallet/trading/tradingTypingUtils';
-export const useTradingReceiveAddressValues = () => {
+
+type TradingReceiveAddressValues = {
+    cryptoId: CryptoId;
+    tradingReceiveAddress: ReturnType<typeof useTradingReceiveAddress>;
+    quote: BuyTrade | ExchangeTrade | undefined;
+    extraFieldDescription: CoinExtraField | undefined;
+    isLoading: boolean;
+};
+
+export const useTradingReceiveAddressValues = (): TradingReceiveAddressValues => {
     const context = useTradingFormContext<TradingTradeBuyExchangeType>();
     const {
         tradingReceiveAddress,

--- a/suite-common/feedback/src/feedbackSlice.ts
+++ b/suite-common/feedback/src/feedbackSlice.ts
@@ -1,4 +1,9 @@
-import { type ActionReducerMapBuilder, type PayloadAction, createSlice } from '@reduxjs/toolkit';
+import {
+    type ActionReducerMapBuilder,
+    type Draft,
+    type PayloadAction,
+    createSlice,
+} from '@reduxjs/toolkit';
 
 type UsageCount<T extends string> = Partial<Record<T, number>>;
 
@@ -27,7 +32,10 @@ export function createFeatureFeedbackSlice<FeatureName extends string>(options?:
         reducers: {
             /** Increments usage count and queues the feedback modal once the threshold is reached.
              * Counting stops at the threshold to avoid re-triggering the modal. */
-            featureUsed: (state, { payload }: PayloadAction<FeatureName>) => {
+            featureUsed: (
+                state: Draft<FeatureFeedbackState<FeatureName>>,
+                { payload }: PayloadAction<FeatureName>,
+            ) => {
                 const counts = state.usageCounts as UsageCount<FeatureName>;
                 const pending = state.pendingFeedbackFeatures as FeatureName[];
 
@@ -49,7 +57,7 @@ export function createFeatureFeedbackSlice<FeatureName extends string>(options?:
              * feedback on toggle-off: a single dispatch both resets the count and opens the
              * modal. */
             feedbackRequested: (
-                state,
+                state: Draft<FeatureFeedbackState<FeatureName>>,
                 {
                     payload,
                 }: PayloadAction<{ feature: FeatureName; isFeatureBeingDisabled?: boolean }>,
@@ -63,7 +71,10 @@ export function createFeatureFeedbackSlice<FeatureName extends string>(options?:
                     pending.push(payload.feature);
                 }
             },
-            feedbackDismissed: (state, { payload }: PayloadAction<FeatureName>) => {
+            feedbackDismissed: (
+                state: Draft<FeatureFeedbackState<FeatureName>>,
+                { payload }: PayloadAction<FeatureName>,
+            ) => {
                 const pending = state.pendingFeedbackFeatures as FeatureName[];
                 const index = pending.indexOf(payload);
                 if (index !== -1) {

--- a/suite-common/redux-utils/src/createReducerWithExtraDeps.ts
+++ b/suite-common/redux-utils/src/createReducerWithExtraDeps.ts
@@ -6,6 +6,10 @@ import { type ExtraDependenciesForReducer } from './extraDependenciesType';
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 type NotFunction<T> = T extends Function ? never : T;
 
+type EnhancedStoreState<TStore extends EnhancedStore<any, any>> = ReturnType<TStore['getState']>;
+type EnhancedStoreAction<TStore extends EnhancedStore<any, any>> =
+    TStore extends EnhancedStore<any, infer TAction> ? TAction : never;
+
 export const createReducerWithExtraDeps =
     <S extends NotFunction<any>>(
         initialState: S | (() => S),
@@ -23,15 +27,15 @@ export const createReducerWithExtraDeps =
             }),
         );
 
-// NOTE: adds the proper thunk dispatch type to the store
-export const castExtraStore = <E, S extends EnhancedStore<any, any>>(
-    store: S,
-    extra: E | null,
+// Adds the thunk dispatch type that configureStore cannot infer through the extra middleware factory.
+export const castExtraStore = <TExtra, TStore extends EnhancedStore<any, any>>(
+    store: TStore,
+    extra: TExtra | null,
 ): {
-    store: S & {
-        dispatch: ThunkDispatch<S, E, any>;
+    store: TStore & {
+        dispatch: ThunkDispatch<EnhancedStoreState<TStore>, TExtra, EnhancedStoreAction<TStore>>;
     };
-    extra: NonNullable<E>;
+    extra: NonNullable<TExtra>;
 } => {
     if (!extra) {
         throw new Error('castExtraStore: Extra dependencies not initialized');

--- a/suite-common/suite-sync/src/data/suiteSyncDataReducer.ts
+++ b/suite-common/suite-sync/src/data/suiteSyncDataReducer.ts
@@ -42,11 +42,14 @@ const ensureWallet = (
     return state.wallets[walletDescriptor];
 };
 
-export const suiteSyncDataSlice = createSlice({
+const suiteSyncDataSlice = createSlice({
     name: 'suiteSyncData',
     initialState: initialSuiteSyncDataState,
     reducers: {
-        upsertManyWallets: (state, action: PayloadAction<SuiteSyncWallet[]>) => {
+        upsertManyWallets: (
+            state: SuiteSyncDataState,
+            action: PayloadAction<SuiteSyncWallet[]>,
+        ) => {
             action.payload.forEach(wallet => {
                 const existing = state.wallets[wallet.walletDescriptor];
 
@@ -60,7 +63,7 @@ export const suiteSyncDataSlice = createSlice({
         },
 
         upsertManyAccounts: (
-            state,
+            state: SuiteSyncDataState,
             action: PayloadAction<{
                 walletDescriptor: WalletDescriptor;
                 accounts: SuiteSyncAccount[];
@@ -74,7 +77,7 @@ export const suiteSyncDataSlice = createSlice({
         },
 
         upsertManyAddresses: (
-            state,
+            state: SuiteSyncDataState,
             action: PayloadAction<{
                 walletDescriptor: WalletDescriptor;
                 addresses: SuiteSyncAddress[];
@@ -88,7 +91,7 @@ export const suiteSyncDataSlice = createSlice({
         },
 
         upsertManyOutputs: (
-            state,
+            state: SuiteSyncDataState,
             action: PayloadAction<{
                 walletDescriptor: WalletDescriptor;
                 outputs: SuiteSyncOutput[];
@@ -101,7 +104,10 @@ export const suiteSyncDataSlice = createSlice({
             });
         },
 
-        clearDataForWallet: (state, action: PayloadAction<WalletDescriptor>) => {
+        clearDataForWallet: (
+            state: SuiteSyncDataState,
+            action: PayloadAction<WalletDescriptor>,
+        ) => {
             delete state.wallets[action.payload];
         },
 
@@ -109,6 +115,7 @@ export const suiteSyncDataSlice = createSlice({
     },
 });
 
+export const suiteSyncDataActions = suiteSyncDataSlice.actions;
 export const {
     upsertManyWallets,
     upsertManyAccounts,
@@ -116,7 +123,7 @@ export const {
     upsertManyOutputs,
     clearDataForWallet,
     clearAll,
-} = suiteSyncDataSlice.actions;
+} = suiteSyncDataActions;
 
 export const suiteSyncDataReducer = suiteSyncDataSlice.reducer;
 

--- a/suite-common/suite-sync/src/index.ts
+++ b/suite-common/suite-sync/src/index.ts
@@ -24,8 +24,8 @@ export type { SuiteSyncInteraction } from './suiteSyncTypes';
 export { createSuiteSyncCompositionRoot } from './createSuiteSyncCompositionRoot';
 export type { SuiteSyncAnalytics, SuiteSyncAnalyticsDep } from './createSuiteSyncCompositionRoot';
 export {
-    suiteSyncSlice,
     suiteSyncReducer,
+    suiteSyncActions,
     initialSuiteSyncState,
     updateSuiteSyncDebugEnabled,
     updateSuiteSyncEnabled,
@@ -57,8 +57,8 @@ export {
 export { prepareSuiteSyncMiddleware } from './suiteSyncMiddleware';
 export {
     suiteSyncDataReducer,
+    suiteSyncDataActions,
     initialSuiteSyncDataState,
-    suiteSyncDataSlice,
     clearAll,
     type SuiteSyncDataRootState,
     type SuiteSyncDataState,

--- a/suite-common/suite-sync/src/suiteSyncSlice.ts
+++ b/suite-common/suite-sync/src/suiteSyncSlice.ts
@@ -87,11 +87,14 @@ type SetSuiteSyncOwnerAction = PayloadAction<{
 
 type SetSuiteSyncRelayConnectionAction = PayloadAction<SuiteSyncRelayConnectionLogEntry>;
 
-export const suiteSyncSlice = createSlice({
+const suiteSyncSlice = createSlice({
     name: 'suiteSync',
     initialState: initialSuiteSyncState,
     reducers: {
-        updateSuiteSyncEnabled: (state, { payload }: PayloadAction<{ isEnabled: boolean }>) => {
+        updateSuiteSyncEnabled: (
+            state: SuiteSyncState,
+            { payload }: PayloadAction<{ isEnabled: boolean }>,
+        ) => {
             state.settings.isSuiteSyncEnabled = payload.isEnabled;
 
             if (!payload.isEnabled) {
@@ -100,15 +103,21 @@ export const suiteSyncSlice = createSlice({
             }
         },
         updateSuiteSyncDebugEnabled: (
-            state,
+            state: SuiteSyncState,
             { payload }: PayloadAction<{ isEnabled: boolean }>,
         ) => {
             state.settings.isSuiteSyncDebugEnabled = payload.isEnabled;
         },
-        setSuiteSyncRelayUrl: (state, { payload }: PayloadAction<{ url: string | null }>) => {
+        setSuiteSyncRelayUrl: (
+            state: SuiteSyncState,
+            { payload }: PayloadAction<{ url: string | null }>,
+        ) => {
             state.settings.suiteSyncRelayUrl = payload.url;
         },
-        setSuiteSyncRelayConnection: (state, { payload }: SetSuiteSyncRelayConnectionAction) => {
+        setSuiteSyncRelayConnection: (
+            state: SuiteSyncState,
+            { payload }: SetSuiteSyncRelayConnectionAction,
+        ) => {
             const relayConnectionState =
                 payload.state === 'connected' ? 'connected' : 'disconnected';
 
@@ -134,7 +143,10 @@ export const suiteSyncSlice = createSlice({
                 });
             }
         },
-        addSuiteSyncRelayConnection: (state, { payload }: PayloadAction<{ url: string }>) => {
+        addSuiteSyncRelayConnection: (
+            state: SuiteSyncState,
+            { payload }: PayloadAction<{ url: string }>,
+        ) => {
             const existingConnection = state.relayConnectionStatuses.find(
                 connection => connection.url === payload.url,
             );
@@ -148,18 +160,21 @@ export const suiteSyncSlice = createSlice({
                 });
             }
         },
-        removeSuiteSyncRelayConnection: (state, { payload }: PayloadAction<{ url: string }>) => {
+        removeSuiteSyncRelayConnection: (
+            state: SuiteSyncState,
+            { payload }: PayloadAction<{ url: string }>,
+        ) => {
             state.relayConnectionStatuses = state.relayConnectionStatuses.filter(
                 connection => connection.url !== payload.url,
             );
         },
-        setSuiteSyncError: (state, { payload }: SetSuiteSyncErrorAction) => {
+        setSuiteSyncError: (state: SuiteSyncState, { payload }: SetSuiteSyncErrorAction) => {
             state.suiteSyncErrors[payload.deviceStaticSessionId] = payload.error;
         },
-        resetSuiteSyncError: (state, { payload }: ResetSuiteSyncErrorAction) => {
+        resetSuiteSyncError: (state: SuiteSyncState, { payload }: ResetSuiteSyncErrorAction) => {
             delete state.suiteSyncErrors[payload.deviceStaticSessionId];
         },
-        setSuiteSyncOwner: (state, { payload }: SetSuiteSyncOwnerAction) => {
+        setSuiteSyncOwner: (state: SuiteSyncState, { payload }: SetSuiteSyncOwnerAction) => {
             if (payload.owner === null) {
                 delete state.suiteSyncOwners[payload.deviceStaticId];
             } else {
@@ -179,6 +194,7 @@ export const suiteSyncSlice = createSlice({
     },
 });
 
+export const suiteSyncActions = suiteSyncSlice.actions;
 export const {
     updateSuiteSyncEnabled,
     updateSuiteSyncDebugEnabled,
@@ -189,6 +205,6 @@ export const {
     setSuiteSyncError,
     resetSuiteSyncError,
     setSuiteSyncOwner,
-} = suiteSyncSlice.actions;
+} = suiteSyncActions;
 
 export const suiteSyncReducer = suiteSyncSlice.reducer;

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -54,6 +54,7 @@ export type CreateAccountActionProps = Pick<
     AccountFailureSpecific;
 
 type CoinjoinAccount = Extract<Account, { backendType: 'coinjoin' }>;
+type CoinjoinAccountStatus = CoinjoinAccount['status'];
 
 const createAccount = createAction(
     `${ACCOUNTS_MODULE_PREFIX}/createAccount`,
@@ -182,7 +183,7 @@ const startCoinjoinAccountSync = createAction(
 
 const endCoinjoinAccountSync = createAction(
     `${ACCOUNTS_MODULE_PREFIX}/endCoinjoinAccountSync`,
-    (account: CoinjoinAccount, status: CoinjoinAccount['status']) => ({
+    (account: CoinjoinAccount, status: CoinjoinAccountStatus) => ({
         payload: {
             accountKey: account.key,
             status,

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -53,6 +53,8 @@ export type CreateAccountActionProps = Pick<
 } & AccountBackendSpecific &
     AccountFailureSpecific;
 
+type CoinjoinAccount = Extract<Account, { backendType: 'coinjoin' }>;
+
 const createAccount = createAction(
     `${ACCOUNTS_MODULE_PREFIX}/createAccount`,
     ({ accountInfo, ...account }: CreateAccountActionProps): { payload: Account } => {
@@ -171,7 +173,7 @@ const renameAccount = createAction(
 
 const startCoinjoinAccountSync = createAction(
     `${ACCOUNTS_MODULE_PREFIX}/startCoinjoinAccountSync`,
-    (account: Extract<Account, { backendType: 'coinjoin' }>) => ({
+    (account: CoinjoinAccount) => ({
         payload: {
             accountKey: account.key,
         },
@@ -180,10 +182,7 @@ const startCoinjoinAccountSync = createAction(
 
 const endCoinjoinAccountSync = createAction(
     `${ACCOUNTS_MODULE_PREFIX}/endCoinjoinAccountSync`,
-    (
-        account: Extract<Account, { backendType: 'coinjoin' }>,
-        status: Extract<Account, { backendType: 'coinjoin' }>['status'],
-    ) => ({
+    (account: CoinjoinAccount, status: CoinjoinAccount['status']) => ({
         payload: {
             accountKey: account.key,
             status,

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -6,7 +6,11 @@ import {
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { type NetworkSymbol, networks, networksCollection } from '@suite-common/wallet-config';
-import { type Account, type ReviewOutput } from '@suite-common/wallet-types';
+import {
+    type Account,
+    type ReviewOutput,
+    type SuccessfulAccount,
+} from '@suite-common/wallet-types';
 import {
     findAccountsByAddress,
     isAccountDiscoverable,
@@ -73,7 +77,7 @@ export const selectAllAccountsToList = createMemoizedSelector(
 
 export const selectAllSuccessfulAccountsToList = createMemoizedSelector(
     [selectAllAccountsToList],
-    accounts => {
+    (accounts): SuccessfulAccount[] => {
         const filteredAccounts = accounts.filter(account => !account.failed);
 
         return returnStableArrayIfEmpty(filteredAccounts);

--- a/suite-common/wallet-core/src/send/sendFormReducer.ts
+++ b/suite-common/wallet-core/src/send/sendFormReducer.ts
@@ -13,11 +13,13 @@ import { sendFormActions } from './sendFormActions';
 import { type SerializedTx } from './sendFormTypes';
 import { accountsActions } from '../accounts/accountsActions';
 
+export type SendFormDrafts = {
+    // Note: suite-native store drafts per tokens, desktop and web store drafts per accountKey only
+    [key: SendFormDraftKey]: FormState;
+};
+
 export type SendState = {
-    drafts: {
-        // Note: suite-native store drafts per tokens, desktop and web store drafts per accountKey only
-        [key: SendFormDraftKey]: FormState;
-    };
+    drafts: SendFormDrafts;
     sendRaw?: boolean;
     precomposedTx?: GeneralPrecomposedTransactionFinal;
     precomposedForm?: FormState; // Used to pass the form state to the review modal. Holds similar data as drafts, but drafts are not used in RBF form.

--- a/suite-common/wallet-core/src/send/sendFormSelectors.ts
+++ b/suite-common/wallet-core/src/send/sendFormSelectors.ts
@@ -12,14 +12,15 @@ import {
 import { getSendFormDraftKey } from '@suite-common/wallet-utils';
 
 import { PAYMENT_REQUEST_BUTTON_NAMES } from './sendFormConstants';
-import { type SendRootState } from './sendFormReducer';
+import { type SendFormDrafts, type SendRootState } from './sendFormReducer';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<DeviceRootState>();
 
 export const selectSendPrecomposedTx = (state: SendRootState) => state.wallet.send.precomposedTx;
 export const selectSendSerializedTx = (state: SendRootState) => state.wallet.send.serializedTx;
 export const selectSendSignedTx = (state: SendRootState) => state.wallet.send.signedTx;
-export const selectSendFormDrafts = (state: SendRootState) => state.wallet.send.drafts;
+export const selectSendFormDrafts = (state: SendRootState): SendFormDrafts =>
+    state.wallet.send.drafts;
 export const selectSendFormAccountKey = (state: SendRootState) => state.wallet.send.accountKey;
 export const selectSendRaw = (state: SendRootState) => state.wallet.send.sendRaw;
 export const selectPrecomposedSendForm = (state: SendRootState) =>

--- a/suite-common/wallet-core/src/stake/__tests__/stakeSelectors.test.ts
+++ b/suite-common/wallet-core/src/stake/__tests__/stakeSelectors.test.ts
@@ -1,10 +1,7 @@
-import { stakeDataSlice } from '../stakeDataSlice';
-import type { StakeDataState } from '../stakeDataSlice';
+import { type StakeDataState, stakeDataInitialState } from '../stakeDataSlice';
 import { stakeInitialState } from '../stakeReducer';
 import type { StakeRootState } from '../stakeReducerTypes';
 import { selectCardanoPoolsInfo, selectEthNextRewardPayout } from '../stakeSelectors';
-
-const stakeDataInitialState = stakeDataSlice.getInitialState();
 
 const buildStakeState = (data: Partial<StakeDataState['data']>): StakeRootState => ({
     wallet: {

--- a/suite-common/wallet-core/src/stake/stakeDataSlice.ts
+++ b/suite-common/wallet-core/src/stake/stakeDataSlice.ts
@@ -14,7 +14,7 @@ export type StakeDataState = {
     };
 };
 
-const initialState: StakeDataState = {
+export const stakeDataInitialState: StakeDataState = {
     error: null,
     isLoading: false,
     lastSuccessAt: null,
@@ -25,9 +25,9 @@ const initialState: StakeDataState = {
     },
 } as const satisfies StakeDataState;
 
-export const stakeDataSlice = createSlice({
+const stakeDataSlice = createSlice({
     name: 'stakeData',
-    initialState,
+    initialState: stakeDataInitialState,
     reducers: {
         fetchStakeDataRequest: state => {
             state.error = null;
@@ -60,9 +60,10 @@ export const stakeDataSlice = createSlice({
             state.error = null;
             state.isLoading = false;
             state.lastSuccessAt = null;
-            state.data = initialState.data;
+            state.data = stakeDataInitialState.data;
         },
     },
 });
 
 export const stakeDataActions = stakeDataSlice.actions;
+export const stakeDataReducer = stakeDataSlice.reducer;

--- a/suite-common/wallet-core/src/stake/stakeReducer.ts
+++ b/suite-common/wallet-core/src/stake/stakeReducer.ts
@@ -2,14 +2,14 @@ import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { cloneObject } from '@trezor/utils';
 
 import { stakeActions } from './stakeActions';
-import { stakeDataSlice } from './stakeDataSlice';
+import { stakeDataInitialState, stakeDataReducer } from './stakeDataSlice';
 import type { StakeState } from './stakeReducerTypes';
 
 export const stakeInitialState: StakeState = {
     precomposedTx: undefined,
     serializedTx: undefined,
     votingDelegation: { type: 'everstake' },
-    data: stakeDataSlice.getInitialState(),
+    data: stakeDataInitialState,
 };
 
 export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState, builder => {
@@ -53,6 +53,6 @@ export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState,
             delete state.resolvedEthereumNonce;
         })
         .addDefaultCase((state, action) => {
-            state.data = stakeDataSlice.reducer(state.data, action);
+            state.data = stakeDataReducer(state.data, action);
         });
 });

--- a/suite-common/wallet-core/src/transactions/transactionsReducerTypes.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsReducerTypes.ts
@@ -16,8 +16,12 @@ export type AccountTransactionsFetchAllStatus = {
     areAllTransactionsLoaded: boolean;
 };
 
+export type TransactionsByAccount = {
+    [key: AccountKey]: WalletAccountTransaction[];
+};
+
 export interface TransactionsState {
-    transactions: { [key: AccountKey]: WalletAccountTransaction[] };
+    transactions: TransactionsByAccount;
     phishing: { [key: AccountKey]: string[] };
     fetchStatusDetail: {
         [key: AccountKey]: AccountTransactionsFetchStatusDetail &

--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
@@ -31,7 +31,7 @@ import {
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { isNotNullOrUndefined, typedObjectKeys } from '@trezor/utils';
 
-import type { TransactionsRootState } from './transactionsReducerTypes';
+import type { TransactionsByAccount, TransactionsRootState } from './transactionsReducerTypes';
 import type { AccountsRootState } from '../accounts/accountsReducer';
 import { selectAccountByKey } from '../accounts/accountsSelectors';
 import {
@@ -59,7 +59,7 @@ export const selectIsLoadingAccountTransactions = (
     accountKey !== null &&
     state.wallet.transactions.fetchStatusDetail?.[accountKey]?.status === 'loading';
 
-export const selectTransactions = (state: TransactionsRootState) =>
+export const selectTransactions = (state: TransactionsRootState): TransactionsByAccount =>
     state.wallet.transactions.transactions;
 
 export const selectAreAllTransactionsLoaded = (
@@ -106,7 +106,7 @@ export const selectPendingAccountAddresses = createMemoizedSelector(
 
 export const selectAllPendingTransactions = createMemoizedSelector(
     [selectTransactions],
-    transactions =>
+    (transactions): TransactionsByAccount =>
         typedObjectKeys(transactions).reduce(
             (response, accountKey) => {
                 response[accountKey] = (transactions[accountKey] ?? []).filter(isPending);

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -17,6 +17,7 @@ import {
     type Account,
     type AccountDescriptor,
     type AccountKey,
+    type AccountWithNetworkType,
     type BaseCurrencyAmount,
     type FailedAccount,
     type GeneralPrecomposedTransactionFinal,
@@ -51,7 +52,9 @@ import { getAccountTotalStakingBalance } from './stakingUtils';
 import { shouldUppercaseTokenSymbol } from './tokenUtils';
 import { isRbfBumpFeeTransaction } from './transactionUtils';
 
-export const isUtxoBased = (account: Account) =>
+export const isUtxoBased = (
+    account: Account,
+): account is AccountWithNetworkType<'bitcoin' | 'cardano'> =>
     account.networkType === 'bitcoin' || account.networkType === 'cardano';
 
 export const isAccountSuccessful = (account: Account): account is SuccessfulAccount =>
@@ -980,7 +983,7 @@ export const getPendingAccount = ({
     receivingAccount?: boolean;
     tx: GeneralPrecomposedTransactionFinal;
     txid: string;
-}) => {
+}): Account => {
     // calculate availableBalance
     let availableBalanceBig = new BigNumber(account.availableBalance);
 

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -487,7 +487,7 @@ export const restoreOrigOutputsOrder = (
     outputs: PROTO.TxOutputType[],
     origOutputs: RbfTransactionParams['outputs'],
     origTxid: string,
-) => {
+): PROTO.TxOutputType[] => {
     const usedIndex: number[] = []; // collect used indexes to avoid duplicates
 
     return outputs

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -547,10 +547,15 @@ export const sumTransactionsFiat = (
 export const findTransaction = (txid: string, transactions: WalletAccountTransaction[]) =>
     transactions.find(t => t?.txid === txid);
 
+type FoundTransaction = {
+    key: AccountKey;
+    tx: WalletAccountTransaction;
+};
+
 export const findTransactions = (
     txid: string,
     transactions: { [key: AccountKey]: WalletAccountTransaction[] },
-) =>
+): FoundTransaction[] =>
     typedObjectKeys(transactions).flatMap(key => {
         // @ts-expect-error: indexing with noUncheckedIndexedAccess
         const txList: WalletAccountTransaction[] = transactions[key];

--- a/suite-native/app/src/navigation/enhanceTabOption.ts
+++ b/suite-native/app/src/navigation/enhanceTabOption.ts
@@ -5,9 +5,13 @@ type TabOption<ParamList extends AppTabsParamList, RouteName extends keyof Param
     routeName: RouteName;
     iconName: IconName;
     focusedIconName: IconName;
-    label: string;
     params?: ParamList[RouteName];
 };
+
+type EnhancedTabOption<
+    ParamList extends AppTabsParamList,
+    RouteName extends keyof ParamList,
+> = Record<string, TabOption<ParamList, RouteName>>;
 
 export const enhanceTabOption = <
     ParamList extends AppTabsParamList,
@@ -17,7 +21,7 @@ export const enhanceTabOption = <
     iconName,
     focusedIconName,
     params,
-}: Omit<TabOption<ParamList, RouteName>, 'label'>) => ({
+}: TabOption<ParamList, RouteName>): EnhancedTabOption<ParamList, RouteName> => ({
     [routeName]: {
         routeName,
         iconName,

--- a/suite-native/atoms/src/Button/utils.ts
+++ b/suite-native/atoms/src/Button/utils.ts
@@ -12,6 +12,12 @@ import type {
 
 type FilledButtonIntent = Exclude<ButtonIntent, 'neutral'>;
 
+type ButtonColors = {
+    backgroundColor: Color;
+    onPressColor: Color;
+    contentColor: Color;
+};
+
 const colorMapDisabled = {
     normal: 'contentDisabled',
     inverse: 'contentOnDarkDisabled',
@@ -309,7 +315,7 @@ export const getButtonColors = ({
     priority = 'primary',
     isDisabled,
     isInverse = false,
-}: ButtonColorProps & { isDisabled: boolean }) => {
+}: ButtonColorProps & { isDisabled: boolean }): ButtonColors => {
     const resolvedProps = { intent, priority, isInverse, isDisabled };
 
     return {

--- a/suite-native/bluetooth/src/bluetoothSlice.ts
+++ b/suite-native/bluetooth/src/bluetoothSlice.ts
@@ -24,7 +24,7 @@ export const bluetoothInitialState: NativeBluetoothState = {
     permissionStatus: 'unavailable',
 };
 
-export const bluetoothSlice = createSliceWithExtraDeps({
+const bluetoothSlice = createSliceWithExtraDeps({
     name: 'bluetooth',
     initialState: bluetoothInitialState,
     reducers: {
@@ -53,3 +53,4 @@ export const bluetoothSlice = createSliceWithExtraDeps({
 });
 
 export const { updatePermissionStatus } = bluetoothSlice.actions;
+export const prepareBluetoothReducer = bluetoothSlice.prepareReducer;

--- a/suite-native/device/src/__tests__/deviceConnectionFixtures.ts
+++ b/suite-native/device/src/__tests__/deviceConnectionFixtures.ts
@@ -16,7 +16,7 @@ import {
     RootStackRoutes,
 } from '@suite-native/navigation';
 import type { RootStackParamList } from '@suite-native/navigation';
-import { appSettingsSlice } from '@suite-native/settings';
+import { type AppSettingsState, appSettingsReducer } from '@suite-native/settings';
 import { FirmwareType, UI_REQUEST } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
@@ -32,7 +32,7 @@ type InitialStateConfig = {
     device?: Partial<ReturnType<typeof deviceReducer>>;
     deviceOnboarding?: Partial<typeof deviceOnboardingSlice.reducer>;
     walletSettings?: Partial<ReturnType<typeof walletSettingsReducer>>;
-    appSettings?: Partial<typeof appSettingsSlice.reducer>;
+    appSettings?: Partial<AppSettingsState>;
     featureFlags?: Partial<typeof featureFlagsSlice.reducer>;
     thp?: Partial<ReturnType<typeof thpReducer>>;
 };
@@ -45,7 +45,7 @@ type RootState = {
         settings: ReturnType<typeof walletSettingsReducer>;
     };
     messageSystem: ReturnType<typeof messageSystemReducer>;
-    appSettings: ReturnType<typeof appSettingsSlice.reducer>;
+    appSettings: AppSettingsState;
     featureFlags: ReturnType<typeof featureFlagsSlice.reducer>;
     thp: ReturnType<typeof thpReducer>;
 };
@@ -124,7 +124,7 @@ const buildInitialState = ({
         },
     },
     appSettings: {
-        ...appSettingsSlice.reducer(undefined, INIT_ACTION),
+        ...appSettingsReducer(undefined, INIT_ACTION),
         ...appSettings,
     },
     messageSystem: { ...messageSystemReducer(undefined, INIT_ACTION) },

--- a/suite-native/feature-feedback/src/featureFeedbackSlice.ts
+++ b/suite-native/feature-feedback/src/featureFeedbackSlice.ts
@@ -1,7 +1,7 @@
 import { createFeatureFeedbackSlice } from '@suite-common/feedback';
 import type { ExperimentalFeature } from '@suite-native/settings';
 
-export const featureFeedbackSlice = createFeatureFeedbackSlice<ExperimentalFeature>();
+const featureFeedbackSlice = createFeatureFeedbackSlice<ExperimentalFeature>();
 
 export const { featureUsed, feedbackRequested, feedbackDismissed } = featureFeedbackSlice.actions;
 export const featureFeedbackReducer = featureFeedbackSlice.reducer;

--- a/suite-native/feature-feedback/src/index.ts
+++ b/suite-native/feature-feedback/src/index.ts
@@ -2,7 +2,6 @@ export { FeatureRatingForm } from './FeatureRatingForm';
 export { FeatureFeedbackAlert } from './FeatureFeedbackAlert';
 export {
     featureFeedbackInitialState,
-    featureFeedbackSlice,
     featureFeedbackReducer,
     featureUsed,
     feedbackRequested,

--- a/suite-native/settings/src/settingsSlice.ts
+++ b/suite-native/settings/src/settingsSlice.ts
@@ -47,7 +47,7 @@ export const appSettingsPersistWhitelist: Array<keyof AppSettingsState> = [
     'earnYieldWorkerBaseUrl',
 ];
 
-export const appSettingsSlice = createSlice({
+const appSettingsSlice = createSlice({
     name: 'appSettings',
     initialState: appSettingsInitialState,
     reducers: {

--- a/suite-native/state/src/__tests__/store.type-test.ts
+++ b/suite-native/state/src/__tests__/store.type-test.ts
@@ -1,0 +1,31 @@
+import { type ThunkAction, type UnknownAction } from '@reduxjs/toolkit';
+
+import { type FullPersistedAppState, type Store, type StoreWithExtra } from '../store';
+
+const verifyStoreType = (store: Store) => {
+    const state: FullPersistedAppState = store.getState();
+    const { payload }: { payload: number } = store.dispatch({ type: 'test', payload: 1 });
+
+    const thunk: ThunkAction<
+        string,
+        FullPersistedAppState,
+        StoreWithExtra['extra'],
+        UnknownAction
+    > = (_dispatch, _getState, { services }) => {
+        const typedServices: StoreWithExtra['services'] = services;
+
+        void typedServices;
+
+        return 'result';
+    };
+    const thunkResult: string = store.dispatch(thunk);
+
+    // @ts-expect-error Dispatch only accepts Redux actions or compatible thunks.
+    store.dispatch('not an action');
+
+    void state;
+    void payload;
+    void thunkResult;
+};
+
+void verifyStoreType;

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -38,7 +38,7 @@ import {
 import { prepareWalletConnectReducer } from '@suite-common/walletconnect/src/walletConnectReducer';
 import { bannerFlagsPersistWhitelist, bannerFlagsReducer } from '@suite-native/banner-flags';
 import { biometricsPersistWhitelist, biometricsSlice } from '@suite-native/biometrics';
-import { bluetoothSlice } from '@suite-native/bluetooth';
+import { prepareBluetoothReducer } from '@suite-native/bluetooth';
 import { deviceAuthorizationReducer } from '@suite-native/device-authorization';
 import { deviceOnboardingReducer } from '@suite-native/device-onboarding';
 import { pendingCoinVisibilitySlice } from '@suite-native/discovery';
@@ -97,7 +97,7 @@ const firmwareReducer = prepareFirmwareReducer(extraDependencies);
 const connectPopupReducer = prepareConnectPopupReducer(extraDependencies);
 const walletConnectReducer = prepareWalletConnectReducer(extraDependencies);
 const walletSettingsReducer = prepareWalletSettingsReducer(extraDependencies);
-const bluetoothReducer = bluetoothSlice.prepareReducer(extraDependencies);
+const bluetoothReducer = prepareBluetoothReducer(extraDependencies);
 const thpReducer = prepareThpReducer(extraDependencies);
 
 type PrepareRootReducersDeps = MMKVStorageDep;

--- a/suite-native/state/src/store.ts
+++ b/suite-native/state/src/store.ts
@@ -1,14 +1,17 @@
 import {
+    type EnhancedStore,
     type Middleware,
     type MiddlewareAPI,
     type StoreEnhancer,
+    type UnknownAction,
     configureStore,
 } from '@reduxjs/toolkit';
-import { persistStore } from 'redux-persist';
+import { type Persistor, persistStore } from 'redux-persist';
 
 import { logsMiddleware } from '@suite-common/logger';
 import {
     type ExtraDependencies,
+    type ExtraDependenciesStatic,
     type ReducerState,
     castExtraStore,
     createStoreWithExtraStoreMiddleware,
@@ -23,6 +26,7 @@ import { deviceConnectionMiddleware, prepareDeviceMiddleware } from '@suite-nati
 import { prepareDiscoveryMiddleware } from '@suite-native/discovery';
 import { messageSystemMiddleware } from '@suite-native/message-system';
 import { sendFormMiddleware } from '@suite-native/send';
+import { type NativeServices } from '@suite-native/services';
 import { createEnsureEncryptionKey, createMMKVStorage } from '@suite-native/storage';
 import {
     prepareTradingLastErrorSentryMiddleware,
@@ -57,6 +61,15 @@ export type FullAppState = ExcludeChildPersists<
 
 export type PreloadedState = DeepPartial<FullPersistedAppState> | undefined;
 
+type NativeExtra = ExtraDependenciesStatic & { services: NativeServices };
+
+export type StoreWithExtra = ReturnType<
+    typeof castExtraStore<NativeExtra, EnhancedStore<FullPersistedAppState, UnknownAction>>
+> & {
+    persistor: Persistor;
+    services: NativeServices;
+};
+
 const ENABLE_REDUX_LOGGER = false;
 const enhancers: Array<StoreEnhancer<any, any>> = [];
 
@@ -89,7 +102,7 @@ const getMiddlewares = (getExtra: () => ExtraDependencies | null) => {
     return middlewares;
 };
 
-export const initStore = (preloadedState?: PreloadedState) => {
+export const initStore = (preloadedState?: PreloadedState): StoreWithExtra => {
     let extra: ReturnType<typeof extraFactory> | null = null as ReturnType<
         typeof extraFactory
     > | null;
@@ -137,5 +150,4 @@ export const initStore = (preloadedState?: PreloadedState) => {
     };
 };
 
-export type StoreWithExtra = Awaited<ReturnType<typeof initStore>>;
 export type Store = StoreWithExtra['store'];

--- a/suite-native/test-utils-store/src/renderWithStore.tsx
+++ b/suite-native/test-utils-store/src/renderWithStore.tsx
@@ -2,7 +2,9 @@ import { type ReactElement } from 'react';
 
 import {
     type RenderHookOptions,
+    type RenderHookResult,
     type RenderOptions,
+    type RenderResult,
     render,
     renderHook,
 } from '@testing-library/react-native';
@@ -24,7 +26,7 @@ export type RenderHookOptionsExtended<Props> = RenderHookOptions<Props> & {
 export const renderWithStoreProvider = (
     element: ReactElement,
     { preloadedState, services, wrapper: Wrapper, store, ...options }: RenderOptionsExtended = {},
-) =>
+): RenderResult =>
     render(element, {
         wrapper: ({ children }) => (
             <StoreProviderForTests
@@ -47,7 +49,7 @@ export const renderHookWithStoreProvider = <Result = unknown, Props = unknown>(
         store,
         ...options
     }: RenderHookOptionsExtended<Props> = {},
-) =>
+): RenderHookResult<Result, Props> =>
     renderHook(callback, {
         wrapper: ({ children }) => (
             <StoreProviderForTests

--- a/suite-native/test-utils/src/renderBasic.tsx
+++ b/suite-native/test-utils/src/renderBasic.tsx
@@ -2,7 +2,9 @@ import { type ReactElement } from 'react';
 
 import {
     type RenderHookOptions,
+    type RenderHookResult,
     type RenderOptions,
+    type RenderResult,
     render,
     renderHook,
 } from '@testing-library/react-native';
@@ -22,7 +24,7 @@ export const renderWithBasicProvider = <Props,>(
         formattersConfig?: FormatterProviderConfig;
         services?: Record<string, unknown>;
     } = {},
-) =>
+): RenderResult =>
     render(element, {
         wrapper: ({ children }) => (
             <BasicProviderForTests formattersConfig={formattersConfig} services={services}>
@@ -43,7 +45,7 @@ export const renderHookWithBasicProvider = <Result, Props>(
         formattersConfig?: FormatterProviderConfig;
         services?: Record<string, unknown>;
     } = {},
-) =>
+): RenderHookResult<Result, Props> =>
     renderHook(callback, {
         wrapper: ({ children }) => (
             <BasicProviderForTests formattersConfig={formattersConfig} services={services}>

--- a/suite/feature-feedback/src/featureFeedbackSlice.ts
+++ b/suite/feature-feedback/src/featureFeedbackSlice.ts
@@ -3,7 +3,7 @@ import { type AnyAction } from '@reduxjs/toolkit';
 import type { FeedbackFeatureName } from '@suite/experimental';
 import { createFeatureFeedbackSlice } from '@suite-common/feedback';
 
-export const featureFeedbackSlice = createFeatureFeedbackSlice<FeedbackFeatureName>({
+const featureFeedbackSlice = createFeatureFeedbackSlice<FeedbackFeatureName>({
     extraReducers: builder =>
         builder.addMatcher(
             (action): action is AnyAction => action.type === '@storage/load',
@@ -11,6 +11,7 @@ export const featureFeedbackSlice = createFeatureFeedbackSlice<FeedbackFeatureNa
         ),
 });
 
-export const { featureUsed, feedbackRequested, feedbackDismissed } = featureFeedbackSlice.actions;
+export const featureFeedbackActions = featureFeedbackSlice.actions;
+export const { featureUsed, feedbackRequested, feedbackDismissed } = featureFeedbackActions;
 export const featureFeedbackReducer = featureFeedbackSlice.reducer;
 export const initialState = featureFeedbackSlice.getInitialState();

--- a/suite/feature-feedback/src/index.ts
+++ b/suite/feature-feedback/src/index.ts
@@ -1,9 +1,9 @@
 export {
-    featureFeedbackSlice,
     featureFeedbackReducer,
     featureUsed,
     feedbackRequested,
     feedbackDismissed,
+    featureFeedbackActions,
 } from './featureFeedbackSlice';
 
 export {

--- a/suite/router/src/router.ts
+++ b/suite/router/src/router.ts
@@ -80,7 +80,7 @@ export const isEqualLocation = (loc1: RouterPathOptional, loc2: RouterPathOption
     (loc1.search ?? '') === (loc2.search ?? '') &&
     (loc1.hash ?? '') === (loc2.hash ?? '');
 
-export const findRoute = (pathname: PathString) => {
+export const findRoute = (pathname: PathString): Route | undefined => {
     const clean = pathname.length > 1 ? pathname.replace(/\/$/, '') : pathname;
 
     return suiteRoutes.find(r => r.pattern === clean);
@@ -225,7 +225,8 @@ export const resolveEffectiveBackgroundRouteName = (
 
 export type WalletParams = CommonWalletParams;
 
-export const getRoute = (name: Route['name']) => suiteRoutes.find(r => r.name === name);
+export const getRoute = (name: Route['name']): Route | undefined =>
+    suiteRoutes.find(r => r.name === name);
 
 export const getRouteHash = (route?: Route, params?: RouteParams) =>
     ensureHashString(

--- a/suite/router/src/routerReducer.ts
+++ b/suite/router/src/routerReducer.ts
@@ -1,4 +1,4 @@
-import { type PayloadAction, createAction, createSlice } from '@reduxjs/toolkit';
+import { type PayloadAction, type Reducer, createAction, createSlice } from '@reduxjs/toolkit';
 
 import { type LocksRootState, selectIsRouterOrUiLocked } from '@suite/locks';
 import { type ModalRootState, selectHasActiveModal } from '@suite/modal';
@@ -81,7 +81,7 @@ const routerSlice = createSlice({
     },
 });
 
-export const routerReducer = routerSlice.reducer;
+export const routerReducer: Reducer<RouterState> = routerSlice.reducer;
 export const { routerLocationChange, anchorChange } = routerSlice.actions;
 
 export const selectRouter = (state: RouterRootState) => state.router;

--- a/suite/router/src/routerReducer.ts
+++ b/suite/router/src/routerReducer.ts
@@ -81,6 +81,7 @@ const routerSlice = createSlice({
     },
 });
 
+// Keep declaration emit from expanding the full RouterState route union.
 export const routerReducer: Reducer<RouterState> = routerSlice.reducer;
 export const { routerLocationChange, anchorChange } = routerSlice.actions;
 

--- a/suite/suite-sync/src/index.ts
+++ b/suite/suite-sync/src/index.ts
@@ -17,7 +17,8 @@ export {
     selectIsSuiteSyncBannerVisible,
     selectIsUnsupportedDeviceBannerDismissed,
     selectShowEnableSuiteSyncModal,
-    suiteSyncSlice,
+    prepareSuiteSyncReducer,
+    desktopSuiteSyncActions,
     updateShowEnableSuiteSyncModal,
 } from './suiteSyncSlice';
 export type { DesktopSuiteSyncRootState, DesktopSuiteSyncState } from './suiteSyncSlice';

--- a/suite/suite-sync/src/suiteSyncSlice.ts
+++ b/suite/suite-sync/src/suiteSyncSlice.ts
@@ -1,3 +1,5 @@
+import { type PayloadAction } from '@reduxjs/toolkit';
+
 import { type MessageSystemRootState } from '@suite-common/message-system';
 import { type AnyAction, createSliceWithExtraDeps } from '@suite-common/redux-utils';
 import {
@@ -28,14 +30,17 @@ export type DesktopSuiteSyncRootState = {
     suiteSync: DesktopSuiteSyncState;
 };
 
-export const suiteSyncSlice = createSliceWithExtraDeps({
+const suiteSyncSlice = createSliceWithExtraDeps({
     name: 'suiteSync',
     initialState: initialSuiteSyncDesktopState,
     reducers: {
-        updateShowEnableSuiteSyncModal: (state, action) => {
+        updateShowEnableSuiteSyncModal: (
+            state: DesktopSuiteSyncState,
+            action: PayloadAction<{ deviceStaticSessionId: StaticSessionId | null }>,
+        ) => {
             state.showEnableSuiteSyncModal = action.payload.deviceStaticSessionId;
         },
-        dismissUnsupportedDeviceBanner: state => {
+        dismissUnsupportedDeviceBanner: (state: DesktopSuiteSyncState) => {
             state.isUnsupportedDeviceBannerDismissed = true;
         },
     },
@@ -130,5 +135,8 @@ export const selectDesktopSuiteSyncInteraction = (
     return interaction;
 };
 
+export const desktopSuiteSyncActions = suiteSyncSlice.actions;
 export const { dismissUnsupportedDeviceBanner, updateShowEnableSuiteSyncModal } =
-    suiteSyncSlice.actions;
+    desktopSuiteSyncActions;
+
+export const prepareSuiteSyncReducer = suiteSyncSlice.prepareReducer;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Code improvement to reduce type-declarations to speedup the type-check

Nothing to manually test, only code improvement


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-pending-account-declaration-size/web/](https://dev.suite.sldev.cz/suite-web/fix-pending-account-declaration-size/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-pending-account-declaration-size&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-pending-account-declaration-size&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-pending-account-declaration-size&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-17T13:36:44.342Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-17T13:37:05.020Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This changeset primarily affects three areas: (1) Suite Sync / labeling infrastructure (suiteSyncSlice, suiteSyncDataReducer), (2) staking state management (stakeDataSlice, stakeReducer), and (3) send form / trading infrastructure (sendFormReducer, sendFormSelectors, sendFormUtils, useTradingReceiveAddressValues). Many changed files (colors.ts, store.ts, createReducerWithExtraDeps.ts, etc.) are extremely broad dependencies imported by 131+ tests — these are likely structural/type-level changes and should not trigger broad test runs unless specific behavioral impact is identified. The recommended strategy focuses on Suite Sync tests at high priority (8 tests), staking and send form tests at medium priority, and trading/transaction tests where specific hooks or reducers were modified.

<details><summary><b>Changed files (45)</b></summary>

- `packages/components/src/config/colors.ts`
- `packages/suite/src/actions/bluetooth/__tests__/desktopBluetoothReducer.test.ts`
- `packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts`
- `packages/suite/src/actions/suite/__tests__/storageActions.test.ts`
- `packages/suite/src/components/suite/asset-picker/hooks/useAccountsWithTokenDisplayNames.ts`
- `packages/suite/src/reducers/store.ts`
- `packages/suite/src/types/suite/index.ts`
- `packages/suite/src/utils/suite/theme.ts`
- `packages/suite/src/utils/wallet/graph/utils.ts`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/useTradingReceiveAddressValues.ts`
- `suite-common/feedback/src/feedbackSlice.ts`
- `suite-common/redux-utils/src/createReducerWithExtraDeps.ts`
- `suite-common/suite-sync/src/data/suiteSyncDataReducer.ts`
- `suite-common/suite-sync/src/index.ts`
- `suite-common/suite-sync/src/suiteSyncSlice.ts`
- `suite-common/wallet-core/src/accounts/accountsActions.ts`
- `suite-common/wallet-core/src/selectors.ts`
- `suite-common/wallet-core/src/send/sendFormReducer.ts`
- `suite-common/wallet-core/src/send/sendFormSelectors.ts`
- `suite-common/wallet-core/src/stake/__tests__/stakeSelectors.test.ts`
- `suite-common/wallet-core/src/stake/stakeDataSlice.ts`
- `suite-common/wallet-core/src/stake/stakeReducer.ts`
- `suite-common/wallet-core/src/transactions/transactionsReducerTypes.ts`
- `suite-common/wallet-core/src/transactions/transactionsSelectors.ts`
- `suite-common/wallet-utils/src/accountUtils.ts`
- `suite-common/wallet-utils/src/sendFormUtils.ts`
- `suite-common/wallet-utils/src/transactionUtils.ts`
- `suite-native/app/src/navigation/enhanceTabOption.ts`
- `suite-native/atoms/src/Button/utils.ts`
- `suite-native/bluetooth/src/bluetoothSlice.ts`
- `suite-native/device/src/__tests__/deviceConnectionFixtures.ts`
- `suite-native/feature-feedback/src/featureFeedbackSlice.ts`
- `suite-native/feature-feedback/src/index.ts`
- `suite-native/settings/src/settingsSlice.ts`
- `suite-native/state/src/__tests__/store.type-test.ts`
- `suite-native/state/src/reducers.ts`
- `suite-native/state/src/store.ts`
- `suite-native/test-utils-store/src/renderWithStore.tsx`
- `suite-native/test-utils/src/renderBasic.tsx`
- `suite/feature-feedback/src/featureFeedbackSlice.ts`
- `suite/feature-feedback/src/index.ts`
- `suite/router/src/router.ts`
- `suite/router/src/routerReducer.ts`
- `suite/suite-sync/src/index.ts`
- `suite/suite-sync/src/suiteSyncSlice.ts`

</details>

**Recommended tests (42)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — Changes to suiteSyncSlice.ts (both suite-common and suite/ versions), suiteSyncDataReducer.ts, and suite-sync/src/index.ts directly affect the Suite Sync labeling feature. This test creates and syncs labels via Evolu Relay and exercises the full Suite Sync write path.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — Directly tests Suite Sync label syncing from the Evolu relay server. Changes to suiteSyncSlice.ts and suiteSyncDataReducer.ts affect the sync read path exercised by this test.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — Tests updating and removing labels via Suite Sync, directly exercising suiteSyncSlice and suiteSyncDataReducer changes. Verifies both UI label updates and relay sync for account, wallet, address, and output labels.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — Tests Suite Sync across multiple passphrase wallets including the sync banner state management, which directly depends on suiteSyncSlice.ts changes.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — Tests label removal via Suite Sync with relay verification. Changes to suiteSyncSlice and suiteSyncDataReducer directly affect the remove label flow and null-sync behavior.
- `suite/e2e/tests/metadata/suite-sync/unsupported-device.test.ts` — Tests Suite Sync unsupported device banner visibility and dismissal, which depends on suiteSyncSlice state management that was changed.
- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — Tests migration from legacy labeling to Suite Sync. Changes to suiteSyncSlice and suiteSyncDataReducer directly affect the migration path and label sync to Evolu relay.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — Tests migrating a legacy Dropbox label to Suite Sync. Directly exercises the suiteSyncSlice migration/enable flow that was modified.

</details>

<details><summary>🟡 <b>Medium priority (28)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Changes to stakeDataSlice.ts and stakeReducer.ts directly affect ETH staking state management. This test exercises the full initial stake flow including pending/confirmed/activated states driven by the stake reducer.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Tests staking additional ETH with state transitions through pending/confirmed/activated phases. Changes to stakeDataSlice.ts and stakeReducer.ts could affect the staking dashboard amounts and progress indicators.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Tests ETH unstaking and claiming flow which relies on stake reducer state management. Changes to stakeReducer.ts and stakeDataSlice.ts could affect the unstaking/claiming dashboard displays.
- `suite/e2e/tests/staking/staking-form.test.ts` — Tests ETH staking form validation including amount calculations and percentage buttons. Changes to stakeDataSlice.ts and stakeReducer.ts may affect available balance computations and form state.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Tests Solana staking which uses the stake slice infrastructure. Changes to stakeDataSlice.ts and stakeReducer.ts could affect SOL staking state management.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Changes to sendFormReducer.ts, sendFormSelectors.ts, and sendFormUtils.ts directly affect the send form state management. This test exercises multiple output management, locktime, OP_RETURN, and unit switching in the send form.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Send SOL test exercises the send form with max amount calculation, fee display, and device confirmation. Changes to sendFormReducer.ts and sendFormSelectors.ts directly affect send form state.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Tests ETH send form with custom gas fees. Changes to sendFormReducer.ts and sendFormSelectors.ts affect the send form state, and sendFormUtils.ts may affect fee calculations.
- `suite/e2e/tests/wallet/send-base.test.ts` — Tests Base network send with custom Ethereum fees and Redux state assertions (wallet.send.serializedTx, wallet.send.drafts). Changes to sendFormReducer directly affect these Redux state checks.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Tests DOGE send with error handling for amounts exceeding MAX_SAFE_INTEGER. Changes to sendFormReducer and sendFormUtils could affect amount validation and error display.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Tests LTC send form with MimbleWimble peg-out transaction handling. Changes to sendFormReducer and sendFormUtils affect the send form broadcast mode flow.
- `suite/e2e/tests/settings/autodetect.test.ts` — Changes to theme.ts and colors.ts directly affect theme color detection and application. This test explicitly verifies theme color values (contentPrimary, surfaceFillPage) match expected CSS colors for light/dark modes.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Changes to useTradingReceiveAddressValues.ts affect how receive addresses are resolved in trading flows. This test verifies the full buy BTC flow including receive address selection and trade confirmation.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests buy ETH flow with receive account selection (adding a new Suite receive account). Changes to useTradingReceiveAddressValues.ts directly affect the receive address resolution path.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Swap flow exercises trading receive address values and the composed transaction info Redux state. Changes to useTradingReceiveAddressValues.ts and sendFormReducer could affect the swap confirmation flow.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests trading form navigation from multiple entry points including asset picker. Changes to useAccountsWithTokenDisplayNames.ts affect the asset picker display used in trading navigation.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — Tests pending transaction display and state transitions. Changes to transactionsSelectors.ts and transactionUtils.ts directly affect how pending/confirmed transactions are selected and rendered.
- `suite/e2e/tests/wallet/transactions.test.ts` — Tests transaction list display and search. Changes to transactionsSelectors.ts affect how transactions are queried, and transactionUtils.ts changes affect transaction data processing.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Tests adding different account types which exercises accountsActions.ts and accountUtils.ts. Changes to these files could affect account creation, counting, and type resolution.
- `suite/e2e/tests/settings/forget-device.test.ts` — Tests device forgetting flow including Bluetooth history handling. Changes to desktopBluetoothReducer.ts directly affect Bluetooth state management used in the forget device flow with BT unpair.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Tests Cardano staking flow which uses stake slice infrastructure. Changes to stakeDataSlice.ts and stakeReducer.ts could affect ADA staking state management.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Tests Cardano reward claiming which uses stake reducer state. Changes to stakeDataSlice.ts and stakeReducer.ts could affect reward display and claim flow state.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Tests Cardano unstaking flow using stake reducer infrastructure. Changes to stakeDataSlice.ts and stakeReducer.ts may affect unstaking state transitions.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form inputs including asset picker and fraction buttons. Changes to useAccountsWithTokenDisplayNames.ts affect asset picker display, and useTradingReceiveAddressValues.ts affects receive account selection.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation and fraction buttons. Changes to sendFormUtils.ts affect amount validation, and useTradingReceiveAddressValues.ts affects the trading flow.
- `suite/e2e/tests/suite/bug-report-form.test.ts` — Changes to feedbackSlice.ts directly affect the feedback/bug report submission flow. This test submits a bug report and verifies the success toast.
- `suite/e2e/tests/general/suite-guide.test.ts` — Tests the Suite Guide panel including bug report submission. Changes to feedbackSlice.ts affect the feedback submission path tested here.
- `suite/e2e/tests/suite/guide.test.ts` — Tests feedback submission through the guide panel. Changes to feedbackSlice.ts directly affect the feedback form submission and success toast flow.

</details>

<details><summary>🟢 <b>Low priority (6)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — Transaction export relies on transactionUtils.ts for data processing. Changes there could affect the exported CSV/JSON/PDF content.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — CSV import populates the send form. Changes to sendFormReducer.ts and sendFormUtils.ts could affect how imported data is processed into send form outputs.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests custom Ethereum fee settings in the swap flow. Changes to sendFormReducer affect the composed transaction info Redux state this test checks.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests custom Bitcoin fee settings in swap. Checks Redux state wallet.trading.composedTransactionInfo which may be affected by sendFormReducer changes.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Tests SOL staking rewards display which relies on stake data slice state. Changes to stakeDataSlice.ts could affect reward fetching and display logic.
- `suite/e2e/tests/wallet/discovery.test.ts` — Tests multi-coin discovery with page reload resilience. Changes to store.ts and accountsActions.ts could affect discovery state persistence across reloads.

</details>

⚠️ **Changes with no test coverage (19)**
- `packages/suite/src/actions/bluetooth/__tests__/desktopBluetoothReducer.test.ts`
- `packages/suite/src/actions/suite/__tests__/storageActions.test.ts`
- `packages/suite/src/types/suite/index.ts`
- `suite-common/wallet-core/src/stake/__tests__/stakeSelectors.test.ts`
- `suite-common/wallet-core/src/transactions/transactionsReducerTypes.ts`
- `suite-native/app/src/navigation/enhanceTabOption.ts`
- `suite-native/atoms/src/Button/utils.ts`
- `suite-native/bluetooth/src/bluetoothSlice.ts`
- `suite-native/device/src/__tests__/deviceConnectionFixtures.ts`
- `suite-native/feature-feedback/src/featureFeedbackSlice.ts`
- `suite-native/feature-feedback/src/index.ts`
- `suite-native/settings/src/settingsSlice.ts`
- `suite-native/state/src/__tests__/store.type-test.ts`
- `suite-native/state/src/reducers.ts`
- `suite-native/state/src/store.ts`
- `suite-native/test-utils-store/src/renderWithStore.tsx`
- `suite-native/test-utils/src/renderBasic.tsx`
- `suite/router/src/router.ts`
- `suite/router/src/routerReducer.ts`

_Updated: 2026-07-17T13:35:00.521Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->