### PR TITLE
test(connect): avoid e2e package self-imports

### DIFF
--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
 import { UI_REQUEST, UI_RESPONSE } from '@trezor/connect-common';
 import type { ApplySettings } from '@trezor/protobuf/src/definitions';
 import { BridgeTransport } from '@trezor/transport-common';
@@ -7,9 +5,8 @@ import type { EmuStartOptsType, TrezorUserEnvLinkClass } from '@trezor/trezor-us
 import { MNEMONICS, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 import { versionUtils } from '@trezor/utils';
 
+import TrezorConnect from '../src';
 import { THP_CREDENTIALS_AUTOCONNECT } from './common-thp-credentials';
-
-// import TrezorConnect from '../src';
 
 // Read emulator start options from EMULATOR_START_OPTS env var (JSON string set by run.ts).
 // In browser mode, Vite's `define` replaces process.env.EMULATOR_START_OPTS at build time.

--- a/packages/connect/e2e/tests/api/init.test.ts
+++ b/packages/connect/e2e/tests/api/init.test.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect from '../../../src';
 
 // error thrown by .init()
 const INIT_ERROR = { code: 'Init_ManifestMissing' };

--- a/packages/connect/e2e/tests/device/authenticateDevice.test.ts
+++ b/packages/connect/e2e/tests/device/authenticateDevice.test.ts
@@ -1,9 +1,8 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
 import type { DeviceAuthenticityConfig } from '@trezor/device-authenticity';
 import { deviceAuthenticityConfig } from '@trezor/device-authenticity';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
+import TrezorConnect from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();

--- a/packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts
+++ b/packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts
@@ -1,8 +1,6 @@
 import { vi } from 'vitest';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
-
+import TrezorConnect from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();

--- a/packages/connect/e2e/tests/device/cancel.test.ts
+++ b/packages/connect/e2e/tests/device/cancel.test.ts
@@ -1,9 +1,8 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
 import type { CoinSymbol } from '@trezor/connect-common';
 import type { TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
 import { Model } from '@trezor/trezor-user-env-link';
 
+import TrezorConnect from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const getAddress = (showOnTrezor: boolean, coin: CoinSymbol = 'regtest') =>

--- a/packages/connect/e2e/tests/device/cancelCoinjoinAuthorization.test.ts
+++ b/packages/connect/e2e/tests/device/cancelCoinjoinAuthorization.test.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
-
+import TrezorConnect from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 describe('TrezorConnect.cancelCoinjoinAuthorization', () => {

--- a/packages/connect/e2e/tests/device/discoverAccounts.test.ts
+++ b/packages/connect/e2e/tests/device/discoverAccounts.test.ts
@@ -1,8 +1,7 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect, { type BundleProgress } from '@trezor/connect';
 import { UI_REQUEST } from '@trezor/connect-common';
 import type { DiscoverAccountsProgress } from '@trezor/connect-common/src/types/api/account/discoverAccounts';
 
+import TrezorConnect, { type BundleProgress } from '../../../src';
 import { getController, initTrezorConnect, setup } from '../../common.setup';
 
 let controller: ReturnType<typeof getController> | undefined;

--- a/packages/connect/e2e/tests/device/info.test.ts
+++ b/packages/connect/e2e/tests/device/info.test.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect, { connectCallableMethods } from '@trezor/connect';
-
+import TrezorConnect, { connectCallableMethods } from '../../../src';
 import { getController, initTrezorConnect, setup } from '../../common.setup';
 const controller = getController();
 

--- a/packages/connect/e2e/tests/device/keepSession.test.ts
+++ b/packages/connect/e2e/tests/device/keepSession.test.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect, { type StaticSessionId } from '@trezor/connect';
-
+import TrezorConnect, { type StaticSessionId } from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();

--- a/packages/connect/e2e/tests/device/methods.test.ts
+++ b/packages/connect/e2e/tests/device/methods.test.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
-
+import TrezorConnect from '../../../src';
 import * as fixtures from '../../__fixtures__';
 import {
     conditionalTest,

--- a/packages/connect/e2e/tests/device/passphrase.test.ts
+++ b/packages/connect/e2e/tests/device/passphrase.test.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
-
+import TrezorConnect from '../../../src';
 import {
     conditionalTest,
     getController,

--- a/packages/connect/e2e/tests/device/pingDevice.test.ts
+++ b/packages/connect/e2e/tests/device/pingDevice.test.ts
@@ -1,8 +1,6 @@
 import { vi } from 'vitest';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
-
+import TrezorConnect from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();

--- a/packages/connect/e2e/tests/device/resetDevice.test.ts
+++ b/packages/connect/e2e/tests/device/resetDevice.test.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
-
+import TrezorConnect from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();

--- a/packages/connect/e2e/tests/device/setBusy.test.ts
+++ b/packages/connect/e2e/tests/device/setBusy.test.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
-
+import TrezorConnect from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();

--- a/packages/connect/e2e/tests/device/thpPairing.test.ts
+++ b/packages/connect/e2e/tests/device/thpPairing.test.ts
@@ -1,8 +1,6 @@
 import { vi } from 'vitest';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect, { type Device, type ThpSettings, type UiEvent } from '@trezor/connect';
-
+import TrezorConnect, { type Device, type ThpSettings, type UiEvent } from '../../../src';
 import { THP_CREDENTIALS } from '../../common-thp-credentials';
 import { getController, initTrezorConnect, restartEmu, setup } from '../../common.setup';
 

--- a/packages/connect/e2e/tests/device/unlockPath.test.ts
+++ b/packages/connect/e2e/tests/device/unlockPath.test.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
-
+import TrezorConnect from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();

--- a/packages/connect/e2e/tests/device/updateConnectSettings.test.ts
+++ b/packages/connect/e2e/tests/device/updateConnectSettings.test.ts
@@ -1,7 +1,6 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
 import { BridgeTransport } from '@trezor/transport-common';
 
+import TrezorConnect from '../../../src';
 import { getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();


### PR DESCRIPTION
## Description

Connect E2E TypeScript files imported `@trezor/connect` from inside the same workspace, causing repeated builds to treat prior declaration output as compiler input and fail with TS5055. The tests now use relative source entry points; the rebase resolution also preserves the current THP credential fixtures and `@trezor/transport-common` imports from develop.

- TypeScript E2E self-importing files: **17 -> 0**
- Rebased scope: **17 files, 17 insertions, 47 deletions**
- Standard PR Connect E2E: **passed** — 17 successful, 7 skipped ([run 30266492728](https://github.com/trezor/trezor-suite/actions/runs/30266492728))
- Manual full Connect E2E (`workflow_dispatch`): **failed** — 146/149 jobs passed ([run 30266845108](https://github.com/trezor/trezor-suite/actions/runs/30266845108))
  - `all-fws` `2-main methods-ethereum` failed in Node and Web on the same single test (`EIP-7702 - Uniswap`: `Failure_DataError`, `tx_type out of bounds`); each job had 80/81 tests pass.
  - `all-models-api / T3W1-2-main` had 96 passed, 28 failed, and 5 skipped tests; failures were predominantly 30-second timeouts plus `Cancelled`/`ThpStateError` responses across device API tests.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-e2e-self-imports&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->