### PR TITLE
refactor(trading): shrink exchange thunks declaration

### DIFF
--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -74,7 +74,8 @@ const UTXO = {
     }),
 };
 
-// The type was needed because of error TS7056: The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed.
+// [typescript-performace]: Keep this explicit type to prevent TypeScript from expanding the
+// inferred type in the emitted declaration.
 export const BTC_ACCOUNT: Omit<SelectedAccountStatus, 'network'> & { network: Partial<Network> } = {
     status: 'loaded',
     account: mockWalletAccount({
@@ -272,7 +273,9 @@ const DEFAULT_FEES: FeesState = {
 
 // - default selectedAccount needs to be explicitly passed from test. merging default with custom will override custom
 // - default fees needs to be explicitly passed from test. merge Arrays will add items, not replace them
-// Todo: Type properly as the Error: "The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed."
+// [typescript-performace]: Keep this explicit type to prevent TypeScript from expanding the
+// inferred type in the emitted declaration.
+// Todo: Replace `any` with an accurate type.
 export const getRootReducer: any = (selectedAccount = BTC_ACCOUNT, fees = DEFAULT_FEES) =>
     combineReducers({
         suite: createReducer(

--- a/packages/suite/src/reducers/suite/index.ts
+++ b/packages/suite/src/reducers/suite/index.ts
@@ -38,7 +38,6 @@ import suite, { type SuiteState } from './suiteReducer';
 import window, { type WindowState } from './windowReducer';
 
 const analytics = prepareAnalyticsReducer(extraDependencies);
-// Type annotation as a workaround for type-check error "The inferred type of 'default' cannot be named..."
 const messageSystem = prepareMessageSystemReducer(extraDependencies);
 const device = prepareDesktopDeviceReducer(extraDependencies);
 const flags = prepareFlagsReducer(extraDependencies);

--- a/suite-common/earn-stablecoin-api/src/services/yieldxyz.ts
+++ b/suite-common/earn-stablecoin-api/src/services/yieldxyz.ts
@@ -33,14 +33,16 @@ type GetYieldOptions = YieldXyzRequestOptions & {
     routeParams: { vaultId: string };
 };
 
-/** Prevents declaration emit from expanding the inferred Yield.xyz list schema. */
+// [typescript-performace]: Keep this explicit type to prevent TypeScript from expanding the
+// inferred type in the emitted declaration.
 export const getYields: (options?: GetYieldsOptions) => Promise<YieldsResponseV2Output> =
     yieldXyzApi('/yields', {
         method: 'GET',
         schema: YieldsResponseV2,
     });
 
-/** Prevents declaration emit from expanding the inferred Yield.xyz detail schema. */
+// [typescript-performace]: Keep this explicit type to prevent TypeScript from expanding the
+// inferred type in the emitted declaration.
 export const getYield: (options: GetYieldOptions) => Promise<YieldResponseV2Output> = yieldXyzApi(
     '/yields/:vaultId',
     {

--- a/suite-common/logger/src/utils.ts
+++ b/suite-common/logger/src/utils.ts
@@ -26,7 +26,8 @@ export const startTime = new Date().toUTCString();
 
 export const prettifyLog = (json: Record<any, any>) => JSON.stringify(json, null, 2);
 
-/** Prevents redacted data from expanding complete account and device unions in declarations. */
+// [typescript-performace]: Keep this explicit type to prevent TypeScript from expanding the
+// inferred type in the emitted declaration.
 type RedactedAccount = Omit<
     DeepPartial<Account>,
     | 'descriptor'
@@ -94,6 +95,8 @@ export const redactAccount = (
     };
 };
 
+// [typescript-performace]: Keep this explicit type to prevent TypeScript from expanding the
+// inferred type in the emitted declaration.
 type RedactedDevice = Omit<
     DeepPartial<TrezorDevice>,
     'id' | 'label' | 'state' | 'firmwareReleaseConfigInfo' | 'features' | 'metadata'

--- a/suite-common/redux-utils/src/selectorsUtils.ts
+++ b/suite-common/redux-utils/src/selectorsUtils.ts
@@ -26,10 +26,9 @@ const createWeakMapSelectorInternal = createSelectorCreator({
     argsMemoize: weakMapMemoize,
 });
 
-/**
- * Forces selectors to expose only their callable contract. Reselect's inferred output type includes
- * recursive input-selector and memoization metadata, which produces oversized declaration files.
- */
+// [typescript-performace]: Keep this explicit type to prevent TypeScript from expanding the
+// inferred type in the emitted declaration.
+// Reselect's inferred output includes recursive input-selector and memoization metadata.
 export type CreateWeakMapSelectorFunction<StateType = never> = {
     <InputSelectors extends SelectorArray<StateType>, Result>(
         inputSelectors: [...InputSelectors],

--- a/suite-common/trading/src/thunks/exchange/index.ts
+++ b/suite-common/trading/src/thunks/exchange/index.ts
@@ -9,7 +9,22 @@ import { sendTransactionThunk } from './sendTransactionThunk';
 import { signDataAndConfirmThunk } from './signDataAndConfirmThunk';
 import { watchExchangeApprovalThunk } from './watchExchangeApprovalThunk';
 
-export const exchangeThunks = {
+// [typescript-performace]: Keep this explicit type to prevent TypeScript from expanding the
+// inferred type in the emitted declaration.
+type ExchangeThunks = {
+    loadInfoThunk: typeof loadExchangeInfoThunk;
+    handleRequestThunk: typeof handleExchangeRequestThunk;
+    selectQuoteThunk: typeof selectExchangeQuoteThunk;
+    confirmTradeThunk: typeof confirmExchangeTradeThunk;
+    confirmApprovalThunk: typeof confirmApprovalThunk;
+    prefetchDexQuoteApprovalThunk: typeof prefetchDexQuoteApprovalThunk;
+    signDataAndConfirmThunk: typeof signDataAndConfirmThunk;
+    sendDexTransactionThunk: typeof sendDexTransactionThunk;
+    sendTransactionThunk: typeof sendTransactionThunk;
+    watchExchangeApprovalThunk: typeof watchExchangeApprovalThunk;
+};
+
+export const exchangeThunks: ExchangeThunks = {
     loadInfoThunk: loadExchangeInfoThunk,
     handleRequestThunk: handleExchangeRequestThunk,
     selectQuoteThunk: selectExchangeQuoteThunk,

--- a/suite-native/module-trading/src/hooks/general/useSheetControls.ts
+++ b/suite-native/module-trading/src/hooks/general/useSheetControls.ts
@@ -10,7 +10,8 @@ import {
 
 type BottomSheetControls = ReturnType<typeof useBottomSheetControls>;
 type FormUnion = BuyFormValues | ExchangeFormValues | SellFormValues;
-// explicit return type declaration, because typescript reaches its limits when trying to infer type
+// [typescript-performace]: Keep this explicit type to prevent TypeScript from expanding the
+// inferred type in the emitted declaration.
 type SheetControls<
     FormValues extends FormUnion,
     Key extends Path<FormValues>,

--- a/suite/e2e/fixtures/invity/index.ts
+++ b/suite/e2e/fixtures/invity/index.ts
@@ -72,10 +72,9 @@ export const invityRequest = {
     sellWatchPayload,
 };
 
-/**
- * `unknown` keeps the heterogeneous JSON payload types out of this aggregate's declaration.
- * The individual fixture exports below retain their inferred types for direct use.
- */
+// [typescript-performace]: Keep this explicit type to prevent TypeScript from expanding the
+// inferred type in the emitted declaration.
+// The individual fixture exports below retain their inferred types for direct use.
 export const invityGeneralResponses: Partial<
     Record<(typeof invityEndpoint)[keyof typeof invityEndpoint], unknown>
 > = {

--- a/suite/router/src/routerReducer.ts
+++ b/suite/router/src/routerReducer.ts
@@ -81,7 +81,8 @@ const routerSlice = createSlice({
     },
 });
 
-// Keep declaration emit from expanding the full RouterState route union.
+// [typescript-performace]: Keep this explicit type to prevent TypeScript from expanding the
+// inferred type in the emitted declaration.
 export const routerReducer: Reducer<RouterState> = routerSlice.reducer;
 export const { routerLocationChange, anchorChange } = routerSlice.actions;
 


### PR DESCRIPTION
## Description

The inferred exchangeThunks object expanded every Redux thunk implementation type into the emitted barrel declaration. A named object contract references each exact thunk type while preventing their structural expansion.\n\n- Declaration: **12,081 → 1,422 bytes**\n- Saved: **10,659 bytes (88.2%)**\n- Expansion ratio: **10.9x → 0.81x**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to the exchange/swap thunk in suite-common/trading, which powers all swap (exchange) trade flows across coins, tokens, and DEX providers. Since this file maps broadly to 131 tests via shared infrastructure, only tests that directly exercise swap trade creation, confirmation, sending, and watch/status polling were prioritized as high/medium, while unrelated flows (buy, sell, onboarding, metadata, staking, etc.) were excluded as they do not touch the exchange thunk's code path. Recommended strategy: run the mocked swap tests (swap-coins, swap-coin-to-token, swap-token-to-coin, swap-tokens, swap-fees-*, swap-dex-lifi) as primary high-confidence checks, followed by swap-history/swap-inputs/swap-token-to-disabled-network for broader confidence, with live/passthrough swap tests as secondary validation given their cost and live-network dependency.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/trading/src/thunks/exchange/index.ts`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/trading/swap-coins.test.ts` — This test directly exercises the swap/exchange trade flow (SOL to BTC) end-to-end including quote fetching, trade confirmation, sending, and watch-status polling, which is exactly the logic implemented in the exchange thunk.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Covers the swap/exchange thunk flow converting a coin to a token, verifying trade confirmation, watch polling, and transaction success status directly tied to the exchange thunk implementation.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Exercises the exchange/swap thunk for token-to-coin trades, including confirmation, sending, and watch-status transitions that would be impacted by changes to the exchange thunk logic.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests SPL token-to-token swap using the same exchange/swap flow (quote, confirm, send, watch), directly dependent on the modified exchange thunk.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Validates fee calculation and composedTransactionInfo populated by the exchange thunk during a BTC swap, directly touching the changed thunk's transaction composition logic.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Validates custom fee handling and composedTransactionInfo for an ETH swap trade, directly exercising the exchange thunk's fee/transaction composition code path.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Covers a DEX-based swap through the exchange flow with multi-step device confirmation and watch-status polling (CONFIRM → CONVERTING → SUCCESS), directly dependent on the exchange thunk's status handling.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trading/swap-history.test.ts` — Verifies swap/exchange trade history display and status polling via the exchange watch endpoint, which relies on data produced by the exchange thunk, though it doesn't exercise the live trade-creation path.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form input handling, quote syncing, and provider selection which invoke the exchange thunk's quote-fetching logic, though it focuses more on form validation than the trade execution itself.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Exercises the swap quotes flow (via the exchange thunk) for a buy asset on a disabled network, verifying provider info display which depends on exchange thunk quote resolution.
- `suite/e2e/tests/trading-poc/passthru-swap-eth-to-btc.test.ts` — This live-quote passthrough swap test exercises the full exchange/swap thunk lifecycle (confirm, send, watch, status transitions) with real trading traffic, providing strong signal on regressions in exchange thunk behavior.
- `suite/e2e/tests/trading-poc/passthru-swap-sol-to-btc.test.ts` — Similar to the ETH passthrough test, this exercises the live exchange thunk flow for SOL to BTC swaps including status polling and confirmation, offering additional coverage for the changed thunk logic.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — This is a live/real swap test using the exchange flow, which would be affected by exchange thunk regressions, but is lower priority due to its live/production nature and longer runtime making it less suited as a primary CI gate.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Similarly exercises the live exchange/swap thunk flow (SPL token to coin) but is a live/production-dependent test better suited for periodic runs rather than every PR touching the thunk.

</details>

_Updated: 2026-07-17T21:03:21.538Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/trading-exchange-thunks-declaration/web/](https://dev.suite.sldev.cz/suite-web/refactor/trading-exchange-thunks-declaration/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/trading-exchange-thunks-declaration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/trading-exchange-thunks-declaration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/trading-exchange-thunks-declaration&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-23T11:42:05.818Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-23T11:42:16.255Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->