### PR TITLE
fix(definitions): disable Robinhood NFT generation

### DIFF
--- a/.github/workflows/release-suite-definitions.yml
+++ b/.github/workflows/release-suite-definitions.yml
@@ -48,7 +48,7 @@ jobs:
           yarn install
           cd suite-common/token-definitions
 
-          yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche robinhood
+          yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche
           yarn coins simple ethereum ethereum-classic polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche robinhood cardano solana stellar tron
           yarn coins advanced solana stellar
 
@@ -61,7 +61,7 @@ jobs:
           yarn install
           cd suite-common/token-definitions
 
-          yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche robinhood
+          yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche
           yarn coins simple ethereum ethereum-classic polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche robinhood cardano solana stellar tron
           yarn coins advanced solana stellar
 


### PR DESCRIPTION
## Description

- Remove the CoinGecko `robinhood` platform from simple NFT definition generation in both develop and production definition builds.
- Keep `robinhood` enabled for simple coin definition generation.
- Prevent definition publishing from failing because CoinGecko rejects `robinhood` as an NFT asset platform with HTTP 400.

## Changelog

No changelog entry needed.

## Testing

- Parsed `.github/workflows/release-suite-definitions.yml` as YAML.
- Passed Nx formatting validation for the workflow.
- Passed `git diff --check`.
- Verified Robinhood is absent from both NFT commands and remains present in both coin commands.
- Locally verified `yarn coins simple robinhood` against CoinGecko's public endpoint; it generated and validated 246 coin definitions.

No unit tests were added because this is a workflow-only configuration fix.

## UI changes

No UI changes.

## Risk and rollout notes

- Robinhood NFT definitions will not be generated until CoinGecko exposes a supported Robinhood NFT platform.
- Robinhood fungible-token definitions continue to be generated.
- The change affects only definition publishing; Suite network support remains in #29939.

## Related context

- Corrects the NFT configuration introduced by #29959.
- Keeps Robinhood Chain network support scoped to #29939.
