### PR TITLE
refactor(device-authenticity): shrink params declaration

### DIFF
--- a/packages/device-authenticity/src/authenticateDeviceParams.ts
+++ b/packages/device-authenticity/src/authenticateDeviceParams.ts
@@ -1,11 +1,22 @@
-import { type Static, Type } from '@trezor/schema-utils';
+import { type Static, type TUnsafe, Type } from '@trezor/schema-utils';
 
 import { DeviceAuthenticityBlacklistConfig } from './config/deviceAuthenticityBlacklistConfigTypes';
 import { DeviceAuthenticityConfig } from './config/deviceAuthenticityConfigTypes';
 
+// [typescript-performace]: Keep these explicit schema aliases to prevent TypeScript from expanding
+// the nested inferred types in the emitted declaration.
+type DeviceAuthenticityConfigSchema = TUnsafe<Static<typeof DeviceAuthenticityConfig>>;
+type DeviceAuthenticityBlacklistConfigSchema = TUnsafe<
+    Static<typeof DeviceAuthenticityBlacklistConfig>
+>;
+
+const deviceAuthenticityConfigSchema: DeviceAuthenticityConfigSchema = DeviceAuthenticityConfig;
+const deviceAuthenticityBlacklistConfigSchema: DeviceAuthenticityBlacklistConfigSchema =
+    DeviceAuthenticityBlacklistConfig;
+
 export type AuthenticateDeviceParams = Static<typeof AuthenticateDeviceParams>;
 export const AuthenticateDeviceParams = Type.Object({
-    config: Type.Optional(DeviceAuthenticityConfig),
-    blacklistConfig: Type.Optional(DeviceAuthenticityBlacklistConfig),
+    config: Type.Optional(deviceAuthenticityConfigSchema),
+    blacklistConfig: Type.Optional(deviceAuthenticityBlacklistConfigSchema),
     allowDebugKeys: Type.Optional(Type.Boolean()),
 });

--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.test.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.test.ts
@@ -8,6 +8,7 @@ import {
     MAX_DECLARATION_SIZE_BYTES,
     MAX_DECLARATION_SOURCE_RATIO,
     MIN_DECLARATION_RATIO_SIZE_BYTES,
+    createRequireTypeDeclarationSize,
     requireTypeDeclarationSize,
 } from './requireTypeDeclarationSize';
 
@@ -16,12 +17,21 @@ jest.mock('../../workspaces');
 const mockListAllWorkspaces = jest.mocked(listAllWorkspaces);
 
 describe(requireTypeDeclarationSize.name, () => {
+    let legitBigFiles: Set<string>;
+    let knownDeclarationSizeViolations: Set<string>;
+    let requireTypeDeclarationSizeForTest: ReturnType<typeof createRequireTypeDeclarationSize>;
     let repoRoot: string;
     let sourceDirectory: string;
     let libDevDirectory: string;
     let context: RepoContext;
 
     beforeEach(() => {
+        legitBigFiles = new Set();
+        knownDeclarationSizeViolations = new Set();
+        requireTypeDeclarationSizeForTest = createRequireTypeDeclarationSize({
+            legitBigFiles,
+            knownDeclarationSizeViolations,
+        });
         repoRoot = mkdtempSync(join(tmpdir(), 'type-declarations-'));
         sourceDirectory = join(repoRoot, 'packages', 'example', 'src');
         libDevDirectory = join(repoRoot, 'packages', 'example', 'libDev');
@@ -47,7 +57,7 @@ describe(requireTypeDeclarationSize.name, () => {
             'export declare const small = 1;',
         );
 
-        const errors = await requireTypeDeclarationSize.verify(context);
+        const errors = await requireTypeDeclarationSizeForTest.verify(context);
 
         expect(errors).toEqual([]);
     });
@@ -58,7 +68,7 @@ describe(requireTypeDeclarationSize.name, () => {
             `export declare const large: "${'x'.repeat(MAX_DECLARATION_SIZE_BYTES)}";`,
         );
 
-        const errors = await requireTypeDeclarationSize.verify(context);
+        const errors = await requireTypeDeclarationSizeForTest.verify(context);
 
         expect(errors).toHaveLength(1);
         expect(errors[0]).toMatch(
@@ -79,7 +89,7 @@ describe(requireTypeDeclarationSize.name, () => {
             'x'.repeat(MIN_DECLARATION_RATIO_SIZE_BYTES + 1),
         );
 
-        const errors = await requireTypeDeclarationSize.verify(context);
+        const errors = await requireTypeDeclarationSizeForTest.verify(context);
 
         expect(errors).toHaveLength(1);
         expect(errors[0]).toMatch(
@@ -102,7 +112,7 @@ describe(requireTypeDeclarationSize.name, () => {
             JSON.stringify({ sources: ['../../../src/mapped.ts'] }),
         );
 
-        const errors = await requireTypeDeclarationSize.verify(context);
+        const errors = await requireTypeDeclarationSizeForTest.verify(context);
 
         expect(errors).toHaveLength(1);
         expect(errors[0]).toContain('packages/example/libDev/example/src/mapped.d.ts');
@@ -116,7 +126,7 @@ describe(requireTypeDeclarationSize.name, () => {
             'x'.repeat(MIN_DECLARATION_RATIO_SIZE_BYTES),
         );
 
-        const errors = await requireTypeDeclarationSize.verify(context);
+        const errors = await requireTypeDeclarationSizeForTest.verify(context);
 
         expect(errors).toEqual([]);
     });
@@ -127,31 +137,21 @@ describe(requireTypeDeclarationSize.name, () => {
         writeFileSync(join(sourceDirectory, 'ratio.ts'), 'x'.repeat(sourceSizeBytes));
         writeFileSync(join(libDevDirectory, 'src', 'ratio.d.ts'), 'x'.repeat(declarationSizeBytes));
 
-        const errors = await requireTypeDeclarationSize.verify(context);
+        const errors = await requireTypeDeclarationSizeForTest.verify(context);
 
         expect(errors).toEqual([]);
     });
 
     it('reports known violations that no longer exceed either limit', async () => {
-        const knownWorkspaceDirectory = join(repoRoot, 'suite-common', 'receive');
-        const knownSourceDirectory = join(knownWorkspaceDirectory, 'src');
-        const knownDeclarationDirectory = join(knownWorkspaceDirectory, 'libDev', 'src');
-        mkdirSync(knownSourceDirectory, { recursive: true });
-        mkdirSync(knownDeclarationDirectory, { recursive: true });
-        writeFileSync(join(knownSourceDirectory, 'receiveSlice.ts'), 'export const small = 1;');
-        writeFileSync(
-            join(knownDeclarationDirectory, 'receiveSlice.d.ts'),
-            'export const small = 1;',
-        );
-        mockListAllWorkspaces.mockReturnValue([
-            { dir: knownWorkspaceDirectory, name: '@suite-common/receive' },
-        ]);
+        knownDeclarationSizeViolations.add('packages/example/libDev/src/receiveSlice.d.ts');
+        writeFileSync(join(sourceDirectory, 'receiveSlice.ts'), 'export const small = 1;');
+        writeFileSync(join(libDevDirectory, 'src', 'receiveSlice.d.ts'), 'export const small = 1;');
 
-        const errors = await requireTypeDeclarationSize.verify(context);
+        const errors = await requireTypeDeclarationSizeForTest.verify(context);
 
         expect(errors).toHaveLength(1);
         expect(errors[0]).toContain(
-            'suite-common/receive/libDev/src/receiveSlice.d.ts no longer violates declaration size limits.',
+            'packages/example/libDev/src/receiveSlice.d.ts no longer violates declaration size limits.',
         );
         expect(errors[0]).toContain(
             'The generated declaration is now within the configured limits, so its temporary exception is stale.',
@@ -164,17 +164,13 @@ describe(requireTypeDeclarationSize.name, () => {
     });
 
     it('explains how to fix a known violation that was not emitted', async () => {
-        const knownWorkspaceDirectory = join(repoRoot, 'suite-common', 'receive');
-        mkdirSync(join(knownWorkspaceDirectory, 'libDev', 'src'), { recursive: true });
-        mockListAllWorkspaces.mockReturnValue([
-            { dir: knownWorkspaceDirectory, name: '@suite-common/receive' },
-        ]);
+        knownDeclarationSizeViolations.add('packages/example/libDev/src/receiveSlice.d.ts');
 
-        const errors = await requireTypeDeclarationSize.verify(context);
+        const errors = await requireTypeDeclarationSizeForTest.verify(context);
 
         expect(errors).toHaveLength(1);
         expect(errors[0]).toContain(
-            'suite-common/receive/libDev/src/receiveSlice.d.ts was not emitted at the expected path.',
+            'packages/example/libDev/src/receiveSlice.d.ts was not emitted at the expected path.',
         );
         expect(errors[0]).toContain(
             'Remove the path from the set if the declaration was deleted, or update it if the declaration moved',
@@ -190,39 +186,32 @@ describe(requireTypeDeclarationSize.name, () => {
             'x'.repeat(MAX_DECLARATION_SIZE_BYTES + 1),
         );
 
-        const errors = await requireTypeDeclarationSize.verify(context);
+        const errors = await requireTypeDeclarationSizeForTest.verify(context);
 
         expect(errors[0]).toContain('packages/example/libDev/src/nested/large.d.mts');
     });
 
-    it('checks schema-derived types that are no longer legitimately large', async () => {
-        const knownWorkspaceDirectory = join(repoRoot, 'packages', 'device-authenticity');
-        const knownDeclarationDirectory = join(knownWorkspaceDirectory, 'libDev', 'src');
-        mkdirSync(knownDeclarationDirectory, { recursive: true });
+    it('ignores schema-derived types that are legitimately large', async () => {
+        legitBigFiles.add('packages/example/libDev/src/authenticateDeviceParams.d.ts');
         writeFileSync(
-            join(knownDeclarationDirectory, 'authenticateDeviceParams.d.ts'),
+            join(libDevDirectory, 'src', 'authenticateDeviceParams.d.ts'),
             'x'.repeat(200 * 1024),
         );
-        mockListAllWorkspaces.mockReturnValue([
-            { dir: knownWorkspaceDirectory, name: '@trezor/device-authenticity' },
-        ]);
 
-        const errors = await requireTypeDeclarationSize.verify(context);
+        const errors = await requireTypeDeclarationSizeForTest.verify(context);
 
-        expect(errors).toHaveLength(1);
-        expect(errors[0]).toContain(
-            'packages/device-authenticity/libDev/src/authenticateDeviceParams.d.ts is 200 KiB; maximum is 50 KiB.',
-        );
+        expect(errors).toEqual([]);
     });
 
     it('does not validate legacy limits for workspaces without declaration output', async () => {
+        knownDeclarationSizeViolations.add('suite-native/intl/libDev/src/messages.d.ts');
         const knownWorkspaceDirectory = join(repoRoot, 'suite-native', 'intl');
         mkdirSync(knownWorkspaceDirectory, { recursive: true });
         mockListAllWorkspaces.mockReturnValue([
             { dir: knownWorkspaceDirectory, name: '@suite-native/intl' },
         ]);
 
-        const errors = await requireTypeDeclarationSize.verify(context);
+        const errors = await requireTypeDeclarationSizeForTest.verify(context);
 
         expect(errors).toEqual([]);
     });
@@ -230,7 +219,7 @@ describe(requireTypeDeclarationSize.name, () => {
     it('ignores workspaces without declaration output', async () => {
         rmSync(libDevDirectory, { recursive: true, force: true });
 
-        const errors = await requireTypeDeclarationSize.verify(context);
+        const errors = await requireTypeDeclarationSizeForTest.verify(context);
 
         expect(errors).toEqual([]);
     });

--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.test.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.test.ts
@@ -195,7 +195,7 @@ describe(requireTypeDeclarationSize.name, () => {
         expect(errors[0]).toContain('packages/example/libDev/src/nested/large.d.mts');
     });
 
-    it('ignores schema-derived types that are legitimately large', async () => {
+    it('checks schema-derived types that are no longer legitimately large', async () => {
         const knownWorkspaceDirectory = join(repoRoot, 'packages', 'device-authenticity');
         const knownDeclarationDirectory = join(knownWorkspaceDirectory, 'libDev', 'src');
         mkdirSync(knownDeclarationDirectory, { recursive: true });
@@ -209,7 +209,10 @@ describe(requireTypeDeclarationSize.name, () => {
 
         const errors = await requireTypeDeclarationSize.verify(context);
 
-        expect(errors).toEqual([]);
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain(
+            'packages/device-authenticity/libDev/src/authenticateDeviceParams.d.ts is 200 KiB; maximum is 50 KiB.',
+        );
     });
 
     it('does not validate legacy limits for workspaces without declaration output', async () => {

--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -178,13 +178,21 @@ const getViolation = (context: DeclarationFileContext) => {
     );
 };
 
-const verifyDeclarationFile = (context: DeclarationFileContext) => {
+type CreateRequireTypeDeclarationSizeParams = {
+    legitBigFiles: ReadonlySet<string>;
+    knownDeclarationSizeViolations: ReadonlySet<string>;
+};
+
+const verifyDeclarationFile = (
+    context: DeclarationFileContext,
+    { legitBigFiles, knownDeclarationSizeViolations }: CreateRequireTypeDeclarationSizeParams,
+) => {
     const declarationPath = normalizePath(relative(context.repoRoot, context.declarationFile));
 
-    if (LEGIT_BIG_FILES.has(declarationPath)) return undefined;
+    if (legitBigFiles.has(declarationPath)) return undefined;
 
     const violation = getViolation(context);
-    const isKnownViolation = KNOWN_DECLARATION_SIZE_VIOLATIONS.has(declarationPath);
+    const isKnownViolation = knownDeclarationSizeViolations.has(declarationPath);
 
     if (isKnownViolation && violation === undefined) {
         return addKnownViolationFailureGuidance(
@@ -198,7 +206,12 @@ const verifyDeclarationFile = (context: DeclarationFileContext) => {
     return violation;
 };
 
-export const requireTypeDeclarationSize: Requirement<'repo'> = {
+// Creator pattern is used to separate the static snapshots LEGIT_BIG_FILES and KNOWN_DECLARATION_SIZE_VIOLATIONS
+// from unit tests, because the snapshots may change and break the tests.
+export const createRequireTypeDeclarationSize = ({
+    legitBigFiles,
+    knownDeclarationSizeViolations,
+}: CreateRequireTypeDeclarationSizeParams): Requirement<'repo'> => ({
     name: 'type-declaration-size',
     scope: 'repo',
     runByDefault: false,
@@ -224,10 +237,15 @@ export const requireTypeDeclarationSize: Requirement<'repo'> = {
                 normalizePath(relative(repoRoot, declarationOutputDirectory)),
         );
         const errors = declarationFiles
-            .map(declarationFile => verifyDeclarationFile({ repoRoot, ...declarationFile }))
+            .map(declarationFile =>
+                verifyDeclarationFile(
+                    { repoRoot, ...declarationFile },
+                    { legitBigFiles, knownDeclarationSizeViolations },
+                ),
+            )
             .filter(error => error !== undefined);
 
-        for (const declarationPath of KNOWN_DECLARATION_SIZE_VIOLATIONS) {
+        for (const declarationPath of knownDeclarationSizeViolations) {
             const isWorkspaceBuilt = builtDeclarationOutputPaths.some(outputPath =>
                 declarationPath.startsWith(`${outputPath}/`),
             );
@@ -244,4 +262,9 @@ export const requireTypeDeclarationSize: Requirement<'repo'> = {
 
         return Promise.resolve(errors.sort());
     },
-};
+});
+
+export const requireTypeDeclarationSize = createRequireTypeDeclarationSize({
+    legitBigFiles: LEGIT_BIG_FILES,
+    knownDeclarationSizeViolations: KNOWN_DECLARATION_SIZE_VIOLATIONS,
+});

--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -32,8 +32,6 @@ const addKnownViolationFailureGuidance = (error: string, correction: string) =>
 const LEGIT_BIG_FILES = new Set<string>([
     'packages/connect-data/libDev/src/map-releases.d.ts',
     'packages/connect/libDev/e2e/__fixtures__/cardanoSignTransaction.d.ts',
-    // Runtime schemas intentionally export their complete inferred static types.
-    'packages/device-authenticity/libDev/src/authenticateDeviceParams.d.ts',
     'packages/icons/libDev/src/index.d.ts',
     'packages/protobuf/libDev/src/definitions/index.d.ts',
     'packages/protobuf/libDev/src/definitions/messages-bitcoin.d.ts',


### PR DESCRIPTION
## Description

The inferred authentication parameter schema expanded both nested authenticity configuration schemas into the emitted declaration. Explicit opaque aliases keep those nested schemas compact while preserving schema-derived static types, reducing the declaration from 5,775 to 959 bytes.\n\nThe declaration-size requirement now uses an injected factory so unit tests exercise exemption behavior with isolated sets instead of depending on the current production snapshots. This preserves meaningful coverage as exemptions are added or removed.\n\n- Declaration: **5,775 -> 959 bytes**\n- Saved: **4,816 bytes (83.4%)**\n- Requirements tests: **161 passed**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is low-risk for E2E coverage: authenticateDeviceParams.ts only clearly impacts the onboarding device authenticity flow, while the requirements type-declaration size files are build-time tooling with no E2E coverage. Running the targeted onboarding authenticity check is sufficient; no broad suite runs are warranted by these changes.

<details><summary><b>Changed files (3)</b></summary>

- `packages/device-authenticity/src/authenticateDeviceParams.ts`
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.test.ts`
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — This test directly exercises the device authenticity check path during onboarding, which is the only user-facing flow plausibly affected by changes to authenticateDeviceParams. A regression here would be immediately visible as a failed authenticity check for T3B1/T3T1 devices.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.test.ts`

_Updated: 2026-07-31T20:42:02.267Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/device-authenticity-params-declaration/web/](https://dev.suite.sldev.cz/suite-web/refactor/device-authenticity-params-declaration/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/device-authenticity-params-declaration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/device-authenticity-params-declaration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T20:44:49.508Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T20:44:20.713Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->