### PR TITLE
fix(transport-common): consolidate surviving fixes from stale transport PRs

### DIFF
--- a/.github/workflows/test-transport.yml
+++ b/.github/workflows/test-transport.yml
@@ -14,6 +14,7 @@ on:
     paths:
       - "packages/transport/**"
       - "packages/transport-bridge/**"
+      - "packages/transport-common/**"
       - "packages/transport-test/**"
       - "packages/protobuf/**"
       - "packages/protocol/**"

--- a/packages/transport-bridge/src/core.test.ts
+++ b/packages/transport-bridge/src/core.test.ts
@@ -81,4 +81,58 @@ describe('transport-bridge core lock safety', () => {
             core.dispose();
         }
     });
+
+    it('release frees the lock and reports device not found when the device vanishes mid-release', async () => {
+        const enumerate = jest
+            .fn()
+            .mockResolvedValueOnce({ success: true, payload: [{ path: '1' }] })
+            .mockResolvedValueOnce({ success: true, payload: [] })
+            .mockResolvedValue({ success: true, payload: [{ path: '1' }] });
+
+        const closeDevice = jest.fn();
+        const core = createCore(createFakeApi({ enumerate, closeDevice }), muteLogger);
+        const { signal } = new AbortController();
+
+        // the device unplugs while release is closing it: closeDevice re-enumerates
+        // to empty, removing the descriptor before releaseDone runs
+        closeDevice.mockImplementation(async () => {
+            await core.enumerate({ signal });
+
+            return { success: true, payload: undefined };
+        });
+
+        try {
+            await core.enumerate({ signal });
+
+            const acquire = await core.acquire({
+                path: PathPublic('1'),
+                previous: 'null',
+                signal,
+                sessionOwner: 'A',
+            });
+            expect(acquire.success).toBe(true);
+            if (!acquire.success) return;
+
+            const release = await core.release({ session: acquire.payload.session });
+            expect(release).toMatchObject({
+                success: false,
+                error: { code: 'device not found' },
+            });
+            expect(closeDevice).toHaveBeenCalledTimes(1);
+
+            // the lock taken by releaseIntent was freed: after the device
+            // reappears (new public path), acquire goes through instead of
+            // deadlocking behind the leaked lock
+            await core.enumerate({ signal });
+            const reacquire = await core.acquire({
+                path: PathPublic('2'),
+                previous: 'null',
+                signal,
+                sessionOwner: 'A',
+            });
+            expect(reacquire).toMatchObject({ success: true });
+        } finally {
+            core.dispose();
+        }
+    });
 });

--- a/packages/transport-common/src/api/abstract.ts
+++ b/packages/transport-common/src/api/abstract.ts
@@ -194,7 +194,8 @@ export abstract class AbstractApi extends TypedEmitter<{
 
         try {
             // note: await is needed here
-            return await this.synchronize(fn);
+            // synchronize per path so that devices don't block each other
+            return await this.synchronize(fn, path);
         } catch (err) {
             // this should never happen, incorrectly handled error on api level. fn should not throw.
             this.logger?.error('transport: abstract api: runInIsolation error', err);

--- a/packages/transport-common/src/api/usb.test.ts
+++ b/packages/transport-common/src/api/usb.test.ts
@@ -280,4 +280,48 @@ describe('api/usb', () => {
         expect(listener).toHaveBeenCalledTimes(1);
         expect(listener).toHaveBeenCalledWith([]);
     });
+
+    it('runInIsolation isolates per path: other paths run in parallel, same path serializes', async () => {
+        const api = new UsbApi({ usbInterface: createUsbMock() });
+
+        const blocker = createDeferred();
+        const order: string[] = [];
+
+        // long operation (e.g. signing awaiting on-device confirmation) holds path 1
+        const path1 = api.runInIsolation(
+            { lock: { read: false, write: true }, path: '1' },
+            async () => {
+                order.push('path1-start');
+                await blocker.promise;
+                order.push('path1-end');
+
+                return { success: true as const, payload: undefined };
+            },
+        );
+
+        // an operation on another device must not queue behind it
+        const path2 = await Promise.race([
+            api.runInIsolation({ lock: { read: true, write: true }, path: '2' }, () => ({
+                success: true as const,
+                payload: 'path2',
+            })),
+            new Promise(resolve => setTimeout(() => resolve('blocked'), 100)),
+        ]);
+        expect(path2).toEqual({ success: true, payload: 'path2' });
+
+        // while an operation on the same path (non-conflicting lock) still serializes
+        const path1Again = api.runInIsolation(
+            { lock: { read: true, write: false }, path: '1' },
+            () => {
+                order.push('path1-again');
+
+                return { success: true as const, payload: undefined };
+            },
+        );
+
+        blocker.resolve(undefined);
+        await path1;
+        await path1Again;
+        expect(order).toEqual(['path1-start', 'path1-end', 'path1-again']);
+    });
 });

--- a/packages/transport-common/src/sessions/background.disconnect.fuzz.test.ts
+++ b/packages/transport-common/src/sessions/background.disconnect.fuzz.test.ts
@@ -1,0 +1,492 @@
+import fc from 'fast-check';
+
+import { DEVICE_NOT_FOUND, UNEXPECTED_ERROR } from '../errors';
+import { type Descriptor, PathInternal, type PathPublic, type Session } from '../types';
+import { SessionsBackground } from './background';
+import { SessionsClient } from './client';
+
+/**
+ * Disconnect/reconnect fuzz harness for the sessions lock protocol.
+ *
+ * background.fuzz.test.ts fuzzes concurrent acquire/steal/release arrival order
+ * but deliberately keeps the device connected for the whole run. The paths this
+ * PR touches live exactly in the window it does not model:
+ *   - releaseDone arriving after the descriptor vanished (device disconnected
+ *     between releaseIntent and releaseDone) must error DEVICE_NOT_FOUND and
+ *     STILL free the lock taken by releaseIntent,
+ *   - acquireDone arriving after a disconnect must not commit a phantom session,
+ *   - reconnects re-mint a fresh public path while stale-path requests are
+ *     still in flight (including parked inside waitInQueue),
+ *   - internal paths are raw USB serials, so hostile serials colliding with
+ *     Object.prototype members ('toString', '__proto__', 'hasOwnProperty')
+ *     must behave like any other path (null-prototype dictionaries).
+ *
+ * The technique is the same as the base harness: SessionsBackground is a
+ * single-threaded message processor, so we fuzz the arrival order of client
+ * messages and admin enumerateDone (disconnect/reconnect) events, fire without
+ * awaiting, and flush microtasks between fires. The 4s lock safety-net timer
+ * never gets a chance to run, so every liveness observation below is about the
+ * lock mechanics themselves.
+ *
+ * Invariants asserted after every run settles:
+ *   INV-A (safety): at most one simultaneously committed owner per device.
+ *         A disconnect legitimately supersedes all owners (the background
+ *         deleted the descriptor); a steal supersedes only the owner whose
+ *         session was deliberately claimed as `previous`.
+ *   INV-B (liveness, no-timer world): every client reaches a terminal state
+ *         and background.locksQueue is empty - each waitInQueue was paired
+ *         with a clearLock. A leaked lock (e.g. releaseDone bailing out before
+ *         clearing) shows up as a wedged actor and a non-empty queue.
+ *   INV-C (no crashes): handleMessage never resolves with the UNEXPECTED_ERROR
+ *         catch-all and never rejects. Either one means an unhandled throw
+ *         inside the background (on pre-fix code: releaseDone dereferencing the
+ *         deleted descriptor). Note: under jest the catch-all's console.error
+ *         is trapped by JestCustomEnv and re-thrown, so a background crash
+ *         surfaces here as a REJECTED handleMessage rather than the
+ *         UNEXPECTED_ERROR response - both are counted.
+ *   INV-D (no pollution): device registration always succeeds even for hostile
+ *         serials, and Object.prototype stays untouched afterwards.
+ */
+
+// enough microtask turns to let any unblocked handleMessage chain settle
+const flushMicrotasks = async () => {
+    for (let i = 0; i < 16; i += 1) {
+        await Promise.resolve();
+    }
+};
+
+// internal paths are raw USB serial numbers reported by the device; a hostile
+// or broken device can present a serial colliding with Object.prototype members
+const INTERNAL_PATHS = ['dev-1', 'toString', '__proto__', 'hasOwnProperty'] as const;
+
+const committedSession = (
+    descriptors: Descriptor[],
+    publicPath: PathPublic | null,
+): Session | null =>
+    publicPath === null ? null : (descriptors.find(d => d.path === publicPath)?.session ?? null);
+
+const isUnexpected = (res: { success: boolean; error?: { code?: string } }) =>
+    !res.success && res.error?.code === UNEXPECTED_ERROR;
+
+type Phase = 'idle' | 'acquired' | 'committed' | 'releasing' | 'done';
+
+interface Actor {
+    index: number;
+    client: SessionsClient;
+    steals: boolean;
+    phase: Phase;
+    busy: boolean; // request in flight; a real client awaits the reply before the next request
+    targetPath: PathPublic | null; // public path captured when acquireIntent fired (may go stale)
+    granted: Session | null;
+    internalPath: PathInternal | null;
+}
+
+interface RunState {
+    // committed-and-not-superseded owners; see INV-A above for what counts as
+    // a legitimate supersede (steal of a claimed session, or a disconnect)
+    owners: { client: number; session: Session }[];
+    maxOwners: number;
+    observedCurrent: Session | null;
+    // sessions some client deliberately claimed as `previous` - only these make
+    // a releaseRequest a legitimate supersede (same oracle as the base harness)
+    claimedPreviouses: Session[];
+    connected: boolean;
+    currentPublicPath: PathPublic | null;
+    lastPublicPath: PathPublic | null; // survives disconnect; used to fire stale-path requests
+    generation: number;
+    adminBusy: boolean;
+    unexpectedErrors: number;
+    registrationFailures: number;
+}
+
+// aggregated across all fc runs: proves the fuzzer actually reaches the code
+// paths this PR changed (a green run that never disconnects proves nothing)
+interface Sentinels {
+    reconnects: number;
+    acquireIntentOnMissingDevice: number;
+    acquireDoneAfterDisconnect: number;
+    releaseDoneAfterDisconnect: number;
+}
+
+interface RunResult {
+    maxOwners: number;
+    allReachedDone: boolean;
+    locksQueueLength: number;
+    unexpectedErrors: number;
+    registrationFailures: number;
+    probeSettled: boolean;
+}
+
+const runDisconnectChurn = async (
+    script: number[],
+    clientCount: number,
+    steals: boolean[],
+    pathPool: string[],
+    sentinels: Sentinels,
+): Promise<RunResult> => {
+    const background = new SessionsBackground();
+    const admin = new SessionsClient(background);
+    await admin.handshake();
+
+    const state: RunState = {
+        owners: [],
+        maxOwners: 0,
+        observedCurrent: null,
+        claimedPreviouses: [],
+        connected: false,
+        currentPublicPath: null,
+        lastPublicPath: null,
+        generation: 0,
+        adminBusy: false,
+        unexpectedErrors: 0,
+        registrationFailures: 0,
+    };
+
+    const connectDevice = (res: Awaited<ReturnType<SessionsClient['enumerateDone']>>) => {
+        if (isUnexpected(res)) state.unexpectedErrors += 1;
+        if (!res.success || res.payload.descriptors.length !== 1) {
+            // the device presented a serial and did not get registered - on
+            // prototype-keyed dictionaries this is what 'toString' paths do
+            state.registrationFailures += 1;
+
+            return;
+        }
+        state.connected = true;
+        state.currentPublicPath = res.payload.descriptors[0]?.path ?? null;
+        state.lastPublicPath = state.currentPublicPath ?? state.lastPublicPath;
+        state.observedCurrent = committedSession(res.payload.descriptors, state.currentPublicPath);
+    };
+
+    // initial connect, generation 0
+    connectDevice(
+        await admin.enumerateDone({
+            descriptors: [{ path: PathInternal(pathPool[0] as string), type: 1, apiType: 'usb' }],
+        }),
+    );
+    state.generation = 1;
+
+    const fireDisconnect = () => {
+        if (state.adminBusy || !state.connected) return;
+        state.adminBusy = true;
+        admin.enumerateDone({ descriptors: [] }).then(
+            res => {
+                state.adminBusy = false;
+                if (isUnexpected(res)) state.unexpectedErrors += 1;
+                // the background deleted the descriptor: every committed owner
+                // has been superseded by the disconnect itself
+                state.owners = [];
+                state.observedCurrent = null;
+                state.connected = false;
+                state.currentPublicPath = null;
+            },
+            () => {
+                state.unexpectedErrors += 1;
+                state.adminBusy = false;
+            },
+        );
+    };
+
+    const fireReconnect = () => {
+        if (state.adminBusy || state.connected) return;
+        state.adminBusy = true;
+        sentinels.reconnects += 1;
+        const internal = pathPool[state.generation % pathPool.length] as string;
+        state.generation += 1;
+        admin
+            .enumerateDone({
+                descriptors: [{ path: PathInternal(internal), type: 1, apiType: 'usb' }],
+            })
+            .then(
+                res => {
+                    state.adminBusy = false;
+                    connectDevice(res);
+                },
+                () => {
+                    state.unexpectedErrors += 1;
+                    state.adminBusy = false;
+                },
+            );
+    };
+
+    // same oracle as the base harness: a releaseRequest supersedes an owner
+    // only if some client deliberately claimed that session as `previous`
+    background.on('releaseRequest', descriptor => {
+        const superseded = descriptor.session;
+        if (superseded === null || !state.claimedPreviouses.includes(superseded)) return;
+        const notified = state.owners.findIndex(o => o.session === superseded);
+        if (notified >= 0) state.owners.splice(notified, 1);
+    });
+
+    try {
+        const actors: Actor[] = Array.from({ length: clientCount }, (_, i) => ({
+            index: i,
+            client: new SessionsClient(background),
+            steals: steals[i] ?? false,
+            phase: 'idle',
+            busy: false,
+            targetPath: null,
+            granted: null,
+            internalPath: null,
+        }));
+
+        const advance = (actor: Actor) => {
+            if (actor.busy || actor.phase === 'done') return;
+
+            if (actor.phase === 'idle') {
+                // while disconnected, fire against the last known (stale) public
+                // path - that is what a real client with outdated descriptors does
+                const target = state.currentPublicPath ?? state.lastPublicPath;
+                if (!target) {
+                    actor.phase = 'done';
+
+                    return;
+                }
+                const previous = actor.steals ? state.observedCurrent : null;
+                if (previous !== null) state.claimedPreviouses.push(previous);
+                actor.targetPath = target;
+                actor.busy = true;
+                actor.client.acquireIntent({ path: target, previous }).then(
+                    res => {
+                        actor.busy = false;
+                        if (isUnexpected(res)) state.unexpectedErrors += 1;
+                        if (res.success) {
+                            actor.granted = res.payload.session;
+                            actor.phase = 'acquired';
+                        } else {
+                            if (!res.success && res.error.code === DEVICE_NOT_FOUND) {
+                                sentinels.acquireIntentOnMissingDevice += 1;
+                            }
+                            actor.phase = 'done';
+                        }
+                    },
+                    () => {
+                        // rejection = crash inside the background (see INV-C)
+                        state.unexpectedErrors += 1;
+                        actor.busy = false;
+                        actor.phase = 'done';
+                    },
+                );
+            } else if (actor.phase === 'acquired') {
+                actor.busy = true;
+                actor.client.acquireDone({ path: actor.targetPath as PathPublic }).then(
+                    res => {
+                        actor.busy = false;
+                        if (isUnexpected(res)) state.unexpectedErrors += 1;
+                        if (res.success && actor.granted) {
+                            state.owners.push({ client: actor.index, session: actor.granted });
+                            state.maxOwners = Math.max(state.maxOwners, state.owners.length);
+                            state.observedCurrent = committedSession(
+                                res.payload.descriptors,
+                                state.currentPublicPath,
+                            );
+                            actor.phase = 'committed';
+                        } else {
+                            // disconnect landed between acquireIntent and
+                            // acquireDone - no phantom session may be committed
+                            if (!res.success && res.error.code === DEVICE_NOT_FOUND) {
+                                sentinels.acquireDoneAfterDisconnect += 1;
+                            }
+                            actor.phase = 'done';
+                        }
+                    },
+                    () => {
+                        state.unexpectedErrors += 1;
+                        actor.busy = false;
+                        actor.phase = 'done';
+                    },
+                );
+            } else if (actor.phase === 'committed') {
+                actor.busy = true;
+                actor.client.releaseIntent({ session: actor.granted as Session }).then(
+                    res => {
+                        actor.busy = false;
+                        if (isUnexpected(res)) state.unexpectedErrors += 1;
+                        if (res.success) {
+                            actor.internalPath = res.payload.path;
+                            actor.phase = 'releasing';
+                        } else {
+                            actor.phase = 'done';
+                        }
+                    },
+                    () => {
+                        state.unexpectedErrors += 1;
+                        actor.busy = false;
+                        actor.phase = 'done';
+                    },
+                );
+            } else if (actor.phase === 'releasing') {
+                actor.busy = true;
+                actor.client.releaseDone({ path: actor.internalPath as PathInternal }).then(
+                    res => {
+                        actor.busy = false;
+                        if (isUnexpected(res)) state.unexpectedErrors += 1;
+                        const owned = state.owners.findIndex(o => o.client === actor.index);
+                        if (owned >= 0) state.owners.splice(owned, 1);
+                        if (res.success) {
+                            state.observedCurrent = committedSession(
+                                res.payload.descriptors,
+                                state.currentPublicPath,
+                            );
+                        } else if (res.error.code === DEVICE_NOT_FOUND) {
+                            // THE path this PR fixes: descriptor vanished between
+                            // releaseIntent and releaseDone; must error (not
+                            // crash) and must have freed the releaseIntent lock
+                            sentinels.releaseDoneAfterDisconnect += 1;
+                        }
+                        actor.phase = 'done';
+                    },
+                    () => {
+                        state.unexpectedErrors += 1;
+                        actor.busy = false;
+                        actor.phase = 'done';
+                    },
+                );
+            }
+        };
+
+        // Phase 1: fuzzed arrival order of client messages and plug/unplug events.
+        // Slot clientCount = disconnect, slot clientCount+1 = reconnect.
+        for (const pick of script) {
+            const slot = pick % (clientCount + 2);
+            if (slot === clientCount) {
+                fireDisconnect();
+            } else if (slot === clientCount + 1) {
+                fireReconnect();
+            } else {
+                const actor = actors[slot];
+                if (actor) advance(actor);
+            }
+
+            await flushMicrotasks();
+        }
+
+        // Phase 2 (liveness): fairly drive every client to a terminal state.
+        // No admin events here - actors either finish their protocol against the
+        // final device state or fail fast against a missing device. A round with
+        // no phase change means someone is wedged behind a leaked lock.
+        for (let round = 0; round < clientCount * 20; round += 1) {
+            if (actors.every(a => a.phase === 'done')) break;
+            const before = actors.map(a => a.phase).join('|');
+            actors.forEach(a => advance(a));
+
+            await flushMicrotasks();
+            if (actors.map(a => a.phase).join('|') === before) break;
+        }
+
+        // Wedge probe: after the churn the device (reconnected if needed) must
+        // be acquirable with microtasks only - i.e. without sitting out the 4s
+        // safety-net timer of a leaked lock.
+        if (!state.connected) {
+            fireReconnect();
+            await flushMicrotasks();
+        }
+        let probeSettled = false;
+        let probeSuccess = false;
+        const probePath = state.currentPublicPath;
+        if (probePath) {
+            const sessionsRes = await admin.getSessions();
+            const current = sessionsRes.success
+                ? committedSession(sessionsRes.payload.descriptors, probePath)
+                : null;
+            admin.acquireIntent({ path: probePath, previous: current }).then(
+                res => {
+                    probeSettled = true;
+                    probeSuccess = res.success;
+                },
+                () => {
+                    state.unexpectedErrors += 1;
+                    probeSettled = true;
+                },
+            );
+            await flushMicrotasks();
+            if (probeSuccess) {
+                // free the lock the probe's own acquireIntent took
+                await admin.acquireDone({ path: probePath, abort: true });
+                await flushMicrotasks();
+            }
+        }
+
+        return {
+            maxOwners: state.maxOwners,
+            allReachedDone: actors.every(a => a.phase === 'done'),
+            // INV-B: every waitInQueue must have been paired with a clearLock;
+            // with the 4s timers never firing, a leak is a non-empty queue
+            locksQueueLength: (background as unknown as { locksQueue: unknown[] }).locksQueue
+                .length,
+            unexpectedErrors: state.unexpectedErrors,
+            registrationFailures: state.registrationFailures,
+            probeSettled,
+        };
+    } finally {
+        background.dispose();
+    }
+};
+
+const churn = (maxClients: number) =>
+    fc.integer({ min: 2, max: maxClients }).chain(clientCount =>
+        fc.record({
+            clientCount: fc.constant(clientCount),
+            steals: fc.array(fc.boolean(), { minLength: clientCount, maxLength: clientCount }),
+            // internal serial per device generation; reconnects cycle through the
+            // pool, so a 1-element pool re-mints the SAME serial (new public path)
+            pathPool: fc.array(fc.constantFrom(...INTERNAL_PATHS), {
+                minLength: 1,
+                maxLength: 3,
+            }),
+            script: fc.array(fc.integer({ min: 0, max: clientCount + 1 }), {
+                minLength: 2,
+                maxLength: 25,
+            }),
+        }),
+    );
+
+describe('sessions fuzz (disconnect/reconnect churn)', () => {
+    it('INV A-D: safety, no leaked lock, no crash, no pollution under unplug churn', async () => {
+        const sentinels: Sentinels = {
+            reconnects: 0,
+            acquireIntentOnMissingDevice: 0,
+            acquireDoneAfterDisconnect: 0,
+            releaseDoneAfterDisconnect: 0,
+        };
+
+        await fc.assert(
+            fc.asyncProperty(churn(4), async ({ clientCount, steals, pathPool, script }) => {
+                const result = await runDisconnectChurn(
+                    script,
+                    clientCount,
+                    steals,
+                    pathPool,
+                    sentinels,
+                );
+
+                // INV-C: an UNEXPECTED_ERROR response is an unhandled throw
+                // inside the background (pre-fix releaseDone crashed here)
+                expect(result.unexpectedErrors).toBe(0);
+                // INV-D: hostile serials must register like any other path
+                expect(result.registrationFailures).toBe(0);
+                // INV-A: never two simultaneously committed owners
+                expect(result.maxOwners).toBeLessThanOrEqual(1);
+                // INV-B: nobody wedged, queue fully drained, device operable
+                expect(result.allReachedDone).toBe(true);
+                expect(result.probeSettled).toBe(true);
+                expect(result.locksQueueLength).toBe(0);
+
+                // INV-D: Object.prototype stays unpolluted after hostile paths
+                const probe: Record<string, unknown> = {};
+                expect(probe.session).toBeUndefined();
+                expect(probe.sessionOwner).toBeUndefined();
+                expect(probe['dev-1']).toBeUndefined();
+                expect(Object.keys(Object.prototype)).toHaveLength(0);
+            }),
+            { numRuns: 5000 },
+        );
+
+        // Prove the fuzzer reached the disconnect windows this PR changed - a
+        // green run that never hit them would be vacuous. Hit rates are far
+        // above per-mille, so over thousands of runs these cannot flake.
+        expect(sentinels.reconnects).toBeGreaterThan(0);
+        expect(sentinels.acquireIntentOnMissingDevice).toBeGreaterThan(0);
+        expect(sentinels.acquireDoneAfterDisconnect).toBeGreaterThan(0);
+        expect(sentinels.releaseDoneAfterDisconnect).toBeGreaterThan(0);
+    }, 240000);
+});

--- a/packages/transport-common/src/sessions/background.test.ts
+++ b/packages/transport-common/src/sessions/background.test.ts
@@ -199,6 +199,51 @@ describe('sessions', () => {
         });
     });
 
+    test('releaseDone with disconnected device errors but releases the lock', async () => {
+        const client1 = new SessionsClient(background);
+        await client1.handshake();
+        await client1.enumerateDone({
+            descriptors: [{ path: PathInternal('1'), type: 1, apiType: 'usb' }],
+        });
+
+        const acquireIntent = await client1.acquireIntent({
+            path: PathPublic('1'),
+            previous: null,
+        });
+        expect(acquireIntent).toMatchObject({ success: true });
+        await client1.acquireDone({ path: PathPublic('1') });
+
+        const releaseIntent = await client1.releaseIntent({ session: Session('1') });
+        expect(releaseIntent).toMatchObject({ success: true, payload: { path: '1' } });
+
+        // device disconnects while the caller is closing it
+        await client1.enumerateDone({ descriptors: [] });
+
+        const releaseDone = await client1.releaseDone({ path: PathInternal('1') });
+        expect(releaseDone).toMatchObject({
+            success: false,
+            error: { code: 'device not found' },
+        });
+
+        // the lock taken by releaseIntent was freed: a fresh acquire of the
+        // reconnected device must resolve immediately, not by waiting out the
+        // 4s safety-net timer of a leaked lock (hence the race; the sentinel
+        // must stay well below lockDuration in background.ts)
+        await client1.enumerateDone({
+            descriptors: [{ path: PathInternal('1'), type: 1, apiType: 'usb' }],
+        });
+        const acquireAgain = await Promise.race([
+            client1.acquireIntent({ path: PathPublic('2'), previous: null }),
+            new Promise(resolve =>
+                setTimeout(() => resolve('stuck behind the safety-net timer'), 1000),
+            ),
+        ]);
+        expect(acquireAgain).toMatchObject({ success: true });
+
+        // cleanup: release the lock acquireAgain just took
+        await client1.acquireDone({ path: PathPublic('2'), abort: true });
+    });
+
     test('acquireDone with abort releases the lock without committing a session', async () => {
         const client1 = new SessionsClient(background);
         await client1.handshake();

--- a/packages/transport-common/src/sessions/background.test.ts
+++ b/packages/transport-common/src/sessions/background.test.ts
@@ -244,6 +244,42 @@ describe('sessions', () => {
         await client1.acquireDone({ path: PathPublic('2'), abort: true });
     });
 
+    // paths are raw USB serial numbers, so a (hostile or broken) device can
+    // present a serial colliding with an Object.prototype member; such a device
+    // must still register and go through the acquire/release lifecycle
+    test('descriptor paths colliding with Object.prototype keys', async () => {
+        const client1 = new SessionsClient(background);
+        await client1.handshake();
+
+        await client1.enumerateDone({
+            descriptors: [
+                { path: PathInternal('toString'), type: 1, apiType: 'usb' },
+                { path: PathInternal('__proto__'), type: 1, apiType: 'usb' },
+            ],
+        });
+
+        const sessions = await client1.getSessions();
+        expect(sessions).toMatchObject({
+            success: true,
+            payload: { descriptors: [{ path: '1' }, { path: '2' }] },
+        });
+
+        const acquireIntent = await client1.acquireIntent({
+            path: PathPublic('1'),
+            previous: null,
+        });
+        expect(acquireIntent).toMatchObject({ success: true, payload: { path: 'toString' } });
+        await client1.acquireDone({ path: PathPublic('1') });
+
+        const releaseIntent = await client1.releaseIntent({ session: Session('1') });
+        expect(releaseIntent).toMatchObject({ success: true, payload: { path: 'toString' } });
+        const releaseDone = await client1.releaseDone({ path: PathInternal('toString') });
+        expect(releaseDone).toMatchObject({ success: true });
+
+        // and nothing leaked into the global prototype
+        expect((Object.prototype as any).session).toBeUndefined();
+    });
+
     test('acquireDone with abort releases the lock without committing a session', async () => {
         const client1 = new SessionsClient(background);
         await client1.handshake();

--- a/packages/transport-common/src/sessions/background.ts
+++ b/packages/transport-common/src/sessions/background.ts
@@ -252,13 +252,20 @@ export class SessionsBackground
     }
 
     private releaseDone(payload: ReleaseDoneRequest) {
-        const { descriptors } = this;
-        // @ts-expect-error: indexing with noUncheckedIndexedAccess
-        const descriptor: Descriptor = descriptors[payload.path];
+        // release the lock first (mirroring acquireDone): it was taken by
+        // releaseIntent and must be freed even when the device is already gone,
+        // otherwise the queue head gets permanently stuck
+        this.clearLock();
+
+        const descriptor = this.descriptors[payload.path];
+
+        // device disconnected between releaseIntent and releaseDone
+        if (!descriptor) {
+            return error({ code: ERRORS.DEVICE_NOT_FOUND });
+        }
+
         descriptor.session = null;
         descriptor.sessionOwner = undefined;
-
-        this.clearLock();
 
         return Promise.resolve(success({ descriptors: Object.values(this.descriptors) }));
     }

--- a/packages/transport-common/src/sessions/background.ts
+++ b/packages/transport-common/src/sessions/background.ts
@@ -47,8 +47,10 @@ export class SessionsBackground
     /**
      * Dictionary where key is path and value is Descriptor
      */
-    private descriptors: DescriptorsDict = {};
-    private pathInternalPathPublicMap: Record<PathInternal, PathPublic> = {};
+    // null prototype: paths are raw USB serial numbers, so inherited keys
+    // ('toString', '__proto__', ...) must not read as existing entries
+    private descriptors: DescriptorsDict = Object.create(null);
+    private pathInternalPathPublicMap: Record<PathInternal, PathPublic> = Object.create(null);
 
     // if lock is set, somebody is doing something with device. we have to wait
     private locksQueue: { id: TimerId; dfd: Deferred<void> }[] = [];
@@ -337,7 +339,7 @@ export class SessionsBackground
     dispose() {
         this.locksQueue.forEach(lock => clearTimeout(lock.id));
         this.locksTimeoutQueue.forEach(timeout => clearTimeout(timeout));
-        this.descriptors = {};
+        this.descriptors = Object.create(null);
         this.lastSessionId = 0;
         this.removeAllListeners();
     }

--- a/packages/transport-common/src/sessions/types.ts
+++ b/packages/transport-common/src/sessions/types.ts
@@ -64,9 +64,10 @@ export interface ReleaseDoneRequest {
     path: PathInternal;
 }
 
-export type ReleaseDoneResponse = BackgroundResponse<{
-    descriptors: Descriptor[];
-}>;
+export type ReleaseDoneResponse = BackgroundResponseWithError<
+    { descriptors: Descriptor[] },
+    typeof ERRORS.DEVICE_NOT_FOUND
+>;
 
 export type GetSessionsRequest = Record<string, never>;
 export type GetSessionsResponse = BackgroundResponse<{

--- a/packages/transport-common/src/transports/abstractApi.test.ts
+++ b/packages/transport-common/src/transports/abstractApi.test.ts
@@ -333,6 +333,28 @@ describe('Usb', () => {
             });
         });
 
+        it('releaseSync completes the release (releaseDone is called)', async () => {
+            const { transport } = await initTest();
+            await transport.enumerate();
+            const acquireRes = await transport.acquire({
+                input: { path: PathPublic('1'), previous: null },
+            });
+            expect(acquireRes).toEqual({ success: true, payload: '1' });
+
+            transport.releaseSync(Session('1'));
+            // releaseSync is fire-and-forget; give its releaseIntent ->
+            // closeDevice -> releaseDone chain time to settle
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            // without releaseDone the session would stay committed, so this
+            // acquire would fail immediately with "wrong previous session" (and
+            // the lock taken by releaseIntent would leak until the 4s safety-net)
+            const reacquireRes = await transport.acquire({
+                input: { path: PathPublic('1'), previous: null },
+            });
+            expect(reacquireRes).toEqual({ success: true, payload: '2' });
+        });
+
         // CURRENTLY LEAKS — see PR #27978 for the fix.
         //
         // AbstractApiTransport.listen() registers three event handlers (one on the api emitter,

--- a/packages/transport-common/src/transports/abstractApi.ts
+++ b/packages/transport-common/src/transports/abstractApi.ts
@@ -212,9 +212,13 @@ export abstract class AbstractApiTransport extends AbstractTransport {
     }
 
     public releaseSync(session: Session) {
-        // Obviously not sync as was advertised. Also looks a bit weird but should be the same as before.
-        this.sessionsClient.releaseIntent({ session }).then(res => {
-            if (res.success) this.api.closeDevice(res.payload.path, { channel: 'read' });
+        // fire-and-forget variant of release(); releaseDone must still run,
+        // otherwise the lock taken by releaseIntent is never freed
+        this.sessionsClient.releaseIntent({ session }).then(async res => {
+            if (res.success) {
+                await this.api.closeDevice(res.payload.path, { channel: 'read' });
+                await this.sessionsClient.releaseDone({ path: res.payload.path });
+            }
         });
     }
 

--- a/packages/transport-common/src/transports/bridge.ts
+++ b/packages/transport-common/src/transports/bridge.ts
@@ -397,7 +397,13 @@ export class BridgeTransport extends AbstractTransport {
     private async post(
         endpoint: '/release',
         options: IncompleteRequestOptions,
-    ): AsyncResultWithTypedError<undefined, BridgeCommonErrors | typeof ERRORS.SESSION_NOT_FOUND>;
+    ): AsyncResultWithTypedError<
+        undefined,
+        | BridgeCommonErrors
+        | typeof ERRORS.SESSION_NOT_FOUND
+        | typeof ERRORS.DEVICE_NOT_FOUND
+        | typeof ERRORS.DEVICE_DISCONNECTED_DURING_ACTION
+    >;
     private async post(
         endpoint: '/abort',
         options: IncompleteRequestOptions,
@@ -458,6 +464,8 @@ export class BridgeTransport extends AbstractTransport {
                 case '/release':
                     return this.unknownError(response.error.code, [
                         ERRORS.SESSION_NOT_FOUND,
+                        // device disconnected between releaseIntent and releaseDone
+                        ERRORS.DEVICE_NOT_FOUND,
                         ERRORS.DEVICE_DISCONNECTED_DURING_ACTION,
                     ]);
                 default:

--- a/packages/utils/src/getMutex.test.ts
+++ b/packages/utils/src/getMutex.test.ts
@@ -166,4 +166,18 @@ describe('getMutex', () => {
             }),
         ]);
     });
+
+    // lockIds come from the outside world (e.g. transport uses USB serial numbers),
+    // so keys inherited from Object.prototype must behave like any other key and
+    // not read as an always-pending lock
+    it('inherited object keys as lockId', async () => {
+        for (const lockId of ['toString', 'constructor', '__proto__']) {
+            const unlock = await lock(lockId);
+            unlock();
+
+            // and the lock is reusable after unlock
+            const unlockAgain = await lock(lockId);
+            unlockAgain();
+        }
+    });
 });

--- a/packages/utils/src/getMutex.ts
+++ b/packages/utils/src/getMutex.ts
@@ -21,7 +21,9 @@
  */
 export const getMutex = () => {
     const DEFAULT_ID = Symbol();
-    const locks: Record<PropertyKey, Promise<void>> = {};
+    // null prototype so that inherited keys ('toString', '__proto__', ...) used as
+    // lockId don't read as an always-pending lock and hang the caller forever
+    const locks: Record<PropertyKey, Promise<void>> = Object.create(null);
 
     return async (lockId: PropertyKey = DEFAULT_ID) => {
         while (locks[lockId]) {


### PR DESCRIPTION
## Description

Consolidates the still-relevant material from three stale transport PRs — #25243, #25305, #26578 — on top of current develop. Most of what those PRs addressed has since landed through other commits (c5758252a1, ae85d1891a, 4bbefa1072, 8cd10ce3c1 and the sessions fuzz suite), so the source PRs are being closed and only the surviving pieces are re-derived here on the post-split `transport-common` layout, one commit per problem:

- **[`sessions/background.ts`](https://github.com/trezor/trezor-suite/blob/5ce452807d9701cc9076115a617375ed6b9831b7/packages/transport-common/src/sessions/background.ts#L256-L274): `releaseDone` no longer crashes on a missing descriptor.** When the device disconnected between `releaseIntent` and `releaseDone`, the unconditional descriptor dereference threw, `clearLock` was skipped and the lock queue head stayed occupied forever — every later acquire/release first waited out its 4s safety-net timer. The lock is now released first (mirroring `acquireDone`) and a structured `DEVICE_NOT_FOUND` error is returned instead of the `UNEXPECTED_ERROR` catch-all; the bridge HTTP `/release` handler and the `BridgeTransport` client both propagate the new code.
- **[`transports/abstractApi.ts`](https://github.com/trezor/trezor-suite/blob/5ce452807d9701cc9076115a617375ed6b9831b7/packages/transport-common/src/transports/abstractApi.ts#L214-L224): `releaseSync` finishes the release with `releaseDone`.** It ran `releaseIntent` + `closeDevice` but never `releaseDone`, so the lock taken by `releaseIntent` leaked permanently and the session was never cleared. `Device.disconnect()` uses `releaseSync`, and on the `TRANSPORT.STOPPED` path the descriptor still exists, so the leak hit a sessions background that keeps running for other clients.
- **[`api/abstract.ts`](https://github.com/trezor/trezor-suite/blob/5ce452807d9701cc9076115a617375ed6b9831b7/packages/transport-common/src/api/abstract.ts#L196-L199): `runInIsolation` synchronizes per path.** The single global mutex meant a long call on one device (e.g. signing waiting for on-device confirmation) blocked every call/receive on all other devices connected to the same node-bridge/local transport. trezord-go served devices independently; operations now serialize only per device.
- **[`getMutex.ts`](https://github.com/trezor/trezor-suite/blob/5ce452807d9701cc9076115a617375ed6b9831b7/packages/utils/src/getMutex.ts#L22-L26): lock ids colliding with `Object.prototype` members no longer hang the mutex.** Hardening required by the per-path change (found in review): the lock table was a plain object, so a `lockId` such as `toString` — and the transport lock id is the raw USB serial number — read the inherited value as an always-pending lock and the acquire loop starved the event loop forever.
- **[`sessions/background.ts`](https://github.com/trezor/trezor-suite/blob/5ce452807d9701cc9076115a617375ed6b9831b7/packages/transport-common/src/sessions/background.ts#L47-L55): session dictionaries are prototype-free too.** Same problem class caught by a follow-up review pass: a device with a serial like `toString` read as already registered and never showed up, and a `__proto__` serial mutated the dictionary prototype instead of storing a descriptor.
- **[`sessions/background.disconnect.fuzz.test.ts`](https://github.com/trezor/trezor-suite/blob/5ce452807d9701cc9076115a617375ed6b9831b7/packages/transport-common/src/sessions/background.disconnect.fuzz.test.ts): disconnect/reconnect fuzz harness.** The existing sessions fuzz suite deliberately never unplugs the device, so the windows this PR changes were only pinned by single deterministic examples. The new harness churns unplug/replug into the fuzzed message order (including hostile serials) and asserts safety, lock liveness without the 4s timers, no background crashes and no prototype pollution; coverage sentinels prove the disconnect windows are actually hit, and on the pre-fix background it shrinks to minimal counterexamples for both fixed bugs.
- **[`test-transport.yml`](https://github.com/trezor/trezor-suite/blob/5ce452807d9701cc9076115a617375ed6b9831b7/.github/workflows/test-transport.yml#L14-L23): transport e2e runs again on PRs touching the sessions/lock core.** The transport package split moved it into `packages/transport-common`, but the `pull_request` paths filter was never updated, so only the nightly cron would catch regressions there.

Each fix comes with a unit test that was verified red on the unfixed code, and each commit in the stack is independently green (verified per-commit). The branch is rebased on current develop (after the `BridgeTransport` move and the test co-location), so the client-side error mapping lives in `transport-common/src/transports/bridge.ts` and all touched tests sit at their co-located paths. Full analysis of what landed where and what was consciously *not* revived from the source PRs (token-based lock refactor, local call/receive guard, clearLock-on-abort) is summarized in the closing comments of the three PRs. A follow-up PR is planned for the `transport-web` browser sessions background (hanging `handleMessage` on a dead SharedWorker + error-response correlation bug), which needs test infra added to that package first.

## Notes for QA

Blast radius is the transport session/lock lifecycle in `@trezor/transport-common`, used by both the bundled node-bridge and the local webusb/nodeusb transports. Worth covering: standard acquire/release flows, unplugging the device while an operation is in flight (especially during release), reloading/closing Suite while a device is connected, and — for the per-path change — two devices connected at once, one busy with signing while the other is used. The `getMutex`, session-dictionary, fuzz-harness and CI workflow changes need no dedicated QA.

## Related Issue

Supersedes #25243, #25305, #26578.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/consolidate-outdated-prs/web/](https://dev.suite.sldev.cz/suite-web/mroz22/consolidate-outdated-prs/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/consolidate-outdated-prs&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/consolidate-outdated-prs&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T13:50:49.505Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T13:51:32.298Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->




