### PR TITLE
refactor(connect): simplify event callback type

### DIFF
--- a/packages/connect-common/src/types/api/events.type-test.ts
+++ b/packages/connect-common/src/types/api/events.type-test.ts
@@ -232,6 +232,9 @@ export const events = (api: TrezorConnect) => {
         payload.shortcut.toLowerCase();
     });
 
+    // @ts-expect-error callback payload must match the selected event
+    api.on(BLOCKCHAIN.CONNECT, (_payload: string) => {});
+
     api.on(BLOCKCHAIN.FIAT_RATES_UPDATE, payload => {
         payload.rates.usd?.toFixed();
     });

--- a/packages/connect-common/src/types/emitter.ts
+++ b/packages/connect-common/src/types/emitter.ts
@@ -1,5 +1,4 @@
-import type { UnionToIntersection } from '@trezor/type-utils';
-import { TypedEmitter } from '@trezor/utils';
+import { type EventReceiver, TypedEmitter } from '@trezor/utils';
 
 import type {
     BLOCKCHAIN_EVENT,
@@ -28,15 +27,9 @@ type ConnectEventMap = {
 
 export type ConnectEvents = keyof ConnectEventMap;
 
-export type ConnectEventCallbacks = UnionToIntersection<
-    {
-        [K in ConnectEvents]: (
-            type: K,
-            cb: ConnectEventMap[K] extends undefined
-                ? () => void
-                : (event: ConnectEventMap[K]) => void,
-        ) => void;
-    }[ConnectEvents]
->;
+export type ConnectEventCallbacks = <T extends ConnectEvents>(
+    type: T,
+    callback: EventReceiver<ConnectEventMap[T]>,
+) => void;
 
 export class ConnectEmitter extends TypedEmitter<ConnectEventMap> {}

--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -47,7 +47,6 @@ const LEGIT_BIG_FILES = new Set<string>([
 // Existing violations to fix incrementally. The requirement reports entries once they can be removed.
 const KNOWN_DECLARATION_SIZE_VIOLATIONS = new Set<string>([
     'packages/connect-common/libDev/src/types/api/cardano/common.d.ts',
-    'packages/connect-common/libDev/src/types/api/internal/index.d.ts',
     'suite-common/calldata/libDev/src/calldata.d.ts',
     'suite-common/calldata/libDev/src/verifier.d.ts',
     'suite-common/receive/libDev/src/receiveSlice.d.ts',

--- a/packages/utils/src/typedEventEmitter.ts
+++ b/packages/utils/src/typedEventEmitter.ts
@@ -16,7 +16,7 @@ type EventKey<T extends EventMap> = string & keyof T;
 type IsUnion<T, U extends T = T> = T extends unknown ? ([U] extends [T] ? 0 : 1) : 2;
 
 // NOTE: case 1. looks like case 4. but works differently. the order matters
-type EventReceiver<T> =
+export type EventReceiver<T> =
     IsUnion<T> extends 1
         ? (event: T) => void // 1. use union payload
         : T extends (...args: any[]) => any


### PR DESCRIPTION
## Description

`ConnectEventCallbacks` represented every Connect event as a 57-member intersection of call signatures, forcing TypeScript to compare the full overload set at `on` and `off` boundaries. The public contract now uses one generic event/payload signature backed by the emitter’s shared `EventReceiver` mapping, preserving zero-payload, union-payload, and mismatched-callback type safety.

- Declaration: **1,478 → 1,345 bytes**
- Saved: **133 bytes (9.0%)**
- Expansion ratio: **0.98x → 1.03x**
- Strict subtype cache: **8,441 → 624 entries (92.6% fewer)**
- Focused check time: **2.70s → 2.11s**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is primarily type-level (connect-common emitter types, type tests, build-size requirements) plus the typedEventEmitter utility. Runtime risk is low-to-moderate, concentrated in event-driven flows. I recommend running two high-priority tests that directly exercise event emission (analytics) and Connect popup lifecycle, plus one medium-priority analytics toggle test as a sanity check on shared emitter infrastructure.

<details><summary><b>Changed files (4)</b></summary>

- `packages/connect-common/src/types/api/events.type-test.ts`
- `packages/connect-common/src/types/emitter.ts`
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`
- `packages/utils/src/typedEventEmitter.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test directly validates analytics event capture (SuiteReady, DeviceConnect, TransportType, etc.) and event ordering. Changes to typedEventEmitter.ts could break event emission/delivery, and this test exercises the full event pipeline end-to-end.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises the full TrezorConnect popup lifecycle including permissions, address confirmation, cancellation, and popup focus/close behavior. The connect-common emitter types and typedEventEmitter utility underpin Connect's event-driven popup communication.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/analytics/toggle.test.ts` — This test verifies analytics enable/disable event firing and session/instance ID persistence. It shares the event emitter infrastructure with the analytics events test and would catch regressions in conditional event emission.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/connect-common/src/types/api/events.type-test.ts`
- `packages/connect-common/src/types/emitter.ts`
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`

_Updated: 2026-08-28T21:07:00.310Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/connect-event-callbacks/web/](https://dev.suite.sldev.cz/suite-web/refactor/connect-event-callbacks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/connect-event-callbacks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/connect-event-callbacks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-28T21:09:13.888Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-28T21:09:22.537Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->