### PR TITLE
refactor(connect): declare callable API interfaces

### DIFF
--- a/packages/connect-common/src/factory.ts
+++ b/packages/connect-common/src/factory.ts
@@ -32,5 +32,7 @@ export const factoryPrivileged = <
         (core as any)[method] = (params: any) => core.call({ ...params, method });
     }
 
-    return core as ExtendedPrivilegedAPI<C>;
+    // The loop adds callable methods dynamically, which TypeScript cannot reflect in C.
+    // Cast through unknown to describe the core's post-augmentation runtime shape.
+    return core as unknown as ExtendedPrivilegedAPI<C>;
 };

--- a/packages/connect-common/src/types/api/account/index.ts
+++ b/packages/connect-common/src/types/api/account/index.ts
@@ -1,6 +1,3 @@
-import type { Static } from '@trezor/schema-utils';
-import { Type } from '@trezor/schema-utils';
-
 import type { discoverAccounts } from './discoverAccounts';
 import type { getAccountInfo } from './getAccountInfo';
 import type { getAddress } from './getAddress';
@@ -11,14 +8,13 @@ import type { verifyMessage } from './verifyMessage';
 import type { selectAccount } from '../selectAccount';
 
 // Generic account and address operations (multi-coin)
-export const TrezorConnectAccount = Type.Object({
-    getAddress: Type.Unsafe<typeof getAddress>(),
-    getPublicKey: Type.Unsafe<typeof getPublicKey>(),
-    getAccountInfo: Type.Unsafe<typeof getAccountInfo>(),
-    discoverAccounts: Type.Unsafe<typeof discoverAccounts>(),
-    selectAccount: Type.Unsafe<typeof selectAccount>(),
-    signMessage: Type.Unsafe<typeof signMessage>(),
-    verifyMessage: Type.Unsafe<typeof verifyMessage>(),
-    getCoinInfo: Type.Unsafe<typeof getCoinInfo>(),
-});
-export type TrezorConnectAccount = Static<typeof TrezorConnectAccount>;
+export interface TrezorConnectAccount {
+    getAddress: typeof getAddress;
+    getPublicKey: typeof getPublicKey;
+    getAccountInfo: typeof getAccountInfo;
+    discoverAccounts: typeof discoverAccounts;
+    selectAccount: typeof selectAccount;
+    signMessage: typeof signMessage;
+    verifyMessage: typeof verifyMessage;
+    getCoinInfo: typeof getCoinInfo;
+}

--- a/packages/connect-common/src/types/api/bitcoin/index.ts
+++ b/packages/connect-common/src/types/api/bitcoin/index.ts
@@ -1,16 +1,12 @@
-import type { Static } from '@trezor/schema-utils';
-import { Type } from '@trezor/schema-utils';
-
 import type { authorizeCoinjoin } from './authorizeCoinjoin';
 import type { cancelCoinjoinAuthorization } from './cancelCoinjoinAuthorization';
 import type { composeTransaction } from './composeTransaction';
 import type { signTransaction } from './signTransaction';
 
 // Bitcoin-specific operations
-export const TrezorConnectBitcoin = Type.Object({
-    signTransaction: Type.Unsafe<typeof signTransaction>(),
-    composeTransaction: Type.Unsafe<typeof composeTransaction>(),
-    authorizeCoinjoin: Type.Unsafe<typeof authorizeCoinjoin>(),
-    cancelCoinjoinAuthorization: Type.Unsafe<typeof cancelCoinjoinAuthorization>(),
-});
-export type TrezorConnectBitcoin = Static<typeof TrezorConnectBitcoin>;
+export interface TrezorConnectBitcoin {
+    signTransaction: typeof signTransaction;
+    composeTransaction: typeof composeTransaction;
+    authorizeCoinjoin: typeof authorizeCoinjoin;
+    cancelCoinjoinAuthorization: typeof cancelCoinjoinAuthorization;
+}

--- a/packages/connect-common/src/types/api/blockchain/index.ts
+++ b/packages/connect-common/src/types/api/blockchain/index.ts
@@ -1,6 +1,3 @@
-import type { Static } from '@trezor/schema-utils';
-import { Type } from '@trezor/schema-utils';
-
 import type { blockchainDisconnect } from './blockchainDisconnect';
 import type { blockchainEstimateFee } from './blockchainEstimateFee';
 import type { blockchainEvmRpcCall } from './blockchainEvmRpcCall';
@@ -19,22 +16,21 @@ import type { blockchainValidateEvmRpcUrl } from './blockchainValidateEvmRpcUrl'
 import type { pushTransaction } from './pushTransaction';
 
 // Blockchain backend operations (no device needed)
-export const TrezorConnectBlockchain = Type.Object({
-    blockchainSubscribe: Type.Unsafe<typeof blockchainSubscribe>(),
-    blockchainUnsubscribe: Type.Unsafe<typeof blockchainUnsubscribe>(),
-    blockchainDisconnect: Type.Unsafe<typeof blockchainDisconnect>(),
-    blockchainSetCustomBackend: Type.Unsafe<typeof blockchainSetCustomBackend>(),
-    blockchainGetInfo: Type.Unsafe<typeof blockchainGetInfo>(),
-    blockchainValidateEvmRpcUrl: Type.Unsafe<typeof blockchainValidateEvmRpcUrl>(),
-    blockchainEstimateFee: Type.Unsafe<typeof blockchainEstimateFee>(),
-    blockchainGetAccountBalanceHistory: Type.Unsafe<typeof blockchainGetAccountBalanceHistory>(),
-    blockchainGetTransactions: Type.Unsafe<typeof blockchainGetTransactions>(),
-    blockchainEvmRpcCall: Type.Unsafe<typeof blockchainEvmRpcCall>(),
-    blockchainGetCurrentFiatRates: Type.Unsafe<typeof blockchainGetCurrentFiatRates>(),
-    blockchainGetContractInfo: Type.Unsafe<typeof blockchainGetContractInfo>(),
-    blockchainGetFiatRatesForTimestamps: Type.Unsafe<typeof blockchainGetFiatRatesForTimestamps>(),
-    blockchainSubscribeFiatRates: Type.Unsafe<typeof blockchainSubscribeFiatRates>(),
-    blockchainUnsubscribeFiatRates: Type.Unsafe<typeof blockchainUnsubscribeFiatRates>(),
-    pushTransaction: Type.Unsafe<typeof pushTransaction>(),
-});
-export type TrezorConnectBlockchain = Static<typeof TrezorConnectBlockchain>;
+export interface TrezorConnectBlockchain {
+    blockchainSubscribe: typeof blockchainSubscribe;
+    blockchainUnsubscribe: typeof blockchainUnsubscribe;
+    blockchainDisconnect: typeof blockchainDisconnect;
+    blockchainSetCustomBackend: typeof blockchainSetCustomBackend;
+    blockchainGetInfo: typeof blockchainGetInfo;
+    blockchainValidateEvmRpcUrl: typeof blockchainValidateEvmRpcUrl;
+    blockchainEstimateFee: typeof blockchainEstimateFee;
+    blockchainGetAccountBalanceHistory: typeof blockchainGetAccountBalanceHistory;
+    blockchainGetTransactions: typeof blockchainGetTransactions;
+    blockchainEvmRpcCall: typeof blockchainEvmRpcCall;
+    blockchainGetCurrentFiatRates: typeof blockchainGetCurrentFiatRates;
+    blockchainGetContractInfo: typeof blockchainGetContractInfo;
+    blockchainGetFiatRatesForTimestamps: typeof blockchainGetFiatRatesForTimestamps;
+    blockchainSubscribeFiatRates: typeof blockchainSubscribeFiatRates;
+    blockchainUnsubscribeFiatRates: typeof blockchainUnsubscribeFiatRates;
+    pushTransaction: typeof pushTransaction;
+}

--- a/packages/connect-common/src/types/api/callable.ts
+++ b/packages/connect-common/src/types/api/callable.ts
@@ -1,36 +1,37 @@
-import { type Static, Type } from '@trezor/schema-utils';
+import type { TrezorConnectAccount } from './account';
+import type { TrezorConnectBitcoin } from './bitcoin';
+import type { TrezorConnectBlockchain } from './blockchain';
+import type { TrezorConnectCardano } from './cardano';
+import type { TrezorConnectDevice } from './device';
+import type { TrezorConnectEthereum } from './ethereum';
+import type { TrezorConnectEvolu } from './evolu';
+import type { TrezorConnectManagement } from './management';
+import type { TrezorConnectMonero } from './monero';
+import type { TrezorConnectNostr } from './nostr';
+import type { TrezorConnectRipple } from './ripple';
+import type { TrezorConnectSolana } from './solana';
+import type { TrezorConnectStellar } from './stellar';
+import type { TrezorConnectTezos } from './tezos';
+import type { TrezorConnectTron } from './tron';
 
-import { TrezorConnectAccount } from './account';
-import { TrezorConnectBitcoin } from './bitcoin';
-import { TrezorConnectBlockchain } from './blockchain';
-import { TrezorConnectCardano } from './cardano';
-import { TrezorConnectDevice } from './device';
-import { TrezorConnectEthereum } from './ethereum';
-import { TrezorConnectEvolu } from './evolu';
-import { TrezorConnectManagement } from './management';
-import { TrezorConnectMonero } from './monero';
-import { TrezorConnectNostr } from './nostr';
-import { TrezorConnectRipple } from './ripple';
-import { TrezorConnectSolana } from './solana';
-import { TrezorConnectStellar } from './stellar';
-import { TrezorConnectTezos } from './tezos';
-import { TrezorConnectTron } from './tron';
+// Keep this composition declarative: deriving it through TypeBox makes TypeScript expand every
+// method signature when resolving one member, while named interfaces preserve domain boundaries.
+export interface TrezorConnectPublicCallable
+    extends
+        TrezorConnectDevice,
+        TrezorConnectBlockchain,
+        TrezorConnectAccount,
+        TrezorConnectBitcoin,
+        TrezorConnectEthereum,
+        TrezorConnectCardano,
+        TrezorConnectMonero,
+        TrezorConnectRipple,
+        TrezorConnectSolana,
+        TrezorConnectStellar,
+        TrezorConnectTezos,
+        TrezorConnectTron,
+        TrezorConnectEvolu,
+        TrezorConnectNostr {}
 
-export const TrezorConnectCallable = Type.Composite([
-    TrezorConnectManagement,
-    TrezorConnectDevice,
-    TrezorConnectBlockchain,
-    TrezorConnectAccount,
-    TrezorConnectBitcoin,
-    TrezorConnectEthereum,
-    TrezorConnectCardano,
-    TrezorConnectMonero,
-    TrezorConnectRipple,
-    TrezorConnectSolana,
-    TrezorConnectStellar,
-    TrezorConnectTezos,
-    TrezorConnectTron,
-    TrezorConnectEvolu,
-    TrezorConnectNostr,
-]);
-export type TrezorConnectCallable = Static<typeof TrezorConnectCallable>;
+export interface TrezorConnectCallable
+    extends TrezorConnectPublicCallable, TrezorConnectManagement {}

--- a/packages/connect-common/src/types/api/cardano/index.ts
+++ b/packages/connect-common/src/types/api/cardano/index.ts
@@ -1,6 +1,3 @@
-import type { Static } from '@trezor/schema-utils';
-import { Type } from '@trezor/schema-utils';
-
 import type { cardanoComposeTransaction } from './cardanoComposeTransaction';
 import type { cardanoGetAddress } from './cardanoGetAddress';
 import type { cardanoGetNativeScriptHash } from './cardanoGetNativeScriptHash';
@@ -9,12 +6,11 @@ import type { cardanoSignMessage } from './cardanoSignMessage';
 import type { cardanoSignTransaction } from './cardanoSignTransaction';
 
 // Cardano-specific operations
-export const TrezorConnectCardano = Type.Object({
-    cardanoGetAddress: Type.Unsafe<typeof cardanoGetAddress>(),
-    cardanoGetPublicKey: Type.Unsafe<typeof cardanoGetPublicKey>(),
-    cardanoGetNativeScriptHash: Type.Unsafe<typeof cardanoGetNativeScriptHash>(),
-    cardanoSignTransaction: Type.Unsafe<typeof cardanoSignTransaction>(),
-    cardanoSignMessage: Type.Unsafe<typeof cardanoSignMessage>(),
-    cardanoComposeTransaction: Type.Unsafe<typeof cardanoComposeTransaction>(),
-});
-export type TrezorConnectCardano = Static<typeof TrezorConnectCardano>;
+export interface TrezorConnectCardano {
+    cardanoGetAddress: typeof cardanoGetAddress;
+    cardanoGetPublicKey: typeof cardanoGetPublicKey;
+    cardanoGetNativeScriptHash: typeof cardanoGetNativeScriptHash;
+    cardanoSignTransaction: typeof cardanoSignTransaction;
+    cardanoSignMessage: typeof cardanoSignMessage;
+    cardanoComposeTransaction: typeof cardanoComposeTransaction;
+}

--- a/packages/connect-common/src/types/api/device/index.ts
+++ b/packages/connect-common/src/types/api/device/index.ts
@@ -1,6 +1,3 @@
-import type { Static } from '@trezor/schema-utils';
-import { Type } from '@trezor/schema-utils';
-
 import type { cipherKeyValue } from './cipherKeyValue';
 import type { firmwareUpdate } from './firmwareUpdate';
 import type { getDeviceState } from './getDeviceState';
@@ -12,15 +9,14 @@ import type { showDeviceTutorial } from './showDeviceTutorial';
 import type { unlockPath } from './unlockPath';
 
 // Device configuration, firmware, security, and hardware control
-export const TrezorConnectDevice = Type.Object({
-    getFeatures: Type.Unsafe<typeof getFeatures>(),
-    getDeviceState: Type.Unsafe<typeof getDeviceState>(),
-    firmwareUpdate: Type.Unsafe<typeof firmwareUpdate>(),
-    showDeviceTutorial: Type.Unsafe<typeof showDeviceTutorial>(),
-    requestLogin: Type.Unsafe<typeof requestLogin>(),
-    cipherKeyValue: Type.Unsafe<typeof cipherKeyValue>(),
-    unlockPath: Type.Unsafe<typeof unlockPath>(),
-    getOwnershipId: Type.Unsafe<typeof getOwnershipId>(),
-    getOwnershipProof: Type.Unsafe<typeof getOwnershipProof>(),
-});
-export type TrezorConnectDevice = Static<typeof TrezorConnectDevice>;
+export interface TrezorConnectDevice {
+    getFeatures: typeof getFeatures;
+    getDeviceState: typeof getDeviceState;
+    firmwareUpdate: typeof firmwareUpdate;
+    showDeviceTutorial: typeof showDeviceTutorial;
+    requestLogin: typeof requestLogin;
+    cipherKeyValue: typeof cipherKeyValue;
+    unlockPath: typeof unlockPath;
+    getOwnershipId: typeof getOwnershipId;
+    getOwnershipProof: typeof getOwnershipProof;
+}

--- a/packages/connect-common/src/types/api/ethereum/index.ts
+++ b/packages/connect-common/src/types/api/ethereum/index.ts
@@ -1,6 +1,3 @@
-import type { Static } from '@trezor/schema-utils';
-import { Type } from '@trezor/schema-utils';
-
 import type { ethereumGetAddress } from './ethereumGetAddress';
 import type { ethereumGetPublicKey } from './ethereumGetPublicKey';
 import type { ethereumSignMessage } from './ethereumSignMessage';
@@ -9,12 +6,11 @@ import type { ethereumSignTypedData } from './ethereumSignTypedData';
 import type { ethereumVerifyMessage } from './ethereumVerifyMessage';
 
 // Ethereum-specific operations
-export const TrezorConnectEthereum = Type.Object({
-    ethereumGetAddress: Type.Unsafe<typeof ethereumGetAddress>(),
-    ethereumGetPublicKey: Type.Unsafe<typeof ethereumGetPublicKey>(),
-    ethereumSignTransaction: Type.Unsafe<typeof ethereumSignTransaction>(),
-    ethereumSignMessage: Type.Unsafe<typeof ethereumSignMessage>(),
-    ethereumSignTypedData: Type.Unsafe<typeof ethereumSignTypedData>(),
-    ethereumVerifyMessage: Type.Unsafe<typeof ethereumVerifyMessage>(),
-});
-export type TrezorConnectEthereum = Static<typeof TrezorConnectEthereum>;
+export interface TrezorConnectEthereum {
+    ethereumGetAddress: typeof ethereumGetAddress;
+    ethereumGetPublicKey: typeof ethereumGetPublicKey;
+    ethereumSignTransaction: typeof ethereumSignTransaction;
+    ethereumSignMessage: typeof ethereumSignMessage;
+    ethereumSignTypedData: typeof ethereumSignTypedData;
+    ethereumVerifyMessage: typeof ethereumVerifyMessage;
+}

--- a/packages/connect-common/src/types/api/evolu/index.ts
+++ b/packages/connect-common/src/types/api/evolu/index.ts
@@ -1,14 +1,10 @@
-import type { Static } from '@trezor/schema-utils';
-import { Type } from '@trezor/schema-utils';
-
 import type { evoluGetDelegatedIdentityKey } from './evoluGetDelegatedIdentityKey';
 import type { evoluGetNode } from './evoluGetNode';
 import type { evoluSignRegistrationRequest } from './evoluSignRegistrationRequest';
 
 // Evolu identity protocol operations
-export const TrezorConnectEvolu = Type.Object({
-    evoluGetNode: Type.Unsafe<typeof evoluGetNode>(),
-    evoluSignRegistrationRequest: Type.Unsafe<typeof evoluSignRegistrationRequest>(),
-    evoluGetDelegatedIdentityKey: Type.Unsafe<typeof evoluGetDelegatedIdentityKey>(),
-});
-export type TrezorConnectEvolu = Static<typeof TrezorConnectEvolu>;
+export interface TrezorConnectEvolu {
+    evoluGetNode: typeof evoluGetNode;
+    evoluSignRegistrationRequest: typeof evoluSignRegistrationRequest;
+    evoluGetDelegatedIdentityKey: typeof evoluGetDelegatedIdentityKey;
+}

--- a/packages/connect-common/src/types/api/index.ts
+++ b/packages/connect-common/src/types/api/index.ts
@@ -1,10 +1,9 @@
-import type { TrezorConnectCallable } from './callable';
+import type { TrezorConnectCallable, TrezorConnectPublicCallable } from './callable';
 import type { TrezorConnectInternal } from './internal';
-import type { TrezorConnectManagement } from './management';
 import type { CallMethodPayload } from '../../events/call';
 import type { ConnectSettings, Manifest } from '../settings';
 
-export type { TrezorConnectCallable };
+export type { TrezorConnectCallable, TrezorConnectPublicCallable };
 
 export interface TrezorConnectCore<InitSettings extends Record<string, any>> {
     init(settings: InitSettings & { manifest: Manifest }): Promise<void>;
@@ -13,9 +12,8 @@ export interface TrezorConnectCore<InitSettings extends Record<string, any>> {
     dispose(): void;
 }
 
-export type TrezorConnectPublicAPI<InitSettings extends Record<string, any>> =
-    TrezorConnectCore<InitSettings> & Omit<TrezorConnectCallable, keyof TrezorConnectManagement>;
+export interface TrezorConnectPublicAPI<InitSettings extends Record<string, any>>
+    extends TrezorConnectCore<InitSettings>, TrezorConnectPublicCallable {}
 
-export type TrezorConnectPrivilegedAPI = TrezorConnectCore<ConnectSettings> &
-    TrezorConnectInternal &
-    TrezorConnectCallable;
+export interface TrezorConnectPrivilegedAPI
+    extends TrezorConnectCore<ConnectSettings>, TrezorConnectInternal, TrezorConnectCallable {}

--- a/packages/connect-common/src/types/api/internal/index.ts
+++ b/packages/connect-common/src/types/api/internal/index.ts
@@ -1,6 +1,3 @@
-import type { Static } from '@trezor/schema-utils';
-import { Type } from '@trezor/schema-utils';
-
 import type { off } from './off';
 import type { on } from './on';
 import type { removeAllListeners } from './removeAllListeners';
@@ -8,11 +5,10 @@ import type { uiResponse } from './uiResponse';
 import type { updateConnectSettings } from './updateConnectSettings';
 
 // Initialization, lifecycle, events, and settings
-export const TrezorConnectInternal = Type.Object({
-    on: Type.Unsafe<typeof on>(),
-    off: Type.Unsafe<typeof off>(),
-    removeAllListeners: Type.Unsafe<typeof removeAllListeners>(),
-    uiResponse: Type.Unsafe<typeof uiResponse>(),
-    updateConnectSettings: Type.Unsafe<typeof updateConnectSettings>(),
-});
-export type TrezorConnectInternal = Static<typeof TrezorConnectInternal>;
+export interface TrezorConnectInternal {
+    on: typeof on;
+    off: typeof off;
+    removeAllListeners: typeof removeAllListeners;
+    uiResponse: typeof uiResponse;
+    updateConnectSettings: typeof updateConnectSettings;
+}

--- a/packages/connect-common/src/types/api/management/index.ts
+++ b/packages/connect-common/src/types/api/management/index.ts
@@ -1,6 +1,3 @@
-import type { Static } from '@trezor/schema-utils';
-import { Type } from '@trezor/schema-utils';
-
 import type { applyFlags } from './applyFlags';
 import type { applySettings } from './applySettings';
 import type { authenticateDevice } from './authenticateDevice';
@@ -24,27 +21,26 @@ import type { thpRemoveCredentials } from './thpRemoveCredentials';
 import type { wipeDevice } from './wipeDevice';
 
 // Device configuration, firmware, security, and hardware control
-export const TrezorConnectManagement = Type.Object({
-    getFirmwareHash: Type.Unsafe<typeof getFirmwareHash>(),
-    resetDevice: Type.Unsafe<typeof resetDevice>(),
-    loadDevice: Type.Unsafe<typeof loadDevice>(),
-    recoveryDevice: Type.Unsafe<typeof recoveryDevice>(),
-    wipeDevice: Type.Unsafe<typeof wipeDevice>(),
-    backupDevice: Type.Unsafe<typeof backupDevice>(),
-    changePin: Type.Unsafe<typeof changePin>(),
-    changeWipeCode: Type.Unsafe<typeof changeWipeCode>(),
-    changeLanguage: Type.Unsafe<typeof changeLanguage>(),
-    applySettings: Type.Unsafe<typeof applySettings>(),
-    applyFlags: Type.Unsafe<typeof applyFlags>(),
-    authenticateDevice: Type.Unsafe<typeof authenticateDevice>(),
-    setBusy: Type.Unsafe<typeof setBusy>(),
-    setBrightness: Type.Unsafe<typeof setBrightness>(),
-    bleUnpair: Type.Unsafe<typeof bleUnpair>(),
-    thpGetCredentials: Type.Unsafe<typeof thpGetCredentials>(),
-    thpRemoveCredentials: Type.Unsafe<typeof thpRemoveCredentials>(),
-    telemetryGet: Type.Unsafe<typeof telemetryGet>(),
-    pingDevice: Type.Unsafe<typeof pingDevice>(),
-    getNonce: Type.Unsafe<typeof getNonce>(),
-    getSettings: Type.Unsafe<typeof getSettings>(),
-});
-export type TrezorConnectManagement = Static<typeof TrezorConnectManagement>;
+export interface TrezorConnectManagement {
+    getFirmwareHash: typeof getFirmwareHash;
+    resetDevice: typeof resetDevice;
+    loadDevice: typeof loadDevice;
+    recoveryDevice: typeof recoveryDevice;
+    wipeDevice: typeof wipeDevice;
+    backupDevice: typeof backupDevice;
+    changePin: typeof changePin;
+    changeWipeCode: typeof changeWipeCode;
+    changeLanguage: typeof changeLanguage;
+    applySettings: typeof applySettings;
+    applyFlags: typeof applyFlags;
+    authenticateDevice: typeof authenticateDevice;
+    setBusy: typeof setBusy;
+    setBrightness: typeof setBrightness;
+    bleUnpair: typeof bleUnpair;
+    thpGetCredentials: typeof thpGetCredentials;
+    thpRemoveCredentials: typeof thpRemoveCredentials;
+    telemetryGet: typeof telemetryGet;
+    pingDevice: typeof pingDevice;
+    getNonce: typeof getNonce;
+    getSettings: typeof getSettings;
+}

--- a/packages/connect-common/src/types/api/monero/index.ts
+++ b/packages/connect-common/src/types/api/monero/index.ts
@@ -1,16 +1,12 @@
-import type { Static } from '@trezor/schema-utils';
-import { Type } from '@trezor/schema-utils';
-
 import type { moneroGetAddress } from './moneroGetAddress';
 import type { moneroGetWatchKey } from './moneroGetWatchKey';
 import type { moneroKeyImageSync } from './moneroKeyImageSync';
 import type { moneroSignTransaction } from './moneroSignTransaction';
 
 // Monero-specific operations
-export const TrezorConnectMonero = Type.Object({
-    moneroGetAddress: Type.Unsafe<typeof moneroGetAddress>(),
-    moneroGetWatchKey: Type.Unsafe<typeof moneroGetWatchKey>(),
-    moneroKeyImageSync: Type.Unsafe<typeof moneroKeyImageSync>(),
-    moneroSignTransaction: Type.Unsafe<typeof moneroSignTransaction>(),
-});
-export type TrezorConnectMonero = Static<typeof TrezorConnectMonero>;
+export interface TrezorConnectMonero {
+    moneroGetAddress: typeof moneroGetAddress;
+    moneroGetWatchKey: typeof moneroGetWatchKey;
+    moneroKeyImageSync: typeof moneroKeyImageSync;
+    moneroSignTransaction: typeof moneroSignTransaction;
+}

--- a/packages/connect-common/src/types/api/nostr/index.ts
+++ b/packages/connect-common/src/types/api/nostr/index.ts
@@ -1,11 +1,8 @@
-import { type Static, Type } from '@trezor/schema-utils';
-
 import type { nostrGetPublicKey } from './nostrGetPublicKey';
 import type { nostrSignEvent } from './nostrSignEvent';
 
 // Nostr protocol operations
-export const TrezorConnectNostr = Type.Object({
-    nostrGetPublicKey: Type.Unsafe<typeof nostrGetPublicKey>(),
-    nostrSignEvent: Type.Unsafe<typeof nostrSignEvent>(),
-});
-export type TrezorConnectNostr = Static<typeof TrezorConnectNostr>;
+export interface TrezorConnectNostr {
+    nostrGetPublicKey: typeof nostrGetPublicKey;
+    nostrSignEvent: typeof nostrSignEvent;
+}

--- a/packages/connect-common/src/types/api/ripple/index.ts
+++ b/packages/connect-common/src/types/api/ripple/index.ts
@@ -1,12 +1,8 @@
-import type { Static } from '@trezor/schema-utils';
-import { Type } from '@trezor/schema-utils';
-
 import type { rippleGetAddress } from './rippleGetAddress';
 import type { rippleSignTransaction } from './rippleSignTransaction';
 
 // Ripple-specific operations
-export const TrezorConnectRipple = Type.Object({
-    rippleGetAddress: Type.Unsafe<typeof rippleGetAddress>(),
-    rippleSignTransaction: Type.Unsafe<typeof rippleSignTransaction>(),
-});
-export type TrezorConnectRipple = Static<typeof TrezorConnectRipple>;
+export interface TrezorConnectRipple {
+    rippleGetAddress: typeof rippleGetAddress;
+    rippleSignTransaction: typeof rippleSignTransaction;
+}

--- a/packages/connect-common/src/types/api/solana/index.ts
+++ b/packages/connect-common/src/types/api/solana/index.ts
@@ -1,16 +1,12 @@
-import type { Static } from '@trezor/schema-utils';
-import { Type } from '@trezor/schema-utils';
-
 import type { solanaComposeTransaction } from './solanaComposeTransaction';
 import type { solanaGetAddress } from './solanaGetAddress';
 import type { solanaGetPublicKey } from './solanaGetPublicKey';
 import type { solanaSignTransaction } from './solanaSignTransaction';
 
 // Solana-specific operations
-export const TrezorConnectSolana = Type.Object({
-    solanaGetAddress: Type.Unsafe<typeof solanaGetAddress>(),
-    solanaGetPublicKey: Type.Unsafe<typeof solanaGetPublicKey>(),
-    solanaSignTransaction: Type.Unsafe<typeof solanaSignTransaction>(),
-    solanaComposeTransaction: Type.Unsafe<typeof solanaComposeTransaction>(),
-});
-export type TrezorConnectSolana = Static<typeof TrezorConnectSolana>;
+export interface TrezorConnectSolana {
+    solanaGetAddress: typeof solanaGetAddress;
+    solanaGetPublicKey: typeof solanaGetPublicKey;
+    solanaSignTransaction: typeof solanaSignTransaction;
+    solanaComposeTransaction: typeof solanaComposeTransaction;
+}

--- a/packages/connect-common/src/types/api/stellar/index.ts
+++ b/packages/connect-common/src/types/api/stellar/index.ts
@@ -1,15 +1,11 @@
 // Stellar types from stellar-sdk
 // https://github.com/stellar/js-stellar-base
 
-import type { Static } from '@trezor/schema-utils';
-import { Type } from '@trezor/schema-utils';
-
 import type { stellarGetAddress } from './stellarGetAddress';
 import type { stellarSignTransaction } from './stellarSignTransaction';
 
 // Stellar-specific operations
-export const TrezorConnectStellar = Type.Object({
-    stellarGetAddress: Type.Unsafe<typeof stellarGetAddress>(),
-    stellarSignTransaction: Type.Unsafe<typeof stellarSignTransaction>(),
-});
-export type TrezorConnectStellar = Static<typeof TrezorConnectStellar>;
+export interface TrezorConnectStellar {
+    stellarGetAddress: typeof stellarGetAddress;
+    stellarSignTransaction: typeof stellarSignTransaction;
+}

--- a/packages/connect-common/src/types/api/tezos/index.ts
+++ b/packages/connect-common/src/types/api/tezos/index.ts
@@ -1,14 +1,10 @@
-import type { Static } from '@trezor/schema-utils';
-import { Type } from '@trezor/schema-utils';
-
 import type { tezosGetAddress } from './tezosGetAddress';
 import type { tezosGetPublicKey } from './tezosGetPublicKey';
 import type { tezosSignTransaction } from './tezosSignTransaction';
 
 // Tezos-specific operations
-export const TrezorConnectTezos = Type.Object({
-    tezosGetAddress: Type.Unsafe<typeof tezosGetAddress>(),
-    tezosGetPublicKey: Type.Unsafe<typeof tezosGetPublicKey>(),
-    tezosSignTransaction: Type.Unsafe<typeof tezosSignTransaction>(),
-});
-export type TrezorConnectTezos = Static<typeof TrezorConnectTezos>;
+export interface TrezorConnectTezos {
+    tezosGetAddress: typeof tezosGetAddress;
+    tezosGetPublicKey: typeof tezosGetPublicKey;
+    tezosSignTransaction: typeof tezosSignTransaction;
+}

--- a/packages/connect-common/src/types/api/tron/index.ts
+++ b/packages/connect-common/src/types/api/tron/index.ts
@@ -1,14 +1,10 @@
-import type { Static } from '@trezor/schema-utils';
-import { Type } from '@trezor/schema-utils';
-
 import type { tronComposeTransaction } from './tronComposeTransaction';
 import type { tronGetAddress } from './tronGetAddress';
 import type { tronSignTransaction } from './tronSignTransaction';
 
 // Tron-specific operations
-export const TrezorConnectTron = Type.Object({
-    tronGetAddress: Type.Unsafe<typeof tronGetAddress>(),
-    tronSignTransaction: Type.Unsafe<typeof tronSignTransaction>(),
-    tronComposeTransaction: Type.Unsafe<typeof tronComposeTransaction>(),
-});
-export type TrezorConnectTron = Static<typeof TrezorConnectTron>;
+export interface TrezorConnectTron {
+    tronGetAddress: typeof tronGetAddress;
+    tronSignTransaction: typeof tronSignTransaction;
+    tronComposeTransaction: typeof tronComposeTransaction;
+}


### PR DESCRIPTION
## Description

The Connect API tiers were derived from nested TypeBox objects and composites, so TypeScript expanded the full callable graph while resolving a single method. This replaces the unused group schemas with declarative domain interfaces composed by extension, preserves the leaf method signatures and existing method-list parity guards, and gives the compiler stable named boundaries. Closes #30023.

- Callable declaration: **13,258 -> 1,404 bytes (89.4% smaller)**
- Direct `getAccountInfo`: **262.3 -> 76.9 ms (70.7% faster)**
- Type instantiations: **6,343 -> 35 (99.4% fewer)**
- Assignability relations: **682 -> 9 (98.7% fewer)**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This PR modifies connect-common's shared API type definitions across nearly all supported coins (bitcoin, ethereum, cardano, solana, tron, ripple, stellar, tezos, monero, nostr) plus core factory/callable/account/device/blockchain/management/internal/evolu types. Since these are TypeScript type contracts consumed by TrezorConnect calls throughout the Suite, the highest risk is to any flow that directly invokes typed connect methods (getAddress, signTransaction, cardanoSignTransaction, solana staking, ethereum send/sign) — a type mismatch could break request/response validation or UI rendering of on-device confirmation data. The factory.ts file maps to 131 tests broadly, so per the heuristic most of those were excluded unless there was concrete evidence the specific coin/API type change would affect that test's assertions. Recommended strategy: run the high-priority coin-specific TrezorConnect and staking/send tests first (Bitcoin, Ethereum, Cardano, Solana) as they most directly exercise the changed type files, followed by medium-priority discovery and sign/verify tests, with low-priority coverage for secondary EVM/UTXO chains.

<details><summary><b>Changed files (19)</b></summary>

- `packages/connect-common/src/factory.ts`
- `packages/connect-common/src/types/api/account/index.ts`
- `packages/connect-common/src/types/api/bitcoin/index.ts`
- `packages/connect-common/src/types/api/blockchain/index.ts`
- `packages/connect-common/src/types/api/callable.ts`
- `packages/connect-common/src/types/api/cardano/index.ts`
- `packages/connect-common/src/types/api/device/index.ts`
- `packages/connect-common/src/types/api/ethereum/index.ts`
- `packages/connect-common/src/types/api/evolu/index.ts`
- `packages/connect-common/src/types/api/index.ts`
- `packages/connect-common/src/types/api/internal/index.ts`
- `packages/connect-common/src/types/api/management/index.ts`
- `packages/connect-common/src/types/api/monero/index.ts`
- `packages/connect-common/src/types/api/nostr/index.ts`
- `packages/connect-common/src/types/api/ripple/index.ts`
- `packages/connect-common/src/types/api/solana/index.ts`
- `packages/connect-common/src/types/api/stellar/index.ts`
- `packages/connect-common/src/types/api/tezos/index.ts`
- `packages/connect-common/src/types/api/tron/index.ts`

</details>

**Recommended tests (22)**

<details><summary>🔴 <b>High priority (13)</b></summary>

- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This test directly exercises TrezorConnect API types (getAddress, bundle) which are defined in connect-common's api type files including bitcoin/index.ts and account/index.ts. Changes to these shared API type definitions could break the request/response contract validated by this test.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — getAccountInfo relies heavily on the account API type definitions in connect-common/types/api/account/index.ts and callable.ts factory used to validate method calls; a change here directly impacts this method's contract.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — This test invokes TrezorConnect.ethereumSignMessage, whose type definitions live in connect-common/types/api/ethereum/index.ts; any change to Ethereum API types could break message signing request/response shape.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Directly calls TrezorConnect.ethereumSignTransaction which depends on the Ethereum API type definitions changed in this PR (packages/connect-common/src/types/api/ethereum/index.ts).
- `suite/e2e/tests/wallet/cardano.test.ts` — Cardano account details, xpub, and address reveal flows use TrezorConnect Cardano methods whose types are defined in the changed cardano/index.ts file; this test validates that Cardano API contract end-to-end.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Cardano staking uses cardanoSignTransaction and related Cardano API calls whose type contracts are defined in the changed cardano/index.ts, directly affecting device confirmation screens and payload structure verified in this test.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Cardano unstaking relies on the same Cardano signing API types that were changed, and this test verifies the transaction confirmation flow and payload details for stake deregistration.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Cardano reward claiming uses cardanoSignTransaction via the changed Cardano API types; this test validates withdrawal transaction details on-device which could break if the type contract changes.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Solana staking transactions rely on solana signing API types defined in the changed solana/index.ts file; this test verifies device confirmation and fee details for staking transactions.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Solana unstake/claim flows use the same solana API types changed in this PR, directly affecting transaction signing and confirmation payloads tested here.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Solana send transaction flow directly depends on the Solana API type definitions that changed, exercising address/amount/fee confirmation contracts.
- `suite/e2e/tests/wallet/receive.test.ts` — This test verifies address reveal for BTC, ETH, SOL, and TRX, exercising bitcoin/index.ts, ethereum/index.ts, solana/index.ts, and tron/index.ts API type contracts all changed in this PR.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Ethereum send transaction flow directly uses the ethereum API type definitions (fees, gas parameters, address) that were changed, and validates device prompt/emulator display of transaction data.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Discovery relies on blockchain API types (blockchain/index.ts) which were changed; this test validates discovery completion after configuring custom backends for BTC/LTC.
- `suite/e2e/tests/wallet/discovery.test.ts` — Multi-coin discovery (BTC, ETH, LTC, etc.) exercises blockchain and account API types changed in this PR; regressions in discovery status reporting would surface here.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Bitcoin sign/verify message uses TrezorConnect signMessage/verifyMessage APIs whose types are defined partly in bitcoin/index.ts; a change could affect signature format validation tested here.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — Ethereum sign/verify message flow depends on ethereum API type definitions that were modified, though it is a narrower and simpler flow than full transaction signing.
- `suite/e2e/tests/wallet/public-keys.test.ts` — Public key retrieval for BTC, LTC, and ADA accounts uses account and cardano API type definitions changed here; a type mismatch could break XPUB display verification.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — selectAccount depends on account API type definitions (account/index.ts) that changed, and asserts on returned account object shape (no xpub/publicKey leakage), which is sensitive to type contract changes.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Bitcoin signTransaction flow depends on bitcoin API type definitions changed in this PR; the test exercises multi-step device confirmation using this API surface.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/wallet/send-base.test.ts` — Base network send transactions use the Ethereum-compatible EVM API types (ethereum/index.ts); included at low priority since it's a secondary EVM chain test with similar coverage to send-eth.test.ts.
- `suite/e2e/tests/wallet/send-doge.test.ts` — DOGE send exercises bitcoin-like API types (bitcoin/index.ts) for a UTXO-based chain; relevant but lower priority since core send-form logic is better covered by BTC-specific tests.

</details>

⚠️ **Changes with no test coverage (10)**
- `packages/connect-common/src/types/api/index.ts`
- `packages/connect-common/src/types/api/internal/index.ts`
- `packages/connect-common/src/types/api/management/index.ts`
- `packages/connect-common/src/types/api/monero/index.ts`
- `packages/connect-common/src/types/api/nostr/index.ts`
- `packages/connect-common/src/types/api/ripple/index.ts`
- `packages/connect-common/src/types/api/stellar/index.ts`
- `packages/connect-common/src/types/api/tezos/index.ts`
- `packages/connect-common/src/types/api/device/index.ts`
- `packages/connect-common/src/types/api/evolu/index.ts`

_Updated: 2026-07-18T22:30:14.526Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/perf/connect-declarative-api/web/](https://dev.suite.sldev.cz/suite-web/perf/connect-declarative-api/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=perf/connect-declarative-api&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=perf/connect-declarative-api&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-18T22:32:50.337Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-18T22:32:08.778Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->