### PR TITLE
chore(suite): cleanup sentryMiddleware return type

### DIFF
--- a/packages/suite/src/middlewares/suite/sentryMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/sentryMiddleware.ts
@@ -74,7 +74,7 @@ const breadcrumbActions = new Set<Action['type']>([
 const sentryMiddleware =
     (api: MiddlewareAPI<Dispatch, AppState>) =>
     (next: Dispatch) =>
-    (action: Action): Action | undefined => {
+    (action: Action): Action => {
         // pass action
         next(action);
 
@@ -129,7 +129,7 @@ const sentryMiddleware =
             }
             case deviceActions.setDeviceAuthenticityResult.type: {
                 const { result } = action.payload;
-                if (!result) return;
+                if (!result) break;
 
                 const reportToSentry = (error: string, errorDetails?: string) => {
                     withSentryScope(scope => {


### PR DESCRIPTION
## Description

Followup to #29945 to clean up the `sentryMiddleware` return type.

This changes the behavior: sentryMiddleware will now always return `next(action)`.
Previously, it early returned, and effectivelly filtered the action out.
That happens only when DAC has a runtime error, in which case we want to [store undefined result](https://github.com/trezor/trezor-suite/blob/f6823d984111f035c1696c141cffa4ae59a1672e/suite-common/device-authenticity/src/checkDeviceAuthenticityThunk.ts#L49-L50). The action is dispatched, but it is no-op if you let undefined into the reducer or filter it out.


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is sentryMiddleware.ts, a Redux middleware responsible for capturing errors/events for Sentry reporting. Since it is a background/cross-cutting middleware rather than a feature-specific module, it maps broadly to nearly all 131 e2e tests via static analysis, but very few tests have direct assertions on Sentry/error-reporting behavior itself. We recommend focusing on analytics-related tests that exercise event dispatching and error/failure flows, since these are the most likely to interact with or be indirectly affected by changes to this middleware; broad regression testing across unrelated feature areas (staking, trading, backup, etc.) is not warranted without further evidence of behavioral changes.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/middlewares/suite/sentryMiddleware.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test verifies Sentry/analytics event capturing behavior extensively, and sentryMiddleware is directly involved in error/event reporting infrastructure that could interact with analytics event dispatching.
- `suite/e2e/tests/analytics/toggle.test.ts` — This test exercises enabling/disabling analytics and verifies event dispatch timing and session/instance IDs, which is closely tied to middleware that intercepts actions for error reporting like sentryMiddleware.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test dispatches simulated failure actions and checks error toast/modal handling, which could be affected if sentryMiddleware alters how error actions are processed or reported, though no direct evidence links it to Sentry specifically.

</details>

_Updated: 2026-07-19T17:22:12.814Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/clenup-sentryMiddleware-return-type/web/](https://dev.suite.sldev.cz/suite-web/chore/clenup-sentryMiddleware-return-type/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->