### PR TITLE
refactor(suite-sync): shrink schema declaration

### DIFF
--- a/suite-common/suite-sync-evolu/src/schema.ts
+++ b/suite-common/suite-sync-evolu/src/schema.ts
@@ -3,7 +3,14 @@ import { AddressTableSchema } from './data/addressTable';
 import { OutputTableSchema } from './data/outputTable';
 import { WalletTableSchema } from './data/walletTable';
 
-export const Schema = {
+// Keep this explicit intersection to prevent TypeScript from expanding every table in the
+// emitted declaration.
+type SuiteSyncSchema = typeof WalletTableSchema &
+    typeof AccountTableSchema &
+    typeof AddressTableSchema &
+    typeof OutputTableSchema;
+
+export const Schema: SuiteSyncSchema = {
     ...WalletTableSchema,
     ...AccountTableSchema,
     ...AddressTableSchema,


### PR DESCRIPTION
## Description

The inferred Evolu Schema spread expanded every table and column definition into the emitted declaration. Typing the combined value as the exact intersection of the four table schema contracts preserves all field types while avoiding structural expansion.\n\n- Declaration: **6,537 → 453 bytes**\n- Saved: **6,084 bytes (93.1%)**\n- Expansion ratio: **18.1x → 0.86x**

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/suite-sync-evolu-schema-declaration/web/](https://dev.suite.sldev.cz/suite-web/refactor/suite-sync-evolu-schema-declaration/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/suite-sync-evolu-schema-declaration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/suite-sync-evolu-schema-declaration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/suite-sync-evolu-schema-declaration&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-23T11:17:28.262Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-23T11:17:30.321Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->