### PR TITLE
refactor(suite-desktop-api): simplify IPC method types

### DIFF
--- a/packages/suite-desktop-api/src/methods.ts
+++ b/packages/suite-desktop-api/src/methods.ts
@@ -1,12 +1,4 @@
-import { type UnionToIntersection } from '@trezor/type-utils';
-
-type MethodFactory<Union> = UnionToIntersection<Union[keyof Union]>;
-
-type OmitFirstArg<F> = F extends (first: any, ...args: infer P) => infer R
-    ? (...args: P) => R
-    : never;
-
-type OmitEvent<E, P> = E extends null ? OmitFirstArg<P> : P;
+export type StrictChannel = { [name: string]: any };
 
 // Find undefined in union `string | undefined`
 export type ExtractUndefined<U> = (U extends undefined ? (k: U) => void : never) extends (
@@ -15,97 +7,122 @@ export type ExtractUndefined<U> = (U extends undefined ? (k: U) => void : never)
     ? I
     : never;
 
-type OptionalParams<C, P> =
-    ExtractUndefined<P> extends undefined
-        ? (channel: C, payload?: P) => void
-        : (channel: C, payload: P) => void;
+type Listener<Payload, Event> = Event extends null
+    ? [Payload] extends [void]
+        ? () => void
+        : (payload: Payload) => void
+    : [Payload] extends [void]
+      ? (event: Event) => void
+      : (event: Event, payload: Payload) => void;
 
-export type StrictChannel = { [name: string]: any };
+type ListenerArgs<Channels extends StrictChannel, Event, C extends keyof Channels> = {
+    [K in C]: [channel: K, listener: Listener<Channels[K], Event>];
+}[C];
+
+type PayloadArgs<Payload> = [Payload] extends [void]
+    ? []
+    : undefined extends Payload
+      ? [payload?: Payload]
+      : [payload: Payload];
+
+type SendArgs<Channel, Payload, Event> = Event extends null
+    ? PayloadArgs<Payload>
+    : [channel: Channel, ...PayloadArgs<Payload>];
+
+type SendWithChannelArgs<Channels extends StrictChannel, Event, C extends keyof Channels> = {
+    [K in C]: SendArgs<K, Channels[K], Event>;
+}[C];
+
+type InvokeArgs<Channel, Method, Event> = Method extends (...args: infer Args) => any
+    ? Event extends null
+        ? Args
+        : [channel: Channel, ...Args]
+    : never;
+
+type InvokeResult<Method> = Method extends (...args: any[]) => infer Result ? Result : never;
+
+type InvokeWithChannelArgs<Channels extends StrictChannel, Event, C extends keyof Channels> = {
+    [K in C]: InvokeArgs<K, Channels[K], Event>;
+}[C];
+
+type SendWithoutChannel<Channels extends StrictChannel> = {
+    [C in keyof Channels]: (...args: PayloadArgs<Channels[C]>) => void;
+}[keyof Channels];
+
+type InvokeWithoutChannel<Channels extends StrictChannel> = {
+    [C in keyof Channels]: (
+        ...args: InvokeArgs<C, Channels[C], null>
+    ) => Promise<InvokeResult<Channels[C]>>;
+}[keyof Channels];
+
+type Handler<Method, Event> = Method extends (...args: infer Args) => infer Result
+    ? Event extends null
+        ? (...args: Args) => Result | Promise<Result>
+        : (event: Event, ...args: Args) => Result | Promise<Result>
+    : never;
+
+type HandleArgs<Channels extends StrictChannel, Event, C extends keyof Channels> = {
+    [K in C]: [channel: K, handler: Handler<Channels[K], Event>];
+}[C];
 
 /**
- * Listener method transforms channels list in to listener function.
- * if generic type <E> is not set first parameter "event" will be omitted.
+ * Listener method maps a channel to its payload without materializing an overload intersection.
+ * If generic type <E> is not set, the first listener parameter "event" will be omitted.
  *
  * usage DesktopApi.on -> ipcRenderer.on:
  * type Fn = ListenerMethod<{'foo': number, 'bar': string }>
- * equals
- * type Fn = ('foo', (payload: number) => {}) & ('bar', (payload: string) => {})
+ * accepts Fn('foo', (payload: number) => {}) and Fn('bar', (payload: string) => {})
  *
  * usage ipcMain.on:
  * type Fn = ListenerMethod<{'foo': number, 'bar': string }, Event>
- * equals
- * type Fn = ('foo', (event: Event, payload: number) => {}) & ('bar', (event: Event, payload: string) => {})
+ * accepts Fn('foo', (event: Event, payload: number) => {}) and Fn('bar', (event: Event, payload: string) => {})
  */
-export type ListenerMethod<Channels extends StrictChannel, E = null> = MethodFactory<{
-    [C in keyof Channels]: (
-        channel: C,
-        listener: OmitEvent<
-            E,
-            Channels[C] extends void ? (event: E) => void : (event: E, payload: Channels[C]) => void
-        >,
-    ) => void;
-}>;
+export type ListenerMethod<Channels extends StrictChannel, E = null> = <C extends keyof Channels>(
+    ...args: ListenerArgs<Channels, E, C>
+) => void;
 
 /**
- * Send method transforms channels list in to send function.
- * if generic type <E> is not set first parameter "channel" will be omitted.
+ * Send method maps a channel to its payload without materializing an overload intersection.
+ * If generic type <E> is not set, the first parameter "channel" will be omitted.
  *
  * usage: DesktopApi.[method] > ipcRenderer.send
- * type Fn = ListenerMethod<{'foo': number, 'bar': string | undefined, 'xyz': void }>
- * equals
- * type Fn = (p: number) => {} & (p?: string) => {} & () => {}
+ * type Fn = SendMethod<{'foo': number, 'bar': string | undefined, 'xyz': void }>
+ * creates a method matching the payload of its single channel.
  *
  * usage: webContents.send
- * type Fn = ListenerMethod<{'foo': number, 'bar': string | undefined, 'xyz': void }, Event>
- * equals
- * type Fn = (c: 'foo', p: number) => {} & (c: 'bar', p?: string) => {} & (c: 'xyz') => {}
+ * type Fn = SendMethod<{'foo': number, 'bar': string | undefined, 'xyz': void }, Event>
+ * accepts Fn('foo', 1), Fn('bar'), and Fn('xyz').
  */
-export type SendMethod<Channels extends StrictChannel, E = null> = MethodFactory<{
-    [C in keyof Channels]: OmitEvent<
-        E,
-        Channels[C] extends void ? (channel: C) => void : OptionalParams<C, Channels[C]>
-    >;
-}>;
+export type SendMethod<Channels extends StrictChannel, E = null> = E extends null
+    ? SendWithoutChannel<Channels>
+    : <C extends keyof Channels>(...args: SendWithChannelArgs<Channels, E, C>) => void;
 
 /**
- * Invoke method transforms channels list in to intersection of invoke functions.
- * if generic type <E> is not set first parameter "channel" will be omitted.
+ * Invoke method maps a channel to its arguments and result without materializing an overload
+ * intersection. If generic type <E> is not set, the first parameter "channel" will be omitted.
  *
  * usage in DesktopApi.[method] definition:
- * type Fn = ListenerMethod<{'foo': () => void, 'bar': (arg: number) => { success: boolean } }>;
- * equals
- * type Fn = () => Promise<void> & (arg: number) => Promise<{ success: boolean }>;
+ * type Fn = InvokeMethod<{'foo': () => void, 'bar': (arg: number) => { success: boolean } }>;
+ * creates a method matching the arguments and result of its single channel.
  *
  * usage in ipcRenderer.invoke:
- * type Fn = ListenerMethod<{'foo': () => void, 'bar': (arg1: number, arg2: boolean) => { success: boolean } }, Electron.IpcMainInvokeEvent>;
- * equals
- * type Fn = (channel: 'foo') => Promise<void> & (channel: 'bar', arg1: number, arg2: boolean) => Promise<{ success: boolean }>;
+ * type Fn = InvokeMethod<{'foo': () => void, 'bar': (arg1: number, arg2: boolean) => { success: boolean } }, Electron.IpcMainInvokeEvent>;
+ * accepts Fn('foo') and Fn('bar', 1, true), preserving the corresponding result type.
  */
-export type InvokeMethod<Channels extends StrictChannel, E = null> = MethodFactory<{
-    [C in keyof Channels]: OmitEvent<
-        E,
-        (channel: C, ...args: Parameters<Channels[C]>) => Promise<ReturnType<Channels[C]>>
-    >;
-}>;
+export type InvokeMethod<Channels extends StrictChannel, E = null> = E extends null
+    ? InvokeWithoutChannel<Channels>
+    : <C extends keyof Channels>(
+          ...args: InvokeWithChannelArgs<Channels, E, C>
+      ) => Promise<InvokeResult<Channels[C]>>;
 
 /**
- * HandleMethod method transforms channels list in to intersection of handle functions.
- * if generic type <E> is not set first parameter "event" will be omitted.
+ * Handle method maps a channel to its handler without materializing an overload intersection.
+ * If generic type <E> is not set, the first handler parameter "event" will be omitted.
  *
  * usage in ipcMain.handle:
  * type Fn = HandleMethod<{'foo': () => void, 'bar': (arg1: number, arg2: boolean) => { success: boolean } }, Electron.IpcMainInvokeEvent>;
- * equals
- * type Fn = (('foo', (event: Electron.IpcMainInvokeEvent) => void) & ('bar', (event: Event, arg1: number, arg2: boolean) => { success: boolean })
+ * accepts handlers whose arguments and result correspond to the selected channel.
  */
-export type HandleMethod<Channels extends StrictChannel, E = null> = MethodFactory<{
-    [C in keyof Channels]: (
-        channel: C,
-        handler: OmitEvent<
-            E,
-            (
-                event: E,
-                ...args: Parameters<Channels[C]>
-            ) => ReturnType<Channels[C]> | Promise<ReturnType<Channels[C]>>
-        >,
-    ) => void;
-}>;
+export type HandleMethod<Channels extends StrictChannel, E = null> = <C extends keyof Channels>(
+    ...args: HandleArgs<Channels, E, C>
+) => void;


### PR DESCRIPTION
## Description

The desktop IPC method helpers converted every channel map into an intersection of overloads, forcing TypeScript to compare a large synthetic signature set throughout Electron call sites. This replaces those intersections with correlated channel-keyed generic tuples, retaining channel/payload/handler/result relationships and the existing single-channel DesktopApi contracts while reducing checker work.

- API check time: **0.89s -> 0.39s (56.2% faster)**
- API assignability cache: **5,659 -> 1,133 entries (80.0% fewer)**
- Desktop core check time: **2.45s -> 2.22s (9.4% faster)**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to packages/suite-desktop-api/src/methods.ts, which defines the method bindings/dispatch layer used by TrezorConnect when running in Electron/suite-desktop coreMode. Since no static test mapping exists for this file, recommendations are inferred from LLM analysis: the trezor-connect test suite is the most direct and reliable signal, as nearly every test in that directory explicitly initializes TrezorConnect with coreMode 'suite-desktop' and exercises the desktop API bridge (exposeConnectWs) for various methods (getAddress, getAccountInfo, signTransaction, selectAccount, sign/verify message, permissions, silent mode). Recommended strategy: run the full trezor-connect suite at high priority since these are the closest functional consumers of the changed file, plus a broader smoke test (send-eth) at low priority to catch any higher-level regression in desktop-mediated signing flows.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite-desktop-api/src/methods.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/trezor-connect/error.test.ts` — This test directly exercises TrezorConnect initialized with coreMode 'suite-desktop', which relies on the desktop API method bindings exposed by packages/suite-desktop-api. Changes to methods.ts could break the desktop-specific TrezorConnect API surface used here.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Uses TrezorConnect.init with coreMode 'suite-desktop' and calls getAddress through the Electron desktop bridge, directly depending on the desktop API method definitions that were changed.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Calls TrezorConnect.getAccountInfo via suite-desktop core mode, exercising the desktop API method dispatch layer that packages/suite-desktop-api/src/methods.ts implements.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Invokes TrezorConnect.signTransaction through the suite-desktop Electron WebSocket bridge (exposeConnectWs), a direct consumer of the desktop API methods module.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Exercises TrezorConnect.ethereumSignTransaction in suite-desktop coreMode, directly relying on the desktop API method bindings that were modified.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Exercises TrezorConnect.ethereumSignMessage via suite-desktop coreMode, another direct consumer of the desktop API method surface affected by this change.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — Calls TrezorConnect.selectAccount using suite-desktop coreMode with exposeConnectWs configuration, directly dependent on desktop API method definitions.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Uses TrezorConnect with coreMode 'suite-desktop' to test permission granting/revoking flows, which route through the desktop API methods; a regression could affect how permission requests are dispatched.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests silent mode behavior with TrezorConnect.init() in suite-desktop coreMode, which depends on desktop API IPC/method wiring that could be impacted by changes in methods.ts.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — Involves signing an Ethereum transaction end-to-end in the desktop app context; if desktop API method dispatch is broken, this higher-level flow could also fail, though it's more indirect than the trezor-connect specific tests.

</details>

_Updated: 2026-07-18T15:17:32.636Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/desktop-ipc-method-types&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/desktop-ipc-method-types&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-18T15:20:57.593Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-18T15:20:35.653Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/desktop-ipc-method-types/web/](https://dev.suite.sldev.cz/suite-web/refactor/desktop-ipc-method-types/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->