### PR TITLE
feat(ci): report TypeScript complexity on PRs

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -60,7 +60,19 @@ jobs:
       - name: "Minimal yarn install"
         uses: ./.github/actions/minimal-yarn-install
       - name: Type Check
-        run: yarn type-check --output-style=stream
+        id: type-check
+        shell: bash
+        run: |
+          set -o pipefail
+          yarn type-check --output-style=stream -- --extendedDiagnostics | tee "$RUNNER_TEMP/typescript-extended-diagnostics.log"
+      - name: Upload TypeScript performance diagnostics
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: typescript-performance-diagnostics
+          path: ${{ runner.temp }}/typescript-extended-diagnostics.log
+          if-no-files-found: error
+          retention-days: 7
       - name: Check Type Declaration Sizes
         run: yarn requirements:verify --only=type-declaration-size
 

--- a/.github/workflows/typescript-performance-baseline.yml
+++ b/.github/workflows/typescript-performance-baseline.yml
@@ -1,0 +1,49 @@
+name: "[Check] TypeScript Performance Baseline"
+
+on:
+  schedule:
+    - cron: "17 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_GHACTIONS_TOKEN }}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  baseline:
+    name: Generate develop baseline
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      NODE_OPTIONS: --max-old-space-size=6144
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          submodules: true
+      - name: Minimal yarn install
+        uses: ./.github/actions/minimal-yarn-install
+      - name: Type check all projects with extended diagnostics
+        shell: bash
+        run: |
+          set -o pipefail
+          yarn type-check:all --output-style=stream -- --extendedDiagnostics | tee "$RUNNER_TEMP/typescript-extended-diagnostics.log"
+      - name: Create baseline snapshot
+        run: |
+          node scripts/ci/typescriptPerformanceSentinel.js parse \
+            --input "$RUNNER_TEMP/typescript-extended-diagnostics.log" \
+            --output "$RUNNER_TEMP/typescript-performance-baseline.json" \
+            --source-sha "${{ github.sha }}"
+      - name: Upload baseline snapshot
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: typescript-performance-baseline
+          path: ${{ runner.temp }}/typescript-performance-baseline.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/typescript-performance-comment.yml
+++ b/.github/workflows/typescript-performance-comment.yml
@@ -1,0 +1,122 @@
+name: "[Bot] TypeScript Performance Comment"
+
+on:
+  workflow_run:
+    workflows:
+      - "[Check] Validation"
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Update TypeScript performance comment
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.pull_requests[0].number != null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted reporter
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Download PR diagnostics
+        id: download-current
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          gh run download "$WORKFLOW_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name typescript-performance-diagnostics \
+            --dir "$RUNNER_TEMP/current"
+
+      - name: Resolve type-check outcome
+        id: type-check-outcome
+        env:
+          CURRENT_DOWNLOAD_OUTCOME: ${{ steps.download-current.outcome }}
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          outcome=$(gh api \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_ID/jobs" \
+            --paginate \
+            --jq '.jobs[].steps[] | select(.name == "Type Check") | .conclusion' \
+            | tail -n 1)
+
+          if [[ "$CURRENT_DOWNLOAD_OUTCOME" != "success" || "$outcome" != "success" ]]; then
+            outcome="failure"
+          fi
+
+          echo "value=$outcome" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare current snapshot
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/current"
+          diagnostics="$RUNNER_TEMP/current/typescript-extended-diagnostics.log"
+          if [[ ! -f "$diagnostics" ]]; then
+            touch "$diagnostics"
+          fi
+
+          node scripts/ci/typescriptPerformanceSentinel.js parse \
+            --input "$diagnostics" \
+            --output "$RUNNER_TEMP/current.json" \
+            --source-sha "$HEAD_SHA"
+
+      - name: Download latest develop baseline
+        id: download-baseline
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          baseline_run_id=$(gh run list \
+            --repo "$GITHUB_REPOSITORY" \
+            --workflow typescript-performance-baseline.yml \
+            --branch develop \
+            --status success \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId')
+
+          if [[ -z "$baseline_run_id" || "$baseline_run_id" == "null" ]]; then
+            exit 1
+          fi
+
+          gh run download "$baseline_run_id" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name typescript-performance-baseline \
+            --dir "$RUNNER_TEMP/baseline"
+
+      - name: Create PR report
+        env:
+          TYPE_CHECK_OUTCOME: ${{ steps.type-check-outcome.outputs.value }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          node scripts/ci/typescriptPerformanceSentinel.js report \
+            --current "$RUNNER_TEMP/current.json" \
+            --baseline "$RUNNER_TEMP/baseline/typescript-performance-baseline.json" \
+            --output "$RUNNER_TEMP/typescript-performance-comment.md" \
+            --type-check-outcome "$TYPE_CHECK_OUTCOME" \
+            --workflow-run-url "https://github.com/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_ID"
+
+      - name: Find existing PR comment
+        id: find-comment
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
+        with:
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "<!-- typescript-performance-sentinel:v1 -->"
+
+      - name: Create or update PR comment
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          body-path: ${{ runner.temp }}/typescript-performance-comment.md
+          edit-mode: replace

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -9,7 +9,7 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "build:core": "yarn g:rimraf dist && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/core.webpack.config.ts",
-        "type-check": "yarn g:tsc --build tsconfig.json && yarn g:tsc --build scripts/tsconfig.json",
+        "type-check": "yarn g:tsc --build tsconfig.json scripts/tsconfig.json",
         "test:unit": "yarn g:jest",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },

--- a/scripts/ci/__tests__/typescriptPerformanceSentinel.test.js
+++ b/scripts/ci/__tests__/typescriptPerformanceSentinel.test.js
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+    createTypeScriptPerformanceReport,
+    parseTypeScriptExtendedDiagnostics,
+} from '../typescriptPerformanceSentinel.js';
+
+const createSnapshot = ({ sourceSha, projects }) => ({
+    schemaVersion: 1,
+    sourceSha,
+    generatedAt: '2026-07-19T12:00:00.000Z',
+    projects,
+});
+
+test('parses deterministic metrics from Nx-prefixed extended diagnostics', () => {
+    const diagnostics = [
+        '\u001b[32m@trezor/alpha: Types: 1,200\u001b[0m',
+        '@trezor/alpha: Instantiations: 340',
+        '@trezor/alpha: Assignability cache size: 90',
+        '@trezor/alpha: Identity cache size: 4',
+        '@trezor/alpha: Subtype cache size: 3',
+        '@trezor/alpha: Strict subtype cache size: 2',
+        '@trezor/alpha: Aggregate Types: 1,200',
+        '@trezor/alpha: Types: 10',
+        'invalid | project: Types: 999',
+    ].join('\n');
+
+    assert.deepEqual(parseTypeScriptExtendedDiagnostics(diagnostics), {
+        '@trezor/alpha': {
+            types: 1210,
+            instantiations: 340,
+            assignabilityCacheSize: 90,
+            identityCacheSize: 4,
+            subtypeCacheSize: 3,
+            strictSubtypeCacheSize: 2,
+        },
+    });
+});
+
+test('renders a comparison for projects present in both snapshots', () => {
+    const baseline = createSnapshot({
+        sourceSha: '1111111111111111111111111111111111111111',
+        projects: {
+            '@trezor/alpha': {
+                types: 1000,
+                instantiations: 500,
+                assignabilityCacheSize: 100,
+                identityCacheSize: 10,
+                subtypeCacheSize: 5,
+                strictSubtypeCacheSize: 2,
+            },
+        },
+    });
+    const current = createSnapshot({
+        sourceSha: '2222222222222222222222222222222222222222',
+        projects: {
+            '@trezor/alpha': {
+                types: 900,
+                instantiations: 550,
+                assignabilityCacheSize: 80,
+                identityCacheSize: 10,
+                subtypeCacheSize: 4,
+                strictSubtypeCacheSize: 2,
+            },
+            '@trezor/new-project': {
+                types: 25,
+                instantiations: 5,
+                assignabilityCacheSize: 3,
+                identityCacheSize: 0,
+                subtypeCacheSize: 0,
+                strictSubtypeCacheSize: 0,
+            },
+        },
+    });
+
+    const report = createTypeScriptPerformanceReport({
+        baseline,
+        current,
+        typeCheckOutcome: 'success',
+        workflowRunUrl: 'https://github.com/trezor/trezor-suite/actions/runs/123',
+    });
+
+    assert.match(report, /<!-- typescript-performance-sentinel:v1 -->/);
+    assert.match(report, /Compared `2222222` with `develop@1111111`/);
+    assert.match(report, /\| Types \| 1,000 \| 900 \| −100 \(−10\.0%\) \|/);
+    assert.match(report, /\| Instantiations \| 500 \| 550 \| \+50 \(\+10\.0%\) \|/);
+    assert.match(report, /@trezor\/new-project.*No baseline/);
+    assert.match(report, /https:\/\/github\.com\/trezor\/trezor-suite\/actions\/runs\/123/);
+});
+
+test('reports unavailable comparison data without presenting stale results', () => {
+    const current = createSnapshot({
+        sourceSha: '2222222222222222222222222222222222222222',
+        projects: {
+            '@trezor/alpha': {
+                types: 100,
+                instantiations: 50,
+                assignabilityCacheSize: 10,
+                identityCacheSize: 1,
+                subtypeCacheSize: 0,
+                strictSubtypeCacheSize: 0,
+            },
+        },
+    });
+
+    const missingBaselineReport = createTypeScriptPerformanceReport({
+        current,
+        typeCheckOutcome: 'success',
+        workflowRunUrl: 'https://github.com/trezor/trezor-suite/actions/runs/123',
+    });
+    const failedTypeCheckReport = createTypeScriptPerformanceReport({
+        current,
+        typeCheckOutcome: 'failure',
+        workflowRunUrl: 'https://github.com/trezor/trezor-suite/actions/runs/123',
+    });
+
+    assert.match(missingBaselineReport, /develop baseline is not available/i);
+    assert.match(failedTypeCheckReport, /type-check did not complete successfully/i);
+});

--- a/scripts/ci/typescriptPerformanceSentinel.js
+++ b/scripts/ci/typescriptPerformanceSentinel.js
@@ -1,0 +1,432 @@
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { parseArgs } from 'node:util';
+
+const SCHEMA_VERSION = 1;
+const MAX_LOG_SIZE_BYTES = 50 * 1024 * 1024;
+const MAX_PROJECT_ROWS = 30;
+const COMMENT_MARKER = '<!-- typescript-performance-sentinel:v1 -->';
+
+const metrics = [
+    { key: 'types', label: 'Types' },
+    { key: 'instantiations', label: 'Instantiations' },
+    { key: 'assignabilityCacheSize', label: 'Assignability cache' },
+    { key: 'identityCacheSize', label: 'Identity cache' },
+    { key: 'subtypeCacheSize', label: 'Subtype cache' },
+    { key: 'strictSubtypeCacheSize', label: 'Strict subtype cache' },
+];
+
+const metricKeyByDiagnosticLabel = new Map([
+    ['Types', 'types'],
+    ['Instantiations', 'instantiations'],
+    ['Assignability cache size', 'assignabilityCacheSize'],
+    ['Identity cache size', 'identityCacheSize'],
+    ['Subtype cache size', 'subtypeCacheSize'],
+    ['Strict subtype cache size', 'strictSubtypeCacheSize'],
+]);
+
+const ansiEscapePattern = new RegExp(
+    `${String.fromCodePoint(27)}(?:[@-Z\\\\-_]|\\[[0-?]*[ -/]*[@-~])`,
+    'g',
+);
+const diagnosticPattern =
+    /^([@A-Za-z0-9][@A-Za-z0-9._/-]{0,127}):\s+(Types|Instantiations|Assignability cache size|Identity cache size|Subtype cache size|Strict subtype cache size):\s+([\d,]+)\s*$/;
+const shaPattern = /^[a-f0-9]{7,40}$/;
+const workflowRunUrlPattern = /^https:\/\/github\.com\/trezor\/trezor-suite\/actions\/runs\/\d+$/;
+
+const createEmptyMetrics = () => ({
+    types: 0,
+    instantiations: 0,
+    assignabilityCacheSize: 0,
+    identityCacheSize: 0,
+    subtypeCacheSize: 0,
+    strictSubtypeCacheSize: 0,
+});
+
+export const parseTypeScriptExtendedDiagnostics = diagnosticLog => {
+    const projects = {};
+
+    for (const rawLine of diagnosticLog.split(/\r?\n/)) {
+        const line = rawLine.replace(ansiEscapePattern, '');
+        const match = line.match(diagnosticPattern);
+
+        if (match === null) {
+            continue;
+        }
+
+        const [, projectName, diagnosticLabel, rawValue] = match;
+        const metricKey = metricKeyByDiagnosticLabel.get(diagnosticLabel);
+
+        if (metricKey === undefined) {
+            continue;
+        }
+
+        const value = Number(rawValue.replaceAll(',', ''));
+
+        if (!Number.isSafeInteger(value) || value < 0) {
+            continue;
+        }
+
+        const projectMetrics = projects[projectName] ?? createEmptyMetrics();
+        projectMetrics[metricKey] += value;
+        projects[projectName] = projectMetrics;
+    }
+
+    return projects;
+};
+
+const isRecord = value => typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isMetrics = value =>
+    isRecord(value) &&
+    metrics.every(({ key }) => Number.isSafeInteger(value[key]) && value[key] >= 0);
+
+const validateSnapshot = snapshot => {
+    if (
+        !isRecord(snapshot) ||
+        snapshot.schemaVersion !== SCHEMA_VERSION ||
+        typeof snapshot.sourceSha !== 'string' ||
+        !shaPattern.test(snapshot.sourceSha) ||
+        typeof snapshot.generatedAt !== 'string' ||
+        !isRecord(snapshot.projects)
+    ) {
+        throw new Error('Invalid TypeScript performance snapshot.');
+    }
+
+    for (const [projectName, projectMetrics] of Object.entries(snapshot.projects)) {
+        if (!diagnosticPattern.test(`${projectName}: Types: 0`) || !isMetrics(projectMetrics)) {
+            throw new Error(`Invalid TypeScript performance data for project "${projectName}".`);
+        }
+    }
+
+    return snapshot;
+};
+
+const sumProjectMetrics = ({ projectNames, projects }) => {
+    const total = createEmptyMetrics();
+
+    for (const projectName of projectNames) {
+        const projectMetrics = projects[projectName];
+
+        for (const { key } of metrics) {
+            total[key] += projectMetrics[key];
+        }
+    }
+
+    return total;
+};
+
+const integerFormatter = new Intl.NumberFormat('en-US');
+const formatInteger = value => integerFormatter.format(value);
+
+const formatChange = ({ baselineValue, currentValue }) => {
+    const difference = currentValue - baselineValue;
+
+    if (difference === 0) {
+        return '0 (0.0%)';
+    }
+
+    const sign = difference > 0 ? '+' : '−';
+    const absoluteDifference = Math.abs(difference);
+
+    if (baselineValue === 0) {
+        return `${sign}${formatInteger(absoluteDifference)} (new)`;
+    }
+
+    const percentage = (absoluteDifference / baselineValue) * 100;
+
+    return `${sign}${formatInteger(absoluteDifference)} (${sign}${percentage.toFixed(1)}%)`;
+};
+
+const createMetricComparisonTable = ({ baselineMetrics, currentMetrics }) => [
+    '| Metric | develop | PR | Change |',
+    '| --- | ---: | ---: | ---: |',
+    ...metrics.map(
+        ({ key, label }) =>
+            `| ${label} | ${formatInteger(baselineMetrics[key])} | ${formatInteger(currentMetrics[key])} | ${formatChange(
+                {
+                    baselineValue: baselineMetrics[key],
+                    currentValue: currentMetrics[key],
+                },
+            )} |`,
+    ),
+];
+
+const createCurrentMetricsTable = currentMetrics => [
+    '| Metric | PR |',
+    '| --- | ---: |',
+    ...metrics.map(({ key, label }) => `| ${label} | ${formatInteger(currentMetrics[key])} |`),
+];
+
+const getProjectDifferenceWeight = ({ baselineMetrics, currentMetrics }) =>
+    Math.abs(currentMetrics.instantiations - baselineMetrics.instantiations) +
+    Math.abs(currentMetrics.types - baselineMetrics.types);
+
+const createProjectComparison = ({ baseline, current }) => {
+    const currentProjectNames = Object.keys(current.projects).sort();
+    const comparableProjectNames = currentProjectNames.filter(
+        projectName => baseline.projects[projectName] !== undefined,
+    );
+    const newProjectNames = currentProjectNames.filter(
+        projectName => baseline.projects[projectName] === undefined,
+    );
+    const baselineTotal = sumProjectMetrics({
+        projectNames: comparableProjectNames,
+        projects: baseline.projects,
+    });
+    const currentTotal = sumProjectMetrics({
+        projectNames: comparableProjectNames,
+        projects: current.projects,
+    });
+    const sortedComparableProjects = comparableProjectNames.sort(
+        (firstProjectName, secondProjectName) =>
+            getProjectDifferenceWeight({
+                baselineMetrics: baseline.projects[secondProjectName],
+                currentMetrics: current.projects[secondProjectName],
+            }) -
+            getProjectDifferenceWeight({
+                baselineMetrics: baseline.projects[firstProjectName],
+                currentMetrics: current.projects[firstProjectName],
+            }),
+    );
+    const displayedProjectNames = [...sortedComparableProjects, ...newProjectNames].slice(
+        0,
+        MAX_PROJECT_ROWS,
+    );
+    const projectRows = displayedProjectNames.map(projectName => {
+        const baselineMetrics = baseline.projects[projectName];
+        const currentMetrics = current.projects[projectName];
+
+        if (baselineMetrics === undefined) {
+            return `| ${projectName} | ${formatInteger(currentMetrics.types)} | ${formatInteger(
+                currentMetrics.instantiations,
+            )} | No baseline |`;
+        }
+
+        return `| ${projectName} | ${formatChange({
+            baselineValue: baselineMetrics.types,
+            currentValue: currentMetrics.types,
+        })} | ${formatChange({
+            baselineValue: baselineMetrics.instantiations,
+            currentValue: currentMetrics.instantiations,
+        })} | Compared |`;
+    });
+    const hiddenProjectCount = currentProjectNames.length - displayedProjectNames.length;
+
+    return {
+        baselineTotal,
+        comparableProjectNames,
+        currentTotal,
+        hiddenProjectCount,
+        projectRows,
+    };
+};
+
+export const createTypeScriptPerformanceReport = ({
+    baseline,
+    current,
+    typeCheckOutcome,
+    workflowRunUrl,
+}) => {
+    validateSnapshot(current);
+
+    if (baseline !== undefined) {
+        validateSnapshot(baseline);
+    }
+
+    const runLink = workflowRunUrlPattern.test(workflowRunUrl)
+        ? `[workflow run](${workflowRunUrl})`
+        : 'workflow run unavailable';
+    const lines = [
+        COMMENT_MARKER,
+        '## TypeScript complexity',
+        '',
+        '> Report-only. Deterministic compiler counters are collected from the existing affected-project type-check; check time and memory are intentionally omitted.',
+        '',
+    ];
+
+    if (typeCheckOutcome !== 'success') {
+        lines.push(
+            '⚠️ The type-check did not complete successfully, so this comment does not show potentially stale or partial counters.',
+            '',
+            `Measured for \`${current.sourceSha.slice(0, 7)}\` · ${runLink}`,
+        );
+
+        return `${lines.join('\n')}\n`;
+    }
+
+    const currentProjectNames = Object.keys(current.projects);
+
+    if (currentProjectNames.length === 0) {
+        lines.push(
+            'No affected TypeScript projects emitted extended diagnostics.',
+            '',
+            `Measured for \`${current.sourceSha.slice(0, 7)}\` · ${runLink}`,
+        );
+
+        return `${lines.join('\n')}\n`;
+    }
+
+    if (baseline === undefined) {
+        const currentTotal = sumProjectMetrics({
+            projectNames: currentProjectNames,
+            projects: current.projects,
+        });
+        lines.push(
+            '⚠️ The develop baseline is not available yet. Current counters are shown without a comparison.',
+            '',
+            ...createCurrentMetricsTable(currentTotal),
+            '',
+            `Measured for \`${current.sourceSha.slice(0, 7)}\` · ${runLink}`,
+        );
+
+        return `${lines.join('\n')}\n`;
+    }
+
+    const comparison = createProjectComparison({ baseline, current });
+    lines.push(
+        `Compared \`${current.sourceSha.slice(0, 7)}\` with \`develop@${baseline.sourceSha.slice(
+            0,
+            7,
+        )}\` across ${comparison.comparableProjectNames.length} affected project(s).`,
+        '',
+        ...createMetricComparisonTable({
+            baselineMetrics: comparison.baselineTotal,
+            currentMetrics: comparison.currentTotal,
+        }),
+        '',
+        '<details>',
+        '<summary>Per-project Types and Instantiations</summary>',
+        '',
+        '| Project | Types change | Instantiations change | Baseline status |',
+        '| --- | ---: | ---: | --- |',
+        ...comparison.projectRows,
+    );
+
+    if (comparison.hiddenProjectCount > 0) {
+        lines.push(
+            `| … | … | … | ${comparison.hiddenProjectCount} additional project(s) omitted |`,
+        );
+    }
+
+    lines.push(
+        '',
+        '</details>',
+        '',
+        `Measured for \`${current.sourceSha.slice(0, 7)}\` · baseline generated ${baseline.generatedAt} · ${runLink}`,
+    );
+
+    return `${lines.join('\n')}\n`;
+};
+
+const getRequiredStringOption = ({ optionName, values }) => {
+    const value = values[optionName];
+
+    if (typeof value !== 'string' || value.length === 0) {
+        throw new Error(`Missing --${optionName}.`);
+    }
+
+    return value;
+};
+
+const readTextFile = filePath => {
+    if (statSync(filePath).size > MAX_LOG_SIZE_BYTES) {
+        throw new Error(`File exceeds ${MAX_LOG_SIZE_BYTES} bytes: ${filePath}`);
+    }
+
+    return readFileSync(filePath, 'utf8');
+};
+
+const readSnapshot = filePath => validateSnapshot(JSON.parse(readTextFile(filePath)));
+
+const writeTextFile = ({ content, filePath }) => {
+    writeFileSync(filePath, content.endsWith('\n') ? content : `${content}\n`, 'utf8');
+};
+
+const runParseCommand = values => {
+    const inputPath = getRequiredStringOption({ optionName: 'input', values });
+    const outputPath = getRequiredStringOption({ optionName: 'output', values });
+    const sourceSha = getRequiredStringOption({ optionName: 'source-sha', values });
+
+    if (!shaPattern.test(sourceSha)) {
+        throw new Error('Invalid --source-sha.');
+    }
+
+    const snapshot = {
+        schemaVersion: SCHEMA_VERSION,
+        sourceSha,
+        generatedAt: new Date().toISOString(),
+        projects: parseTypeScriptExtendedDiagnostics(readTextFile(inputPath)),
+    };
+
+    writeTextFile({ content: JSON.stringify(snapshot, null, 2), filePath: outputPath });
+};
+
+const runReportCommand = values => {
+    const currentPath = getRequiredStringOption({ optionName: 'current', values });
+    const outputPath = getRequiredStringOption({ optionName: 'output', values });
+    const typeCheckOutcome = getRequiredStringOption({
+        optionName: 'type-check-outcome',
+        values,
+    });
+    const workflowRunUrl = getRequiredStringOption({ optionName: 'workflow-run-url', values });
+    const baselinePath = values.baseline;
+    const baseline =
+        typeof baselinePath === 'string' && existsSync(baselinePath)
+            ? readSnapshot(baselinePath)
+            : undefined;
+    const report = createTypeScriptPerformanceReport({
+        baseline,
+        current: readSnapshot(currentPath),
+        typeCheckOutcome,
+        workflowRunUrl,
+    });
+
+    writeTextFile({ content: report, filePath: outputPath });
+};
+
+const main = () => {
+    const { positionals, values } = parseArgs({
+        args: process.argv.slice(2),
+        allowPositionals: true,
+        options: {
+            baseline: { type: 'string' },
+            current: { type: 'string' },
+            input: { type: 'string' },
+            output: { type: 'string' },
+            'source-sha': { type: 'string' },
+            'type-check-outcome': { type: 'string' },
+            'workflow-run-url': { type: 'string' },
+        },
+        strict: true,
+    });
+    const command = positionals[0];
+
+    if (command === 'parse') {
+        runParseCommand(values);
+
+        return;
+    }
+
+    if (command === 'report') {
+        runReportCommand(values);
+
+        return;
+    }
+
+    throw new Error('Expected command "parse" or "report".');
+};
+
+const isExecutedDirectly =
+    process.argv[1] !== undefined &&
+    pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+
+if (isExecutedDirectly) {
+    try {
+        main();
+    } catch (error) {
+        console.error(error instanceof Error ? error.message : error);
+        process.exitCode = 1;
+    }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,6 +6,7 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
+        "test:unit": "node --test ci/__tests__/typescriptPerformanceSentinel.test.js",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "generate-package": "tsx generatePackage.ts"
     },


### PR DESCRIPTION
## Description

TypeScript complexity regressions currently require manual traces and provide no PR-level feedback. The existing affected-project type-check now forwards `--extendedDiagnostics` and uploads its raw log; a trusted follow-up workflow compares six deterministic compiler counters with a nightly, Nx-cached `develop` baseline and replaces one sticky PR comment on every run. PR code never receives a write token, performance remains report-only, and noisy time and memory measurements are intentionally excluded. Because the reporter runs only from trusted `develop`, dispatch the baseline workflow once after merge; this PR validates the diagnostics artifact, while sticky comments begin after the reporter lands.

- PR-side TypeScript compiler passes: **1 → 1**
- Additional PR-side baseline compilations: **0**
- Deterministic counters reported: **6**
- Sticky comments per PR: **1**
- Develop baseline frequency: **nightly**

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ci/typescript-performance-sentinel/web/](https://dev.suite.sldev.cz/suite-web/ci/typescript-performance-sentinel/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/typescript-performance-sentinel&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/typescript-performance-sentinel&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-19T07:58:53.910Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->