### PR TITLE
refactor(earn): shrink yield opportunities declaration

### DIFF
--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -52,7 +52,6 @@ const KNOWN_DECLARATION_SIZE_VIOLATIONS = new Set<string>([
     'packages/connect-common/libDev/src/types/api/internal/index.d.ts',
     'suite-common/calldata/libDev/src/calldata.d.ts',
     'suite-common/calldata/libDev/src/verifier.d.ts',
-    'suite-common/earn-stablecoin-api/libDev/src/hooks/useAllYieldOpportunities.d.ts',
     'suite-common/earn-staking-api/libDev/src/staking/services/index.d.ts',
     'suite-common/receive/libDev/src/receiveSlice.d.ts',
 ]);

--- a/suite-common/earn-stablecoin-api/src/hooks/useAllYieldOpportunities.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/useAllYieldOpportunities.ts
@@ -1,5 +1,5 @@
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-defs';
-import { commonQueryKeys, useQuery } from '@suite-common/react-query';
+import { type UseQueryResult, commonQueryKeys, useQuery } from '@suite-common/react-query';
 
 import { YIELD_OPPORTUNITIES_DEFAULT_LIMIT, queriesStaleTime } from '../config';
 import { getYields } from '../services';
@@ -14,7 +14,7 @@ const stableEmptyArray: YieldDtoV2[] = [];
 export const useAllYieldOpportunities = ({
     limit = YIELD_OPPORTUNITIES_DEFAULT_LIMIT,
     enabled = true,
-}: UseAllYieldOpportunitiesProps = {}) =>
+}: UseAllYieldOpportunitiesProps = {}): UseQueryResult<YieldDtoV2[], Error> =>
     useQuery({
         queryKey: commonQueryKeys.yieldOpportunitiesList({ limit }),
         queryFn: async ({ signal }) => {


### PR DESCRIPTION
## Description

The inferred hook return type expanded React Query's implementation result union into the emitted declaration. An explicit UseQueryResult contract retains the Yield opportunity data and error types while exposing a stable public query boundary. The now-stale declaration-size exception is removed because the emitted output is within the enforced limits.

- Declaration: **9,928 -> 426 bytes**
- Saved: **9,502 bytes (95.7%)**
- Expansion ratio: **10.2x -> 0.41x**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The earn-stablecoin-api hook is a broad dependency mapped to many tests, but no listed E2E test specifically exercises stablecoin yield-opportunity functionality. The safest E2E smoke check is the general link/route coverage test for /earn pages. The requirements/type-declaration file has no E2E coverage and is best validated by build/unit checks rather than the Playwright suite.

<details><summary><b>Changed files (2)</b></summary>

- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`
- `suite-common/earn-stablecoin-api/src/hooks/useAllYieldOpportunities.ts`

</details>

**Recommended tests (1)**

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test navigates all /earn/* routes, including /earn/yield/* pages that consume yield-opportunity data. If the useAllYieldOpportunities hook change caused those pages to crash or fail to attach content, the route-load assertions here would fail, providing a cheap smoke-signal of a broad regression.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`

_Updated: 2026-07-31T12:08:13.667Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/earn-all-yield-opportunities-declaration/web/](https://dev.suite.sldev.cz/suite-web/refactor/earn-all-yield-opportunities-declaration/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/earn-all-yield-opportunities-declaration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/earn-all-yield-opportunities-declaration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/earn-all-yield-opportunities-declaration&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T12:10:18.430Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T12:10:09.868Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->