### PR TITLE
refactor(connect): shrink internal API declaration

### DIFF
--- a/packages/connect-common/src/factory.ts
+++ b/packages/connect-common/src/factory.ts
@@ -32,5 +32,5 @@ export const factoryPrivileged = <
         (core as any)[method] = (params: any) => core.call({ ...params, method });
     }
 
-    return core as ExtendedPrivilegedAPI<C>;
+    return core as unknown as ExtendedPrivilegedAPI<C>;
 };

--- a/packages/connect-common/src/types/api/internal/index.ts
+++ b/packages/connect-common/src/types/api/internal/index.ts
@@ -1,4 +1,4 @@
-import type { Static } from '@trezor/schema-utils';
+import type { Static, TUnsafe } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
 
 import type { off } from './off';
@@ -8,7 +8,15 @@ import type { uiResponse } from './uiResponse';
 import type { updateConnectSettings } from './updateConnectSettings';
 
 // Initialization, lifecycle, events, and settings
-export const TrezorConnectInternal = Type.Object({
+type TrezorConnectInternalSchema = {
+    on: typeof on;
+    off: typeof off;
+    removeAllListeners: typeof removeAllListeners;
+    uiResponse: typeof uiResponse;
+    updateConnectSettings: typeof updateConnectSettings;
+};
+
+export const TrezorConnectInternal: TUnsafe<TrezorConnectInternalSchema> = Type.Object({
     on: Type.Unsafe<typeof on>(),
     off: Type.Unsafe<typeof off>(),
     removeAllListeners: Type.Unsafe<typeof removeAllListeners>(),


### PR DESCRIPTION
## Description

The inferred internal API schema expanded the full Connect event callback overload set into its declaration. A named internal API contract and checked TUnsafe schema boundary preserve the API while keeping the declaration linked to the existing function types; the privileged factory cast now uses the same explicit unknown bridge as the public factory.\n\n- Declaration: **16,767 → 734 bytes**\n- Saved: **16,033 bytes (95.6%)**\n- Expansion ratio: **21.4x → 0.70x**


It contributes only modestly to the whole repo. The large local cache reduction does not translate into a meaningful full-build speedup.

Matched forced `@trezor/connect` builds:

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Connect instantiations | 926,011 | 920,023 | −5,988 (0.65%) |
| Connect subtype cache | 38,204 | 37,978 | −226 (0.59%) |
| 28-project aggregate instantiations | 3,954,309 | 3,948,342 | −5,967 (0.15%) |
| Aggregate strict-subtype cache | 98,739 | 90,922 | −7,817 (7.9%) |
| Total build time | 35.53s | 35.49s | effectively unchanged |

The actual value is therefore:

- Removing a pathological 57-overload public type that TypeScript must structurally compare.
- Preventing its cost from growing as more Connect events are added.
- Slightly reducing downstream SDK type instantiation.
- Potentially improving isolated IDE/language-service comparisons, though we have not measured that directly.

It is not a substantial

You’re right: this is not a meaningful whole-repository build-time optimization.

Matched forced builds of `@trezor/connect` show:

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Connect instantiations | 926,011 | 920,023 | −5,988 (0.65%) |
| Connect subtype cache | 38,204 | 37,978 | −226 (0.59%) |
| 28-project aggregate instantiations | 3,954,309 | 3,948,342 | −5,967 (0.15%) |
| Aggregate strict-subtype cache | 98,739 | 90,922 | −7,817 (7.92%) |
| Total build time | 35.53s | 35.49s | effectively unchanged |

Its value is primarily preventative: it removes a 57-overload intersection from a public API boundary, improves editor/type-comparison behavior, and prevents complexity growing with every new Connect event. But it does not noticeably accelerate a complete build.

I would characterize #30004 as a small type-complexity cleanup, not a significant repository performance improvement. The PR description currently overemphasizes the isolated `connect-common` result and should include these downstream numbers for proper context.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are core to @trezor/connect-common: factory.ts (the method/API call factory used across all TrezorConnect API methods) and the internal API type definitions. While factory.ts statically maps to 131 tests, most of those are broad Suite E2E flows (onboarding, staking, trading, metadata) that only transitively depend on connect-common through deep imports and are unlikely to be directly affected. The highest-risk, most directly affected tests are the trezor-connect/* suite, which explicitly exercises TrezorConnect API method calls (getAddress, getAccountInfo, selectAccount, signTransaction, ethereumSignMessage/Transaction, permissions, silent mode, popup lifecycle) built via this factory and typed via the internal API types. Recommend running the full trezor-connect/* test suite as the targeted, minimal validation set for this change.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect-common/src/factory.ts`
- `packages/connect-common/src/types/api/internal/index.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises TrezorConnect popup/web flows (getAddress, cardanoGetAddress, cancellation, permissions) which directly depend on connect-common's factory and internal API types used to construct connect method requests/responses.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Covers the same TrezorConnect popup lifecycle and API factory-driven method calls (getAddress) across the webextension bridge, directly exercising connect-common factory logic.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Directly tests TrezorConnect.getAddress single and bundle calls, which rely on the connect-common factory to build API method calls and the internal API types for request/response shaping.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Exercises TrezorConnect.getAccountInfo method invocation and account selection modal, directly depending on the connect-common method factory for constructing and validating the API call.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — Tests TrezorConnect.selectAccount with multiple selection types and privacy checks on returned account objects, which depends on the internal API type definitions and factory used to build/validate this connect method.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Directly invokes TrezorConnect.ethereumSignMessage, a method constructed via the connect-common factory; a regression in factory or internal API types could break message signing calls.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Directly invokes TrezorConnect.ethereumSignTransaction, relying on the connect-common factory to build the method call and internal API types for the transaction payload structure.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Directly invokes TrezorConnect.signTransaction (Bitcoin), which depends on the connect-common factory and internal API types for constructing and validating the signing request.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests the TrezorConnect permissions modal and connected apps flow which relies on the factory to construct getAddress calls, and could surface regressions if internal API types affecting request permission structures changed.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Uses TrezorConnect.signMessage and permission modal flows built via the factory; silent mode behavior itself is unrelated but the underlying connect call construction could be impacted by factory changes.
- `suite/e2e/tests/trezor-connect/error.test.ts` — Validates error handling for an invalid derivation path passed to ethereumGetAddress, a method built via the connect-common factory; a factory or type regression could alter error surfacing behavior.

</details>

_Updated: 2026-07-17T20:33:48.113Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/connect-common-internal-declaration/web/](https://dev.suite.sldev.cz/suite-web/refactor/connect-common-internal-declaration/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/connect-common-internal-declaration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/connect-common-internal-declaration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-17T20:36:55.619Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-17T20:36:52.674Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->