### PR TITLE
fix(desktop): expose desktop api declarations

### DIFF
--- a/packages/suite-desktop-api/package.json
+++ b/packages/suite-desktop-api/package.json
@@ -13,6 +13,7 @@
     },
     "main": "./src/main.ts",
     "browser": "./src/renderer.ts",
+    "types": "./libDev/src/types.d.ts",
     "scripts": {
         "test:unit": "yarn g:jest",
         "type-check": "yarn g:tsc --build tsconfig.json",

--- a/packages/suite-desktop-api/src/main.ts
+++ b/packages/suite-desktop-api/src/main.ts
@@ -19,4 +19,9 @@ export type {
     BootstrapTorEvent,
     TorStatusEvent,
     HandshakeTorModule,
+    BridgeSettings,
+    ConnectPopupResponse,
+    Status,
+    TorSettings,
+    TraySettings,
 } from './messages';

--- a/packages/suite-desktop-api/src/types.ts
+++ b/packages/suite-desktop-api/src/types.ts
@@ -1,0 +1,2 @@
+export * from './main';
+export { desktopApi } from './renderer';

--- a/packages/suite-desktop-core/src/libs/connect-popup-messages.ts
+++ b/packages/suite-desktop-core/src/libs/connect-popup-messages.ts
@@ -3,7 +3,7 @@
  * Used by both connect-ws (WebSocket) and mcp-server (MCP) modules
  * to route responses from the renderer back to the correct caller.
  */
-import type { ConnectPopupResponse } from '@trezor/suite-desktop-api/src/messages';
+import type { ConnectPopupResponse } from '@trezor/suite-desktop-api';
 import { type Deferred, createDeferred } from '@trezor/utils';
 
 import { ipcMain } from '../typed-electron';

--- a/packages/suite-desktop-core/src/modules/tray.ts
+++ b/packages/suite-desktop-core/src/modules/tray.ts
@@ -6,7 +6,7 @@ import path from 'path';
 
 import { DEVICE, type DeviceEvent } from '@trezor/connect';
 import { validateIpcMessage } from '@trezor/ipc-proxy';
-import { type Status, type TraySettings } from '@trezor/suite-desktop-api/src/messages';
+import { type Status, type TraySettings } from '@trezor/suite-desktop-api';
 
 import { app, ipcMain } from '../typed-electron';
 import { type ModuleInitBackground, mainThreadEmitter } from './module';

--- a/packages/suite/src/hooks/suite/useBridgeDesktopApi.ts
+++ b/packages/suite/src/hooks/suite/useBridgeDesktopApi.ts
@@ -1,8 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { isDesktop } from '@trezor/env-utils';
-import { desktopApi } from '@trezor/suite-desktop-api';
-import { type BridgeSettings } from '@trezor/suite-desktop-api/src/messages';
+import { type BridgeSettings, desktopApi } from '@trezor/suite-desktop-api';
 
 interface Process {
     service: boolean;

--- a/packages/suite/src/views/settings/SettingsGeneral/TorExternal.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/TorExternal.tsx
@@ -4,8 +4,7 @@ import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
 import { selectTorState } from '@suite/tor';
 import { ActionColumn, ActionSelect, SectionItem, TextColumn } from '@trezor/product-components';
-import { desktopApi } from '@trezor/suite-desktop-api';
-import { type TorSettings } from '@trezor/suite-desktop-api/src/messages';
+import { type TorSettings, desktopApi } from '@trezor/suite-desktop-api';
 
 import { useSelector } from 'src/hooks/suite';
 


### PR DESCRIPTION
## Description

@trezor/suite-desktop-api has separate Electron main and renderer runtime entries but no declaration entry combining their public type surface. Four consumers therefore import message types from src/messages, bypassing package boundaries and defeating strict project-reference declaration resolution. This adds a declaration-only facade, exports the message types from the package root, and migrates all four deep imports without changing runtime behavior.

Declaration entry: missing -> ./libDev/src/index.d.ts. Cross-workspace @trezor/suite-desktop-api/src/messages imports: 4 -> 0.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set focuses on the desktop Electron layer: the suite-desktop-api package (main.ts, types.ts), the connect-popup-messages library (popup lifecycle/IPC), the system tray module, the useBridgeDesktopApi hook, and the TorExternal settings component. The highest risk areas are desktop bridge daemon management, TrezorConnect popup window behavior (open/close/cancel/focus), and silent-mode IPC focus events, since these are directly implemented in the changed files. Recommended strategy is to run the desktop bridge and trezor-connect popup/session E2E tests first (high priority), followed by settings-general and bridge/session related tests (medium) to catch regressions in secondary but related flows. Since suite-desktop-api and connect-popup-messages.ts and tray.ts had no static test coverage mapping, the high-priority tests above were inferred from LLM behavior descriptions rather than static import mapping.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite-desktop-api/package.json`
- `packages/suite-desktop-api/src/main.ts`
- `packages/suite-desktop-api/src/types.ts`
- `packages/suite-desktop-core/src/libs/connect-popup-messages.ts`
- `packages/suite-desktop-core/src/modules/tray.ts`
- `packages/suite/src/hooks/suite/useBridgeDesktopApi.ts`
- `packages/suite/src/views/settings/SettingsGeneral/TorExternal.tsx`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test directly exercises the desktop bridge daemon lifecycle and desktop API surface (suite-desktop-api main.ts/types.ts) which are changed here, including bridge spawn/stop behavior tied to the Electron main process.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Tests bridge spawning, stopping, and reconnection through the desktop app, which relies on suite-desktop-api's main process bridge management and the useBridgeDesktopApi hook that was directly modified.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test exercises the desktop Suite Web popup flow for TrezorConnect, directly touching connect-popup-messages.ts logic (popup lifecycle, cancellation, focus/close handling) which was changed.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Covers popup lifecycle behaviors (popup blocked, force-close recovery, focusing existing popup, cancellation) that are implemented via connect-popup-messages.ts, a directly changed file.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Silent mode relies on IPC 'app/focus' events and window visibility control in the Electron desktop app, directly tied to suite-desktop-api types/main.ts and tray.ts window/focus management that changed.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests TrezorConnect permission modal process/behavior in suite-desktop core mode; changes to suite-desktop-api types/main.ts could affect IPC-based permission flows.
- `suite/e2e/tests/settings/general.test.ts` — This test covers the Settings General page including toggles similar to Tor/analytics settings; TorExternal.tsx is a component within this exact settings view that was directly modified.
- `suite/e2e/tests/suite/bridge.test.ts` — Exercises the Bridge page flow and WebUSB fallback, which is closely related to bridge/transport handling potentially affected by useBridgeDesktopApi hook changes.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Tests bridge session stealing/reclaiming and device status updates across tabs, functionality closely tied to bridge desktop API state management that was changed.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite-desktop-core/src/modules/tray.ts`

_Updated: 2026-07-20T11:46:45.375Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/desktop-api-declaration-entries/web/](https://dev.suite.sldev.cz/suite-web/fix/desktop-api-declaration-entries/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/desktop-api-declaration-entries&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/desktop-api-declaration-entries&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-20T11:50:18.469Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-20T11:50:01.725Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->