### PR TITLE
test(e2e): object-arg passThroughShamirBackup + single-shamir/PIN emulator support (2/3 of #26628)

### DIFF
--- a/docker/docker-compose.suite-ci-e2e.yml
+++ b/docker/docker-compose.suite-ci-e2e.yml
@@ -1,6 +1,6 @@
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:97b797fb349737b93a1d2dbe6bda6673dcc9cafb
+    image: ghcr.io/trezor/trezor-user-env:d656287715562840ab53cce98204f2424a9c9306
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/packages/suite/src/views/onboarding/steps/BackupTypeStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/BackupTypeStep.tsx
@@ -87,6 +87,7 @@ export const BackupTypeStep = () => {
     return (
         <OnboardingCard
             icon={WalletIcon}
+            data-testid="@onboarding/wallet-backup-type"
             heading={
                 <Column gap={8} alignItems="center" justifyContent="center">
                     <Badge intent="neutral" size="medium">

--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -4,6 +4,7 @@ import { TypedEmitter, resolveAfter } from '@trezor/utils';
 
 import { type Firmwares, Model } from './types';
 import { WebsocketClient, type WebsocketClientEvents } from './websocket-client';
+
 export interface SetupEmu {
     mnemonic?: string;
     pin?: string;
@@ -125,7 +126,6 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
         // todo: legacy api, should be removed
         this.send = this.client.send.bind(this.client);
     }
-
     public async setupEmu(options?: SetupEmu) {
         const defaults = {
             pin: '',
@@ -243,7 +243,6 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
 
         return null;
     }
-
     async stopEmu() {
         await this.client.send({ type: 'emulator-stop' });
 
@@ -316,6 +315,12 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
 
         return null;
     }
+    async readAndConfirmSingleShamirMnemonicEmu() {
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
+        await this.client.send({ type: 'emulator-read-and-confirm-single-shamir-mnemonic' });
+
+        return null;
+    }
     async applySettings(options: ApplySettings) {
         if (JSON.stringify(this.currentEmulatorSettings) === JSON.stringify(options)) {
             console.log('Emulator already has the same settings applied, skipping setup');
@@ -335,26 +340,29 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
 
         return null;
     }
+    async inputPin(pin: string) {
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
+        await this.client.send({ type: 'emulator-input-pin', pin });
+
+        return null;
+    }
     async selectNumOfWordsEmu(num: number) {
         await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY * 2);
         await this.client.send({ type: 'emulator-select-num-of-words', num });
 
         return null;
     }
-
     async getScreenContent() {
         const { response } = await this.client.send({ type: 'emulator-get-screen-content' });
 
         return response;
     }
-
     async getDebugState() {
         await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         const { response } = await this.client.send({ type: 'emulator-get-debug-state' });
 
         return response;
     }
-
     async getPairingInfo(thp_channel_id: string, nfcData?: string) {
         // user-env expects something, cannot be undefined
         const d = nfcData ? Buffer.from(nfcData, 'hex') : undefined;
@@ -374,7 +382,6 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
             code_entry_code: Number(response.code_entry_code).toString().padStart(6, '0'),
         };
     }
-
     async logTestDetails(text: string) {
         await this.client.send({ type: 'log', text });
 

--- a/suite/e2e/support/device.ts
+++ b/suite/e2e/support/device.ts
@@ -82,6 +82,11 @@ export class DeviceFixture {
     }
 
     @step()
+    async inputPin(pin: string) {
+        await TrezorUserEnvLink.inputPin(pin);
+    }
+
+    @step()
     async tapCenter() {
         await TrezorUserEnvLink.clickEmu(EMULATOR_CENTER_COORDINATES[this.model]);
     }
@@ -103,6 +108,11 @@ export class DeviceFixture {
     @step()
     async readAndConfirmAtomicShamirMnemonic(options: ReadAndConfirmAtomicShamirMnemonicEmu) {
         await TrezorUserEnvLink.readAndConfirmAtomicShamirMnemonicEmu(options);
+    }
+
+    @step()
+    async readAndConfirmSingleShamirMnemonic() {
+        await TrezorUserEnvLink.readAndConfirmSingleShamirMnemonicEmu();
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/onboarding/backupSection.ts
+++ b/suite/e2e/support/pageObjects/onboarding/backupSection.ts
@@ -54,11 +54,15 @@ export class BackupSection {
     }
 
     @step()
-    async passThroughShamirBackup(
-        shares: number,
-        threshold: number,
-        { deviceConfirmations }: { deviceConfirmations: number },
-    ) {
+    async passThroughShamirBackup({
+        shares = 1,
+        threshold = 1,
+        deviceConfirmations,
+    }: {
+        shares?: number;
+        threshold?: number;
+        deviceConfirmations: number;
+    }) {
         const backupButton = this.page.getByTestId('@onboarding/create-backup-button');
         const closeButton = this.page.getByTestId('@onboarding/continue-button');
 
@@ -77,7 +81,12 @@ export class BackupSection {
         }
 
         await this.page.waitForTimeout(1000);
-        await this.device.readAndConfirmAtomicShamirMnemonic({ shares, threshold });
+
+        if (shares > 1) {
+            await this.device.readAndConfirmAtomicShamirMnemonic({ shares, threshold });
+        } else {
+            await this.device.readAndConfirmSingleShamirMnemonic();
+        }
 
         await closeButton.click();
     }

--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -42,8 +42,10 @@ export class OnboardingPage {
     readonly finalButton: Locator;
     readonly continueAtYourOwnRiskButton: Locator;
     readonly deviceCompromisedModal: Locator;
+    readonly thpPairingModal: Locator;
     readonly pairingInputAtIndex = (index: number) =>
-        this.page.getByTestId('@modal/thp-paring').locator('input').nth(index);
+        this.thpPairingModal.locator('input').nth(index);
+    readonly walletBackupTypeCard: Locator;
     readonly onboardingFeedbackBanner: Locator;
     readonly onboardingFeedbackBannerCTAButton: Locator;
 
@@ -90,6 +92,8 @@ export class OnboardingPage {
         this.onboardingFeedbackBannerCTAButton = this.page.getByTestId(
             '@dashboard/onboarding-feedback-banner/button',
         );
+        this.walletBackupTypeCard = this.page.getByTestId('@onboarding/wallet-backup-type');
+        this.thpPairingModal = this.page.getByTestId('@modal/thp-paring');
     }
 
     @step()
@@ -117,6 +121,9 @@ export class OnboardingPage {
             // index is provably valid by loop bound
             await this.pairingInputAtIndex(i).fill(getIndexOrThrow(code, i));
         }
+
+        await expect(this.thpPairingModal).toBeHidden();
+        await expect(this.devicePrompt.acquireDeviceButton).toBeHidden();
     }
 
     @step()

--- a/suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
@@ -15,29 +15,35 @@ test.describe('Onboarding - create wallet', { tag: ['@T2T1'] }, () => {
         onboardingPage,
         devicePrompt,
     }) => {
-        await analyticsSection.passThroughAnalytics();
-        await onboardingPage.firmware.continueThroughFirmware();
-
-        // Select backup type (no device interaction, just navigates to SecurityStep)
-        await onboardingPage.createWalletButton.click();
-        await onboardingPage.selectSeedType('shamir-advanced');
-
-        // Start backup
-        const shares = 3;
-        const threshold = 2;
-        await onboardingPage.backup.passThroughShamirBackup(shares, threshold, {
-            deviceConfirmations: 4,
+        await test.step('Device onboarding steps', async () => {
+            await analyticsSection.passThroughAnalytics();
+            await onboardingPage.firmware.continueThroughFirmware();
         });
 
-        await onboardingPage.pin.setPinButton.click();
-        await devicePrompt.confirmOnDevicePromptIsShown();
+        await test.step('Select backup type and create wallet with backup', async () => {
+            await onboardingPage.createWalletButton.click();
+            await onboardingPage.selectSeedType('shamir-advanced');
 
-        await device.pressYes();
-        await device.type('12');
-        await device.type('12');
-        await devicePrompt.confirmOnDevicePromptIsShown();
-        await device.pressYes();
-        await onboardingPage.finalButton.click();
-        await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({ timeout: 30_000 });
+            await onboardingPage.backup.passThroughShamirBackup({
+                shares: 3,
+                threshold: 2,
+                deviceConfirmations: 4,
+            });
+        });
+
+        await test.step('Set PIN', async () => {
+            await onboardingPage.pin.setPinButton.click();
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await device.pressYes();
+            await device.inputPin('12');
+            await device.inputPin('12');
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await device.pressYes();
+        });
+
+        await test.step('Finish wallet creation', async () => {
+            await onboardingPage.finalButton.click();
+            await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({ timeout: 30_000 });
+        });
     });
 });

--- a/suite/e2e/tests/onboarding/t3b1/t3b1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t3b1/t3b1-create-wallet.test.ts
@@ -1,0 +1,59 @@
+import { TestCategory, TestPriority } from '@trezor/e2e-utils';
+
+import { expect, test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+test.describe('Onboarding - create wallet', { tag: ['@T3B1'] }, () => {
+    test.use({
+        setupEmulator: false,
+    });
+
+    test.beforeEach(async ({ onboardingPage }) => {
+        await onboardingPage.disableNecessaryFirmwareChecks();
+    });
+
+    test(
+        'Success (Shamir backup)',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Verify that a user can successfully create a wallet during the onboarding process.',
+                category: TestCategory.Onboarding,
+                priority: TestPriority.Critical,
+            }),
+        },
+        async ({ device, onboardingPage, devicePrompt, analyticsSection }) => {
+            await test.step('Device onboarding steps', async () => {
+                await analyticsSection.passThroughAnalytics();
+                await onboardingPage.firmware.continueThroughFirmware();
+                await onboardingPage.tutorial.skip();
+            });
+
+            await test.step('Select backup type and create wallet with backup', async () => {
+                await onboardingPage.createWalletButton.click();
+                await onboardingPage.selectSeedType('shamir-advanced');
+
+                await onboardingPage.backup.passThroughShamirBackup({
+                    shares: 3,
+                    threshold: 2,
+                    deviceConfirmations: 3,
+                });
+            });
+
+            await test.step('Set PIN', async () => {
+                await onboardingPage.pin.setPinButton.click();
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await device.pressYes();
+                await device.inputPin('12');
+                await device.inputPin('12');
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await device.pressYes();
+            });
+
+            await test.step('Finish wallet creation', async () => {
+                await onboardingPage.finalButton.click();
+                await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({ timeout: 30_000 });
+            });
+        },
+    );
+});

--- a/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts
+++ b/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts
@@ -53,15 +53,12 @@ test.describe('Onboarding - create wallet', { tag: ['@desktopOnly', '@T3T1'] }, 
             });
 
             await test.step('Select backup type and create wallet with backup', async () => {
-                // Select backup type (no device interaction, just navigates to SecurityStep)
                 await onboardingPage.createWalletButton.click();
                 await onboardingPage.selectSeedType('shamir-advanced');
 
-                // SecurityStep: check backup seed cards, create wallet + backup on device, continue
-                // In the new atomic flow, wallet creation and backup happen together
-                const shares = 3;
-                const threshold = 2;
-                await onboardingPage.backup.passThroughShamirBackup(shares, threshold, {
+                await onboardingPage.backup.passThroughShamirBackup({
+                    shares: 3,
+                    threshold: 2,
                     deviceConfirmations: 3,
                 });
             });
@@ -70,8 +67,8 @@ test.describe('Onboarding - create wallet', { tag: ['@desktopOnly', '@T3T1'] }, 
                 await onboardingPage.pin.setPinButton.click();
                 await devicePrompt.confirmOnDevicePromptIsShown();
                 await device.pressYes();
-                await device.selectNumberOfWords(12);
-                await device.selectNumberOfWords(12);
+                await device.inputPin('12');
+                await device.inputPin('12');
 
                 await devicePrompt.confirmOnDevicePromptIsShown();
                 await device.pressYes();

--- a/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
@@ -1,6 +1,6 @@
 import { TestCategory, TestPriority } from '@trezor/e2e-utils';
 
-import { test } from '../../../support/fixtures';
+import { expect, test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe('Onboarding - create wallet', { tag: ['@T3T1'] }, () => {
@@ -23,34 +23,37 @@ test.describe('Onboarding - create wallet', { tag: ['@T3T1'] }, () => {
             }),
         },
         async ({ device, onboardingPage, devicePrompt, analyticsSection }) => {
-            await analyticsSection.passThroughAnalytics();
-
-            // Device onboarding steps
-            await onboardingPage.firmware.continueThroughFirmware();
-            await onboardingPage.tutorial.skip();
-
-            // Select backup type (no device interaction, just navigates to SecurityStep)
-            await onboardingPage.createWalletButton.click();
-            await onboardingPage.selectSeedType('shamir-advanced');
-
-            // SecurityStep: check backup seed cards, create wallet + backup on device, continue
-            // In the new atomic flow, wallet creation and backup happen together
-            const shares = 3;
-            const threshold = 2;
-            await onboardingPage.backup.passThroughShamirBackup(shares, threshold, {
-                deviceConfirmations: 3,
+            await test.step('Device onboarding steps', async () => {
+                await analyticsSection.passThroughAnalytics();
+                await onboardingPage.firmware.continueThroughFirmware();
+                await onboardingPage.tutorial.skip();
             });
 
-            // Set PIN
-            await onboardingPage.pin.setPinButton.click();
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await device.pressYes();
-            await device.selectNumberOfWords(12);
-            await device.selectNumberOfWords(12);
+            await test.step('Select backup type and create wallet with backup', async () => {
+                await onboardingPage.createWalletButton.click();
+                await onboardingPage.selectSeedType('shamir-advanced');
 
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await device.pressYes();
-            await onboardingPage.finalButton.click();
+                await onboardingPage.backup.passThroughShamirBackup({
+                    shares: 3,
+                    threshold: 2,
+                    deviceConfirmations: 3,
+                });
+            });
+
+            await test.step('Set PIN', async () => {
+                await onboardingPage.pin.setPinButton.click();
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await device.pressYes();
+                await device.inputPin('12');
+                await device.inputPin('12');
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await device.pressYes();
+            });
+
+            await test.step('Finish wallet creation', async () => {
+                await onboardingPage.finalButton.click();
+                await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({ timeout: 30_000 });
+            });
         },
     );
 });

--- a/suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts
@@ -1,7 +1,30 @@
+import type { BackupType } from '@suite-common/suite-types';
 import { TestCategory, TestPriority } from '@trezor/e2e-utils';
 
 import { expect, test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+const testCases: {
+    name: string;
+    testCase: string;
+    seedType: BackupType;
+    backup: { shares?: number; threshold?: number; deviceConfirmations: number };
+}[] = [
+    {
+        name: 'Success (Shamir backup)',
+        testCase:
+            'Verify that a user can successfully create a wallet during the onboarding process.',
+        seedType: 'shamir-advanced',
+        backup: { shares: 3, threshold: 2, deviceConfirmations: 3 },
+    },
+    {
+        name: 'Success (Single-share Backup)',
+        testCase:
+            'Verify that a user can successfully create a wallet with single-share backup during the onboarding process.',
+        seedType: 'shamir-single',
+        backup: { deviceConfirmations: 3 },
+    },
+];
 
 test.describe('Onboarding - create wallet', { tag: ['@T3W1'] }, () => {
     test.use({ setupEmulator: false });
@@ -10,68 +33,74 @@ test.describe('Onboarding - create wallet', { tag: ['@T3W1'] }, () => {
         await onboardingPage.disableNecessaryFirmwareChecks();
     });
 
-    test(
-        'Success (Shamir backup)',
-        {
-            annotation: createTestAnnotation({
-                testCase:
-                    'Verify that a user can successfully create a wallet during the onboarding process.',
-                category: TestCategory.Onboarding,
-                priority: TestPriority.Critical,
-            }),
-        },
-        async ({
-            page,
-            device,
-            onboardingPage,
-            devicePrompt,
-            analyticsSection,
-            dashboardPage,
-            assetsSection,
-        }) => {
-            await onboardingPage.optionallyDismissFwHashCheckError();
-            await analyticsSection.continueButton.click();
+    for (const { name, testCase, seedType, backup } of testCases) {
+        test(
+            name,
+            {
+                annotation: createTestAnnotation({
+                    testCase,
+                    category: TestCategory.Onboarding,
+                    priority: TestPriority.Critical,
+                }),
+            },
+            async ({
+                page,
+                device,
+                devicePrompt,
+                onboardingPage,
+                analyticsSection,
+                dashboardPage,
+                assetsSection,
+            }) => {
+                await test.step('Complete device onboarding', async () => {
+                    await onboardingPage.optionallyDismissFwHashCheckError();
+                    await analyticsSection.continueButton.click();
+                    await onboardingPage.pairTHP();
+                    await analyticsSection.continueButton.click();
+                    await onboardingPage.firmware.continueThroughFirmware();
+                    await page.waitForTimeout(500);
+                    await onboardingPage.tutorial.skip();
+                });
 
-            await devicePrompt.allowConnectToTrezor();
-            await onboardingPage.enterTHPPairingCode();
-            await analyticsSection.continueButton.click();
+                await test.step('Create a new wallet', async () => {
+                    await onboardingPage.createWalletButton.click();
+                    await expect(onboardingPage.walletBackupTypeCard).toBeVisible();
+                });
 
-            await onboardingPage.firmware.continueThroughFirmware();
-            await page.waitForTimeout(500);
-            await onboardingPage.tutorial.skip();
+                await test.step(`Select backup type "${seedType}"`, async () => {
+                    await onboardingPage.selectSeedType(seedType);
+                });
 
-            // Create wallet with Shamir backup
-            await onboardingPage.createWalletButton.click();
-            await onboardingPage.selectSeedType('shamir-advanced');
+                await test.step('Create a wallet backup', async () => {
+                    await onboardingPage.backup.passThroughShamirBackup(backup);
+                });
 
-            // Create backup with Shamir shares and threshold
-            await onboardingPage.backup.passThroughShamirBackup({
-                shares: 3,
-                threshold: 2,
-                deviceConfirmations: 3,
-            });
+                await test.step('Set PIN', async () => {
+                    await onboardingPage.pin.setPinButton.click();
+                    await devicePrompt.confirmOnDevicePromptIsShown();
+                    await device.pressYes();
+                    await device.inputPin('12');
+                    await device.inputPin('12');
+                    await devicePrompt.confirmOnDevicePromptIsShown();
+                    await device.pressYes();
+                });
 
-            // Set PIN
-            await onboardingPage.pin.setPinButton.click();
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await device.pressYes();
-            // method is used as a workaround to setup PIN with value 12
-            await device.selectNumberOfWords(12);
-            await device.selectNumberOfWords(12);
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await device.pressYes();
+                await test.step('Finish wallet creation', async () => {
+                    await onboardingPage.finalButton.click();
 
-            await test.step('Finish wallet creation', async () => {
-                await onboardingPage.finalButton.click();
-                await expect(onboardingPage.onboardingFeedbackBanner).toBeVisible();
-                await onboardingPage.onboardingFeedbackBannerCTAButton.click();
-                await dashboardPage.discoveryEmptyPrimaryButton.click();
-                await assetsSection.enableNetworkViaActivateAssetsModal(['btc', 'eth']);
+                    await expect(onboardingPage.onboardingFeedbackBanner).toBeVisible();
+                    await onboardingPage.onboardingFeedbackBannerCTAButton.click();
 
-                await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({ timeout: 30_000 });
-                await expect(dashboardPage.walletReady).toBeVisible({ timeout: 30_000 });
-                await expect(onboardingPage.onboardingFeedbackBanner).toBeHidden();
-            });
-        },
-    );
+                    await dashboardPage.discoveryEmptyPrimaryButton.click();
+                    await assetsSection.enableNetworkViaActivateAssetsModal(['btc', 'eth']);
+
+                    await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({
+                        timeout: 30_000,
+                    });
+                    await expect(dashboardPage.walletReady).toBeVisible({ timeout: 30_000 });
+                    await expect(onboardingPage.onboardingFeedbackBanner).toBeHidden();
+                });
+            },
+        );
+    }
 });

--- a/suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts
@@ -45,10 +45,9 @@ test.describe('Onboarding - create wallet', { tag: ['@T3W1'] }, () => {
             await onboardingPage.selectSeedType('shamir-advanced');
 
             // Create backup with Shamir shares and threshold
-            const shares = 3;
-            const threshold = 2;
-
-            await onboardingPage.backup.passThroughShamirBackup(shares, threshold, {
+            await onboardingPage.backup.passThroughShamirBackup({
+                shares: 3,
+                threshold: 2,
                 deviceConfirmations: 3,
             });
 

--- a/suite/thp/src/connection/ThpPairingFailedModal.tsx
+++ b/suite/thp/src/connection/ThpPairingFailedModal.tsx
@@ -28,7 +28,7 @@ export const ThpPairingFailedModal = () => {
         <Modal
             heading={<Translation id="TR_THP_ENTER_ONE_TIME_CODE" />}
             description={<Translation id="TR_THP_CHECK_TREZOR_FOR_CODE" />}
-            data-testid="@modal/thp-paring-failed"
+            data-testid="@modal/thp-pairing-failed"
             width={600}
             bottomContent={
                 <>


### PR DESCRIPTION
Part **2 of 3** splitting #26628. **Stacked on #30007** (base is `split/onboarding-teststep-refactor`, not `develop`) — GitHub will retarget this to `develop` once 1/3 merges.

## What this does
The enablement layer for the new T3W1 single-shamir coverage in 3/3:
- **`backupSection.ts`** — `passThroughShamirBackup` now takes a single config object (`{ shares?, threshold?, deviceConfirmations }`) and branches to single-share vs multi-share verification.
- **`api.ts` / `device.ts`** — new emulator helpers `inputPin` and `readAndConfirmSingleShamirMnemonic`; **tenv image bump** (`docker-compose.suite-ci-e2e.yml`) for the new single-shamir endpoint.
- **`onboardingPage.ts`** — THP pairing-modal + wallet-backup-type locators; `enterTHPPairingCode` awaits modal dismissal.
- Product test ids: `BackupTypeStep.tsx` (`@onboarding/wallet-backup-type`), `ThpPairingFailedModal.tsx` (typo fix `thp-paring-failed` → `thp-pairing-failed`).
- Adapts existing shamir create-wallet callers to the new signature: `t2t1-create-wallet`, `t3t1-create-wallet`, `t3t1-create-wallet-offline`, and the existing `t3w1-create-wallet` call site (so this PR compiles standalone).

## Validation
`yarn workspace @trezor/suite-e2e type-check` matches the `develop` baseline exactly (no new type errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/split/onboarding-shamir-helper-enablement/web/](https://dev.suite.sldev.cz/suite-web/split/onboarding-shamir-helper-enablement/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=split/onboarding-shamir-helper-enablement&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=split/onboarding-shamir-helper-enablement&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-20T13:38:09.835Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-20T13:37:16.034Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->