### PR TITLE
test(trading): shrink slippage helper declaration

### DIFF
--- a/suite-native/trading-slippage/src/__tests__/testUtils.ts
+++ b/suite-native/trading-slippage/src/__tests__/testUtils.ts
@@ -7,6 +7,8 @@ import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { localeInitialState, localeReducer } from '@suite-native/intl';
 import {
+    type RenderHookResult,
+    type RenderResult,
     createLightStore,
     createStaticReducer,
     renderHookWithStoreProvider,
@@ -49,7 +51,7 @@ export const createSlippageTestStore = (quote: ExchangeTrade | undefined = mercu
 export const renderWithSlippageTestProvider = (
     element: ReactElement,
     { store, quote }: SlippageTestOptions = {},
-) => {
+): RenderResult => {
     const preloadedState = store ? undefined : getSlippageTestPreloadedState(quote);
 
     return renderWithStoreProvider(element, { preloadedState, store });
@@ -58,7 +60,7 @@ export const renderWithSlippageTestProvider = (
 export const renderHookWithSlippageTestProvider = <Result>(
     callback: () => Result,
     { store, quote }: SlippageTestOptions = {},
-) => {
+): RenderHookResult<Result, unknown> => {
     const preloadedState = store ? undefined : getSlippageTestPreloadedState(quote);
 
     return renderHookWithStoreProvider(callback, { preloadedState, store });


### PR DESCRIPTION
## Description

The inferred slippage render helpers expanded the full React Native Testing Library component and hook result surfaces into their emitted declaration. Explicit RenderResult and RenderHookResult contracts preserve those testing APIs behind their existing named types.\n\n- Declaration: **20,447 → 1,767 bytes**\n- Saved: **18,680 bytes (91.4%)**\n- Expansion ratio: **9.6x → 0.79x**

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native-trading-slippage-test-utils-declaration&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->