### PR TITLE
test(trading): shrink test utility declaration

### DIFF
--- a/suite-native/module-trading/src/__tests__/tradingTestUtils.ts
+++ b/suite-native/module-trading/src/__tests__/tradingTestUtils.ts
@@ -20,7 +20,9 @@ import { appSettingsInitialState } from '@suite-native/settings';
 import {
     type PreloadedStatePartial,
     type RenderHookOptionsExtended,
+    type RenderHookResult,
     type RenderOptionsExtended,
+    type RenderResult,
     createStaticReducer,
     createStoreFromPreloadedState,
     mergePreloadedState,
@@ -55,6 +57,15 @@ const createBaseTradingPreloadedState = (tradeType: TradingTestTradeType) => ({
 
 export type TradingTestPreloadedState = ReturnType<typeof createBaseTradingPreloadedState>;
 
+type TradingLightStoreState = Omit<TradingTestPreloadedState, 'wallet'> & {
+    wallet: Omit<TradingTestPreloadedState['wallet'], 'formDrafts'> & {
+        formDrafts: ReturnType<typeof formDraftReducer>;
+        transactions: typeof transactionsInitialState;
+    };
+};
+
+type TradingLightStore = ReturnType<typeof configureMockStore<TradingLightStoreState>>;
+
 export const createTradingFeatureFlags = (
     overrides: Partial<typeof featureFlagsInitialState> = {},
 ) => ({
@@ -85,7 +96,7 @@ export const createTradingTestStore = (args?: {
 export const createTradingLightStore = (args?: {
     overrides?: PreloadedStatePartial<TradingTestPreloadedState>;
     tradeType?: TradingTestTradeType;
-}) => {
+}): TradingLightStore => {
     const preloadedState = createTradingPreloadedState(args);
 
     const reducer = {
@@ -139,7 +150,7 @@ type RenderHookWithTradingProviderOptions<Props> = TradingProviderOptions &
 export const renderWithTradingProvider = (
     element: ReactElement,
     { overrides, tradeType, ...options }: RenderWithTradingProviderOptions = {},
-) =>
+): RenderResult =>
     renderWithStoreProvider(element, {
         preloadedState: createTradingPreloadedState({ overrides, tradeType }),
         ...options,
@@ -148,7 +159,7 @@ export const renderWithTradingProvider = (
 export const renderHookWithTradingProvider = <Result, Props>(
     callback: (props: Props) => Result,
     { overrides, tradeType, ...options }: RenderHookWithTradingProviderOptions<Props> = {},
-) =>
+): RenderHookResult<Result, Props> =>
     renderHookWithStoreProvider<Result, Props>(callback, {
         preloadedState: createTradingPreloadedState({ overrides, tradeType }),
         ...options,


### PR DESCRIPTION
## Description

The module-trading test utility exposed fully inferred mock-store and React Native render-helper return types, causing the complete Redux state and testing-library query surface to be repeated throughout its declaration. Named store-state and render-result contracts preserve the precise public helper types while keeping the emitted declaration compact.

- Declaration: **30,550 → 4,441 bytes**
- Saved: **26,109 bytes (85.5%)**
- Expansion ratio: **4.85x → 0.66x**

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native-trading-test-utils-declaration&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->