### PR TITLE
perf(suite): replace styled TypeScript plugin with Stylelint

### DIFF
--- a/IDE.md
+++ b/IDE.md
@@ -2,7 +2,8 @@
 
 ## Visual Studio Code
 
-Copy the code below to `.vscode/settings.json`
+Install the [Stylelint extension](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint),
+then copy the code below to `.vscode/settings.json`.
 
 ```JSON
 {
@@ -10,6 +11,7 @@ Copy the code below to `.vscode/settings.json`
         "source.fixAll.eslint": true
     },
     "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "stylelint.validate": ["css", "postcss", "typescript", "typescriptreact"],
     "typescript.reportStyleChecksAsWarnings": false,
     "cSpell.words": ["blockbook", "bootloader", "cardano", "webworkers"],
     "editor.formatOnSave": true,
@@ -42,3 +44,28 @@ Copy the code below to `.vscode/settings.json`
     }
 }
 ```
+
+## Zed
+
+Install the [Stylelint extension](https://zed.dev/extensions?query=stylelint), then add this to
+your Zed settings:
+
+```JSON
+{
+    "lsp": {
+        "stylelint-lsp": {
+            "settings": {
+                "stylelint": {
+                    "packageManager": "yarn",
+                    "validate": ["css", "postcss", "typescript", "typescriptreact"]
+                }
+            }
+        }
+    }
+}
+```
+
+Stylelint uses the repository's `postcss-styled-syntax` configuration to validate CSS inside
+styled-components template literals. It runs in its own language server, so the diagnostics work
+with either the TypeScript language server or tsgo. It reports invalid CSS and provides code
+actions, but CSS completion remains editor-specific.

--- a/packages/components/.depcheckrc.json
+++ b/packages/components/.depcheckrc.json
@@ -4,7 +4,6 @@
         "stylelint-config-standard",
         "@babel/preset-react",
         "postcss-styled-syntax",
-        "typescript-styled-plugin",
         "@storybook/react-webpack5",
         "@storybook/addon-links",
         "@storybook/addon-docs",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -59,7 +59,6 @@
         "storybook": "^10.3.4",
         "stream-browserify": "^3.0.0",
         "stylelint": "^17.1.1",
-        "stylelint-config-standard": "^40.0.0",
-        "typescript-styled-plugin": "^0.18.3"
+        "stylelint-config-standard": "^40.0.0"
     }
 }

--- a/packages/components/src/config/colors.ts
+++ b/packages/components/src/config/colors.ts
@@ -6,9 +6,8 @@ import { type BoxShadows, type Colors, colorVariants, mapBoxShadowsToCSS } from 
 /**
  * IMPORTANT:
  *
- * You have to do this in the every package where you are accessing these theme props
- *    1) create `styled.d.ts` file in the root of the project with overwrite of DefaultTheme
- *    2) add `typescript-styled-plugin` into the packages devDependencies
+ * Create a `styled.d.ts` file that overrides `DefaultTheme` in every package that accesses
+ * these theme props.
  *
  *  See `suite` package for reference.
  */

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -6,9 +6,6 @@
                 "./packages/theme/src/*"
             ]
         },
-        "plugins": [
-            { "name": "typescript-styled-plugin" }
-        ],
         "outDir": "./libDev"
     },
     "include": [".", "**/*.json"],

--- a/packages/connect-explorer/.depcheckrc.json
+++ b/packages/connect-explorer/.depcheckrc.json
@@ -5,7 +5,6 @@
         "rimraf",
         "webpack-cli",
         "babel-plugin-styled-components",
-        "typescript-styled-plugin",
         "nextra-theme-docs",
         "// yarn depcheck does not support *.mdx files by default. It may solvable by custom-parser. But it is probably not worth the hassle",
         "remark-gfm",

--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -62,7 +62,6 @@
         "eslint-plugin-mdx": "^3.8.1",
         "html-webpack-plugin": "5.6.7",
         "rimraf": "^6.1.2",
-        "typescript-styled-plugin": "^0.18.3",
         "webpack": "5.108.1",
         "webpack-cli": "^7.0.3"
     }

--- a/packages/connect-explorer/tsconfig.json
+++ b/packages/connect-explorer/tsconfig.json
@@ -9,10 +9,7 @@
             "@suite-common/icons/src/icons": [
                 "./src/icons/minimalIcons.ts"
             ]
-        },
-        "plugins": [
-            { "name": "typescript-styled-plugin" }
-        ]
+        }
     },
     "include": [
         "next-env.d.ts",

--- a/packages/product-components/.depcheckrc.json
+++ b/packages/product-components/.depcheckrc.json
@@ -4,7 +4,6 @@
         "stylelint-config-standard",
         "@babel/preset-react",
         "postcss-styled-syntax",
-        "typescript-styled-plugin",
         "@storybook/react-webpack5",
         "@storybook/addon-links",
         "@storybook/addon-docs"

--- a/packages/product-components/package.json
+++ b/packages/product-components/package.json
@@ -60,7 +60,6 @@
         "storybook": "^10.3.4",
         "stylelint": "^17.1.1",
         "stylelint-config-standard": "^40.0.0",
-        "svgo": "^4.0.1",
-        "typescript-styled-plugin": "^0.18.3"
+        "svgo": "^4.0.1"
     }
 }

--- a/packages/product-components/tsconfig.json
+++ b/packages/product-components/tsconfig.json
@@ -6,9 +6,6 @@
                 "./packages/theme/src/*"
             ]
         },
-        "plugins": [
-            { "name": "typescript-styled-plugin" }
-        ],
         "outDir": "./libDev"
     },
     "include": [".", "**/*.json"],

--- a/packages/suite/.depcheckrc.json
+++ b/packages/suite/.depcheckrc.json
@@ -1,10 +1,4 @@
 {
     "ignore-patterns": ["libDev", "lib"],
-    "ignores": [
-        "invity-api",
-        "src",
-        "stylelint-config-standard",
-        "postcss-styled-syntax",
-        "typescript-styled-plugin"
-    ]
+    "ignores": ["invity-api", "src", "stylelint-config-standard", "postcss-styled-syntax"]
 }

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -1,12 +1,6 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "plugins": [
-            {
-                "name": "typescript-styled-plugin",
-                "tags": ["styled", "css", "sty"]
-            }
-        ],
         "outDir": "./libDev",
         "paths": { "src/*": ["./src/*"] }
     },

--- a/scripts/list-outdated-dependencies/trade-dependencies.txt
+++ b/scripts/list-outdated-dependencies/trade-dependencies.txt
@@ -70,7 +70,6 @@ tslib
 tsx
 type-fest
 typescript
-typescript-styled-plugin
 ua-parser-js
 @react-native/jest-preset
 @svgr/cli

--- a/suite/trading/tsconfig.json
+++ b/suite/trading/tsconfig.json
@@ -1,10 +1,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "libDev",
-        "plugins": [
-            { "name": "typescript-styled-plugin" }
-        ]
+        "outDir": "libDev"
     },
     "include": ["src/**/*", "styled.d.ts"],
     "references": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2559,31 +2559,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emmetio/abbreviation@npm:^2.2.3":
-  version: 2.2.3
-  resolution: "@emmetio/abbreviation@npm:2.2.3"
-  dependencies:
-    "@emmetio/scanner": "npm:^1.0.0"
-  checksum: 10/2e159ced15adf30a77ef88809537a6d5c46388ce34f4fe260c9a46a7fac0e1222ed5ee60e9f79a34442a0ea8a050ef26ca5d98ca6d6af191f8d34df8ea49d32a
-  languageName: node
-  linkType: hard
-
-"@emmetio/css-abbreviation@npm:^2.1.4":
-  version: 2.1.4
-  resolution: "@emmetio/css-abbreviation@npm:2.1.4"
-  dependencies:
-    "@emmetio/scanner": "npm:^1.0.0"
-  checksum: 10/3b286d00692fa2046be61ace72094fd00cfe5a60a02bc903290d5b3194ed2fa402b7af49eb6fdeb38d0562c4bad3493437bb1b7a4966bf71346c17b455426da6
-  languageName: node
-  linkType: hard
-
-"@emmetio/scanner@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@emmetio/scanner@npm:1.0.0"
-  checksum: 10/bd23e141e1d1b9e1837630437542e1725bf42cd514aa1e37c284b7e95e1bf3fc39a6235d9888d30f6e16f7c8bc9bea63121273641ab76ca8aff680191e99e5cb
-  languageName: node
-  linkType: hard
-
 "@emnapi/core@npm:1.4.5":
   version: 1.4.5
   resolution: "@emnapi/core@npm:1.4.5"
@@ -16106,7 +16081,6 @@ __metadata:
     styled-components: "npm:^6.3.9"
     stylelint: "npm:^17.1.1"
     stylelint-config-standard: "npm:^40.0.0"
-    typescript-styled-plugin: "npm:^0.18.3"
   languageName: unknown
   linkType: soft
 
@@ -16263,7 +16237,6 @@ __metadata:
     stylelint: "npm:^17.1.1"
     stylelint-config-standard: "npm:^40.0.0"
     swr: "npm:^2.4.1"
-    typescript-styled-plugin: "npm:^0.18.3"
     webpack: "npm:5.108.1"
     webpack-cli: "npm:^7.0.3"
   languageName: unknown
@@ -16596,7 +16569,6 @@ __metadata:
     stylelint: "npm:^17.1.1"
     stylelint-config-standard: "npm:^40.0.0"
     svgo: "npm:^4.0.1"
-    typescript-styled-plugin: "npm:^0.18.3"
     yup: "npm:1.7.1"
     zxcvbn: "npm:^4.4.2"
   languageName: unknown
@@ -25182,16 +25154,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"emmet@npm:^2.3.0":
-  version: 2.3.6
-  resolution: "emmet@npm:2.3.6"
-  dependencies:
-    "@emmetio/abbreviation": "npm:^2.2.3"
-    "@emmetio/css-abbreviation": "npm:^2.1.4"
-  checksum: 10/9c6ae669036bf8531607c192f17a8eb164093a5e87f0ed82a7d3c023b081a95142d9d3cee9c2c0f7596f322b8208d39ec7b60a7bf87df733c793eb3d200b5c84
-  languageName: node
-  linkType: hard
-
 "emoji-regex-xs@npm:^1.0.0":
   version: 1.0.0
   resolution: "emoji-regex-xs@npm:1.0.0"
@@ -32928,13 +32890,6 @@ __metadata:
   version: 3.3.1
   resolution: "jsonc-parser@npm:3.3.1"
   checksum: 10/9b0dc391f20b47378f843ef1e877e73ec652a5bdc3c5fa1f36af0f119a55091d147a86c1ee86a232296f55c929bba174538c2bf0312610e0817a22de131cc3f4
-  languageName: node
-  linkType: hard
-
-"jsonc-parser@npm:^2.3.0":
-  version: 2.3.1
-  resolution: "jsonc-parser@npm:2.3.1"
-  checksum: 10/a152a04049571e66cc065f0f5d5206f27242852b3e54d0d11a1303bb607cfdb144dce406bab215257b0c879fe1678e4f7f0eb9f21d813c149bfdaa84631f9feb
   languageName: node
   linkType: hard
 
@@ -45139,26 +45094,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-styled-plugin@npm:^0.18.3":
-  version: 0.18.3
-  resolution: "typescript-styled-plugin@npm:0.18.3"
-  dependencies:
-    typescript-template-language-service-decorator: "npm:^2.3.2"
-    vscode-css-languageservice: "npm:^5.1.4"
-    vscode-emmet-helper: "npm:^2.6.4"
-    vscode-languageserver-textdocument: "npm:^1.0.1"
-    vscode-languageserver-types: "npm:^3.16.0"
-  checksum: 10/77a728d83b3baf140cdb0224c3a1bba92202fb1359c1dbbb144119283cc7958b7c1c4f19e434ab4069904b7f454257a54cb1608bb16f739178bb9ec448440ce7
-  languageName: node
-  linkType: hard
-
-"typescript-template-language-service-decorator@npm:^2.3.2":
-  version: 2.3.2
-  resolution: "typescript-template-language-service-decorator@npm:2.3.2"
-  checksum: 10/372dccc55ec1d4e99fed09813d038a6830216b1f82d8f58ac39edbcbb39ccab177e95960457c14b314dcf1a353de613471b5aba32c2504c68367f7729c13206b
-  languageName: node
-  linkType: hard
-
 "typescript@npm:6.0.3":
   version: 6.0.3
   resolution: "typescript@npm:6.0.3"
@@ -46559,53 +46494,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vscode-css-languageservice@npm:^5.1.4":
-  version: 5.4.2
-  resolution: "vscode-css-languageservice@npm:5.4.2"
-  dependencies:
-    vscode-languageserver-textdocument: "npm:^1.0.4"
-    vscode-languageserver-types: "npm:^3.16.0"
-    vscode-nls: "npm:^5.0.0"
-    vscode-uri: "npm:^3.0.3"
-  checksum: 10/6039d90ffad4c6891404f2e1e56046f4fa251f95d3e73aa1fab48d65edee822af35e73ea63c49e4b9b5b4f472dea0007d760744a7a07b91a10c788867a1319c4
-  languageName: node
-  linkType: hard
-
-"vscode-emmet-helper@npm:^2.6.4":
-  version: 2.6.4
-  resolution: "vscode-emmet-helper@npm:2.6.4"
-  dependencies:
-    emmet: "npm:^2.3.0"
-    jsonc-parser: "npm:^2.3.0"
-    vscode-languageserver-textdocument: "npm:^1.0.1"
-    vscode-languageserver-types: "npm:^3.15.1"
-    vscode-nls: "npm:^5.0.0"
-    vscode-uri: "npm:^2.1.2"
-  checksum: 10/153344f2c20bd07bb14196d94bd69fea024af6d7a4b3c6cb6abeb9acf6eac825c20bce2062e6ab9d8a0d06f5c50243d4c11bce49522153f70b53668dfbb5b1eb
-  languageName: node
-  linkType: hard
-
-"vscode-languageserver-textdocument@npm:^1.0.1, vscode-languageserver-textdocument@npm:^1.0.4":
-  version: 1.0.7
-  resolution: "vscode-languageserver-textdocument@npm:1.0.7"
-  checksum: 10/dfc3a59c533ba0abbb0380d37b4c9c198b58c929e52882ccf559cd4698f06e79eeb8187b2542566e58a045b6b5a728ef056565d3192117cb27337bd853edea31
-  languageName: node
-  linkType: hard
-
-"vscode-languageserver-types@npm:^3.15.1, vscode-languageserver-types@npm:^3.16.0":
-  version: 3.17.2
-  resolution: "vscode-languageserver-types@npm:3.17.2"
-  checksum: 10/117964de44586292b39209c067f057b440c82d2dc278114f9da2d851ccb4f4a70fa7b7af6cf10c3041e63cb927f326e5b08d04fb0bdcf9c15075df1563322a7a
-  languageName: node
-  linkType: hard
-
-"vscode-nls@npm:^5.0.0":
-  version: 5.2.0
-  resolution: "vscode-nls@npm:5.2.0"
-  checksum: 10/7dd0d07e5f1fd7a7d1b35eabea20322e2efef4e93cebe6de45ee015ea0152ec1c354fd763d3987aed1db261f466ff31631d6acd679ac67af608fb49b9868e1ab
-  languageName: node
-  linkType: hard
-
 "vscode-oniguruma@npm:^1.7.0":
   version: 1.7.0
   resolution: "vscode-oniguruma@npm:1.7.0"
@@ -46617,20 +46505,6 @@ __metadata:
   version: 8.0.0
   resolution: "vscode-textmate@npm:8.0.0"
   checksum: 10/9fa7d66d6042cb090d116c2d8820d34c8870cfcbaed6e404da89f66b899970ed0ac47b59a2e30fc40a25af5414822bb3ea27974f714e9b91910d69c894be95f7
-  languageName: node
-  linkType: hard
-
-"vscode-uri@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "vscode-uri@npm:2.1.2"
-  checksum: 10/9384da42075dafc97f09194119c2f84f9e7838badccc768721aba31d43f96e597744129b717a9fd46162ca7102d6b9a658d4b873b019ead91814ee5cb798b433
-  languageName: node
-  linkType: hard
-
-"vscode-uri@npm:^3.0.3":
-  version: 3.0.6
-  resolution: "vscode-uri@npm:3.0.6"
-  checksum: 10/26ff3b179471378db71893f438bdddc1b751f7fcb75aae573fb94eda3daaaeca7a337443385a2ef922322feb541d0a7323dfe6d24898d6a7773cd3ff51a2d231
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This is the tsgo-compatible alternative to #30019. The legacy JavaScript tsserver plugin was configured in five TypeScript projects even though tsgo cannot load it, while classic tsserver pays its project-wide editor cost. This removes the plugin and its private dependency tree, and preserves invalid CSS property/value diagnostics through the existing Stylelint 17 and postcss-styled-syntax setup. The IDE guide enables the independent Stylelint language server for TypeScript and TSX in Zed and VS Code; unlike #30019, this option intentionally leaves CSS completion to the editor.

- TypeScript projects with plugin: **5 → 0**
- Non-lockfile plugin references: **14 → 0**
- Plugin-specific lock entries: **14 → 0**
- Lockfile: **126 lines removed**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set is almost entirely composed of build/config metadata (tsconfig.json, package.json, .depcheckrc.json) across several packages, which typically affect only build tooling, dependency resolution, or type-checking rather than runtime behavior — these have no direct E2E test coverage and are unlikely to cause functional regressions. The one substantive source change is packages/components/src/config/colors.ts, a shared color/theme definitions file used transitively by nearly all 131 mapped E2E tests; per the broad-utility heuristic, only tests with explicit color/theme assertions (settings/general and settings/autodetect) are flagged, at low priority, since a colors.ts change could subtly break theme rendering without breaking component logic broadly. Given the low functional risk, a lightweight smoke/build validation plus these two targeted theme tests should be sufficient; full E2E suite execution is not warranted for this diff.

<details><summary><b>Changed files (13)</b></summary>

- `packages/components/.depcheckrc.json`
- `packages/components/package.json`
- `packages/components/src/config/colors.ts`
- `packages/components/tsconfig.json`
- `packages/connect-explorer/.depcheckrc.json`
- `packages/connect-explorer/package.json`
- `packages/connect-explorer/tsconfig.json`
- `packages/product-components/.depcheckrc.json`
- `packages/product-components/package.json`
- `packages/product-components/tsconfig.json`
- `packages/suite/.depcheckrc.json`
- `packages/suite/tsconfig.json`
- `suite/trading/tsconfig.json`

</details>

**Recommended tests (2)**

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — This test explicitly verifies theme switching (light/dark) and color-dependent UI state, which is the one behavior directly tied to changes in packages/components/src/config/colors.ts. Most other config/tsconfig/package.json changes are build tooling only, so this is a targeted check on visual/theme color correctness.
- `suite/e2e/tests/settings/autodetect.test.ts` — This test asserts specific CSS color values (standard.contentPrimary, dark.surfaceFillPage) for light/dark themes, directly exercising the color definitions module that was changed, making it a concrete regression check for colors.ts.

</details>

⚠️ **Changes with no test coverage (12)**
- `packages/components/.depcheckrc.json`
- `packages/components/package.json`
- `packages/components/tsconfig.json`
- `packages/connect-explorer/.depcheckrc.json`
- `packages/connect-explorer/package.json`
- `packages/connect-explorer/tsconfig.json`
- `packages/product-components/.depcheckrc.json`
- `packages/product-components/package.json`
- `packages/product-components/tsconfig.json`
- `packages/suite/.depcheckrc.json`
- `packages/suite/tsconfig.json`
- `suite/trading/tsconfig.json`

_Updated: 2026-07-18T21:02:50.079Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/perf/remove-styled-typescript-plugin/web/](https://dev.suite.sldev.cz/suite-web/perf/remove-styled-typescript-plugin/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=perf/remove-styled-typescript-plugin&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=perf/remove-styled-typescript-plugin&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-18T21:06:15.922Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-18T21:06:13.163Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->