### PR TITLE
fix(connect): expose browser api type

### DIFF
--- a/packages/connect/src/exports.ts
+++ b/packages/connect/src/exports.ts
@@ -1,4 +1,17 @@
+import type { TrezorConnectPrivilegedAPI } from '@trezor/connect-common';
+
 export * from '@trezor/connect-common';
+
+/**
+ * Connect API exposed by the browser entry, including its browser-only WebUSB device picker.
+ *
+ * Use this type instead of importing the browser implementation directly. The WebUSB action should
+ * eventually move behind an environment abstraction or dependency injection rather than becoming
+ * part of the shared Connect API.
+ */
+export type TrezorConnectWithBrowserAPI = TrezorConnectPrivilegedAPI & {
+    requestWebUSBDevice: () => Promise<void>;
+};
 
 // note: only @trezor/connect re-exports protobuf runtime
 export { MessagesSchema as PROTO } from '@trezor/protobuf';

--- a/packages/suite/src/components/firmware/FirmwareInstallation.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInstallation.tsx
@@ -1,9 +1,7 @@
 import { FirmwareProgressBar, useFirmwareDesktopUpdate } from '@suite/firmware-upgrade';
 import { Translation } from '@suite/intl';
 import { Banner, Card, Column } from '@trezor/components';
-import TrezorConnect from '@trezor/connect';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: expose the browser-specific TrezorConnect type via the @trezor/connect barrel and remove this exception (see #27376)
-import type TrezorConnectBrowser from '@trezor/connect/src/index.browser';
+import TrezorConnect, { type TrezorConnectWithBrowserAPI } from '@trezor/connect';
 import { BluetoothIcon, TrezorDevicesFilledIcon } from '@trezor/icons';
 
 import { FirmwareOffer } from 'src/components/firmware/FirmwareOffer';
@@ -57,7 +55,7 @@ export const FirmwareInstallation = ({
                             <Banner.Button
                                 onClick={() => {
                                     (
-                                        TrezorConnect as typeof TrezorConnectBrowser
+                                        TrezorConnect as TrezorConnectWithBrowserAPI
                                     ).requestWebUSBDevice();
                                 }}
                             >

--- a/packages/suite/src/components/suite/WebUsbButton.tsx
+++ b/packages/suite/src/components/suite/WebUsbButton.tsx
@@ -1,13 +1,11 @@
 import { Translation } from '@suite/intl';
 import { Button, type ButtonProps } from '@trezor/components';
-import TrezorConnect from '@trezor/connect';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: expose the browser-specific TrezorConnect type via the @trezor/connect barrel and remove this exception (see #27376)
-import type TrezorConnectBrowser from '@trezor/connect/src/index.browser';
+import TrezorConnect, { type TrezorConnectWithBrowserAPI } from '@trezor/connect';
 import { MagnifyingGlassIcon } from '@trezor/icons';
 
 const handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.stopPropagation();
-    (TrezorConnect as typeof TrezorConnectBrowser).requestWebUSBDevice();
+    (TrezorConnect as TrezorConnectWithBrowserAPI).requestWebUSBDevice();
 };
 
 type WebUsbButtonProps = Omit<ButtonProps, 'onClick' | 'data-testid' | 'children' | 'iconRight'> & {


### PR DESCRIPTION
## Description

Suite consumers need the browser-only WebUSB device picker, but importing the browser implementation directly bypasses the public Connect entry and breaks strict package-boundary type-checking.

Export `TrezorConnectWithBrowserAPI` from `@trezor/connect` and use it at the two WebUSB call sites. Its JSDoc identifies this as a browser-entry compatibility type and records that WebUSB should eventually move behind an environment abstraction or dependency injection rather than become part of the shared Connect API. Focused lint and the Connect and Suite package type-checks pass.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch a specific firmware installation UI component, a WebUSB connection button component, and the public API surface exported by the connect package. Both suite components map to a very broad set of 132 tests via transitive imports, so per the broad-utility heuristic only tests with direct behavioral overlap (firmware update modals, onboarding firmware/device-connect flows, and the Bridge/WebUSB fallback page) were promoted to high/medium priority. The connect exports file has no static coverage, so tests exercising core TrezorConnect API methods (getAddress, permissions/init) were inferred as relevant since they directly consume the exported API surface. Recommended strategy: run the custom-firmware and onboarding firmware-check tests as primary gates, plus a couple of TrezorConnect API smoke tests and the WebUSB/Bridge fallback test for broader confidence.

<details><summary><b>Changed files (3)</b></summary>

- `packages/connect/src/exports.ts`
- `packages/suite/src/components/firmware/FirmwareInstallation.tsx`
- `packages/suite/src/components/suite/WebUsbButton.tsx`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/firmware/custom-firmware.test.ts` — This test directly exercises the custom firmware installation flow in Settings > Device tab, which is the core functionality implemented by FirmwareInstallation.tsx. It asserts on the firmware installation completing and prompting reconnect, directly covering the changed component's behavior.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — This test exercises firmware hash/revision checks and firmware continuation during onboarding, which involves the same firmware installation UI/logic surface that was modified.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test specifically validates firmware readiness detection during onboarding, directly related to the FirmwareInstallation component's logic for checking and reporting firmware state.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — This test opens and closes the firmware update modal from device settings, which is a direct entry point into the FirmwareInstallation component's UI, so regressions in that component could surface here.
- `suite/e2e/tests/settings/t3b1-device-settings.test.ts` — This test also opens/closes the firmware update modal via the settings device tab, providing coverage of the FirmwareInstallation component on another device model.
- `suite/e2e/tests/suite/bridge.test.ts` — This test exercises the Bridge page flow that offers 'use WebUSB instead', directly touching WebUsbButton functionality and its interaction with the connect device prompt.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — TrezorConnect.getAddress is a core exported API surface from packages/connect/src/exports.ts; this test directly exercises the connect API export and its device confirmation flow, making it a good sanity check for changes to the connect package's public exports.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — This test verifies TrezorConnect.init and permission-granting behavior, directly relying on the public API surface exported from packages/connect/src/exports.ts, so a change there could break app initialization or method calls.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — This test includes device connection prompts and firmware continuation steps during onboarding, which touch both WebUsbButton (device connect) and FirmwareInstallation (firmware step), but the coverage is incidental rather than a primary focus.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test covers device connect prompts and bridge reconnection scenarios which indirectly involve WebUSB/transport connection UI, providing a loose signal if WebUsbButton behavior regresses.

</details>

_Updated: 2026-07-20T07:26:40.228Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/connect-browser-api-type/web/](https://dev.suite.sldev.cz/suite-web/fix/connect-browser-api-type/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-browser-api-type&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-browser-api-type&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-browser-api-type&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-20T07:29:57.641Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-20T07:29:45.022Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->