### PR TITLE
fix(blockchain-link): expose worker entries

### DIFF
--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -40,6 +40,38 @@
                 "types": "./lib/index.d.ts",
                 "default": "./lib/index.js"
             },
+            "./workers/baseWorker": {
+                "types": "./lib/workers/baseWorker.d.ts",
+                "default": "./lib/workers/baseWorker.js"
+            },
+            "./workers/blockbook": {
+                "types": "./lib/workers/blockbook/index.d.ts",
+                "default": "./lib/workers/blockbook/index.js"
+            },
+            "./workers/blockfrost": {
+                "types": "./lib/workers/blockfrost/index.d.ts",
+                "default": "./lib/workers/blockfrost/index.js"
+            },
+            "./workers/electrum": {
+                "types": "./lib/workers/electrum/index.d.ts",
+                "default": "./lib/workers/electrum/index.js"
+            },
+            "./workers/evm-rpc": {
+                "types": "./lib/workers/evm-rpc/index.d.ts",
+                "default": "./lib/workers/evm-rpc/index.js"
+            },
+            "./workers/ripple": {
+                "types": "./lib/workers/ripple/index.d.ts",
+                "default": "./lib/workers/ripple/index.js"
+            },
+            "./workers/solana": {
+                "types": "./lib/workers/solana/index.d.ts",
+                "default": "./lib/workers/solana/index.js"
+            },
+            "./workers/stellar": {
+                "types": "./lib/workers/stellar/index.d.ts",
+                "default": "./lib/workers/stellar/index.js"
+            },
             "./lib/*": "./lib/*"
         },
         "browser": {

--- a/packages/blockchain-link/src/workers/baseWorker.ts
+++ b/packages/blockchain-link/src/workers/baseWorker.ts
@@ -1,3 +1,5 @@
+/// <reference lib="webworker" />
+
 // Abstract class extended by WorkerModule (see /src/workers/*/index.ts)
 // Provides an interface of WorkerGlobalScope to behave as regular WebWorker (see /src/index.ts)
 // Goal is to Make no difference from the implementation point of view between:

--- a/packages/blockchain-link/workers/baseWorker/index.ts
+++ b/packages/blockchain-link/workers/baseWorker/index.ts
@@ -1,0 +1,1 @@
+export * from '../../src/workers/baseWorker';

--- a/packages/blockchain-link/workers/blockbook/index.ts
+++ b/packages/blockchain-link/workers/blockbook/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/blockbook';

--- a/packages/blockchain-link/workers/blockfrost/index.ts
+++ b/packages/blockchain-link/workers/blockfrost/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/blockfrost';

--- a/packages/blockchain-link/workers/electrum/index.ts
+++ b/packages/blockchain-link/workers/electrum/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/electrum';

--- a/packages/blockchain-link/workers/evm-rpc/index.ts
+++ b/packages/blockchain-link/workers/evm-rpc/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/evm-rpc';

--- a/packages/blockchain-link/workers/ripple/index.ts
+++ b/packages/blockchain-link/workers/ripple/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/ripple';

--- a/packages/blockchain-link/workers/solana/index.ts
+++ b/packages/blockchain-link/workers/solana/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/solana';

--- a/packages/blockchain-link/workers/stellar/index.ts
+++ b/packages/blockchain-link/workers/stellar/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/stellar';

--- a/packages/connect/e2e/vitest.config.ts
+++ b/packages/connect/e2e/vitest.config.ts
@@ -17,7 +17,7 @@ const alias = [
     },
 ];
 
-// Plugin to resolve bare module specifiers (e.g. @trezor/blockchain-link/src/workers/blockbook)
+// Plugin to resolve bare module specifiers (e.g. @trezor/blockchain-link/workers/blockbook)
 // inside new Worker(new URL(..., import.meta.url)) calls.
 // In dev mode, Vite doesn't bundle — the browser constructs the URL at runtime and has no way to
 // resolve bare package specifiers, so we must expand them to /@fs/ paths that the dev server

--- a/packages/connect/src/workers/workers.browser.ts
+++ b/packages/connect/src/workers/workers.browser.ts
@@ -1,4 +1,4 @@
-import type { BaseWorker } from '@trezor/blockchain-link/src/workers/baseWorker';
+import type { BaseWorker } from '@trezor/blockchain-link/workers/baseWorker';
 
 type WorkerAsyncImporter = () => Promise<BaseWorker<unknown>>;
 
@@ -6,7 +6,7 @@ const BlockbookWorker = () =>
     new Worker(
         new URL(
             /* webpackChunkName: "workers/blockbook-worker" */
-            '@trezor/blockchain-link/src/workers/blockbook',
+            '@trezor/blockchain-link/workers/blockbook',
             import.meta.url,
         ),
         { type: 'module' },
@@ -16,7 +16,7 @@ const BlockfrostWorker = () =>
     new Worker(
         new URL(
             /* webpackChunkName: "workers/blockfrost-worker" */
-            '@trezor/blockchain-link/src/workers/blockfrost',
+            '@trezor/blockchain-link/workers/blockfrost',
             import.meta.url,
         ),
         { type: 'module' },
@@ -26,7 +26,7 @@ const RippleWorker = () =>
     new Worker(
         new URL(
             /* webpackChunkName: "workers/ripple-worker" */
-            '@trezor/blockchain-link/src/workers/ripple',
+            '@trezor/blockchain-link/workers/ripple',
             import.meta.url,
         ),
         { type: 'module' },
@@ -36,7 +36,7 @@ const StellarWorker = () =>
     new Worker(
         new URL(
             /* webpackChunkName: "workers/stellar-worker" */
-            '@trezor/blockchain-link/src/workers/stellar',
+            '@trezor/blockchain-link/workers/stellar',
             import.meta.url,
         ),
         { type: 'module' },
@@ -46,14 +46,14 @@ const StellarWorker = () =>
 const SolanaWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/solana-worker" */
-        '@trezor/blockchain-link/src/workers/solana'
+        '@trezor/blockchain-link/workers/solana'
     ).then(w => w.default());
 const ElectrumWorker = undefined;
 
 const EvmRpcWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/evm-rpc-worker" */
-        '@trezor/blockchain-link/src/workers/evm-rpc'
+        '@trezor/blockchain-link/workers/evm-rpc'
     ).then(w => w.default());
 
 export {

--- a/packages/connect/src/workers/workers.native.ts
+++ b/packages/connect/src/workers/workers.native.ts
@@ -1,9 +1,9 @@
-import BlockbookWorker from '@trezor/blockchain-link/src/workers/blockbook';
-import BlockfrostWorker from '@trezor/blockchain-link/src/workers/blockfrost';
-import ElectrumWorker from '@trezor/blockchain-link/src/workers/electrum';
-import RippleWorker from '@trezor/blockchain-link/src/workers/ripple';
-import SolanaWorker from '@trezor/blockchain-link/src/workers/solana';
-import StellarWorker from '@trezor/blockchain-link/src/workers/stellar';
+import BlockbookWorker from '@trezor/blockchain-link/workers/blockbook';
+import BlockfrostWorker from '@trezor/blockchain-link/workers/blockfrost';
+import ElectrumWorker from '@trezor/blockchain-link/workers/electrum';
+import RippleWorker from '@trezor/blockchain-link/workers/ripple';
+import SolanaWorker from '@trezor/blockchain-link/workers/solana';
+import StellarWorker from '@trezor/blockchain-link/workers/stellar';
 
 export {
     BlockbookWorker,

--- a/packages/connect/src/workers/workers.ts
+++ b/packages/connect/src/workers/workers.ts
@@ -1,42 +1,42 @@
-import type { BaseWorker } from '@trezor/blockchain-link/src/workers/baseWorker';
+import type { BaseWorker } from '@trezor/blockchain-link/workers/baseWorker';
 
 type WorkerAsyncImporter = () => Promise<BaseWorker<unknown>>;
 
 const BlockbookWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/blockbook-worker" */
-        '@trezor/blockchain-link/src/workers/blockbook'
+        '@trezor/blockchain-link/workers/blockbook'
     ).then(w => w.default());
 const RippleWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/ripple-worker" */
-        '@trezor/blockchain-link/src/workers/ripple'
+        '@trezor/blockchain-link/workers/ripple'
     ).then(w => w.default());
 const BlockfrostWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/blockfrost-worker" */
-        '@trezor/blockchain-link/src/workers/blockfrost'
+        '@trezor/blockchain-link/workers/blockfrost'
     ).then(w => w.default());
 const ElectrumWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/electrum-worker" */
-        '@trezor/blockchain-link/src/workers/electrum'
+        '@trezor/blockchain-link/workers/electrum'
     ).then(w => w.default());
 const SolanaWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/solana-worker" */
-        '@trezor/blockchain-link/src/workers/solana'
+        '@trezor/blockchain-link/workers/solana'
     ).then(w => w.default());
 const StellarWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/stellar-worker" */
-        '@trezor/blockchain-link/src/workers/stellar'
+        '@trezor/blockchain-link/workers/stellar'
     ).then(w => w.default());
 
 const EvmRpcWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/evm-rpc-worker" */
-        '@trezor/blockchain-link/src/workers/evm-rpc'
+        '@trezor/blockchain-link/workers/evm-rpc'
     ).then(w => w.default());
 
 export {


### PR DESCRIPTION
## Description

Connect imports Blockchain Link worker implementations through `@trezor/blockchain-link/src/workers/*`. Under declaration-based project references, those internal imports are checked with Connect's compiler environment and lose the Web Worker ambient types required by `WorkerGlobalScope`.

This prerequisite for #27060 exposes stable public subpaths for every worker used by Connect, maps them to emitted artifacts for published packages, declares the implementation's `webworker` library dependency explicitly, and migrates the browser, native, and dynamic worker loaders to those public entries. Focused typechecks, production library builds, lint, and compilation on top of #27060's strict typecheck configuration pass for the affected worker entries.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies core blockchain-link worker implementations (baseWorker, blockbook, blockfrost, electrum, evm-rpc, ripple, solana, stellar) and the TrezorConnect worker bootstrapping files (workers.browser.ts, workers.native.ts, workers.ts). These are foundational, per-network communication layers, so regressions would manifest as broken discovery, balance sync, transaction broadcast, or staking flows for the specific affected coin/network rather than being isolated to one feature. Testing strategy: prioritize tests that directly configure custom backends (Blockbook/Electrum/Blockfrost) or drive staking/send transactions per network (BTC, ETH, SOL, ADA, LTC, DOGE), since these most directly exercise the changed worker code paths; TrezorConnect worker changes warrant smoke tests of the connect popup, sign, and getAddress flows. Given workers.browser.ts and baseWorker.ts each statically map to 100+ tests, most of that breadth was demoted/omitted since it reflects transitive imports rather than direct functional coupling.

<details><summary><b>Changed files (13)</b></summary>

- `packages/blockchain-link/package.json`
- `packages/blockchain-link/src/workers/baseWorker.ts`
- `packages/blockchain-link/workers/baseWorker/index.ts`
- `packages/blockchain-link/workers/blockbook/index.ts`
- `packages/blockchain-link/workers/blockfrost/index.ts`
- `packages/blockchain-link/workers/electrum/index.ts`
- `packages/blockchain-link/workers/evm-rpc/index.ts`
- `packages/blockchain-link/workers/ripple/index.ts`
- `packages/blockchain-link/workers/solana/index.ts`
- `packages/blockchain-link/workers/stellar/index.ts`
- `packages/connect/src/workers/workers.browser.ts`
- `packages/connect/src/workers/workers.native.ts`
- `packages/connect/src/workers/workers.ts`

</details>

**Recommended tests (30)**

<details><summary>🔴 <b>High priority (18)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test directly exercises Blockbook backend discovery for BTC and LTC; the changed blockbook worker (workers/blockbook/index.ts) and baseWorker.ts are the exact code paths responsible for backend communication and discovery completion.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Configures custom Blockbook backends for BTC/ETH and validates both successful connection and discovery error handling, directly testing the blockbook worker and baseWorker logic that were modified.
- `suite/e2e/tests/settings/coins.test.ts` — Enables mainnet/testnet networks and configures a custom Blockbook backend for ETH, exercising the same blockbook worker/backend discovery code paths that were changed.
- `suite/e2e/tests/wallet/discovery.test.ts` — Activates multiple coins (BTC, ETH, LTC, ETC, BCH, DOGE, XRP, ZEC) and drives full account discovery, directly stressing blockbook, ripple (XRP), and baseWorker code changes across many chains simultaneously.
- `suite/e2e/tests/settings/electrum.test.ts` — Configures a custom Electrum backend for the RegTest network and verifies discovery completes successfully, directly testing the changed electrum worker (workers/electrum/index.ts).
- `suite/e2e/tests/staking/ada/stake.test.ts` — Uses a mocked Blockfrost backend for Cardano staking flows, directly exercising the changed blockfrost worker (workers/blockfrost/index.ts) for transaction confirmation and account state updates.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Exercises Blockfrost-backed Cardano unstaking flow including balance updates and confirmation, directly hitting the modified blockfrost worker code path.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Claims Cardano staking rewards via mocked Blockfrost backend, directly exercising the changed blockfrost worker for reward/withdrawal transaction handling.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Uses a custom Blockbook backend mock for ETH and drives staking transaction confirmation/status updates, directly testing changed blockbook worker and baseWorker.ts logic for EVM-based accounts.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Exercises blockbook-backed ETH staking and pending/confirmed transaction status transitions, directly touching the changed blockbook worker and baseWorker code.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Exercises blockbook-backed ETH unstaking and claim flows with pending/confirmed transaction polling, directly hitting changed blockbook worker logic.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Uses a Solana staking mock backend and exercises staking, epoch transitions, and transaction confirmation, directly testing the changed solana worker and baseWorker.ts.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Exercises the full Solana unstake/claim lifecycle against a mocked Solana backend, directly stressing the changed solana worker code.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Exercises additional Solana staking with transaction simulation and epoch advancement, directly relying on the changed solana worker's transaction/backend handling.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Fetches and displays SOL staking rewards via mocked backend calls, directly exercising the changed solana worker's data-fetching code paths.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Sends a max SOL transaction with fee/reserve calculation and device confirmation, directly exercising the changed solana worker's transaction construction and broadcast logic.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Uses a Blockbook backend mock for DOGE and tests sign-transaction error handling, directly exercising the changed blockbook worker code path.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Configures a custom mocked Blockbook backend for LTC and sends a MimbleWimble peg-out transaction, directly testing the changed blockbook worker.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/wallet/coin-balance.test.ts` — Tests regtest BTC balance updates after receiving funds, which relies on blockbook/electrum-style backend communication paths touched by the base worker changes.
- `suite/e2e/tests/wallet/without-device.test.ts` — Enables and funds a regtest network, relying on blockchain-link backend workers for discovery and balance sync, which could be impacted by baseWorker changes.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Exercises BTC regtest send form transactions (OP_RETURN, locktime, satoshi units) relying on blockbook backend communication affected by the worker changes.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Swap flow relies on Solana send requests being routed through the blockchain-link solana worker for transaction broadcast; a regression could break live swap sending.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Solana-based token swap depends on the solana worker's send-request mocking/handling infrastructure that was changed.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Sell flow for SOL routes send requests through the mocked Solana backend, exercising the changed solana worker code for transaction handling.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — TrezorConnect worker initialization (workers.browser.ts / workers.ts) is directly used for the getAddress flow via connect-web in desktop mode, making this a good smoke test for the worker instantiation changes.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Directly exercises TrezorConnect's transaction signing flow which depends on the worker bootstrapping code in workers.browser.ts/workers.ts that changed.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Uses TrezorConnect.ethereumSignTransaction which relies on the same worker initialization path (workers.browser.ts/workers.ts) that was modified.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Exercises the full TrezorConnect popup flow (init, getAddress, cardanoGetAddress) which depends on correct worker loading via workers.browser.ts; regressions here could break the popup integration entirely.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/wallet/public-keys.test.ts` — Verifies XPUB retrieval for BTC/LTC/ADA which relies on backend workers (blockbook/blockfrost) for account data fetch, a plausible but indirect regression path.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — Exports transaction history across BTC/LTC/ETH/ADA accounts, which depends on backend workers fetching transaction data; a worker regression could produce incomplete or malformed exports.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/blockchain-link/package.json`
- `packages/blockchain-link/workers/stellar/index.ts`
- `packages/connect/src/workers/workers.native.ts`

_Updated: 2026-07-19T16:49:32.874Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/blockchain-link-worker-exports/web/](https://dev.suite.sldev.cz/suite-web/fix/blockchain-link-worker-exports/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/blockchain-link-worker-exports&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/blockchain-link-worker-exports&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/blockchain-link-worker-exports&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-19T16:52:30.420Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-19T16:52:18.601Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->