### PR TITLE
fix(suite): multishare backup device param

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal.tsx
@@ -116,7 +116,11 @@ export const MultiShareBackupModal = ({ onCancel }: MultiShareBackupModalProps) 
 
                     if (response.success) {
                         setStep('backup-seed');
-                        TrezorConnect.backupDevice().then(response => {
+                        TrezorConnect.backupDevice({
+                            device: {
+                                path: device.path,
+                            },
+                        }).then(response => {
                             if (response.success) {
                                 analytics.report({
                                     type: events.settingsDeviceMultiShareBackupEvent.name,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

possible fix for https://satoshilabs.slack.com/archives/CKZHV2G13/p1783687837667499

if you have more than one device connected the backup will fail with "device not found" error



## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to MultiShareBackupModal.tsx, a specific modal component for multi-share (Shamir) backup creation. The file maps to 131 tests via static analysis, but this is because it's part of the broadly-imported Redux modal tree. The only test that directly exercises this component is the create-additional-share test (high priority). Three other backup-related tests are included at medium priority since they exercise related backup modal infrastructure. All other 127 tests are omitted as they have no concrete connection to multi-share backup functionality.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal.tsx`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/backup/t3t1-t2t1-create-additional-share.test.ts` — This test directly exercises the Multi-Share Backup flow, which is the exact component being changed (MultiShareBackupModal.tsx). It navigates to device settings, initiates multi-share backup creation, and interacts with the modal's 'Got It' button and confirmation flows.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/backup/t2t1-success.test.ts` — This test covers the backup flow including post-backup checkboxes and the backup close button, which may share modal infrastructure with MultiShareBackupModal. A regression in the modal component could affect backup completion flows.
- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test covers backup failure scenarios including error handling in backup modals. Changes to MultiShareBackupModal could affect shared backup modal infrastructure or error states.
- `suite/e2e/tests/backup/t2t1-misc.test.ts` — This test covers backup modal behavior such as checkbox state reset and device disconnection during backup. It exercises backup modal lifecycle which may share components with MultiShareBackupModal.

</details>

_Updated: 2026-07-17T10:55:58.265Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/suite-multishare-backup/web/](https://dev.suite.sldev.cz/suite-web/fix/suite-multishare-backup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-multishare-backup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-multishare-backup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-17T10:59:07.964Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-17T10:59:06.788Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->