### PR TITLE
test(e2e): wrap t1b1/t2t1 onboarding tests in test.step (1/3 of #26628)

### DIFF
--- a/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
@@ -59,16 +59,14 @@ test.describe('Onboarding - create wallet', { tag: ['@firmware-ready', '@T1B1'] 
                 await page.getByTestId('@onboarding/continue-button').click();
             });
 
-            await test.step('Lets set PIN', async () => {
+            await test.step('Set PIN', async () => {
                 await page.waitForTimeout(2_000);
                 const pin = '12345';
 
                 await onboardingPage.pin.setPinButton.click();
                 await devicePrompt.confirmOnDevicePromptIsShown();
                 await device.pressYes();
-                // enter the PIN
                 await trezorInput.enterPinOnBlindMatrix(pin);
-                // re-enter the PIN
                 await trezorInput.enterPinOnBlindMatrix(pin);
             });
 

--- a/suite/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts
+++ b/suite/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts
@@ -16,25 +16,27 @@ test.describe('Onboarding - recover wallet T1B1', { tag: ['@firmware-ready', '@T
         recoveryModal,
         devicePrompt,
     }) => {
-        await analyticsSection.passThroughAnalytics();
+        await test.step('Start wallet recovery process', async () => {
+            await analyticsSection.passThroughAnalytics();
+            await onboardingPage.firmware.continueThroughFirmware();
+            await onboardingPage.recoverWalletButton.click();
+            await recoveryModal.selectWordCount(24);
+            await recoveryModal.selectRecoveryButton('standard').click();
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await device.pressYes();
+        });
 
-        // Start wallet recovery process
-        await onboardingPage.firmware.continueThroughFirmware();
-        await onboardingPage.recoverWalletButton.click();
-        await recoveryModal.selectWordCount(24);
-        await recoveryModal.selectRecoveryButton('standard').click();
-        await devicePrompt.confirmOnDevicePromptIsShown();
-        await device.pressYes();
+        await test.step('Disconnect the device', async () => {
+            await device.powerOff();
+            await devicePrompt.connectDevicePromptIsShown();
+            await device.powerOn();
+        });
 
-        // Disconnect the device
-        await device.powerOff();
-        await devicePrompt.connectDevicePromptIsShown();
-        await device.powerOn();
-
-        // Retry recovery process
-        await onboardingPage.retryRecoveryButton.click();
-        await recoveryModal.selectWordCount(24);
-        await recoveryModal.selectRecoveryButton('standard').click();
-        await devicePrompt.confirmOnDevicePromptIsShown();
+        await test.step('Retry recovery process', async () => {
+            await onboardingPage.retryRecoveryButton.click();
+            await recoveryModal.selectWordCount(24);
+            await recoveryModal.selectRecoveryButton('standard').click();
+            await devicePrompt.confirmOnDevicePromptIsShown();
+        });
     });
 });

--- a/suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts
+++ b/suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts
@@ -34,25 +34,27 @@ test.describe('Onboarding - recover wallet T1B1', { tag: ['@firmware-ready', '@T
             recoveryModal,
             trezorInput,
         }) => {
-            await analyticsSection.passThroughAnalytics();
+            await test.step('Start wallet recovery process', async () => {
+                await analyticsSection.passThroughAnalytics();
+                await onboardingPage.firmware.continueThroughFirmware();
+                await onboardingPage.recoverWalletButton.click();
+                await recoveryModal.selectWordCount(24);
+                await recoveryModal.selectRecoveryButton('standard').click();
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await page.waitForTimeout(1000);
+                await device.pressYes();
+            });
 
-            // Start wallet recovery process
-            await onboardingPage.firmware.continueThroughFirmware();
-            await onboardingPage.recoverWalletButton.click();
-            await recoveryModal.selectWordCount(24);
-            await recoveryModal.selectRecoveryButton('standard').click();
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await page.waitForTimeout(1000);
-            await device.pressYes();
+            await test.step('Input mnemonic', async () => {
+                await trezorInput.inputMnemonicT1B1(mnemonic);
+            });
 
-            // Input mnemonic
-            await trezorInput.inputMnemonicT1B1(mnemonic);
-
-            // Finalize recovery, skip pin, and verify success
-            await onboardingPage.continueRecoveryButton.click();
-            await onboardingPage.pin.skip();
-            await onboardingPage.finalButton.click();
-            await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({ timeout: 30_000 });
+            await test.step('Finalize recovery, skip pin, and verify success', async () => {
+                await onboardingPage.continueRecoveryButton.click();
+                await onboardingPage.pin.skip();
+                await onboardingPage.finalButton.click();
+                await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({ timeout: 30_000 });
+            });
         },
     );
 });

--- a/suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts
+++ b/suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts
@@ -19,24 +19,26 @@ test.describe('Onboarding - recover wallet T2T1', { tag: ['@T2T1'] }, () => {
             }),
         },
         async ({ page, device, onboardingPage, analyticsSection, devicePrompt }) => {
-            await analyticsSection.passThroughAnalytics();
-            await onboardingPage.firmware.continueThroughFirmware();
+            await test.step('Start wallet recovery process and confirm on device', async () => {
+                await analyticsSection.passThroughAnalytics();
+                await onboardingPage.firmware.continueThroughFirmware();
+                await onboardingPage.recoverWalletButton.click();
+                await onboardingPage.startRecoveryButton.click();
+                await devicePrompt.confirmOnDevicePromptIsShown();
+            });
 
-            // Start wallet recovery process and confirm on device
-            await onboardingPage.recoverWalletButton.click();
-            await onboardingPage.startRecoveryButton.click();
-            await devicePrompt.confirmOnDevicePromptIsShown();
+            await test.step('Disconnect device', async () => {
+                await page.waitForTimeout(1000);
+                await device.powerOff();
+                await page.waitForTimeout(500);
+                await devicePrompt.connectDevicePromptIsShown();
+                await device.powerOn();
+            });
 
-            // Disconnect device
-            await page.waitForTimeout(1000);
-            await device.powerOff();
-            await page.waitForTimeout(500);
-            await devicePrompt.connectDevicePromptIsShown();
-            await device.powerOn();
-
-            // Check that you can retry
-            await onboardingPage.retryRecoveryButton.click();
-            await devicePrompt.confirmOnDevicePromptIsShown();
+            await test.step('Check that you can retry', async () => {
+                await onboardingPage.retryRecoveryButton.click();
+                await devicePrompt.confirmOnDevicePromptIsShown();
+            });
         },
     );
 });

--- a/suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts
+++ b/suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts
@@ -24,33 +24,37 @@ test.describe('Onboarding - recover wallet T2T1', { tag: ['@T2T1'] }, () => {
             }),
         },
         async ({ onboardingPage, device, devicePrompt }) => {
-            // Start wallet recovery process and confirm on device
-            await onboardingPage.firmware.continueThroughFirmware();
-            await onboardingPage.recoverWalletButton.click();
-            await onboardingPage.startRecoveryButton.click();
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await device.pressYes();
+            await test.step('Start wallet recovery process and confirm on device', async () => {
+                await onboardingPage.firmware.continueThroughFirmware();
+                await onboardingPage.recoverWalletButton.click();
+                await onboardingPage.startRecoveryButton.click();
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await device.pressYes();
 
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await device.selectNumberOfWords(12);
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await device.selectNumberOfWords(12);
 
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await device.pressYes();
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await device.pressYes();
+            });
 
-            // Input mnemonic
-            for (let i = 0; i < 12; i++) {
-                await device.type('all');
-            }
+            await test.step('Input mnemonic', async () => {
+                for (let i = 0; i < 12; i++) {
+                    await device.type('all');
+                }
+            });
 
-            // Confirm recovery success
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await device.pressYes();
+            await test.step('Confirm recovery success', async () => {
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await device.pressYes();
+            });
 
-            // Finalize recovery, skip pin, and check success
-            await onboardingPage.continueRecoveryButton.click();
-            await onboardingPage.pin.skip();
-            await onboardingPage.finalButton.click();
-            await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({ timeout: 30_000 });
+            await test.step('Finalize recovery, skip pin, and check success', async () => {
+                await onboardingPage.continueRecoveryButton.click();
+                await onboardingPage.pin.skip();
+                await onboardingPage.finalButton.click();
+                await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({ timeout: 30_000 });
+            });
         },
     );
 });


### PR DESCRIPTION
Part **1 of 3** splitting #26628 into reviewable pieces. Stacked; review/merge in order 1 → 2 → 3.

## What this does
Pure readability refactor of existing onboarding e2e tests: flat `// step` comments are grouped into `test.step(...)` blocks. **No behavioral change** — same locators, same calls, same assertions.

## Files (5)
- `t1b1-create-wallet`, `t1b1-recovery-fail`, `t1b1-recovery-success`
- `t2t1-recovery-fail`, `t2t1-recovery-success`

## Notes
- Content is byte-identical to the corresponding files in #26628.
- Safe to skim — nothing functional changed.

Follow-ups (stacked on top): PR 2/3 (shared helper + emulator/tenv + product test ids), PR 3/3 (new T3B1 + T3W1 single-shamir tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/split/onboarding-teststep-refactor/web/](https://dev.suite.sldev.cz/suite-web/split/onboarding-teststep-refactor/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=split/onboarding-teststep-refactor&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=split/onboarding-teststep-refactor&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-18T11:06:53.498Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-18T11:06:02.506Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->