### PR TITLE
refactor(components): expose select option

### DIFF
--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -36,6 +36,7 @@ export const allowedSelectFrameProps = allowedFormCellFrameProps;
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedSelectFrameProps)[number]>;
 
 export type { Option } from './types';
+export { Option as SelectOption } from './customComponents';
 
 // This intentionally exposes only the capability used by consumers instead of deriving it from
 // react-select's generic SelectInstance, which would leak that implementation type into our public API.

--- a/suite/labeling/src/LabelingSettings.tsx
+++ b/suite/labeling/src/LabelingSettings.tsx
@@ -27,9 +27,7 @@ import {
     selectTurnOffSuiteSyncDep,
     selectTurnOnSuiteSyncDep,
 } from '@suite-common/suite-sync-types';
-import { Box, Column, LoadingContent, Tooltip } from '@trezor/components';
-// eslint-disable-next-line local-rules/no-package-deep-imports
-import { Option as SelectOption } from '@trezor/components/src/components/form/Select/customComponents';
+import { Box, Column, LoadingContent, SelectOption, Tooltip } from '@trezor/components';
 import {
     ActionColumn,
     ActionSelect,


### PR DESCRIPTION
## Description

Suite labeling imports the Select option renderer through an internal @trezor/components source path, coupling the consumer to the package layout and preventing declaration-only workspace resolution. Export the renderer as SelectOption from the public Select API and consume that export from @suite/labeling.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch a widely-shared Select form component (131 statically mapped tests) and the LabelingSettings component (no static coverage mapping, but clearly tied to the metadata/labeling feature area). Given the broad-utility heuristic, most Select-referencing tests were excluded unless they specifically exercise Select-based UI (dropdowns, provider selectors, currency/theme/language pickers) or overlap with labeling settings. Recommended strategy: prioritize the metadata/labeling test suite (which directly exercises LabelingSettings' provider dropdown, a Select instance) and a handful of settings tests that heavily use Select controls, rather than running the full 130+ test suite.

<details><summary><b>Changed files (2)</b></summary>

- `packages/components/src/components/form/Select/Select.tsx`
- `suite/labeling/src/LabelingSettings.tsx`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test exercises the metadata/labeling UI extensively (label editing, search, provider selection) which is the direct feature area of LabelingSettings.tsx, making it the most relevant coverage for this change.
- `suite/e2e/tests/metadata/legacy/switching-providers.test.ts` — Tests switching between metadata providers and the settings UI for connecting/disconnecting providers, which is core functionality likely implemented or configured via LabelingSettings.tsx.
- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — Directly exercises the application settings metadataSelectInput (a Select component) used to enable/disable/switch labeling providers, combining both changed files' functionality (Select + LabelingSettings).

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — Uses the metadata provider selection dropdown and connect/disconnect provider buttons within settings, which are part of the labeling settings UI that may use the Select component.
- `suite/e2e/tests/metadata/legacy/google-api-errors.test.ts` — Tests the metadataSelectInput dropdown for choosing a provider (Google) within Settings > Application, directly exercising the Select component in the labeling settings context.
- `suite/e2e/tests/settings/general.test.ts` — Exercises multiple Select-based settings controls (fiat currency selector, theme selector, language selector) in the general settings page, providing direct coverage of the Select component's behavior across various use cases.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — Uses backend type selector dropdowns (a Select component) for configuring custom blockbook backends, offering some incidental coverage of Select component regressions.
- `suite/e2e/tests/staking/staking-form.test.ts` — Uses percentage/fraction buttons and crypto/fiat input switching which may rely on Select-like dropdown components; included as low-confidence incidental coverage given the breadth of Select usage.

</details>

_Updated: 2026-07-19T15:33:52.336Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/components-export-select-option/web/](https://dev.suite.sldev.cz/suite-web/fix/components-export-select-option/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/components-export-select-option&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/components-export-select-option&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-19T15:36:55.416Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-19T15:36:38.037Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->