### PR TITLE
refactor(connect): shrink callable declaration

### DIFF
--- a/packages/connect-common/src/types/api/callable.ts
+++ b/packages/connect-common/src/types/api/callable.ts
@@ -1,23 +1,21 @@
-import { type TUnsafe, Type } from '@trezor/schema-utils';
+import type { TrezorConnectAccount } from './account';
+import type { TrezorConnectBitcoin } from './bitcoin';
+import type { TrezorConnectBlockchain } from './blockchain';
+import type { TrezorConnectCardano } from './cardano';
+import type { TrezorConnectDevice } from './device';
+import type { TrezorConnectEthereum } from './ethereum';
+import type { TrezorConnectEvolu } from './evolu';
+import type { TrezorConnectManagement } from './management';
+import type { TrezorConnectMonero } from './monero';
+import type { TrezorConnectNostr } from './nostr';
+import type { TrezorConnectRipple } from './ripple';
+import type { TrezorConnectSolana } from './solana';
+import type { TrezorConnectStellar } from './stellar';
+import type { TrezorConnectTezos } from './tezos';
+import type { TrezorConnectTron } from './tron';
 
-import { TrezorConnectAccount } from './account';
-import { TrezorConnectBitcoin } from './bitcoin';
-import { TrezorConnectBlockchain } from './blockchain';
-import { TrezorConnectCardano } from './cardano';
-import { TrezorConnectDevice } from './device';
-import { TrezorConnectEthereum } from './ethereum';
-import { TrezorConnectEvolu } from './evolu';
-import { TrezorConnectManagement } from './management';
-import { TrezorConnectMonero } from './monero';
-import { TrezorConnectNostr } from './nostr';
-import { TrezorConnectRipple } from './ripple';
-import { TrezorConnectSolana } from './solana';
-import { TrezorConnectStellar } from './stellar';
-import { TrezorConnectTezos } from './tezos';
-import { TrezorConnectTron } from './tron';
-
-// The explicit intersection prevents TypeBox from expanding the entire callable API in the
-// generated type declaration.
+// The explicit intersection prevents TypeScript from expanding the entire callable API in the
+// generated declaration.
 export type TrezorConnectCallable = TrezorConnectManagement &
     TrezorConnectDevice &
     TrezorConnectBlockchain &
@@ -33,21 +31,3 @@ export type TrezorConnectCallable = TrezorConnectManagement &
     TrezorConnectTron &
     TrezorConnectEvolu &
     TrezorConnectNostr;
-
-export const TrezorConnectCallable: TUnsafe<TrezorConnectCallable> = Type.Composite([
-    TrezorConnectManagement,
-    TrezorConnectDevice,
-    TrezorConnectBlockchain,
-    TrezorConnectAccount,
-    TrezorConnectBitcoin,
-    TrezorConnectEthereum,
-    TrezorConnectCardano,
-    TrezorConnectMonero,
-    TrezorConnectRipple,
-    TrezorConnectSolana,
-    TrezorConnectStellar,
-    TrezorConnectTezos,
-    TrezorConnectTron,
-    TrezorConnectEvolu,
-    TrezorConnectNostr,
-]);

--- a/packages/connect-common/src/types/api/callable.ts
+++ b/packages/connect-common/src/types/api/callable.ts
@@ -16,6 +16,8 @@ import { TrezorConnectStellar } from './stellar';
 import { TrezorConnectTezos } from './tezos';
 import { TrezorConnectTron } from './tron';
 
+// The explicit intersection prevents TypeBox from expanding the entire callable API in the
+// generated type declaration.
 export type TrezorConnectCallable = TrezorConnectManagement &
     TrezorConnectDevice &
     TrezorConnectBlockchain &

--- a/packages/connect-common/src/types/api/callable.ts
+++ b/packages/connect-common/src/types/api/callable.ts
@@ -1,4 +1,4 @@
-import { type Static, Type } from '@trezor/schema-utils';
+import { type TUnsafe, Type } from '@trezor/schema-utils';
 
 import { TrezorConnectAccount } from './account';
 import { TrezorConnectBitcoin } from './bitcoin';
@@ -16,7 +16,23 @@ import { TrezorConnectStellar } from './stellar';
 import { TrezorConnectTezos } from './tezos';
 import { TrezorConnectTron } from './tron';
 
-export const TrezorConnectCallable = Type.Composite([
+export type TrezorConnectCallable = TrezorConnectManagement &
+    TrezorConnectDevice &
+    TrezorConnectBlockchain &
+    TrezorConnectAccount &
+    TrezorConnectBitcoin &
+    TrezorConnectEthereum &
+    TrezorConnectCardano &
+    TrezorConnectMonero &
+    TrezorConnectRipple &
+    TrezorConnectSolana &
+    TrezorConnectStellar &
+    TrezorConnectTezos &
+    TrezorConnectTron &
+    TrezorConnectEvolu &
+    TrezorConnectNostr;
+
+export const TrezorConnectCallable: TUnsafe<TrezorConnectCallable> = Type.Composite([
     TrezorConnectManagement,
     TrezorConnectDevice,
     TrezorConnectBlockchain,
@@ -33,4 +49,3 @@ export const TrezorConnectCallable = Type.Composite([
     TrezorConnectEvolu,
     TrezorConnectNostr,
 ]);
-export type TrezorConnectCallable = Static<typeof TrezorConnectCallable>;

--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -48,7 +48,6 @@ const LEGIT_BIG_FILES = new Set<string>([
 
 // Existing violations to fix incrementally. The requirement reports entries once they can be removed.
 const KNOWN_DECLARATION_SIZE_VIOLATIONS = new Set<string>([
-    'packages/connect-common/libDev/src/types/api/callable.d.ts',
     'packages/connect-common/libDev/src/types/api/cardano/common.d.ts',
     'packages/connect-common/libDev/src/types/api/internal/index.d.ts',
     'suite-common/calldata/libDev/src/calldata.d.ts',


### PR DESCRIPTION
## Description

The callable API schema exposed TypeBox’s fully inferred composite construction type, causing the emitted declaration to expand every Connect API surface. The runtime schema has no value consumers, so keeping only the equivalent intersection of the existing API types preserves the callable contract without emitting schema internals.

- Declaration: **12,000 → 1,225 bytes**
- Saved: **10,775 bytes (89.8%)**

## Notes for QA

Type-only API declaration change; no manual QA is needed.

## Related Issue

Related #29904

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Both changed files are type-level or build-tooling artifacts: `callable.ts` is a TypeScript type declaration for Connect API methods (erased at runtime) and `requireTypeDeclarationSize.ts` is a static requirement check on declaration file sizes. Neither is exercised by Playwright E2E tests, and no static or inferred test coverage exists. The appropriate validation is type-checking / linting, not E2E execution.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect-common/src/types/api/callable.ts`
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/connect-common/src/types/api/callable.ts`
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`

_Updated: 2026-07-31T11:06:32.728Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/connect-callable-declaration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/connect-callable-declaration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T11:10:01.132Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T11:09:47.816Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/connect-callable-declaration/web/](https://dev.suite.sldev.cz/suite-web/refactor/connect-callable-declaration/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->
