### PR TITLE
fix(suite-native): handle missing fiat rates in earn deposits total

### DIFF
--- a/suite-common/wallet-core/src/earn/__tests__/earnDepositsFiatUtils.test.ts
+++ b/suite-common/wallet-core/src/earn/__tests__/earnDepositsFiatUtils.test.ts
@@ -1,0 +1,197 @@
+import { type RatesByKey, type TokenAddress, toTokenAddress } from '@suite-common/wallet-types';
+import { getFiatRateKey } from '@suite-common/wallet-utils';
+
+import {
+    type EarnStablecoinYieldDepositFiatInput,
+    calculateEarnDepositsFiatData,
+    getEarnDepositsFiatStatus,
+} from '../earnDepositsFiatUtils';
+
+const USDC_CONTRACT_CHECKSUMMED = toTokenAddress('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48');
+const USDC_CONTRACT_LOWERCASE = toTokenAddress('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
+
+const createRates = (rates: Record<string, number>) =>
+    Object.fromEntries(Object.entries(rates).map(([key, rate]) => [key, { rate }])) as RatesByKey;
+
+const createYieldDeposit = (
+    tokenContractAddress: TokenAddress,
+): EarnStablecoinYieldDepositFiatInput => ({
+    id: 'yield-1',
+    networkSymbol: 'eth',
+    tokenContractAddress,
+    balance: '4',
+});
+
+describe(calculateEarnDepositsFiatData.name, () => {
+    it('calculates staking and stablecoin yield deposits using available rates', () => {
+        const result = calculateEarnDepositsFiatData({
+            stakingDeposits: [{ id: 'staking-1', symbol: 'eth', balance: '2' }],
+            stablecoinYieldDeposits: [createYieldDeposit(USDC_CONTRACT_LOWERCASE)],
+            currentFiatRates: createRates({
+                [getFiatRateKey('eth', 'usd')]: 3_000,
+                [getFiatRateKey('eth', 'usd', USDC_CONTRACT_LOWERCASE)]: 1,
+            }),
+            baseCurrencyCode: 'usd',
+        });
+
+        expect(result.stakingDeposits[0]?.fiatAmount.toFixed()).toBe('6000');
+        expect(result.stablecoinYieldDeposits[0]?.fiatAmount.toFixed()).toBe('4');
+        expect(result.totalDepositedFiatAmount.toFixed()).toBe('6004');
+        expect(result.missingRateTickers).toEqual([]);
+    });
+
+    it('finds a token rate stored under a differently cased contract address', () => {
+        const result = calculateEarnDepositsFiatData({
+            stakingDeposits: [],
+            stablecoinYieldDeposits: [createYieldDeposit(USDC_CONTRACT_LOWERCASE)],
+            currentFiatRates: createRates({
+                [getFiatRateKey('eth', 'usd', USDC_CONTRACT_CHECKSUMMED)]: 1,
+            }),
+            baseCurrencyCode: 'usd',
+        });
+
+        expect(result.stablecoinYieldDeposits[0]?.fiatAmount.toFixed()).toBe('4');
+        expect(result.missingStablecoinYieldRateTickers).toEqual([]);
+    });
+
+    it('normalizes and deduplicates tickers for deposits with missing rates', () => {
+        const result = calculateEarnDepositsFiatData({
+            stakingDeposits: [
+                { id: 'staking-1', symbol: 'eth', balance: '2' },
+                { id: 'staking-2', symbol: 'eth', balance: '1' },
+            ],
+            stablecoinYieldDeposits: [
+                createYieldDeposit(USDC_CONTRACT_CHECKSUMMED),
+                { ...createYieldDeposit(USDC_CONTRACT_LOWERCASE), id: 'yield-2' },
+            ],
+            currentFiatRates: createRates({}),
+            baseCurrencyCode: 'usd',
+        });
+
+        expect(result.missingStakingRateTickers).toEqual([{ symbol: 'eth' }]);
+        expect(result.missingStablecoinYieldRateTickers).toEqual([
+            { symbol: 'eth', tokenAddress: USDC_CONTRACT_LOWERCASE },
+        ]);
+        expect(result.missingRateTickers).toEqual([
+            { symbol: 'eth' },
+            { symbol: 'eth', tokenAddress: USDC_CONTRACT_LOWERCASE },
+        ]);
+        expect(result.hasStakingFiatRate).toBe(false);
+        expect(result.hasStablecoinYieldFiatRate).toBe(false);
+    });
+
+    it('keeps only loaded rates in the lower-bound total', () => {
+        const result = calculateEarnDepositsFiatData({
+            stakingDeposits: [{ id: 'staking-1', symbol: 'eth', balance: '2' }],
+            stablecoinYieldDeposits: [createYieldDeposit(USDC_CONTRACT_LOWERCASE)],
+            currentFiatRates: createRates({
+                [getFiatRateKey('eth', 'usd', USDC_CONTRACT_LOWERCASE)]: 1,
+            }),
+            baseCurrencyCode: 'usd',
+        });
+
+        expect(result.totalDepositedFiatAmount.toFixed()).toBe('4');
+        expect(result.hasStakingFiatRate).toBe(false);
+        expect(result.hasStablecoinYieldFiatRate).toBe(true);
+    });
+
+    it('treats a rate of zero as missing', () => {
+        const result = calculateEarnDepositsFiatData({
+            stakingDeposits: [{ id: 'staking-1', symbol: 'eth', balance: '2' }],
+            stablecoinYieldDeposits: [createYieldDeposit(USDC_CONTRACT_LOWERCASE)],
+            currentFiatRates: createRates({
+                [getFiatRateKey('eth', 'usd')]: 0,
+                [getFiatRateKey('eth', 'usd', USDC_CONTRACT_LOWERCASE)]: 0,
+            }),
+            baseCurrencyCode: 'usd',
+        });
+
+        expect(result.hasStakingFiatRate).toBe(false);
+        expect(result.hasStablecoinYieldFiatRate).toBe(false);
+        expect(result.missingRateTickers).toEqual([
+            { symbol: 'eth' },
+            { symbol: 'eth', tokenAddress: USDC_CONTRACT_LOWERCASE },
+        ]);
+        expect(result.totalDepositedFiatAmount.toFixed()).toBe('0');
+    });
+
+    it('omits empty deposits from the calculated results', () => {
+        const result = calculateEarnDepositsFiatData({
+            stakingDeposits: [{ id: 'staking-1', symbol: 'eth', balance: null }],
+            stablecoinYieldDeposits: [
+                { ...createYieldDeposit(USDC_CONTRACT_LOWERCASE), balance: '0' },
+            ],
+            currentFiatRates: createRates({}),
+            baseCurrencyCode: 'usd',
+        });
+
+        expect(result.stakingDeposits).toEqual([]);
+        expect(result.stablecoinYieldDeposits).toEqual([]);
+        expect(result.missingRateTickers).toEqual([]);
+        expect(result.totalDepositedFiatAmount.toFixed()).toBe('0');
+    });
+});
+
+describe(getEarnDepositsFiatStatus.name, () => {
+    it('reports a complete total when no rates are missing', () => {
+        const result = getEarnDepositsFiatStatus({
+            missingStakingRateTickers: [],
+            missingStablecoinYieldRateTickers: [],
+            hasStakingFiatRate: true,
+            hasStablecoinYieldFiatRate: true,
+            isFiatRatesLoading: false,
+        });
+
+        expect(result).toEqual({
+            isFiatTotalIncomplete: false,
+            isFiatTotalUnavailable: false,
+            isStakingFiatRateMissing: false,
+            isStablecoinYieldFiatRateMissing: false,
+        });
+    });
+
+    it('reports a lower-bound total when only one deposit type has a rate', () => {
+        const result = getEarnDepositsFiatStatus({
+            missingStakingRateTickers: [{ symbol: 'eth' }],
+            missingStablecoinYieldRateTickers: [],
+            hasStakingFiatRate: false,
+            hasStablecoinYieldFiatRate: true,
+            isFiatRatesLoading: false,
+        });
+
+        expect(result).toEqual({
+            isFiatTotalIncomplete: true,
+            isFiatTotalUnavailable: false,
+            isStakingFiatRateMissing: true,
+            isStablecoinYieldFiatRateMissing: false,
+        });
+    });
+
+    it('reports an unavailable total when no deposit type has a rate', () => {
+        const result = getEarnDepositsFiatStatus({
+            missingStakingRateTickers: [{ symbol: 'eth' }],
+            missingStablecoinYieldRateTickers: [
+                { symbol: 'eth', tokenAddress: USDC_CONTRACT_LOWERCASE },
+            ],
+            hasStakingFiatRate: false,
+            hasStablecoinYieldFiatRate: false,
+            isFiatRatesLoading: false,
+        });
+
+        expect(result.isFiatTotalIncomplete).toBe(true);
+        expect(result.isFiatTotalUnavailable).toBe(true);
+    });
+
+    it('does not report an incomplete total while missing rates are loading', () => {
+        const result = getEarnDepositsFiatStatus({
+            missingStakingRateTickers: [{ symbol: 'eth' }],
+            missingStablecoinYieldRateTickers: [],
+            hasStakingFiatRate: false,
+            hasStablecoinYieldFiatRate: false,
+            isFiatRatesLoading: true,
+        });
+
+        expect(result.isFiatTotalIncomplete).toBe(false);
+        expect(result.isFiatTotalUnavailable).toBe(false);
+    });
+});

--- a/suite-common/wallet-core/src/earn/earnDepositsFiatUtils.ts
+++ b/suite-common/wallet-core/src/earn/earnDepositsFiatUtils.ts
@@ -1,0 +1,224 @@
+import { A, F } from '@mobily/ts-belt';
+
+import { type NetworkSymbol, type StakingNetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type BaseCurrencyAmount,
+    type CryptoBaseCurrencyPair,
+    type RatesByKey,
+    type TickerId,
+    type TokenAddress,
+    asBaseCurrencyAmount,
+    toTokenAddress,
+} from '@suite-common/wallet-types';
+import {
+    getContractAddressForNetworkSymbol,
+    getFiatRateKey,
+    toFiatCurrency,
+} from '@suite-common/wallet-utils';
+import { type BaseCurrencyCode } from '@trezor/blockchain-link-types';
+import { BigNumber } from '@trezor/utils';
+
+export type EarnStakingDepositFiatInput = {
+    id: string;
+    symbol: StakingNetworkSymbol;
+    balance: string | null;
+};
+
+export type EarnStablecoinYieldDepositFiatInput = {
+    id: string;
+    networkSymbol: NetworkSymbol;
+    tokenContractAddress: TokenAddress;
+    balance: string | null;
+};
+
+export type CalculatedEarnStakingDeposit<
+    TDeposit extends EarnStakingDepositFiatInput = EarnStakingDepositFiatInput,
+> = {
+    deposit: TDeposit;
+    balance: string;
+    fiatAmount: BaseCurrencyAmount;
+    hasFiatRate: boolean;
+};
+
+export type CalculatedEarnStablecoinYieldDeposit<
+    TDeposit extends EarnStablecoinYieldDepositFiatInput = EarnStablecoinYieldDepositFiatInput,
+> = {
+    deposit: TDeposit;
+    balance: string;
+    fiatAmount: BaseCurrencyAmount;
+    hasFiatRate: boolean;
+    normalizedTokenAddress: TokenAddress;
+};
+
+type CalculateEarnDepositsFiatDataParams<
+    TStakingDeposit extends EarnStakingDepositFiatInput,
+    TStablecoinYieldDeposit extends EarnStablecoinYieldDepositFiatInput,
+> = {
+    stakingDeposits: TStakingDeposit[];
+    stablecoinYieldDeposits: TStablecoinYieldDeposit[];
+    currentFiatRates: RatesByKey | undefined;
+    baseCurrencyCode: BaseCurrencyCode;
+};
+
+type GetEarnDepositsFiatStatusParams = {
+    missingStakingRateTickers: TickerId[];
+    missingStablecoinYieldRateTickers: TickerId[];
+    hasStakingFiatRate: boolean;
+    hasStablecoinYieldFiatRate: boolean;
+    isFiatRatesLoading: boolean;
+};
+
+const getUniqueTickers = (tickers: TickerId[]): TickerId[] =>
+    F.toMutable(
+        A.uniqBy(tickers, ticker =>
+            ticker.tokenAddress ? `${ticker.symbol}-${ticker.tokenAddress}` : ticker.symbol,
+        ),
+    );
+
+const getTokenFiatRate = (
+    currentFiatRates: RatesByKey | undefined,
+    fiatRateKey: CryptoBaseCurrencyPair,
+): number | undefined => {
+    if (!currentFiatRates) {
+        return undefined;
+    }
+
+    const exactRate = currentFiatRates[fiatRateKey]?.rate;
+    if (exactRate !== undefined) {
+        return exactRate;
+    }
+
+    // Rates fetched for account tokens use the blockbook contract-address casing,
+    // which may differ from the casing returned by the yield provider.
+    const lowerCasedFiatRateKey = fiatRateKey.toLowerCase();
+    const caseInsensitiveMatch = Object.entries(currentFiatRates).find(
+        ([key]) => key.toLowerCase() === lowerCasedFiatRateKey,
+    );
+
+    return caseInsensitiveMatch?.[1]?.rate;
+};
+
+const calculateDepositFiat = (balance: string, rate: number | undefined) => {
+    const fiatAmount = toFiatCurrency({ amount: balance, rate });
+
+    return {
+        fiatAmount: asBaseCurrencyAmount(new BigNumber(fiatAmount ?? '0')),
+        hasFiatRate: fiatAmount !== null,
+    };
+};
+
+export const calculateEarnDepositsFiatData = <
+    TStakingDeposit extends EarnStakingDepositFiatInput,
+    TStablecoinYieldDeposit extends EarnStablecoinYieldDepositFiatInput,
+>({
+    stakingDeposits,
+    stablecoinYieldDeposits,
+    currentFiatRates,
+    baseCurrencyCode,
+}: CalculateEarnDepositsFiatDataParams<TStakingDeposit, TStablecoinYieldDeposit>) => {
+    const calculatedStakingDeposits: CalculatedEarnStakingDeposit<TStakingDeposit>[] =
+        stakingDeposits.flatMap(deposit => {
+            if (deposit.balance === null || deposit.balance === '0') {
+                return [];
+            }
+
+            const fiatRateKey = getFiatRateKey(deposit.symbol, baseCurrencyCode);
+            const fiatRate = currentFiatRates?.[fiatRateKey]?.rate;
+
+            return [
+                {
+                    deposit,
+                    balance: deposit.balance,
+                    ...calculateDepositFiat(deposit.balance, fiatRate),
+                },
+            ];
+        });
+
+    const calculatedStablecoinYieldDeposits: CalculatedEarnStablecoinYieldDeposit<TStablecoinYieldDeposit>[] =
+        stablecoinYieldDeposits.flatMap(deposit => {
+            if (deposit.balance === null || deposit.balance === '0') {
+                return [];
+            }
+
+            const normalizedTokenAddress = toTokenAddress(
+                getContractAddressForNetworkSymbol(
+                    deposit.networkSymbol,
+                    deposit.tokenContractAddress,
+                ),
+            );
+            const fiatRateKey = getFiatRateKey(
+                deposit.networkSymbol,
+                baseCurrencyCode,
+                normalizedTokenAddress,
+            );
+            const fiatRate = getTokenFiatRate(currentFiatRates, fiatRateKey);
+
+            return [
+                {
+                    deposit,
+                    balance: deposit.balance,
+                    ...calculateDepositFiat(deposit.balance, fiatRate),
+                    normalizedTokenAddress,
+                },
+            ];
+        });
+
+    const missingStakingRateTickers = getUniqueTickers(
+        calculatedStakingDeposits.flatMap(({ deposit, hasFiatRate }) =>
+            hasFiatRate ? [] : [{ symbol: deposit.symbol }],
+        ),
+    );
+    const missingStablecoinYieldRateTickers = getUniqueTickers(
+        calculatedStablecoinYieldDeposits.flatMap(
+            ({ deposit, hasFiatRate, normalizedTokenAddress }) =>
+                hasFiatRate
+                    ? []
+                    : [{ symbol: deposit.networkSymbol, tokenAddress: normalizedTokenAddress }],
+        ),
+    );
+    const missingRateTickers = getUniqueTickers([
+        ...missingStakingRateTickers,
+        ...missingStablecoinYieldRateTickers,
+    ]);
+    const totalDepositedFiatAmount = asBaseCurrencyAmount(
+        [...calculatedStakingDeposits, ...calculatedStablecoinYieldDeposits].reduce(
+            (sum, deposit) => sum.plus(deposit.fiatAmount),
+            new BigNumber(0),
+        ),
+    );
+
+    return {
+        stakingDeposits: calculatedStakingDeposits,
+        stablecoinYieldDeposits: calculatedStablecoinYieldDeposits,
+        missingStakingRateTickers,
+        missingStablecoinYieldRateTickers,
+        missingRateTickers,
+        totalDepositedFiatAmount,
+        hasStakingFiatRate: calculatedStakingDeposits.some(({ hasFiatRate }) => hasFiatRate),
+        hasStablecoinYieldFiatRate: calculatedStablecoinYieldDeposits.some(
+            ({ hasFiatRate }) => hasFiatRate,
+        ),
+    };
+};
+
+export const getEarnDepositsFiatStatus = ({
+    missingStakingRateTickers,
+    missingStablecoinYieldRateTickers,
+    hasStakingFiatRate,
+    hasStablecoinYieldFiatRate,
+    isFiatRatesLoading,
+}: GetEarnDepositsFiatStatusParams) => {
+    const isStakingFiatRateMissing = missingStakingRateTickers.length > 0;
+    const isStablecoinYieldFiatRateMissing = missingStablecoinYieldRateTickers.length > 0;
+    const isFiatTotalIncomplete =
+        (isStakingFiatRateMissing || isStablecoinYieldFiatRateMissing) && !isFiatRatesLoading;
+    const isFiatTotalUnavailable =
+        isFiatTotalIncomplete && !hasStakingFiatRate && !hasStablecoinYieldFiatRate;
+
+    return {
+        isFiatTotalIncomplete,
+        isFiatTotalUnavailable,
+        isStakingFiatRateMissing,
+        isStablecoinYieldFiatRateMissing,
+    };
+};

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -25,6 +25,7 @@ export * from './discovery/discoveryReducer';
 export * from './discovery/discoverySelectors';
 export * from './discovery/discoveryThunks';
 export * from './discovery/selectDeviceThunk';
+export * from './earn/earnDepositsFiatUtils';
 export * from './explorer/explorerActions';
 export * from './explorer/explorerReducer';
 export * from './explorer/explorerSelectors';

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -17,6 +17,7 @@ export const messages = {
             enable: 'Enable',
             gotIt: 'Got it',
             next: 'Next',
+            retry: 'Retry',
             tryAgain: 'Try again',
             edit: 'Edit',
             yes: 'Yes',
@@ -2712,6 +2713,7 @@ export const messages = {
                 networkStaking: '{networkName} staking',
                 availableRewards: 'Available rewards',
                 claimRewardsButton: 'Claim rewards',
+                incompleteFiatTotal: 'Some fiat rates couldn’t load. Total may be incomplete.',
             },
             activeSheet: {
                 stakingTitle: 'Your stakes',

--- a/suite-native/module-earn/src/components/EarnDepositsCard.tsx
+++ b/suite-native/module-earn/src/components/EarnDepositsCard.tsx
@@ -9,6 +9,8 @@ import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     Box,
     Card,
+    HStack,
+    InlineAlertBox,
     ListItemSkeleton,
     Text,
     VStack,
@@ -62,7 +64,15 @@ export const EarnDepositsCard = ({
 }: EarnDepositsCardProps) => {
     const { applyStyle } = useNativeStyles();
     const navigation = useNavigation<NavigationProp>();
-    const { stakingRow, stablecoinYieldRow, totalDepositedFiatAmount } = useEarnDepositsCardData({
+    const {
+        stakingRow,
+        stablecoinYieldRow,
+        totalDepositedFiatAmount,
+        isFiatRatesLoading,
+        isFiatTotalIncomplete,
+        isFiatTotalUnavailable,
+        retryMissingFiatRates,
+    } = useEarnDepositsCardData({
         stakingActiveItems,
         stablecoinYieldActiveItems,
     });
@@ -144,12 +154,37 @@ export const EarnDepositsCard = ({
                                 <Text variant="body-md" color="contentSecondary">
                                     <Translation id="earn.earnScreen.depositsCard.title" />
                                 </Text>
-                                <BaseCurrencyAmountFormatter
-                                    value={totalDepositedFiatAmount}
-                                    variant="headline-md"
-                                    isDiscreetText={false}
-                                />
+                                {isFiatTotalUnavailable ? (
+                                    <Text variant="headline-md">
+                                        <Translation id="earn.notAvailableShort" />
+                                    </Text>
+                                ) : (
+                                    <HStack spacing="sp4" alignItems="center">
+                                        {isFiatTotalIncomplete && (
+                                            <Text variant="headline-md">~</Text>
+                                        )}
+                                        <BaseCurrencyAmountFormatter
+                                            value={totalDepositedFiatAmount}
+                                            variant="headline-md"
+                                            isDiscreetText={false}
+                                            isLoading={isFiatRatesLoading}
+                                        />
+                                    </HStack>
+                                )}
                             </VStack>
+
+                            {isFiatTotalIncomplete && (
+                                <InlineAlertBox
+                                    testID="@earn/deposits-card/incomplete-fiat-total"
+                                    intent="warning"
+                                    title={
+                                        <Translation id="earn.earnScreen.depositsCard.incompleteFiatTotal" />
+                                    }
+                                    buttonLabel={<Translation id="generic.buttons.retry" />}
+                                    buttonProps={{ priority: 'secondary' }}
+                                    onButtonPress={() => void retryMissingFiatRates()}
+                                />
+                            )}
 
                             <StablecoinYieldClaimRewardsCardSection
                                 claimRewards={stablecoinYieldClaimSummaries}

--- a/suite-native/module-earn/src/hooks/__tests__/useEarnDepositsCardData.test.ts
+++ b/suite-native/module-earn/src/hooks/__tests__/useEarnDepositsCardData.test.ts
@@ -1,0 +1,189 @@
+import { useMissingRateTickersQuery } from '@suite-common/wallet-core';
+import { type TokenAddress, toTokenAddress, toTokenSymbol } from '@suite-common/wallet-types';
+import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import { getFiatRateKey } from '@suite-common/wallet-utils';
+import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+
+import { type StablecoinYieldEarnItem, type StakingEarnItem } from '../../types';
+import { useEarnDepositsCardData } from '../useEarnDepositsCardData';
+
+jest.mock('@suite-common/wallet-core', () => ({
+    ...jest.requireActual('@suite-common/wallet-core'),
+    useMissingRateTickersQuery: jest.fn(),
+}));
+
+const useMissingRateTickersQueryMock = jest.mocked(useMissingRateTickersQuery);
+const refetchMissingRateTickersMock = jest.fn();
+
+// The hook only reads these fields; constructing the full UseQueryResult is impractical,
+// so the single cast below is the last resort the tests skill allows for such mocks.
+const createMissingRateTickersQueryResult = (
+    overrides: Partial<Pick<ReturnType<typeof useMissingRateTickersQuery>, 'isFetching'>> = {},
+): ReturnType<typeof useMissingRateTickersQuery> =>
+    ({
+        isFetching: false,
+        refetch: refetchMissingRateTickersMock,
+        ...overrides,
+    }) as unknown as ReturnType<typeof useMissingRateTickersQuery>;
+
+// Checksummed casing as returned by blockbook for account tokens (EIP-55).
+const USDC_CONTRACT_CHECKSUMMED = toTokenAddress('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48');
+// Lowercase casing as it arrives from the yield.xyz API (vault.token.address).
+const USDC_CONTRACT_LOWERCASE = toTokenAddress('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
+const DAI_CONTRACT_LOWERCASE = toTokenAddress('0x0000000000000000000000000000000000000004');
+const RECEIPT_TOKEN_CONTRACT = toTokenAddress('0x0000000000000000000000000000000000000003');
+
+const ethAccountKey = mockAccountKey({ symbol: 'eth' });
+
+const stakingItem: StakingEarnItem = {
+    id: 'staking-eth-account-1',
+    type: 'staking',
+    symbol: 'eth',
+    accountKey: ethAccountKey,
+    balance: '2',
+};
+
+const createYieldItem = (underlyingContract: TokenAddress): StablecoinYieldEarnItem => ({
+    id: 'vault-1-account-1',
+    type: 'stablecoin-yield',
+    yieldId: 'vault-1',
+    vaultName: 'Steakhouse USDC',
+    tokenSymbol: toTokenSymbol('USDC'),
+    networkSymbol: 'eth',
+    underlyingTokenContract: underlyingContract,
+    receiptTokenContract: RECEIPT_TOKEN_CONTRACT,
+    contractAddress: RECEIPT_TOKEN_CONTRACT,
+    tokenContractAddress: underlyingContract,
+    accountKey: ethAccountKey,
+    accountLabel: undefined,
+    tokenBalance: '4',
+    apy: 5.3,
+});
+
+const renderDepositsCardData = ({
+    items,
+    stakingItems = [],
+    currentRates,
+}: {
+    items: StablecoinYieldEarnItem[];
+    stakingItems?: StakingEarnItem[];
+    currentRates: Record<string, { rate: number }>;
+}) =>
+    renderHookWithStoreProvider(
+        () =>
+            useEarnDepositsCardData({
+                stakingActiveItems: stakingItems,
+                stablecoinYieldActiveItems: items,
+            }),
+        {
+            preloadedState: {
+                wallet: {
+                    fiat: { current: currentRates, historic: {} },
+                    settings: { localCurrency: 'usd' },
+                },
+            },
+        },
+    );
+
+describe('useEarnDepositsCardData', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        useMissingRateTickersQueryMock.mockReturnValue(createMissingRateTickersQueryResult());
+    });
+
+    it('includes the yield position in the total when the token rate is available', () => {
+        const { result } = renderDepositsCardData({
+            items: [createYieldItem(USDC_CONTRACT_LOWERCASE)],
+            currentRates: {
+                [getFiatRateKey('eth', 'usd', USDC_CONTRACT_LOWERCASE)]: { rate: 1 },
+            },
+        });
+
+        expect(result.current.totalDepositedFiatAmount.toFixed()).toBe('4');
+        expect(result.current.isFiatRatesLoading).toBe(false);
+    });
+
+    it('includes the yield position when the rate is stored under a differently cased contract address', () => {
+        const { result } = renderDepositsCardData({
+            items: [createYieldItem(USDC_CONTRACT_LOWERCASE)],
+            currentRates: {
+                [getFiatRateKey('eth', 'usd', USDC_CONTRACT_CHECKSUMMED)]: { rate: 1 },
+            },
+        });
+
+        expect(result.current.totalDepositedFiatAmount.toFixed()).toBe('4');
+        expect(useMissingRateTickersQueryMock).toHaveBeenLastCalledWith({
+            missingRateTickers: [],
+            baseCurrencyCode: 'usd',
+        });
+    });
+
+    it('requests the missing token rate and reports the fiat loading state', () => {
+        useMissingRateTickersQueryMock.mockReturnValue(
+            createMissingRateTickersQueryResult({ isFetching: true }),
+        );
+
+        const { result } = renderDepositsCardData({
+            items: [createYieldItem(USDC_CONTRACT_CHECKSUMMED)],
+            currentRates: {
+                [getFiatRateKey('eth', 'usd')]: { rate: 3000 },
+            },
+        });
+
+        expect(useMissingRateTickersQueryMock).toHaveBeenLastCalledWith({
+            missingRateTickers: [{ symbol: 'eth', tokenAddress: USDC_CONTRACT_LOWERCASE }],
+            baseCurrencyCode: 'usd',
+        });
+        expect(result.current.isFiatRatesLoading).toBe(true);
+
+        // The position stays listed with its token balance even while its rate is missing.
+        expect(result.current.stablecoinYieldRow?.activeItems[0]?.balance).toBe('4');
+        expect(result.current.totalDepositedFiatAmount.toFixed()).toBe('0');
+    });
+
+    it('reports an incomplete total and allows retry when the rate remains missing', () => {
+        const { result } = renderDepositsCardData({
+            items: [createYieldItem(USDC_CONTRACT_LOWERCASE)],
+            currentRates: {},
+        });
+
+        expect(result.current.isFiatRatesLoading).toBe(false);
+        expect(result.current.isFiatTotalIncomplete).toBe(true);
+        expect(result.current.isFiatTotalUnavailable).toBe(true);
+
+        result.current.retryMissingFiatRates();
+
+        expect(refetchMissingRateTickersMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports a lower-bound total when only some yield rates are available', () => {
+        const { result } = renderDepositsCardData({
+            items: [
+                createYieldItem(USDC_CONTRACT_LOWERCASE),
+                createYieldItem(DAI_CONTRACT_LOWERCASE),
+            ],
+            currentRates: {
+                [getFiatRateKey('eth', 'usd', USDC_CONTRACT_LOWERCASE)]: { rate: 1 },
+            },
+        });
+
+        expect(result.current.totalDepositedFiatAmount.toFixed()).toBe('4');
+        expect(result.current.isFiatTotalIncomplete).toBe(true);
+        expect(result.current.isFiatTotalUnavailable).toBe(false);
+    });
+
+    it('reports an unavailable total and requests a missing staking rate', () => {
+        const { result } = renderDepositsCardData({
+            items: [],
+            stakingItems: [stakingItem],
+            currentRates: {},
+        });
+
+        expect(useMissingRateTickersQueryMock).toHaveBeenLastCalledWith({
+            missingRateTickers: [{ symbol: 'eth' }],
+            baseCurrencyCode: 'usd',
+        });
+        expect(result.current.isFiatTotalIncomplete).toBe(true);
+        expect(result.current.isFiatTotalUnavailable).toBe(true);
+    });
+});

--- a/suite-native/module-earn/src/hooks/useEarnDepositsCardData.ts
+++ b/suite-native/module-earn/src/hooks/useEarnDepositsCardData.ts
@@ -2,15 +2,15 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
-import { selectBaseCurrency, selectCurrentFiatRates } from '@suite-common/wallet-core';
-import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import {
-    compareEarnByAmountDesc,
-    getFiatRateKey,
-    toFiatCurrency,
-} from '@suite-common/wallet-utils';
+    calculateEarnDepositsFiatData,
+    getEarnDepositsFiatStatus,
+    selectBaseCurrency,
+    selectCurrentFiatRates,
+    useMissingRateTickersQuery,
+} from '@suite-common/wallet-core';
+import { compareEarnByAmountDesc } from '@suite-common/wallet-utils';
 import { useTranslate } from '@suite-native/intl';
-import { BigNumber } from '@trezor/utils';
 
 import {
     type EarnDepositsCardActiveItem,
@@ -56,93 +56,110 @@ export const useEarnDepositsCardData = ({
     const currentFiatRates = useSelector(selectCurrentFiatRates);
     const fiatCurrency = useSelector(selectBaseCurrency);
 
+    const stakingDeposits = useMemo(
+        () =>
+            stakingActiveItems.flatMap(item => {
+                if (item.accountKey === null) {
+                    return [];
+                }
+
+                return [{ ...item, accountKey: item.accountKey }];
+            }),
+        [stakingActiveItems],
+    );
+    const stablecoinYieldDeposits = useMemo(
+        () =>
+            stablecoinYieldActiveItems.flatMap(item => {
+                if (item.accountKey === null) {
+                    return [];
+                }
+
+                return [
+                    {
+                        ...item,
+                        accountKey: item.accountKey,
+                        balance: item.tokenBalance,
+                    },
+                ];
+            }),
+        [stablecoinYieldActiveItems],
+    );
+
+    const {
+        stakingDeposits: calculatedStakingDeposits,
+        stablecoinYieldDeposits: calculatedStablecoinYieldDeposits,
+        missingStakingRateTickers,
+        missingStablecoinYieldRateTickers,
+        missingRateTickers,
+        totalDepositedFiatAmount,
+        hasStakingFiatRate,
+        hasStablecoinYieldFiatRate: hasStablecoinFiatRate,
+    } = useMemo(
+        () =>
+            calculateEarnDepositsFiatData({
+                stakingDeposits,
+                stablecoinYieldDeposits,
+                currentFiatRates,
+                baseCurrencyCode: fiatCurrency,
+            }),
+        [currentFiatRates, fiatCurrency, stablecoinYieldDeposits, stakingDeposits],
+    );
+
     const stakingRows = useMemo(
         () =>
-            stakingActiveItems
-                .flatMap(item => {
-                    if (item.accountKey === null || item.balance === null || item.balance === '0') {
-                        return [];
-                    }
-
-                    const fiatRateKey = getFiatRateKey(item.symbol, fiatCurrency);
-                    const fiatRate = currentFiatRates?.[fiatRateKey]?.rate;
-                    const fiatAmount = asBaseCurrencyAmount(
-                        new BigNumber(
-                            toFiatCurrency({ amount: item.balance, rate: fiatRate }) ?? '0',
-                        ),
-                    );
-
-                    return [
-                        {
-                            id: item.id,
+            calculatedStakingDeposits
+                .map(
+                    ({ deposit, balance, fiatAmount }) =>
+                        ({
+                            id: deposit.id,
                             type: 'staking',
-                            title: item.accountLabel ?? getNetworkDisplaySymbolName(item.symbol),
-                            symbol: item.symbol,
-                            accountKey: item.accountKey,
-                            balance: item.balance,
+                            title:
+                                deposit.accountLabel ?? getNetworkDisplaySymbolName(deposit.symbol),
+                            symbol: deposit.symbol,
+                            accountKey: deposit.accountKey,
+                            balance,
                             fiatAmount,
-                        } satisfies EarnDepositsCardActiveItem,
-                    ];
-                })
+                        }) satisfies EarnDepositsCardActiveItem,
+                )
                 // Active positions are ordered by fiat value, highest first (matches desktop).
                 .sort(compareEarnByAmountDesc(row => row.fiatAmount)),
-        [currentFiatRates, fiatCurrency, stakingActiveItems],
+        [calculatedStakingDeposits],
     );
 
     const stablecoinRows = useMemo(
         () =>
-            stablecoinYieldActiveItems.flatMap(item => {
-                if (
-                    item.accountKey === null ||
-                    item.tokenBalance === null ||
-                    item.tokenBalance === '0'
-                ) {
-                    return [];
-                }
-
-                const fiatRateKey = getFiatRateKey(
-                    item.networkSymbol,
-                    fiatCurrency,
-                    item.tokenContractAddress,
-                );
-
-                const fiatRate = currentFiatRates?.[fiatRateKey]?.rate;
-                const fiatAmount = asBaseCurrencyAmount(
-                    new BigNumber(
-                        toFiatCurrency({ amount: item.tokenBalance, rate: fiatRate }) ?? '0',
-                    ),
-                );
-
-                return [
-                    {
-                        id: item.id,
+            calculatedStablecoinYieldDeposits.map(
+                ({ deposit, balance, fiatAmount }) =>
+                    ({
+                        id: deposit.id,
                         type: 'stablecoin-yield',
-                        title: item.vaultName,
-                        networkSymbol: item.networkSymbol,
-                        tokenSymbol: item.tokenSymbol,
-                        contractAddress: item.contractAddress,
-                        tokenContractAddress: item.tokenContractAddress,
-                        accountKey: item.accountKey,
-                        accountLabel: item.accountLabel,
-                        balance: item.tokenBalance,
+                        title: deposit.vaultName,
+                        networkSymbol: deposit.networkSymbol,
+                        tokenSymbol: deposit.tokenSymbol,
+                        contractAddress: deposit.contractAddress,
+                        tokenContractAddress: deposit.tokenContractAddress,
+                        accountKey: deposit.accountKey,
+                        accountLabel: deposit.accountLabel,
+                        balance,
                         fiatAmount,
-                        apy: item.apy,
-                    } satisfies EarnDepositsCardActiveItem,
-                ];
-            }),
-        [currentFiatRates, fiatCurrency, stablecoinYieldActiveItems],
+                        apy: deposit.apy,
+                    }) satisfies EarnDepositsCardActiveItem,
+            ),
+        [calculatedStablecoinYieldDeposits],
     );
 
-    const totalDepositedFiatAmount = useMemo(
-        () =>
-            asBaseCurrencyAmount(
-                [...stakingRows, ...stablecoinRows].reduce(
-                    (sum, item) => sum.plus(item.fiatAmount),
-                    new BigNumber(0),
-                ),
-            ),
-        [stakingRows, stablecoinRows],
-    );
+    const missingRateTickersQuery = useMissingRateTickersQuery({
+        missingRateTickers,
+        baseCurrencyCode: fiatCurrency,
+    });
+    const isFiatRatesLoading = missingRateTickersQuery.isFetching;
+    const { isFiatTotalIncomplete, isFiatTotalUnavailable } = getEarnDepositsFiatStatus({
+        missingStakingRateTickers,
+        missingStablecoinYieldRateTickers,
+        hasStakingFiatRate,
+        hasStablecoinYieldFiatRate: hasStablecoinFiatRate,
+        isFiatRatesLoading,
+    });
 
     const stakingTitle = useMemo(() => {
         const firstStakingSymbol = stakingRows[0]?.symbol;
@@ -190,6 +207,10 @@ export const useEarnDepositsCardData = ({
         stakingRow,
         stablecoinYieldRow,
         totalDepositedFiatAmount,
+        isFiatRatesLoading,
+        isFiatTotalIncomplete,
+        isFiatTotalUnavailable,
+        retryMissingFiatRates: missingRateTickersQuery.refetch,
         shouldShowCard: stakingRow !== null || stablecoinYieldRow !== null,
     };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

"Your deposits" on the mobile Earn screen silently counted a position as $0 when its fiat rate was missing - the underlying token rate is never auto-fetched once the whole balance is deposited (the account holds only the vault receipt token), and a contract-address casing mismatch caused the same miss.

Now the rate lookup normalizes the address (with a case-insensitive fallback), missing rates are fetched via `useMissingRateTickersQuery`, and the card shows a skeleton, a `≥` lower-bound prefix, or `N/A` with a Retry warning instead of a silently wrong total.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #29977

## Screenshots:
<img width="400" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-20 at 15 15 19" src="https://github.com/user-attachments/assets/ed9e06b5-4b5a-40a8-9e34-65871b5796ca" />
<img width="400" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-20 at 15 12 26" src="https://github.com/user-attachments/assets/75d1f262-c42b-41ef-9aac-1064a99d7a2f" />
<img width="400"  alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-20 at 15 18 09" src="https://github.com/user-attachments/assets/bf38ffdb-78d6-4be6-b020-9901c77c5fea" />



<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in suite-native (module-earn hooks/components, intl messages) and suite-common/wallet-core (earn deposits fiat utility), none of which are covered by the Playwright E2E suite under suite/e2e, since that suite targets Suite-web/Desktop rather than suite-native (mobile). Unit tests already exist and were changed alongside the source (earnDepositsFiatUtils.test.ts, useEarnDepositsCardData.test.ts), which should be the primary regression safety net — running those unit tests is more directly relevant than any E2E test. The E2E tests recommended here are best-effort inferred matches based on shared 'earn/staking deposit' domain logic, but confidence is low since suite-native components/hooks aren't exercised by suite/e2e at all.

<details><summary><b>Changed files (7)</b></summary>

- `suite-common/wallet-core/src/earn/__tests__/earnDepositsFiatUtils.test.ts`
- `suite-common/wallet-core/src/earn/earnDepositsFiatUtils.ts`
- `suite-common/wallet-core/src/index.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-earn/src/components/EarnDepositsCard.tsx`
- `suite-native/module-earn/src/hooks/__tests__/useEarnDepositsCardData.test.ts`
- `suite-native/module-earn/src/hooks/useEarnDepositsCardData.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the ETH staking dashboard including deposit/reward/pending amounts, which is the domain of the changed earnDepositsFiatUtils and useEarnDepositsCardData/EarnDepositsCard files (fiat calculations and card data for staking/earn deposits). Although this is a Suite-web e2e test and the changes are in suite-native/suite-common packages, it is the closest available E2E coverage for 'earn deposits' fiat/amount logic.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Covers ETH staking amounts/rewards display which shares conceptual logic with earnDepositsFiatUtils fiat calculations, but this is Suite-web not suite-native so the actual changed component (EarnDepositsCard) is not exercised here.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Touches ETH staking/earn deposit amount displays similar in domain to the changed earn fiat utils, providing tangential regression coverage for deposit/reward fiat calculations.

</details>

⚠️ **Changes with no test coverage (7)**
- `suite-common/wallet-core/src/earn/__tests__/earnDepositsFiatUtils.test.ts`
- `suite-common/wallet-core/src/earn/earnDepositsFiatUtils.ts`
- `suite-common/wallet-core/src/index.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-earn/src/components/EarnDepositsCard.tsx`
- `suite-native/module-earn/src/hooks/__tests__/useEarnDepositsCardData.test.ts`
- `suite-native/module-earn/src/hooks/useEarnDepositsCardData.ts`

_Updated: 2026-07-20T15:38:32.161Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/earn-deposits-missing-fiat-rates/web/](https://dev.suite.sldev.cz/suite-web/fix/earn-deposits-missing-fiat-rates/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/earn-deposits-missing-fiat-rates&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/earn-deposits-missing-fiat-rates&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/earn-deposits-missing-fiat-rates&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-20T15:41:00.956Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-20T15:41:41.346Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->