### PR TITLE
Cardano staking updates

### DIFF
--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -29,6 +29,7 @@ import {
 import {
     asAmountSubunit,
     getAddressParameters,
+    getCardanoAccountPoolId,
     getDelegationCertificates,
     getDerivationType,
     getNetworkId,
@@ -115,7 +116,7 @@ export const prepareTxPlan = async (
 
     const addressParameters = getAddressParameters(account, changeAddress.path);
 
-    const selectedPool = selectBestCardanoPool(cardanoPools);
+    const selectedPool = selectBestCardanoPool(cardanoPools, getCardanoAccountPoolId(account));
 
     const certificates = [];
 

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -1,4 +1,8 @@
-import { asTypedDesktopAnalytics, events } from '@suite/analytics';
+import {
+    type StakingCardanoPoolDelegationPayload,
+    asTypedDesktopAnalytics,
+    events,
+} from '@suite/analytics';
 import { selectSelectedDevice } from '@suite-common/device';
 import { type AdaPools } from '@suite-common/earn-staking-api';
 import { type ExtraDependencies } from '@suite-common/redux-utils';
@@ -10,6 +14,7 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     CARDANO_EVERSTAKE_DREP,
+    EVERSTAKE_POOL_NAMES,
     MIN_CARDANO_AMOUNT_FOR_STAKING,
     MIN_CARDANO_BALANCE_FOR_STAKING,
     MIN_CARDANO_FOR_WITHDRAWALS,
@@ -37,6 +42,7 @@ import {
     getStakingPath,
     getUnusedChangeAddress,
     getVotingCertificates,
+    isCardanoStakedWithEverstake,
     isTestnet,
     networkAmountToSmallestUnit,
     parseDrepBech32,
@@ -177,7 +183,7 @@ export const prepareTxPlan = async (
 
     if (!response.success) throw new Error(response.error.message);
 
-    return { txPlan: response.payload[0], certificates, withdrawals };
+    return { txPlan: response.payload[0], certificates, withdrawals, selectedPool };
 };
 
 const getTransactionData = (
@@ -303,6 +309,30 @@ export const composeTransaction =
         );
     };
 
+// Report the pool from the certificate that was actually signed, not a later
+// recomputation — a divergence from the account pool must stay observable.
+const getPoolDelegation = (
+    stakeType: StakeType,
+    account: Account,
+    selectedPool: ReturnType<typeof selectBestCardanoPool>,
+    cardanoPools: AdaPools['pools'],
+): StakingCardanoPoolDelegationPayload | undefined => {
+    if (stakeType !== 'stake') return undefined;
+
+    const fromPool = getCardanoAccountPoolId(account);
+
+    return {
+        fromPool: fromPool ? (EVERSTAKE_POOL_NAMES[fromPool] ?? fromPool) : undefined,
+        toPool: EVERSTAKE_POOL_NAMES[selectedPool.bech32] ?? selectedPool.bech32,
+        toPoolSaturation: cardanoPools.find(pool => pool.id === selectedPool.bech32)?.saturation,
+        poolsDataAvailable: cardanoPools.length > 0,
+        isEverstakeToEverstake:
+            fromPool !== null &&
+            fromPool !== selectedPool.bech32 &&
+            isCardanoStakedWithEverstake(account, cardanoPools),
+    };
+};
+
 export const signTransaction =
     (formValues: StakeFormState, transactionInfo: PrecomposedTransactionFinal) =>
     async (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
@@ -338,7 +368,7 @@ export const signTransaction =
             return;
         }
 
-        const { txPlan, certificates, withdrawals } = txData;
+        const { txPlan, certificates, withdrawals, selectedPool } = txData;
 
         if (!txPlan || txPlan.type === 'nonfinal') return;
 
@@ -396,5 +426,13 @@ export const signTransaction =
             return signedTx;
         }
 
-        return signedTx.payload.serializedTx;
+        return {
+            serializedTx: signedTx.payload.serializedTx,
+            poolDelegation: getPoolDelegation(
+                formValues.stakeType,
+                account,
+                selectedPool,
+                cardanoPools,
+            ),
+        };
     };

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -1,4 +1,8 @@
-import { asTypedDesktopAnalytics, events } from '@suite/analytics';
+import {
+    type StakingCardanoPoolDelegationPayload,
+    asTypedDesktopAnalytics,
+    events,
+} from '@suite/analytics';
 import { closeModal, openDeferredModal, openModal, preserveModal } from '@suite/modal';
 import { selectSelectedDevice } from '@suite-common/device';
 import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
@@ -89,7 +93,7 @@ export const cancelSignTx =
 
 // private, called from signTransaction only
 const pushTransaction =
-    (stakeType: StakeType) =>
+    (stakeType: StakeType, cardanoPoolDelegation?: StakingCardanoPoolDelegationPayload) =>
     async (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
         const { serializedTx, precomposedTx } = getState().wallet.stake;
         const { account } = getState().wallet.selectedAccount;
@@ -130,6 +134,13 @@ const pushTransaction =
                 symbol: account.symbol,
                 txid,
             };
+
+            if (cardanoPoolDelegation) {
+                asTypedDesktopAnalytics(extra.services.analytics).report({
+                    type: events.stakingCardanoPoolDelegationEvent.name,
+                    payload: cardanoPoolDelegation,
+                });
+            }
 
             if (stakeType === 'stake') {
                 dispatch(
@@ -268,10 +279,18 @@ export const signTransaction =
             );
         }
 
+        let cardanoPoolDelegation: StakingCardanoPoolDelegationPayload | undefined;
         if (isSupportedAdaStakingNetworkSymbol(account.symbol)) {
-            serializedTx = await dispatch(
+            const signResult = await dispatch(
                 stakeFormCardanoActions.signTransaction(formValues, enhancedTxInfo),
             );
+
+            if (signResult && 'serializedTx' in signResult) {
+                serializedTx = signResult.serializedTx;
+                cardanoPoolDelegation = signResult.poolDelegation;
+            } else {
+                serializedTx = signResult;
+            }
         }
 
         if (typeof serializedTx !== 'string') {
@@ -305,7 +324,7 @@ export const signTransaction =
         );
 
         if (account?.networkType === 'cardano') {
-            return dispatch(pushTransaction(formValues.stakeType));
+            return dispatch(pushTransaction(formValues.stakeType, cardanoPoolDelegation));
         }
 
         // Open a deferred modal and get the decision

--- a/packages/suite/src/hooks/earn/useCardanoStaking.ts
+++ b/packages/suite/src/hooks/earn/useCardanoStaking.ts
@@ -8,6 +8,7 @@ import {
 } from '@suite-common/wallet-types';
 import {
     getAddressParameters,
+    getCardanoAccountPoolId,
     getDelegationCertificates,
     getStakingPath,
     getUnusedChangeAddress,
@@ -70,7 +71,10 @@ export const useCardanoStaking = (): CardanoStaking => {
 
             const addressParameters = getAddressParameters(account, changeAddress.path);
 
-            const selectedPool = selectBestCardanoPool(cardanoPools);
+            const selectedPool = selectBestCardanoPool(
+                cardanoPools,
+                getCardanoAccountPoolId(account),
+            );
 
             let certificates: CardanoCertificate[] = [];
 

--- a/packages/suite/src/views/wallet/staking/components/AdaStakingDashboard/CardanoNewProviderCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/AdaStakingDashboard/CardanoNewProviderCard.tsx
@@ -7,7 +7,7 @@ import {
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import {
-    isCardanoStakedWithEverstake,
+    isCardanoStakedOutsideEverstake,
     isCardanoStakedWithFiveBinaries,
 } from '@suite-common/wallet-utils';
 
@@ -24,7 +24,7 @@ export function CardanoNewProviderCard({ account }: CardanoNewProviderCardProps)
 
     const hasPendingTx = useSelector(state => hasPendingStakeTypeTransaction(state, account.key));
     const cardanoStakingPools = useSelector(selectCardanoPoolsInfo);
-    const isStakedWithEverstake = isCardanoStakedWithEverstake(account, cardanoStakingPools);
+    const isStakedOutsideEverstake = isCardanoStakedOutsideEverstake(account, cardanoStakingPools);
     const isStakedWithFiveBinaries = isCardanoStakedWithFiveBinaries(account);
     const isStakingRoute = routeName?.includes('staking');
 
@@ -35,12 +35,12 @@ export function CardanoNewProviderCard({ account }: CardanoNewProviderCardProps)
     const isCardanoNetworkType = account?.networkType === 'cardano';
 
     if (
-        isStakedWithEverstake ||
+        !isStakedOutsideEverstake ||
         hasPendingTx ||
         !isNewProviderBannerEnabled ||
         !isCardanoNetworkType ||
         !isStakingActive ||
-        (!isStakedWithEverstake && !isStakedWithFiveBinaries && !isStakingRoute)
+        (!isStakedWithFiveBinaries && !isStakingRoute)
     ) {
         return null;
     }

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/DebugOnlyCardanoStakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/DebugOnlyCardanoStakingCard.tsx
@@ -1,9 +1,11 @@
 import styled from 'styled-components';
 
 import { DebugOnlyBadge, selectIsDebugModeActive } from '@suite/debug';
+import { EVERSTAKE_POOL_NAMES } from '@suite-common/wallet-constants';
 import { selectCardanoPoolsInfo } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import {
+    getCardanoAccountPoolId,
     isCardanoStakedWithEverstake,
     isCardanoStakedWithFiveBinaries,
 } from '@suite-common/wallet-utils';
@@ -26,6 +28,8 @@ export const DebugOnlyCardanoStakingCard = ({ account }: DebugOnlyCardanoStaking
     const cardanoStakingPools = useSelector(selectCardanoPoolsInfo);
     const isStakedWithEverstake = isCardanoStakedWithEverstake(account, cardanoStakingPools);
     const isStakedWithFiveBinaries = isCardanoStakedWithFiveBinaries(account);
+    const poolId = getCardanoAccountPoolId(account);
+    const poolName = poolId ? EVERSTAKE_POOL_NAMES[poolId] : undefined;
 
     if (!isDebugModeActive || account.networkType !== 'cardano') return null;
 
@@ -68,6 +72,19 @@ export const DebugOnlyCardanoStakingCard = ({ account }: DebugOnlyCardanoStaking
                             </Paragraph>
                         </ParagraphWrapper>
                     </InfoItem>
+
+                    {poolName && (
+                        <InfoItem
+                            label="Pool name"
+                            direction="row"
+                            labelWidth={90}
+                            verticalAlignment="start"
+                        >
+                            <ParagraphWrapper>
+                                <Paragraph typographyStyle="body-xs">{poolName}</Paragraph>
+                            </ParagraphWrapper>
+                        </InfoItem>
+                    )}
 
                     <InfoItem
                         label="Stake address"

--- a/suite-common/wallet-constants/src/cardanoConstants.ts
+++ b/suite-common/wallet-constants/src/cardanoConstants.ts
@@ -32,8 +32,10 @@ export const FIVE_BINARIES_POOLS = [
     'pool1z9m2kxeat06t30yf6ar7sqpert0cjdgxzcv2dv36dcwcqcqtgk4',
 ];
 
-export const EVERSTAKE_POOLS = [
-    'pool1sysgx87cwxnqy0pqn8g97gdhd0dmre9rw3jvpn2k7apuwa7cgkn',
-    'pool1n0uxgs5qfk5n9xl7qvq9jt8zuu02cntrsjnjayjlqtejyffnemj',
-    'pool13rt3ngkek4l876980ect869cu978d36dcyh22ts4nwuf7ncq02u',
-];
+export const EVERSTAKE_POOL_NAMES: Record<string, string> = {
+    pool1sysgx87cwxnqy0pqn8g97gdhd0dmre9rw3jvpn2k7apuwa7cgkn: 'EVE6',
+    pool1n0uxgs5qfk5n9xl7qvq9jt8zuu02cntrsjnjayjlqtejyffnemj: 'EVE7',
+    pool13rt3ngkek4l876980ect869cu978d36dcyh22ts4nwuf7ncq02u: 'EVE8',
+};
+
+export const EVERSTAKE_POOLS = Object.keys(EVERSTAKE_POOL_NAMES);

--- a/suite-common/wallet-constants/src/cardanoConstants.ts
+++ b/suite-common/wallet-constants/src/cardanoConstants.ts
@@ -22,8 +22,6 @@ export const CARDANO_EVERSTAKE_DREP = {
     bech32: 'drep1yt8p080ajks6zdnxd9z6a6q60p9sm9j5rl7tc63mfna8r6cnp4wr3',
 };
 
-export const CARDANO_POOL_SATURATION_SAFE_THRESHOLD = 75; // in percentage
-
 export const MIN_CARDANO_AMOUNT_FOR_SEND = new BigNumber(1_000_000);
 
 export const FIVE_BINARIES_POOLS = [

--- a/suite-common/wallet-utils/src/__fixtures__/cardanoStakingUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/cardanoStakingUtils.ts
@@ -1,0 +1,205 @@
+import { bech32 } from '@scure/base';
+
+import { type AdaPools } from '@suite-common/earn-staking-api';
+import {
+    CARDANO_EVERSTAKE_STAKING_POOL,
+    EVERSTAKE_POOLS,
+    FIVE_BINARIES_POOLS,
+} from '@suite-common/wallet-constants';
+
+// Real Everstake pools; saturations mirror the live endpoint values of 2026-08-01.
+const [eve6, eve7, eve8] = EVERSTAKE_POOLS as [string, string, string];
+const EVE6_SATURATION = 80.77;
+const EVE7_SATURATION = 76.42;
+const EVE8_SATURATION = 62.64;
+
+// A decodable pool id that is intentionally NOT in EVERSTAKE_POOLS.
+const apiOnlyPool = bech32.encode('pool', bech32.toWords(new Uint8Array(28).fill(7)));
+
+const pool = (id: string, saturation: number): AdaPools['pools'][number] => ({
+    id,
+    saturation,
+    apy: 2.5,
+});
+
+const livePools = [
+    pool(eve6, EVE6_SATURATION),
+    pool(eve7, EVE7_SATURATION),
+    pool(eve8, EVE8_SATURATION),
+];
+
+export const selectBestCardanoPool = [
+    {
+        description: 'no pool data (endpoint down) falls back to the hardcoded pool',
+        pools: undefined,
+        result: CARDANO_EVERSTAKE_STAKING_POOL.bech32,
+    },
+    {
+        description: 'empty pool list falls back to the hardcoded pool',
+        pools: [],
+        result: CARDANO_EVERSTAKE_STAKING_POOL.bech32,
+    },
+    {
+        description: 'least saturated pool is picked (live situation: EVE8)',
+        pools: livePools,
+        result: eve8,
+    },
+    {
+        description: 'does not rely on the API ordering',
+        pools: [
+            pool(eve8, EVE8_SATURATION),
+            pool(eve6, EVE6_SATURATION),
+            pool(eve7, EVE7_SATURATION),
+        ],
+        result: eve8,
+    },
+    {
+        description: 'all pools nearly full still yield the least saturated one',
+        pools: [pool(eve6, 100), pool(eve7, 97.3), pool(eve8, 98.1)],
+        result: eve7,
+    },
+    {
+        description: 'single pool is picked',
+        pools: [pool(eve6, EVE6_SATURATION)],
+        result: eve6,
+    },
+];
+
+export const selectBestCardanoPoolWithCurrentPool = [
+    ...EVERSTAKE_POOLS.map((everstakePoolId, index) => ({
+        description: `hardcoded Everstake pool [${index}] is kept even without any pool data`,
+        pools: undefined,
+        currentPoolId: everstakePoolId,
+        result: everstakePoolId,
+    })),
+    {
+        description: 'pool listed only by the endpoint is kept',
+        pools: [pool(apiOnlyPool, 95.2), pool(eve8, EVE8_SATURATION)],
+        currentPoolId: apiOnlyPool,
+        result: apiOnlyPool,
+    },
+    {
+        description: 'foreign pool is moved to the least saturated Everstake pool',
+        pools: livePools,
+        currentPoolId: 'pool1foreignforeignforeignforeignforeignforeignfore',
+        result: eve8,
+    },
+    {
+        description: 'foreign pool without pool data is moved to the hardcoded pool',
+        pools: [],
+        currentPoolId: 'pool1foreignforeignforeignforeignforeignforeignfore',
+        result: CARDANO_EVERSTAKE_STAKING_POOL.bech32,
+    },
+    {
+        description: 'account without delegation gets the least saturated pool',
+        pools: livePools,
+        currentPoolId: null,
+        result: eve8,
+    },
+];
+
+const cardanoAccount = (poolId?: string) => ({
+    networkType: 'cardano',
+    misc: { staking: { poolId } },
+});
+
+const [everstakePool] = EVERSTAKE_POOLS as [string];
+const [fiveBinariesPool] = FIVE_BINARIES_POOLS as [string];
+const foreignPool = 'pool1foreignforeignforeignforeignforeignforeignfore';
+const fetchedPools = [pool(everstakePool, EVE6_SATURATION)];
+
+export const isCardanoStakedWithEverstake = [
+    {
+        description: 'hardcoded Everstake pool without any pool data',
+        account: cardanoAccount(everstakePool),
+        pools: [],
+        result: true,
+    },
+    {
+        description: 'pool present only in the fetched list',
+        account: cardanoAccount('pool1listedbyapi'),
+        pools: [pool('pool1listedbyapi', 50)],
+        result: true,
+    },
+    {
+        description: 'foreign pool with pool data available',
+        account: cardanoAccount(foreignPool),
+        pools: fetchedPools,
+        result: false,
+    },
+    {
+        description: 'account without delegation',
+        account: cardanoAccount(undefined),
+        pools: fetchedPools,
+        result: false,
+    },
+    {
+        description: 'non-cardano account',
+        account: { networkType: 'ethereum' },
+        pools: fetchedPools,
+        result: false,
+    },
+];
+
+export const isCardanoStakedOutsideEverstake = [
+    {
+        description: 'foreign pool with pool data available',
+        account: cardanoAccount(foreignPool),
+        pools: fetchedPools,
+        result: true,
+    },
+    {
+        description: 'hardcoded Everstake pool with pool data available',
+        account: cardanoAccount(everstakePool),
+        pools: fetchedPools,
+        result: false,
+    },
+    {
+        description: 'hardcoded Everstake pool without pool data',
+        account: cardanoAccount(everstakePool),
+        pools: [],
+        result: false,
+    },
+    {
+        description: 'foreign pool without pool data (EVERSTAKE_POOLS is the complete set)',
+        account: cardanoAccount(foreignPool),
+        pools: [],
+        result: true,
+    },
+    {
+        description: 'Five Binaries pool without pool data',
+        account: cardanoAccount(fiveBinariesPool),
+        pools: [],
+        result: true,
+    },
+    {
+        description: 'Five Binaries pool with pool data available',
+        account: cardanoAccount(fiveBinariesPool),
+        pools: fetchedPools,
+        result: true,
+    },
+    {
+        description: 'account without delegation',
+        account: cardanoAccount(undefined),
+        pools: [],
+        result: false,
+    },
+];
+
+export const isCardanoStakedWithFiveBinaries = [
+    {
+        description: 'Five Binaries pool',
+        account: cardanoAccount(fiveBinariesPool),
+        result: true,
+    },
+    {
+        description: 'Everstake pool',
+        account: cardanoAccount(everstakePool),
+        result: false,
+    },
+    {
+        description: 'account without delegation',
+        account: cardanoAccount(undefined),
+        result: false,
+    },
+];

--- a/suite-common/wallet-utils/src/cardanoStakingUtils.test.ts
+++ b/suite-common/wallet-utils/src/cardanoStakingUtils.test.ts
@@ -1,0 +1,55 @@
+import { type AdaPools } from '@suite-common/earn-staking-api';
+import { CARDANO_EVERSTAKE_STAKING_POOL } from '@suite-common/wallet-constants';
+import { type Account } from '@suite-common/wallet-types';
+
+import * as fixtures from './__fixtures__/cardanoStakingUtils';
+import {
+    isCardanoStakedOutsideEverstake,
+    isCardanoStakedWithEverstake,
+    isCardanoStakedWithFiveBinaries,
+    poolBech32ToHex,
+    selectBestCardanoPool,
+} from './cardanoStakingUtils';
+
+describe('cardano staking utils', () => {
+    fixtures.selectBestCardanoPool.forEach(f => {
+        it(`selectBestCardanoPool: ${f.description}`, () => {
+            expect(selectBestCardanoPool(f.pools).bech32).toEqual(f.result);
+        });
+    });
+
+    fixtures.selectBestCardanoPoolWithCurrentPool.forEach(f => {
+        it(`selectBestCardanoPool: ${f.description}`, () => {
+            expect(selectBestCardanoPool(f.pools, f.currentPoolId).bech32).toEqual(f.result);
+        });
+    });
+
+    it('selectBestCardanoPool: returns the bech32 id together with its hex form', () => {
+        expect(selectBestCardanoPool(undefined)).toEqual(CARDANO_EVERSTAKE_STAKING_POOL);
+        expect(poolBech32ToHex(CARDANO_EVERSTAKE_STAKING_POOL.bech32)).toEqual(
+            CARDANO_EVERSTAKE_STAKING_POOL.hex,
+        );
+    });
+
+    fixtures.isCardanoStakedWithEverstake.forEach(f => {
+        it(`isCardanoStakedWithEverstake: ${f.description}`, () => {
+            expect(
+                isCardanoStakedWithEverstake(f.account as Account, f.pools as AdaPools['pools']),
+            ).toBe(f.result);
+        });
+    });
+
+    fixtures.isCardanoStakedOutsideEverstake.forEach(f => {
+        it(`isCardanoStakedOutsideEverstake: ${f.description}`, () => {
+            expect(
+                isCardanoStakedOutsideEverstake(f.account as Account, f.pools as AdaPools['pools']),
+            ).toBe(f.result);
+        });
+    });
+
+    fixtures.isCardanoStakedWithFiveBinaries.forEach(f => {
+        it(`isCardanoStakedWithFiveBinaries: ${f.description}`, () => {
+            expect(isCardanoStakedWithFiveBinaries(f.account as Account)).toBe(f.result);
+        });
+    });
+});

--- a/suite-common/wallet-utils/src/cardanoStakingUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoStakingUtils.ts
@@ -4,7 +4,6 @@ import { type AdaPools } from '@suite-common/earn-staking-api';
 import { type NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
 import {
     CARDANO_EVERSTAKE_STAKING_POOL,
-    CARDANO_POOL_SATURATION_SAFE_THRESHOLD,
     EVERSTAKE_POOLS,
     FIVE_BINARIES_POOLS,
 } from '@suite-common/wallet-constants';
@@ -92,27 +91,30 @@ export const poolBech32ToHex = (poolId: string): string => {
     return Buffer.from(bytes).toString('hex');
 };
 
-export const selectBestCardanoPool = (pools?: AdaPools['pools']) => {
-    if (!pools || pools.length === 0) return CARDANO_EVERSTAKE_STAKING_POOL;
-
-    // find the one within the threshold
-    const bestPool = pools.find(pool => pool.saturation < CARDANO_POOL_SATURATION_SAFE_THRESHOLD);
-
-    if (bestPool) {
+export const selectBestCardanoPool = (pools?: AdaPools['pools'], currentPoolId?: string | null) => {
+    // An account already delegated to an Everstake pool must never be moved to another
+    // pool, no matter which UI flow composes the delegation.
+    if (
+        currentPoolId &&
+        (EVERSTAKE_POOLS.includes(currentPoolId) || pools?.some(pool => pool.id === currentPoolId))
+    ) {
         return {
-            hex: poolBech32ToHex(bestPool.id),
-            bech32: bestPool.id,
+            hex: poolBech32ToHex(currentPoolId),
+            bech32: currentPoolId,
         };
     }
 
-    // pick the last one (lowest saturation)
-    const fallbackIndex = pools.length - 1;
-    // @ts-expect-error: indexing with noUncheckedIndexedAccess
-    const fallback: (typeof pools)[number] = pools[fallbackIndex];
+    if (!pools || pools.length === 0) return CARDANO_EVERSTAKE_STAKING_POOL;
+
+    // Sort client-side instead of relying on the API ordering contract; new stakes
+    // always go to the least saturated pool.
+    const [bestPool] = pools.toSorted((a, b) => a.saturation - b.saturation);
+
+    if (!bestPool) return CARDANO_EVERSTAKE_STAKING_POOL;
 
     return {
-        hex: poolBech32ToHex(fallback.id),
-        bech32: fallback.id,
+        hex: poolBech32ToHex(bestPool.id),
+        bech32: bestPool.id,
     };
 };
 

--- a/suite-native/staking/src/selectors.test.ts
+++ b/suite-native/staking/src/selectors.test.ts
@@ -100,19 +100,19 @@ const getTestState = (accounts: Account[]) => ({
                     ada: {
                         pools: [
                             {
-                                apy: 2.43,
-                                saturation: 81.09,
-                                id: 'pool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqs6cy',
+                                apy: 2.4,
+                                saturation: 80.77,
+                                id: 'pool1sysgx87cwxnqy0pqn8g97gdhd0dmre9rw3jvpn2k7apuwa7cgkn',
                             },
                             {
-                                apy: 5.8,
-                                saturation: 1.92,
+                                apy: 2.06,
+                                saturation: 76.42,
+                                id: 'pool1n0uxgs5qfk5n9xl7qvq9jt8zuu02cntrsjnjayjlqtejyffnemj',
+                            },
+                            {
+                                apy: 1.96,
+                                saturation: 62.64,
                                 id: 'pool13rt3ngkek4l876980ect869cu978d36dcyh22ts4nwuf7ncq02u',
-                            },
-                            {
-                                apy: 2.43,
-                                saturation: 0.05,
-                                id: 'pool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq2crtxv',
                             },
                         ],
                     },
@@ -230,7 +230,7 @@ describe('main staking selectors', () => {
 
             const result = selectApy(testState as any, { networkSymbol: 'ada' });
 
-            expect(result).toBe(5.8);
+            expect(result).toBe(1.96);
         });
 
         it('should return matched pool APY for ADA account with known poolId', () => {
@@ -243,7 +243,7 @@ describe('main staking selectors', () => {
                 networkType: 'cardano',
                 misc: {
                     staking: {
-                        poolId: 'pool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqs6cy',
+                        poolId: 'pool1sysgx87cwxnqy0pqn8g97gdhd0dmre9rw3jvpn2k7apuwa7cgkn',
                     },
                 },
             } as unknown as Account;
@@ -251,7 +251,7 @@ describe('main staking selectors', () => {
 
             const result = selectApy(testState as any, { accountKey: ada1Key });
 
-            expect(result).toBe(2.43);
+            expect(result).toBe(2.4);
         });
 
         it('should return null for ADA account staked outside known pools', () => {

--- a/suite/analytics/src/analyticsEvents.ts
+++ b/suite/analytics/src/analyticsEvents.ts
@@ -11,3 +11,8 @@ export type SuiteReadyPayload = Extract<
     AnalyticsDesktopEvents,
     { type: EventType.SuiteReady }
 >['payload'];
+
+export type StakingCardanoPoolDelegationPayload = Extract<
+    AnalyticsDesktopEvents,
+    { type: EventType.StakingCardanoPoolDelegation }
+>['payload'];

--- a/suite/analytics/src/constants.ts
+++ b/suite/analytics/src/constants.ts
@@ -100,6 +100,7 @@ export enum EventType {
     SettingsLoadNetworksClicked = 'settings/load-networks-clicked',
     SettingsTor = 'settings/tor',
     SettingsTorOnionLinks = 'settings/tor/onion-links',
+    StakingCardanoPoolDelegation = 'staking/cardano-pool-delegation',
     StakingChangeDelegate = 'staking/change-delegate',
     StakingClaim = 'staking/claim',
     StakingConfirm = 'staking/confirm',

--- a/suite/analytics/src/events/index.ts
+++ b/suite/analytics/src/events/index.ts
@@ -80,6 +80,7 @@ export { settingsGeneralNetworkReserveEvent } from './settingsGeneralNetworkRese
 export { settingsLoadNetworksClickedEvent } from './settingsLoadNetworksClickedEvent';
 export { settingsTorEvent } from './settingsTorEvent';
 export { settingsTorOnionLinksEvent } from './settingsTorOnionLinksEvent';
+export { stakingCardanoPoolDelegationEvent } from './stakingCardanoPoolDelegationEvent';
 export { stakingChangeDelegateEvent } from './stakingChangeDelegateEvent';
 export { stakingClaimEvent } from './stakingClaimEvent';
 export { stakingConfirmEvent } from './stakingConfirmEvent';

--- a/suite/analytics/src/events/stakingCardanoPoolDelegationEvent.ts
+++ b/suite/analytics/src/events/stakingCardanoPoolDelegationEvent.ts
@@ -1,0 +1,47 @@
+import type { AttributeDef, EventDef } from '@suite-common/analytics';
+
+import { EventType } from '../constants';
+
+type Attributes = {
+    fromPool?: AttributeDef<string>;
+    toPool: AttributeDef<string>;
+    toPoolSaturation?: AttributeDef<number>;
+    poolsDataAvailable: AttributeDef<boolean>;
+    isEverstakeToEverstake: AttributeDef<boolean>;
+};
+
+export const stakingCardanoPoolDelegationEvent: EventDef<
+    Attributes,
+    EventType.StakingCardanoPoolDelegation
+> = {
+    name: EventType.StakingCardanoPoolDelegation,
+    descriptionTrigger: 'A Cardano pool delegation transaction is successfully broadcast',
+    changelog: [{ version: '26.8.0', notes: 'added' }],
+
+    attributes: {
+        fromPool: {
+            changelog: [{ version: '26.8.0', notes: 'added' }],
+            description:
+                'Pool the account was delegated to before — name (e.g. EVE7) when known, bech32 id otherwise; not sent for a first delegation',
+        },
+        toPool: {
+            changelog: [{ version: '26.8.0', notes: 'added' }],
+            description:
+                'Pool the new delegation certificate points to — name (e.g. EVE8) when known, bech32 id otherwise',
+        },
+        toPoolSaturation: {
+            changelog: [{ version: '26.8.0', notes: 'added' }],
+            description:
+                'Saturation percentage (0-100) of the target pool at selection time; not sent when pool data is unavailable',
+        },
+        poolsDataAvailable: {
+            changelog: [{ version: '26.8.0', notes: 'added' }],
+            description: 'Whether the pools endpoint data was available at pool selection time',
+        },
+        isEverstakeToEverstake: {
+            changelog: [{ version: '26.8.0', notes: 'added' }],
+            description:
+                'Whether an account already delegated to an Everstake pool is being moved to a different pool; expected to always be `false`, `true` signals a regression',
+        },
+    },
+};

--- a/suite/analytics/src/index.ts
+++ b/suite/analytics/src/index.ts
@@ -10,7 +10,11 @@ export {
     AppUpdateEventStatus,
 } from './definitions';
 export { asTypedDesktopAnalytics } from './asTypedDesktopAnalytics';
-export type { AnalyticsDesktopEvents, SuiteReadyPayload } from './analyticsEvents';
+export type {
+    AnalyticsDesktopEvents,
+    StakingCardanoPoolDelegationPayload,
+    SuiteReadyPayload,
+} from './analyticsEvents';
 
 export * from './events';
 export * as events from './events';


### PR DESCRIPTION

## Description

Users staked with Everstake were still being migrated between Everstake Cardano pools (#25827).

- `selectBestCardanoPool` now knows the account's current pool and never moves an account already delegated to an Everstake pool, no matter which flow composes the transaction.
- New stakes always go to the least saturated pool, sorted client-side instead of trusting endpoint order; the saturation-threshold strategy and `CARDANO_POOL_SATURATION_SAFE_THRESHOLD` are removed.
- Everstake pool names (EVE6/EVE7/EVE8) added to the pool config as `EVERSTAKE_POOL_NAMES`.
- New analytics event `staking/cardano-pool-delegation` reported after a successful broadcast, with the payload captured at signing time; `fromPool`/`toPool` are reported as pool names when known, bech32 id otherwise; `isEverstakeToEverstake` must always be `false` and serves as a regression alarm.
- The debug-only Cardano staking card shows the pool name when known.
- New unit-test suite for `cardanoStakingUtils` (29 cases) using the real pools and live saturations.

## Notes for QA

- Account delegated to EVE6/EVE7/EVE8: no "update provider" banner, and any delegation composed for it keeps the current pool — including with the staking endpoint blocked.
- Account delegated to a foreign or Five Binaries pool: the migration offer still appears; with the endpoint blocked the target falls back to the hardcoded EVE8 pool.
- New stake from an undelegated account: goes to the least saturated Everstake pool (currently EVE8).
- A successful delegation broadcast emits `staking/cardano-pool-delegation` with pool names in `fromPool`/`toPool` and `isEverstakeToEverstake: false`.

## Related Issue

Resolve #25827

## Screenshots:


<img width="1073" height="761" alt="Screenshot 2026-08-01 at 12 46 20" src="https://github.com/user-attachments/assets/c9ecf6ae-c0e0-4559-bead-0c7eeabcbdea" />

<img width="500"  alt="IMG_4123" src="https://github.com/user-attachments/assets/5d09966e-ae6a-4e82-a943-84f47b1ac0cf" />
<img width="670" height="251" alt="Screenshot 2026-08-01 at 12 47 53" src="https://github.com/user-attachments/assets/0b5e4fe1-d4d7-44bd-8c8d-bb92f728001a" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly focused on Cardano staking (transaction actions, hook, dashboard UI, constants, and utilities) plus a new Cardano pool delegation analytics event. The highest-value tests are the three Cardano staking E2E specs, which directly exercise the changed code paths end-to-end. The analytics staking-events test provides the nearest regression coverage for the new analytics event, though it does not yet assert it directly. Other files are either unit-test fixtures, native-suite tests, or broad analytics exports with no specific E2E target.

<details><summary><b>Changed files (15)</b></summary>

- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts`
- `packages/suite/src/actions/wallet/stakeActions.ts`
- `packages/suite/src/hooks/earn/useCardanoStaking.ts`
- `packages/suite/src/views/wallet/staking/components/AdaStakingDashboard/CardanoNewProviderCard.tsx`
- `packages/suite/src/views/wallet/staking/components/StakingDashboard/components/DebugOnlyCardanoStakingCard.tsx`
- `suite-common/wallet-constants/src/cardanoConstants.ts`
- `suite-common/wallet-utils/src/__fixtures__/cardanoStakingUtils.ts`
- `suite-common/wallet-utils/src/cardanoStakingUtils.test.ts`
- `suite-common/wallet-utils/src/cardanoStakingUtils.ts`
- `suite-native/staking/src/selectors.test.ts`
- `suite/analytics/src/analyticsEvents.ts`
- `suite/analytics/src/constants.ts`
- `suite/analytics/src/events/index.ts`
- `suite/analytics/src/events/stakingCardanoPoolDelegationEvent.ts`
- `suite/analytics/src/index.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — Directly exercises the Cardano rewards-claim flow that relies on stakeFormCardanoActions, useCardanoStaking, cardanoStakingUtils, and cardanoConstants. Any regression in Cardano staking transaction composition or reward calculation would be immediately visible here.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Covers the full Cardano delegation/stake flow including stake key registration, delegation, vote delegation, and deposit/fee handling. Changes to Cardano staking actions and utilities directly affect the assertions in this test.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Validates Cardano stake key deregistration and deposit return, which depends on the same Cardano staking actions, constants, and utility functions that were modified.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — The closest existing E2E coverage for staking analytics; the change set adds a new Cardano pool delegation analytics event, and this test exercises staking-related analytics for ADA. While it does not assert the new event directly, it is the most relevant analytics regression test.

</details>

⚠️ **Changes with no test coverage (8)**
- `suite-common/wallet-utils/src/__fixtures__/cardanoStakingUtils.ts`
- `suite-common/wallet-utils/src/cardanoStakingUtils.test.ts`
- `suite-native/staking/src/selectors.test.ts`
- `suite/analytics/src/analyticsEvents.ts`
- `suite/analytics/src/constants.ts`
- `suite/analytics/src/events/index.ts`
- `suite/analytics/src/events/stakingCardanoPoolDelegationEvent.ts`
- `suite/analytics/src/index.ts`

_Updated: 2026-08-04T15:51:09.670Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/cardano-pools/web/](https://dev.suite.sldev.cz/suite-web/feat/cardano-pools/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/cardano-pools&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/cardano-pools&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/cardano-pools&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T15:53:08.806Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T15:53:27.684Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->
