### PR TITLE
refactor(e2e): toast validation

### DIFF
--- a/packages/product-components/src/components/Notifications/ExchangeInfoNotification.tsx
+++ b/packages/product-components/src/components/Notifications/ExchangeInfoNotification.tsx
@@ -14,6 +14,7 @@ export type ExchangeInfoNotificationProps = {
     send: ExchangeInfoAsset;
     receive: ExchangeInfoAsset;
     renderAmount?: (amount: ReactNode, side: ExchangeInfoAmountSide) => ReactNode;
+    'data-testid'?: string;
 };
 
 export const ExchangeInfoNotification = ({
@@ -21,13 +22,16 @@ export const ExchangeInfoNotification = ({
     send,
     receive,
     renderAmount,
+    'data-testid': dataTestId,
 }: ExchangeInfoNotificationProps) => {
     const sendAmount = renderAmount ? renderAmount(send.amount, 'send') : send.amount;
     const receiveAmount = renderAmount ? renderAmount(receive.amount, 'receive') : receive.amount;
 
     return (
         <Column gap={4}>
-            <Text typographyStyle="body-md-strong">{message}</Text>
+            <Text typographyStyle="body-md-strong" data-testid={`${dataTestId}/message`}>
+                {message}
+            </Text>
             <Row gap={8} alignItems="center">
                 <ExchangeAssetWithFallback asset={send} />
                 <ExchangeAmountWithSymbol amount={sendAmount} asset={send} />

--- a/packages/product-components/src/components/Notifications/TransactionNotification.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionNotification.tsx
@@ -21,6 +21,7 @@ export type TransactionNotificationProps = {
     isInfiniteApproval?: boolean;
     unlimitedApprovalLabel?: ReactNode;
     renderAmount?: (amount: ReactNode) => ReactNode;
+    'data-testid'?: string;
 };
 
 export const TransactionNotification = ({
@@ -34,9 +35,12 @@ export const TransactionNotification = ({
     isInfiniteApproval,
     unlimitedApprovalLabel,
     renderAmount,
+    'data-testid': dataTestId,
 }: TransactionNotificationProps) => (
     <Column gap={4}>
-        <Text typographyStyle="body-md-strong">{message}</Text>
+        <Text typographyStyle="body-md-strong" data-testid={dataTestId && `${dataTestId}/message`}>
+            {message}
+        </Text>
         {amount && (
             <Row gap={8} alignItems="center">
                 <TransactionIcon

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/ExchangeInfoRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/ExchangeInfoRenderer.tsx
@@ -33,6 +33,7 @@ export const ExchangeInfoRenderer = ({ render: View, ...props }: ExchangeInfoRen
             messageValues={{
                 content: (
                     <ExchangeInfoNotification
+                        data-testid="@toast/tx-exchange"
                         message={
                             <Translation
                                 id={props.message}

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
@@ -103,6 +103,7 @@ export const TransactionRenderer = ({ render: View, ...props }: TransactionRende
             messageValues={{
                 content: (
                     <TransactionNotification
+                        data-testid={toastTestIdPrefix}
                         message={
                             <Translation
                                 id={props.message}

--- a/suite/e2e/support/pageObjects/staking/stakingSection.ts
+++ b/suite/e2e/support/pageObjects/staking/stakingSection.ts
@@ -1,10 +1,11 @@
-import { Locator, Page, expect } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 
 import { colorVariants } from '@trezor/theme';
 import { hexToRgba } from '@trezor/utils';
 
 import { RewardsList } from './rewardList';
 import { step } from '../../common';
+import { expect } from '../../testExtends/customMatchers';
 
 export class StakingSection {
     readonly rewardList: RewardsList;
@@ -56,13 +57,13 @@ export class StakingSection {
     readonly fiatTicker: Locator;
     readonly cryptoTicker: Locator;
     readonly stakedToast: Locator;
-    readonly stakedToastAccount: Locator;
+    readonly stakedToastMessage: Locator;
     readonly stakedToastAmount: Locator;
     readonly unstakedToast: Locator;
-    readonly unstakedToastAccount: Locator;
+    readonly unstakedToastMessage: Locator;
     readonly unstakedToastAmount: Locator;
     readonly claimedToast: Locator;
-    readonly claimedToastAccount: Locator;
+    readonly claimedToastMessage: Locator;
     readonly claimedToastAmount: Locator;
     readonly claimRewardsButton: Locator;
     readonly cardanoRewardAmount: Locator;
@@ -134,13 +135,13 @@ export class StakingSection {
         this.fiatTicker = this.page.getByTestId('@staking/form/fiat-input/input-addon');
         this.cryptoTicker = this.page.getByTestId('@staking/form/crypto-input/input-addon');
         this.stakedToast = this.page.getByTestId('@toast/tx-staked');
-        this.stakedToastAccount = this.page.getByTestId('@toast/tx-staked/account');
+        this.stakedToastMessage = this.page.getByTestId('@toast/tx-staked/message');
         this.stakedToastAmount = this.page.getByTestId('@toast/tx-staked/amount');
         this.unstakedToast = this.page.getByTestId('@toast/tx-unstaked');
-        this.unstakedToastAccount = this.page.getByTestId('@toast/tx-unstaked/account');
+        this.unstakedToastMessage = this.page.getByTestId('@toast/tx-unstaked/message');
         this.unstakedToastAmount = this.page.getByTestId('@toast/tx-unstaked/amount');
         this.claimedToast = this.page.getByTestId('@toast/tx-claimed');
-        this.claimedToastAccount = this.page.getByTestId('@toast/tx-claimed/account');
+        this.claimedToastMessage = this.page.getByTestId('@toast/tx-claimed/message');
         this.claimedToastAmount = this.page.getByTestId('@toast/tx-claimed/amount');
         this.claimRewardsButton = this.page.getByTestId('@account/staking/claim-rewards-button');
         this.cardanoRewardAmount = this.page.getByTestId('@account/staking/rewards-with-symbol');
@@ -152,6 +153,46 @@ export class StakingSection {
         );
         this.cardanoStakedFullBalanceText = this.page.getByTestId('@account/staking/full-balance');
         this.claimWarningBanner = this.page.getByTestId('@modal/claim/fee-warning-banner');
+    }
+
+    /**
+     * @param params.type - The staking toast type ('staked' | 'unstaked' | 'claimed')
+     * @param params.account - The account label shown in the toast (e.g., 'Solana #1')
+     * @param params.amount - The expected amount with symbol (e.g., '0.1 SOL')
+     */
+    @step()
+    async verifyStakingToast({
+        type,
+        account,
+        amount,
+    }: {
+        type: 'staked' | 'unstaked' | 'claimed';
+        account: string;
+        amount: string;
+    }) {
+        const toasts = {
+            staked: {
+                messageLocator: this.stakedToastMessage,
+                amountLocator: this.stakedToastAmount,
+                translationKey: 'TOAST_TX_STAKED',
+            },
+            unstaked: {
+                messageLocator: this.unstakedToastMessage,
+                amountLocator: this.unstakedToastAmount,
+                translationKey: 'TOAST_TX_UNSTAKED',
+            },
+            claimed: {
+                messageLocator: this.claimedToastMessage,
+                amountLocator: this.claimedToastAmount,
+                translationKey: 'TOAST_TX_CLAIMED',
+            },
+        } as const;
+        const toast = toasts[type];
+
+        await expect(toast.messageLocator).toHaveTranslation(toast.translationKey, {
+            values: { account },
+        });
+        await expect(toast.amountLocator).toHaveText(amount);
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/suite/e2e/support/pageObjects/trading/tradingPage.ts
@@ -54,8 +54,7 @@ export class TradingPage {
     readonly transactions: TradingTransactionsSection;
 
     // Swap toast notifications
-    readonly swapToastSendAccount: Locator;
-    readonly swapToastReceiveAccount: Locator;
+    readonly swapToastMessage: Locator;
     readonly swapToastSendAmount: Locator;
     readonly swapToastReceiveAmount: Locator;
 
@@ -94,8 +93,7 @@ export class TradingPage {
         this.transactions = new TradingTransactionsSection(page);
 
         // Swap toast notifications
-        this.swapToastSendAccount = this.page.getByTestId('@toast/tx-exchange/send-account');
-        this.swapToastReceiveAccount = this.page.getByTestId('@toast/tx-exchange/receive-account');
+        this.swapToastMessage = this.page.getByTestId('@toast/tx-exchange/message');
         this.swapToastSendAmount = this.page.getByTestId('@toast/tx-exchange/send-amount');
         this.swapToastReceiveAmount = this.page.getByTestId('@toast/tx-exchange/receive-amount');
     }
@@ -333,6 +331,34 @@ export class TradingPage {
         await this.inputs.cryptoAmount.fill(amount);
         await quotesResponsePromise;
         await this.quotes.waitForSync();
+    }
+
+    /**
+     * @param params.sendAccount - The account label the swap is sent from (e.g., 'Solana #1')
+     * @param params.receiveAccount - The account label the swap is received to (e.g., 'Bitcoin #1')
+     * @param params.sendAmount - The expected send amount (e.g., '0.001')
+     * @param params.receiveAmount - The expected receive amount (localized, e.g., '0.00002')
+     */
+    @step()
+    async verifySwapToast({
+        sendAccount,
+        receiveAccount,
+        sendAmount,
+        receiveAmount,
+    }: {
+        sendAccount: string;
+        receiveAccount: string;
+        sendAmount: string;
+        receiveAmount: string;
+    }) {
+        await expect(this.swapToastMessage).toHaveTranslation('TOAST_TX_EXCHANGE_BROADCASTED', {
+            values: {
+                sendAccount,
+                receiveAccount,
+            },
+        });
+        await expect(this.swapToastSendAmount).toHaveText(sendAmount);
+        await expect(this.swapToastReceiveAmount).toHaveText(receiveAmount);
     }
 
     @step()

--- a/suite/e2e/tests/staking/ada/claim.test.ts
+++ b/suite/e2e/tests/staking/ada/claim.test.ts
@@ -261,10 +261,11 @@ test.describe('Staking - Cardano', { tag: ['@T3W1', '@T3T1'] }, () => {
             });
 
             await test.step('Verify claimed and staked account', async () => {
-                await expect(stakingSection.claimedToastAccount).toContainText('Cardano #1');
-                await expect(stakingSection.claimedToastAmount).toContainText(
-                    bigRewardAmountFormatted,
-                );
+                await stakingSection.verifyStakingToast({
+                    type: 'claimed',
+                    account: 'Cardano #1',
+                    amount: bigRewardAmountFormatted,
+                });
                 await expect(stakingSection.claimRewardsButton).toBeDisabled();
                 await expect(stakingSection.unstakeToClaimButton).toBeEnabled();
                 await expect(stakingSection.startStakingButton).toBeHidden();

--- a/suite/e2e/tests/staking/ada/stake.test.ts
+++ b/suite/e2e/tests/staking/ada/stake.test.ts
@@ -249,8 +249,11 @@ test.describe('Staking - Cardano', { tag: ['@T3W1', '@T3T1'] }, () => {
                     },
                 });
                 await devicePrompt.waitForPromptAndConfirm();
-                await expect(stakingSection.stakedToastAccount).toContainText('Cardano #1');
-                await expect(stakingSection.stakedToastAmount).toContainText(finalBalanceFormatted);
+                await stakingSection.verifyStakingToast({
+                    type: 'staked',
+                    account: 'Cardano #1',
+                    amount: finalBalanceFormatted,
+                });
             });
 
             await test.step('Verify account is staked', async () => {

--- a/suite/e2e/tests/staking/ada/unstake.test.ts
+++ b/suite/e2e/tests/staking/ada/unstake.test.ts
@@ -172,10 +172,11 @@ test.describe('Staking - Cardano', { tag: ['@T3W1', '@T3T1'] }, () => {
             });
 
             await test.step('Verify unstaked account', async () => {
-                await expect(stakingSection.unstakedToastAccount).toContainText('Cardano #1');
-                await expect(stakingSection.unstakedToastAmount).toContainText(
-                    unstakedAmountFormatted,
-                );
+                await stakingSection.verifyStakingToast({
+                    type: 'unstaked',
+                    account: 'Cardano #1',
+                    amount: unstakedAmountFormatted,
+                });
                 await expect(walletPage.topPanelBalanceWithSymbol).toHaveText(
                     finalBalanceFormatted,
                 );

--- a/suite/e2e/tests/staking/eth/initial-stake.test.ts
+++ b/suite/e2e/tests/staking/eth/initial-stake.test.ts
@@ -145,10 +145,11 @@ test.describe('ETH staking', { tag: ['@T3W1', '@T3T1'] }, () => {
                     nonce: '2',
                 });
                 await devicePrompt.sendButton.click();
-                await expect(stakingSection.stakedToastAccount).toContainText('Ethereum #1');
-                await expect(stakingSection.stakedToastAmount).toContainText(
-                    '0.100204158497493752 ETH',
-                );
+                await stakingSection.verifyStakingToast({
+                    type: 'staked',
+                    account: 'Ethereum #1',
+                    amount: '0.100204158497493752 ETH',
+                });
             });
 
             await test.step('Verify pending transaction', async () => {

--- a/suite/e2e/tests/staking/eth/stake-more.test.ts
+++ b/suite/e2e/tests/staking/eth/stake-more.test.ts
@@ -178,10 +178,11 @@ test.describe('ETH staking', { tag: ['@T3W1', '@T3T1'] }, () => {
                     nonce: '2',
                 });
                 await devicePrompt.sendButton.click();
-                await expect(stakingSection.stakedToastAccount).toContainText('Ethereum #1');
-                await expect(stakingSection.stakedToastAmount).toContainText(
-                    '0.100204158497493752 ETH',
-                );
+                await stakingSection.verifyStakingToast({
+                    type: 'staked',
+                    account: 'Ethereum #1',
+                    amount: '0.100204158497493752 ETH',
+                });
             });
 
             await test.step('Verify pending transaction', async () => {

--- a/suite/e2e/tests/staking/eth/unstake.test.ts
+++ b/suite/e2e/tests/staking/eth/unstake.test.ts
@@ -107,8 +107,11 @@ test.describe('ETH unstaking and claim', { tag: ['@T3W1', '@T3T1'] }, () => {
                     nonce: '2',
                 });
                 await devicePrompt.sendButton.click();
-                await expect(stakingSection.unstakedToastAccount).toContainText('Ethereum #1');
-                await expect(stakingSection.unstakedToastAmount).toContainText('3234 ETH');
+                await stakingSection.verifyStakingToast({
+                    type: 'unstaked',
+                    account: 'Ethereum #1',
+                    amount: '3234 ETH',
+                });
             });
 
             await test.step('Verify pending transaction', async () => {
@@ -238,8 +241,11 @@ test.describe('ETH unstaking and claim', { tag: ['@T3W1', '@T3T1'] }, () => {
                     ],
                 });
                 await devicePrompt.sendButton.click();
-                await expect(stakingSection.claimedToastAccount).toContainText('Ethereum #1');
-                await expect(stakingSection.claimedToastAmount).toContainText('3234 ETH');
+                await stakingSection.verifyStakingToast({
+                    type: 'claimed',
+                    account: 'Ethereum #1',
+                    amount: '3234 ETH',
+                });
                 await expect(stakingSection.claimCard).toBeHidden();
                 await expect(walletPage.balanceOfAccount({ symbol: 'eth', atIndex: 0 })).toHaveText(
                     '4,468',

--- a/suite/e2e/tests/staking/sol/initial-stake.test.ts
+++ b/suite/e2e/tests/staking/sol/initial-stake.test.ts
@@ -104,10 +104,11 @@ test.describe('sol staking', { tag: ['@T3W1', '@T3T1'] }, () => {
                 solanaStakingMock.confirmTransaction();
                 solanaStakingMock.setStakeAccounts([solStakingAccountFirst.payload]);
                 await devicePrompt.sendButton.click();
-                await expect(stakingSection.stakedToastAccount).toContainText('Solana #1');
-                await expect(stakingSection.stakedToastAmount).toContainText(
-                    stakedAndRentFormatted,
-                );
+                await stakingSection.verifyStakingToast({
+                    type: 'staked',
+                    account: 'Solana #1',
+                    amount: stakedAndRentFormatted,
+                });
             });
 
             await test.step('Verify pending on dashboard', async () => {

--- a/suite/e2e/tests/staking/sol/stake-more.test.ts
+++ b/suite/e2e/tests/staking/sol/stake-more.test.ts
@@ -119,10 +119,11 @@ test.describe('sol staking', { tag: ['@T3W1', '@T3T1'] }, () => {
                     solStakingAccountSecond.payload,
                 ]);
                 await devicePrompt.sendButton.click();
-                await expect(stakingSection.stakedToastAccount).toContainText('Solana #1');
-                await expect(stakingSection.stakedToastAmount).toContainText(
-                    stakeMoreAndRentFormatted,
-                );
+                await stakingSection.verifyStakingToast({
+                    type: 'staked',
+                    account: 'Solana #1',
+                    amount: stakeMoreAndRentFormatted,
+                });
             });
 
             await test.step('Verify pending on dashboard', async () => {

--- a/suite/e2e/tests/staking/sol/unstake.test.ts
+++ b/suite/e2e/tests/staking/sol/unstake.test.ts
@@ -110,10 +110,11 @@ test.describe('sol staking', { tag: ['@T3W1', '@T3T1'] }, () => {
             await test.step('Send Unstake and verify on dashboard', async () => {
                 solanaStakingMock.confirmTransaction();
                 await devicePrompt.sendButton.click();
-                await expect(stakingSection.unstakedToastAccount).toContainText('Solana #1');
-                await expect(stakingSection.unstakedToastAmount).toContainText(
-                    stakedAmountFormatted,
-                );
+                await stakingSection.verifyStakingToast({
+                    type: 'unstaked',
+                    account: 'Solana #1',
+                    amount: stakedAmountFormatted,
+                });
                 solanaStakingMock.setupUnstakingAccount();
                 await stakingSection.expectStakingAmounts({
                     expected: {
@@ -197,10 +198,11 @@ test.describe('sol staking', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await devicePrompt.waitForFinalPromptAndConfirm();
                 solanaStakingMock.setStakeAccounts([]);
                 await devicePrompt.sendButton.click();
-                await expect(stakingSection.claimedToastAccount).toContainText('Solana #1');
-                await expect(stakingSection.claimedToastAmount).toContainText(
-                    unstakingAndRentFormatted,
-                );
+                await stakingSection.verifyStakingToast({
+                    type: 'claimed',
+                    account: 'Solana #1',
+                    amount: unstakingAndRentFormatted,
+                });
             });
 
             await test.step('Verify dashboard is back to initial state', async () => {

--- a/suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts
+++ b/suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts
@@ -119,10 +119,12 @@ test.describe(
             await test.step('Send crypto to provider', async () => {
                 await devicePrompt.sendButton.click();
 
-                await expect(tradingPage.swapToastSendAccount).toContainText(accountLabel);
-                await expect(tradingPage.swapToastReceiveAccount).toContainText('Base #1');
-                await expect(tradingPage.swapToastSendAmount).toContainText(sendAmount);
-                await expect(tradingPage.swapToastReceiveAmount).toContainText(receiveAmount);
+                await tradingPage.verifySwapToast({
+                    sendAccount: accountLabel,
+                    receiveAccount: 'Base #1',
+                    sendAmount,
+                    receiveAmount,
+                });
 
                 await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
                     'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',

--- a/suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts
+++ b/suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts
@@ -135,10 +135,12 @@ test.describe(
             await test.step('Send crypto to provider', async () => {
                 await devicePrompt.sendButton.click();
 
-                await expect(tradingPage.swapToastSendAccount).toContainText(accountLabel);
-                await expect(tradingPage.swapToastReceiveAccount).toContainText(accountLabel);
-                await expect(tradingPage.swapToastSendAmount).toContainText(sendAmount);
-                await expect(tradingPage.swapToastReceiveAmount).toContainText(receiveAmount);
+                await tradingPage.verifySwapToast({
+                    sendAccount: accountLabel,
+                    receiveAccount: accountLabel,
+                    sendAmount,
+                    receiveAmount,
+                });
 
                 await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
                     'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',

--- a/suite/e2e/tests/trading-poc/passthru-swap-eth-to-btc.test.ts
+++ b/suite/e2e/tests/trading-poc/passthru-swap-eth-to-btc.test.ts
@@ -154,10 +154,12 @@ test.describe('Trading POC - passthru swap ETH', { tag: ['@T3W1', '@T3T1'] }, ()
 
             await expect.poll(() => passthruTradingMock.blockedSendCount).toBeGreaterThan(0);
 
-            await expect(tradingPage.swapToastSendAccount).toContainText(accountLabel);
-            await expect(tradingPage.swapToastReceiveAccount).toContainText('Bitcoin #1');
-            await expect(tradingPage.swapToastSendAmount).toContainText(sendAmount);
-            await expect(tradingPage.swapToastReceiveAmount).toContainText(receiveAmount);
+            await tradingPage.verifySwapToast({
+                sendAccount: accountLabel,
+                receiveAccount: 'Bitcoin #1',
+                sendAmount,
+                receiveAmount,
+            });
         });
 
         for (const { transactionStatus, displayedText, translationValues } of transactionStates) {

--- a/suite/e2e/tests/trading-poc/passthru-swap-sol-to-btc.test.ts
+++ b/suite/e2e/tests/trading-poc/passthru-swap-sol-to-btc.test.ts
@@ -147,10 +147,12 @@ test.describe('Trading POC - passthru swap', { tag: ['@T3W1', '@T3T1'] }, () => 
 
             await expect.poll(() => passthruTradingMock.blockedSendCount).toBeGreaterThan(0);
 
-            await expect(tradingPage.swapToastSendAccount).toContainText(accountLabel);
-            await expect(tradingPage.swapToastReceiveAccount).toContainText('Bitcoin #1');
-            await expect(tradingPage.swapToastSendAmount).toContainText(sendAmount);
-            await expect(tradingPage.swapToastReceiveAmount).toContainText(receiveAmount);
+            await tradingPage.verifySwapToast({
+                sendAccount: accountLabel,
+                receiveAccount: 'Bitcoin #1',
+                sendAmount,
+                receiveAmount,
+            });
         });
 
         for (const { transactionStatus, displayedText, translationValues } of transactionStates) {

--- a/suite/e2e/tests/trading/swap-coin-to-token.test.ts
+++ b/suite/e2e/tests/trading/swap-coin-to-token.test.ts
@@ -80,10 +80,12 @@ test.describe('Trading - Swap coin to token', { tag: ['@webOnly', '@T3W1', '@T3T
         // Thanks to our mocked responses, the crypto is actually not send.
         await test.step('Send crypto to provider', async () => {
             await devicePrompt.sendButton.click();
-            await expect(tradingPage.swapToastSendAccount).toContainText('Solana #1');
-            await expect(tradingPage.swapToastReceiveAccount).toContainText('Ethereum #1');
-            await expect(tradingPage.swapToastSendAmount).toContainText(sendAmount);
-            await expect(tradingPage.swapToastReceiveAmount).toContainText(receiveAmount);
+            await tradingPage.verifySwapToast({
+                sendAccount: 'Solana #1',
+                receiveAccount: 'Ethereum #1',
+                sendAmount,
+                receiveAmount,
+            });
             await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
                 'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',
             );

--- a/suite/e2e/tests/trading/swap-coins.test.ts
+++ b/suite/e2e/tests/trading/swap-coins.test.ts
@@ -150,10 +150,12 @@ test.describe('Trading - Swap coins', { tag: ['@webOnly', '@T3T1', '@T3W1'] }, (
         await test.step('Send crypto to provider', async () => {
             await page.clock.install();
             await devicePrompt.sendButton.click();
-            await expect(tradingPage.swapToastSendAccount).toContainText('Solana #1');
-            await expect(tradingPage.swapToastReceiveAccount).toContainText('Bitcoin #1');
-            await expect(tradingPage.swapToastSendAmount).toContainText(sendAmount);
-            await expect(tradingPage.swapToastReceiveAmount).toContainText(receiveAmount);
+            await tradingPage.verifySwapToast({
+                sendAccount: 'Solana #1',
+                receiveAccount: 'Bitcoin #1',
+                sendAmount,
+                receiveAmount,
+            });
         });
 
         for (const { transactionStatus, displayedText, translationValues } of transactionStates) {

--- a/suite/e2e/tests/trading/swap-dex-lifi.test.ts
+++ b/suite/e2e/tests/trading/swap-dex-lifi.test.ts
@@ -234,10 +234,12 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@webOnly', '@T3T1', '@T3W1'
         await test.step('Broadcast the signed DEX transaction', async () => {
             await page.clock.install();
             await devicePrompt.sendButton.click();
-            await expect(tradingPage.swapToastSendAccount).toContainText(accountLabel);
-            await expect(tradingPage.swapToastReceiveAccount).toContainText(accountLabel);
-            await expect(tradingPage.swapToastSendAmount).toContainText(sendAmount);
-            await expect(tradingPage.swapToastReceiveAmount).toContainText(receiveAmount);
+            await tradingPage.verifySwapToast({
+                sendAccount: accountLabel,
+                receiveAccount: accountLabel,
+                sendAmount,
+                receiveAmount,
+            });
         });
 
         await test.step('Wait 30s for watch refresh and status change to Processing', async () => {

--- a/suite/e2e/tests/trading/swap-token-to-coin.test.ts
+++ b/suite/e2e/tests/trading/swap-token-to-coin.test.ts
@@ -80,10 +80,13 @@ test.describe('Trading - Swap token to coin', { tag: ['@webOnly', '@T3W1', '@T3T
         // Thanks to our mocked responses, the crypto is actually not send.
         await test.step('Send crypto to provider', async () => {
             await devicePrompt.sendButton.click();
-            await expect(tradingPage.swapToastSendAccount).toContainText('Solana #1');
-            await expect(tradingPage.swapToastReceiveAccount).toContainText('Bitcoin #1');
-            await expect(tradingPage.swapToastSendAmount).toContainText(sendAmount);
-            await expect(tradingPage.swapToastReceiveAmount).toContainText(receiveAmount);
+            await tradingPage.verifySwapToast({
+                sendAccount: 'Solana #1',
+                receiveAccount: 'Bitcoin #1',
+                sendAmount,
+                receiveAmount,
+            });
+
             await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
                 'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',
             );

--- a/suite/e2e/tests/trading/swap-tokens.test.ts
+++ b/suite/e2e/tests/trading/swap-tokens.test.ts
@@ -82,10 +82,12 @@ test.describe('Trading - Swap tokens', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, 
         // Thanks to our mocked responses, the crypto is actually not send.
         await test.step('Send crypto to provider', async () => {
             await devicePrompt.sendButton.click();
-            await expect(tradingPage.swapToastSendAccount).toContainText('Solana #1');
-            await expect(tradingPage.swapToastReceiveAccount).toContainText('Solana #1');
-            await expect(tradingPage.swapToastSendAmount).toContainText(sendAmount);
-            await expect(tradingPage.swapToastReceiveAmount).toContainText(receiveAmount);
+            await tradingPage.verifySwapToast({
+                sendAccount: 'Solana #1',
+                receiveAccount: 'Solana #1',
+                sendAmount,
+                receiveAmount,
+            });
             await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
                 'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',
             );


### PR DESCRIPTION
## Description

Unifies toast validation in staking and trading e2e tests:

- Adds `verifyStakingToast` helper to the staking page object and a similar helper for trading swap toasts, replacing repeated inline assertions in each test
- Validates toast messages via the `toHaveTranslation` custom matcher instead of hardcoded text
- Adds `message` test IDs to transaction/exchange notifications to make the full toast message assertable


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-toasts&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-toasts&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-17T12:09:01.671Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-17T12:08:46.787Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor-toasts/web/](https://dev.suite.sldev.cz/suite-web/refactor-toasts/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->