### PR TITLE
fix(suite-desktop-core): guard coinjoin splice(indexOf) from deleting the wrong element on a disable race

### DIFF
--- a/packages/suite-desktop-core/src/modules/coinjoin.ts
+++ b/packages/suite-desktop-core/src/modules/coinjoin.ts
@@ -98,7 +98,10 @@ export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) 
                     logger.debug(SERVICE_NAME, `${BACKEND_CHANNEL} call ${method}`);
                     if (method === 'disable') {
                         backend.dispose();
-                        backends.splice(backends.indexOf(backend), 1);
+                        const backendIndex = backends.indexOf(backend);
+                        if (backendIndex !== -1) {
+                            backends.splice(backendIndex, 1);
+                        }
 
                         return Promise.resolve();
                     }
@@ -157,7 +160,10 @@ export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) 
                         }
                     }
                     if (method === 'disable') {
-                        clients.splice(clients.indexOf(client), 1);
+                        const clientIndex = clients.indexOf(client);
+                        if (clientIndex !== -1) {
+                            clients.splice(clientIndex, 1);
+                        }
 
                         if (clients.length === 0) {
                             logger.debug(SERVICE_NAME, `${CLIENT_CHANNEL} binary stop`);


### PR DESCRIPTION
## Description

Split out from the bug-fix sweep umbrella #29735.

In the desktop coinjoin module, the backend and client are removed on `disable` via `arr.splice(arr.indexOf(x), 1)`. When `indexOf` returns `-1` — which happens when the entry was already removed by a concurrent `dispose`/`disable` on a reload race — `splice(-1, 1)` does not no-op; it deletes the **last** element of the array, evicting an unrelated live backend/client. Both sites are now guarded with an explicit index check.

```js
const backendIndex = backends.indexOf(backend);
if (backendIndex !== -1) {
    backends.splice(backendIndex, 1);
}
```

### Note on the same pattern elsewhere

A repo-wide sweep for `splice(x.indexOf(y), 1)` also surfaced `suite-common/device/src/deviceReducer.ts` (`disconnectDevice`). That one is **not** a live bug and is intentionally left unchanged: the spliced element comes from `draft.devices.filter(...)`, so it is guaranteed to still be present and `indexOf` cannot return `-1`. Adding a guard there would be a speculative no-op.

## Related PRs

Part of the #29735 sweep, alongside:
- #28995 — `fix(connect)`: size bare uint/int EIP-712 fields as 256-bit
- #29392 — `fix(device-mutex)`: make prioritizedLock enqueue the task at the front
- #30011 — `fix(suite-desktop-core, icons)`: operator precedence in two log statements

## Notes for QA

`@suite-desktop-core` coinjoin only. Hard to reproduce deterministically (requires a dispose/disable to race an in-flight disable, e.g. quick reload or app close while coinjoin is stopping). The change is purely defensive: with the guard, a stale disable is a no-op instead of evicting the last live backend/client from the array. No change to the normal enable/disable lifecycle. Low blast radius; regression risk is essentially nil.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file, packages/suite-desktop-core/src/modules/coinjoin.ts, implements the desktop Electron module for CoinJoin (Tor-based coin mixing) functionality. None of the 91 candidate E2E tests in the provided suite reference CoinJoin, Tor, or this module in their behaviors, entry points, or source hints — the closest related area (bridge-tor tests) covers bridge daemon spawning and Tor-adjacent bridge behavior, not CoinJoin logic itself. Since there is no statically mapped or inferable test coverage for this specific module, no confident recommendations can be made from the current test suite; a manual/exploratory test of the CoinJoin feature (if present in a different suite, e.g. wallet-level coinjoin E2E tests not listed here) is advised, or new test coverage should be added for this module.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite-desktop-core/src/modules/coinjoin.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/suite-desktop-core/src/modules/coinjoin.ts`

_Updated: 2026-07-18T11:54:43.548Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-coinjoin-splice-guard/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-coinjoin-splice-guard/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-coinjoin-splice-guard&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-coinjoin-splice-guard&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-18T11:58:37.874Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-18T11:57:56.270Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->