### PR TITLE
refactor(connect): shrink Stellar type declarations

### DIFF
--- a/packages/connect-common/src/types/api/stellar/common.ts
+++ b/packages/connect-common/src/types/api/stellar/common.ts
@@ -2,7 +2,7 @@
 // https://github.com/stellar/js-stellar-base
 
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
-import type { Static } from '@trezor/schema-utils';
+import type { Static, TSchema, TUnsafe } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
 
 import { DerivationPath } from '../../params';
@@ -181,8 +181,26 @@ export const StellarClaimClaimableBalanceOperation = Type.Object({
     balanceId: Type.String(), // Proto: "balance_id"
 });
 
-export type StellarOperation = Static<typeof StellarOperation>;
-export const StellarOperation = Type.Union([
+// [typescript-performace]: Keep this explicit type to prevent TypeScript from expanding the
+// inferred type in the emitted declaration.
+export type StellarOperation =
+    | StellarCreateAccountOperation
+    | StellarPaymentOperation
+    | StellarPathPaymentStrictReceiveOperation
+    | StellarPathPaymentStrictSendOperation
+    | StellarPassiveSellOfferOperation
+    | StellarManageSellOfferOperation
+    | StellarManageBuyOfferOperation
+    | StellarSetOptionsOperation
+    | StellarChangeTrustOperation
+    | StellarAllowTrustOperation
+    | StellarAccountMergeOperation
+    | StellarInflationOperation
+    | StellarManageDataOperation
+    | StellarBumpSequenceOperation
+    | StellarClaimClaimableBalanceOperation;
+
+export const StellarOperation: TUnsafe<StellarOperation> = Type.Union([
     StellarCreateAccountOperation,
     StellarPaymentOperation,
     StellarPathPaymentStrictReceiveOperation,
@@ -247,8 +265,42 @@ export const StellarSignedTx = Type.Object({
 });
 
 // NOTE: StellarOperation (stellar-sdk) transformed to type & payload from PROTO
-export type StellarOperationMessage = Static<typeof StellarOperationMessage>;
-export const StellarOperationMessage = Type.Union([
+type StellarOperationMessageOf<
+    TType extends string,
+    TOperation extends TSchema,
+> = Static<TOperation> & { type: TType };
+
+// [typescript-performace]: Keep this explicit type to prevent TypeScript from expanding the
+// inferred type in the emitted declaration.
+export type StellarOperationMessage =
+    | StellarOperationMessageOf<'StellarCreateAccountOp', typeof PROTO.StellarCreateAccountOp>
+    | StellarOperationMessageOf<'StellarPaymentOp', typeof PROTO.StellarPaymentOp>
+    | StellarOperationMessageOf<
+          'StellarPathPaymentStrictReceiveOp',
+          typeof PROTO.StellarPathPaymentStrictReceiveOp
+      >
+    | StellarOperationMessageOf<
+          'StellarPathPaymentStrictSendOp',
+          typeof PROTO.StellarPathPaymentStrictSendOp
+      >
+    | StellarOperationMessageOf<'StellarManageSellOfferOp', typeof PROTO.StellarManageSellOfferOp>
+    | StellarOperationMessageOf<'StellarManageBuyOfferOp', typeof PROTO.StellarManageBuyOfferOp>
+    | StellarOperationMessageOf<
+          'StellarCreatePassiveSellOfferOp',
+          typeof PROTO.StellarCreatePassiveSellOfferOp
+      >
+    | StellarOperationMessageOf<'StellarSetOptionsOp', typeof PROTO.StellarSetOptionsOp>
+    | StellarOperationMessageOf<'StellarChangeTrustOp', typeof PROTO.StellarChangeTrustOp>
+    | StellarOperationMessageOf<'StellarAllowTrustOp', typeof PROTO.StellarAllowTrustOp>
+    | StellarOperationMessageOf<'StellarAccountMergeOp', typeof PROTO.StellarAccountMergeOp>
+    | StellarOperationMessageOf<'StellarManageDataOp', typeof PROTO.StellarManageDataOp>
+    | StellarOperationMessageOf<'StellarBumpSequenceOp', typeof PROTO.StellarBumpSequenceOp>
+    | StellarOperationMessageOf<
+          'StellarClaimClaimableBalanceOp',
+          typeof PROTO.StellarClaimClaimableBalanceOp
+      >;
+
+export const StellarOperationMessage: TUnsafe<StellarOperationMessage> = Type.Union([
     Type.Intersect([
         Type.Object({
             type: Type.Literal('StellarCreateAccountOp'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Declaration: **78,072 → 23,038 bytes**
- Saved: **55,034 bytes (70.5%)**
- Expansion ratio: **5.8x → 1.48x**

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a TypeScript type definition for Stellar API common types in packages/connect-common. It maps statically to 134 tests, but this is purely because it's a transitive dependency pulled in by the shared build graph (a classic broad-utility false positive) — none of the E2E test descriptions in the LLM analysis mention Stellar functionality, Stellar send/receive flows, or connect-common's stellar types being exercised. Since this is a type-only file (no runtime logic) and no test in the analyzed suite touches Stellar (XLM) features directly, there is no concrete evidence any specific E2E test's behavior would be affected. Recommended strategy: no dedicated E2E test run is warranted for this change; rely on TypeScript compilation/type-checking and unit tests for connect-common instead.

<details><summary><b>Changed files (1)</b></summary>

- `packages/connect-common/src/types/api/stellar/common.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/connect-common/src/types/api/stellar/common.ts`

_Updated: 2026-07-27T13:48:22.150Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/stellar-declaration-size/web/](https://dev.suite.sldev.cz/suite-web/fix/stellar-declaration-size/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/stellar-declaration-size&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/stellar-declaration-size&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T13:52:32.171Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T13:52:00.520Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->