### PR TITLE
refactor(suite): narrow reducer action contracts

### DIFF
--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -1,3 +1,5 @@
+import { type Action } from 'redux';
+
 import { metadataActions } from '@suite/metadata';
 import {
     routerLocationChange,
@@ -20,7 +22,7 @@ import { type SelectedAccountStatus, type WalletParams } from '@suite-common/wal
 import { isChanged } from '@trezor/utils';
 
 import { accountSearchActions } from 'src/reducers/wallet/accountSearchReducer';
-import { type Action, type AppState, type Dispatch, type GetState } from 'src/types/suite';
+import { type AppState, type Dispatch, type GetState } from 'src/types/suite';
 import { getSelectedAccount } from 'src/utils/wallet/accountUtils';
 
 // move to selector!!!!

--- a/packages/suite/src/reducers/desktop/__tests__/desktopReducer.test.ts
+++ b/packages/suite/src/reducers/desktop/__tests__/desktopReducer.test.ts
@@ -1,6 +1,6 @@
 import type { HandshakeElectron } from '@trezor/suite-desktop-api';
 
-import * as SUITE from 'src/actions/suite/constants/suiteConstants';
+import { desktopHandshake } from 'src/actions/suite/suiteActions';
 
 import { desktopReducer } from '../index';
 
@@ -16,8 +16,6 @@ const handshakePayload: HandshakeElectron = {
 
 describe('desktop reducer', () => {
     it('SUITE.DESKTOP_HANDSHAKE', () => {
-        expect(
-            desktopReducer(null, { type: SUITE.DESKTOP_HANDSHAKE, payload: handshakePayload }),
-        ).toEqual(handshakePayload);
+        expect(desktopReducer(null, desktopHandshake(handshakePayload))).toEqual(handshakePayload);
     });
 });

--- a/packages/suite/src/reducers/desktop/index.ts
+++ b/packages/suite/src/reducers/desktop/index.ts
@@ -1,7 +1,14 @@
+import { type Action as ReduxAction } from 'redux';
+
 import type { HandshakeElectron } from '@trezor/suite-desktop-api';
 
 import { SUITE } from 'src/actions/suite/constants';
-import { type Action } from 'src/types/suite';
+import { type SuiteAction } from 'src/actions/suite/suiteActions';
+
+type DesktopHandshakeAction = Extract<SuiteAction, { type: typeof SUITE.DESKTOP_HANDSHAKE }>;
+
+const isDesktopHandshakeAction = (action: ReduxAction): action is DesktopHandshakeAction =>
+    action.type === SUITE.DESKTOP_HANDSHAKE;
 
 export type DesktopState = null | Pick<HandshakeElectron, 'paths' | 'urls'>;
 
@@ -9,13 +16,19 @@ const initialState: DesktopState = null;
 
 export const desktopReducer = (
     state: DesktopState = initialState,
-    action: Action,
+    action: ReduxAction,
 ): DesktopState => {
-    switch (action.type) {
+    if (!isDesktopHandshakeAction(action)) {
+        return state;
+    }
+
+    const desktopAction: DesktopHandshakeAction = action;
+
+    switch (desktopAction.type) {
         case SUITE.DESKTOP_HANDSHAKE:
             return {
                 ...state,
-                ...action.payload,
+                ...desktopAction.payload,
             };
 
         default:

--- a/packages/suite/src/reducers/onboarding/onboardingReducer.ts
+++ b/packages/suite/src/reducers/onboarding/onboardingReducer.ts
@@ -1,13 +1,26 @@
 import { produce } from 'immer';
+import { type Action as ReduxAction } from 'redux';
 
 import { type OnboardingAnalytics } from '@suite/analytics';
 import { type BackupType } from '@suite-common/suite-types';
-import { DEVICE } from '@trezor/connect';
+import { DEVICE, type DeviceEvent } from '@trezor/connect';
+import { isArrayMember } from '@trezor/utils';
 
 import { ONBOARDING } from 'src/actions/onboarding/constants';
+import { type OnboardingAction } from 'src/actions/onboarding/onboardingActions';
 import * as STEP from 'src/constants/onboarding/steps';
 import type { AnyPath, AnyStepId } from 'src/types/onboarding';
-import { type Action } from 'src/types/suite';
+
+type DeviceDisconnectAction = DeviceEvent & { type: typeof DEVICE.DISCONNECT };
+type OnboardingReducerAction = OnboardingAction | DeviceDisconnectAction;
+
+const ONBOARDING_REDUCER_ACTION_TYPES = [
+    ...Object.values(ONBOARDING),
+    DEVICE.DISCONNECT,
+] as const satisfies OnboardingReducerAction['type'][];
+
+const isOnboardingReducerAction = (action: ReduxAction): action is OnboardingReducerAction =>
+    isArrayMember(action.type, ONBOARDING_REDUCER_ACTION_TYPES);
 
 export interface OnboardingRootState {
     onboarding: OnboardingState;
@@ -51,42 +64,51 @@ const addPath = (path: AnyPath, state: OnboardingState) => {
 const removePath = (paths: AnyPath[], state: OnboardingState) =>
     state.path.filter(p => !paths.includes(p));
 
-const ALLOWED_ACTION_TYPES = new Set<Action['type']>([
+const ALLOWED_ACTION_TYPES = new Set<OnboardingReducerAction['type']>([
     ONBOARDING.RESET_ONBOARDING,
     ONBOARDING.ENABLE_ONBOARDING_REDUCER,
     ONBOARDING.ANALYTICS,
 ]);
 
-const onboarding = (state: OnboardingState = initialState, action: Action) => {
+const onboarding = (state: OnboardingState = initialState, action: ReduxAction) => {
+    if (!isOnboardingReducerAction(action)) {
+        return state;
+    }
+
     if (!state.isActive && !ALLOWED_ACTION_TYPES.has(action.type)) {
         return state;
     }
 
+    const onboardingAction: OnboardingReducerAction = action;
+
     return produce(state, draft => {
-        switch (action.type) {
+        switch (onboardingAction.type) {
             case ONBOARDING.ENABLE_ONBOARDING_REDUCER:
-                draft.isActive = action.payload;
+                draft.isActive = onboardingAction.payload;
                 break;
             case ONBOARDING.SET_STEP_ACTIVE:
-                draft.activeStepId = action.stepId;
+                draft.activeStepId = onboardingAction.stepId;
                 break;
             case ONBOARDING.ADD_PATH:
-                draft.path = addPath(action.payload, state);
+                draft.path = addPath(onboardingAction.payload, state);
                 break;
             case ONBOARDING.REMOVE_PATH:
-                draft.path = removePath(action.payload, state);
+                draft.path = removePath(onboardingAction.payload, state);
                 break;
             case DEVICE.DISCONNECT:
-                draft.prevDeviceId = action.payload.id ?? null;
+                draft.prevDeviceId = onboardingAction.payload.id ?? null;
                 break;
             case ONBOARDING.ANALYTICS:
-                draft.onboardingAnalytics = { ...state.onboardingAnalytics, ...action.payload };
+                draft.onboardingAnalytics = {
+                    ...state.onboardingAnalytics,
+                    ...onboardingAction.payload,
+                };
                 break;
             case ONBOARDING.SELECT_BACKUP_TYPE:
-                draft.backupType = action.payload;
+                draft.backupType = onboardingAction.payload;
                 break;
             case ONBOARDING.SELECT_BACKUP_MEDIUM:
-                draft.backupMedium = action.payload;
+                draft.backupMedium = onboardingAction.payload;
                 break;
 
             case ONBOARDING.RESET_ONBOARDING:

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -7,6 +7,7 @@ import {
     type MiddlewareAPI,
     type Reducer,
     type ReducersMapObject,
+    type Action as ReduxAction,
     type UnknownAction,
     combineReducers,
     configureStore,
@@ -165,9 +166,7 @@ const patchConfirm = (statePatch: any) =>
             JSON.stringify(statePatch, null, 4),
     );
 
-type RootReducerShape = typeof rootReducer;
 export type PreloadedState = Partial<AppState>;
-type InferredAction = Parameters<RootReducerShape>[1];
 
 export type SuiteStoreDeps = HistoryDep &
     PlatformEncryptionDep &
@@ -223,7 +222,7 @@ export const initStore = (
     > | null;
 
     const store = configureStore({
-        reducer: rootReducer as Reducer<AppState, InferredAction, PreloadedState>,
+        reducer: rootReducer as Reducer<AppState, ReduxAction, PreloadedState>,
         preloadedState: patchedState,
         middleware: getDefaultMiddleware =>
             getDefaultMiddleware({

--- a/packages/suite/src/reducers/suite/guideReducer.ts
+++ b/packages/suite/src/reducers/suite/guideReducer.ts
@@ -1,9 +1,11 @@
+import { type Action as ReduxAction } from 'redux';
+
 import type { ActiveView, GuideCategory, GuideNode } from '@suite-common/suite-types';
 import { variables } from '@trezor/components';
 import * as indexNodeJSON from '@trezor/suite-data/files/guide/index.json';
 
 import { GUIDE } from 'src/actions/suite/constants';
-import { type Action } from 'src/types/suite';
+import { type GuideAction } from 'src/actions/suite/guideActions';
 
 export interface GuideState {
     open: boolean;
@@ -24,8 +26,10 @@ export const initialState: GuideState = {
 };
 
 // NOTE: we cannot use immer in this reducer, because GuideCategory mimics the react node and immer uses Object.freeze()
-const guideReducer = (state: GuideState = initialState, action: Action): GuideState => {
-    switch (action.type) {
+const guideReducer = (state: GuideState = initialState, action: ReduxAction): GuideState => {
+    const guideAction = action as GuideAction;
+
+    switch (guideAction.type) {
         case GUIDE.OPEN:
             return {
                 ...state,
@@ -40,12 +44,12 @@ const guideReducer = (state: GuideState = initialState, action: Action): GuideSt
         case GUIDE.SET_VIEW:
             return {
                 ...state,
-                view: action.payload,
+                view: guideAction.payload,
             };
         case GUIDE.SET_INDEX_NODE:
             return {
                 ...state,
-                indexNode: action.payload,
+                indexNode: guideAction.payload,
             };
         case GUIDE.UNSET_NODE:
             return {
@@ -55,12 +59,12 @@ const guideReducer = (state: GuideState = initialState, action: Action): GuideSt
         case GUIDE.OPEN_NODE:
             return {
                 ...state,
-                currentNode: action.payload,
+                currentNode: guideAction.payload,
             };
         case GUIDE.SET_WIDTH:
             return {
                 ...state,
-                width: action.payload,
+                width: guideAction.payload,
             };
         default:
             return state;

--- a/packages/suite/src/reducers/suite/index.ts
+++ b/packages/suite/src/reducers/suite/index.ts
@@ -30,7 +30,6 @@ import {
     prepareDesktopDeviceReducer,
 } from 'src/actions/device/deviceSlice';
 import { extraDependencies } from 'src/support/extraDependencies';
-import { type Action } from 'src/types/suite';
 
 import guide, { type GuideState } from './guideReducer';
 import protocol, { type ProtocolState } from './protocolReducer';
@@ -72,7 +71,7 @@ export type SuiteReducersState = {
     walletConnect: WalletConnectState;
 };
 
-export const suiteReducers: ReducersMapObject<SuiteReducersState, Action & UnknownAction> = {
+export const suiteReducers: ReducersMapObject<SuiteReducersState, UnknownAction> = {
     suite,
     discreetMode: discreetModeReducer,
     tor: torReducer,

--- a/packages/suite/src/reducers/suite/protocolReducer.ts
+++ b/packages/suite/src/reducers/suite/protocolReducer.ts
@@ -1,9 +1,16 @@
 import { produce } from 'immer';
+import { type Action as ReduxAction } from 'redux';
 
 import type { Protocol } from '@suite-common/suite-constants';
+import { isArrayMember } from '@trezor/utils';
 
 import { PROTOCOL } from 'src/actions/suite/constants';
-import type { Action } from 'src/types/suite';
+import { type ProtocolAction } from 'src/actions/suite/protocolActions';
+
+const PROTOCOL_ACTION_TYPES = Object.values(PROTOCOL);
+
+const isProtocolAction = (action: ReduxAction): action is ProtocolAction =>
+    isArrayMember(action.type, PROTOCOL_ACTION_TYPES);
 
 export interface SendFormState {
     scheme: Protocol;
@@ -25,18 +32,27 @@ export const initialState: ProtocolState = {
     sendForm: {},
 };
 
-const protocolReducer = (state: ProtocolState = initialState, action: Action): ProtocolState =>
-    produce(state, draft => {
-        switch (action.type) {
+const protocolReducer = (
+    state: ProtocolState = initialState,
+    action: ReduxAction,
+): ProtocolState => {
+    if (!isProtocolAction(action)) {
+        return state;
+    }
+
+    const protocolAction: ProtocolAction = action;
+
+    return produce(state, draft => {
+        switch (protocolAction.type) {
             case PROTOCOL.FILL_SEND_FORM:
-                draft.sendForm.shouldFill = action.payload;
+                draft.sendForm.shouldFill = protocolAction.payload;
                 break;
             case PROTOCOL.SAVE_COIN_PROTOCOL:
-                draft.sendForm.address = action.payload.address;
-                draft.sendForm.scheme = action.payload.scheme;
-                draft.sendForm.amount = action.payload.amount;
-                draft.sendForm.token = action.payload.token;
-                draft.sendForm.tokenAmount = action.payload.tokenAmount;
+                draft.sendForm.address = protocolAction.payload.address;
+                draft.sendForm.scheme = protocolAction.payload.scheme;
+                draft.sendForm.amount = protocolAction.payload.amount;
+                draft.sendForm.token = protocolAction.payload.token;
+                draft.sendForm.tokenAmount = protocolAction.payload.tokenAmount;
                 draft.sendForm.shouldFill = false;
                 break;
             case PROTOCOL.RESET:
@@ -44,5 +60,6 @@ const protocolReducer = (state: ProtocolState = initialState, action: Action): P
             // no default
         }
     });
+};
 
 export default protocolReducer;

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -1,11 +1,38 @@
 import { produce } from 'immer';
+import { type Action as ReduxAction } from 'redux';
 
 import type { CountryCode } from '@suite-common/geolocation';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { TRANSPORT, type TransportInfo } from '@trezor/connect';
+import { TRANSPORT, type TransportEvent, type TransportInfo } from '@trezor/connect';
+import { isArrayMember } from '@trezor/utils';
 
 import { STORAGE, SUITE } from 'src/actions/suite/constants';
-import { type Action } from 'src/types/suite';
+import { type StorageAction } from 'src/actions/suite/storageActions';
+import { type SuiteAction } from 'src/actions/suite/suiteActions';
+
+type SuiteReducerAction = StorageAction | SuiteAction | TransportEvent;
+
+const SUITE_REDUCER_ACTION_TYPES = [
+    STORAGE.LOAD,
+    STORAGE.ERROR,
+    STORAGE.CORRUPTED,
+    SUITE.INIT,
+    SUITE.READY,
+    SUITE.ERROR,
+    SUITE.SET_RECENTLY_CONNECTED_DEVICE,
+    SUITE.SET_RECENTLY_DISCONNECTED_DEVICE,
+    SUITE.ADD_DEVICE_ID_TO_SEEN_DISCONNECT_NOTIFICATION,
+    SUITE.EVM_CONFIRM_EXPLANATION_MODAL,
+    SUITE.EVM_CLOSE_EXPLANATION_BANNER,
+    SUITE.SET_SEND_FORM_PREFILL,
+    SUITE.SET_TRANSACTION_HISTORY_PREFILL,
+    TRANSPORT.START,
+    TRANSPORT.ERROR,
+    SUITE.ONLINE_STATUS,
+] as const satisfies SuiteReducerAction['type'][];
+
+const isSuiteReducerAction = (action: ReduxAction): action is SuiteReducerAction =>
+    isArrayMember(action.type, SUITE_REDUCER_ACTION_TYPES);
 
 export type SuiteRootState = {
     suite: SuiteState;
@@ -69,24 +96,31 @@ const initialState: SuiteState = {
 
 export const suiteInitialState = initialState;
 
-const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteState =>
-    produce(state, draft => {
-        switch (action.type) {
+const suiteReducer = (state: SuiteState = initialState, action: ReduxAction): SuiteState => {
+    if (!isSuiteReducerAction(action)) {
+        return state;
+    }
+
+    const suiteAction: SuiteReducerAction = action;
+
+    return produce(state, draft => {
+        switch (suiteAction.type) {
             case STORAGE.LOAD:
                 draft.evmSettings = {
                     ...draft.evmSettings,
-                    ...action.payload.suiteSettings?.evmSettings,
+                    ...suiteAction.payload.suiteSettings?.evmSettings,
                 };
                 draft.seenDisconnectNotificationForDeviceIds = [
                     ...draft.seenDisconnectNotificationForDeviceIds,
-                    ...(action.payload.suiteSettings?.seenDisconnectNotificationForDeviceIds ?? []),
+                    ...(suiteAction.payload.suiteSettings?.seenDisconnectNotificationForDeviceIds ??
+                        []),
                 ];
                 break;
             case STORAGE.ERROR:
-                draft.lifecycle = { status: 'db-error', error: action.payload };
+                draft.lifecycle = { status: 'db-error', error: suiteAction.payload };
                 break;
             case STORAGE.CORRUPTED:
-                draft.lifecycle = { status: 'db-corrupted', error: action.payload };
+                draft.lifecycle = { status: 'db-corrupted', error: suiteAction.payload };
                 break;
             case SUITE.INIT:
                 draft.lifecycle = { status: 'loading' };
@@ -96,19 +130,19 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
                 break;
 
             case SUITE.ERROR:
-                draft.lifecycle = { status: 'error', error: action.error };
+                draft.lifecycle = { status: 'error', error: suiteAction.error };
                 break;
 
             case SUITE.SET_RECENTLY_CONNECTED_DEVICE:
-                draft.recentlyConnectedDeviceRef = action.payload;
+                draft.recentlyConnectedDeviceRef = suiteAction.payload;
                 break;
             case SUITE.SET_RECENTLY_DISCONNECTED_DEVICE:
-                draft.recentlyDisconnectedDevice = action.payload;
+                draft.recentlyDisconnectedDevice = suiteAction.payload;
                 break;
             case SUITE.ADD_DEVICE_ID_TO_SEEN_DISCONNECT_NOTIFICATION:
                 draft.seenDisconnectNotificationForDeviceIds = [
                     ...draft.seenDisconnectNotificationForDeviceIds,
-                    action.payload.deviceId,
+                    suiteAction.payload.deviceId,
                 ];
                 break;
 
@@ -117,9 +151,9 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
                     ...draft.evmSettings,
                     confirmExplanationModalClosed: {
                         ...draft.evmSettings.confirmExplanationModalClosed,
-                        [action.symbol]: {
-                            ...draft.evmSettings.confirmExplanationModalClosed[action.symbol],
-                            [action.route]: true,
+                        [suiteAction.symbol]: {
+                            ...draft.evmSettings.confirmExplanationModalClosed[suiteAction.symbol],
+                            [suiteAction.route]: true,
                         },
                     },
                 };
@@ -130,21 +164,21 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
                     ...draft.evmSettings,
                     explanationBannerClosed: {
                         ...draft.evmSettings.explanationBannerClosed,
-                        [action.symbol]: true,
+                        [suiteAction.symbol]: true,
                     },
                 };
                 break;
 
             case SUITE.SET_SEND_FORM_PREFILL:
-                draft.prefillFields.sendForm = action.payload.contractAddress;
+                draft.prefillFields.sendForm = suiteAction.payload.contractAddress;
                 break;
 
             case SUITE.SET_TRANSACTION_HISTORY_PREFILL:
-                draft.prefillFields.transactionHistory = action.payload;
+                draft.prefillFields.transactionHistory = suiteAction.payload;
                 break;
 
             case TRANSPORT.START: {
-                const { ...transport } = action.payload;
+                const { ...transport } = suiteAction.payload;
                 const transports = draft.transport?.transports ?? [];
                 const index = transports.findIndex(t => t.apiType === transport.apiType);
                 if (index >= 0) transports[index] = transport;
@@ -153,7 +187,7 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
                 break;
             }
             case TRANSPORT.ERROR: {
-                const { apiType, error } = action.payload;
+                const { apiType, error } = suiteAction.payload;
                 const transports =
                     !draft.transport || !apiType
                         ? (draft.transport?.transports ?? [])
@@ -162,11 +196,12 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
                 break;
             }
             case SUITE.ONLINE_STATUS:
-                draft.online = action.payload;
+                draft.online = suiteAction.payload;
                 break;
 
             // no default
         }
     });
+};
 
 export default suiteReducer;

--- a/packages/suite/src/reducers/suite/windowReducer.ts
+++ b/packages/suite/src/reducers/suite/windowReducer.ts
@@ -1,9 +1,16 @@
 import { produce } from 'immer';
+import { type Action as ReduxAction } from 'redux';
 
 import { type BreakpointFlags, initialBreakpointFlags } from '@trezor/theme';
+import { isArrayMember } from '@trezor/utils';
 
 import { WINDOW } from 'src/actions/suite/constants';
-import { type Action } from 'src/types/suite';
+import { type WindowAction } from 'src/actions/suite/windowActions';
+
+const WINDOW_ACTION_TYPES = Object.values(WINDOW);
+
+const isWindowAction = (action: ReduxAction): action is WindowAction =>
+    isArrayMember(action.type, WINDOW_ACTION_TYPES);
 
 export interface WindowState extends BreakpointFlags {
     isVisible: boolean;
@@ -18,18 +25,25 @@ export const initialState: WindowState = {
     isVisible: true,
 };
 
-const windowReducer = (state: WindowState = initialState, action: Action): WindowState =>
-    produce(state, draft => {
-        switch (action.type) {
+const windowReducer = (state: WindowState = initialState, action: ReduxAction): WindowState => {
+    if (!isWindowAction(action)) {
+        return state;
+    }
+
+    const windowAction: WindowAction = action;
+
+    return produce(state, draft => {
+        switch (windowAction.type) {
             case WINDOW.UPDATE_BREAKPOINTS:
-                Object.assign(draft, action.payload);
+                Object.assign(draft, windowAction.payload);
                 break;
             case WINDOW.UPDATE_WINDOW_VISIBILITY:
-                draft.isVisible = action.payload.isVisible;
+                draft.isVisible = windowAction.payload.isVisible;
                 break;
             // no default
         }
     });
+};
 
 export default windowReducer;
 

--- a/packages/suite/src/reducers/wallet/graphReducer.ts
+++ b/packages/suite/src/reducers/wallet/graphReducer.ts
@@ -1,13 +1,30 @@
 import { produce } from 'immer';
+import { type Action as ReduxAction } from 'redux';
 
 import { accountsActions } from '@suite-common/wallet-core';
+import { isArrayMember } from '@trezor/utils';
 
 import { STORAGE } from 'src/actions/suite/constants';
+import { type StorageLoadAction } from 'src/actions/suite/storageActions';
 import { GRAPH } from 'src/actions/wallet/constants';
+import { type GraphAction } from 'src/actions/wallet/graphActions';
 import { SETTINGS } from 'src/config/suite';
-import { type Action as SuiteAction } from 'src/types/suite';
-import { type Account, type WalletAction } from 'src/types/wallet';
+import { type Account } from 'src/types/wallet';
 import { type AccountIdentifier, type GraphData, type GraphRange } from 'src/types/wallet/graph';
+
+type GraphReducerAction =
+    | GraphAction
+    | StorageLoadAction
+    | ReturnType<typeof accountsActions.removeAccount>;
+
+const GRAPH_REDUCER_ACTION_TYPES = [
+    ...Object.values(GRAPH),
+    STORAGE.LOAD,
+    accountsActions.removeAccount.type,
+] as const satisfies GraphReducerAction['type'][];
+
+const isGraphReducerAction = (action: ReduxAction): action is GraphReducerAction =>
+    isArrayMember(action.type, GRAPH_REDUCER_ACTION_TYPES);
 
 export interface GraphState {
     data: GraphData[];
@@ -80,23 +97,26 @@ const remove = (draft: GraphState, accounts: Account[]) => {
     updateError(draft);
 };
 
-const graphReducer = (
-    state: GraphState = initialState,
-    action: WalletAction | SuiteAction,
-): GraphState =>
-    produce(state, draft => {
-        switch (action.type) {
+const graphReducer = (state: GraphState = initialState, action: ReduxAction): GraphState => {
+    if (!isGraphReducerAction(action)) {
+        return state;
+    }
+
+    const graphAction: GraphReducerAction = action;
+
+    return produce(state, draft => {
+        switch (graphAction.type) {
             case STORAGE.LOAD:
-                loadFromStorage(draft, action.payload.graph);
+                loadFromStorage(draft, graphAction.payload.graph);
                 break;
             case GRAPH.ACCOUNT_GRAPH_START:
-                update(draft, action.payload);
+                update(draft, graphAction.payload);
                 break;
             case GRAPH.ACCOUNT_GRAPH_SUCCESS:
-                update(draft, action.payload);
+                update(draft, graphAction.payload);
                 break;
             case GRAPH.ACCOUNT_GRAPH_FAIL:
-                update(draft, action.payload);
+                update(draft, graphAction.payload);
                 break;
             case GRAPH.AGGREGATED_GRAPH_START:
                 draft.isLoading = true;
@@ -105,16 +125,17 @@ const graphReducer = (
                 draft.isLoading = false;
                 break;
             case GRAPH.SET_SELECTED_RANGE:
-                draft.selectedRange = action.payload;
+                draft.selectedRange = graphAction.payload;
                 break;
             case accountsActions.removeAccount.type: {
-                if (accountsActions.removeAccount.match(action)) {
-                    remove(draft, action.payload);
+                if (accountsActions.removeAccount.match(graphAction)) {
+                    remove(draft, graphAction.payload);
                 }
                 break;
             }
             // no default
         }
     });
+};
 
 export default graphReducer;

--- a/packages/suite/src/reducers/wallet/index.ts
+++ b/packages/suite/src/reducers/wallet/index.ts
@@ -1,7 +1,7 @@
-import { type Reducer, type UnknownAction, combineReducers } from 'redux';
+import { type Reducer, type Action as ReduxAction, combineReducers } from 'redux';
 
 import { selectedAccountReducer } from '@suite/account';
-import { type CoinjoinAction, type CoinjoinState, coinjoinReducer } from '@suite/coinjoin';
+import { type CoinjoinState, coinjoinReducer } from '@suite/coinjoin';
 import { type TradingState, prepareTradingReducer } from '@suite-common/trading';
 import {
     type AccountsState,
@@ -37,7 +37,6 @@ import {
 } from '@suite-common/wallet-types';
 
 import { extraDependencies } from 'src/support/extraDependencies';
-import { type Action } from 'src/types/suite';
 
 import accountSearchReducer, { type AccountSearchState } from './accountSearchReducer';
 import formDraftReducer from './formDraftReducer';
@@ -79,7 +78,7 @@ export type WalletState = {
 
 export const walletReducers: Reducer<
     WalletState,
-    Action | UnknownAction | CoinjoinAction,
+    ReduxAction,
     Partial<Omit<WalletState, 'graph' | 'coinjoin'>>
 > = combineReducers({
     fiat: fiatRatesReducer,


### PR DESCRIPTION
## Description

The Suite root reducer forced TypeScript to repeatedly relate the app-wide `Action` (42 top-level sources), `WalletAction` (22 sources), and inferred root action through leaf reducers and reducer maps, flattening them into hundreds of concrete variants. This replaces reducer-facing contracts with cheap Redux `Action` boundaries, restores exact local unions where payloads are read, narrows the suite and wallet reducer maps, removes the root `InferredAction`, and gives `graphReducer` only its handled actions. Typed dispatch and cross-feature middleware remain intentionally broad because they genuinely consume the app-wide set; the balanced A/B timing was environmentally noisy, so only the deterministic counter reduction is claimed.

- Types: **464,966 -> 463,653** (1,313 fewer, 0.28%)
- Instantiations: **2,339,844 -> 2,333,398** (6,446 fewer, 0.28%)
- Assignability cache: **396,082 -> 381,147** (14,935 fewer, 3.77%)
- Changed declarations: **14,127 -> 14,164 bytes** (+37 bytes, +0.26%)
- Affected-graph median: **65.030 -> 39.495 seconds** (inconclusive; samples ranged from 30.414 to 97.732 seconds under external compiler load)
- Validation: all 4 affected projects type-checked; Nx also passed 162 prerequisite tasks; 5 Jest suites / 26 tests passed; focused ESLint, depcheck, and `git diff --check` passed.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set touches core Redux reducers (suite, onboarding, wallet, desktop, guide, protocol, window, graph) and the selectedAccountActions module, which are foundational and imported by nearly all e2e tests, making static coverage mapping too broad to be useful directly. The highest-risk, most concrete impacts are: onboarding flow state persistence (onboardingReducer), guide panel state (guideReducer), account selection logic (selectedAccountActions), and transaction graph range state (graphReducer) — tests exercising these specific behaviors were prioritized as high. Session/window/device-status related tests were given medium priority since suiteReducer/windowReducer/desktop reducer changes could subtly affect device connection and session-switching behavior. Given the reducers' central role, a full regression run of onboarding, dashboard, and wallet suites is recommended beyond this targeted list, since unit test coverage (desktopReducer.test.ts) exists but provides no signal for UI-level regressions.

<details><summary><b>Changed files (12)</b></summary>

- `packages/suite/src/actions/wallet/selectedAccountActions.ts`
- `packages/suite/src/reducers/desktop/__tests__/desktopReducer.test.ts`
- `packages/suite/src/reducers/desktop/index.ts`
- `packages/suite/src/reducers/onboarding/onboardingReducer.ts`
- `packages/suite/src/reducers/store.ts`
- `packages/suite/src/reducers/suite/guideReducer.ts`
- `packages/suite/src/reducers/suite/index.ts`
- `packages/suite/src/reducers/suite/protocolReducer.ts`
- `packages/suite/src/reducers/suite/suiteReducer.ts`
- `packages/suite/src/reducers/suite/windowReducer.ts`
- `packages/suite/src/reducers/wallet/graphReducer.ts`
- `packages/suite/src/reducers/wallet/index.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/suite/initial-run.test.ts` — This test directly exercises the onboarding/initial-run flow persistence across reloads, which is governed by onboardingReducer.ts and suiteReducer.ts state (analytics consent, complete-onboarding flag). Changes to these reducers could break whether the initial run screen correctly persists or is skipped after completion.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — Onboarding reducer changes directly affect the onboarding step machine including analytics consent screen persistence and completion, which this test verifies end-to-end.
- `suite/e2e/tests/suite/guide.test.ts` — guideReducer.ts was directly modified; this test exercises guide panel open/close, navigation, search, and feedback submission state that is backed by this reducer.
- `suite/e2e/tests/general/suite-guide.test.ts` — Directly tests the guide panel bug report and article search functionality, which relies on guideReducer.ts state that was changed in this PR.
- `suite/e2e/tests/wallet/transactions.test.ts` — graphReducer.ts was directly modified and this test exercises the account transaction graph range selector (day/week/month/year/all), which is the core state managed by that reducer.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Dashboard graph and portfolio value display rely on wallet graph/account reducers; discreet mode toggling interacts with selectedAccountActions and graph state that were changed.
- `suite/e2e/tests/wallet/account-search.test.ts` — selectedAccountActions.ts governs which account is selected/displayed; this test exercises account filtering/search which depends on selected account state transitions.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test exercises ejecting a wallet and adding a standard wallet then viewing account balance, directly touching selected account selection logic and wallet reducer state changed in this PR.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test relies heavily on suiteReducer/windowReducer-managed device/session status transitions (Connected, Use Here) across tab reloads and new-tab session takeovers, both of which were modified.
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — desktop/index.ts reducer changes affect desktop-specific state management including app window/bridge lifecycle behavior verified by this daemon-mode bridge spawning test.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test verifies bridge process lifecycle tied to desktop app state (window focus, reconnection), which is managed via the changed desktop reducer and windowReducer.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — This test checks app/focus IPC behavior tied to window visibility state which could be influenced by windowReducer changes, though the primary logic under test is TrezorConnect permissions rather than the reducer itself.
- `suite/e2e/tests/wallet/without-device.test.ts` — Device disconnected banner and reconnect flows are influenced by suiteReducer state transitions for device status, which were changed, but this test's core focus (regtest funding, send flow) is only tangentially related.

</details>

⚠️ **Changes with no test coverage (5)**
- `packages/suite/src/reducers/desktop/__tests__/desktopReducer.test.ts`
- `packages/suite/src/reducers/suite/protocolReducer.ts`
- `packages/suite/src/reducers/store.ts`
- `packages/suite/src/reducers/suite/index.ts`
- `packages/suite/src/reducers/wallet/index.ts`

_Updated: 2026-07-19T14:40:22.971Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/narrow-suite-action-types/web/](https://dev.suite.sldev.cz/suite-web/refactor/narrow-suite-action-types/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/narrow-suite-action-types&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/narrow-suite-action-types&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-19T14:43:37.586Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-19T14:42:24.983Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->