### PR TITLE
ci(definitions): publish Robinhood token definitions

### DIFF
--- a/.github/workflows/release-suite-definitions.yml
+++ b/.github/workflows/release-suite-definitions.yml
@@ -48,8 +48,8 @@ jobs:
           yarn install
           cd suite-common/token-definitions
 
-          yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche
-          yarn coins simple ethereum ethereum-classic polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche cardano solana stellar tron
+          yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche robinhood
+          yarn coins simple ethereum ethereum-classic polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche robinhood cardano solana stellar tron
           yarn coins advanced solana stellar
 
       - name: Build and sign ${{ github.event.inputs.environment }} token-definitions files
@@ -61,8 +61,8 @@ jobs:
           yarn install
           cd suite-common/token-definitions
 
-          yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche
-          yarn coins simple ethereum ethereum-classic polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche cardano solana stellar tron
+          yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche robinhood
+          yarn coins simple ethereum ethereum-classic polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche robinhood cardano solana stellar tron
           yarn coins advanced solana stellar
 
       - name: Upload ${{ github.event.inputs.environment }} token-definitions files


### PR DESCRIPTION
## Description

- Add CoinGecko platform `robinhood` to simple coin and NFT definition generation.
- Apply the platform to both token-definition build stages.
- Split this workflow change from #29939 so definition publishing can be reviewed independently from Suite network support.

## Changelog

No changelog entry needed.

## Testing

- Parsed `.github/workflows/release-suite-definitions.yml` as YAML.
- Confirmed the workflow passes Prettier validation and `git diff --check`.
- No unit tests were added because this is a workflow-only configuration change.

## UI changes

No UI changes.

## Risk and rollout notes

- The workflow depends on the `robinhood` CoinGecko platform returning supported token data.
- Both the generated coin and NFT definition sets are affected.
- The change does not enable Robinhood Chain in Suite; network support remains scoped to #29939.

## Related context

- Split from #29939.
- [Robinhood Chain token contracts](https://docs.robinhood.com/chain/contracts/)

Notes for QA 
- follow the main PR description https://github.com/trezor/trezor-suite/pull/29939
