### PR TITLE
test(e2e): T3B1 onboarding + T3W1 single-shamir onboarding tests (3/3 of #26628)

### DIFF
--- a/suite/e2e/tests/onboarding/t3b1/t3b1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t3b1/t3b1-create-wallet.test.ts
@@ -1,0 +1,59 @@
+import { TestCategory, TestPriority } from '@trezor/e2e-utils';
+
+import { expect, test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+test.describe('Onboarding - create wallet', { tag: ['@T3B1'] }, () => {
+    test.use({
+        setupEmulator: false,
+    });
+
+    test.beforeEach(async ({ onboardingPage }) => {
+        await onboardingPage.disableNecessaryFirmwareChecks();
+    });
+
+    test(
+        'Success (Shamir backup)',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Verify that a user can successfully create a wallet during the onboarding process.',
+                category: TestCategory.Onboarding,
+                priority: TestPriority.Critical,
+            }),
+        },
+        async ({ device, onboardingPage, devicePrompt, analyticsSection }) => {
+            await test.step('Device onboarding steps', async () => {
+                await analyticsSection.passThroughAnalytics();
+                await onboardingPage.firmware.continueThroughFirmware();
+                await onboardingPage.tutorial.skip();
+            });
+
+            await test.step('Select backup type and create wallet with backup', async () => {
+                await onboardingPage.createWalletButton.click();
+                await onboardingPage.selectSeedType('shamir-advanced');
+
+                await onboardingPage.backup.passThroughShamirBackup({
+                    shares: 3,
+                    threshold: 2,
+                    deviceConfirmations: 3,
+                });
+            });
+
+            await test.step('Set PIN', async () => {
+                await onboardingPage.pin.setPinButton.click();
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await device.pressYes();
+                await device.inputPin('12');
+                await device.inputPin('12');
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await device.pressYes();
+            });
+
+            await test.step('Finish wallet creation', async () => {
+                await onboardingPage.finalButton.click();
+                await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({ timeout: 30_000 });
+            });
+        },
+    );
+});

--- a/suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts
@@ -1,7 +1,30 @@
+import type { BackupType } from '@suite-common/suite-types';
 import { TestCategory, TestPriority } from '@trezor/e2e-utils';
 
 import { expect, test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+const testCases: {
+    name: string;
+    testCase: string;
+    seedType: BackupType;
+    backup: { shares?: number; threshold?: number; deviceConfirmations: number };
+}[] = [
+    {
+        name: 'Success (Shamir backup)',
+        testCase:
+            'Verify that a user can successfully create a wallet during the onboarding process.',
+        seedType: 'shamir-advanced',
+        backup: { shares: 3, threshold: 2, deviceConfirmations: 3 },
+    },
+    {
+        name: 'Success (Single-share Backup)',
+        testCase:
+            'Verify that a user can successfully create a wallet with single-share backup during the onboarding process.',
+        seedType: 'shamir-single',
+        backup: { deviceConfirmations: 3 },
+    },
+];
 
 test.describe('Onboarding - create wallet', { tag: ['@T3W1'] }, () => {
     test.use({ setupEmulator: false });
@@ -10,68 +33,74 @@ test.describe('Onboarding - create wallet', { tag: ['@T3W1'] }, () => {
         await onboardingPage.disableNecessaryFirmwareChecks();
     });
 
-    test(
-        'Success (Shamir backup)',
-        {
-            annotation: createTestAnnotation({
-                testCase:
-                    'Verify that a user can successfully create a wallet during the onboarding process.',
-                category: TestCategory.Onboarding,
-                priority: TestPriority.Critical,
-            }),
-        },
-        async ({
-            page,
-            device,
-            onboardingPage,
-            devicePrompt,
-            analyticsSection,
-            dashboardPage,
-            assetsSection,
-        }) => {
-            await onboardingPage.optionallyDismissFwHashCheckError();
-            await analyticsSection.continueButton.click();
+    for (const { name, testCase, seedType, backup } of testCases) {
+        test(
+            name,
+            {
+                annotation: createTestAnnotation({
+                    testCase,
+                    category: TestCategory.Onboarding,
+                    priority: TestPriority.Critical,
+                }),
+            },
+            async ({
+                page,
+                device,
+                devicePrompt,
+                onboardingPage,
+                analyticsSection,
+                dashboardPage,
+                assetsSection,
+            }) => {
+                await test.step('Complete device onboarding', async () => {
+                    await onboardingPage.optionallyDismissFwHashCheckError();
+                    await analyticsSection.continueButton.click();
+                    await onboardingPage.pairTHP();
+                    await analyticsSection.continueButton.click();
+                    await onboardingPage.firmware.continueThroughFirmware();
+                    await page.waitForTimeout(500);
+                    await onboardingPage.tutorial.skip();
+                });
 
-            await devicePrompt.allowConnectToTrezor();
-            await onboardingPage.enterTHPPairingCode();
-            await analyticsSection.continueButton.click();
+                await test.step('Create a new wallet', async () => {
+                    await onboardingPage.createWalletButton.click();
+                    await expect(onboardingPage.walletBackupTypeCard).toBeVisible();
+                });
 
-            await onboardingPage.firmware.continueThroughFirmware();
-            await page.waitForTimeout(500);
-            await onboardingPage.tutorial.skip();
+                await test.step(`Select backup type "${seedType}"`, async () => {
+                    await onboardingPage.selectSeedType(seedType);
+                });
 
-            // Create wallet with Shamir backup
-            await onboardingPage.createWalletButton.click();
-            await onboardingPage.selectSeedType('shamir-advanced');
+                await test.step('Create a wallet backup', async () => {
+                    await onboardingPage.backup.passThroughShamirBackup(backup);
+                });
 
-            // Create backup with Shamir shares and threshold
-            await onboardingPage.backup.passThroughShamirBackup({
-                shares: 3,
-                threshold: 2,
-                deviceConfirmations: 3,
-            });
+                await test.step('Set PIN', async () => {
+                    await onboardingPage.pin.setPinButton.click();
+                    await devicePrompt.confirmOnDevicePromptIsShown();
+                    await device.pressYes();
+                    await device.inputPin('12');
+                    await device.inputPin('12');
+                    await devicePrompt.confirmOnDevicePromptIsShown();
+                    await device.pressYes();
+                });
 
-            // Set PIN
-            await onboardingPage.pin.setPinButton.click();
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await device.pressYes();
-            // method is used as a workaround to setup PIN with value 12
-            await device.selectNumberOfWords(12);
-            await device.selectNumberOfWords(12);
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await device.pressYes();
+                await test.step('Finish wallet creation', async () => {
+                    await onboardingPage.finalButton.click();
 
-            await test.step('Finish wallet creation', async () => {
-                await onboardingPage.finalButton.click();
-                await expect(onboardingPage.onboardingFeedbackBanner).toBeVisible();
-                await onboardingPage.onboardingFeedbackBannerCTAButton.click();
-                await dashboardPage.discoveryEmptyPrimaryButton.click();
-                await assetsSection.enableNetworkViaActivateAssetsModal(['btc', 'eth']);
+                    await expect(onboardingPage.onboardingFeedbackBanner).toBeVisible();
+                    await onboardingPage.onboardingFeedbackBannerCTAButton.click();
 
-                await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({ timeout: 30_000 });
-                await expect(dashboardPage.walletReady).toBeVisible({ timeout: 30_000 });
-                await expect(onboardingPage.onboardingFeedbackBanner).toBeHidden();
-            });
-        },
-    );
+                    await dashboardPage.discoveryEmptyPrimaryButton.click();
+                    await assetsSection.enableNetworkViaActivateAssetsModal(['btc', 'eth']);
+
+                    await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({
+                        timeout: 30_000,
+                    });
+                    await expect(dashboardPage.walletReady).toBeVisible({ timeout: 30_000 });
+                    await expect(onboardingPage.onboardingFeedbackBanner).toBeHidden();
+                });
+            },
+        );
+    }
 });


### PR DESCRIPTION
Part **3 of 3** splitting #26628 — the actual new coverage. **Stacked on #30008** (base is `split/onboarding-shamir-helper-enablement`) — retargets to `develop` as the stack merges.

## What this does
- **`t3b1-create-wallet.test.ts`** (new) — T3B1 create-wallet onboarding.
- **`t3w1-create-wallet.test.ts`** — extends the T3W1 suite with a **single-share Shamir** scenario alongside the existing multi-share flow (data-driven over both backup types), using the object-arg helper + single-shamir emulator support from 2/3.

## Depends on
- 2/3 (#30008) for the object-arg `passThroughShamirBackup`, single-shamir emulator endpoint, `walletBackupTypeCard` / THP locators, and `device.inputPin`.

## Validation
`yarn workspace @trezor/suite-e2e type-check` matches the `develop` baseline exactly. The union of PRs 1+2+3 is byte-identical to #26628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)