### PR TITLE
fix(transaction-search): don't return all transactions for a non-numeric `!=` search

### DIFF
--- a/suite-common/transaction-search/src/__fixtures__/searchTransactions.fixture.ts
+++ b/suite-common/transaction-search/src/__fixtures__/searchTransactions.fixture.ts
@@ -139,6 +139,12 @@ export const searchTransactionsFixture = [
         ],
     },
     {
+        // A non-numeric value after an operator must not match any transaction.
+        description: 'Non-numeric operator search matches nothing',
+        search: '!= notanumber',
+        result: [],
+    },
+    {
         description: 'Date search',
         search: '2020-12-03',
         result: [

--- a/suite-common/transaction-search/src/simpleSearchTransactions.ts
+++ b/suite-common/transaction-search/src/simpleSearchTransactions.ts
@@ -127,9 +127,8 @@ export const simpleSearchTransactions = (
         }
 
         // Is number?
-        if (!Number.isNaN(search)) {
-            const amount = new BigNumber(search);
-
+        const amount = new BigNumber(search);
+        if (!amount.isNaN()) {
             return transactions.filter(t => numberSearchFilter(t, amount, searchOperator));
         }
 
@@ -139,7 +138,7 @@ export const simpleSearchTransactions = (
     const txsToSearch: string[] = [];
 
     // Searching for an amount (without operator)
-    if (!Number.isNaN(search)) {
+    if (!new BigNumber(search).isNaN()) {
         const foundTxsForNumber = transactions.flatMap(transaction => {
             const targetAmounts = getTargetAmounts(transaction);
             if (targetAmounts.filter(targetAmount => targetAmount.includes(search)).length === 0) {


### PR DESCRIPTION
### What

In the transaction search box, an amount-operator search with a **non-numeric operand after `!=`** (e.g. `!= abc`) returns the **entire transaction list** instead of nothing. All other operators already behaved correctly.

### Root cause

The "is this operand a number?" guard called [`Number.isNaN(search)`](https://github.com/trezor/trezor-suite/blob/53cd5a5cadfe6bcf8b92b57df476ec2c99f422d2/suite-common/transaction-search/src/simpleSearchTransactions.ts#L130) on `search`, which is a **string**. `Number.isNaN` does not coerce — it only returns `true` for the actual `NaN` *number* value, so `Number.isNaN(<any string>)` is always `false`, and `!false` makes the guard always pass. The [`return []`](https://github.com/trezor/trezor-suite/blob/53cd5a5cadfe6bcf8b92b57df476ec2c99f422d2/suite-common/transaction-search/src/simpleSearchTransactions.ts#L136) branch for non-numeric operands was unreachable.

So for a non-numeric operand the code fell through to `new BigNumber('abc')` = `NaN` and called [`numberSearchFilter(t, NaN, '!=')`](https://github.com/trezor/trezor-suite/blob/53cd5a5cadfe6bcf8b92b57df476ec2c99f422d2/suite-common/transaction-search/src/simpleSearchTransactions.ts#L133). The [`!=` branch](https://github.com/trezor/trezor-suite/blob/53cd5a5cadfe6bcf8b92b57df476ec2c99f422d2/suite-common/transaction-search/src/numberSearchFilter.ts#L33-L34) returns `!bnTargetAmount.eq(amount)`, and `BigNumber(x).eq(NaN)` is always `false`, so `!false` = `true` — **every** transaction matches.

Why only `!=` and not `<` / `>` / `=`: their comparators (`lte` / `gte` / `eq` against `NaN`) all return `false`, so those already yielded an (accidentally) empty result. `!=` is the sole inversion, so it flipped to "match everything". Numeric operands (`!= 5`) were unaffected.

### Fix

Build the `BigNumber` first and gate on [`BigNumber.isNaN()`](https://github.com/trezor/trezor-suite/blob/93f4d9186275d1769ec2e8825a1dac29655396a3/suite-common/transaction-search/src/simpleSearchTransactions.ts#L129-L135), which does parse the string. A non-numeric operand now correctly returns `[]`. The same one-character-class of bug in the operator-less amount path is fixed the same way.

### Impact

- **Reachable, user-facing.** The operator syntax is not obscure — it is explicitly advertised to users: the pro-tip lists all operators including `!=` ([`TR_TRANSACTIONS_SEARCH_PRO_TIP`](https://github.com/trezor/trezor-suite/blob/53cd5a5cadfe6bcf8b92b57df476ec2c99f422d2/suite/intl/src/messages.ts#L7661)) and a dedicated tip documents `!=` with a concrete example `!= -0.01` ([`TR_TRANSACTIONS_SEARCH_TIP_4`](https://github.com/trezor/trezor-suite/blob/53cd5a5cadfe6bcf8b92b57df476ec2c99f422d2/suite/intl/src/messages.ts#L7681)). The search input passes the raw string through with no validation.
- **Two call sites:** the live transaction list ([`TransactionList.tsx#L68`](https://github.com/trezor/trezor-suite/blob/53cd5a5cadfe6bcf8b92b57df476ec2c99f422d2/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx#L68)) and the transaction export ([`exportTransactionsActions.ts#L74`](https://github.com/trezor/trezor-suite/blob/53cd5a5cadfe6bcf8b92b57df476ec2c99f422d2/packages/suite/src/actions/wallet/exportTransactionsActions.ts#L74)). Via export, a user who types `!= <something non-numeric>` exports **all** transactions while believing the result is filtered.
- **Severity is low-to-moderate:** the failure is a misleading/no-op search result (the whole list shows), not data loss or a crash. But it is a genuine correctness bug a real user can hit by following the app's own documented syntax.

### Test

Adds a fixture case `!= notanumber → []` to [`searchTransactions.fixture.ts`](https://github.com/trezor/trezor-suite/blob/93f4d9186275d1769ec2e8825a1dac29655396a3/suite-common/transaction-search/src/__fixtures__/searchTransactions.fixture.ts#L142-L146), exercised by the existing fixture-driven `advancedSearchTransactions.test.ts`. It fails against the old code (all txs returned) and passes with the fix.

### Notes for QA

Reproducible on `develop`:
1. Open any account with several transactions → transaction list.
2. In the search box type `!= abc` (or any text after `!=` that isn't a number).
3. **Before:** the full transaction list is shown (search appears to do nothing). **After:** no results.
4. Also verify the export path: with `!= abc` in the search box, export to CSV/JSON — before the fix it exports every transaction; after, it exports none.
5. Sanity-check unaffected cases still work: `!= 5` (numeric) filters correctly, and `< abc` / `> abc` / `= abc` return no results as before.

Blast radius is limited to transaction search/export string handling; no device, signing, or balance logic is touched.

---

Part of the continuously-improve bug-fix sweep — split out from the umbrella #29735.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are isolated to the transaction-search package (simpleSearchTransactions.ts logic and its test fixture), which is a fairly narrow, feature-specific utility rather than a broad shared dependency despite the large static coverage count (likely due to transitive imports through common wallet bundles). The only E2E test with direct, concrete behavioral overlap is wallet/transactions.test.ts, which exercises searching for a transaction by address on a BTC account. Other tests statically mapped to this file (metadata, staking, passphrase, onboarding, etc.) do not exercise transaction search functionality and were excluded per the broad-utility heuristic. Recommend running transactions.test.ts as the primary check, with pending-transactions.test.ts as a lower-priority sanity check on transaction list rendering.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/transaction-search/src/__fixtures__/searchTransactions.fixture.ts`
- `suite-common/transaction-search/src/simpleSearchTransactions.ts`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly exercises transaction search functionality on a BTC account ('User can find the latest transaction... and search for it by its address'), which is the exact feature implemented in simpleSearchTransactions.ts.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test displays and manages transaction lists (pending/confirmed groups) which could be affected if simpleSearchTransactions logic touches shared transaction list/filtering behavior, though it doesn't directly test search.

</details>

_Updated: 2026-07-18T13:25:07.540Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/txsearch-noneq-nonnumeric/web/](https://dev.suite.sldev.cz/suite-web/mroz22/txsearch-noneq-nonnumeric/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/txsearch-noneq-nonnumeric&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/txsearch-noneq-nonnumeric&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/txsearch-noneq-nonnumeric&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-18T13:28:36.789Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-18T13:28:33.797Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->