### PR TITLE
refactor(earn): shrink staking services declaration

### DIFF
--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -50,7 +50,6 @@ const KNOWN_DECLARATION_SIZE_VIOLATIONS = new Set<string>([
     'packages/connect-common/libDev/src/types/api/internal/index.d.ts',
     'suite-common/calldata/libDev/src/calldata.d.ts',
     'suite-common/calldata/libDev/src/verifier.d.ts',
-    'suite-common/earn-staking-api/libDev/src/staking/services/index.d.ts',
     'suite-common/receive/libDev/src/receiveSlice.d.ts',
 ]);
 

--- a/suite-common/earn-staking-api/src/staking/services/index.ts
+++ b/suite-common/earn-staking-api/src/staking/services/index.ts
@@ -10,48 +10,88 @@ import {
     stakingStatsResponse,
     stakingTrxStatsResponse,
 } from '../../api/schemas';
+import type {
+    AdaPools,
+    EthOrSolStats,
+    EthValidatorsQueue,
+    ReportStakingTxIds,
+    SolRewardsHistory,
+    SolRewardsTotal,
+    StakingBatch,
+    StakingBatchParams,
+    StakingCardanoPoolsParams,
+    StakingEthereumValidatorsQueueParams,
+    StakingSolanaRewardsHistoryParams,
+    TrxStats,
+} from '../../api/types';
 import { EARN_API_BASE_URL } from '../../constants';
 
 export const earnHttpClient = createHttpClient({
     baseUrl: EARN_API_BASE_URL,
 });
 
-export const getStakingBatch = earnHttpClient('/', {
+type RequestOptions = { signal?: AbortSignal };
+type StakingBatchNetwork = Exclude<StakingBatchParams['networks'], string | undefined>[number];
+type StakingBatchRequestParams = Omit<StakingBatchParams, 'networks'> & {
+    networks?: StakingBatchParams['networks'] | readonly StakingBatchNetwork[];
+};
+
+export const getStakingBatch: (
+    options?: RequestOptions & { params?: StakingBatchRequestParams },
+) => Promise<StakingBatch> = earnHttpClient('/', {
     method: 'GET',
     schema: stakingBatchResponse,
 });
 
-export const getStakingStats = earnHttpClient('/:networkSymbol/stats', {
+export const getStakingStats: (
+    options: RequestOptions & { routeParams: { networkSymbol: 'eth' | 'sol' } },
+) => Promise<EthOrSolStats> = earnHttpClient('/:networkSymbol/stats', {
     method: 'GET',
     schema: stakingStatsResponse,
 });
 
-export const getTronStakingStats = earnHttpClient('/trx/stats', {
-    method: 'GET',
-    schema: stakingTrxStatsResponse,
-});
+export const getTronStakingStats: (options?: RequestOptions) => Promise<TrxStats> = earnHttpClient(
+    '/trx/stats',
+    {
+        method: 'GET',
+        schema: stakingTrxStatsResponse,
+    },
+);
 
-export const getEthereumValidatorsQueue = earnHttpClient('/eth/validators-queue', {
+export const getEthereumValidatorsQueue: (
+    options?: RequestOptions & { params?: StakingEthereumValidatorsQueueParams },
+) => Promise<EthValidatorsQueue> = earnHttpClient('/eth/validators-queue', {
     method: 'GET',
     schema: stakingEthereumValidatorsQueueResponse,
 });
 
-export const getCardanoPools = earnHttpClient('/ada/pools', {
+export const getCardanoPools: (
+    options?: RequestOptions & { params?: StakingCardanoPoolsParams },
+) => Promise<AdaPools> = earnHttpClient('/ada/pools', {
     method: 'GET',
     schema: stakingCardanoPoolsResponse,
 });
 
-export const getSolanaRewardsHistory = earnHttpClient('/sol/rewards/:address', {
+export const getSolanaRewardsHistory: (
+    options: RequestOptions & {
+        routeParams: { address: string };
+        params?: StakingSolanaRewardsHistoryParams;
+    },
+) => Promise<SolRewardsHistory> = earnHttpClient('/sol/rewards/:address', {
     method: 'GET',
     schema: stakingSolanaRewardsHistoryResponse,
 });
 
-export const getSolanaRewardsTotal = earnHttpClient('/sol/rewards/:address/total', {
+export const getSolanaRewardsTotal: (
+    options: RequestOptions & { routeParams: { address: string } },
+) => Promise<SolRewardsTotal> = earnHttpClient('/sol/rewards/:address/total', {
     method: 'GET',
     schema: stakingSolanaRewardsTotalResponse,
 });
 
-export const reportStakingTxIds = earnHttpClient('/report', {
+export const reportStakingTxIds: (
+    options: RequestOptions & { body: ReportStakingTxIds },
+) => Promise<unknown> = earnHttpClient('/report', {
     method: 'POST',
     schema: reportStakingTxIdsResponse,
     timeout: 60_000,


### PR DESCRIPTION
## Description

The inferred staking endpoint functions expanded generated schemas and HTTP client implementation types into the emitted barrel declaration. Explicit endpoint contracts preserve route, query, body, signal, and response types while exposing a compact public service API. The batch endpoint also accepts readonly network arrays, preserving compatibility with caller constants such as `PROD_STAKING_SYMBOLS`. The now-stale declaration-size exception is removed because the emitted output is within the enforced limits.

- Declaration: **8,521 -> 2,675 bytes**
- Saved: **5,846 bytes (68.6%)**
- Expansion ratio: **5.3x -> 0.86x**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The `earn-staking-api/src/staking/services/index.ts` file is a broad dependency (133 static mappings), so only tests that actually exercise staking service behavior are recommended. The change primarily risks affecting ADA, ETH, and SOL staking operations plus shared form validation. A representative subset covering initial staking for each chain and the staking form is recommended at high priority, with unstake/claim flows at medium priority. The `requireTypeDeclarationSize.ts` file is a build/package requirements utility with no E2E coverage.

<details><summary><b>Changed files (2)</b></summary>

- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`
- `suite-common/earn-staking-api/src/staking/services/index.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — Directly exercises Cardano staking services including delegation, deposit/fee handling, and device confirmation flows. A change to the staking services index could break the Cardano staking code path.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Directly exercises Ethereum staking services including pool contract interaction, transaction signing, and pending/activation state handling. A change to the staking services index could break ETH staking.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Directly exercises Solana staking services including stake account creation, epoch transitions, and device signing. A change to the staking services index could break SOL staking.
- `suite/e2e/tests/staking/staking-form.test.ts` — Validates staking form input handling, amount validation, fiat/crypto conversion, and fee calculations that depend on staking service utilities. A change to the staking services index could affect shared validation logic.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/unstake.test.ts` — Exercises Cardano unstaking and reward claiming services which share the same staking service infrastructure as the stake flow. A regression in shared service wiring could affect unstake operations.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Exercises Ethereum unstaking and claim services which share the same staking service infrastructure as the stake flow. A regression in shared service wiring could affect unstake/claim operations.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Exercises Solana unstaking and claim services which share the same staking service infrastructure as the stake flow. A regression in shared service wiring could affect unstake/claim operations.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`

_Updated: 2026-08-03T10:17:32.371Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/earn-staking-services-declaration/web/](https://dev.suite.sldev.cz/suite-web/refactor/earn-staking-services-declaration/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/earn-staking-services-declaration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/earn-staking-services-declaration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/earn-staking-services-declaration&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T11:00:03.911Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T10:35:56.107Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->