### PR TITLE
fix(connect): remove webextension deep imports

### DIFF
--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -17,6 +17,7 @@
     },
     "license": "MIT",
     "description": "Collection of assets and utils used by trezor-connect library.",
+    "sideEffects": false,
     "main": "./src/index.ts",
     "files": [
         "lib/",

--- a/packages/connect-common/src/index.ts
+++ b/packages/connect-common/src/index.ts
@@ -16,5 +16,6 @@ export {
     corsValidator,
 } from './data/connectSettings';
 export * from './utils/debug';
+export * from './utils/cancelParams';
 export * from './utils/urlUtils';
 export { connectCallableMethods } from './callableMethods';

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -14,6 +14,7 @@ const TrezorConnect = factoryPublic(
 );
 
 export default TrezorConnect;
+export { CoreInSuiteDesktop, CoreInSuiteWeb };
 export * from '@trezor/connect-common/src/constants';
 export * from '@trezor/connect-common/src/events';
 export * from '@trezor/connect-common/src/types';

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -1,15 +1,13 @@
-// note: at the moment, there is something in the root of @trezor/connect-common that pulls entire PROTO runtime, thus
-// these targeted imports
-import { CORE_CALL_CANCEL, POPUP } from '@trezor/connect-common/src/events';
-import { factoryPublic } from '@trezor/connect-common/src/factory';
-import { TrezorConnectDynamic } from '@trezor/connect-common/src/impl/dynamic';
-// Import as src not lib due to webpack issues with inlining content script later
-import { ServiceWorkerWindowChannel } from '@trezor/connect-common/src/messageChannel/serviceworker-window';
-import type { ConnectDynamicSettings } from '@trezor/connect-common/src/types';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- intra-tier wiring: connect-webextension composes implementations from connect-web (see #27376)
-import { CoreInSuiteDesktop } from '@trezor/connect-web/src/impl/core-in-suite-desktop';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- intra-tier wiring: connect-webextension composes implementations from connect-web (see #27376)
-import { CoreInSuiteWeb } from '@trezor/connect-web/src/impl/core-in-suite-web';
+import {
+    CORE_CALL_CANCEL,
+    type ConnectDynamicSettings,
+    POPUP,
+    ServiceWorkerWindowChannel,
+    TrezorConnectDynamic,
+    type TrezorConnectPublicAPI,
+    factoryPublic,
+} from '@trezor/connect-common';
+import { CoreInSuiteDesktop, CoreInSuiteWeb } from '@trezor/connect-web';
 
 const impl = new TrezorConnectDynamic({
     implementations: {
@@ -19,7 +17,7 @@ const impl = new TrezorConnectDynamic({
 });
 
 // Bind all methods due to shadowing `this`
-const TrezorConnect = factoryPublic(impl);
+const TrezorConnect: TrezorConnectPublicAPI<ConnectDynamicSettings> = factoryPublic(impl);
 
 const initProxyChannel = () => {
     const channel = new ServiceWorkerWindowChannel<{
@@ -103,6 +101,4 @@ initProxyChannel();
 
 // eslint-disable-next-line import/no-default-export
 export default TrezorConnect;
-export * from '@trezor/connect-common/src/constants';
-export * from '@trezor/connect-common/src/events';
-export type * from '@trezor/connect-common/src/types';
+export * from '@trezor/connect-common';

--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -1,12 +1,15 @@
-import { ERRORS } from '@trezor/connect-common/src/constants';
-import { CORE_CALL, POPUP, createErrorMessage } from '@trezor/connect-common/src/events';
-import { factoryPublic } from '@trezor/connect-common/src/factory';
-import { WindowServiceWorkerChannel } from '@trezor/connect-common/src/messageChannel/window-serviceworker';
-import type { ConnectDynamicSettings } from '@trezor/connect-common/src/types';
 import {
+    CORE_CALL,
     type CancelParams,
+    type ConnectDynamicSettings,
+    ERRORS,
+    POPUP,
+    type TrezorConnectPublicAPI,
+    WindowServiceWorkerChannel,
     createCoreCallCancelMessage,
-} from '@trezor/connect-common/src/utils/cancelParams';
+    createErrorMessage,
+    factoryPublic,
+} from '@trezor/connect-common';
 
 let _channel: any;
 
@@ -70,10 +73,13 @@ const call = async (params: any) => {
     }
 };
 
-const TrezorConnect = factoryPublic({ init, call, cancel, dispose });
+const TrezorConnect: TrezorConnectPublicAPI<ConnectDynamicSettings> = factoryPublic({
+    init,
+    call,
+    cancel,
+    dispose,
+});
 
 // eslint-disable-next-line import/no-default-export
 export default TrezorConnect;
-export * from '@trezor/connect-common/src/constants';
-export * from '@trezor/connect-common/src/events';
-export * from '@trezor/connect-common/src/types';
+export * from '@trezor/connect-common';


### PR DESCRIPTION
## Description

@trezor/connect-webextension depended on internal source paths, while importing from the connect-common root retained runtime schema modules because the package lacked side-effect metadata. Mark connect-common as side-effect-free, expose only the missing cancellation helpers and Core classes from the existing roots, retain the separate webextension composition, and explicitly type its public API. Root-import bundle verification: 159 KiB to 42.7 KiB minified and 39.5 KiB to 13.6 KiB gzip; PR scope reduced from 14 files to 5 files.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch the public entrypoints and package metadata of connect-common, connect-web, and connect-webextension (including the webextension proxy), which are foundational packages consumed by all TrezorConnect-based E2E tests. Since there is no static coverage mapping, tests were inferred directly from the LLM analysis of which suites exercise TrezorConnect.init and its API methods (getAddress, selectAccount, signMessage, signTransaction, getAccountInfo, permissions, silent mode) via connect-web and connect-webextension. Recommended strategy: run the full trezor-connect/* test suite, prioritizing the popup and webextension proxy tests (highest risk given direct changes to proxy/index.ts and both package index.ts files), followed by broader API method coverage tests at medium priority.

<details><summary><b>Changed files (5)</b></summary>

- `packages/connect-common/package.json`
- `packages/connect-common/src/index.ts`
- `packages/connect-web/src/index.ts`
- `packages/connect-webextension/src/index.ts`
- `packages/connect-webextension/src/proxy/index.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test directly exercises the connect-web package's public API (TrezorConnect.getAddress, cardanoGetAddress, cancel) via the popup flow in suite-web, which is exactly what connect-web/src/index.ts exports. Changes to the index entrypoint could break initialization, popup lifecycle, or method dispatch.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test exercises the connect-webextension package end-to-end, including its proxy mechanism to Suite Web, directly covering changes to connect-webextension/src/index.ts and proxy/index.ts.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Covers TrezorConnect.getAddress including bundle and forced on-device confirmation flows, exercising core API surface exported from connect-web/index.ts which was changed.
- `suite/e2e/tests/trezor-connect/error.test.ts` — Verifies TrezorConnect.init and error handling in suite-desktop core mode; index.ts changes to connect-web/connect-common could affect initialization and error propagation paths tested here.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — Exercises TrezorConnect.selectAccount API surface and privacy guarantees (no xpub/publicKey leakage), which could be impacted by changes to the connect-common/connect-web exported types or API shape.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests the permissions modal and remembered-permissions logic tied to TrezorConnect.init/getAddress calls, which rely on the connect-web index entrypoint that was modified.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Uses TrezorConnect.init() and signMessage via connect-web in suite-desktop core mode; changes to the package's index/entrypoint could affect IPC focus behavior and silent mode handling tested here.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Exercises the connect-web API (ethereumSignMessage) in suite-desktop core mode; verifies the exported API still functions correctly after index.ts changes.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Exercises connect-web's ethereumSignTransaction API surface, providing coverage for potential regressions in the modified index.ts entrypoint.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Exercises TrezorConnect.getAccountInfo API through connect-web, covering another exported method that could be affected by index.ts changes.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Exercises TrezorConnect.signTransaction through connect-web in suite-desktop mode, providing additional coverage of the modified package's core API surface.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/connect-common/package.json`

_Updated: 2026-07-20T09:03:29.694Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/connect-webextension-public-imports/web/](https://dev.suite.sldev.cz/suite-web/fix/connect-webextension-public-imports/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-webextension-public-imports&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-webextension-public-imports&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-20T09:07:00.326Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-20T09:05:57.485Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->