### PR TITLE
refactor(analytics): narrow desktop event boundaries

### DIFF
--- a/packages/analytics-uploader/mocks/mockAnalytics.ts
+++ b/packages/analytics-uploader/mocks/mockAnalytics.ts
@@ -1,8 +1,7 @@
 import type { Analytics } from '../src/analytics';
-import type { Event } from '../src/types';
 
 /** `report` is a spy, so a test asserts on it through the mock it was given. */
-export type MockedAnalytics<T extends Event> = Analytics<T> & {
+export type MockedAnalytics<T> = Analytics<T> & {
     report: jest.MockedFunction<Analytics<T>['report']>;
 };
 
@@ -11,7 +10,7 @@ export type MockedAnalytics<T extends Event> = Analytics<T> & {
  * (e.g. `mockAnalytics<AnalyticsSharedEvents>()`) or use a typed wrapper such
  * as `mockNativeAnalytics` / `mockDesktopAnalytics`.
  */
-export const mockAnalytics = <T extends Event = never>(
+export const mockAnalytics = <T = never>(
     report: jest.MockedFunction<Analytics<T>['report']> = jest.fn(),
 ): MockedAnalytics<T> => ({
     init: () => {},

--- a/packages/analytics-uploader/src/analytics.ts
+++ b/packages/analytics-uploader/src/analytics.ts
@@ -7,7 +7,7 @@ import type {
 } from './types';
 import { encodeDataToQueryString, getRandomId, getUrl, reportEvent } from './utils';
 
-export interface Analytics<T extends AnalyticsEvent> {
+export interface Analytics<T> {
     init: (enabled: boolean | undefined, options: InitOptions) => void;
     enable: () => void;
     disable: () => void;

--- a/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 
-import { type AnalyticsDesktopEvents, selectDesktopAnalyticsDep } from '@suite/analytics';
-import { events } from '@suite-common/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
+import { type EventInstance, events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -86,6 +86,13 @@ const getPendingDurationMs = (
     return undefined;
 };
 
+type YieldResolutionAnalyticsEvent =
+    | EventInstance<typeof events.yieldDepositEvent>
+    | EventInstance<typeof events.yieldWithdrawEvent>
+    | EventInstance<typeof events.yieldClaimEvent>;
+
+type YieldResolutionAnalytics = Pick<Analytics<YieldResolutionAnalyticsEvent>, 'report'>;
+
 const resolveReportedType = <T extends string>(
     outcome: 'success' | 'error' | 'leftPending',
     successType: T,
@@ -97,7 +104,7 @@ const resolveReportedType = <T extends string>(
 };
 
 const reportResolution = (
-    analytics: Analytics<AnalyticsDesktopEvents>,
+    analytics: YieldResolutionAnalytics,
     resolution: ResolutionEventType,
     outcome: 'success' | 'error' | 'leftPending',
     context: ReportContext,

--- a/suite-common/analytics/src/eventDefinition.ts
+++ b/suite-common/analytics/src/eventDefinition.ts
@@ -77,7 +77,7 @@ export type EventDef<A, N extends EventName = EventName> =
 // `infer` pulls the data type (`A`) and event name (`N`) out of `EventDef`. If `E` contains several
 // event definitions joined with `|`, TypeScript translates each one separately. This keeps every
 // event name paired with the correct payload.
-export type EventInstance<E extends EventDef<any, any>> =
+export type EventInstance<E> =
     E extends EventDef<infer A, infer N>
         ? IsAttributeMap<A> extends true
             ? AttributeEventInstance<A, N>

--- a/suite/analytics/mocks/mockDesktopAnalytics.ts
+++ b/suite/analytics/mocks/mockDesktopAnalytics.ts
@@ -1,8 +1,8 @@
-import type { Analytics } from '@trezor/analytics-uploader';
 import { type MockedAnalytics, mockAnalytics } from '@trezor/analytics-uploader/mocks';
 
 import type { AnalyticsDesktopEvents } from '../src/analyticsEvents';
+import type { DesktopAnalytics } from '../src/createAnalytics';
 
 export const mockDesktopAnalytics = (
-    report?: jest.MockedFunction<Analytics<AnalyticsDesktopEvents>['report']>,
-): MockedAnalytics<AnalyticsDesktopEvents> => mockAnalytics<AnalyticsDesktopEvents>(report);
+    report?: jest.MockedFunction<DesktopAnalytics['report']>,
+): MockedAnalytics<AnalyticsDesktopEvents> => mockAnalytics(report);

--- a/suite/analytics/src/analyticsEvents.ts
+++ b/suite/analytics/src/analyticsEvents.ts
@@ -1,18 +1,13 @@
 import type { AnalyticsSharedEvents, EventInstance } from '@suite-common/analytics';
 
-import { type EventType } from './constants';
 import * as desktopEventsData from './events';
 
 export const desktopEvents = desktopEventsData;
 export type AnyDesktopEventsDef = (typeof desktopEvents)[keyof typeof desktopEvents];
 export type AnalyticsDesktopEvents = EventInstance<AnyDesktopEventsDef> | AnalyticsSharedEvents;
 
-export type SuiteReadyPayload = Extract<
-    AnalyticsDesktopEvents,
-    { type: EventType.SuiteReady }
->['payload'];
+export type SuiteReadyPayload = EventInstance<typeof desktopEvents.suiteReadyEvent>['payload'];
 
-export type StakingCardanoPoolDelegationPayload = Extract<
-    AnalyticsDesktopEvents,
-    { type: EventType.StakingCardanoPoolDelegation }
+export type StakingCardanoPoolDelegationPayload = EventInstance<
+    typeof desktopEvents.stakingCardanoPoolDelegationEvent
 >['payload'];

--- a/suite/analytics/src/createAnalytics.ts
+++ b/suite/analytics/src/createAnalytics.ts
@@ -2,15 +2,17 @@ import { type Analytics, QueuedAnalytics } from '@trezor/analytics-uploader';
 
 import { type AnalyticsDesktopEvents } from './analyticsEvents';
 
+export type DesktopAnalytics = Analytics<AnalyticsDesktopEvents>;
+
 export type DesktopAnalyticsDep = {
-    analytics: Analytics<AnalyticsDesktopEvents>;
+    analytics: DesktopAnalytics;
 };
 
 export const selectDesktopAnalyticsDep = (services: any): DesktopAnalyticsDep => ({
     analytics: services.analytics,
 });
 
-export const createAnalytics = (): Analytics<AnalyticsDesktopEvents> =>
+export const createAnalytics = (): DesktopAnalytics =>
     new QueuedAnalytics<AnalyticsDesktopEvents>({
         version: process.env.VERSION!,
         app: 'suite',

--- a/suite/analytics/src/index.ts
+++ b/suite/analytics/src/index.ts
@@ -1,5 +1,6 @@
 export {
     createAnalytics,
+    type DesktopAnalytics,
     type DesktopAnalyticsDep,
     selectDesktopAnalyticsDep,
 } from './createAnalytics';


### PR DESCRIPTION
## Description

The full desktop analytics event union makes TypeScript repeat expensive comparisons inside helpers and the uploader. Keep strict event types at reporting call sites while using narrower contracts for the queue, payload helpers, yield reporter, and typed mocks, preserving runtime behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is focused on analytics infrastructure and yield pending-transaction tracking. The highest-risk regressions are in analytics event emission and the yield vault redeem/withdraw flows. Run the two core analytics tests and the two yield tests unconditionally; add the three narrower analytics event tests as medium-confidence coverage. The analytics uploader and desktop analytics mocks are not exercised by any E2E test in this set.

<details><summary><b>Changed files (8)</b></summary>

- `packages/analytics-uploader/mocks/mockAnalytics.ts`
- `packages/analytics-uploader/src/analytics.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts`
- `suite-common/analytics/src/eventDefinition.ts`
- `suite/analytics/mocks/mockDesktopAnalytics.ts`
- `suite/analytics/src/analyticsEvents.ts`
- `suite/analytics/src/createAnalytics.ts`
- `suite/analytics/src/index.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — Directly exercises analytics event emission and payload validation (SuiteReady, DeviceConnect, settings analytics), which is the primary behavior impacted by changes in suite/analytics/src/analyticsEvents.ts, createAnalytics.ts, index.ts and suite-common/analytics/src/eventDefinition.ts. Coverage for these core analytics files is inferred from the test's assertions rather than static mapping.
- `suite/e2e/tests/analytics/toggle.test.ts` — Validates analytics enable/disable lifecycle, settingsAnalyticsEvent payloads, and session/instance ID handling, all of which depend on the analytics initialization and event creation logic in the changed suite/analytics files. Coverage is inferred from the test's direct assertions on analytics state and events.
- `suite/e2e/tests/yield/redeem.test.ts` — The changed file packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts is specifically part of the yield flow, and this test exercises the USDC Prime Vault redeem flow through transaction simulation, device confirmation, and post-transaction dashboard updates where pending-transaction tracking would be active.
- `suite/e2e/tests/yield/withdrawal.test.ts` — Directly covers the yield withdrawal flow for a USDC vault, including transaction simulation, device confirmation, and dashboard state updates after the transaction — the exact domain where useYieldPendingTransactionTracking.ts operates.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — Tests PromoDashboardBanner analytics event emission; changes to analytics event definitions or the analytics dispatcher could alter this event's payload or timing. Coverage inferred from the test's analytics assertions.
- `suite/e2e/tests/analytics/staking-events.test.ts` — Tests StakingNavigate analytics event payload and networkSymbol values; modifications to analytics event creation or type definitions could affect this event. Coverage inferred from the test's event assertions.
- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — Validates WalletConnect analytics events (WalletConnectInit, WalletConnectPaired, etc.); changes to analytics event definitions or initialization could impact these events. Coverage inferred from the test's event assertions.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/analytics-uploader/mocks/mockAnalytics.ts`
- `suite/analytics/mocks/mockDesktopAnalytics.ts`

_Updated: 2026-09-10T13:31:48.303Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/analytics-desktop-event-boundaries/web/](https://dev.suite.sldev.cz/suite-web/refactor/analytics-desktop-event-boundaries/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/analytics-desktop-event-boundaries&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/analytics-desktop-event-boundaries&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap SPL token to coin via CEX > Swap USDT to SOL via CEX | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T13:35:37.149Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap ETH to SOL | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T13:34:41.717Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->