### PR TITLE
refactor(suite): stabilize WordInput select boundary

### DIFF
--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -37,6 +37,10 @@ type AllowedFrameProps = Pick<FrameProps, (typeof allowedSelectFrameProps)[numbe
 
 export type { Option } from './types';
 
+export type SelectRef = {
+    clearValue: () => void;
+};
+
 export type SelectProps = AllowedFrameProps &
     Omit<FormCellProps, 'children'> &
     Omit<ReactSelectProps<OptionType>, 'onChange' | 'menuIsOpen' | 'styles'> & {
@@ -46,7 +50,7 @@ export type SelectProps = AllowedFrameProps &
         isClean?: boolean;
         isMenuOpen?: boolean;
         isLoading?: boolean;
-        onChange?: (value: OptionType, ref?: SelectInstance<OptionType, boolean> | null) => void;
+        onChange?: (value: OptionType, ref?: SelectRef | null) => void;
         'data-testid'?: string;
         openMenuOnFocus?: boolean;
         /** When using menuPortalTarget (e.g. in modals), set this so the menu appears above the modal */

--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -37,6 +37,8 @@ type AllowedFrameProps = Pick<FrameProps, (typeof allowedSelectFrameProps)[numbe
 
 export type { Option } from './types';
 
+// This intentionally exposes only the capability used by consumers instead of deriving it from
+// react-select's generic SelectInstance, which would leak that implementation type into our public API.
 export type SelectRef = {
     clearValue: () => void;
 };

--- a/packages/suite/src/components/suite/WordInput.tsx
+++ b/packages/suite/src/components/suite/WordInput.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { type SelectInstance, createFilter } from 'react-select';
+import { createFilter } from 'react-select';
 
 import { useTranslation } from '@suite/intl';
 import { selectModalRequestId } from '@suite/modal';
@@ -13,6 +13,7 @@ import { useSelector } from 'src/hooks/suite';
 const options = bip39EnglishWordlist.map(item => ({ label: item, value: item }));
 
 type Option = { label: string; value: string };
+type WordInputSelectRef = { clearValue: () => void };
 
 export const WordInput = memo(() => {
     const { translationString } = useTranslation();
@@ -28,7 +29,7 @@ export const WordInput = memo(() => {
             noOptionsMessage={({ inputValue }: { inputValue: string }) =>
                 translationString('TR_WORD_DOES_NOT_EXIST', { word: inputValue })
             }
-            onChange={async (item: Option, ref?: SelectInstance<Option, boolean> | null) => {
+            onChange={async (item: Option, ref?: WordInputSelectRef | null) => {
                 await resolveAfter(600);
                 TrezorConnect.uiResponse({
                     type: UI_RESPONSE.RECEIVE_WORD,

--- a/packages/suite/src/components/suite/WordInput.tsx
+++ b/packages/suite/src/components/suite/WordInput.tsx
@@ -3,7 +3,7 @@ import { createFilter } from 'react-select';
 
 import { useTranslation } from '@suite/intl';
 import { selectModalRequestId } from '@suite/modal';
-import { Select } from '@trezor/components';
+import { Select, type SelectRef } from '@trezor/components';
 import TrezorConnect, { UI_RESPONSE } from '@trezor/connect';
 import { bip39EnglishWordlist } from '@trezor/crypto-utils';
 import { resolveAfter } from '@trezor/utils';
@@ -13,7 +13,6 @@ import { useSelector } from 'src/hooks/suite';
 const options = bip39EnglishWordlist.map(item => ({ label: item, value: item }));
 
 type Option = { label: string; value: string };
-type WordInputSelectRef = { clearValue: () => void };
 
 export const WordInput = memo(() => {
     const { translationString } = useTranslation();
@@ -29,7 +28,7 @@ export const WordInput = memo(() => {
             noOptionsMessage={({ inputValue }: { inputValue: string }) =>
                 translationString('TR_WORD_DOES_NOT_EXIST', { word: inputValue })
             }
-            onChange={async (item: Option, ref?: WordInputSelectRef | null) => {
+            onChange={async (item: Option, ref?: SelectRef | null) => {
                 await resolveAfter(600);
                 TrezorConnect.uiResponse({
                     type: UI_RESPONSE.RECEIVE_WORD,


### PR DESCRIPTION
## Description

The WordInput change handler exposed the complete generic react-select instance even though it only needs clearValue(). A small shared SelectRef capability now keeps that third-party implementation type out of the public callback contract, and an explanatory comment documents why the type is intentionally declared rather than derived from SelectInstance; runtime behavior remains unchanged.

- Declaration: **143 → 143 bytes**
- Saved: **0 bytes (0.0%)**
- Expansion ratio: **0.08x → 0.08x**
- Focused check: **1,191.4 → 903.9 ms (24.1% faster)**
- Shared-boundary instantiations: **604,142 → 604,101 (0.0%)**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The two changed files are both broad shared UI components: Select.tsx underlies numerous dropdown interactions across settings, metadata, and trading flows, while WordInput.tsx is specifically used for mnemonic/seed word entry during onboarding and recovery flows. Rather than running all 131 statically-mapped tests, we focused on tests whose behaviors explicitly exercise dropdown selection (Select) or word-by-word mnemonic input (WordInput) per the LLM behavior descriptions. Recommended strategy: prioritize settings/metadata/trading tests that actively drive Select option selection, and prioritize T1B1/T2T1 recovery tests that actively drive WordInput entry, since these most directly touch the modified components' interaction logic.

<details><summary><b>Changed files (2)</b></summary>

- `packages/components/src/components/form/Select/Select.tsx`
- `packages/suite/src/components/suite/WordInput.tsx`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — This test directly exercises multiple Select dropdown components (fiat currency select, language select, theme selector) via settingsPage.changeTheme/changeLanguage flows, making it a direct exerciser of the changed Select component's core interaction pattern (open, choose option, confirm selection).
- `suite/e2e/tests/settings/coins.test.ts` — This test exercises custom backend configuration which involves a Select dropdown (backend type selector) and network toggles, directly testing Select component behavior in the settings/coins flow.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test configures custom backend URLs via a backend type Select dropdown for BTC/ETH, directly exercising Select's option selection and value display behavior.
- `suite/e2e/tests/metadata/legacy/switching-providers.test.ts` — This test heavily uses a metadata provider Select dropdown (selectDropdownOptionWithRetry, metadataSelectInput) to switch between Dropbox and Google providers, directly stressing the Select component's option list and selection state.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts` — This T1B1 recovery test directly uses the T1B1-specific mnemonic word input flow (inputMnemonicT1B1), exercising the WordInput component used for entering recovery seed words.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts` — Advanced recovery flow explicitly presents 'word input fields' for the user to enter recovery words, directly exercising the WordInput component across multiple word-count scenarios (24 and 12 words) and reconnection retries.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/metadata/legacy/google-api-errors.test.ts` — Uses metadataSelectInput/metadataSelectInputOption dropdown selection with retry logic to pick a metadata provider, exercising the Select component during provider configuration.
- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — Uses the metadataSelectInput dropdown to enable/disable labeling and verify displayed translation states, directly touching Select component rendering and value display.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test switches fiat currency via a Select dropdown in the sell form and validates ticker/currency displays, directly exercising Select's option-switching behavior in a trading context.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts` — Covers recovery flow entry into word-count/recovery-type selection which precedes WordInput usage, and retry behavior after device disconnection during recovery.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — T2T1 recovery flow involves mnemonic word input (inputMnemonicT2T1) similar in nature to WordInput usage, relevant to verify cross-device consistency of the changed component.
- `suite/e2e/tests/recovery/t1b1-dry-run.test.ts` — Uses T1B1 mnemonic input during a recovery dry-run flow, directly exercising the WordInput component for 24-word entry outside of full onboarding.
- `suite/e2e/tests/recovery/t2t1-dry-run.test.ts` — Uses trezorInput.inputMnemonicT2T1 for entering a 12-word mnemonic during dry-run recovery, directly testing the WordInput component's input handling.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/recovery/dry-run.test.ts` — Standard recovery dry-run also uses mnemonic input (inputMnemonicT2T1) though it is less specific to WordInput edge cases than the dedicated T2T1/T1B1 tests.

</details>

_Updated: 2026-07-19T07:49:51.416Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/suite-word-input-select-boundary/web/](https://dev.suite.sldev.cz/suite-web/refactor/suite-word-input-select-boundary/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/suite-word-input-select-boundary&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/suite-word-input-select-boundary&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-19T07:53:11.155Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-19T07:52:32.827Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->