### PR TITLE
fix(product-components): use shared theme augmentation

### DIFF
--- a/packages/product-components/styled.d.ts
+++ b/packages/product-components/styled.d.ts
@@ -1,9 +1,0 @@
-import 'styled-components';
-import { SuiteThemeColors } from '@trezor/components';
-import { BoxShadows, Colors, ThemeVariant } from '@trezor/theme';
-
-declare module 'styled-components' {
-    export interface DefaultTheme extends SuiteThemeColors, Colors, BoxShadows {
-        variant: ThemeVariant;
-    }
-}


### PR DESCRIPTION
## Description

After #30282 moved the styled-components DefaultTheme contract into the emitted @trezor/components entrypoint, Product Components still carried an identical root-only augmentation. Remove that duplicate and rely on the shared emitted contract already loaded through the Product Components public entrypoint; the stale intermediaryTheme variant change was dropped because #30282 fixed the actual Connect Explorer provider and the broader change produced duplicate-property type errors.

- Duplicate Product Components augmentation: **9 lines / 307 bytes -> 0**
- Theme contract sources in its dependency path: **2 -> 1**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file, packages/product-components/styled.d.ts, is a TypeScript type declaration file (styled-components type augmentation) with no static test coverage mapping and no runtime behavior of its own — it only affects compile-time type checking. None of the 50 candidate E2E tests exercise TypeScript type definitions directly, and there is no evidence in the LLM analysis that any test's behavior depends on this declaration file. Given this is a type-only change with no functional/UI impact, no E2E tests are recommended to run; standard TypeScript compilation/type-check in CI is the appropriate validation for this change.

<details><summary><b>Changed files (1)</b></summary>

- `packages/product-components/styled.d.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/product-components/styled.d.ts`

_Updated: 2026-07-27T14:05:15.293Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/components-export-default-theme/web/](https://dev.suite.sldev.cz/suite-web/fix/components-export-default-theme/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/components-export-default-theme&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/components-export-default-theme&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T14:09:05.989Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T14:08:02.418Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->