### PR TITLE
test(trading): shrink history helper declaration

### DIFF
--- a/suite-native/trading-history/src/__tests__/tradingHistoryTestUtils.ts
+++ b/suite-native/trading-history/src/__tests__/tradingHistoryTestUtils.ts
@@ -8,6 +8,7 @@ import { localeInitialState } from '@suite-native/intl';
 import {
     type PreloadedStatePartial,
     type RenderOptionsExtended,
+    type RenderResult,
     mergePreloadedState,
     renderWithStoreProvider,
 } from '@suite-native/test-utils-store';
@@ -45,7 +46,7 @@ type RenderWithTradingProviderOptions = TradingProviderOptions &
 export const renderWithTradingHistoryProvider = (
     element: ReactElement,
     { overrides, ...options }: RenderWithTradingProviderOptions = {},
-) =>
+): RenderResult =>
     renderWithStoreProvider(element, {
         preloadedState: createTradingPreloadedState({ overrides }),
         ...options,


### PR DESCRIPTION
## Description

The inferred trading-history render helper return expanded the full React Native Testing Library query surface into its emitted declaration. An explicit RenderResult contract preserves the complete testing API behind its existing named public type.\n\n- Declaration: **20,348 → 1,685 bytes**\n- Saved: **18,663 bytes (91.7%)**\n- Expansion ratio: **11.0x → 0.89x**

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native-trading-history-test-utils-declaration&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->