### PR TITLE
refactor(connect): reduce inferred declaration surfaces

### DIFF
--- a/packages/connect-electron/src/index.ts
+++ b/packages/connect-electron/src/index.ts
@@ -18,8 +18,12 @@ const initIpcProxy = async () => {
     proxy = await createIpcProxy<TrezorConnectPrivilegedAPI>('TrezorConnect');
 };
 
+type TrezorConnectElectronAPI = TrezorConnectPrivilegedAPI & {
+    initIpcProxy: () => Promise<void>;
+};
+
 // Exported to enable using directly
-const TrezorConnect = factoryPrivileged({
+const TrezorConnect: TrezorConnectElectronAPI = factoryPrivileged({
     on: getProxy('on'),
     off: getProxy('off'),
     removeAllListeners: getProxy('removeAllListeners'),

--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -8,7 +8,10 @@ import {
 import { type CallMethodPayload, createErrorMessage } from '@trezor/connect-common/src/events';
 import { factoryPublic } from '@trezor/connect-common/src/factory';
 import type { ConnectMobileSettings, Manifest } from '@trezor/connect-common/src/types';
-import type { TrezorConnectCore } from '@trezor/connect-common/src/types/api';
+import type {
+    TrezorConnectCore,
+    TrezorConnectPublicAPI,
+} from '@trezor/connect-common/src/types/api';
 import {
     type CancelParams,
     normalizeCancelParams,
@@ -27,6 +30,10 @@ type BuildUrlParams = {
     connectSrc: string | undefined;
     callbackUrl: string;
     manifest?: Manifest;
+};
+
+type TrezorConnectMobileAPI = TrezorConnectPublicAPI<ConnectMobileSettings> & {
+    handleDeeplink: (url: string) => void;
 };
 
 const buildUrl = ({ method, id, params, connectSrc, callbackUrl, manifest }: BuildUrlParams) => {
@@ -184,7 +191,7 @@ export class TrezorConnectDeeplink implements TrezorConnectCore<ConnectMobileSet
     }
 }
 
-const TrezorConnect = factoryPublic(new TrezorConnectDeeplink());
+const TrezorConnect: TrezorConnectMobileAPI = factoryPublic(new TrezorConnectDeeplink());
 
 // eslint-disable-next-line import/no-default-export
 export default TrezorConnect;

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -1,10 +1,14 @@
 import { factoryPublic } from '@trezor/connect-common/src/factory';
 import { TrezorConnectDynamic } from '@trezor/connect-common/src/impl/dynamic';
+import type {
+    ConnectDynamicSettings,
+    TrezorConnectPublicAPI,
+} from '@trezor/connect-common/src/types';
 
 import { CoreInSuiteDesktop } from './impl/core-in-suite-desktop';
 import { CoreInSuiteWeb } from './impl/core-in-suite-web';
 
-const TrezorConnect = factoryPublic(
+const TrezorConnect: TrezorConnectPublicAPI<ConnectDynamicSettings> = factoryPublic(
     new TrezorConnectDynamic({
         implementations: {
             'core-in-suite-desktop': new CoreInSuiteDesktop(),

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -5,7 +5,10 @@ import { factoryPublic } from '@trezor/connect-common/src/factory';
 import { TrezorConnectDynamic } from '@trezor/connect-common/src/impl/dynamic';
 // Import as src not lib due to webpack issues with inlining content script later
 import { ServiceWorkerWindowChannel } from '@trezor/connect-common/src/messageChannel/serviceworker-window';
-import type { ConnectDynamicSettings } from '@trezor/connect-common/src/types';
+import type {
+    ConnectDynamicSettings,
+    TrezorConnectPublicAPI,
+} from '@trezor/connect-common/src/types';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports -- intra-tier wiring: connect-webextension composes implementations from connect-web (see #27376)
 import { CoreInSuiteDesktop } from '@trezor/connect-web/src/impl/core-in-suite-desktop';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports -- intra-tier wiring: connect-webextension composes implementations from connect-web (see #27376)
@@ -19,7 +22,7 @@ const impl = new TrezorConnectDynamic({
 });
 
 // Bind all methods due to shadowing `this`
-const TrezorConnect = factoryPublic(impl);
+const TrezorConnect: TrezorConnectPublicAPI<ConnectDynamicSettings> = factoryPublic(impl);
 
 const initProxyChannel = () => {
     const channel = new ServiceWorkerWindowChannel<{

--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -2,7 +2,10 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { CORE_CALL, POPUP, createErrorMessage } from '@trezor/connect-common/src/events';
 import { factoryPublic } from '@trezor/connect-common/src/factory';
 import { WindowServiceWorkerChannel } from '@trezor/connect-common/src/messageChannel/window-serviceworker';
-import type { ConnectDynamicSettings } from '@trezor/connect-common/src/types';
+import type {
+    ConnectDynamicSettings,
+    TrezorConnectPublicAPI,
+} from '@trezor/connect-common/src/types';
 import {
     type CancelParams,
     createCoreCallCancelMessage,
@@ -70,7 +73,12 @@ const call = async (params: any) => {
     }
 };
 
-const TrezorConnect = factoryPublic({ init, call, cancel, dispose });
+const TrezorConnect: TrezorConnectPublicAPI<ConnectDynamicSettings> = factoryPublic({
+    init,
+    call,
+    cancel,
+    dispose,
+});
 
 // eslint-disable-next-line import/no-default-export
 export default TrezorConnect;

--- a/packages/connect/src/data/coinInfo.ts
+++ b/packages/connect/src/data/coinInfo.ts
@@ -2,6 +2,7 @@
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import type {
     BitcoinNetworkInfo,
+    CoinInfo,
     CoinSymbol,
     EthereumNetworkInfo,
     MiscNetworkInfo,
@@ -118,7 +119,7 @@ export const fixCoinInfoNetwork = (ci: BitcoinNetworkInfo, path: number[]) => {
 const getCoinInfo = (coin: CoinSymbol) =>
     getBitcoinNetwork(coin) || getEthereumNetwork(coin) || getMiscNetwork(coin);
 
-export const getCoinInfoOrThrow = (coin: string) => {
+export const getCoinInfoOrThrow = (coin: string): Readonly<CoinInfo> => {
     // `coin` is unvalidated caller input; a non-shortcut resolves to undefined below
     const coinInfo = getCoinInfo(coin as CoinSymbol);
     if (!coinInfo) {
@@ -272,7 +273,11 @@ export const getUniqueNetworks = <T extends { shortcut: string }>(networks: (T |
         return result.concat(info);
     }, []);
 
-export const getAllNetworks = () => [...bitcoinNetworks, ...ethereumNetworks, ...miscNetworks];
+export const getAllNetworks = (): CoinInfo[] => [
+    ...bitcoinNetworks,
+    ...ethereumNetworks,
+    ...miscNetworks,
+];
 
 // Populate the network registries from the bundled coin definitions on module load.
 parseCoinsJson({ ...coins, ...coinsEth });

--- a/packages/connect/src/index.browser.ts
+++ b/packages/connect/src/index.browser.ts
@@ -1,9 +1,18 @@
-import { ERRORS, type UpdateConnectSettings, factoryPrivileged } from '@trezor/connect-common';
+import {
+    ERRORS,
+    type TrezorConnectPrivilegedAPI,
+    type UpdateConnectSettings,
+    factoryPrivileged,
+} from '@trezor/connect-common';
 import { type AbstractTransportParams, BridgeTransport, TRANSPORT } from '@trezor/transport-common';
 import { WebUsbTransport } from '@trezor/transport-web';
 
 import { config } from './data/config';
 import { CoreInModule } from './impl/core-in-module';
+
+type TrezorConnectBrowserAPI = TrezorConnectPrivilegedAPI & {
+    requestWebUSBDevice: () => Promise<void>;
+};
 
 class CoreInModuleWeb extends CoreInModule {
     protected defaultTransports(params: AbstractTransportParams) {
@@ -32,7 +41,7 @@ class CoreInModuleWeb extends CoreInModule {
 }
 
 // Exported to enable using directly
-const TrezorConnect = factoryPrivileged(new CoreInModuleWeb());
+const TrezorConnect: TrezorConnectBrowserAPI = factoryPrivileged(new CoreInModuleWeb());
 
 export default TrezorConnect;
 

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,4 +1,8 @@
-import { type UpdateConnectSettings, factoryPrivileged } from '@trezor/connect-common';
+import {
+    type TrezorConnectPrivilegedAPI,
+    type UpdateConnectSettings,
+    factoryPrivileged,
+} from '@trezor/connect-common';
 import { type AbstractTransportParams, BridgeTransport } from '@trezor/transport-common';
 
 import { updateProxy } from './backend/BlockchainLink';
@@ -14,7 +18,7 @@ class CoreInModuleNode extends CoreInModule {
     }
 }
 
-const TrezorConnect = factoryPrivileged(new CoreInModuleNode());
+const TrezorConnect: TrezorConnectPrivilegedAPI = factoryPrivileged(new CoreInModuleNode());
 
 export default TrezorConnect;
 

--- a/suite-common/connect-popup/src/connectPopupActions.ts
+++ b/suite-common/connect-popup/src/connectPopupActions.ts
@@ -11,14 +11,14 @@ import {
 
 const ACTION_PREFIX = '@suite-common/connect-popup';
 
+type InitiateCallPayload = Pick<
+    ConnectPopupCall & { state: 'ongoing' },
+    'method' | 'methodInfo' | 'source' | 'payload'
+>;
+
 const initiateCall = createAction(
     `${ACTION_PREFIX}/initiateCall`,
-    (
-        payload: Pick<
-            ConnectPopupCall & { state: 'ongoing' },
-            'method' | 'methodInfo' | 'source' | 'payload'
-        >,
-    ) => ({
+    (payload: InitiateCallPayload) => ({
         payload,
     }),
 );
@@ -35,65 +35,70 @@ const finishCall = createAction(`${ACTION_PREFIX}/finishCall`);
 
 const clearCall = createAction(`${ACTION_PREFIX}/clearCall`);
 
+type ConfirmAddressesPayload = Pick<
+    ConnectPopupCall & { state: 'address-confirmation' },
+    'addresses' | 'exported'
+>;
+
 const confirmAddresses = createAction(
     `${ACTION_PREFIX}/confirmAddresses`,
-    (
-        payload: Pick<
-            ConnectPopupCall & { state: 'address-confirmation' },
-            'addresses' | 'exported'
-        >,
-    ) => ({
+    (payload: ConfirmAddressesPayload) => ({
         payload,
     }),
 );
+
+type SelectAccountPayload = Pick<
+    ConnectPopupCallWithState<'select-account'>,
+    'options' | 'selectedAccountTypeKey' | 'candidates' | 'page' | 'exported' | 'manualPhase'
+>;
 
 const selectAccount = createAction(
     `${ACTION_PREFIX}/selectAccount`,
-    (
-        payload: Pick<
-            ConnectPopupCallWithState<'select-account'>,
-            | 'options'
-            | 'selectedAccountTypeKey'
-            | 'candidates'
-            | 'page'
-            | 'exported'
-            | 'manualPhase'
-        >,
-    ) => ({
+    (payload: SelectAccountPayload) => ({
         payload,
     }),
 );
+
+type UpdateSelectAccountPayload = Partial<
+    Pick<
+        ConnectPopupCallWithState<'select-account'>,
+        | 'selectedAccountTypeKey'
+        | 'candidates'
+        | 'page'
+        | 'exported'
+        | 'totalCandidates'
+        | 'manualPhase'
+        | 'manualAccountIndex'
+    >
+>;
 
 const updateSelectAccount = createAction(
     `${ACTION_PREFIX}/updateSelectAccount`,
-    (
-        payload: Partial<
-            Pick<
-                ConnectPopupCallWithState<'select-account'>,
-                | 'selectedAccountTypeKey'
-                | 'candidates'
-                | 'page'
-                | 'exported'
-                | 'totalCandidates'
-                | 'manualPhase'
-                | 'manualAccountIndex'
-            >
-        >,
-    ) => ({
+    (payload: UpdateSelectAccountPayload) => ({
         payload,
     }),
 );
+
+type SetSelectedAccountKeyPayload = Pick<
+    ConnectPopupCall & { state: 'ongoing' },
+    'selectedAccountKey'
+>;
 
 const setSelectedAccountKey = createAction(
     `${ACTION_PREFIX}/setSelectedAccountKey`,
-    (payload: Pick<ConnectPopupCall & { state: 'ongoing' }, 'selectedAccountKey'>) => ({
+    (payload: SetSelectedAccountKeyPayload) => ({
         payload,
     }),
 );
 
+type DeeplinkCallbackPayload = Pick<
+    ConnectPopupCall & { state: 'deeplink-callback' },
+    'callbackUrl'
+>;
+
 const deeplinkCallback = createAction(
     `${ACTION_PREFIX}/deeplinkCallback`,
-    (payload: Pick<ConnectPopupCall & { state: 'deeplink-callback' }, 'callbackUrl'>) => ({
+    (payload: DeeplinkCallbackPayload) => ({
         payload,
     }),
 );
@@ -130,16 +135,23 @@ const setAppSilentMode = createAction(
     }),
 );
 
+type TxSimulationPayload = Pick<ConnectPopupCallWithState<'tx-simulation'>, 'fromAddress'>;
+
 const txSimulation = createAction(
     `${ACTION_PREFIX}/txSimulation`,
-    (payload: Pick<ConnectPopupCallWithState<'tx-simulation'>, 'fromAddress'>) => ({
+    (payload: TxSimulationPayload) => ({
         payload,
     }),
 );
 
+type SetSelectedFeePayload = Pick<
+    ConnectPopupCallWithState<'tx-simulation' | 'ongoing'>,
+    'selectedFee'
+>;
+
 const setSelectedFee = createAction(
     `${ACTION_PREFIX}/txSimulationSetFee`,
-    (payload: Pick<ConnectPopupCallWithState<'tx-simulation' | 'ongoing'>, 'selectedFee'>) => ({
+    (payload: SetSelectedFeePayload) => ({
         payload,
     }),
 );

--- a/suite-common/connect-popup/src/connectPopupPromiseManager.ts
+++ b/suite-common/connect-popup/src/connectPopupPromiseManager.ts
@@ -1,6 +1,9 @@
 import { type CallMethodAnyResponse } from '@trezor/connect';
 import { type Deferred, createDeferred } from '@trezor/utils';
 
+type GetDeferred<Resolve> = (clear?: boolean) => Deferred<Resolve>;
+type AwaitDeferred = () => Promise<void>;
+
 // Custom helper, createDeferredManager didn't fit the needs here
 const createDeferredWrapper = <Resolve = void>(id: string) => {
     let _deferred: Deferred<Resolve> | undefined;
@@ -30,9 +33,10 @@ const createDeferredWrapper = <Resolve = void>(id: string) => {
 
 // Deferred for the entire Connect call
 const callDeferredWrapper = createDeferredWrapper<Awaited<CallMethodAnyResponse>>('popup-call');
-export const getPopupCallDeferred = callDeferredWrapper.getDeferred;
-export const queuePopupCall = callDeferredWrapper.awaitDeferred;
+export const getPopupCallDeferred: GetDeferred<Awaited<CallMethodAnyResponse>> =
+    callDeferredWrapper.getDeferred;
+export const queuePopupCall: AwaitDeferred = callDeferredWrapper.awaitDeferred;
 
 // Deferred for the permission request
 const permissionDeferredWrapper = createDeferredWrapper('popup-permission');
-export const getPermissionDeferred = permissionDeferredWrapper.getDeferred;
+export const getPermissionDeferred: GetDeferred<void> = permissionDeferredWrapper.getDeferred;


### PR DESCRIPTION
## Description

Connect entry points, coin metadata helpers, and popup actions inferred implementation-heavy declaration types that increased downstream type-check work. Explicit public API, return, thunk, and promise-manager contracts preserve runtime behavior while keeping emitted declarations at stable package boundaries; the rebase also adopts BridgeTransport from @trezor/transport-common.

- Explicit Connect entry-point contracts: **0 -> 7**
- Files with narrowed declaration surfaces: **0 -> 10**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set touches the core TrezorConnect entrypoints across all platforms (web, webextension, electron, mobile) plus the shared connect-popup action/promise-manager logic and coinInfo data — these are foundational to every TrezorConnect-based interaction (permissions modal, popup lifecycle, address/account/transaction requests). Since coinInfo.ts and index.browser.ts show up in the static mapping for 132 tests (a broad-utility signal), most Suite E2E tests are not meaningfully impacted by this change and were excluded; instead, the focus is on the dedicated trezor-connect/* test suite which directly exercises the popup permission flow, cancellation/close behavior, silent mode, and the various getAddress/getAccountInfo/selectAccount/signTransaction API calls that flow through the changed code. Recommend running the full trezor-connect test suite (high priority for popup/permission-related tests, medium for API-method-specific tests) as the primary confidence check, since the connect-webextension and connect-electron entrypoints have no other statically-mapped coverage.

<details><summary><b>Changed files (10)</b></summary>

- `packages/connect-electron/src/index.ts`
- `packages/connect-mobile/src/index.ts`
- `packages/connect-web/src/index.ts`
- `packages/connect-webextension/src/index.ts`
- `packages/connect-webextension/src/proxy/index.ts`
- `packages/connect/src/data/coinInfo.ts`
- `packages/connect/src/index.browser.ts`
- `packages/connect/src/index.ts`
- `suite-common/connect-popup/src/connectPopupActions.ts`
- `suite-common/connect-popup/src/connectPopupPromiseManager.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test directly exercises the TrezorConnect popup lifecycle (permissions modal, cancellation, popup close/reopen, popup-blocked detection) via connect-web's index.ts, which is directly changed, along with connectPopupActions.ts and connectPopupPromiseManager.ts that manage the popup call/response flow.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test specifically exercises the webextension's TrezorConnect popup flow (getAddress, cancellation, popup close/reopen, focusing existing popup) directly touching connect-webextension/src/index.ts and proxy/index.ts, both changed files, as well as the shared connectPopupActions/promiseManager logic.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Directly tests the permissions modal and remembered-permissions flow that connectPopupActions.ts and connectPopupPromiseManager.ts implement, including the 'Remember' checkbox and forgetting apps, which are core to the changed popup action/promise management code.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests silent-mode behavior of the connect popup (whether Suite is brought to foreground), directly depending on connectPopupActions.ts/connectPopupPromiseManager.ts logic for managing popup permissions and window focus during TrezorConnect calls.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Exercises TrezorConnect.getAddress end-to-end including permissions modal and address confirmation, directly invoking connect/src/index.ts and index.browser.ts entry points that were changed, plus coinInfo.ts for BTC address derivation.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — Exercises TrezorConnect.selectAccount which relies on the core connect index.ts/index.browser.ts entry points and coinInfo for account discovery/derivation, and also flows through the connect popup permission/promise management.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Uses TrezorConnect.getAccountInfo and the permissions modal flow for account selection, exercising the same core connect entrypoints and coinInfo data changed in this PR.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Signs a Bitcoin transaction via TrezorConnect API, going through the changed core connect index files and the permissions modal/popup logic, exercising the transaction-signing code path affected by coinInfo changes.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Exercises TrezorConnect.ethereumSignTransaction through the changed connect index entrypoints and permissions modal, providing coverage for a different coin type (ETH) than the BTC-focused tests.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Exercises TrezorConnect.ethereumSignMessage which also flows through the changed connect entrypoints and permissions modal, but overlaps significantly with other sign/message tests already selected at higher priority.
- `suite/e2e/tests/trezor-connect/error.test.ts` — Verifies error handling in TrezorConnect (invalid derivation path) via the connect index/browser entrypoints in suite-desktop core mode, providing minor additional coverage of core initialization changes.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/connect-mobile/src/index.ts`

_Updated: 2026-07-20T09:30:09.157Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-connect-type-declaration-surfaces/web/](https://dev.suite.sldev.cz/suite-web/fix-connect-type-declaration-surfaces/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-connect-type-declaration-surfaces&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-connect-type-declaration-surfaces&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-connect-type-declaration-surfaces&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-20T09:33:46.753Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-20T09:33:15.488Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->