### PR TITLE
fix(suite): declare application type entry

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -3,6 +3,7 @@
     "suiteVersion": "26.8.0",
     "version": "1.0.0",
     "private": true,
+    "types": "./libDev/index.d.ts",
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint": "yarn lint:styles && yarn lint:js",


### PR DESCRIPTION
## Description

`@trezor/suite` already defines an intentional package facade at its root `index.ts`, exporting the providers and store types consumed by other workspaces. Its inferred TypeScript root emits that facade to `libDev/index.d.ts`, so the `libDev/src/index.d.ts` path assigned by #27060 does not exist and causes consumers to fall back into Suite source.

This prerequisite for #27060 declares the existing `libDev/index.d.ts` artifact as the package type entry. Both the Suite and `@suite/test-utils` typechecks pass on `develop`; applying the entry on top of #27060 narrows the remaining Suite failure to a separate Connect browser deep-import prerequisite.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only change is to packages/suite/package.json, a manifest file (likely dependency versions, scripts, or metadata) with no direct static test coverage mapping. Without visibility into what specifically changed within the package.json (e.g., a dependency bump, a new script, or a version field), it's not possible to confidently infer which specific E2E behaviors would be affected. Since package.json changes can range from trivial (metadata/version bump) to impactful (dependency upgrades affecting build/runtime), the safest strategy is to run a lightweight smoke/sanity subset of the full E2E suite (e.g., onboarding and dashboard load tests) as a general safety net rather than targeting specific feature tests, but no specific test can be recommended with concrete evidence from the available analysis.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/package.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/suite/package.json`

_Updated: 2026-07-19T17:25:45.847Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/suite-declaration-entry/web/](https://dev.suite.sldev.cz/suite-web/fix/suite-declaration-entry/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-declaration-entry&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-declaration-entry&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-19T17:29:25.879Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-19T17:28:58.745Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->