### PR TITLE
feat(suite): unify asset icon + network badge (web)

### DIFF
--- a/packages/product-components/src/components/AssetIcon/AssetIcon.stories.tsx
+++ b/packages/product-components/src/components/AssetIcon/AssetIcon.stories.tsx
@@ -1,0 +1,102 @@
+import { type Meta, type StoryObj } from '@storybook/react';
+
+import { getFramePropsStory } from '@trezor/components';
+
+import { AssetIcon as AssetIconComponent, type AssetIconProps } from './AssetIcon';
+import { allowedAssetLogoFrameProps, allowedAssetLogoSizes } from '../AssetLogo/AssetLogoWithId';
+
+const NETWORK_SYMBOLS = [
+    'btc',
+    'eth',
+    'pol',
+    'bsc',
+    'arb',
+    'base',
+    'op',
+    'avax',
+    'sol',
+    'trx',
+    'ada',
+    'xrp',
+    'ltc',
+    'doge',
+] as const;
+
+const meta: Meta<AssetIconProps> = {
+    title: 'AssetIcon',
+    component: AssetIconComponent,
+    argTypes: {
+        ...getFramePropsStory(allowedAssetLogoFrameProps).argTypes,
+        size: {
+            options: allowedAssetLogoSizes,
+            control: { type: 'select' },
+        },
+        symbol: {
+            options: NETWORK_SYMBOLS,
+            control: { type: 'select' },
+        },
+        contractAddress: {
+            control: { type: 'text' },
+        },
+        placeholder: {
+            control: { type: 'text' },
+        },
+        shouldTryToFetch: {
+            control: { type: 'boolean' },
+        },
+        isBordered: {
+            control: { type: 'boolean' },
+        },
+    },
+};
+
+export default meta;
+
+export const NativeSingleAsset: StoryObj<AssetIconProps> = {
+    args: {
+        size: 40,
+        symbol: 'btc',
+        placeholder: 'BTC',
+        ...getFramePropsStory(allowedAssetLogoFrameProps).args,
+    },
+};
+
+export const NativeTokenNetwork: StoryObj<AssetIconProps> = {
+    args: {
+        size: 40,
+        symbol: 'eth',
+        placeholder: 'ETH',
+        ...getFramePropsStory(allowedAssetLogoFrameProps).args,
+    },
+};
+
+export const Token: StoryObj<AssetIconProps> = {
+    args: {
+        size: 40,
+        symbol: 'eth',
+        contractAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC on Ethereum
+        placeholder: 'USDC',
+        shouldTryToFetch: true,
+        ...getFramePropsStory(allowedAssetLogoFrameProps).args,
+    },
+};
+
+export const SmallNoBadge: StoryObj<AssetIconProps> = {
+    args: {
+        size: 20,
+        symbol: 'eth',
+        placeholder: 'ETH',
+        ...getFramePropsStory(allowedAssetLogoFrameProps).args,
+    },
+};
+
+export const UnknownSymbolFallback: StoryObj<AssetIconProps> = {
+    args: {
+        size: 40,
+        symbol: 'eth',
+        contractAddress: '0x0000000000000000000000000000000000000001',
+        placeholder: 'XYZ',
+        shouldTryToFetch: false,
+        ...getFramePropsStory(allowedAssetLogoFrameProps).args,
+    },
+};

--- a/packages/product-components/src/components/AssetIcon/AssetIcon.tsx
+++ b/packages/product-components/src/components/AssetIcon/AssetIcon.tsx
@@ -1,0 +1,68 @@
+import { isCryptoIconSymbol, isNetworkIconSymbol } from '@suite-common/icons/src/iconUtils';
+import {
+    type NetworkSymbol,
+    getNetworkOptional,
+    shouldShowNetworkBadge,
+} from '@suite-common/wallet-config';
+import { Box } from '@trezor/components';
+
+import { AssetLogo } from '../AssetLogo/AssetLogo';
+import { type AllowedFrameProps, type AssetLogoSize } from '../AssetLogo/AssetLogoWithId';
+import { CoinLogo } from '../CoinLogo/CoinLogo';
+import { NetworkIconBadge } from '../NetworkIcon/NetworkIconBadge';
+
+export type AssetIconProps = AllowedFrameProps & {
+    symbol: NetworkSymbol;
+    contractAddress?: string | null;
+    size: AssetLogoSize;
+    placeholder?: string;
+    placeholderWithTooltip?: boolean;
+    shouldTryToFetch?: boolean;
+    isBordered?: boolean;
+    customLogoUrl?: string;
+    'data-testid'?: string;
+};
+
+export const AssetIcon = ({
+    symbol,
+    contractAddress,
+    size,
+    placeholder,
+    placeholderWithTooltip,
+    shouldTryToFetch,
+    isBordered,
+    customLogoUrl,
+    margin,
+    'data-testid': dataTestId,
+}: AssetIconProps) => {
+    const nativeCoinSymbol = getNetworkOptional(symbol)?.settlementLayer ?? symbol;
+
+    const disc =
+        !contractAddress && isCryptoIconSymbol(nativeCoinSymbol) ? (
+            <CoinLogo symbol={nativeCoinSymbol} type="token" size={size} data-testid={dataTestId} />
+        ) : (
+            <AssetLogo
+                symbol={symbol}
+                contractAddress={contractAddress}
+                size={size}
+                placeholder={placeholder}
+                placeholderWithTooltip={placeholderWithTooltip}
+                shouldTryToFetch={shouldTryToFetch}
+                isBordered={isBordered}
+                customLogoUrl={customLogoUrl}
+                showNetworkIcon={false}
+                data-testid={dataTestId}
+            />
+        );
+
+    const content =
+        shouldShowNetworkBadge(symbol) && isNetworkIconSymbol(symbol) ? (
+            <NetworkIconBadge networkSymbol={symbol} parentSize={size}>
+                {disc}
+            </NetworkIconBadge>
+        ) : (
+            disc
+        );
+
+    return <Box margin={margin}>{content}</Box>;
+};

--- a/packages/product-components/src/components/AssetLogo/assetLogoUtils.ts
+++ b/packages/product-components/src/components/AssetLogo/assetLogoUtils.ts
@@ -1,11 +1,4 @@
-import { isNetworkIconSymbol } from '@suite-common/icons/src/iconUtils';
-import {
-    type NetworkSymbolExtended,
-    getNetwork,
-    getNetworkByCoingeckoId,
-    getNetworkFeatures,
-    isNetworkSymbol,
-} from '@suite-common/wallet-config';
+import { getNetwork, getNetworkByCoingeckoId, isNetworkSymbol } from '@suite-common/wallet-config';
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
@@ -19,19 +12,6 @@ export const makeCacheKey = (coingeckoId: string, addressesKey: string) =>
 
 export const makeAddressKey = (coingeckoId: string, address: string) =>
     `${coingeckoId}::${address}`;
-
-export function shouldShowNetworkIcon(
-    networkSymbol?: NetworkSymbolExtended,
-    contractAddress?: string | null,
-) {
-    return (
-        networkSymbol &&
-        isNetworkIconSymbol(networkSymbol) &&
-        isNetworkSymbol(networkSymbol) &&
-        Boolean(contractAddress) &&
-        getNetworkFeatures(networkSymbol).includes('tokens')
-    );
-}
 
 export const getCoingeckoIdAndContractAddressIncludesNativeTokens = (
     coingeckoId: string,

--- a/packages/product-components/src/components/TopAssets/TopAssets.tsx
+++ b/packages/product-components/src/components/TopAssets/TopAssets.tsx
@@ -1,9 +1,8 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Card, Column, GhostContainer, Row, Text } from '@trezor/components';
 
-import { AssetLogo } from '../AssetLogo/AssetLogo';
+import { AssetIcon } from '../AssetIcon/AssetIcon';
 import { type AssetLogoProps } from '../AssetLogo/AssetLogoWithId';
-import { CoinLogo } from '../CoinLogo/CoinLogo';
 
 export type Asset = {
     id: string;
@@ -47,21 +46,12 @@ export function TopAssets({
                         cursor="pointer"
                     >
                         <Column alignItems="center" justifyContent="center" gap={4}>
-                            {asset.isNativeToken ? (
-                                <CoinLogo
-                                    size={logoSize}
-                                    // @ts-expect-error
-                                    symbol={asset.symbol}
-                                    type="tokenWithNetwork"
-                                />
-                            ) : (
-                                <AssetLogo
-                                    size={logoSize}
-                                    symbol={asset.networkSymbol}
-                                    contractAddress={asset.contractAddress}
-                                    placeholder={asset.displaySymbol}
-                                />
-                            )}
+                            <AssetIcon
+                                size={logoSize}
+                                symbol={asset.networkSymbol}
+                                contractAddress={asset.contractAddress}
+                                placeholder={asset.displaySymbol}
+                            />
                             <Text typographyStyle="body-sm" intent="neutral">
                                 {asset.displaySymbol}
                             </Text>

--- a/packages/product-components/src/index.ts
+++ b/packages/product-components/src/index.ts
@@ -25,6 +25,8 @@ export { type ModelFor, type ColorsFor } from './components/DeviceAnimation/devi
 export { DeviceWithScene } from './components/DeviceWithScene/DeviceWithScene';
 export { getModelFrontColor, getLargeModelImagePath } from './utils/getModelFrontColor';
 export { DataAnalytics } from './components/DataAnalytics';
+export { AssetIcon, type AssetIconProps } from './components/AssetIcon/AssetIcon';
+export { shouldShowNetworkBadge } from '@suite-common/wallet-config';
 export { AssetLogo } from './components/AssetLogo/AssetLogo';
 export { AssetLogoWithId } from './components/AssetLogo/AssetLogoWithId';
 export {
@@ -33,7 +35,6 @@ export {
     type AssetLogoSize,
     allowedAssetLogoSizes,
 } from './components/AssetLogo/AssetLogoWithId';
-export { shouldShowNetworkIcon } from './components/AssetLogo/assetLogoUtils';
 export { isNetworkIconSymbol as isNetworkSymbolWithIcon } from '@suite-common/icons/src/iconUtils';
 export * from './components/TopAssets/TopAssets';
 export { ExchangeInfoNotification } from './components/Notifications/ExchangeInfoNotification';

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetDetails.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetDetails.tsx
@@ -1,24 +1,17 @@
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import {
+    type NetworkSymbol,
+    getNetwork,
+    shouldShowNetworkBadge,
+} from '@suite-common/wallet-config';
 import { Badge, Column, Row, Text } from '@trezor/components';
-import { hasOwn } from '@trezor/utils';
 
 type AssetDetailsProps = {
     name: string;
     displaySymbol: string;
-} & (
-    | {
-          networkSymbol: NetworkSymbol;
-      }
-    | {
-          networkName: string;
-      }
-);
+    networkSymbol: NetworkSymbol;
+};
 
-export function AssetDetails({ name, displaySymbol, ...props }: AssetDetailsProps) {
-    const badge = hasOwn(props, 'networkSymbol')
-        ? getNetwork(props.networkSymbol).name
-        : props.networkName;
-
+export function AssetDetails({ name, displaySymbol, networkSymbol }: AssetDetailsProps) {
     return (
         <Column overflow="hidden" alignItems="flex-start" justifyContent="flex-start">
             <Text typographyStyle="body-md" ellipsisLineCount={1} maxWidth="100%">
@@ -28,7 +21,9 @@ export function AssetDetails({ name, displaySymbol, ...props }: AssetDetailsProp
                 <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
                     {displaySymbol}
                 </Text>
-                {badge !== name && <Badge size="small">{badge}</Badge>}
+                {shouldShowNetworkBadge(networkSymbol) && (
+                    <Badge size="small">{getNetwork(networkSymbol).name}</Badge>
+                )}
             </Row>
         </Column>
     );

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AssetRowAccountWithBalance.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AssetRowAccountWithBalance.tsx
@@ -1,8 +1,9 @@
 import { getDisplaySymbol, getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
-import { Column, Row, Text } from '@trezor/components';
-import { CoinLogo } from '@trezor/product-components';
+import { Row } from '@trezor/components';
+import { AssetIcon } from '@trezor/product-components';
 
+import { AssetDetails } from '../AssetDetails';
 import { ItemClickableContainer } from '../ItemClickableContainer';
 import { AccountAmount } from './AccountAmount';
 
@@ -20,15 +21,12 @@ export function AssetRowAccountWithBalance({
     return (
         <ItemClickableContainer onClick={() => onClick(account)}>
             <Row data-testid={dataTestId} gap={12} alignItems="center" overflow="hidden">
-                <CoinLogo symbol={account.symbol} size={40} type="tokenWithNetwork" />
-                <Column overflow="hidden" alignItems="flex-start" justifyContent="flex-start">
-                    <Text typographyStyle="body-md" ellipsisLineCount={1} maxWidth="100%">
-                        {getNetworkDisplaySymbolName(account.symbol)}
-                    </Text>
-                    <Text intent="neutral" priority="secondary" typographyStyle="body-sm">
-                        {getDisplaySymbol(account.symbol)}
-                    </Text>
-                </Column>
+                <AssetIcon symbol={account.symbol} size={40} />
+                <AssetDetails
+                    name={getNetworkDisplaySymbolName(account.symbol)}
+                    displaySymbol={getDisplaySymbol(account.symbol)}
+                    networkSymbol={account.symbol}
+                />
             </Row>
             <AccountAmount account={account} />
         </ItemClickableContainer>

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAsset/AssetRowAsset.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAsset/AssetRowAsset.tsx
@@ -1,6 +1,6 @@
 import { type TradingAssetOption } from '@suite-common/trading';
 import { Row } from '@trezor/components';
-import { AssetLogo, CoinLogo, shouldShowNetworkIcon } from '@trezor/product-components';
+import { AssetIcon } from '@trezor/product-components';
 
 import { AssetDetails } from '../AssetDetails';
 import { ItemClickableContainer } from '../ItemClickableContainer';
@@ -19,24 +19,16 @@ export function AssetRowAsset({ asset, dataTestId, onClick }: AssetRowAssetProps
             }}
         >
             <Row data-testid={dataTestId} gap={12} overflow="hidden" maxWidth="100%">
-                {asset.isNativeToken ? (
-                    <CoinLogo size={40} symbol={asset.symbol} type="tokenWithNetwork" />
-                ) : (
-                    <AssetLogo
-                        size={40}
-                        symbol={asset.networkSymbol}
-                        contractAddress={asset.contractAddress}
-                        placeholder={asset.displaySymbol}
-                        showNetworkIcon={shouldShowNetworkIcon(
-                            asset.networkSymbol,
-                            asset.contractAddress,
-                        )}
-                    />
-                )}
+                <AssetIcon
+                    size={40}
+                    symbol={asset.networkSymbol}
+                    contractAddress={asset.contractAddress}
+                    placeholder={asset.displaySymbol}
+                />
                 <AssetDetails
                     name={asset.displaySymbolName ?? asset.name}
                     displaySymbol={asset.displaySymbol}
-                    networkName={asset.networkName}
+                    networkSymbol={asset.networkSymbol}
                 />
             </Row>
         </ItemClickableContainer>

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx
@@ -1,7 +1,7 @@
 import { getDisplaySymbol } from '@suite-common/wallet-config';
 import { type Account, asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { Row } from '@trezor/components';
-import { AssetLogo, shouldShowNetworkIcon } from '@trezor/product-components';
+import { AssetIcon } from '@trezor/product-components';
 
 import { type TokensWithRates } from 'src/utils/wallet/tokenUtils';
 
@@ -33,12 +33,11 @@ export function AssetRowToken({
             isDisabled={!onClick}
         >
             <Row data-testid={dataTestId} gap={12} overflow="hidden" flex="1" minWidth={0}>
-                <AssetLogo
+                <AssetIcon
                     size={40}
                     symbol={account.symbol}
                     contractAddress={token.contract}
                     placeholder={getDisplaySymbol(token.symbol!, token.contract)}
-                    showNetworkIcon={shouldShowNetworkIcon(account.symbol, token.contract)}
                 />
                 <AssetDetails
                     name={token.name!}

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/__tests__/AssetDetails.badge.test.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/__tests__/AssetDetails.badge.test.tsx
@@ -1,0 +1,54 @@
+import { render } from '@testing-library/react';
+
+import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
+
+import { ThemeProvider } from 'src/support/suite/ThemeProvider';
+
+import { AssetDetails } from '../AssetDetails';
+
+const renderAD = (ui: React.ReactElement) =>
+    render(<ThemeProvider themeVariant="light">{ui}</ThemeProvider>);
+
+describe('AssetDetails network chip', () => {
+    it('native base shows "Base" network chip', () => {
+        const { queryByText } = renderAD(
+            <AssetDetails
+                name={getNetworkDisplaySymbolName('base')}
+                displaySymbol="ETH"
+                networkSymbol="base"
+            />,
+        );
+        expect(queryByText('Base')).toBeTruthy();
+    });
+
+    it('native eth shows "Ethereum" chip too (token-network, uniform rule)', () => {
+        const { getAllByText } = renderAD(
+            <AssetDetails
+                name={getNetworkDisplaySymbolName('eth')}
+                displaySymbol="ETH"
+                networkSymbol="eth"
+            />,
+        );
+        // "Ethereum" appears twice: as the name and as the network chip
+        expect(getAllByText('Ethereum')).toHaveLength(2);
+    });
+
+    it('token USDC on eth shows "Ethereum" chip', () => {
+        const { queryByText } = renderAD(
+            <AssetDetails name="USDC" displaySymbol="USDC" networkSymbol="eth" />,
+        );
+        expect(queryByText('Ethereum')).toBeTruthy();
+    });
+
+    it('native btc (single-asset) shows no network chip', () => {
+        const { queryByText } = renderAD(
+            <AssetDetails
+                name={getNetworkDisplaySymbolName('btc')}
+                displaySymbol="BTC"
+                networkSymbol="btc"
+            />,
+        );
+        // Only the name "Bitcoin" is rendered, no network chip
+        expect(queryByText('Bitcoin')).toBeTruthy();
+    });
+});

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/__tests__/AssetIcon.test.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/__tests__/AssetIcon.test.tsx
@@ -1,0 +1,41 @@
+import { render } from '@testing-library/react';
+
+import { AssetIcon } from '@trezor/product-components';
+
+jest.mock('react-svg', () => ({
+    ReactSVG: ({ src }: { src: unknown }) => <span data-svg="1" data-src={String(src)} />,
+}));
+
+jest.mock('@suite-common/icons/src/cryptoIcons', () => ({
+    cryptoIcons: new Proxy({}, { get: (_t, key) => `coin:${String(key)}` }),
+}));
+
+jest.mock('@suite-common/icons/src/networkIcons', () => ({
+    networkIcons: new Proxy({}, { get: (_t, key) => `net:${String(key)}` }),
+}));
+
+const iconSrcs = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('[data-svg="1"]')).map(n => n.getAttribute('data-src'));
+
+describe('AssetIcon', () => {
+    it('native L2 coin renders settlement-layer disc + own network badge', () => {
+        // Base settles on Ethereum → ETH coin disc, Base network badge
+        const { container } = render(<AssetIcon symbol="base" size={40} placeholder="ETH" />);
+        expect(iconSrcs(container)).toEqual(['coin:eth', 'net:base']);
+    });
+
+    it('native L1 token-network coin renders disc + (redundant) own network badge', () => {
+        const { container } = render(<AssetIcon symbol="eth" size={40} placeholder="ETH" />);
+        expect(iconSrcs(container)).toEqual(['coin:eth', 'net:eth']);
+    });
+
+    it('native single-asset coin renders disc without a network badge', () => {
+        const { container } = render(<AssetIcon symbol="btc" size={40} placeholder="BTC" />);
+        expect(iconSrcs(container)).toEqual(['coin:btc']);
+    });
+
+    it('renders no badge below the minimum parent size', () => {
+        const { container } = render(<AssetIcon symbol="eth" size={20} placeholder="ETH" />);
+        expect(iconSrcs(container)).toEqual(['coin:eth']);
+    });
+});

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx
@@ -13,12 +13,7 @@ import {
 } from '@suite-common/wallet-types';
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { Card, Column, Divider, H4, InfoItem, Row, Text } from '@trezor/components';
-import {
-    AssetLogo,
-    CoinLogo,
-    isCoinSymbol,
-    shouldShowNetworkIcon,
-} from '@trezor/product-components';
+import { AssetIcon } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
 import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
@@ -60,31 +55,16 @@ const TransactionReviewOutputAssetsCryptoCurrency = ({
             : network.displaySymbol,
     );
 
-    const renderAssetLogo = () => {
-        if (contractAddress) {
-            return (
-                <AssetLogo
-                    size={24}
-                    symbol={symbol}
-                    contractAddress={contractAddress}
-                    placeholder={displaySymbol ?? ''}
-                    showNetworkIcon={shouldShowNetworkIcon(symbol, contractAddress)}
-                />
-            );
-        }
-
-        if (isCoinSymbol(symbol)) {
-            return <CoinLogo size={24} symbol={symbol} type="tokenWithNetwork" />;
-        }
-
-        return null;
-    };
-
     return (
         <InfoItem
             label={
                 <Row alignItems="center" gap={12} margin={{ left: 32 }}>
-                    {renderAssetLogo()}
+                    <AssetIcon
+                        size={24}
+                        symbol={symbol}
+                        contractAddress={contractAddress}
+                        placeholder={displaySymbol ?? ''}
+                    />
                     <Text
                         intent={type === 'receive' ? 'brand' : 'critical'}
                         data-testid={`@modal/assets/${type}/crypto`}

--- a/packages/suite/src/types/trading/trading.ts
+++ b/packages/suite/src/types/trading/trading.ts
@@ -72,9 +72,8 @@ export interface TradingCryptoListProps {
 
 export type TradingCoinLogoProps = {
     cryptoId: CryptoId;
-    className?: string;
     size?: AssetLogoProps['size'];
-} & Pick<AssetLogoProps, 'showNetworkIcon' | 'margin'>;
+} & Pick<AssetLogoProps, 'margin'>;
 
 export interface TradingGetAmountLabelsProps {
     type: TradingType;

--- a/packages/suite/src/views/wallet/trading/common/TradingCoinLogo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingCoinLogo.tsx
@@ -1,35 +1,22 @@
-import styled from 'styled-components';
-
 import { parseCryptoId } from '@suite-common/trading';
 import { getNetworkByCoingeckoId } from '@suite-common/wallet-config';
-import { AssetLogo } from '@trezor/product-components';
+import { AssetIcon } from '@trezor/product-components';
 
 import { type TradingCoinLogoProps } from 'src/types/trading/trading';
 
-const Wrapper = styled.div``;
-
-export const TradingCoinLogo = ({
-    cryptoId,
-    size = 24,
-    margin,
-    className,
-    showNetworkIcon,
-}: TradingCoinLogoProps) => {
+export const TradingCoinLogo = ({ cryptoId, size = 24, margin }: TradingCoinLogoProps) => {
     const { networkId, contractAddress } = parseCryptoId(cryptoId);
     const networkSymbol = getNetworkByCoingeckoId(networkId)?.symbol;
 
     if (!networkSymbol) return null;
 
     return (
-        <Wrapper className={className}>
-            <AssetLogo
-                symbol={networkSymbol}
-                contractAddress={contractAddress}
-                size={size}
-                placeholder={networkId.toUpperCase()}
-                margin={margin}
-                showNetworkIcon={showNetworkIcon}
-            />
-        </Wrapper>
+        <AssetIcon
+            symbol={networkSymbol}
+            contractAddress={contractAddress}
+            size={size}
+            placeholder={networkId.toUpperCase()}
+            margin={margin}
+        />
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputContent.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputContent.tsx
@@ -6,7 +6,7 @@ import {
     type TradingAssetSellOption,
 } from '@suite-common/trading';
 import { Column, Row, Text } from '@trezor/components';
-import { AssetLogo, CoinLogo } from '@trezor/product-components';
+import { AssetIcon, shouldShowNetworkBadge } from '@trezor/product-components';
 
 export type AssetPickerInputContentProps = {} & (
     | {
@@ -22,31 +22,18 @@ export type AssetPickerInputContentProps = {} & (
 );
 
 export function AssetPickerInputContent({ value }: AssetPickerInputContentProps) {
-    const {
-        isNativeToken,
-        networkSymbol,
-        symbol,
-        displaySymbol,
-        name,
-        contractAddress,
-        networkName,
-        displaySymbolName,
-    } = value;
-    const showNetwork = networkSymbol !== displaySymbol.toLowerCase();
+    const { networkSymbol, displaySymbol, name, contractAddress, networkName, displaySymbolName } =
+        value;
+    const showNetwork = shouldShowNetworkBadge(networkSymbol);
 
     return (
         <Row gap={12}>
-            {isNativeToken ? (
-                <CoinLogo size={32} symbol={symbol} type="tokenWithNetwork" />
-            ) : (
-                <AssetLogo
-                    size={32}
-                    symbol={networkSymbol}
-                    contractAddress={contractAddress}
-                    placeholder={displaySymbol}
-                    showNetworkIcon={showNetwork}
-                />
-            )}
+            <AssetIcon
+                size={32}
+                symbol={networkSymbol}
+                contractAddress={contractAddress}
+                placeholder={displaySymbol}
+            />
             <Column alignItems="start">
                 <Text
                     intent="neutral"

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
@@ -7,7 +7,7 @@ import { cryptoIdToNetworkSymbolAndContractAddress, useTradingAssets } from '@su
 import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { Card, Column, Row, Skeleton, Text } from '@trezor/components';
-import { AssetLogo, CoinLogo } from '@trezor/product-components';
+import { AssetIcon, shouldShowNetworkBadge } from '@trezor/product-components';
 
 import { BaseCurrencyValue } from 'src/components/suite';
 import { type TradingPayGetLabelType } from 'src/types/trading/trading';
@@ -43,20 +43,12 @@ export const TradingInfoItem = ({
     const isExternalAddress = !account && !!receiveAddress;
     const testIdPrefix = `@trading/detail/${isReceive ? 'receive' : 'send'}`;
 
-    const {
-        id,
-        isNativeToken,
-        networkSymbol,
-        name,
-        displaySymbol,
-        networkName,
-        contractAddress,
-        symbol,
-    } = createAssetOptionFromCryptoId(currency);
+    const { id, isNativeToken, networkSymbol, name, displaySymbol, networkName, contractAddress } =
+        createAssetOptionFromCryptoId(currency);
 
     const displayName = isNativeToken ? getNetworkDisplaySymbolName(networkSymbol) : name;
 
-    const showNetwork = networkSymbol !== displaySymbol.toLowerCase();
+    const showNetwork = shouldShowNetworkBadge(networkSymbol);
 
     if (!amount || !currency) return null;
 
@@ -98,17 +90,12 @@ export const TradingInfoItem = ({
                 <Card type="contrast" paddingType="none">
                     <Row padding={16} gap={8} justifyContent="space-between">
                         <Row gap={8} alignItems="center">
-                            {isNativeToken ? (
-                                <CoinLogo size={40} symbol={symbol} type="tokenWithNetwork" />
-                            ) : (
-                                <AssetLogo
-                                    size={40}
-                                    symbol={networkSymbol}
-                                    contractAddress={contractAddress}
-                                    placeholder={displaySymbol}
-                                    showNetworkIcon={showNetwork}
-                                />
-                            )}
+                            <AssetIcon
+                                size={40}
+                                symbol={networkSymbol}
+                                contractAddress={contractAddress}
+                                placeholder={displaySymbol}
+                            />
                             <Column alignItems="start">
                                 <Text data-testid={`${testIdPrefix}-asset-name`}>
                                     {displayName}

--- a/suite-common/wallet-config/src/__tests__/utils.test.ts
+++ b/suite-common/wallet-config/src/__tests__/utils.test.ts
@@ -9,6 +9,7 @@ import {
     isAccountBasedNetwork,
     isAccountOfNetwork,
     isNetworkUsingExternalBackend,
+    shouldShowNetworkBadge,
 } from '../utils';
 
 const { btc: bitcoin, eth: ethereum, test: testnet, regtest } = networks;
@@ -124,5 +125,31 @@ describe(getNetworksWithMevProtection.name, () => {
 describe(getNetworksWithNativeTokenReserve.name, () => {
     it('returns string with all networks with native token reserve', () => {
         expect(getNetworksWithNativeTokenReserve()).toEqual('Base, Optimism, Solana');
+    });
+});
+
+describe(shouldShowNetworkBadge.name, () => {
+    it.each<NetworkSymbol>(['btc', 'ltc', 'bch', 'doge'])(
+        'returns false for single-asset network %s',
+        symbol => {
+            expect(shouldShowNetworkBadge(symbol)).toBe(false);
+        },
+    );
+
+    it.each<NetworkSymbol>([
+        'eth',
+        'pol',
+        'bsc',
+        'arb',
+        'base',
+        'op',
+        'avax',
+        'sol',
+        'trx',
+        'ada',
+        'etc',
+        'xlm',
+    ])('returns true for token-supporting network %s', symbol => {
+        expect(shouldShowNetworkBadge(symbol)).toBe(true);
     });
 });

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -109,6 +109,9 @@ export const isAccountBasedNetwork = (symbol: NetworkSymbol) => {
 export const getNetworkFeatures = (symbol: NetworkSymbol): NetworkFeature[] =>
     networks[symbol]?.features;
 
+export const shouldShowNetworkBadge = (symbol: NetworkSymbol): boolean =>
+    getNetworkFeatures(symbol).includes('tokens');
+
 export const getCoingeckoId = (symbol: NetworkSymbol) => networks[symbol].coingeckoId;
 
 export const isNetworkSymbol = (symbol: NetworkSymbolExtended): symbol is NetworkSymbol =>


### PR DESCRIPTION
## Description

Replaces the duplicated `isNativeToken ? CoinLogo : AssetLogo` fork (and 5 divergent "show badge?" derivations) with one `AssetIcon` component in `@trezor/product-components`, driven by a single predicate `shouldShowNetworkBadge(symbol)` (= network supports tokens). Badge **and** text label are gated by the same predicate, so they can't disagree.

**Rule:** single-asset networks (btc, ltc, …) → no badge/label. Token-networks (eth, base, pol, …) → badge + label on natives and tokens uniformly. Visible change: native token-network coins now show a badge where they didn't before.

Scope: trading + shared asset-picker rows.

## Notes for QA

Check the network badge/label is consistent across trading pickers/amounts/confirm and asset-picker rows: single-asset coins show nothing, token-networks show badge+label everywhere (incl. native ETH/Base). Testids unchanged.

## Related Issue

#29926

## Follow-ups (separate PRs)

- **suite-native** — same unification (`CryptoIconWithNetwork` / `IconByCryptoId` → consume shared `shouldShowNetworkBadge`)

## Screenshots:
<img width="929" height="557" alt="image" src="https://github.com/user-attachments/assets/30be1609-8120-4a4c-90f5-594b1f99ddd3" />
<img width="587" height="575" alt="image" src="https://github.com/user-attachments/assets/82429819-a63b-4e35-9c58-9862d326b38c" />
<img width="629" height="552" alt="image" src="https://github.com/user-attachments/assets/8e6bd9db-2a0b-4658-b591-f9ea63000c99" />
<img width="638" height="637" alt="image" src="https://github.com/user-attachments/assets/c89bb0b7-fd26-4a4f-b9e5-92ac2798266c" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily affects asset icon/logo rendering components (AssetIcon, AssetLogo, TradingCoinLogo), asset picker row components (AssetDetails, AssetRowAsset, AssetRowToken, AssetRowAccountWithBalance), trading form input components (AssetPickerInputContent, TradingInfoItem), and wallet-config utilities. The risk is concentrated in the trading/swap/buy/sell flows where asset pickers and trade confirmation screens are heavily used. The wallet-config utils.ts and assetLogoUtils.ts are very broadly imported (131 tests each) but likely contain only minor utility changes, so broad testing is unnecessary. The recommended strategy focuses on trading flow tests that directly exercise asset selection, rendering, and trade confirmation UI.

<details><summary><b>Changed files (18)</b></summary>

- `packages/product-components/src/components/AssetIcon/AssetIcon.stories.tsx`
- `packages/product-components/src/components/AssetIcon/AssetIcon.tsx`
- `packages/product-components/src/components/AssetLogo/assetLogoUtils.ts`
- `packages/product-components/src/components/TopAssets/TopAssets.tsx`
- `packages/product-components/src/index.ts`
- `packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetDetails.tsx`
- `packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AssetRowAccountWithBalance.tsx`
- `packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAsset/AssetRowAsset.tsx`
- `packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx`
- `packages/suite/src/components/suite/asset-picker/components/AssetRow/__tests__/AssetDetails.badge.test.tsx`
- `packages/suite/src/components/suite/asset-picker/components/AssetRow/__tests__/AssetIcon.test.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx`
- `packages/suite/src/types/trading/trading.ts`
- `packages/suite/src/views/wallet/trading/common/TradingCoinLogo.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputContent.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx`
- `suite-common/wallet-config/src/__tests__/utils.test.ts`
- `suite-common/wallet-config/src/utils.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test directly exercises the asset picker UI (selecting sell/buy assets, verifying currency tickers, filling crypto amounts) which is rendered by the changed AssetRowAsset, AssetRowToken, AssetRowAccountWithBalance, AssetDetails, and AssetPickerInputContent components. It also validates fraction buttons and balance display, making it the most comprehensive E2E validation of the asset picker changes.
- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates to Buy/Sell/Swap forms from multiple entry points and verifies the correct cryptocurrency name is displayed in each form. It directly exercises AssetPickerInputContent and TradingCoinLogo components, validating that asset icons and labels render correctly across different trading form types.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test exercises the full buy flow including viewing quotes with provider logos (SVG icons), confirming trade details via TradingInfoItem, and asset picker interaction via AssetPickerInputContent. Changes to TradingCoinLogo and TradingInfoItem could affect the visual rendering of the buy confirmation screen.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test fills a swap form selecting sell/buy assets and verifies confirmation details (exchange type, provider name, crypto amounts) rendered by TradingInfoItem. It exercises the asset picker rows and the swap confirmation screen where TradingCoinLogo is used.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — This test swaps a Solana token (USDT) to Bitcoin, exercising the AssetRowToken component for token selection and TradingInfoItem for confirmation details. Token-specific rendering in the asset picker is directly affected by changes to AssetRowToken.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test validates sell form inputs including the currency ticker display and country selector which use AssetPickerInputContent. It also verifies fraction buttons and balance calculations that depend on correct asset row rendering.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test selects a Solana SPL token (Jupiter/JUP) via the asset picker and verifies the buy flow confirmation. It exercises AssetPickerInputContent for token selection and TradingInfoItem for displaying trade details.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This test verifies DEX swap confirmation details including provider name, slippage, minimum received, and crypto amounts rendered by TradingInfoItem. Changes to this component could break the display of these critical swap details.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test verifies sell trade confirmation details including fiat amount, crypto amount, provider, and payment method displayed via TradingInfoItem. The KYC warning and provider logo (SVG) assertion also touches TradingCoinLogo.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test uses the global receive/send flow which opens an asset picker to filter and select accounts. The AssetRowAccountWithBalance component is directly used to render account rows in this picker, and changes could break account selection or labeling display.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test verifies assets display in grid/table views and the 'Activate Assets' modal. TradingCoinLogo and AssetPickerInputContent are used in trading-related components visible from the asset section's buy button flow.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-history.test.ts` — This test views swap trade history details rendered by TradingInfoItem (provider, amounts, status). Changes to this component could affect the display of historical trade details in the sidebar.
- `suite/e2e/tests/trading/buy-negative.test.ts` — This test validates buy form error states and disabled buttons. While it uses AssetPickerInputContent to open the buy modal dropdown, the test focuses on validation logic rather than visual rendering, so the risk is lower.

</details>

⚠️ **Changes with no test coverage (7)**
- `packages/product-components/src/components/AssetIcon/AssetIcon.stories.tsx`
- `packages/product-components/src/components/AssetIcon/AssetIcon.tsx`
- `packages/product-components/src/index.ts`
- `packages/suite/src/components/suite/asset-picker/components/AssetRow/__tests__/AssetDetails.badge.test.tsx`
- `packages/suite/src/components/suite/asset-picker/components/AssetRow/__tests__/AssetIcon.test.tsx`
- `packages/suite/src/types/trading/trading.ts`
- `suite-common/wallet-config/src/__tests__/utils.test.ts`

_Updated: 2026-07-17T08:24:54.232Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/unify-asset-icon-network-badge-29926/web/](https://dev.suite.sldev.cz/suite-web/feat/unify-asset-icon-network-badge-29926/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/unify-asset-icon-network-badge-29926&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/unify-asset-icon-network-badge-29926&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/unify-asset-icon-network-badge-29926&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-17T08:26:59.796Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-17T08:26:57.082Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->