### PR TITLE
fix(connect): declare normalized bitcoin paths

### DIFF
--- a/packages/connect-common/src/utils/__tests__/pathUtils.type-test.ts
+++ b/packages/connect-common/src/utils/__tests__/pathUtils.type-test.ts
@@ -1,0 +1,21 @@
+import type { MessagesSchema as PROTO } from '@trezor/protobuf';
+
+import type { ProtoWithDerivationPath } from '../../types/params';
+import { fixPath } from '../pathUtils';
+
+declare const inputWithDerivationPath: ProtoWithDerivationPath<PROTO.TxInputType>;
+declare const outputWithDerivationPath: ProtoWithDerivationPath<PROTO.TxOutputType>;
+
+const normalizedInput: PROTO.TxInputType = fixPath(inputWithDerivationPath);
+const normalizedOutput: PROTO.TxOutputType = fixPath(outputWithDerivationPath);
+
+// @ts-expect-error A normalized input must not be typed as a transaction output.
+const normalizedInputAsOutput: PROTO.TxOutputType = fixPath(inputWithDerivationPath);
+
+// @ts-expect-error A normalized output must not be typed as a transaction input.
+const normalizedOutputAsInput: PROTO.TxInputType = fixPath(outputWithDerivationPath);
+
+void normalizedInput;
+void normalizedOutput;
+void normalizedInputAsOutput;
+void normalizedOutputAsInput;

--- a/packages/connect-common/src/utils/pathUtils.ts
+++ b/packages/connect-common/src/utils/pathUtils.ts
@@ -11,7 +11,7 @@ import { arrayPartition } from '@trezor/utils';
 
 import { ERRORS } from '../constants';
 import type { CoinInfo } from '../types/coinInfo';
-import type { DerivationPath, ProtoWithAddressN, ProtoWithDerivationPath } from '../types/params';
+import type { DerivationPath, ProtoWithDerivationPath } from '../types/params';
 
 export const getSlip44ByPath = (path: number[]) => {
     // @ts-expect-error: indexing with noUncheckedIndexedAccess
@@ -185,13 +185,11 @@ export const getSerializedPath = (path: number[]) =>
         })
         .join('/')}`;
 
-export const fixPath = <
-    T extends
-        | ProtoWithDerivationPath<PROTO.TxInputType>
-        | ProtoWithDerivationPath<PROTO.TxOutputType>,
->(
-    utxo: T,
-): ProtoWithAddressN<T> => {
+export function fixPath(utxo: ProtoWithDerivationPath<PROTO.TxInputType>): PROTO.TxInputType;
+export function fixPath(utxo: ProtoWithDerivationPath<PROTO.TxOutputType>): PROTO.TxOutputType;
+export function fixPath(
+    utxo: ProtoWithDerivationPath<PROTO.TxInputType> | ProtoWithDerivationPath<PROTO.TxOutputType>,
+): PROTO.TxInputType | PROTO.TxOutputType {
     // make sure bip32 indices are unsigned
     if (utxo.address_n && Array.isArray(utxo.address_n)) {
         utxo.address_n = utxo.address_n.map(i => i >>> 0);
@@ -201,8 +199,8 @@ export const fixPath = <
         utxo.address_n = getHDPath(utxo.address_n);
     }
 
-    return utxo as ProtoWithAddressN<T>;
-};
+    return utxo as PROTO.TxInputType | PROTO.TxOutputType;
+}
 
 export const getLabel = (label: string, coinInfo?: CoinInfo) => {
     if (coinInfo) {


### PR DESCRIPTION
## Description

`fixPath` normalizes string or numeric derivation paths into protobuf-compatible numeric paths, but its generic return type attempted to reverse-infer the original protobuf union through `ProtoWithDerivationPath`. That inference becomes unstable across emitted declaration boundaries, leaving callers with a type that still permits string paths and causing Bitcoin input/output TS2322 and TS2345 errors.

This prerequisite for #27060 gives `fixPath` explicit overloads for transaction inputs and outputs while preserving its runtime behavior. Connect typecheck, the production declaration build, focused lint, and all 29 path/input/output unit tests pass; applying the change on top of #27060 removes the Bitcoin declaration-boundary errors.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/connect-bitcoin-declaration-types/web/](https://dev.suite.sldev.cz/suite-web/fix/connect-bitcoin-declaration-types/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-bitcoin-declaration-types&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-bitcoin-declaration-types&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-bitcoin-declaration-types&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-23T12:30:40.461Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-23T12:30:57.561Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** LLM test selector skipped: Anthropic credit balance exhausted. Falling back to the full e2e suite.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect-common/src/utils/__tests__/pathUtils.type-test.ts`
- `packages/connect-common/src/utils/pathUtils.ts`

</details>

_No test recommendations found._

_Updated: 2026-07-23T12:27:32.856Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->