### PR TITLE
refactor(styles): bound exported styled component types

### DIFF
--- a/packages/components/src/components/Table/TableRow.tsx
+++ b/packages/components/src/components/Table/TableRow.tsx
@@ -1,17 +1,19 @@
-import { type ReactNode } from 'react';
+import { type ComponentPropsWithRef, type ComponentType, type ReactNode } from 'react';
 
 import styled, { css } from 'styled-components';
 
 import { useTable } from './TableContext';
 import { useTableHeader } from './TableHeader';
 
-export const Row = styled.tr<{
+type RowProps = {
     $isCollapsed: boolean;
     $verticalAlign?: string;
     $isHighlighted: boolean;
     $isHeader: boolean;
     $hasBorderTop: boolean;
-}>`
+};
+
+export const Row: ComponentType<ComponentPropsWithRef<'tr'> & RowProps> = styled.tr<RowProps>`
     ${({ $hasBorderTop, theme }) =>
         $hasBorderTop &&
         css`

--- a/packages/components/src/components/animations/AnimationPrimitives.tsx
+++ b/packages/components/src/components/animations/AnimationPrimitives.tsx
@@ -1,3 +1,5 @@
+import { type ComponentPropsWithRef, type ComponentType } from 'react';
+
 import styled, { css } from 'styled-components';
 
 import { borders } from '@trezor/theme';
@@ -20,31 +22,32 @@ export type AllowedAnimationPrimitiveFrameProps = Pick<
 export const shapes = ['CIRCLE', 'ROUNDED', 'ROUNDED-SMALL'] as const;
 export type Shape = (typeof shapes)[number];
 
-export const AnimationWrapper = styled.div<
-    TransientProps<AllowedAnimationPrimitiveFrameProps> & {
-        shape?: Shape;
-    }
->`
-    overflow: hidden;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+type AnimationWrapperProps = TransientProps<AllowedAnimationPrimitiveFrameProps> & {
+    shape?: Shape;
+};
 
-    ${withFrameProps}
+export const AnimationWrapper: ComponentType<ComponentPropsWithRef<'div'> & AnimationWrapperProps> =
+    styled.div<AnimationWrapperProps>`
+        overflow: hidden;
+        display: flex;
+        justify-content: center;
+        align-items: center;
 
-    ${({ shape }) =>
-        shape === 'CIRCLE' &&
-        css`
-            border-radius: 50%;
-        `};
-    ${({ shape }) =>
-        shape === 'ROUNDED' &&
-        css`
-            border-radius: 30px;
-        `};
-    ${({ shape }) =>
-        shape === 'ROUNDED-SMALL' &&
-        css`
-            border-radius: ${borders.radii.xs};
-        `};
-`;
+        ${withFrameProps}
+
+        ${({ shape }) =>
+            shape === 'CIRCLE' &&
+            css`
+                border-radius: 50%;
+            `};
+        ${({ shape }) =>
+            shape === 'ROUNDED' &&
+            css`
+                border-radius: 30px;
+            `};
+        ${({ shape }) =>
+            shape === 'ROUNDED-SMALL' &&
+            css`
+                border-radius: ${borders.radii.xs};
+            `};
+    `;

--- a/packages/components/src/components/form/BottomText.tsx
+++ b/packages/components/src/components/form/BottomText.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { type ComponentPropsWithRef, type ComponentType, type ReactNode } from 'react';
 
 import styled, { keyframes } from 'styled-components';
 
@@ -19,7 +19,7 @@ const slideDown = keyframes`
     }
 `;
 
-export const Container = styled.div`
+export const Container: ComponentType<ComponentPropsWithRef<'div'>> = styled.div`
     animation: ${slideDown} 0.18s ease-in-out forwards;
 `;
 

--- a/packages/components/src/components/form/FloatingLabel.tsx
+++ b/packages/components/src/components/form/FloatingLabel.tsx
@@ -1,3 +1,5 @@
+import { type ComponentPropsWithRef, type ComponentType } from 'react';
+
 import styled, { css } from 'styled-components';
 
 import { INPUT_PADDING } from './utils';
@@ -8,32 +10,33 @@ type FloatingLabelProps = {
     $isDisabled?: boolean;
 };
 
-export const FloatingLabel = styled.label<FloatingLabelProps>`
-    --transform: translateY(-50%) translateY(-10px) scale(0.75);
+export const FloatingLabel: ComponentType<ComponentPropsWithRef<'label'> & FloatingLabelProps> =
+    styled.label<FloatingLabelProps>`
+        --transform: translateY(-50%) translateY(-10px) scale(0.75);
 
-    position: absolute;
-    left: ${INPUT_PADDING}px;
-    top: 50%;
-    transition: 120ms ${motionEasingStrings.enter};
-    transform-origin: left;
-    transform: translateY(-50%);
-    pointer-events: none;
-    color: ${({ theme }) => theme.contentSecondary};
+        position: absolute;
+        left: ${INPUT_PADDING}px;
+        top: 50%;
+        transition: 120ms ${motionEasingStrings.enter};
+        transform-origin: left;
+        transform: translateY(-50%);
+        pointer-events: none;
+        color: ${({ theme }) => theme.contentSecondary};
 
-    ${({ $isActive }) =>
-        $isActive &&
-        css`
-            transform: var(--transform);
-        `}
+        ${({ $isActive }) =>
+            $isActive &&
+            css`
+                transform: var(--transform);
+            `}
 
-    :is(input, textarea):focus ~ &,
+        :is(input, textarea):focus ~ &,
     :is(input, textarea):not(:placeholder-shown) ~ & {
-        transform: var(--transform);
-    }
+            transform: var(--transform);
+        }
 
-    ${({ $isDisabled }) =>
-        $isDisabled &&
-        css`
-            color: ${({ theme }) => theme.contentDisabled};
-        `}
-`;
+        ${({ $isDisabled }) =>
+            $isDisabled &&
+            css`
+                color: ${({ theme }) => theme.contentDisabled};
+            `}
+    `;

--- a/packages/components/src/components/form/SelectBar/SelectBar.tsx
+++ b/packages/components/src/components/form/SelectBar/SelectBar.tsx
@@ -66,7 +66,7 @@ const Puck = styled.div<{
         `}
 `;
 
-const Option = styled.div<{ $isSelected: boolean; $isDisabled: boolean }>`
+const OptionWrapper = styled.div<{ $isSelected: boolean; $isDisabled: boolean }>`
     position: relative;
     width: 100%;
     min-width: 0;
@@ -222,7 +222,7 @@ export const SelectBar = <V extends ValueTypes>({
                                     minWidth={0}
                                     overflow="hidden"
                                 >
-                                    <Option
+                                    <OptionWrapper
                                         onClick={handleOptionClick(option)}
                                         $isDisabled={!!isDisabled}
                                         $isSelected={isSelected}
@@ -251,7 +251,7 @@ export const SelectBar = <V extends ValueTypes>({
                                                 </Text>
                                             </Box>
                                         </Column>
-                                    </Option>
+                                    </OptionWrapper>
                                 </Text>
                             );
                         })}

--- a/packages/components/src/components/form/TopAddons.tsx
+++ b/packages/components/src/components/form/TopAddons.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type ComponentPropsWithRef, type ComponentType } from 'react';
 
 import styled from 'styled-components';
 
@@ -6,10 +6,13 @@ import { spacings } from '@trezor/theme';
 
 import { Row } from '../Flex/Flex';
 
-export const HoverAddonRight = styled.div<{ $isVisible?: boolean }>`
-    opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
-    transition: opacity 0.1s ease-out;
-`;
+type HoverAddonRightProps = { $isVisible?: boolean };
+
+export const HoverAddonRight: ComponentType<ComponentPropsWithRef<'div'> & HoverAddonRightProps> =
+    styled.div<HoverAddonRightProps>`
+        opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
+        transition: opacity 0.1s ease-out;
+    `;
 
 type TopAddonsProps = {
     isHovered?: boolean;

--- a/packages/components/src/components/loaders/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/components/loaders/ProgressBar/ProgressBar.tsx
@@ -1,3 +1,5 @@
+import { type ComponentType } from 'react';
+
 import styled, { useTheme } from 'styled-components';
 
 import { type CSSColor } from '@trezor/theme';
@@ -30,7 +32,7 @@ export type ProgressBarProps = {
     'data-testid'?: string;
 };
 
-export const ProgressBar = ({
+const ProgressBarComponent = ({
     max = 100,
     value,
     backgroundColor,
@@ -46,4 +48,8 @@ export const ProgressBar = ({
     );
 };
 
-ProgressBar.Value = Value;
+ProgressBarComponent.Value = Value;
+
+export const ProgressBar: ComponentType<ProgressBarProps> & {
+    Value: ComponentType<ValueProps>;
+} = ProgressBarComponent;

--- a/packages/components/src/utils/useScrollShadow.tsx
+++ b/packages/components/src/utils/useScrollShadow.tsx
@@ -1,4 +1,12 @@
-import { type RefObject, useCallback, useEffect, useRef, useState } from 'react';
+import {
+    type ComponentPropsWithRef,
+    type ComponentType,
+    type RefObject,
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+} from 'react';
 
 import styled, { type DefaultTheme } from 'styled-components';
 
@@ -21,6 +29,16 @@ type MapArgs = {
 type UseScrollShadowProps = {
     externalRef?: RefObject<HTMLDivElement | null>;
     backgroundColor?: Color;
+};
+
+type UseScrollShadowReturn = {
+    scrollElementRef: RefObject<HTMLDivElement | null>;
+    onScroll: () => void;
+    ShadowContainer: ComponentType<ComponentPropsWithRef<'div'>>;
+    ShadowTop: ComponentType;
+    ShadowBottom: ComponentType;
+    ShadowLeft: ComponentType;
+    ShadowRight: ComponentType;
 };
 
 export const mapDirectionToGradient = ({
@@ -61,7 +79,10 @@ const Gradient = styled.div<GradientProps>`
         mapDirectionToGradient({ $direction, $backgroundColor, theme })};
 `;
 
-export const useScrollShadow = ({ externalRef, backgroundColor }: UseScrollShadowProps = {}) => {
+export const useScrollShadow = ({
+    externalRef,
+    backgroundColor,
+}: UseScrollShadowProps = {}): UseScrollShadowReturn => {
     const internalRef = useRef<HTMLDivElement | null>(null);
     const scrollElementRef = externalRef || internalRef;
 

--- a/packages/product-components/src/components/IconSet/IconSetBase.tsx
+++ b/packages/product-components/src/components/IconSet/IconSetBase.tsx
@@ -1,4 +1,4 @@
-import { Children, type ReactNode } from 'react';
+import { Children, type ComponentPropsWithRef, type ComponentType, type ReactNode } from 'react';
 
 import styled, { css } from 'styled-components';
 
@@ -76,11 +76,14 @@ const overlappingIconStyles = ($size: number, $gap: number, $length: number) =>
         }
     `;
 
-export const IconWrapper = styled.div<{ $size: number; $gap: number; $length: number }>`
-    border-radius: ${borders.radii.full};
+type IconWrapperProps = { $size: number; $gap: number; $length: number };
 
-    ${({ $size, $gap, $length }) => overlappingIconStyles($size, $gap, $length)}
-`;
+export const IconWrapper: ComponentType<ComponentPropsWithRef<'div'> & IconWrapperProps> =
+    styled.div<IconWrapperProps>`
+        border-radius: ${borders.radii.full};
+
+        ${({ $size, $gap, $length }) => overlappingIconStyles($size, $gap, $length)}
+    `;
 
 const CountContainer = styled.div<{
     $size: TokenIconSize;

--- a/packages/product-components/src/components/Settings/ActionButton.tsx
+++ b/packages/product-components/src/components/Settings/ActionButton.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { type ComponentType, type ReactNode } from 'react';
 
 import styled from 'styled-components';
 
@@ -9,13 +9,10 @@ const { SCREEN_SIZE } = variables;
 
 type WithTooltipProps = { tooltipContent?: ReactNode; isTooltipActive?: boolean };
 
-export const ActionButton = styled(
-    ({
-        tooltipContent,
-        isTooltipActive,
-        children,
-        ...buttonProps
-    }: WithTooltipProps & ButtonProps) => (
+export type ActionButtonProps = WithTooltipProps & ButtonProps;
+
+export const ActionButton: ComponentType<ActionButtonProps> = styled(
+    ({ tooltipContent, isTooltipActive, children, ...buttonProps }: ActionButtonProps) => (
         <div>
             <Tooltip content={tooltipContent} isActive={isTooltipActive} cursor="inherit">
                 <Button

--- a/packages/product-components/src/components/Settings/ActionColumn.tsx
+++ b/packages/product-components/src/components/Settings/ActionColumn.tsx
@@ -1,10 +1,12 @@
+import { type ComponentPropsWithRef, type ComponentType } from 'react';
+
 import styled from 'styled-components';
 
 import { variables } from '@trezor/components';
 
 const { SCREEN_SIZE } = variables;
 
-export const ActionColumn = styled.div`
+export const ActionColumn: ComponentType<ComponentPropsWithRef<'div'>> = styled.div`
     display: flex;
     align-items: center;
     justify-content: flex-end;

--- a/packages/product-components/src/components/Settings/ActionSelect.tsx
+++ b/packages/product-components/src/components/Settings/ActionSelect.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { type ComponentType, type ReactNode } from 'react';
 
 import styled from 'styled-components';
 
@@ -9,8 +9,10 @@ const { SCREEN_SIZE } = variables;
 
 type WithTooltipProps = { tooltipContent?: ReactNode; isTooltipActive?: boolean };
 
-export const ActionSelect = styled(
-    ({ tooltipContent, isTooltipActive, ...selectProps }: SelectProps & WithTooltipProps) => (
+export type ActionSelectProps = SelectProps & WithTooltipProps;
+
+export const ActionSelect: ComponentType<ActionSelectProps> = styled(
+    ({ tooltipContent, isTooltipActive, ...selectProps }: ActionSelectProps) => (
         <Tooltip content={tooltipContent} isActive={isTooltipActive} cursor="inherit">
             <Select
                 {...selectProps}

--- a/packages/suite/src/components/suite/ConnectAppBar.tsx
+++ b/packages/suite/src/components/suite/ConnectAppBar.tsx
@@ -1,3 +1,5 @@
+import { type ComponentPropsWithRef, type ComponentType } from 'react';
+
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
@@ -17,7 +19,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { SuiteBanners } from './banners';
 
-export const ConnectBarWrapper = styled.div`
+export const ConnectBarWrapper: ComponentType<ComponentPropsWithRef<'div'>> = styled.div`
     position: absolute;
     top: 0;
     left: 0;

--- a/packages/suite/src/components/suite/DeviceMatrixExplanation.tsx
+++ b/packages/suite/src/components/suite/DeviceMatrixExplanation.tsx
@@ -25,7 +25,7 @@ const Wrapper = styled.div<{ $isGuideOpen?: boolean }>`
     }
 `;
 
-const Item = styled.div`
+const ItemWrapper = styled.div`
     display: flex;
     align-items: center;
     width: 100%;
@@ -77,7 +77,7 @@ export const DeviceMatrixExplanation = ({ items }: DeviceMatrixExplanationProps)
     return (
         <Wrapper $isGuideOpen={isGuideOpen}>
             {items.map(item => (
-                <Item key={item.key}>
+                <ItemWrapper key={item.key}>
                     <ItemIconWrapper>
                         {item.icon ? (
                             <Icon
@@ -96,7 +96,7 @@ export const DeviceMatrixExplanation = ({ items }: DeviceMatrixExplanationProps)
                         )}
                     </ItemIconWrapper>
                     <ItemText>{item.title}</ItemText>
-                </Item>
+                </ItemWrapper>
             ))}
         </Wrapper>
     );

--- a/packages/suite/src/components/suite/layouts/ContentContainer.tsx
+++ b/packages/suite/src/components/suite/layouts/ContentContainer.tsx
@@ -1,10 +1,12 @@
+import { type ComponentPropsWithRef, type ComponentType } from 'react';
+
 import styled from 'styled-components';
 
 import { spacingsPx } from '@trezor/theme';
 
 import { HORIZONTAL_LAYOUT_PADDINGS, MAX_CONTENT_WIDTH } from 'src/constants/suite/layout';
 
-export const ContentContainer = styled.div`
+export const ContentContainer: ComponentType<ComponentPropsWithRef<'div'>> = styled.div`
     position: relative;
     display: flex;
     flex-direction: column;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/BasicName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/BasicName.tsx
@@ -1,10 +1,12 @@
+import { type ComponentPropsWithRef, type ComponentType } from 'react';
+
 import styled from 'styled-components';
 
 import { H2 } from '@trezor/components';
 
 import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 
-export const NoDragContainer = styled.div`
+export const NoDragContainer: ComponentType<ComponentPropsWithRef<'div'>> = styled.div`
     -webkit-app-region: no-drag;
 `;
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
@@ -1,4 +1,10 @@
-import { type ReactNode, useRef, useState } from 'react';
+import {
+    type ComponentPropsWithRef,
+    type ComponentType,
+    type ReactNode,
+    useRef,
+    useState,
+} from 'react';
 
 import styled from 'styled-components';
 
@@ -24,14 +30,16 @@ import { SwitchDeviceLayer } from './SwitchDeviceLayer';
 import { useResponsiveContextOnChange } from './useResponsiveContextOnChange';
 import { ModalSwitcher } from '../../modals/ModalSwitcher/ModalSwitcher';
 
-export const Wrapper = styled.div`
+type DivComponent = ComponentType<ComponentPropsWithRef<'div'>>;
+
+export const Wrapper: DivComponent = styled.div`
     display: flex;
     flex: 1;
     flex-direction: row;
     overflow: auto;
 `;
 
-export const PageWrapper = styled.div`
+export const PageWrapper: DivComponent = styled.div`
     position: relative;
     display: flex;
     flex: 1;
@@ -40,7 +48,7 @@ export const PageWrapper = styled.div`
     overflow-x: hidden;
 `;
 
-export const Body = styled.div`
+export const Body: DivComponent = styled.div`
     display: flex;
     flex-direction: column;
     flex: 1;
@@ -48,7 +56,7 @@ export const Body = styled.div`
 `;
 
 // AppWrapper and MenuSecondary creates own scrollbars independently
-export const Columns = styled.div`
+export const Columns: DivComponent = styled.div`
     display: flex;
     flex-direction: row;
     flex: 1 0 100%;
@@ -56,7 +64,7 @@ export const Columns = styled.div`
     padding: 0;
 `;
 
-export const AppWrapper = styled.div`
+export const AppWrapper: DivComponent = styled.div`
     display: flex;
     flex: 1;
     flex-direction: column;
@@ -71,7 +79,7 @@ export const AppWrapper = styled.div`
     }
 `;
 
-export const MainContentContainer = styled.div`
+export const MainContentContainer: DivComponent = styled.div`
     display: flex;
     flex: 1;
     flex-direction: column;

--- a/packages/suite/src/components/suite/notifications/Toaster/ReactToastifyStyles.tsx
+++ b/packages/suite/src/components/suite/notifications/Toaster/ReactToastifyStyles.tsx
@@ -1,3 +1,5 @@
+import { type ComponentPropsWithRef, type ComponentType } from 'react';
+
 import styled from 'styled-components';
 
 /**
@@ -5,7 +7,7 @@ import styled from 'styled-components';
  * Styles are inlined based on:
  * https://fkhadra.github.io/react-toastify/ssr
  */
-export const ReactToastifyStyles = styled.div`
+export const ReactToastifyStyles: ComponentType<ComponentPropsWithRef<'div'>> = styled.div`
     /* stylelint-disable */
     :root {
         --toastify-color-light: #fff;

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/StandardFee.styles.ts
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/StandardFee.styles.ts
@@ -1,3 +1,5 @@
+import { type ComponentPropsWithRef, type ComponentType } from 'react';
+
 import styled from 'styled-components';
 
 import { spacingsPx } from '@trezor/theme';
@@ -5,7 +7,7 @@ import { spacingsPx } from '@trezor/theme';
 // Can't be in `StandardFee` component because of circular dependency:
 // - `StandardFee` imports `BitcoinFeeCards`, `EthereumFeeCards`, `MiscFeeCards`
 // - `BitcoinFeeCards`, `EthereumFeeCards`, `MiscFeeCards` import `FeeCardsWrapper`
-export const FeeCardsWrapper = styled.div`
+export const FeeCardsWrapper: ComponentType<ComponentPropsWithRef<'div'>> = styled.div`
     width: 100%;
     display: flex;
     flex-wrap: wrap;

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItemBlurWrapper.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItemBlurWrapper.tsx
@@ -1,6 +1,14 @@
+import type { ComponentType, PropsWithChildren } from 'react';
+
 import styled, { css } from 'styled-components';
 
-export const BlurWrapper = styled.span<{ $isBlurred: boolean }>`
+type BlurWrapperProps = {
+    $isBlurred: boolean;
+};
+
+type BlurWrapperComponent = ComponentType<PropsWithChildren<BlurWrapperProps>>;
+
+const StyledBlurWrapper = styled.span<BlurWrapperProps>`
     ${({ $isBlurred }) =>
         $isBlurred &&
         css`
@@ -12,3 +20,5 @@ export const BlurWrapper = styled.span<{ $isBlurred: boolean }>`
             }
         `};
 `;
+
+export const BlurWrapper: BlurWrapperComponent = StyledBlurWrapper;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuNotice.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuNotice.tsx
@@ -1,8 +1,10 @@
+import { type ComponentPropsWithRef, type ComponentType } from 'react';
+
 import styled from 'styled-components';
 
 import { spacingsPx, typography } from '@trezor/theme';
 
-export const AccountsMenuNotice = styled.div`
+export const AccountsMenuNotice: ComponentType<ComponentPropsWithRef<'div'>> = styled.div`
     display: flex;
     justify-content: center;
     text-align: center;

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetTableExtraRowsSection.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetTableExtraRowsSection.tsx
@@ -1,3 +1,5 @@
+import { type ComponentPropsWithRef, type ComponentType } from 'react';
+
 import styled, { css } from 'styled-components';
 
 import { borders } from '@trezor/theme';
@@ -24,9 +26,13 @@ const mapPositionToBottom = (position: DashedLinePosition) => {
     }
 };
 
-export const AssetTableExtraRowsSection = styled.div<{
+type AssetTableExtraRowsSectionProps = {
     $dashedLinePosition?: DashedLinePosition;
-}>`
+};
+
+export const AssetTableExtraRowsSection: ComponentType<
+    ComponentPropsWithRef<'div'> & AssetTableExtraRowsSectionProps
+> = styled.div<AssetTableExtraRowsSectionProps>`
     ${({ $dashedLinePosition }) =>
         $dashedLinePosition &&
         css`

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/TS7Banner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/TS7Banner.tsx
@@ -1,3 +1,5 @@
+import { type ComponentPropsWithRef, type ComponentType } from 'react';
+
 import styled from 'styled-components';
 
 import { useExternalLink } from '@suite/external-links';
@@ -16,7 +18,7 @@ type TS7BannerProps = {
     onCTAClick: () => void;
 };
 
-export const ImageContainer = styled.div`
+export const ImageContainer: ComponentType<ComponentPropsWithRef<'div'>> = styled.div`
     height: 100%;
     display: flex;
     align-items: flex-end;

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/OptionWithContent.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/OptionWithContent.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, forwardRef } from 'react';
+import { type ComponentPropsWithRef, type ComponentType, type ReactNode, forwardRef } from 'react';
 
 import styled, { css } from 'styled-components';
 
@@ -12,56 +12,59 @@ import { useLayoutSize } from 'src/hooks/suite';
 
 import { typesToLabelMap } from './typesToLabelMap';
 
-export const OptionText = styled.div`
+export const OptionText: ComponentType<ComponentPropsWithRef<'div'>> = styled.div`
     display: flex;
     flex: 1;
     flex-direction: column;
     justify-content: center;
 `;
 
-export const OptionStyled = styled.div<{ $hasHoverInteraction?: boolean; $disabled?: boolean }>`
-    display: flex;
-    flex-direction: row;
+type OptionStyledProps = { $hasHoverInteraction?: boolean; $disabled?: boolean };
 
-    gap: ${spacingsPx.md};
+export const OptionStyled: ComponentType<ComponentPropsWithRef<'div'> & OptionStyledProps> =
+    styled.div<OptionStyledProps>`
+        display: flex;
+        flex-direction: row;
 
-    padding-top: ${spacingsPx.sm};
-    padding-bottom: ${spacingsPx.sm};
+        gap: ${spacingsPx.md};
 
-    ${variables.SCREEN_QUERY.BELOW_LAPTOP} {
-        padding-top: ${spacingsPx.xs};
-        padding-bottom: ${spacingsPx.xs};
-    }
+        padding-top: ${spacingsPx.sm};
+        padding-bottom: ${spacingsPx.sm};
 
-    align-items: center;
-    cursor: pointer;
+        ${variables.SCREEN_QUERY.BELOW_LAPTOP} {
+            padding-top: ${spacingsPx.xs};
+            padding-bottom: ${spacingsPx.xs};
+        }
 
-    color: ${({ $disabled, theme }) => ($disabled ? theme.contentSecondary : undefined)};
+        align-items: center;
+        cursor: pointer;
 
-    ${({ $hasHoverInteraction }) =>
-        $hasHoverInteraction
-            ? css`
-                  &:hover {
-                      background-color: ${({ theme }) => theme.elementFillElevatedHovered};
-                      transition: background 0.2s ease;
+        color: ${({ $disabled, theme }) => ($disabled ? theme.contentSecondary : undefined)};
 
-                      margin-left: -10px;
-                      margin-right: -10px;
-                      padding-left: 10px;
-                      padding-right: 10px;
+        ${({ $hasHoverInteraction }) =>
+            $hasHoverInteraction
+                ? css`
+                      &:hover {
+                          background-color: ${({ theme }) => theme.elementFillElevatedHovered};
+                          transition: background 0.2s ease;
 
-                      ${variables.SCREEN_QUERY.BELOW_LAPTOP} {
-                          margin-left: -6px;
-                          margin-right: -6px;
-                          padding-left: 6px;
-                          padding-right: 6px;
+                          margin-left: -10px;
+                          margin-right: -10px;
+                          padding-left: 10px;
+                          padding-right: 10px;
+
+                          ${variables.SCREEN_QUERY.BELOW_LAPTOP} {
+                              margin-left: -6px;
+                              margin-right: -6px;
+                              padding-left: 6px;
+                              padding-right: 6px;
+                          }
+
+                          border-radius: ${borders.radii.xs};
                       }
-
-                      border-radius: ${borders.radii.xs};
-                  }
-              `
-            : ''};
-`;
+                  `
+                : ''};
+    `;
 
 const DownIconCircle = styled.div`
     border-radius: ${borders.radii.full};

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinBalanceSection.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinBalanceSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { type ComponentPropsWithRef, type ComponentType, useMemo } from 'react';
 
 import styled, { useTheme } from 'styled-components';
 
@@ -13,7 +13,7 @@ import { BalancePrivacyBreakdown } from './BalancePrivacyBreakdown/BalancePrivac
 import { CoinjoinBalanceError, type CoinjoinBalanceErrorProps } from './CoinjoinBalanceError';
 import { CoinjoinStatusWheel } from './CoinjoinStatusWheel/CoinjoinStatusWheel';
 
-export const Container = styled.div`
+export const Container: ComponentType<ComponentPropsWithRef<'div'>> = styled.div`
     display: flex;
     justify-content: space-between;
     gap: 8px;


### PR DESCRIPTION
## Description

Several exported styled-components were publishing full implementation-specific styled types through shared component and Suite declarations, multiplying checker work at each consumer. This builds on the transaction blur boundary by giving the promising ordinary component exports explicit React contracts, explicitly typing the scroll-shadow and ProgressBar surfaces, and removing two private value/type name collisions. Styled selectors whose identity is part of the CSS API remain unchanged, and typescript-styled-plugin is intentionally out of scope. Across the 25 affected declaration modules, fresh emits and matched Suite compiler diagnostics show a smaller public type surface and less deterministic checker work; elapsed time remained noisy, so no wall-clock speedup is claimed.

- Declaration: **19,584 → 13,906 bytes**
- Saved: **5,678 bytes (29.0%)**
- Expansion ratio: **0.25x → 0.17x**
- Suite types: **471,673 → 467,420 (4,253 fewer, 0.9%)**
- Suite instantiations: **2,381,952 → 2,309,898 (72,054 fewer, 3.0%)**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set is dominated by broad, low-level shared components (animations, form inputs, ProgressBar, TableRow, IconSetBase, Settings action components, SuiteLayout) that are transitively imported by nearly all 131 e2e tests, making blanket high-priority recommendations impractical. Real risk is concentrated in a handful of specific, narrowly-scoped changed files: TS7Banner (dashboard promo banner), AssetTableExtraRowsSection (asset table/activation), OptionWithContent (Shamir backup type selection in onboarding), TransactionItemBlurWrapper (discreet-mode blurring), StandardFee styles (fee display), and CoinjoinBalanceSection (wallet transaction summary). Recommended strategy: run the high-priority tests that directly exercise these specific components, plus a smaller set of medium/low tests for shared Settings action components and TableRow, rather than the full 131-test suite.

<details><summary><b>Changed files (25)</b></summary>

- `packages/components/src/components/Table/TableRow.tsx`
- `packages/components/src/components/animations/AnimationPrimitives.tsx`
- `packages/components/src/components/form/BottomText.tsx`
- `packages/components/src/components/form/FloatingLabel.tsx`
- `packages/components/src/components/form/SelectBar/SelectBar.tsx`
- `packages/components/src/components/form/TopAddons.tsx`
- `packages/components/src/components/loaders/ProgressBar/ProgressBar.tsx`
- `packages/components/src/utils/useScrollShadow.tsx`
- `packages/product-components/src/components/IconSet/IconSetBase.tsx`
- `packages/product-components/src/components/Settings/ActionButton.tsx`
- `packages/product-components/src/components/Settings/ActionColumn.tsx`
- `packages/product-components/src/components/Settings/ActionSelect.tsx`
- `packages/suite/src/components/suite/ConnectAppBar.tsx`
- `packages/suite/src/components/suite/DeviceMatrixExplanation.tsx`
- `packages/suite/src/components/suite/layouts/ContentContainer.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/BasicName.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx`
- `packages/suite/src/components/suite/notifications/Toaster/ReactToastifyStyles.tsx`
- `packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/StandardFee.styles.ts`
- `packages/suite/src/components/wallet/TransactionItem/TransactionItemBlurWrapper.tsx`
- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuNotice.tsx`
- `packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetTableExtraRowsSection.tsx`
- `packages/suite/src/views/dashboard/DashboardPromoBanner/TS7Banner.tsx`
- `packages/suite/src/views/onboarding/steps/SelectBackupType/OptionWithContent.tsx`
- `packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinBalanceSection.tsx`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Directly exercises AssetTableExtraRowsSection.tsx (asset activation, grid/table view) which was changed, and also uses ActionButton/ActionColumn/ActionSelect settings components for enabling networks and TableRow for asset table rendering.
- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — Directly tests the TS7 dashboard promo banner (TS7Banner.tsx), which was modified, including click behavior and analytics event firing.
- `suite/e2e/tests/wallet/transactions.test.ts` — Covers the account transaction overview and pagination/graph flows that render TransactionItemBlurWrapper and TableRow, both changed in this PR; the CoinjoinBalanceSection component (also changed) is part of the wallet transaction summary UI.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Discreet mode hides/reveals balances across TransactionItem, Asset rows and account rows which use TransactionItemBlurWrapper (changed) and TableRow (changed); a regression in blur/reveal logic would be directly visible here.
- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — This test exercises the SelectBackupType flow (Shamir advanced backup selection), which directly uses OptionWithContent.tsx that was changed in this PR.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — Also exercises Shamir/advanced backup type selection (OptionWithContent.tsx) during onboarding wallet creation, providing additional device-model coverage for the changed backup-option component.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — Tests balance display and truncation behavior on account rows, which rely on TableRow and blur/reveal wrapper components changed in this PR; balance formatting regressions would surface here.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Exercises the send form fee section and pending transaction list which use StandardFee styles and TableRow-based transaction rows, both changed in this PR.
- `suite/e2e/tests/settings/coins.test.ts` — Directly exercises the Settings coins tab, which uses ActionButton/ActionColumn/ActionSelect components for enabling/disabling networks and custom backends, all changed in this PR.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Custom backend configuration UI in the Coins settings tab relies on ActionButton/ActionSelect/ActionColumn components that were changed, and also touches CoinjoinBalanceSection-adjacent wallet view flows.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — Uses general Settings page action components (ActionButton/ActionSelect) for changing theme/fiat/language, providing incidental coverage of the changed Settings action components.
- `suite/e2e/tests/wallet/account-search.test.ts` — Account list rendering relies on TableRow for account rows; a rendering/interaction regression from the TableRow change could surface here, though the test's primary focus is search filtering, not table rendering.

</details>

_Updated: 2026-07-18T13:10:59.462Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/styled-transaction-blur-type&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/styled-transaction-blur-type&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-18T13:13:53.458Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-18T13:13:00.157Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/styled-transaction-blur-type/web/](https://dev.suite.sldev.cz/suite-web/refactor/styled-transaction-blur-type/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->