### PR TITLE
test(router): shrink thunk fixture declaration

### DIFF
--- a/suite/router/src/__fixtures__/routerThunks.ts
+++ b/suite/router/src/__fixtures__/routerThunks.ts
@@ -1,6 +1,33 @@
+import { type Route } from '../route';
 import { getRoute } from '../router';
 
-export const init = [
+type InitFixture = {
+    description: string;
+    state?: {
+        router: {
+            loaded: boolean;
+            url: string;
+            pathname: string;
+            hash?: string;
+            app: string;
+            params?: unknown;
+            route?: Route;
+        };
+    };
+    result?: {
+        app: string;
+        hash: string;
+        params?: unknown;
+        pathname: string;
+        loaded: boolean;
+        anchor?: string;
+        search: string;
+        route?: Route;
+        settingsBackRoute: { name: string };
+    };
+};
+
+export const init: readonly InitFixture[] = [
     {
         description: `success`,
         state: undefined,


### PR DESCRIPTION
## Description

The inferred router init fixture expanded the complete Route union into its emitted declaration. A narrow explicit fixture contract keeps Route as the named public boundary while preserving fixture behavior and test coverage.\n\n- Declaration: **24,371 → 2,107 bytes**\n- Saved: **22,264 bytes (91.4%)**\n- Expansion ratio: **11.6x → 0.75x**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a test fixture for router thunks (suite/router/src/__fixtures__/routerThunks.ts), which is likely used in unit/integration tests for routing logic rather than directly exercised by E2E tests. No static coverage mapping exists for this file, and it does not appear to be imported by any of the 108 cataloged E2E test files based on their source_hints. Since fixtures typically support lower-level unit tests (not Playwright E2E suites), the risk to E2E test behavior is low; only the check-links test, which broadly validates router-config route coverage, has plausible indirect relevance. Recommend running check-links.test.ts as a light-touch sanity check, with no strong signal for broader E2E test execution.

<details><summary><b>Changed files (1)</b></summary>

- `suite/router/src/__fixtures__/routerThunks.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test explicitly validates every route defined in the router-config against a coverage mapping (SECTIONS), so changes to router fixtures/thunks used in testing routing logic could affect route coverage assertions or navigation behavior across the app.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/router/src/__fixtures__/routerThunks.ts`

_Updated: 2026-07-17T21:12:56.401Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/router-thunks-fixture-declaration/web/](https://dev.suite.sldev.cz/suite-web/refactor/router-thunks-fixture-declaration/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/router-thunks-fixture-declaration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/router-thunks-fixture-declaration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-23T11:27:14.233Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-23T11:27:04.667Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->