### PR TITLE
feat(e2e-utils): add reporter watchdog

### DIFF
--- a/.github/workflows/template-suite-run-e2e.yml
+++ b/.github/workflows/template-suite-run-e2e.yml
@@ -46,6 +46,11 @@ on:
         description: "Flag to run GitHub Reporter, only on Release workflows"
         required: false
         type: string
+      reporterWatchdog:
+        description: "Reporter watchdog mode. When 'true', targets the sandbox GitHub Project and makes the test step non-blocking (a genuine synthetic failure must not red the job)."
+        required: false
+        default: "false"
+        type: string
       enable-coverage:
         description: "Enable code coverage collection with Currents and upload the coverage map. Only works for web and requires instrumentation of the code."
         required: false
@@ -182,9 +187,12 @@ jobs:
 
       - name: Run Playwright E2E Tests
         shell: bash
+        # in reporter-watchdog mode a synthetic test fails on purpose; the separate verify job is the health verdict.
+        continue-on-error: ${{ inputs.reporterWatchdog == 'true' }}
         env:
           COMPOSE_FILE: ./docker/docker-compose.suite-ci-e2e.yml
           GITHUB_ACTION: true
+          REPORTER_WATCHDOG: ${{ inputs.reporterWatchdog }}
           CURRENTS_PROJECT_ID: ${{ inputs.currents-project-id }}
           CURRENTS_RECORD_KEY: ${{ secrets.currents-record-key }}
           CURRENTS_CI_BUILD_ID: ${{ inputs.currents-ci-build-id }}
@@ -215,6 +223,12 @@ jobs:
             COVERAGE_OPT="--pwc-coverage"
           else
             COVERAGE_OPT=""
+          fi
+
+          if [[ "${{ inputs.reporterWatchdog }}" == "true" ]]; then
+            PW_CONFIG="./playwright-config/playwright-reporter-watchdog.config.ts"
+          else
+            PW_CONFIG="${{ inputs.pw-config }}"
           fi
 
           # Build spec filter args if a spec list was provided
@@ -255,7 +269,7 @@ jobs:
           # Start services
           docker compose up -d ${{ inputs.containers }}
 
-          echo "Starting ${{ inputs.target }} Playwright tests with config ${{ inputs.pw-config }} for test group ${{ inputs.test-group }}"
+          echo "Starting ${{ inputs.target }} Playwright tests with config $PW_CONFIG for test group ${{ inputs.test-group }}"
 
           # Currents orchestration is a two-step process since @currents/playwright v2:
           #   1. discover: list/select the tests (all test-selection flags live here)
@@ -264,7 +278,7 @@ jobs:
 
           yarn workspace @trezor/suite-e2e test:orchestrated:e2e discover \
             --pwc-discovery-file "$DISCOVERY_FILE" \
-            --config=${{ inputs.pw-config }} \
+            --config=$PW_CONFIG \
             $PASS_WITH_NO_TESTS \
             $SPEC_ARGS
 
@@ -275,7 +289,7 @@ jobs:
 
           yarn workspace @trezor/suite-e2e test:orchestrated:e2e run \
             --pwc-discovery-file "$DISCOVERY_FILE" \
-            --config=${{ inputs.pw-config }} \
+            --config=$PW_CONFIG \
             --pwc-cancel-after-failures ${{ inputs.fail-fast }} \
             --pwc-disable-test-tags \
             --pwc-skip-reporter-injection \

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -9,6 +9,17 @@ on:
         required: false
         default: ""
   workflow_call:
+    inputs:
+      testFilter:
+        description: "(optional) Run the publisher for specific tests. Can be multiple tests' filenames separated by whitespace."
+        required: false
+        default: ""
+        type: string
+      reporterWatchdog:
+        description: "Reporter watchdog mode: target the sandbox GitHub Project instead of the real release board"
+        required: false
+        default: "false"
+        type: string
 
 concurrency:
   group: manual-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -66,6 +77,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
           GITHUB_REPORTER_VERBOSE: true
           RELEASE_BUILD: ${{ env.release_build }}
+          REPORTER_WATCHDOG: ${{ inputs.reporterWatchdog }}
         run: |
           echo "Starting Playwright Reporter for manual regression suite"
           yarn workspace @trezor/suite-e2e github:report:manual ${{ inputs.testFilter }}

--- a/.github/workflows/test-suite-native-e2e-manual-reporter.yml
+++ b/.github/workflows/test-suite-native-e2e-manual-reporter.yml
@@ -8,9 +8,21 @@ on:
         description: "(optional) Run the publisher for specific tests. Can be multiple tests' filenames separated by whitespace. Ex: test1.test.ts test2.test.ts"
         required: false
         default: ""
+  workflow_call:
+    inputs:
+      testFilter:
+        description: "(optional) Run the publisher for specific tests. Can be multiple tests' filenames separated by whitespace."
+        required: false
+        default: ""
+        type: string
+      reporterWatchdog:
+        description: "Reporter watchdog mode: target the sandbox GitHub Project instead of the real release board"
+        required: false
+        default: "false"
+        type: string
 
 concurrency:
-  group: manual-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: native-manual-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -66,6 +78,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
           GITHUB_REPORTER_VERBOSE: true
           RELEASE_BUILD: ${{ env.release_build }}
+          REPORTER_WATCHDOG: ${{ inputs.reporterWatchdog }}
         run: |
           echo "Starting Jest Reporter for manual regression suite"
           yarn workspace @suite-native/app github:report:manual ${{ inputs.testFilter }}

--- a/.github/workflows/test-suite-reporter-watchdog.yml
+++ b/.github/workflows/test-suite-reporter-watchdog.yml
@@ -1,0 +1,121 @@
+name: "[Test] Reporter watchdog"
+# Dry-runs the REAL release-reporting chain against the sandbox "Trezor Suite reporter healthcheck"
+# GitHub Project, so reporter breakage is caught within ~24h instead of mid-release.
+#
+# The Playwright jobs are non-blocking here (one synthetic test fails on purpose to exercise the
+# issue-creation path); reading the sandbox back in the `verify` job is the sole health verdict.
+# See packages/e2e-utils/src/githubReporter/watchdog/README.md for the full design.
+
+permissions:
+  id-token: write # nested build-suite-web-e2e / release-connect use AWS OIDC
+  contents: read
+
+on:
+  schedule:
+    # offset from the 00:00 nightly, which deploys the instrumented develop web build to the same S3 path
+    - cron: "0 22 * * 0-4"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "packages/e2e-utils/src/githubReporter/**"
+      - "packages/e2e-utils/src/enums/testAnnotations.ts"
+      - "suite/e2e/support/reporters/**"
+      - "suite/e2e/playwright-config/playwright-base.config.ts"
+      - "suite/e2e/playwright-config/playwright-manual.config.ts"
+      - "suite/e2e/playwright-config/playwright-reporter-watchdog.config.ts"
+      - "suite/e2e/reporter-watchdog/**"
+      - ".github/workflows/template-suite-run-e2e.yml"
+      - ".github/workflows/test-suite-manual-release.yml"
+      - ".github/workflows/test-suite-web-desktop-e2e-release.yml"
+      - ".github/workflows/test-suite-reporter-watchdog.yml"
+      - ".github/actions/resolve-test-matrix/**"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  wipe-sandbox:
+    if: >-
+      github.repository == 'trezor/trezor-suite' &&
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: trezor-bot-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ secrets.TREZOR_BOT_APP_ID }}
+          private-key: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: yarn
+
+      - name: Install dependencies
+        shell: bash
+        run: yarn workspaces focus @trezor/e2e-utils
+
+      - name: Wipe sandbox project
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
+        run: yarn workspace @trezor/e2e-utils reporter-watchdog:wipe
+
+  call-test-suite-manual-release:
+    needs: wipe-sandbox
+    uses: ./.github/workflows/test-suite-manual-release.yml
+    secrets: inherit
+    with:
+      reporterWatchdog: "true"
+      testFilter: "reporter-watchdog.manual.spec.ts"
+
+  call-test-suite-web-desktop-e2e-release:
+    needs: wipe-sandbox
+    uses: ./.github/workflows/test-suite-web-desktop-e2e-release.yml
+    secrets: inherit
+    with:
+      publish_results_to_github: true
+      reporterWatchdog: "true"
+
+  # Read-back of the sandbox project is the sole health verdict, not the Playwright exit codes.
+  verify:
+    needs:
+      - wipe-sandbox
+      - call-test-suite-manual-release
+      - call-test-suite-web-desktop-e2e-release
+    # Run even if the callers failed (missing items => correct red verdict), but never on a non-wiped sandbox.
+    if: ${{ !cancelled() && needs.wipe-sandbox.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: trezor-bot-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ secrets.TREZOR_BOT_APP_ID }}
+          private-key: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: yarn
+
+      - name: Install dependencies
+        shell: bash
+        run: yarn workspaces focus @trezor/e2e-utils
+
+      - name: Verify sandbox report
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
+        run: yarn workspace @trezor/e2e-utils reporter-watchdog:verify

--- a/.github/workflows/test-suite-reporter-watchdog.yml
+++ b/.github/workflows/test-suite-reporter-watchdog.yml
@@ -7,7 +7,7 @@ name: "[Test] Reporter watchdog"
 # See packages/e2e-utils/src/githubReporter/watchdog/README.md for the full design.
 
 permissions:
-  id-token: write # nested build-suite-web-e2e / release-connect use AWS OIDC
+  id-token: write
   contents: read
 
 on:
@@ -24,9 +24,13 @@ on:
       - "suite/e2e/playwright-config/playwright-manual.config.ts"
       - "suite/e2e/playwright-config/playwright-reporter-watchdog.config.ts"
       - "suite/e2e/reporter-watchdog/**"
+      - "suite-native/app/e2e/support/reporter/**"
+      - "suite-native/app/e2e/reporter-watchdog/**"
+      - "suite-native/app/e2e/jest.config.reporter.js"
       - ".github/workflows/template-suite-run-e2e.yml"
       - ".github/workflows/test-suite-manual-release.yml"
       - ".github/workflows/test-suite-web-desktop-e2e-release.yml"
+      - ".github/workflows/test-suite-native-e2e-manual-reporter.yml"
       - ".github/workflows/test-suite-reporter-watchdog.yml"
       - ".github/actions/resolve-test-matrix/**"
 
@@ -78,19 +82,27 @@ jobs:
 
   call-test-suite-web-desktop-e2e-release:
     needs: wipe-sandbox
+    # Skipped on PR to not clash with web deploy of PR test workflow
+    if: github.event_name != 'pull_request'
     uses: ./.github/workflows/test-suite-web-desktop-e2e-release.yml
     secrets: inherit
     with:
       publish_results_to_github: true
       reporterWatchdog: "true"
 
-  # Read-back of the sandbox project is the sole health verdict, not the Playwright exit codes.
+  call-test-suite-native-manual-release:
+    needs: wipe-sandbox
+    uses: ./.github/workflows/test-suite-native-e2e-manual-reporter.yml
+    secrets: inherit
+    with:
+      reporterWatchdog: "true"
+
   verify:
     needs:
       - wipe-sandbox
       - call-test-suite-manual-release
       - call-test-suite-web-desktop-e2e-release
-    # Run even if the callers failed (missing items => correct red verdict), but never on a non-wiped sandbox.
+      - call-test-suite-native-manual-release
     if: ${{ !cancelled() && needs.wipe-sandbox.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
@@ -118,4 +130,6 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
+          # Automated workflow is skipped on PR to not clash with web deploy of PR test workflow
+          REPORTER_WATCHDOG_EXPECT_AUTOMATED: ${{ github.event_name != 'pull_request' }}
         run: yarn workspace @trezor/e2e-utils reporter-watchdog:verify

--- a/.github/workflows/test-suite-web-desktop-e2e-release.yml
+++ b/.github/workflows/test-suite-web-desktop-e2e-release.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: false
         type: boolean
+      reporterWatchdog:
+        description: "Reporter watchdog mode: run only the synthetic reporter-watchdog tests against the sandbox project"
+        required: false
+        default: "false"
+        type: string
   workflow_call:
     inputs:
       publish_results_to_github:
@@ -25,6 +30,11 @@ on:
         required: false
         default: false
         type: boolean
+      reporterWatchdog:
+        description: "Reporter watchdog mode: run only the synthetic reporter-watchdog tests against the sandbox project"
+        required: false
+        default: "false"
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -49,6 +59,42 @@ jobs:
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
           echo "release_build=${BRANCH_NAME}-${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
 
+  resolve-matrix:
+    if: github.repository == 'trezor/trezor-suite'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix-desktop: ${{ steps.matrix.outputs.matrix-desktop }}
+      matrix-web: ${{ steps.matrix.outputs.matrix-web }}
+      currents-desktop: ${{ steps.mode.outputs.currents-desktop }}
+      currents-web: ${{ steps.mode.outputs.currents-web }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Resolve worker counts and Currents projects
+        id: mode
+        shell: bash
+        # Reporter Watchdog runs minimal number of groups and reports to sandbox Currents project
+        run: |
+          if [[ "${{ inputs.reporterWatchdog }}" == "true" ]]; then
+            echo "max-desktop=1" >> $GITHUB_OUTPUT
+            echo "max-web=1" >> $GITHUB_OUTPUT
+            echo "currents-desktop=iBEsWE" >> $GITHUB_OUTPUT
+            echo "currents-web=iBEsWE" >> $GITHUB_OUTPUT
+          else
+            echo "max-desktop=7" >> $GITHUB_OUTPUT
+            echo "max-web=10" >> $GITHUB_OUTPUT
+            echo "currents-desktop=4ytF0E" >> $GITHUB_OUTPUT
+            echo "currents-web=Og0NOQ" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Resolve test matrix
+        id: matrix
+        uses: ./.github/actions/resolve-test-matrix
+        with:
+          max-desktop: ${{ steps.mode.outputs.max-desktop }}
+          max-web: ${{ steps.mode.outputs.max-web }}
+
   # ── Desktop ────────────────────────────────────────────────────────────────
 
   build-app:
@@ -60,20 +106,22 @@ jobs:
     needs:
       - build-app
       - extract-branch
+      - resolve-matrix
     strategy:
       fail-fast: false
       matrix:
-        TEST_GROUP: [1, 2, 3, 4, 5, 6, 7]
+        TEST_GROUP: ${{ fromJSON(needs.resolve-matrix.outputs.matrix-desktop) }}
     uses: ./.github/workflows/template-suite-run-e2e.yml
     with:
       target: "desktop"
       pw-config: "./playwright-config/playwright-desktop.config.ts"
       test-group: ${{ matrix.TEST_GROUP }}
       fail-fast: "false"
-      currents-project-id: "4ytF0E"
+      currents-project-id: ${{ needs.resolve-matrix.outputs.currents-desktop }}
       download-artifact-name: "desktop-app-build-e2e"
       release-build: ${{ needs.extract-branch.outputs.release_build }}
       run-reporter: ${{ inputs.publish_results_to_github == true }}
+      reporterWatchdog: ${{ inputs.reporterWatchdog }}
     secrets:
       currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}
       e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}
@@ -114,20 +162,22 @@ jobs:
       - build-web
       - build-connect
       - extract-branch
+      - resolve-matrix
     strategy:
       fail-fast: false
       matrix:
-        TEST_GROUP: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        TEST_GROUP: ${{ fromJSON(needs.resolve-matrix.outputs.matrix-web) }}
     uses: ./.github/workflows/template-suite-run-e2e.yml
     with:
       target: "web"
       pw-config: "./playwright-config/playwright-web.config.ts"
       test-group: ${{ matrix.TEST_GROUP }}
       fail-fast: "false"
-      currents-project-id: "Og0NOQ"
+      currents-project-id: ${{ needs.resolve-matrix.outputs.currents-web }}
       release-build: ${{ needs.extract-branch.outputs.release_build }}
       run-reporter: ${{ inputs.publish_results_to_github == true }}
       download-artifact-name: "connect-explorer-webextension-dev.suite.sldev.cz"
+      reporterWatchdog: ${{ inputs.reporterWatchdog }}
     secrets:
       currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}
       e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}

--- a/packages/e2e-utils/package.json
+++ b/packages/e2e-utils/package.json
@@ -21,7 +21,10 @@
         "fix-bot:publish": "tsx src/fixBot/publish.ts",
         "fix-bot:notify": "tsx src/fixBot/notify.ts",
         "fix-bot:update-ledger": "tsx src/fixBot/ledger.ts",
-        "gh-pr-stats": "tsx ./src/ghPrStats/index.ts"
+        "gh-pr-stats": "tsx ./src/ghPrStats/index.ts",
+        "github:create:project": "tsx src/githubReporter/scriptCreateProject.ts",
+        "reporter-watchdog:wipe": "tsx src/githubReporter/watchdog/wipe.ts",
+        "reporter-watchdog:verify": "tsx src/githubReporter/watchdog/verify.ts"
     },
     "dependencies": {
         "@anthropic-ai/sdk": "0.100.0",

--- a/packages/e2e-utils/src/githubReporter/gitHubProject.ts
+++ b/packages/e2e-utils/src/githubReporter/gitHubProject.ts
@@ -9,12 +9,10 @@ import { type BaseAnnotation, annotationsForProjectFields } from '../enums/testA
 const ORGANIZATION = 'trezor';
 const ORG_ID = 'MDEyOk9yZ2FuaXphdGlvbjQxNDY0NDc=';
 const QA_TEAM_ID = 'T_kwDOAD9FD84AMZXd';
-// DevOps is working on tokens in our GitHub atm. Once that is settled we can rework this
-// and try to create project separately for each build. Needs to be discussed with DevOps.
-// And we would need to some kind of cleanup after each build of projects not longer used.
-// Until then we will use one project for all builds and have name hardcoded here.
-// We should first try this approach and get feedback from QA after one release.
-const PROJECT_NAME = 'Trezor Suite release testing';
+export const SANDBOX_PROJECT_NAME = 'Trezor Suite reporter healthcheck';
+const DEFAULT_PROJECT_NAME = 'Trezor Suite release testing';
+const PROJECT_NAME =
+    process.env.REPORTER_WATCHDOG === 'true' ? SANDBOX_PROJECT_NAME : DEFAULT_PROJECT_NAME;
 const RETRY_CONF = {
     attempts: 3,
     gap: 500,
@@ -55,24 +53,6 @@ export class GitHubProject {
                 this.logger.logError(`No existing project found.`);
                 throw new Error('No existing project found.');
             }
-
-            // We cannot get atm right token to be able to create project from Github Actions
-            // await this.createProject(annotationsForProjectFields);
-
-            // // Instead of taking projectId from 'createProject()' we run another 'findExistingProject()' query again
-            // // Goal is to avoid conflicts by searching for the project again, by its name and choosing the oldest
-            // // Source of conflict: Parallel workflows on CI (Web x Desktop), parallel groups in one workflow
-            // const createdProject = await this.findExistingProject();
-            // if (createdProject) {
-            //     this._projectId = createdProject.id;
-            //     this.logger.log(
-            //         `Using created project: ${createdProject.title} (${createdProject.id})`,
-            //     );
-
-            //     return;
-            // } else {
-            //     throw new Error('Failed to find the created project');
-            // }
         } catch (error) {
             this.logger.logError('Project initialization failed.');
             throw error;

--- a/packages/e2e-utils/src/githubReporter/gitHubReporterBase.ts
+++ b/packages/e2e-utils/src/githubReporter/gitHubReporterBase.ts
@@ -34,7 +34,7 @@ abstract class GitHubReporterBase implements LoggingFunctions {
     protected _fieldsInGitHub: ProjectField[] | null = null;
     protected pendingOperations: Promise<any>[] = [];
     protected initState: InitializationState = InitializationState.NOT_STARTED;
-    protected createdIssuesMap: Map<string, string> = new Map();
+    protected issueCreationPromises: Map<string, Promise<string>> = new Map();
     protected failedTestFilenames: string[] = [];
 
     protected initializationPromise: Promise<void> | null = null;
@@ -191,18 +191,24 @@ abstract class GitHubReporterBase implements LoggingFunctions {
                 try {
                     await this.waitForOnBeginInit();
 
-                    if (report.isRetryAttempt && this.createdIssuesMap.has(report.id)) {
-                        // Retry attempts update the existing issue instead of creating a new one
-                        await this.updateIssue(report);
+                    const pendingCreation = this.issueCreationPromises.get(report.id);
+
+                    if (report.isRetryAttempt && pendingCreation) {
+                        // If this is a retry attempt, update the issue
+                        const issueNodeId = await pendingCreation;
+                        await this.updateIssue(report, issueNodeId);
                     } else if (!report.isManual && report.status === TestStatus.AutoPass) {
+                        // If it is passed automated test, we don't need to create an issue
                         this.log(
                             `Skipping reporting because test is automated and passed: "${report.testTitle}"`,
                         );
 
                         return;
                     } else {
-                        // Otherwise, create a new issue(s)
-                        await this.createIssuePerOs(report);
+                        // Otherwise, create a new issue(s).
+                        const creationPromise = this.createIssuePerOs(report);
+                        this.issueCreationPromises.set(report.id, creationPromise);
+                        await creationPromise;
                     }
                 } catch (error) {
                     this.logError(`Failed to process test end for "${report.testTitle}":`, error);
@@ -345,11 +351,10 @@ abstract class GitHubReporterBase implements LoggingFunctions {
         }
     }
 
-    protected async updateIssue(report: TestReportProviderBase): Promise<void> {
-        const issueNodeId = this.createdIssuesMap.get(report.id);
-        if (!issueNodeId) {
-            throw new Error(`Issue ID not found for test retried test "${report.testTitle}"`);
-        }
+    protected async updateIssue(
+        report: TestReportProviderBase,
+        issueNodeId: string,
+    ): Promise<void> {
         this.log(
             `[${issueNodeId}] Updating GitHub draft issue with a retry of test "${report.testTitle}"...`,
         );
@@ -371,10 +376,12 @@ abstract class GitHubReporterBase implements LoggingFunctions {
         this.log(`[${issueNodeId}] Successfully updated test result for "${report.testTitle}"`);
     }
 
-    protected async createIssuePerOs(report: TestReportProviderBase): Promise<void> {
+    protected async createIssuePerOs(report: TestReportProviderBase): Promise<string> {
         if (!report.osMatrix || report.osMatrix.length === 0) {
             throw new Error(`No OS matrix found for test "${report.testTitle}"`);
         }
+
+        let lastIssueNodeId = '';
 
         for (const operationSystem of report.osMatrix) {
             const issueNodeId = await scheduleAction(async () => {
@@ -403,7 +410,7 @@ abstract class GitHubReporterBase implements LoggingFunctions {
                 );
             }
 
-            this.createdIssuesMap.set(report.id, issueNodeId);
+            lastIssueNodeId = issueNodeId;
             this.log(
                 `[${issueNodeId}] Successfully created issue "(OS ${operationSystem}) ${report.testTitle}"`,
             );
@@ -431,6 +438,8 @@ abstract class GitHubReporterBase implements LoggingFunctions {
                 `[${issueNodeId}] Successfully recorded test result for "(OS ${operationSystem}) ${report.testTitle}"`,
             );
         }
+
+        return lastIssueNodeId;
     }
 }
 

--- a/packages/e2e-utils/src/githubReporter/projectRequests.ts
+++ b/packages/e2e-utils/src/githubReporter/projectRequests.ts
@@ -3,10 +3,13 @@ import type { Octokit } from '@octokit/rest';
 import {
     type CreateFieldResponse,
     type CreateProjectMutation,
+    type DeleteProjectItemResponse,
     type LoggingFunctions,
     type Project,
     type ProjectField,
     type ProjectFieldsResponse,
+    type ProjectItem,
+    type ProjectItemsResponse,
     type ProjectQueryResponse,
 } from './types';
 
@@ -187,5 +190,60 @@ export class ProjectRequests {
 
         await this.octokit.graphql(mutation);
         this.logger.log(`Successfully replaced all options for field ${fieldId}`);
+    }
+
+    async getProjectItems(projectId: string): Promise<ProjectItem[]> {
+        this.logger.log(`Fetching items for project ${projectId}...`);
+
+        const query = `
+            query ($projectId: ID!) {
+              node(id: $projectId) {
+                ... on ProjectV2 {
+                  items(first: 100) {
+                    nodes {
+                      id
+                      content { ... on DraftIssue { title } }
+                      fieldValues(first: 20) {
+                        nodes {
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            name
+                            field { ... on ProjectV2FieldCommon { name } }
+                          }
+                          ... on ProjectV2ItemFieldTextValue {
+                            text
+                            field { ... on ProjectV2FieldCommon { name } }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        `;
+
+        const response = await this.octokit.graphql<ProjectItemsResponse>(query, { projectId });
+        this.logger.log(`Successfully retrieved items for project ${projectId}`);
+
+        return response.node.items.nodes;
+    }
+
+    async deleteProjectV2Item(projectId: string, itemId: string): Promise<string> {
+        this.logger.log(`Deleting item ${itemId} from project ${projectId}...`);
+
+        const mutation = `
+            mutation ($projectId: ID!, $itemId: ID!) {
+              deleteProjectV2Item(input: { projectId: $projectId, itemId: $itemId }) {
+                deletedItemId
+              }
+            }
+        `;
+
+        const response = await this.octokit.graphql<DeleteProjectItemResponse>(mutation, {
+            projectId,
+            itemId,
+        });
+
+        return response.deleteProjectV2Item.deletedItemId;
     }
 }

--- a/packages/e2e-utils/src/githubReporter/scriptCreateProject.ts
+++ b/packages/e2e-utils/src/githubReporter/scriptCreateProject.ts
@@ -4,7 +4,7 @@ import path from 'path';
 
 import { GitHubProject } from './gitHubProject';
 
-dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 class ScriptLogger {
     log(...args: any[]): void {

--- a/packages/e2e-utils/src/githubReporter/types.ts
+++ b/packages/e2e-utils/src/githubReporter/types.ts
@@ -77,6 +77,32 @@ export interface AddDraftIssueResponse {
     };
 }
 
+export interface ProjectItemFieldValue {
+    name?: string;
+    text?: string;
+    field?: { name: string };
+}
+
+export interface ProjectItem {
+    id: string;
+    content: { title?: string } | null;
+    fieldValues: { nodes: ProjectItemFieldValue[] };
+}
+
+export interface ProjectItemsResponse {
+    node: {
+        items: {
+            nodes: ProjectItem[];
+        };
+    };
+}
+
+export interface DeleteProjectItemResponse {
+    deleteProjectV2Item: {
+        deletedItemId: string;
+    };
+}
+
 export type ValueOrOptionId = string | { optionId: string };
 
 export interface TestDetailsAnnotation {

--- a/packages/e2e-utils/src/githubReporter/watchdog/README.md
+++ b/packages/e2e-utils/src/githubReporter/watchdog/README.md
@@ -1,0 +1,67 @@
+# Reporter Watchdog
+
+The GitHub reporter (this package's `githubReporter`, injected as a Playwright reporter) populates the
+"Trezor Suite release testing" GitHub Project board once a month during release testing. Because it only
+runs monthly, unrelated changes to the test framework or CI workflows silently break it, and the breakage
+is discovered mid-release.
+
+The watchdog dry-runs the **real reporter chain** — same workflows, same build + docker, same reporter
+injection — against a dedicated sandbox project (`Trezor Suite reporter healthcheck`), so breakage is
+caught within ~24h and on PRs that touch the fragile surface.
+
+## Modes
+
+|                | Real (monthly)                                                           | Watchdog                                                                                        |
+| -------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| Entry          | `workflow_dispatch` on `test-suite-release-e2e-report-orchestration.yml` | `schedule` / `pull_request` (paths) / `workflow_dispatch` on `test-suite-reporter-watchdog.yml` |
+| GitHub Project | Trezor Suite release testing                                             | Trezor Suite reporter healthcheck                                                               |
+| Test selection | full suites                                                              | 2 automated synthetics + 3 manual synthetics (`suite/e2e/reporter-watchdog/`)                   |
+| Verdict        | n/a                                                                      | `verify` job reads the sandbox back                                                             |
+
+The real orchestration workflow contains no watchdog code — a monthly dispatch structurally cannot fall
+into sandbox mode. The only mode switch is the `reporterWatchdog` flag threaded through the callers into
+`REPORTER_WATCHDOG`, which flips the project name in `gitHubProject.ts` and the manual config's `testDir`.
+
+## Call graph (watchdog run)
+
+```
+test-suite-reporter-watchdog.yml
+  ├─ wipe-sandbox                     delete all sandbox items (clean slate)
+  ├─ call-test-suite-manual-release   → github:report:manual, testFilter=reporter-watchdog.manual.spec.ts
+  │                                     3 describe.skip synthetics → issued as Todo with full field spread
+  ├─ call-test-suite-web-desktop-e2e-release   (1 desktop + 1 web template job via resolve-matrix)
+  │                                     → playwright-reporter-watchdog.config.ts
+  │                                     "automated pass" → AutoPass → no issue
+  │                                     "automated fail" → genuine failure → Auto FAIL issue (+ retries exercise updateIssue)
+  └─ verify                           read sandbox: FAIL issue present, PASS absent, manual issues + fields present,
+                                      Release Build populated; exit code = health verdict
+```
+
+## Why the synthetic tests look the way they do
+
+- The automated specs use bare `@playwright/test` (no fixtures) → no trezor-user-env, no app, instant.
+- They are tagged only `@reporterWatchdog`, which no real Playwright project selects (every real project
+  greps for a device model, `@noDevice`, or `@group=manual`), so they can never red normal runs.
+- The failing test must fail **genuinely**: `test.fail()` marks the outcome expected → classified AutoPass →
+  the reporter skips issue creation. Its failure is neutralized by a watchdog-gated `continue-on-error`
+  in `template-suite-run-e2e.yml`; the `verify` job is the sole gate.
+- The manual specs are `describe.skip` with empty bodies → reported as Todo without launching anything.
+
+## Bootstrap & rollout
+
+- One-time (already done): create the sandbox project with
+  `REPORTER_WATCHDOG=true yarn workspace @trezor/e2e-utils github:create:project`.
+- Local runs of `reporter-watchdog:wipe` / `reporter-watchdog:verify` need a project-scoped `GITHUB_TOKEN`
+  in `packages/e2e-utils/.env`; on CI the trezor-bot app token is used.
+- The nightly cron (22:00 UTC Sun–Thu, offset from the 00:00 nightly whose instrumented web build shares the S3 path)
+  and the Actions-UI dispatch button activate once the workflow lands on develop; the introducing PR
+  self-tests via the `pull_request` paths filter.
+
+## Known caveats
+
+- **The `verify` job conclusion is the only red signal** — the Playwright template jobs are green by design.
+- The web and desktop runs both report the failing synthetic; near-simultaneous first failures can race
+  `createIssue` and leave a duplicate sandbox item. Harmless (verify matches by title) and wiped next run.
+- Watchdog runs record to a dedicated Currents project (`iBEsWE`, resolved in the release caller's
+  `resolve-matrix` job), so the nightly synthetic failure never pollutes the release dashboards.
+  The manual path never talks to Currents (its CLI `--reporter=` replaces the config reporters).

--- a/packages/e2e-utils/src/githubReporter/watchdog/README.md
+++ b/packages/e2e-utils/src/githubReporter/watchdog/README.md
@@ -1,9 +1,10 @@
 # Reporter Watchdog
 
-The GitHub reporter (this package's `githubReporter`, injected as a Playwright reporter) populates the
-"Trezor Suite release testing" GitHub Project board once a month during release testing. Because it only
-runs monthly, unrelated changes to the test framework or CI workflows silently break it, and the breakage
-is discovered mid-release.
+The GitHub reporter (this package's `githubReporter`, consumed as a Playwright reporter by web/desktop and
+as a Jest reporter by suite-native) populates the "Trezor Suite release testing" GitHub Project board once a
+month during release testing. Because it only runs monthly, unrelated changes to the test framework or CI
+workflows silently break it, and the breakage is discovered mid-release (e.g. the June 2026 native release
+run failed on a ts-node/ESM incompatibility introduced a month earlier).
 
 The watchdog dry-runs the **real reporter chain** — same workflows, same build + docker, same reporter
 injection — against a dedicated sandbox project (`Trezor Suite reporter healthcheck`), so breakage is
@@ -11,16 +12,17 @@ caught within ~24h and on PRs that touch the fragile surface.
 
 ## Modes
 
-|                | Real (monthly)                                                           | Watchdog                                                                                        |
-| -------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
-| Entry          | `workflow_dispatch` on `test-suite-release-e2e-report-orchestration.yml` | `schedule` / `pull_request` (paths) / `workflow_dispatch` on `test-suite-reporter-watchdog.yml` |
-| GitHub Project | Trezor Suite release testing                                             | Trezor Suite reporter healthcheck                                                               |
-| Test selection | full suites                                                              | 2 automated synthetics + 3 manual synthetics (`suite/e2e/reporter-watchdog/`)                   |
-| Verdict        | n/a                                                                      | `verify` job reads the sandbox back                                                             |
+|                | Real (monthly)                                                                                                           | Watchdog                                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Entry          | `workflow_dispatch` on `test-suite-release-e2e-report-orchestration.yml` and `test-suite-native-e2e-manual-reporter.yml` | `schedule` / `pull_request` (paths) / `workflow_dispatch` on `test-suite-reporter-watchdog.yml`                                             |
+| GitHub Project | Trezor Suite release testing                                                                                             | Trezor Suite reporter healthcheck                                                                                                           |
+| Test selection | full suites                                                                                                              | 2 automated + 3 manual synthetics (`suite/e2e/reporter-watchdog/`) + 2 native manual synthetics (`suite-native/app/e2e/reporter-watchdog/`) |
+| Verdict        | n/a                                                                                                                      | `verify` job reads the sandbox back                                                                                                         |
 
-The real orchestration workflow contains no watchdog code — a monthly dispatch structurally cannot fall
-into sandbox mode. The only mode switch is the `reporterWatchdog` flag threaded through the callers into
-`REPORTER_WATCHDOG`, which flips the project name in `gitHubProject.ts` and the manual config's `testDir`.
+The real workflows contain no watchdog code — a monthly dispatch structurally cannot fall into sandbox mode.
+The only mode switch is the `reporterWatchdog` flag threaded through the callers into `REPORTER_WATCHDOG`,
+which flips the project name in `gitHubProject.ts`, the Playwright manual config's `testDir`, and the native
+Jest reporter config's `testMatch`.
 
 ## Call graph (watchdog run)
 
@@ -33,8 +35,10 @@ test-suite-reporter-watchdog.yml
   │                                     → playwright-reporter-watchdog.config.ts
   │                                     "automated pass" → AutoPass → no issue
   │                                     "automated fail" → genuine failure → Auto FAIL issue (+ retries exercise updateIssue)
-  └─ verify                           read sandbox: FAIL issue present, PASS absent, manual issues + fields present,
-                                      Release Build populated; exit code = health verdict
+  ├─ call-test-suite-native-manual-release   → native github:report:manual (Jest)
+  │                                     2 describe.skip synthetics → issued as Todo with full field spread
+  └─ verify                           read sandbox: FAIL issue present, PASS absent, manual issues (web + native)
+                                      + fields present, Release Build populated; exit code = health verdict
 ```
 
 ## Why the synthetic tests look the way they do
@@ -46,13 +50,18 @@ test-suite-reporter-watchdog.yml
   the reporter skips issue creation. Its failure is neutralized by a watchdog-gated `continue-on-error`
   in `template-suite-run-e2e.yml`; the `verify` job is the sole gate.
 - The manual specs are `describe.skip` with empty bodies → reported as Todo without launching anything.
+- The native specs are Jest, not Playwright: `describe.skip` + `wrappedIt` metadata, selected by a
+  `REPORTER_WATCHDOG`-gated `testMatch` in `jest.config.reporter.js`. Their `/manual/` path segment is what
+  classifies them as manual (Jest has no tags; `isManual` is path-based). All are skipped → Jest exits 0 →
+  the native job needs no `continue-on-error`.
 
 ## Bootstrap & rollout
 
 - One-time (already done): create the sandbox project with
   `REPORTER_WATCHDOG=true yarn workspace @trezor/e2e-utils github:create:project`.
 - Local runs of `reporter-watchdog:wipe` / `reporter-watchdog:verify` need a project-scoped `GITHUB_TOKEN`
-  in `packages/e2e-utils/.env`; on CI the trezor-bot app token is used.
+  in `packages/e2e-utils/.env`; a local native reporter run reads it from `suite-native/app/e2e/.env`.
+  On CI the trezor-bot app token is used.
 - The nightly cron (22:00 UTC Sun–Thu, offset from the 00:00 nightly whose instrumented web build shares the S3 path)
   and the Actions-UI dispatch button activate once the workflow lands on develop; the introducing PR
   self-tests via the `pull_request` paths filter.
@@ -64,4 +73,7 @@ test-suite-reporter-watchdog.yml
   `createIssue` and leave a duplicate sandbox item. Harmless (verify matches by title) and wiped next run.
 - Watchdog runs record to a dedicated Currents project (`iBEsWE`, resolved in the release caller's
   `resolve-matrix` job), so the nightly synthetic failure never pollutes the release dashboards.
-  The manual path never talks to Currents (its CLI `--reporter=` replaces the config reporters).
+  The manual paths (web and native) never talk to Currents.
+- A native spec that fails to load produces no reporter output at all (the Jest reporter prints per-test
+  results only, and suite-level errors have none) — the watchdog catches this only indirectly, via missing
+  sandbox items → red verify.

--- a/packages/e2e-utils/src/githubReporter/watchdog/samples.ts
+++ b/packages/e2e-utils/src/githubReporter/watchdog/samples.ts
@@ -62,6 +62,41 @@ export const EXPECTED_MANUAL = REPORTER_WATCHDOG_MANUAL_SAMPLES.map(sample => ({
     },
 }));
 
+export const REPORTER_WATCHDOG_NATIVE_MANUAL_SAMPLES: ReporterWatchdogManualSample[] = [
+    {
+        testCase: 'Reporter watchdog native manual sample A',
+        prerequisites: ['none'],
+        steps: ['step one'],
+        category: TestCategory.Dashboard,
+        priority: TestPriority.Medium,
+        stream: TestStream.Growth,
+        deviceModel: DeviceModel.T2T1,
+        osMatrix: [TestOsMatrix.Android],
+    },
+    {
+        testCase: 'Reporter watchdog native manual sample B',
+        prerequisites: ['none'],
+        steps: ['step one'],
+        category: TestCategory.Accounts,
+        priority: TestPriority.AsNecessary,
+        stream: TestStream.Wallet,
+        deviceModel: DeviceModel.T3B1,
+        osMatrix: [TestOsMatrix.MacOSArm],
+    },
+];
+
+export const EXPECTED_NATIVE_MANUAL = REPORTER_WATCHDOG_NATIVE_MANUAL_SAMPLES.map(sample => ({
+    title: sample.testCase,
+    fields: {
+        Status: TestStatus.Todo,
+        'Test Run': 'Manual',
+        Stream: sample.stream,
+        Priority: sample.priority,
+        'OS Matrix': sample.osMatrix[0],
+        'Device Model': sample.deviceModel,
+    },
+}));
+
 interface ReporterWatchdogAutomatedSample {
     testCase: string;
     shouldFail: boolean;

--- a/packages/e2e-utils/src/githubReporter/watchdog/samples.ts
+++ b/packages/e2e-utils/src/githubReporter/watchdog/samples.ts
@@ -1,0 +1,73 @@
+import {
+    DeviceModel,
+    TestCategory,
+    TestOsMatrix,
+    TestPriority,
+    TestStatus,
+    TestStream,
+} from '../../enums/testAnnotations';
+
+interface ReporterWatchdogManualSample {
+    testCase: string;
+    prerequisites: string[];
+    steps: string[];
+    category: TestCategory;
+    priority: TestPriority;
+    stream: TestStream;
+    deviceModel: DeviceModel;
+    osMatrix: TestOsMatrix[];
+}
+
+export const REPORTER_WATCHDOG_MANUAL_SAMPLES: ReporterWatchdogManualSample[] = [
+    {
+        testCase: 'Reporter watchdog manual sample A',
+        prerequisites: ['none'],
+        steps: ['step one'],
+        category: TestCategory.General,
+        priority: TestPriority.Low,
+        stream: TestStream.Foundation,
+        deviceModel: DeviceModel.T3T1,
+        osMatrix: [TestOsMatrix.Linux],
+    },
+    {
+        testCase: 'Reporter watchdog manual sample B',
+        prerequisites: ['none'],
+        steps: ['step one'],
+        category: TestCategory.Wallets,
+        priority: TestPriority.High,
+        stream: TestStream.Wallet,
+        deviceModel: DeviceModel.T2B1,
+        osMatrix: [TestOsMatrix.Windows],
+    },
+    {
+        testCase: 'Reporter watchdog manual sample C',
+        prerequisites: ['none'],
+        steps: ['step one'],
+        category: TestCategory.Firmware,
+        priority: TestPriority.Critical,
+        stream: TestStream.Firmware,
+        deviceModel: DeviceModel.T1B1,
+        osMatrix: [TestOsMatrix.Android],
+    },
+];
+
+export const EXPECTED_MANUAL = REPORTER_WATCHDOG_MANUAL_SAMPLES.map(sample => ({
+    title: sample.testCase,
+    fields: {
+        Status: TestStatus.Todo,
+        Stream: sample.stream,
+        Priority: sample.priority,
+        'OS Matrix': sample.osMatrix[0],
+        'Device Model': sample.deviceModel,
+    },
+}));
+
+interface ReporterWatchdogAutomatedSample {
+    testCase: string;
+    shouldFail: boolean;
+}
+
+export const REPORTER_WATCHDOG_AUTOMATED_SAMPLES: ReporterWatchdogAutomatedSample[] = [
+    { testCase: 'automated pass', shouldFail: false },
+    { testCase: 'automated fail', shouldFail: true },
+];

--- a/packages/e2e-utils/src/githubReporter/watchdog/sandboxProject.ts
+++ b/packages/e2e-utils/src/githubReporter/watchdog/sandboxProject.ts
@@ -1,0 +1,54 @@
+import { Octokit } from '@octokit/rest';
+import dotenv from 'dotenv';
+import path from 'path';
+
+import { scheduleAction } from '@trezor/utils';
+
+import { SANDBOX_PROJECT_NAME } from '../gitHubProject';
+import { type ProjectRequests } from '../projectRequests';
+import { type LoggingFunctions } from '../types';
+
+// The project-scoped PAT lives in the e2e-utils env file.
+dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
+
+const ORGANIZATION = 'trezor';
+
+// GitHub Projects has read-after-write lag; callers wrap the thin request methods in this retry (as the reporter does).
+export const RETRY_CONF = {
+    attempts: 5,
+    gap: 500,
+};
+
+export const createLogger = (label: string): LoggingFunctions => ({
+    log: (...args: any[]) => console.warn(`[${label}]`, ...args),
+    logError: (...args: any[]) => console.error(`[${label} ERROR]`, ...args),
+    logResponse: () => {},
+});
+
+export const createOctokit = (): Octokit => {
+    if (!process.env.GITHUB_TOKEN) {
+        throw new Error('GITHUB_TOKEN environment variable is required');
+    }
+
+    return new Octokit({ auth: process.env.GITHUB_TOKEN });
+};
+
+// Resolves the sandbox project strictly by name; wipe/verify can therefore never touch the real release board.
+export const resolveSandboxProject = async (
+    projects: ProjectRequests,
+): Promise<{ id: string; title: string; number: number }> => {
+    const found = await scheduleAction(
+        () => projects.getProjectFromOrganization(ORGANIZATION, SANDBOX_PROJECT_NAME),
+        RETRY_CONF,
+    );
+    const project = found.find(p => p.title === SANDBOX_PROJECT_NAME);
+    if (!project) {
+        throw new Error(
+            `Sandbox project "${SANDBOX_PROJECT_NAME}" not found. Got: ${found
+                .map(p => p.title)
+                .join(' | ')}`,
+        );
+    }
+
+    return project;
+};

--- a/packages/e2e-utils/src/githubReporter/watchdog/verify.ts
+++ b/packages/e2e-utils/src/githubReporter/watchdog/verify.ts
@@ -1,0 +1,87 @@
+import { scheduleAction } from '@trezor/utils';
+
+import { TestStatus } from '../../enums/testAnnotations';
+import { ProjectRequests } from '../projectRequests';
+import { type ProjectItem } from '../types';
+import { EXPECTED_MANUAL, REPORTER_WATCHDOG_AUTOMATED_SAMPLES } from './samples';
+import { RETRY_CONF, createLogger, createOctokit, resolveSandboxProject } from './sandboxProject';
+
+// Flattens an item's field values into a { fieldName: value } map.
+const fieldMap = (item: ProjectItem): Record<string, string> => {
+    const map: Record<string, string> = {};
+    for (const node of item.fieldValues.nodes) {
+        if (node.field?.name) {
+            map[node.field.name] = node.name ?? node.text ?? '';
+        }
+    }
+
+    return map;
+};
+
+async function main() {
+    const logger = createLogger('Reporter Watchdog Verify');
+    const octokit = createOctokit();
+    const projects = new ProjectRequests(octokit, logger);
+
+    const project = await resolveSandboxProject(projects);
+    logger.log(`Verifying project "${project.title}" (${project.id})`);
+
+    const items = await scheduleAction(() => projects.getProjectItems(project.id), RETRY_CONF);
+    logger.log(`Found ${items.length} item(s)`);
+
+    const errors: string[] = [];
+
+    // 1. Automated failures must create an Auto FAIL issue; automated passes must create nothing.
+    for (const sample of REPORTER_WATCHDOG_AUTOMATED_SAMPLES) {
+        const item = items.find(i => i.content?.title === sample.testCase);
+        if (sample.shouldFail) {
+            if (!item) {
+                errors.push(`Missing automated FAIL issue "${sample.testCase}"`);
+            } else if (fieldMap(item).Status !== TestStatus.AutoFail) {
+                errors.push(
+                    `Automated FAIL issue "${sample.testCase}" has Status "${fieldMap(item).Status}", expected "${TestStatus.AutoFail}"`,
+                );
+            }
+        } else if (item) {
+            errors.push(`Automated PASS issue "${sample.testCase}" should be absent but was found`);
+        }
+    }
+
+    // 2. Each manual sample must be present with its fields resolved.
+    for (const expected of EXPECTED_MANUAL) {
+        const item = items.find(i => i.content?.title === expected.title);
+        if (!item) {
+            errors.push(`Missing manual issue "${expected.title}"`);
+            continue;
+        }
+
+        const values = fieldMap(item);
+        for (const [field, value] of Object.entries(expected.fields)) {
+            if (values[field] !== value) {
+                errors.push(
+                    `Manual issue "${expected.title}" field "${field}" is "${values[field]}", expected "${value}"`,
+                );
+            }
+        }
+    }
+
+    // 3. Every issue must carry a Release Build value (covers the TEXT field write path).
+    for (const item of items) {
+        if (!fieldMap(item)['Release Build']) {
+            errors.push(`Issue "${item.content?.title ?? item.id}" has empty "Release Build"`);
+        }
+    }
+
+    if (errors.length > 0) {
+        logger.logError(`Reporter watchdog verification FAILED with ${errors.length} problem(s):`);
+        errors.forEach(e => logger.logError(`  - ${e}`));
+        process.exit(1);
+    }
+
+    logger.log('Reporter watchdog verification PASSED');
+}
+
+main().catch(error => {
+    console.error('Verify failed:', error?.message || error);
+    process.exit(1);
+});

--- a/packages/e2e-utils/src/githubReporter/watchdog/verify.ts
+++ b/packages/e2e-utils/src/githubReporter/watchdog/verify.ts
@@ -3,7 +3,11 @@ import { scheduleAction } from '@trezor/utils';
 import { TestStatus } from '../../enums/testAnnotations';
 import { ProjectRequests } from '../projectRequests';
 import { type ProjectItem } from '../types';
-import { EXPECTED_MANUAL, REPORTER_WATCHDOG_AUTOMATED_SAMPLES } from './samples';
+import {
+    EXPECTED_MANUAL,
+    EXPECTED_NATIVE_MANUAL,
+    REPORTER_WATCHDOG_AUTOMATED_SAMPLES,
+} from './samples';
 import { RETRY_CONF, createLogger, createOctokit, resolveSandboxProject } from './sandboxProject';
 
 // Flattens an item's field values into a { fieldName: value } map.
@@ -30,25 +34,30 @@ async function main() {
     logger.log(`Found ${items.length} item(s)`);
 
     const errors: string[] = [];
+    const expectAutomated = process.env.REPORTER_WATCHDOG_EXPECT_AUTOMATED !== 'false';
 
     // 1. Automated failures must create an Auto FAIL issue; automated passes must create nothing.
-    for (const sample of REPORTER_WATCHDOG_AUTOMATED_SAMPLES) {
-        const item = items.find(i => i.content?.title === sample.testCase);
-        if (sample.shouldFail) {
-            if (!item) {
-                errors.push(`Missing automated FAIL issue "${sample.testCase}"`);
-            } else if (fieldMap(item).Status !== TestStatus.AutoFail) {
+    if (expectAutomated) {
+        for (const sample of REPORTER_WATCHDOG_AUTOMATED_SAMPLES) {
+            const item = items.find(i => i.content?.title === sample.testCase);
+            if (sample.shouldFail) {
+                if (!item) {
+                    errors.push(`Missing automated FAIL issue "${sample.testCase}"`);
+                } else if (fieldMap(item).Status !== TestStatus.AutoFail) {
+                    errors.push(
+                        `Automated FAIL issue "${sample.testCase}" has Status "${fieldMap(item).Status}", expected "${TestStatus.AutoFail}"`,
+                    );
+                }
+            } else if (item) {
                 errors.push(
-                    `Automated FAIL issue "${sample.testCase}" has Status "${fieldMap(item).Status}", expected "${TestStatus.AutoFail}"`,
+                    `Automated PASS issue "${sample.testCase}" should be absent but was found`,
                 );
             }
-        } else if (item) {
-            errors.push(`Automated PASS issue "${sample.testCase}" should be absent but was found`);
         }
     }
 
-    // 2. Each manual sample must be present with its fields resolved.
-    for (const expected of EXPECTED_MANUAL) {
+    // 2. Each manual sample (web + native) must be present with its fields resolved.
+    for (const expected of [...EXPECTED_MANUAL, ...EXPECTED_NATIVE_MANUAL]) {
         const item = items.find(i => i.content?.title === expected.title);
         if (!item) {
             errors.push(`Missing manual issue "${expected.title}"`);

--- a/packages/e2e-utils/src/githubReporter/watchdog/wipe.ts
+++ b/packages/e2e-utils/src/githubReporter/watchdog/wipe.ts
@@ -1,0 +1,33 @@
+import { scheduleAction } from '@trezor/utils';
+
+import { ProjectRequests } from '../projectRequests';
+import { RETRY_CONF, createLogger, createOctokit, resolveSandboxProject } from './sandboxProject';
+
+// Deletes every item in the sandbox project so each reporter watchdog run starts from a clean slate.
+async function main() {
+    const logger = createLogger('Reporter Watchdog Wipe');
+    const octokit = createOctokit();
+    const projects = new ProjectRequests(octokit, logger);
+
+    const project = await resolveSandboxProject(projects);
+    logger.log(`Wiping project "${project.title}" (${project.id})`);
+
+    const items = await scheduleAction(() => projects.getProjectItems(project.id), RETRY_CONF);
+    logger.log(`Found ${items.length} item(s) to delete`);
+
+    for (const item of items) {
+        await scheduleAction(() => projects.deleteProjectV2Item(project.id, item.id), RETRY_CONF);
+        logger.log(`Deleted item ${item.id} ("${item.content?.title ?? 'untitled'}")`);
+    }
+
+    const remaining = await scheduleAction(() => projects.getProjectItems(project.id), RETRY_CONF);
+    if (remaining.length > 0) {
+        throw new Error(`Wipe incomplete: ${remaining.length} item(s) still present`);
+    }
+    logger.log('Sandbox project is clean');
+}
+
+main().catch(error => {
+    console.error('Wipe failed:', error?.message || error);
+    process.exit(1);
+});

--- a/packages/e2e-utils/src/index.ts
+++ b/packages/e2e-utils/src/index.ts
@@ -16,6 +16,7 @@ export { ProjectRequests } from './githubReporter/projectRequests';
 export {
     REPORTER_WATCHDOG_AUTOMATED_SAMPLES,
     REPORTER_WATCHDOG_MANUAL_SAMPLES,
+    REPORTER_WATCHDOG_NATIVE_MANUAL_SAMPLES,
 } from './githubReporter/watchdog/samples';
 export { TestReportProviderBase, createTestAnnotation } from './githubReporter/annotationBase';
 export type { TestDetailsAnnotation, TestMetadataInput } from './githubReporter/types';

--- a/packages/e2e-utils/src/index.ts
+++ b/packages/e2e-utils/src/index.ts
@@ -12,6 +12,11 @@ export { GoogleMock } from './mocks/google';
 export { GitHubReporterBase, InitializationState } from './githubReporter/gitHubReporterBase';
 export { GitHubProject } from './githubReporter/gitHubProject';
 export { IssueRequests } from './githubReporter/issueRequests';
+export { ProjectRequests } from './githubReporter/projectRequests';
+export {
+    REPORTER_WATCHDOG_AUTOMATED_SAMPLES,
+    REPORTER_WATCHDOG_MANUAL_SAMPLES,
+} from './githubReporter/watchdog/samples';
 export { TestReportProviderBase, createTestAnnotation } from './githubReporter/annotationBase';
 export type { TestDetailsAnnotation, TestMetadataInput } from './githubReporter/types';
 export type * from './githubReporter/types';

--- a/suite-native/app/e2e/jest.config.reporter.js
+++ b/suite-native/app/e2e/jest.config.reporter.js
@@ -18,5 +18,9 @@ module.exports = {
     },
     verbose: true,
     reporters: ['<rootDir>/e2e/support/reporter/index.js'],
-    testMatch: ['<rootDir>/e2e/tests/manual/**/*.test.ts'],
+    // In reporter-watchdog mode the synthetic manual specs live in their own reporter-watchdog/ folder instead.
+    testMatch:
+        process.env.REPORTER_WATCHDOG === 'true'
+            ? ['<rootDir>/e2e/reporter-watchdog/**/*.test.ts']
+            : ['<rootDir>/e2e/tests/manual/**/*.test.ts'],
 };

--- a/suite-native/app/e2e/reporter-watchdog/manual/reporterWatchdog.test.ts
+++ b/suite-native/app/e2e/reporter-watchdog/manual/reporterWatchdog.test.ts
@@ -1,0 +1,11 @@
+// Synthetic manual tests for the reporter watchdog. describe.skip + empty bodies => reported as Todo.
+// The /manual/ path segment is what makes the reporter classify them as manual (Jest has no tags).
+import { REPORTER_WATCHDOG_NATIVE_MANUAL_SAMPLES } from '@trezor/e2e-utils';
+
+import { it } from '../../support/wrappedIt';
+
+describe.skip('Reporter watchdog native manual', () => {
+    REPORTER_WATCHDOG_NATIVE_MANUAL_SAMPLES.forEach(sample => {
+        it(sample.testCase, sample, async () => {});
+    });
+});

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -13,7 +13,6 @@
         "test:e2e:web:canary": "yarn xvfb-maybe -- playwright test --config=./playwright-config/playwright-web-local-canary.config.ts",
         "test:orchestrated:e2e": "NODE_OPTIONS='--no-warnings=DEP0040' yarn xvfb-maybe -- pwc-p",
         "github:report:manual": "NODE_OPTIONS='--no-warnings=DEP0040' yarn xvfb-maybe -- playwright test --config=./playwright-config/playwright-manual.config.ts --reporter=./support/reporters/gitHubReporter.ts",
-        "github:create:project": "tsx ./support/reporters/scriptCreateProject.ts",
         "git:bisect": "./scripts/bisect-commits.sh",
         "decode:sol:stake": "tsx ./scripts/decode-sol-staking-account.ts",
         "docker:suite-sync": "./scripts/docker-suite-sync.sh",

--- a/suite/e2e/playwright-config/playwright-manual.config.ts
+++ b/suite/e2e/playwright-config/playwright-manual.config.ts
@@ -2,8 +2,11 @@ import { defineConfig } from '@playwright/test';
 
 import { baseConfig } from './playwright-base.config';
 
+// Real release sanity test reporter discovers the manual tests under tests/.
+// In reporter-watchdog mode the synthetic manual specs live in their own reporter-watchdog/ folder instead.
 const config = defineConfig({
     ...baseConfig,
+    testDir: process.env.REPORTER_WATCHDOG === 'true' ? '../reporter-watchdog' : '../tests',
     projects: [
         {
             name: 'manual',

--- a/suite/e2e/playwright-config/playwright-reporter-watchdog.config.ts
+++ b/suite/e2e/playwright-config/playwright-reporter-watchdog.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@playwright/test';
+
+import { baseConfig } from './playwright-base.config';
+
+// Runs the automated watchdog synthetic tests; grepInvert keeps the manual specs out (they run via the real manual path).
+const config = defineConfig({
+    ...baseConfig,
+    testDir: '../reporter-watchdog',
+    projects: [
+        {
+            name: 'reporterWatchdog',
+            grep: /@reporterWatchdog/,
+            grepInvert: /@group=manual/,
+        },
+    ],
+});
+
+/* eslint-disable-next-line import/no-default-export */
+export default config;

--- a/suite/e2e/reporter-watchdog/reporter-watchdog.automated.spec.ts
+++ b/suite/e2e/reporter-watchdog/reporter-watchdog.automated.spec.ts
@@ -1,0 +1,11 @@
+// Synthetic automated tests for the reporter watchdog. Bare @playwright/test (no fixtures/tenv/app)
+// so they run instantly. Tagged only @reporterWatchdog, so no real project selects them (see playwright-project-builder).
+import { expect, test } from '@playwright/test';
+
+import { REPORTER_WATCHDOG_AUTOMATED_SAMPLES } from '@trezor/e2e-utils';
+
+REPORTER_WATCHDOG_AUTOMATED_SAMPLES.forEach(sample => {
+    test(sample.testCase, { tag: ['@reporterWatchdog'] }, () => {
+        expect(sample.shouldFail).toBe(false);
+    });
+});

--- a/suite/e2e/reporter-watchdog/reporter-watchdog.manual.spec.ts
+++ b/suite/e2e/reporter-watchdog/reporter-watchdog.manual.spec.ts
@@ -1,0 +1,17 @@
+// Synthetic manual tests for the reporter watchdog. describe.skip + empty bodies => never launch tenv/app,
+// reported as Todo. Tagged @group=manual + @reporterWatchdog so only the real manual path (scoped by testFilter) runs them.
+import { REPORTER_WATCHDOG_MANUAL_SAMPLES } from '@trezor/e2e-utils';
+
+import { test } from '../support/fixtures';
+import { createTestAnnotation } from '../support/reporters/annotations';
+
+// eslint-disable-next-line playwright/no-skipped-test
+test.describe.skip(
+    'Reporter watchdog manual',
+    { tag: ['@group=manual', '@reporterWatchdog'] },
+    () => {
+        REPORTER_WATCHDOG_MANUAL_SAMPLES.forEach(sample => {
+            test(sample.testCase, { annotation: createTestAnnotation(sample) }, async () => {});
+        });
+    },
+);


### PR DESCRIPTION
Nightly + PR-triggered dry-run of the real release-reporting chain (manual + native manual + web/desktop callers, synthetic tests) against the sandbox "Trezor Suite reporter healthcheck" project, with wipe/verify scripts whose read-back is the health verdict.

## Description

The GitHub release reporter only runs once a month, so unrelated changes to the
test framework or CI workflows silently break it and the breakage is discovered
mid-release. This PR adds a watchdog that dry-runs the **real reporter chain**
nightly and on PRs touching the fragile surface, so breakage is caught within ~24h.

### Documentation
packages/e2e-utils/src/githubReporter/watchdog/README.md

### How it works

`test-suite-reporter-watchdog.yml` (cron 22:00 UTC Sun–Thu, `workflow_dispatch`,
path-filtered `pull_request`):

1. **wipe-sandbox** — deletes all items in the sandbox "Trezor Suite reporter
   healthcheck" GitHub Project.
2. Calls the **real release workflows** with a `reporterWatchdog` flag that scopes
   them to synthetic tests and flips the reporter to the sandbox project via the
   `REPORTER_WATCHDOG` env (which also switches the manual Playwright `testDir` and
   the native Jest `testMatch`):
   - **manual (web/desktop)**: 3 `describe.skip` Playwright synthetics → issued as Todo with a full field spread
   - **native manual**: 2 `describe.skip` Jest synthetics → issued as Todo with a full field spread
   - **automated (web + desktop)**: one passing synthetic (no issue) and one
     genuinely failing synthetic (Auto FAIL issue; CI retries exercise `updateIssue`).
     Runs on schedule/dispatch only — **skipped on PRs** so its web build/deploy can't
     clash with the PR's own web deploy to the shared dev S3 path.
3. **verify** — reads the sandbox back and asserts the expected issues/fields (web +
   native manual always; automated only when that leg ran, i.e. not on PRs) plus that
   every issue carries a Release Build. Its exit code is the sole health verdict (the
   Playwright step is `continue-on-error` in watchdog mode since one test fails by design).

### Notes

- Real mode is untouched: the flag defaults `"false"` everywhere and the monthly
  dispatch cannot reach sandbox mode; wipe/verify resolve the sandbox strictly by name.
- Also fixes a duplicate-issue race in the reporter: retry attempts now reuse the
  in-flight issue creation instead of creating a second issue, and a failed creation
  self-evicts so a later attempt can retry.
- Watchdog runs record to a dedicated Currents project (`iBEsWE`) so the nightly
  synthetic failure stays out of release stats; the manual paths never talk to Currents.
- Worker counts drop to 1+1 in watchdog mode via the `resolve-matrix` job.
- Design details in `packages/e2e-utils/src/githubReporter/watchdog/README.md`.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/reporter-healthcheck/web/](https://dev.suite.sldev.cz/suite-web/reporter-healthcheck/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=reporter-healthcheck&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=reporter-healthcheck&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=reporter-healthcheck&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-18T10:26:59.072Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-18T10:27:40.017Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->