### PR TITLE
refactor(suite): narrow graph reducer action boundary

### DIFF
--- a/packages/suite/src/reducers/wallet/graphReducer.ts
+++ b/packages/suite/src/reducers/wallet/graphReducer.ts
@@ -1,12 +1,14 @@
 import { produce } from 'immer';
+import { type Action } from 'redux';
 
 import { accountsActions } from '@suite-common/wallet-core';
 
 import { STORAGE } from 'src/actions/suite/constants';
+import { type StorageLoadAction } from 'src/actions/suite/storageActions';
 import { GRAPH } from 'src/actions/wallet/constants';
+import { type GraphAction } from 'src/actions/wallet/graphActions';
 import { SETTINGS } from 'src/config/suite';
-import { type Action as SuiteAction } from 'src/types/suite';
-import { type Account, type WalletAction } from 'src/types/wallet';
+import { type Account } from 'src/types/wallet';
 import { type AccountIdentifier, type GraphData, type GraphRange } from 'src/types/wallet/graph';
 
 export interface GraphState {
@@ -80,11 +82,32 @@ const remove = (draft: GraphState, accounts: Account[]) => {
     updateError(draft);
 };
 
-const graphReducer = (
-    state: GraphState = initialState,
-    action: WalletAction | SuiteAction,
-): GraphState =>
-    produce(state, draft => {
+type GraphReducerAction =
+    | GraphAction
+    | StorageLoadAction
+    | ReturnType<typeof accountsActions.removeAccount>;
+
+const isGraphReducerAction = (action: Action): action is GraphReducerAction => {
+    switch (action.type) {
+        case STORAGE.LOAD:
+        case GRAPH.ACCOUNT_GRAPH_START:
+        case GRAPH.ACCOUNT_GRAPH_SUCCESS:
+        case GRAPH.ACCOUNT_GRAPH_FAIL:
+        case GRAPH.AGGREGATED_GRAPH_START:
+        case GRAPH.AGGREGATED_GRAPH_SUCCESS:
+        case GRAPH.SET_SELECTED_RANGE:
+            return true;
+        default:
+            return accountsActions.removeAccount.match(action);
+    }
+};
+
+const graphReducer = (state: GraphState = initialState, action: Action): GraphState => {
+    if (!isGraphReducerAction(action)) {
+        return state;
+    }
+
+    return produce(state, draft => {
         switch (action.type) {
             case STORAGE.LOAD:
                 loadFromStorage(draft, action.payload.graph);
@@ -107,14 +130,12 @@ const graphReducer = (
             case GRAPH.SET_SELECTED_RANGE:
                 draft.selectedRange = action.payload;
                 break;
-            case accountsActions.removeAccount.type: {
-                if (accountsActions.removeAccount.match(action)) {
-                    remove(draft, action.payload);
-                }
+            case accountsActions.removeAccount.type:
+                remove(draft, action.payload);
                 break;
-            }
             // no default
         }
     });
+};
 
 export default graphReducer;


### PR DESCRIPTION
## Description

The graph reducer accepted the complete WalletAction and SuiteAction unions despite handling only eight action shapes. It now accepts the base Redux Action required by reducer composition, then uses a local type guard to narrow payload access to graph actions, storage load, and account removal. Unknown actions still return the existing state unchanged.

- Action parameter: **469 union members → 1 base action type**
- Rendered parameter type: **65,370 → 11 characters (99.98% smaller)**
- Declaration: **503 → 404 bytes (19.7% smaller)**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is the wallet graph reducer, which manages state for the portfolio/account balance graph shown on the dashboard and account transaction overview. Since this reducer maps broadly to 131 tests via transitive imports (a global suite dependency), only tests that directly exercise graph-related UI behavior (time-range filtering, balance/graph visibility after discovery or onboarding) are recommended, rather than the full breadth of suite tests. Focus testing on suite/e2e/tests/wallet/transactions.test.ts for direct graph range-selector coverage, supplemented by smoke checks on graph visibility in backup and discovery flows.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/reducers/wallet/graphReducer.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly exercises the account transaction overview graph, including cycling through all time range filters (day/week/month/year/all), which is the core UI functionality backed by the wallet graph reducer's state.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies account balance display and updates after receiving funds on a regtest account, which relies on wallet state (including graph/balance data) managed in reducers similar to graphReducer.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/backup/t2t1-misc.test.ts` — This test asserts the dashboard graph becomes visible after onboarding, providing a basic smoke check that graph rendering/state still initializes correctly.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test asserts the dashboard portfolio graph is visible after discovery completes with a custom backend, giving another smoke check on graph state rendering after account discovery.

</details>

_Updated: 2026-07-19T14:30:33.857Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/graph-reducer-actions&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/graph-reducer-actions&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-19T14:34:13.582Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-19T14:32:54.816Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/graph-reducer-actions/web/](https://dev.suite.sldev.cz/suite-web/refactor/graph-reducer-actions/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->