### PR TITLE
refactor(earn): shrink paginated yield declaration

### DIFF
--- a/suite-common/earn-stablecoin-api/src/hooks/useGetYieldOpportunities.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/useGetYieldOpportunities.ts
@@ -1,7 +1,12 @@
 import type z from 'zod';
 
 import { type GetYieldsQueryParams } from '@suite-common/earn-stablecoin-defs';
-import { commonQueryKeys, useInfiniteQuery } from '@suite-common/react-query';
+import {
+    type InfiniteData,
+    type UseInfiniteQueryResult,
+    commonQueryKeys,
+    useInfiniteQuery,
+} from '@suite-common/react-query';
 
 import { YIELD_OPPORTUNITIES_DEFAULT_LIMIT, queriesStaleTime } from '../config';
 import { getYields } from '../services';
@@ -19,7 +24,10 @@ export function useGetYieldOpportunities({
     limit = YIELD_OPPORTUNITIES_DEFAULT_LIMIT,
     sort = 'statusEnterDesc',
     enabled = true,
-}: UseGetYieldOpportunitiesProps = {}) {
+}: UseGetYieldOpportunitiesProps = {}): UseInfiniteQueryResult<
+    InfiniteData<Awaited<ReturnType<typeof getYields>>>,
+    Error
+> {
     return useInfiniteQuery({
         queryKey: commonQueryKeys.yieldOpportunitiesPages({ limit, sort }),
         queryFn: ({ pageParam, signal }) =>

--- a/suite-common/react-query/src/index.ts
+++ b/suite-common/react-query/src/index.ts
@@ -9,6 +9,8 @@ export {
     type QueryOptions,
     type UseQueryOptions,
     type UseQueryResult,
+    type UseInfiniteQueryResult,
+    type InfiniteData,
     keepPreviousData,
 } from '@tanstack/react-query';
 export * from './constants/queryKeys';


### PR DESCRIPTION
## Description

The inferred paginated hook return type expanded React Query's infinite-query implementation union into the emitted declaration. An explicit UseInfiniteQueryResult contract, re-exported through the shared query package, retains the exact paginated yield data and error types behind a stable public boundary.\n\n- Declaration: **10,512 → 637 bytes**\n- Saved: **9,875 bytes (93.9%)**\n- Expansion ratio: **8.1x → 0.44x**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files—useGetYieldOpportunities.ts (a hook in the earn-stablecoin-api package) and react-query/src/index.ts (a shared react-query wrapper/export module)—have no corresponding E2E test suite in the analyzed 107 tests. None of the described test behaviors, entry points, or source hints reference stablecoin yield/earn opportunities, staking yield deposit/withdraw flows for stablecoins, or the react-query package directly. The existing staking tests (ADA, ETH, SOL) cover validator/Everstake staking flows but not the stablecoin yield opportunity hook or generic react-query index exports. Given the lack of any direct or inferable test coverage, no specific E2E test can be confidently recommended; manual/unit-level testing or new E2E coverage for the stablecoin yield feature is advised.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/earn-stablecoin-api/src/hooks/useGetYieldOpportunities.ts`
- `suite-common/react-query/src/index.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `suite-common/earn-stablecoin-api/src/hooks/useGetYieldOpportunities.ts`
- `suite-common/react-query/src/index.ts`

_Updated: 2026-07-17T20:55:27.587Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/earn-yield-opportunities-declaration/web/](https://dev.suite.sldev.cz/suite-web/refactor/earn-yield-opportunities-declaration/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/earn-yield-opportunities-declaration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/earn-yield-opportunities-declaration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/earn-yield-opportunities-declaration&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-20T15:36:50.119Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-20T15:36:53.822Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->