### PR TITLE
perf(types): enable isolated declarations in pilot packages

### DIFF
--- a/packages/blockchain-link-types/src/baseCurrency.ts
+++ b/packages/blockchain-link-types/src/baseCurrency.ts
@@ -52,12 +52,13 @@ export const valuablesBaseCurrencies = {
     xau: { code: 'xau', label: 'Gold' },
 } as const;
 
-export const valuablesBaseCurrencyCodes = typedObjectKeys(valuablesBaseCurrencies);
+export const valuablesBaseCurrencyCodes: (keyof typeof valuablesBaseCurrencies)[] =
+    typedObjectKeys(valuablesBaseCurrencies);
 
-export const baseCurrencies = {
+export const baseCurrencies: typeof fiatBaseCurrencies & typeof valuablesBaseCurrencies = {
     ...fiatBaseCurrencies,
     ...valuablesBaseCurrencies,
-} as const;
+};
 
 export type BaseCurrencyCode = keyof typeof baseCurrencies;
 export type BaseCurrency = (typeof baseCurrencies)[BaseCurrencyCode];

--- a/packages/blockchain-link-types/tsconfig.json
+++ b/packages/blockchain-link-types/tsconfig.json
@@ -1,6 +1,10 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": { "outDir": "libDev" },
+    "compilerOptions": {
+        "allowJs": false,
+        "isolatedDeclarations": true,
+        "outDir": "libDev"
+    },
     "references": [
         { "path": "../utils" },
         { "path": "../utxo-lib" },

--- a/packages/type-utils/tsconfig.json
+++ b/packages/type-utils/tsconfig.json
@@ -1,5 +1,9 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": { "outDir": "libDev" },
+    "compilerOptions": {
+        "allowJs": false,
+        "isolatedDeclarations": true,
+        "outDir": "libDev"
+    },
     "references": []
 }

--- a/suite-common/analytics/src/analyticsEvents.ts
+++ b/suite-common/analytics/src/analyticsEvents.ts
@@ -1,6 +1,6 @@
 import { type EventInstance } from './eventDefinition';
 import * as sharedEventsData from './events';
 
-export const sharedEvents = sharedEventsData;
+export const sharedEvents: typeof sharedEventsData = sharedEventsData;
 export type AnySharedEventDef = (typeof sharedEvents)[keyof typeof sharedEvents];
 export type AnalyticsSharedEvents = EventInstance<AnySharedEventDef>;

--- a/suite-common/analytics/tsconfig.json
+++ b/suite-common/analytics/tsconfig.json
@@ -1,6 +1,10 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": { "outDir": "libDev" },
+    "compilerOptions": {
+        "allowJs": false,
+        "isolatedDeclarations": true,
+        "outDir": "libDev"
+    },
     "references": [
         { "path": "../wallet-config" },
         { "path": "../wallet-types" }

--- a/suite-common/suite-sync-types/tsconfig.json
+++ b/suite-common/suite-sync-types/tsconfig.json
@@ -1,6 +1,10 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": { "outDir": "libDev" },
+    "compilerOptions": {
+        "allowJs": false,
+        "isolatedDeclarations": true,
+        "outDir": "libDev"
+    },
     "references": [
         {
             "path": "../delegated-identity-key-types"

--- a/suite-common/wallet-types/src/baseCurrency.ts
+++ b/suite-common/wallet-types/src/baseCurrency.ts
@@ -6,9 +6,10 @@ import { type BigNumber } from '@trezor/utils';
  * In case of BTC this also can contain value converted to Sats. // Todo: Consider to separate those situations.
  */
 export type BaseCurrencyAmount = BigNumber & Branded<`base-currency-amount`>;
-export const asBaseCurrencyAmount = (value: BigNumber) => value as BaseCurrencyAmount;
+export const asBaseCurrencyAmount = (value: BigNumber): BaseCurrencyAmount =>
+    value as BaseCurrencyAmount;
 
 export const areBaseCurrencyAmountsEqual = (
     a: BaseCurrencyAmount | undefined,
     b: BaseCurrencyAmount | undefined,
-) => a === b || (a !== undefined && b !== undefined && a.eq(b));
+): boolean => a === b || (a !== undefined && b !== undefined && a.eq(b));

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -22,7 +22,16 @@ import { type AccountDescriptor } from './account';
 
 export type { PrecomposedTransactionFinalCardano } from '@trezor/connect';
 
-const COMMON_PRECOMPOSE_ERRORS = {
+type CommonPrecomposeErrors = {
+    readonly AMOUNT_NOT_ENOUGH_CURRENCY_FEE: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE';
+    readonly AMOUNT_IS_NOT_ENOUGH: 'AMOUNT_IS_NOT_ENOUGH';
+    readonly AMOUNT_IS_TOO_LOW: 'AMOUNT_IS_TOO_LOW';
+    readonly AMOUNT_IS_LESS_THAN_RESERVE: 'AMOUNT_IS_LESS_THAN_RESERVE';
+    readonly REMAINING_BALANCE_LESS_THAN_RENT: 'REMAINING_BALANCE_LESS_THAN_RENT';
+    readonly AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT';
+};
+
+const COMMON_PRECOMPOSE_ERRORS: CommonPrecomposeErrors = {
     AMOUNT_NOT_ENOUGH_CURRENCY_FEE: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE',
     AMOUNT_IS_NOT_ENOUGH: 'AMOUNT_IS_NOT_ENOUGH',
     AMOUNT_IS_TOO_LOW: 'AMOUNT_IS_TOO_LOW',
@@ -30,27 +39,37 @@ const COMMON_PRECOMPOSE_ERRORS = {
     REMAINING_BALANCE_LESS_THAN_RENT: 'REMAINING_BALANCE_LESS_THAN_RENT',
     AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT:
         'AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT',
-} as const satisfies Record<string, string>;
+};
+
+type SuitePrecomposeErrors = typeof COMMON_PRECOMPOSE_ERRORS & {
+    readonly TR_NOT_ENOUGH_SELECTED: 'TR_NOT_ENOUGH_SELECTED';
+    readonly TR_NOT_ENOUGH_ANONYMIZED_FUNDS_WARNING: 'TR_NOT_ENOUGH_ANONYMIZED_FUNDS_WARNING';
+    readonly TR_GENERIC_ERROR_TITLE: 'TR_GENERIC_ERROR_TITLE';
+};
+
+type SuiteNativePrecomposeErrors = typeof COMMON_PRECOMPOSE_ERRORS & {
+    readonly TR_STAKE_NOT_ENOUGH_FUNDS: 'TR_STAKE_NOT_ENOUGH_FUNDS';
+};
 
 /**
  * @trezor/suite (packages/suite) errors
  */
-export const SUITE_PRECOMPOSE_ERRORS = {
+export const SUITE_PRECOMPOSE_ERRORS: SuitePrecomposeErrors = {
     ...COMMON_PRECOMPOSE_ERRORS,
     TR_NOT_ENOUGH_SELECTED: 'TR_NOT_ENOUGH_SELECTED',
     TR_NOT_ENOUGH_ANONYMIZED_FUNDS_WARNING: 'TR_NOT_ENOUGH_ANONYMIZED_FUNDS_WARNING',
     TR_GENERIC_ERROR_TITLE: 'TR_GENERIC_ERROR_TITLE',
-} as const satisfies Record<string, string>;
+};
 
 type SuitePrecomposeError = ObjectValues<typeof SUITE_PRECOMPOSE_ERRORS>;
 
 /**
  * @suite-native/* errors
  */
-export const SUITE_NATIVE_PRECOMPOSE_ERRORS = {
+export const SUITE_NATIVE_PRECOMPOSE_ERRORS: SuiteNativePrecomposeErrors = {
     ...COMMON_PRECOMPOSE_ERRORS,
     TR_STAKE_NOT_ENOUGH_FUNDS: 'TR_STAKE_NOT_ENOUGH_FUNDS',
-} as const satisfies Record<string, string>;
+};
 
 type SuiteNativePrecomposeError = ObjectValues<typeof SUITE_NATIVE_PRECOMPOSE_ERRORS>;
 

--- a/suite-common/wallet-types/tsconfig.json
+++ b/suite-common/wallet-types/tsconfig.json
@@ -1,6 +1,10 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": { "outDir": "libDev" },
+    "compilerOptions": {
+        "allowJs": false,
+        "isolatedDeclarations": true,
+        "outDir": "libDev"
+    },
     "references": [
         { "path": "../metadata-types" },
         { "path": "../wallet-config" },


### PR DESCRIPTION
## Description

Investigation outcome: `isolatedDeclarations` is a useful correctness guardrail for exported declarations, but it does not speed up the current IDE or Nx paths. Zed’s TypeScript language server still constructs the project, resolves dependencies, and performs semantic checking; Nx likewise does not use TypeScript’s per-file declaration transform. The 30.2x result below is therefore only a `transpileDeclaration` capability microbenchmark, not an end-to-end codebase or IDE improvement. This pilot is being closed because it does not address the intended IDE-performance problem; the declaration-expansion prevention pattern can be reconsidered independently.

- Isolated-declaration diagnostics: **7 → 0**
- Current IDE speedup: **none demonstrated**
- Whole-project `tsc --noCheck`: **29.750 s → 29.649 s (0.34%, within noise)**
- Capability microbenchmark: **17.717 s → 0.587 s (30.2x, not used by Zed or Nx)**

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=perf/isolated-declarations-pilot&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->