### PR TITLE
fix(connect): constrain entrypoint declarations

### DIFF
--- a/packages/connect/src/index.browser.ts
+++ b/packages/connect/src/index.browser.ts
@@ -1,4 +1,9 @@
-import { ERRORS, type UpdateConnectSettings, factoryPrivileged } from '@trezor/connect-common';
+import {
+    ERRORS,
+    type TrezorConnectPrivilegedAPI,
+    type UpdateConnectSettings,
+    factoryPrivileged,
+} from '@trezor/connect-common';
 // Deep import bypasses the `@trezor/transport` barrel so browser bundlers
 // do not resolve sibling node-only modules (`UdpTransport`/`dgram`,
 // `NodeUsbTransport`/`usb`).
@@ -36,7 +41,9 @@ class CoreInModuleWeb extends CoreInModule {
 }
 
 // Exported to enable using directly
-const TrezorConnect = factoryPrivileged(new CoreInModuleWeb());
+const TrezorConnect: TrezorConnectPrivilegedAPI & {
+    requestWebUSBDevice: () => Promise<void>;
+} = factoryPrivileged(new CoreInModuleWeb());
 
 export default TrezorConnect;
 

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,4 +1,8 @@
-import { type UpdateConnectSettings, factoryPrivileged } from '@trezor/connect-common';
+import {
+    type TrezorConnectPrivilegedAPI,
+    type UpdateConnectSettings,
+    factoryPrivileged,
+} from '@trezor/connect-common';
 import { BridgeTransport } from '@trezor/transport/src/transports/bridge';
 import type { AbstractTransportParams } from '@trezor/transport-common';
 
@@ -15,7 +19,7 @@ class CoreInModuleNode extends CoreInModule {
     }
 }
 
-const TrezorConnect = factoryPrivileged(new CoreInModuleNode());
+const TrezorConnect: TrezorConnectPrivilegedAPI = factoryPrivileged(new CoreInModuleNode());
 
 export default TrezorConnect;
 


### PR DESCRIPTION
## Description

The Connect node and browser entry points export the fully inferred result of `factoryPrivileged`. TypeScript therefore serializes every callable method back to its implementation module and retains private transport/core classes, leaking `@trezor/*/src/*` specifiers into the public declaration surface and pulling those internals into downstream typechecks.

This prerequisite for #27060 constrains both exported values to the existing `TrezorConnectPrivilegedAPI` contract while preserving the browser-only `requestWebUSBDevice` method explicitly. Connect typecheck, lint, and production declaration builds pass on both `develop` and #27060, and the node/browser entry declarations no longer contain internal source specifiers.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch the core TrezorConnect package entry points (index.ts and index.browser.ts), which define the public API (init, getAddress, selectAccount, signTransaction, signMessage, cancel, etc.) consumed both by Suite internally and by third-party integrations via popup/webextension. Since 131 tests statically reference index.browser.ts as a broad shared dependency, we applied the broad-utility heuristic and focused only on tests in the trezor-connect/ suite that directly and explicitly exercise the TrezorConnect public API surface (init, getAddress, selectAccount, signTransaction, signMessage, permissions, silent mode, popup lifecycle) rather than tests that merely transitively import Suite code using connect internally. These are the tests most likely to catch a regression in the changed entry-point files, since they call the API methods directly rather than through abstracted Suite UI flows.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect/src/index.browser.ts`
- `packages/connect/src/index.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (11)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test directly exercises the TrezorConnect public API (getAddress, cardanoGetAddress) through the browser entry point (index.browser.ts), including popup lifecycle, cancellation, and popup-blocked scenarios that are defined at the package's main export surface.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Exercises the same TrezorConnect browser API surface (getAddress) via a webextension consumer, directly testing the exported init/getAddress/cancel methods from index.browser.ts.
- `suite/e2e/tests/trezor-connect/error.test.ts` — Directly calls TrezorConnect.init and TrezorConnect.ethereumGetAddress to validate error handling for invalid input, exercising the core public API entry points that were changed.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Calls TrezorConnect.ethereumSignMessage via TrezorConnect.init, directly testing the API surface exported from the changed index files.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Calls TrezorConnect.ethereumSignTransaction directly, validating the core signing API exposed through the changed connect entry point.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Directly tests TrezorConnect.getAccountInfo API call and permission/account-selection flow, which routes through the changed index entry point.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Extensively tests TrezorConnect.getAddress including single/bundle requests and on-device confirmation flows, directly exercising the changed API surface.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests TrezorConnect permission granting/remembering/revocation logic tied directly to TrezorConnect.init and getAddress calls from the changed entry point.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — Directly tests TrezorConnect.selectAccount API (multi/single selection, cancellation, privacy guarantees), a core method exposed via the changed index files.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Directly exercises TrezorConnect.signTransaction, testing the core Bitcoin signing API path exported from the changed connect package entry point.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests TrezorConnect.init behavior around silent mode and window focus IPC, directly validating init-level configuration options exposed by the changed index entry point.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Bridge connectivity and device reconnection rely on the TrezorConnect transport layer initialized through the changed index entry points; a regression here could break bridge-based device communication broadly.

</details>

_Updated: 2026-07-19T17:03:44.150Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/connect-public-declaration-imports/web/](https://dev.suite.sldev.cz/suite-web/fix/connect-public-declaration-imports/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-public-declaration-imports&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-public-declaration-imports&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-public-declaration-imports&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-19T17:06:57.573Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-19T17:06:44.352Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->