### PR TITLE
fix(requirements): align webextension typecheck exemption

### DIFF
--- a/packages/requirements/src/requirements/package-json/__tests__/requirePackageJsonScripts.test.ts
+++ b/packages/requirements/src/requirements/package-json/__tests__/requirePackageJsonScripts.test.ts
@@ -58,6 +58,26 @@ describe(requirePackageJsonScripts.name, () => {
         expect(errors).toEqual([]);
     });
 
+    it('does not require the type-check script for the webextension example', async () => {
+        context = {
+            ...context,
+            workspaceName: '@trezor/webextension-mv3-sw-ts',
+        };
+
+        writeFileSync(
+            join(workspaceDir, 'package.json'),
+            JSON.stringify({
+                scripts: {
+                    'lint:js': validScripts['lint:js'],
+                },
+            }),
+        );
+
+        const errors = await requirePackageJsonScripts.verify(context);
+
+        expect(errors).toEqual([]);
+    });
+
     it('reports missing depcheck script', async () => {
         writeFileSync(
             join(workspaceDir, 'package.json'),

--- a/packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts
+++ b/packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts
@@ -62,6 +62,7 @@ const REQUIRED_SCRIPTS: Record<string, RequiredScriptConfig> = {
             'connect-example-electron-main',
             'connect-mobile-example',
             'connect-example-node',
+            '@trezor/webextension-mv3-sw-ts',
         ],
     },
     'test:unit': {


### PR DESCRIPTION
## Description

The webextension example is intentionally exempt from declaration-only tsconfig enforcement while its Connect deep-import dependencies are unresolved, but the package-script requirement still enforces the standardized type-check command. Exempt the same workspace from the type-check script requirement and cover the policy with a focused test.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files (requirePackageJsonScripts.ts and its unit test) belong to the internal 'requirements' package, which is a Node-based build/dev tooling utility unrelated to the Suite web app's Playwright E2E test surface (onboarding, staking, trading, wallet, settings, etc.). None of the 14 candidate E2E tests reference this package or its functionality in their behaviors, entry points, or source hints, and there is no static or inferred coverage linking this change to any user-facing flow exercised by these tests. This change already has its own dedicated unit test (requirePackageJsonScripts.test.ts) which is the appropriate verification mechanism; no E2E tests need to be run for this change.

<details><summary><b>Changed files (2)</b></summary>

- `packages/requirements/src/requirements/package-json/__tests__/requirePackageJsonScripts.test.ts`
- `packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/requirements/src/requirements/package-json/__tests__/requirePackageJsonScripts.test.ts`
- `packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts`

_Updated: 2026-07-19T15:43:37.915Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/requirements-align-typecheck-ignores/web/](https://dev.suite.sldev.cz/suite-web/fix/requirements-align-typecheck-ignores/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/requirements-align-typecheck-ignores&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/requirements-align-typecheck-ignores&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-19T15:47:29.788Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-19T15:47:06.338Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->