### PR TITLE
fix(suite-desktop-core, icons): correct operator precedence in two log statements

### DIFF
--- a/packages/suite-desktop-core/src/modules/event-logging/contents.ts
+++ b/packages/suite-desktop-core/src/modules/event-logging/contents.ts
@@ -37,7 +37,7 @@ export const init: ModuleInit = ({ mainWindowProxy }) => {
             if (unresponsiveStart !== 0) {
                 logger.warn(
                     SERVICE_NAME,
-                    `Responsive again after ${(+new Date() - unresponsiveStart / 1000).toFixed(1)}s`,
+                    `Responsive again after ${((+new Date() - unresponsiveStart) / 1000).toFixed(1)}s`,
                 );
                 unresponsiveStart = 0;
             }

--- a/suite-common/icons/scripts/downloadCryptoIcons.ts
+++ b/suite-common/icons/scripts/downloadCryptoIcons.ts
@@ -167,7 +167,7 @@ async function ensureDirectoryExists(path: string) {
         await fs.writeFile(UPDATED_ICONS_LIST_FILE, JSON.stringify(updatedIcons, null, 2));
 
         if (Date.now() - startedAt > RUN_LIMIT_SECONDS * 1000) {
-            console.log(`${i + 1 / coins.length}: Run limit reached`);
+            console.log(`${i + 1}/${coins.length}: Run limit reached`);
             break;
         }
 


### PR DESCRIPTION
## Description

Split out from the bug-fix sweep umbrella #29735. Two independent one-line fixes of the same kind — a `/` in a log template mis-grouped by operator precedence, producing a nonsensical number.

### `suite-desktop-core` — unresponsive-duration log

```js
`Responsive again after ${(+new Date() - unresponsiveStart / 1000).toFixed(1)}s`
```
`/` binds tighter than `-`, so this evaluated as `now - (unresponsiveStart / 1000)` instead of `(now - unresponsiveStart) / 1000`. Since `unresponsiveStart` is an epoch timestamp in ms, the log printed an astronomically large number (~10¹² s) instead of the actual hang duration — defeating the purpose of the log. Fixed by grouping the subtraction: `((+new Date() - unresponsiveStart) / 1000)`.

### `icons` — downloadCryptoIcons progress log

```js
console.log(`${i + 1 / coins.length}: Run limit reached`);
```
`/` bound before `+`, so this printed `i` plus a tiny fraction instead of the intended `current/total` progress indicator. Fixed to a literal fraction: `${i + 1}/${coins.length}`.

## Related PRs

Part of the #29735 sweep, alongside:
- #28995 — `fix(connect)`: size bare uint/int EIP-712 fields as 256-bit
- #29392 — `fix(device-mutex)`: make prioritizedLock enqueue the task at the front

## Notes for QA

No QA needed. Both changes are log-message-only (a desktop warn log and a dev-script `console.log`); no functional, wire, or persisted behavior changes, and no confidential data involved. To sanity-check the desktop one, trigger a renderer hang and confirm the "Responsive again after Xs" log now shows a realistic duration.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Neither changed file has any static or inferred E2E test coverage. `packages/suite-desktop-core/src/modules/event-logging/contents.ts` appears to be an internal desktop event-logging module (likely used for debug/log file generation) that isn't directly exercised by any of the 99 candidate Playwright tests, none of which reference event-logging or log-file content generation in their behaviors or source hints. `suite-common/icons/scripts/downloadCryptoIcons.ts` is a build-time/dev script for downloading crypto icon assets, not something exercised at runtime by E2E tests (no test asserts on icon-download behavior). Given the lack of direct or plausible indirect coverage, no specific test recommendations can be made with confidence; a manual review or targeted smoke test of the desktop app's log export feature (if one exists) and a visual check of icon rendering would be a reasonable fallback, but this is outside the scope of the provided test suite.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite-desktop-core/src/modules/event-logging/contents.ts`
- `suite-common/icons/scripts/downloadCryptoIcons.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/suite-desktop-core/src/modules/event-logging/contents.ts`
- `suite-common/icons/scripts/downloadCryptoIcons.ts`

_Updated: 2026-07-18T11:44:55.274Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-log-operator-precedence/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-log-operator-precedence/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-log-operator-precedence&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-log-operator-precedence&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fix-log-operator-precedence&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-18T11:49:03.944Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-18T11:48:31.420Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->