### PR TITLE
refactor(earn): shrink vault query declaration

### DIFF
--- a/suite-common/earn-stablecoin-api/src/hooks/useGetVaultByAddress.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/useGetVaultByAddress.ts
@@ -1,4 +1,5 @@
-import { commonQueryKeys, useQuery } from '@suite-common/react-query';
+import { type YieldDtoV2Output } from '@suite-common/earn-stablecoin-defs';
+import { type UseQueryResult, commonQueryKeys, useQuery } from '@suite-common/react-query';
 
 import { getYields } from '../services';
 
@@ -7,7 +8,10 @@ interface GetVaultByAddressProps {
     outputToken: string | undefined;
 }
 
-export function useGetVaultByAddress({ enabled, outputToken }: GetVaultByAddressProps) {
+export function useGetVaultByAddress({
+    enabled,
+    outputToken,
+}: GetVaultByAddressProps): UseQueryResult<YieldDtoV2Output | null, Error> {
     return useQuery({
         enabled: Boolean(enabled && outputToken),
         queryKey: commonQueryKeys.yieldOpportunitiesByAddress(outputToken),


### PR DESCRIPTION
## Description

The inferred vault hook return type expanded React Query's implementation result union into the emitted declaration. An explicit UseQueryResult contract keeps the Yield vault-or-null data type and error type while exposing the stable public query boundary.\n\n- Declaration: **9,933 → 432 bytes**\n- Saved: **9,501 bytes (95.7%)**\n- Expansion ratio: **13.1x → 0.48x**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file, useGetVaultByAddress.ts, belongs to the earn-stablecoin-api package, which is not referenced by any concrete behavior or source hint in the 28 candidate tests' LLM analysis. The 28-test mapping appears to stem from a broad shared dependency chain (e.g., a common earn/staking package or bundler graph) rather than genuine functional overlap — none of the tests' behaviors, entry points, or key assertions mention vault lookups, stablecoin vaults, or the useGetVaultByAddress hook. Applying the broad-utility heuristic, none of these 28 tests show concrete evidence of being affected by this specific change, so no test is recommended with confidence. Recommend manual/unit test verification of the hook itself, or a targeted search for any stablecoin-vault-specific E2E test not present in this candidate list.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/earn-stablecoin-api/src/hooks/useGetVaultByAddress.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-common/earn-stablecoin-api/src/hooks/useGetVaultByAddress.ts`

_Updated: 2026-07-20T16:02:58.778Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/earn-vault-address-declaration/web/](https://dev.suite.sldev.cz/suite-web/refactor/earn-vault-address-declaration/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/earn-vault-address-declaration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/earn-vault-address-declaration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/earn-vault-address-declaration&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-20T16:06:26.283Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-20T16:06:15.191Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->