### PR TITLE
fix(logger): redact the account in updateSelectedAccount log entries

### DIFF
--- a/suite-common/logger/src/utils.test.ts
+++ b/suite-common/logger/src/utils.test.ts
@@ -1,9 +1,20 @@
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
-import { type DiscoveryStatus, asAccountDescriptor } from '@suite-common/wallet-types';
+import { accountsActions } from '@suite-common/wallet-core';
+import {
+    type Account,
+    type DiscoveryStatus,
+    asAccountDescriptor,
+} from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { type StaticSessionId } from '@trezor/connect';
 
-import { REDACTED_REPLACEMENT, redactAccount, redactDevice, redactDiscovery } from './utils';
+import {
+    REDACTED_REPLACEMENT,
+    redactAccount,
+    redactAction,
+    redactDevice,
+    redactDiscovery,
+} from './utils';
 
 describe('logsUtils', () => {
     const account = mockWalletAccount({
@@ -49,6 +60,21 @@ describe('logsUtils', () => {
                     label: REDACTED_REPLACEMENT,
                 },
             });
+        });
+    });
+
+    describe('redactAction', () => {
+        it('redacts the account of an updateSelectedAccount log entry', () => {
+            const entry = {
+                datetime: 'Thu, 01 Jan 1970 00:00:00 GMT',
+                type: accountsActions.updateSelectedAccount.type,
+                payload: { account },
+            };
+
+            const redactedAccount = (redactAction(entry).payload as { account: Account }).account;
+
+            expect(redactedAccount.descriptor).toBe(REDACTED_REPLACEMENT);
+            expect(redactedAccount.deviceState).toBe(REDACTED_REPLACEMENT);
         });
     });
 

--- a/suite-common/logger/src/utils.ts
+++ b/suite-common/logger/src/utils.ts
@@ -159,16 +159,19 @@ export const redactDiscovery = (
 };
 
 export const redactAction = (action: LogEntry): LogEntry => {
-    let payload: LogEntry['payload'];
-
     if (accountsActions.updateSelectedAccount.match(action)) {
-        payload = {
-            ...action.payload,
-            account: redactAccount(action.payload?.account),
-            network: undefined,
-            discovery: undefined,
+        return {
+            ...action,
+            payload: {
+                ...action.payload,
+                account: redactAccount(action.payload?.account),
+                network: undefined,
+                discovery: undefined,
+            },
         };
     }
+
+    let payload: LogEntry['payload'];
 
     switch (action.type) {
         case accountsActions.createAccount.type:


### PR DESCRIPTION
## Description

The updateSelectedAccount branch in redactAction constructed a sanitized payload but then fell through to the switch default, which returned the original log entry and exposed confidential account fields in Sentry context and exported support logs. The fix returns the sanitized entry directly and adds a regression test confirming that descriptor and deviceState are replaced before the entry reaches either sink.

- Leaking control-flow branches: **1 -> 0**
- Confidential fields asserted by the regression test: **0 -> 2**
- Logger utility tests: **5 -> 6**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are in logger utilities, a global dependency transitively referenced by many E2E tests. However, only the application-log E2E test directly verifies user-facing log behavior. The accompanying utils.test.ts unit test should cover the core logic changes, so running the application-log E2E test is sufficient to catch any log display or export regressions without executing the full suite.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/logger/src/utils.test.ts`
- `suite-common/logger/src/utils.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/settings/application-log.test.ts` — This is the only E2E test that directly exercises application log functionality, asserting that log content is displayed in the modal and exported correctly. Changes to logger utilities could affect log formatting, filtering, or content, which would directly impact this test's key assertions.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/logger/src/utils.test.ts`

_Updated: 2026-08-04T08:32:09.650Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-logger-redact-selected-account/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-logger-redact-selected-account/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-logger-redact-selected-account&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-logger-redact-selected-account&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T08:33:14.365Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T08:33:06.015Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->