### PR TITLE
fix(suite-native): emit storybook entry types

### DIFF
--- a/suite-native/storybook/package.json
+++ b/suite-native/storybook/package.json
@@ -5,6 +5,7 @@
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
     "main": ".rnstorybook/index",
+    "types": "./libDev/src/index.d.ts",
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",

--- a/suite-native/storybook/src/index.ts
+++ b/suite-native/storybook/src/index.ts
@@ -1,0 +1,1 @@
+export { StorybookUI } from '../.rnstorybook';

--- a/suite-native/storybook/tsconfig.json
+++ b/suite-native/storybook/tsconfig.json
@@ -1,6 +1,11 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
+    "include": [
+        ".",
+        ".rnstorybook/**/*.ts",
+        ".rnstorybook/**/*.tsx"
+    ],
     "references": [
         { "path": "../alerts" },
         { "path": "../intl" },


### PR DESCRIPTION
## Description

The native app consumes @suite-native/storybook, but its runtime entry is inside .rnstorybook and the default TypeScript glob does not emit hidden-directory declarations. Add a normal src declaration façade, explicitly include the generated runtime sources, and point the package types entry at the emitted façade without changing its runtime main.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native-storybook-declaration-entry&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->