### PR TITLE
refactor(suite-native): bound cancel navigation targets

### DIFF
--- a/suite-native/device-authorization/src/components/ConnectDeviceScreenHeader.tsx
+++ b/suite-native/device-authorization/src/components/ConnectDeviceScreenHeader.tsx
@@ -13,8 +13,8 @@ import { Translation } from '@suite-native/intl';
 import {
     type AuthorizeDeviceStackParamList,
     type AuthorizeDeviceStackRoutes,
+    type CancelNavigationTarget,
     type CloseActionType,
-    type NavigateParameters,
     type RootStackParamList,
     type StackToStackCompositeNavigationProps,
     useInterceptNativeNavigation,
@@ -25,7 +25,7 @@ import { selectDeviceRequestedPin } from '../deviceAuthorizationSlice';
 
 type ConnectDeviceScreenHeaderProps = {
     shouldDisplayCancelButton?: boolean;
-    onCancelNavigationTarget?: NavigateParameters<RootStackParamList>;
+    onCancelNavigationTarget?: CancelNavigationTarget;
     closeActionType?: CloseActionType;
     onCancel?: () => void;
 };

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -400,9 +400,17 @@ export type DeviceAuthenticityStackParamList = {
     [DeviceAuthenticityStackRoutes.AuthenticitySuccess]: undefined;
 };
 
+type CancelNavigationTargetParamList = {
+    [RootStackRoutes.AppTabs]: NavigatorScreenParams<AppTabsParamList>;
+    [RootStackRoutes.SendStack]: NavigatorScreenParams<SendStackParamList>;
+    [RootStackRoutes.StellarManageTokenStack]: NavigatorScreenParams<StellarManageTokenStackParamList>;
+};
+
+export type CancelNavigationTarget = NavigateParameters<CancelNavigationTargetParamList>;
+
 export type AuthorizeDeviceStackParamList = {
     [AuthorizeDeviceStackRoutes.DeviceConnectionGuard]:
-        | { onCancelNavigationTarget: NavigateParameters<RootStackParamList> }
+        | { onCancelNavigationTarget: CancelNavigationTarget }
         | undefined;
     [AuthorizeDeviceStackRoutes.ConnectDeviceCrossroads]: undefined;
     [AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice]: undefined;


### PR DESCRIPTION
## Description

RootStackParamList recursively includes AuthorizeDeviceStackParamList while the DeviceConnectionGuard cancellation target points back to RootStackParamList. This change bounds that public target to the three destinations used by current callers and updates the header contract, preserving runtime behavior while removing the recursive type edge. The focused checker counters improve, while the two controlled whole-graph trials remain inconclusive with unfavorable point estimates; the PR stays draft for evaluation.

- Tracking issue: **https://github.com/trezor/trezor-suite/issues/29904**
- Affected TypeScript projects: **64**
- Device-authorization instantiations: **140,542 → 139,942**
- Trial 1 mean: **400.344 → 505.775 seconds**
- Trial 2 mean: **330.645 → 336.826 seconds**
- Combined difference: **+55.805 seconds (+15.3% slower)**
- Combined paired 95% CI: **−13.246 to +124.857 seconds**
- Trial 1 benchmark: **https://github.com/trezor/trezor-suite/pull/30025#issuecomment-5013232598**
- Trial 2 benchmark: **https://github.com/trezor/trezor-suite/pull/30025#issuecomment-5013417124**

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native-navigation-cancel-target-type&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->