### PR TITLE
refactor(suite-native): store graph data in Redux

### DIFF
--- a/suite-native/graph/src/components/GraphBaseCurrencyBalance.tsx
+++ b/suite-native/graph/src/components/GraphBaseCurrencyBalance.tsx
@@ -1,24 +1,19 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
-import { type Atom, useAtomValue } from 'jotai';
+import { type Atom } from 'jotai';
 
-import { useFormatters } from '@suite-common/formatters';
 import { type FiatGraphPoint } from '@suite-common/graph';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
-import { type BaseCurrencyAmount, asBaseCurrencyAmount } from '@suite-common/wallet-types';
-import { Box, BoxSkeleton, DiscreetTextTrigger, HStack, Text, VStack } from '@suite-native/atoms';
-import { BaseCurrencyAmountLargeFormatter } from '@suite-native/formatters';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
-import { BigNumber } from '@trezor/utils';
+import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
 
-import { GraphDateFormatter } from './GraphDateFormatter';
-import { PriceChangeIndicator } from './PriceChangeIndicator';
+import { GraphBaseCurrencyBalanceContent } from './GraphBaseCurrencyBalanceContent';
+import { GraphBaseCurrencyBalanceFallback } from './GraphBaseCurrencyBalanceFallback';
+import { GraphBaseCurrencyBalanceSkeleton } from './GraphBaseCurrencyBalanceSkeleton';
 
-type GraphFiatBalanceProps = {
-    selectedPointFiatValueAtom: Atom<string>;
-    selectedPointTimestampAtom: Atom<number | null>;
-    referencePointAtom: Atom<FiatGraphPoint | null>;
-    percentageChangeAtom: Atom<number>;
+type GraphFiatBalanceProps<TGraphPoint extends FiatGraphPoint = FiatGraphPoint> = {
+    points: TGraphPoint[];
+    selectedPointAtom: Atom<TGraphPoint | null>;
     isGestureActiveAtom: Atom<boolean>;
     showChange?: boolean;
     isLoading?: boolean;
@@ -26,117 +21,48 @@ type GraphFiatBalanceProps = {
     isHistoryEnabledAccount?: boolean;
 };
 
-const wrapperStyle = prepareNativeStyle(_ => ({
-    height: 72, // Hardcoded because of some margin magic in FiatBalanceFormatter.
-    alignItems: 'center',
-}));
+const getReferencePoint = <TGraphPoint extends FiatGraphPoint>(points: TGraphPoint[]) =>
+    points.find(point => point.value > 0) ?? points[0] ?? null;
 
-const Skeleton = () => (
-    <VStack alignItems="center" spacing="sp8">
-        <BoxSkeleton elevation="0" width={180} height={44} />
-        <BoxSkeleton elevation="0" width={140} height={20} />
-    </VStack>
-);
-
-const FormattedBalance = ({ value }: { value: BaseCurrencyAmount }) => (
-    <DiscreetTextTrigger testID="@home/portfolio/fiat-balance-header/discreet-trigger">
-        <BaseCurrencyAmountLargeFormatter
-            value={value}
-            testID="@home/portfolio/fiat-balance-header"
-        />
-    </DiscreetTextTrigger>
-);
-
-const SelectedPointFiatBalance = ({
-    selectedPointFiatValueAtom,
-}: Pick<GraphFiatBalanceProps, 'selectedPointFiatValueAtom'>) => {
-    const selectedPointFiatValue = useAtomValue(selectedPointFiatValueAtom);
-    const selectedPointFiatBalance = asBaseCurrencyAmount(new BigNumber(selectedPointFiatValue));
-
-    return <FormattedBalance value={selectedPointFiatBalance} />;
-};
-
-const Balance = ({
-    selectedPointFiatValueAtom,
-    isGestureActiveAtom,
-    totalBaseCurrencyBalance,
-}: Pick<
-    GraphFiatBalanceProps,
-    'selectedPointFiatValueAtom' | 'isGestureActiveAtom' | 'totalBaseCurrencyBalance'
->) => {
-    const isGestureActive = useAtomValue(isGestureActiveAtom);
-
-    // While the user is not swiping the graph, the live total balance is displayed, because
-    // the last graph point is frozen at fetch time and its value goes stale as rates move.
-    if (!isGestureActive && totalBaseCurrencyBalance !== undefined) {
-        return <FormattedBalance value={totalBaseCurrencyBalance} />;
-    }
-
-    return <SelectedPointFiatBalance selectedPointFiatValueAtom={selectedPointFiatValueAtom} />;
-};
-
-export const GraphBaseCurrencyBalance = ({
-    selectedPointFiatValueAtom,
-    selectedPointTimestampAtom,
-    referencePointAtom,
-    percentageChangeAtom,
+export const GraphBaseCurrencyBalance = <TGraphPoint extends FiatGraphPoint>({
+    points,
+    selectedPointAtom,
     isGestureActiveAtom,
     showChange = true,
     isLoading = false,
     totalBaseCurrencyBalance,
     isHistoryEnabledAccount = true,
-}: GraphFiatBalanceProps) => {
-    const { applyStyle } = useNativeStyles();
-    const firstGraphPoint = useAtomValue(referencePointAtom);
-    const { DateTimeFormatter } = useFormatters();
-
+}: GraphFiatBalanceProps<TGraphPoint>) => {
+    const firstGraphPoint = useMemo(() => getReferencePoint(points), [points]);
     const hasDeviceDiscovery = useSelector(selectHasRunningDiscovery);
     const hasBalance = Number(totalBaseCurrencyBalance) !== 0;
     const showLoading = isLoading || !firstGraphPoint;
     const showBalanceFallback =
         !hasDeviceDiscovery && ((hasBalance && showLoading) || !isHistoryEnabledAccount);
 
-    // If discovery finished but the graph still loading or missing first point, we just show the latest total balance
     if (showBalanceFallback) {
         return (
-            <Box style={applyStyle(wrapperStyle)}>
-                <Balance
-                    selectedPointFiatValueAtom={selectedPointFiatValueAtom}
-                    isGestureActiveAtom={isGestureActiveAtom}
-                    totalBaseCurrencyBalance={totalBaseCurrencyBalance}
-                />
-                {showChange && (
-                    <HStack alignItems="center">
-                        {/*  Empty space to prevent layout shift */}
-                        <Text variant="body-sm" color="contentSecondary">
-                            <DateTimeFormatter value={new Date()} />
-                        </Text>
-                    </HStack>
-                )}
-            </Box>
+            <GraphBaseCurrencyBalanceFallback
+                selectedPointAtom={selectedPointAtom}
+                isGestureActiveAtom={isGestureActiveAtom}
+                showChange={showChange}
+                totalBaseCurrencyBalance={totalBaseCurrencyBalance}
+            />
         );
     }
 
     if (showLoading) {
-        return <Skeleton />;
+        return <GraphBaseCurrencyBalanceSkeleton />;
     }
 
     return (
-        <Box style={applyStyle(wrapperStyle)}>
-            <Balance
-                selectedPointFiatValueAtom={selectedPointFiatValueAtom}
-                isGestureActiveAtom={isGestureActiveAtom}
-                totalBaseCurrencyBalance={totalBaseCurrencyBalance}
-            />
-            {showChange && (
-                <HStack alignItems="center">
-                    <GraphDateFormatter
-                        firstPointDate={firstGraphPoint.date}
-                        selectedPointTimestampAtom={selectedPointTimestampAtom}
-                    />
-                    <PriceChangeIndicator percentageChangeAtom={percentageChangeAtom} />
-                </HStack>
-            )}
-        </Box>
+        <GraphBaseCurrencyBalanceContent
+            points={points}
+            firstGraphPoint={firstGraphPoint}
+            selectedPointAtom={selectedPointAtom}
+            isGestureActiveAtom={isGestureActiveAtom}
+            showChange={showChange}
+            totalBaseCurrencyBalance={totalBaseCurrencyBalance}
+        />
     );
 };

--- a/suite-native/graph/src/components/GraphBaseCurrencyBalanceAmount.tsx
+++ b/suite-native/graph/src/components/GraphBaseCurrencyBalanceAmount.tsx
@@ -1,0 +1,48 @@
+import { type Atom, useAtomValue } from 'jotai';
+
+import { type FiatGraphPoint } from '@suite-common/graph';
+import { type BaseCurrencyAmount, asBaseCurrencyAmount } from '@suite-common/wallet-types';
+import { DiscreetTextTrigger } from '@suite-native/atoms';
+import { BaseCurrencyAmountLargeFormatter } from '@suite-native/formatters';
+import { BigNumber } from '@trezor/utils';
+
+export type GraphBaseCurrencyBalanceAmountProps<TGraphPoint extends FiatGraphPoint> = {
+    selectedPointAtom: Atom<TGraphPoint | null>;
+    isGestureActiveAtom: Atom<boolean>;
+    totalBaseCurrencyBalance?: BaseCurrencyAmount;
+};
+
+const FormattedBalance = ({ value }: { value: BaseCurrencyAmount }) => (
+    <DiscreetTextTrigger testID="@home/portfolio/fiat-balance-header/discreet-trigger">
+        <BaseCurrencyAmountLargeFormatter
+            value={value}
+            testID="@home/portfolio/fiat-balance-header"
+        />
+    </DiscreetTextTrigger>
+);
+
+const SelectedPointFiatBalance = <TGraphPoint extends FiatGraphPoint>({
+    selectedPointAtom,
+}: Pick<GraphBaseCurrencyBalanceAmountProps<TGraphPoint>, 'selectedPointAtom'>) => {
+    const selectedPoint = useAtomValue(selectedPointAtom);
+    const selectedPointFiatValue = String(selectedPoint?.value ?? 0);
+    const selectedPointFiatBalance = asBaseCurrencyAmount(new BigNumber(selectedPointFiatValue));
+
+    return <FormattedBalance value={selectedPointFiatBalance} />;
+};
+
+export const GraphBaseCurrencyBalanceAmount = <TGraphPoint extends FiatGraphPoint>({
+    selectedPointAtom,
+    isGestureActiveAtom,
+    totalBaseCurrencyBalance,
+}: GraphBaseCurrencyBalanceAmountProps<TGraphPoint>) => {
+    const isGestureActive = useAtomValue(isGestureActiveAtom);
+
+    // While the user is not swiping the graph, the live total balance is displayed, because
+    // the last graph point is frozen at fetch time and its value goes stale as rates move.
+    if (!isGestureActive && totalBaseCurrencyBalance !== undefined) {
+        return <FormattedBalance value={totalBaseCurrencyBalance} />;
+    }
+
+    return <SelectedPointFiatBalance selectedPointAtom={selectedPointAtom} />;
+};

--- a/suite-native/graph/src/components/GraphBaseCurrencyBalanceChange.tsx
+++ b/suite-native/graph/src/components/GraphBaseCurrencyBalanceChange.tsx
@@ -1,0 +1,38 @@
+import { type Atom, useAtomValue } from 'jotai';
+
+import { type FiatGraphPoint } from '@suite-common/graph';
+import { HStack } from '@suite-native/atoms';
+
+import { percentageDiff } from '../utils';
+import { GraphDateFormatter } from './GraphDateFormatter';
+import { PriceChangeIndicator } from './PriceChangeIndicator';
+
+type GraphBaseCurrencyBalanceChangeProps<TGraphPoint extends FiatGraphPoint> = {
+    points: TGraphPoint[];
+    firstGraphPoint: TGraphPoint;
+    selectedPointAtom: Atom<TGraphPoint | null>;
+};
+
+export const GraphBaseCurrencyBalanceChange = <TGraphPoint extends FiatGraphPoint>({
+    points,
+    firstGraphPoint,
+    selectedPointAtom,
+}: GraphBaseCurrencyBalanceChangeProps<TGraphPoint>) => {
+    const selectedPoint = useAtomValue(selectedPointAtom);
+    const lastGraphPoint = points[points.length - 1] ?? null;
+    const displayedPoint = selectedPoint ?? lastGraphPoint;
+    const selectedPointTimestamp = displayedPoint?.date.getTime() ?? null;
+    const percentageChange = displayedPoint
+        ? percentageDiff(firstGraphPoint.value, displayedPoint.value)
+        : 0;
+
+    return (
+        <HStack alignItems="center">
+            <GraphDateFormatter
+                firstPointDate={firstGraphPoint.date}
+                selectedPointTimestamp={selectedPointTimestamp}
+            />
+            <PriceChangeIndicator percentageChange={percentageChange} />
+        </HStack>
+    );
+};

--- a/suite-native/graph/src/components/GraphBaseCurrencyBalanceContent.tsx
+++ b/suite-native/graph/src/components/GraphBaseCurrencyBalanceContent.tsx
@@ -1,0 +1,51 @@
+import { type Atom } from 'jotai';
+
+import { type FiatGraphPoint } from '@suite-common/graph';
+import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
+import { Box } from '@suite-native/atoms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+import { GraphBaseCurrencyBalanceAmount } from './GraphBaseCurrencyBalanceAmount';
+import { GraphBaseCurrencyBalanceChange } from './GraphBaseCurrencyBalanceChange';
+
+type GraphBaseCurrencyBalanceContentProps<TGraphPoint extends FiatGraphPoint> = {
+    points: TGraphPoint[];
+    firstGraphPoint: TGraphPoint;
+    selectedPointAtom: Atom<TGraphPoint | null>;
+    isGestureActiveAtom: Atom<boolean>;
+    showChange: boolean;
+    totalBaseCurrencyBalance?: BaseCurrencyAmount;
+};
+
+const wrapperStyle = prepareNativeStyle(_ => ({
+    height: 72,
+    alignItems: 'center',
+}));
+
+export const GraphBaseCurrencyBalanceContent = <TGraphPoint extends FiatGraphPoint>({
+    points,
+    firstGraphPoint,
+    selectedPointAtom,
+    isGestureActiveAtom,
+    showChange,
+    totalBaseCurrencyBalance,
+}: GraphBaseCurrencyBalanceContentProps<TGraphPoint>) => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <Box style={applyStyle(wrapperStyle)}>
+            <GraphBaseCurrencyBalanceAmount
+                selectedPointAtom={selectedPointAtom}
+                isGestureActiveAtom={isGestureActiveAtom}
+                totalBaseCurrencyBalance={totalBaseCurrencyBalance}
+            />
+            {showChange && (
+                <GraphBaseCurrencyBalanceChange
+                    points={points}
+                    firstGraphPoint={firstGraphPoint}
+                    selectedPointAtom={selectedPointAtom}
+                />
+            )}
+        </Box>
+    );
+};

--- a/suite-native/graph/src/components/GraphBaseCurrencyBalanceFallback.tsx
+++ b/suite-native/graph/src/components/GraphBaseCurrencyBalanceFallback.tsx
@@ -1,0 +1,49 @@
+import { type Atom } from 'jotai';
+
+import { useFormatters } from '@suite-common/formatters';
+import { type FiatGraphPoint } from '@suite-common/graph';
+import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
+import { Box, HStack, Text } from '@suite-native/atoms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+import { GraphBaseCurrencyBalanceAmount } from './GraphBaseCurrencyBalanceAmount';
+
+type GraphBaseCurrencyBalanceFallbackProps<TGraphPoint extends FiatGraphPoint> = {
+    selectedPointAtom: Atom<TGraphPoint | null>;
+    isGestureActiveAtom: Atom<boolean>;
+    showChange: boolean;
+    totalBaseCurrencyBalance?: BaseCurrencyAmount;
+};
+
+const wrapperStyle = prepareNativeStyle(_ => ({
+    height: 72,
+    alignItems: 'center',
+}));
+
+export const GraphBaseCurrencyBalanceFallback = <TGraphPoint extends FiatGraphPoint>({
+    selectedPointAtom,
+    isGestureActiveAtom,
+    showChange,
+    totalBaseCurrencyBalance,
+}: GraphBaseCurrencyBalanceFallbackProps<TGraphPoint>) => {
+    const { applyStyle } = useNativeStyles();
+    const { DateTimeFormatter } = useFormatters();
+
+    return (
+        <Box style={applyStyle(wrapperStyle)}>
+            <GraphBaseCurrencyBalanceAmount
+                selectedPointAtom={selectedPointAtom}
+                isGestureActiveAtom={isGestureActiveAtom}
+                totalBaseCurrencyBalance={totalBaseCurrencyBalance}
+            />
+            {showChange && (
+                <HStack alignItems="center">
+                    {/* Empty space to prevent layout shift. */}
+                    <Text variant="body-sm" color="contentSecondary">
+                        <DateTimeFormatter value={new Date()} />
+                    </Text>
+                </HStack>
+            )}
+        </Box>
+    );
+};

--- a/suite-native/graph/src/components/GraphBaseCurrencyBalanceSkeleton.tsx
+++ b/suite-native/graph/src/components/GraphBaseCurrencyBalanceSkeleton.tsx
@@ -1,0 +1,8 @@
+import { BoxSkeleton, VStack } from '@suite-native/atoms';
+
+export const GraphBaseCurrencyBalanceSkeleton = () => (
+    <VStack alignItems="center" spacing="sp8">
+        <BoxSkeleton elevation="0" width={180} height={44} />
+        <BoxSkeleton elevation="0" width={140} height={20} />
+    </VStack>
+);

--- a/suite-native/graph/src/components/GraphDateFormatter.tsx
+++ b/suite-native/graph/src/components/GraphDateFormatter.tsx
@@ -1,22 +1,13 @@
-import { type Atom, useAtomValue } from 'jotai';
-
 import { useFormatters } from '@suite-common/formatters';
 import { Text } from '@suite-native/atoms';
 
-type SelectedPointTimestampAtom = Atom<number | null>;
-
 type GraphDateFormatterProps = {
     firstPointDate: Date;
-    selectedPointTimestampAtom: SelectedPointTimestampAtom;
+    selectedPointTimestamp: number | null;
 };
 
-const WeekFormatter = ({
-    selectedPointTimestampAtom,
-}: {
-    selectedPointTimestampAtom: SelectedPointTimestampAtom;
-}) => {
+const WeekFormatter = ({ selectedPointTimestamp }: { selectedPointTimestamp: number | null }) => {
     const { DateTimeFormatter } = useFormatters();
-    const selectedPointTimestamp = useAtomValue(selectedPointTimestampAtom);
 
     // Empty space to prevent layout shift
     if (selectedPointTimestamp === null) return <Text> </Text>;
@@ -25,13 +16,11 @@ const WeekFormatter = ({
 };
 
 const OtherDateFormatter = ({
-    selectedPointTimestampAtom,
+    selectedPointTimestamp,
 }: {
-    selectedPointTimestampAtom: SelectedPointTimestampAtom;
+    selectedPointTimestamp: number | null;
 }) => {
     const { DateFormatter } = useFormatters();
-
-    const selectedPointTimestamp = useAtomValue(selectedPointTimestampAtom);
 
     if (selectedPointTimestamp === null) return null;
 
@@ -42,7 +31,7 @@ const millisecondsPerTwoWeek = 1209600000;
 
 export const GraphDateFormatter = ({
     firstPointDate,
-    selectedPointTimestampAtom,
+    selectedPointTimestamp,
 }: GraphDateFormatterProps) => {
     const millisecondElapsedFromFistPoint = new Date().getTime() - firstPointDate.getTime();
     // this check is significantly faster than using date-fns/differenceInWeeks(days)
@@ -52,7 +41,7 @@ export const GraphDateFormatter = ({
 
     return (
         <Text variant="body-sm" color="contentSecondary">
-            <Formatter selectedPointTimestampAtom={selectedPointTimestampAtom} />
+            <Formatter selectedPointTimestamp={selectedPointTimestamp} />
         </Text>
     );
 };

--- a/suite-native/graph/src/components/PriceChangeIndicator.tsx
+++ b/suite-native/graph/src/components/PriceChangeIndicator.tsx
@@ -1,15 +1,9 @@
-import { type Atom, useAtom } from 'jotai';
-
 import { PriceChangeBadge } from '@suite-native/atoms';
 
-type PercentageChangeAtom = Atom<number>;
-
 type PriceChangeIndicatorProps = {
-    percentageChangeAtom: PercentageChangeAtom;
+    percentageChange: number;
 };
 
-export const PriceChangeIndicator = ({ percentageChangeAtom }: PriceChangeIndicatorProps) => {
-    const [percentageChange] = useAtom(percentageChangeAtom);
-
-    return <PriceChangeBadge valuePercentageChange={percentageChange} />;
-};
+export const PriceChangeIndicator = ({ percentageChange }: PriceChangeIndicatorProps) => (
+    <PriceChangeBadge valuePercentageChange={percentageChange} />
+);

--- a/suite-native/graph/src/createGraphAtoms.ts
+++ b/suite-native/graph/src/createGraphAtoms.ts
@@ -1,91 +1,30 @@
-import { type Atom, type PrimitiveAtom, type WritableAtom, atom } from 'jotai';
+import { type Atom, type PrimitiveAtom, atom } from 'jotai';
 
-import { type FiatGraphPoint, type GroupedBalanceMovementEvent } from '@suite-common/graph';
-
-import { percentageDiff } from './utils';
+import { type FiatGraphPoint } from '@suite-common/graph';
 
 export type GraphAtoms<TGraphPoint extends FiatGraphPoint = FiatGraphPoint> = {
-    /** Points of the graph line, written by the graph data source. */
-    graphPointsAtom: PrimitiveAtom<TGraphPoint[]>;
-    /** Transaction events displayed on the account detail graph line. */
-    graphEventsAtom: PrimitiveAtom<GroupedBalanceMovementEvent[] | undefined>;
     /** Point of the graph line selected by the swipe gesture. Null while there is no gesture. */
     selectedPointAtom: PrimitiveAtom<TGraphPoint | null>;
     isGestureActiveAtom: Atom<boolean>;
-    /** First point of the graph line with some value, used as the base of the percentage change. */
-    referencePointAtom: Atom<TGraphPoint | null>;
-    /** Fiat value of the point selected by the swipe gesture. */
-    selectedPointFiatValueAtom: Atom<string>;
-    /** Date of the selected point, or of the last point while there is no gesture. */
-    selectedPointTimestampAtom: Atom<number | null>;
-    percentageChangeAtom: Atom<number>;
-    /** Write-only atom resetting all the base atoms back to their initial values. */
-    resetGraphAtom: WritableAtom<null, [], void>;
 };
 
 /**
- * Creates a bundle of atoms holding the state of one graph instance.
+ * Creates a bundle of atoms holding gesture state of one graph instance.
  *
  * Use the atomic jotai structure for absolute minimum re-renders and maximum performance,
- * otherwise the graph would be freezing on slower devices while the point swipe gesture is active.
+ * otherwise the graph could freeze on slower devices while the point swipe gesture is active.
  * Each graph (portfolio, account detail) instantiates one module-level bundle, so its components
- * can subscribe to exactly the piece of state they display instead of receiving drilled props.
+ * can subscribe to gesture state without receiving drilled props.
  */
 export const createGraphAtoms = <
     TGraphPoint extends FiatGraphPoint = FiatGraphPoint,
 >(): GraphAtoms<TGraphPoint> => {
-    const graphPointsAtom = atom<TGraphPoint[]>([]);
-    const graphEventsAtom = atom<GroupedBalanceMovementEvent[] | undefined>(undefined);
     const selectedPointAtom = atom<TGraphPoint | null>(null);
 
     const isGestureActiveAtom = atom(get => get(selectedPointAtom) !== null);
 
-    const lastPointAtom = atom(get => {
-        const graphPoints = get(graphPointsAtom);
-
-        return graphPoints[graphPoints.length - 1] ?? null;
-    });
-
-    // Reference is usually the first point, same as Revolut does in their app.
-    const referencePointAtom = atom(get => {
-        const graphPoints = get(graphPointsAtom);
-
-        return graphPoints.find(point => point.value > 0) ?? graphPoints[0] ?? null;
-    });
-
-    const selectedPointFiatValueAtom = atom(get => String(get(selectedPointAtom)?.value ?? 0));
-
-    const selectedPointTimestampAtom = atom(get => {
-        const displayedPoint = get(selectedPointAtom) ?? get(lastPointAtom);
-
-        return displayedPoint?.date.getTime() ?? null;
-    });
-
-    // While there is no gesture, the change of the last point against the reference is displayed.
-    const percentageChangeAtom = atom(get => {
-        const referencePoint = get(referencePointAtom);
-        const comparedPoint = get(selectedPointAtom) ?? get(lastPointAtom);
-
-        if (!referencePoint || !comparedPoint) return 0;
-
-        return percentageDiff(referencePoint.value, comparedPoint.value);
-    });
-
-    const resetGraphAtom = atom(null, (_get, set) => {
-        set(graphPointsAtom, []);
-        set(graphEventsAtom, undefined);
-        set(selectedPointAtom, null);
-    });
-
     return {
-        graphPointsAtom,
-        graphEventsAtom,
         selectedPointAtom,
         isGestureActiveAtom,
-        referencePointAtom,
-        selectedPointFiatValueAtom,
-        selectedPointTimestampAtom,
-        percentageChangeAtom,
-        resetGraphAtom,
     };
 };

--- a/suite-native/graph/src/graphDataUtils.ts
+++ b/suite-native/graph/src/graphDataUtils.ts
@@ -1,0 +1,44 @@
+import {
+    type FiatGraphPoint,
+    type FiatGraphPointWithCryptoBalance,
+    type GroupedBalanceMovementEvent,
+} from '@suite-common/graph';
+import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
+
+import { type StoredFiatGraphPoint, type StoredGroupedBalanceMovementEvent } from './types';
+
+export const serializeGraphPoints = (
+    points: FiatGraphPoint[] | FiatGraphPointWithCryptoBalance[],
+): StoredFiatGraphPoint[] =>
+    points.map(point => ({
+        ...point,
+        date: point.date.getTime(),
+    }));
+
+export const serializeGraphEvents = (
+    events: GroupedBalanceMovementEvent[] | undefined,
+): StoredGroupedBalanceMovementEvent[] | undefined =>
+    events?.map(event => ({
+        ...event,
+        date: event.date.getTime(),
+    }));
+
+export const deserializeGraphPoints = <TGraphPoint extends FiatGraphPoint = FiatGraphPoint>(
+    points: StoredFiatGraphPoint[] | undefined,
+): TGraphPoint[] =>
+    returnStableArrayIfEmpty(
+        points?.map(point => ({
+            ...point,
+            date: new Date(point.date),
+        })) as TGraphPoint[] | undefined,
+    );
+
+export const deserializeGraphEvents = (
+    events: StoredGroupedBalanceMovementEvent[] | undefined,
+): GroupedBalanceMovementEvent[] =>
+    returnStableArrayIfEmpty(
+        events?.map(event => ({
+            ...event,
+            date: new Date(event.date),
+        })),
+    );

--- a/suite-native/graph/src/graphInstances.ts
+++ b/suite-native/graph/src/graphInstances.ts
@@ -7,9 +7,16 @@ export type AccountGraphInstanceId =
     | `account:${AccountKey}`
     | `account:${AccountKey}:token:${TokenAddress}`;
 export type GraphInstanceId = PortfolioGraphInstanceId | AccountGraphInstanceId;
+export type GraphInstanceStateKey = `graph:${GraphInstanceId}`;
 
 export const isGraphInstanceId = (instanceId: string): instanceId is GraphInstanceId =>
     instanceId === PORTFOLIO_GRAPH_INSTANCE_ID || instanceId.startsWith('account:');
+
+export const getGraphInstanceStateKey = (instanceId: GraphInstanceId): GraphInstanceStateKey =>
+    `graph:${instanceId}`;
+
+export const getGraphInstanceIdFromStateKey = (stateKey: GraphInstanceStateKey): GraphInstanceId =>
+    stateKey.slice('graph:'.length) as GraphInstanceId;
 
 type GetAccountGraphInstanceIdParams = {
     accountKey: AccountKey;

--- a/suite-native/graph/src/graphInstances.ts
+++ b/suite-native/graph/src/graphInstances.ts
@@ -8,6 +8,9 @@ export type AccountGraphInstanceId =
     | `account:${AccountKey}:token:${TokenAddress}`;
 export type GraphInstanceId = PortfolioGraphInstanceId | AccountGraphInstanceId;
 
+export const isGraphInstanceId = (instanceId: string): instanceId is GraphInstanceId =>
+    instanceId === PORTFOLIO_GRAPH_INSTANCE_ID || instanceId.startsWith('account:');
+
 type GetAccountGraphInstanceIdParams = {
     accountKey: AccountKey;
     tokenContract?: TokenAddress;

--- a/suite-native/graph/src/graphPersistTransform.ts
+++ b/suite-native/graph/src/graphPersistTransform.ts
@@ -8,7 +8,7 @@ import {
     getAccountGraphInstanceId,
     getPortfolioGraphInstanceId,
 } from './graphInstances';
-import { DEFAULT_GRAPH_TIMEFRAME_HOURS, type GraphInstanceState, type GraphState } from './slice';
+import { type GraphInstanceState, type GraphState, getGraphTimeframeOrDefault } from './slice';
 import { type TimeframeHoursValue } from './types';
 
 type Graphs = GraphState['graphs'];
@@ -35,7 +35,7 @@ const rehydrateGraphState = (persistedState: PersistedGraphState | undefined): G
     Object.entries(persistedState?.graphs ?? {}).forEach(([instanceId, persistedGraph]) => {
         if (persistedGraph) {
             graphs[instanceId as GraphInstanceId] = {
-                timeframeHours: persistedGraph.timeframeHours ?? DEFAULT_GRAPH_TIMEFRAME_HOURS,
+                timeframeHours: getGraphTimeframeOrDefault(persistedGraph.timeframeHours),
             };
         }
     });

--- a/suite-native/graph/src/graphPersistTransform.ts
+++ b/suite-native/graph/src/graphPersistTransform.ts
@@ -5,8 +5,12 @@ import { filterKeysByPartialMatch, selectDeviceStatesNotRemembered } from '@suit
 
 import {
     type GraphInstanceId,
+    type GraphInstanceStateKey,
     getAccountGraphInstanceId,
+    getGraphInstanceIdFromStateKey,
+    getGraphInstanceStateKey,
     getPortfolioGraphInstanceId,
+    isGraphInstanceId,
 } from './graphInstances';
 import { type GraphInstanceState, type GraphState, getGraphTimeframeOrDefault } from './slice';
 import { type TimeframeHoursValue } from './types';
@@ -22,8 +26,10 @@ type PersistedGraphState = Partial<{
 
 const persistGraphs = (graphs: Graphs): PersistedGraphs =>
     Object.fromEntries(
-        Object.entries(graphs).flatMap(([instanceId, graph]) => {
+        Object.entries(graphs).flatMap(([stateKey, graph]) => {
             if (!graph) return [];
+
+            const instanceId = getGraphInstanceIdFromStateKey(stateKey as GraphInstanceStateKey);
 
             return [[instanceId, { timeframeHours: graph.timeframeHours }]];
         }),
@@ -33,15 +39,15 @@ const rehydrateGraphState = (persistedState: PersistedGraphState | undefined): G
     const graphs: Graphs = {};
 
     Object.entries(persistedState?.graphs ?? {}).forEach(([instanceId, persistedGraph]) => {
-        if (persistedGraph) {
-            graphs[instanceId as GraphInstanceId] = {
+        if (persistedGraph && isGraphInstanceId(instanceId)) {
+            graphs[getGraphInstanceStateKey(instanceId)] = {
                 timeframeHours: getGraphTimeframeOrDefault(persistedGraph.timeframeHours),
             };
         }
     });
 
     if (persistedState?.portfolioGraphTimeframe !== undefined) {
-        graphs[getPortfolioGraphInstanceId()] = {
+        graphs[getGraphInstanceStateKey(getPortfolioGraphInstanceId())] = {
             timeframeHours: persistedState.portfolioGraphTimeframe,
         };
     }
@@ -49,7 +55,7 @@ const rehydrateGraphState = (persistedState: PersistedGraphState | undefined): G
     Object.entries(persistedState?.accountToGraphTimeframeMap ?? {}).forEach(
         ([accountKey, timeframeHours]) => {
             const instanceId = getAccountGraphInstanceId({ accountKey: accountKey as AccountKey });
-            graphs[instanceId] = { timeframeHours };
+            graphs[getGraphInstanceStateKey(instanceId)] = { timeframeHours };
         },
     );
 

--- a/suite-native/graph/src/graphSelectors.ts
+++ b/suite-native/graph/src/graphSelectors.ts
@@ -1,12 +1,35 @@
+import {
+    type FiatGraphPoint,
+    type FiatGraphPointWithCryptoBalance,
+    type GroupedBalanceMovementEvent,
+} from '@suite-common/graph';
+import { createWeakMapSelector } from '@suite-common/redux-utils';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
 
+import { deserializeGraphEvents, deserializeGraphPoints } from './graphDataUtils';
 import {
     type GraphInstanceId,
     getAccountGraphInstanceId,
     getPortfolioGraphInstanceId,
 } from './graphInstances';
 import { DEFAULT_GRAPH_TIMEFRAME_HOURS, type GraphSliceRootState } from './slice';
-import { type TimeframeHoursValue } from './types';
+import {
+    type StoredFiatGraphPoint,
+    type StoredGroupedBalanceMovementEvent,
+    type TimeframeHoursValue,
+} from './types';
+
+const createGraphMemoizedSelector = createWeakMapSelector.withTypes<GraphSliceRootState>();
+
+const selectStoredGraphPoints = (
+    state: GraphSliceRootState,
+    instanceId: GraphInstanceId,
+): StoredFiatGraphPoint[] | undefined => state.graph.graphs[instanceId]?.points;
+
+const selectStoredGraphEvents = (
+    state: GraphSliceRootState,
+    instanceId: GraphInstanceId,
+): StoredGroupedBalanceMovementEvent[] | undefined => state.graph.graphs[instanceId]?.events;
 
 export const selectGraphTimeframe = (
     state: GraphSliceRootState,
@@ -52,3 +75,35 @@ export const selectAccountGraphError = (
     tokenContract?: TokenAddress,
 ): string | null =>
     selectGraphError(state, getAccountGraphInstanceId({ accountKey, tokenContract }));
+
+export const selectGraphPoints = createGraphMemoizedSelector(
+    [selectStoredGraphPoints],
+    (points: StoredFiatGraphPoint[] | undefined): FiatGraphPoint[] =>
+        deserializeGraphPoints(points),
+);
+
+export const selectPortfolioGraphPoints = (state: GraphSliceRootState): FiatGraphPoint[] =>
+    selectGraphPoints(state, getPortfolioGraphInstanceId());
+
+export const selectAccountGraphPoints = (
+    state: GraphSliceRootState,
+    accountKey: AccountKey,
+    tokenContract?: TokenAddress,
+): FiatGraphPointWithCryptoBalance[] =>
+    selectGraphPoints(
+        state,
+        getAccountGraphInstanceId({ accountKey, tokenContract }),
+    ) as FiatGraphPointWithCryptoBalance[];
+
+export const selectGraphEvents = createGraphMemoizedSelector(
+    [selectStoredGraphEvents],
+    (events: StoredGroupedBalanceMovementEvent[] | undefined): GroupedBalanceMovementEvent[] =>
+        deserializeGraphEvents(events),
+);
+
+export const selectAccountGraphEvents = (
+    state: GraphSliceRootState,
+    accountKey: AccountKey,
+    tokenContract?: TokenAddress,
+): GroupedBalanceMovementEvent[] =>
+    selectGraphEvents(state, getAccountGraphInstanceId({ accountKey, tokenContract }));

--- a/suite-native/graph/src/graphSelectors.ts
+++ b/suite-native/graph/src/graphSelectors.ts
@@ -12,7 +12,7 @@ import {
     getAccountGraphInstanceId,
     getPortfolioGraphInstanceId,
 } from './graphInstances';
-import { DEFAULT_GRAPH_TIMEFRAME_HOURS, type GraphSliceRootState } from './slice';
+import { type GraphSliceRootState, getGraphTimeframeOrDefault } from './slice';
 import {
     type StoredFiatGraphPoint,
     type StoredGroupedBalanceMovementEvent,
@@ -35,7 +35,7 @@ export const selectGraphTimeframe = (
     state: GraphSliceRootState,
     instanceId: GraphInstanceId,
 ): TimeframeHoursValue =>
-    state.graph.graphs[instanceId]?.timeframeHours ?? DEFAULT_GRAPH_TIMEFRAME_HOURS;
+    getGraphTimeframeOrDefault(state.graph.graphs[instanceId]?.timeframeHours);
 
 export const selectPortfolioGraphTimeframe = (state: GraphSliceRootState): TimeframeHoursValue =>
     selectGraphTimeframe(state, getPortfolioGraphInstanceId());

--- a/suite-native/graph/src/graphSelectors.ts
+++ b/suite-native/graph/src/graphSelectors.ts
@@ -10,6 +10,7 @@ import { deserializeGraphEvents, deserializeGraphPoints } from './graphDataUtils
 import {
     type GraphInstanceId,
     getAccountGraphInstanceId,
+    getGraphInstanceStateKey,
     getPortfolioGraphInstanceId,
 } from './graphInstances';
 import { type GraphSliceRootState, getGraphTimeframeOrDefault } from './slice';
@@ -24,18 +25,22 @@ const createGraphMemoizedSelector = createWeakMapSelector.withTypes<GraphSliceRo
 const selectStoredGraphPoints = (
     state: GraphSliceRootState,
     instanceId: GraphInstanceId,
-): StoredFiatGraphPoint[] | undefined => state.graph.graphs[instanceId]?.points;
+): StoredFiatGraphPoint[] | undefined =>
+    state.graph.graphs[getGraphInstanceStateKey(instanceId)]?.points;
 
 const selectStoredGraphEvents = (
     state: GraphSliceRootState,
     instanceId: GraphInstanceId,
-): StoredGroupedBalanceMovementEvent[] | undefined => state.graph.graphs[instanceId]?.events;
+): StoredGroupedBalanceMovementEvent[] | undefined =>
+    state.graph.graphs[getGraphInstanceStateKey(instanceId)]?.events;
 
 export const selectGraphTimeframe = (
     state: GraphSliceRootState,
     instanceId: GraphInstanceId,
 ): TimeframeHoursValue =>
-    getGraphTimeframeOrDefault(state.graph.graphs[instanceId]?.timeframeHours);
+    getGraphTimeframeOrDefault(
+        state.graph.graphs[getGraphInstanceStateKey(instanceId)]?.timeframeHours,
+    );
 
 export const selectPortfolioGraphTimeframe = (state: GraphSliceRootState): TimeframeHoursValue =>
     selectGraphTimeframe(state, getPortfolioGraphInstanceId());
@@ -50,7 +55,7 @@ export const selectAccountGraphTimeframe = (
 export const selectGraphIsLoading = (
     state: GraphSliceRootState,
     instanceId: GraphInstanceId,
-): boolean => state.graph.graphs[instanceId]?.isLoading ?? true;
+): boolean => state.graph.graphs[getGraphInstanceStateKey(instanceId)]?.isLoading ?? true;
 
 export const selectPortfolioGraphIsLoading = (state: GraphSliceRootState): boolean =>
     selectGraphIsLoading(state, getPortfolioGraphInstanceId());
@@ -64,7 +69,7 @@ export const selectAccountGraphIsLoading = (
 export const selectGraphError = (
     state: GraphSliceRootState,
     instanceId: GraphInstanceId,
-): string | null => state.graph.graphs[instanceId]?.error ?? null;
+): string | null => state.graph.graphs[getGraphInstanceStateKey(instanceId)]?.error ?? null;
 
 export const selectPortfolioGraphError = (state: GraphSliceRootState): string | null =>
     selectGraphError(state, getPortfolioGraphInstanceId());

--- a/suite-native/graph/src/graphThunkTypes.ts
+++ b/suite-native/graph/src/graphThunkTypes.ts
@@ -1,7 +1,11 @@
 import { type AccountItem, type FetchGraphDataParams } from '@suite-common/graph';
 
 import { type GraphInstanceId } from './graphInstances';
-import { type TimeframeHoursValue } from './types';
+import {
+    type StoredFiatGraphPoint,
+    type StoredGroupedBalanceMovementEvent,
+    type TimeframeHoursValue,
+} from './types';
 
 export enum RefetchGraphThunkStatus {
     Fetched = 'fetched',
@@ -9,9 +13,15 @@ export enum RefetchGraphThunkStatus {
     WaitingForDiscovery = 'waitingForDiscovery',
 }
 
-export type RefetchGraphThunkResult = {
-    status: RefetchGraphThunkStatus;
-};
+export type RefetchGraphThunkResult =
+    | {
+          status: RefetchGraphThunkStatus.Fetched;
+          points: StoredFiatGraphPoint[];
+          events?: StoredGroupedBalanceMovementEvent[];
+      }
+    | {
+          status: RefetchGraphThunkStatus.Interrupted | RefetchGraphThunkStatus.WaitingForDiscovery;
+      };
 
 export type RefetchGraphThunkParams = {
     instanceId: GraphInstanceId;

--- a/suite-native/graph/src/graphThunks.ts
+++ b/suite-native/graph/src/graphThunks.ts
@@ -1,41 +1,33 @@
 import { type useDispatch } from 'react-redux';
 
 import { A } from '@mobily/ts-belt';
-import { getDefaultStore } from 'jotai';
 
 import {
     type AccountItem,
     type FetchGraphDataParams,
-    type FiatGraphPoint,
-    type FiatGraphPointWithCryptoBalance,
     fetchGraphData,
     getTimeFrameForHistoryHours,
 } from '@suite-common/graph';
 import { createThunk } from '@suite-common/redux-utils';
 
-import { accountDetailGraphAtoms } from './accountDetailGraphAtoms';
-import { type GraphInstanceId, isPortfolioGraphInstanceId } from './graphInstances';
+import { serializeGraphEvents, serializeGraphPoints } from './graphDataUtils';
+import { type GraphInstanceId } from './graphInstances';
 import {
     type RefetchGraphThunkParams,
     type RefetchGraphThunkResult,
     RefetchGraphThunkStatus,
 } from './graphThunkTypes';
-import { portfolioGraphAtoms } from './portfolioGraphAtoms';
 import { type TimeframeHoursValue } from './types';
 import { checkAndReportGraphError, omitErrorMessageSensitiveData } from './utils';
 
 const GRAPH_MODULE_PREFIX = '@suite-native/graph';
 const GRAPH_NOT_AVAILABLE_ERROR_MESSAGE = 'Graph is not available for testnet coins.';
 
-// The app doesn't mount any jotai Provider, so all atoms live in the default store
-// and it is safe to write them from outside of React. Do not add a jotai Provider.
-const jotaiStore = getDefaultStore();
-
-// Timestamp of the last started fetch per atom bundle, so a finished fetch can detect
+// Timestamp of the last started fetch per graph instance, so a finished fetch can detect
 // that it was interrupted by a newer one and its result should be thrown away.
-const lastFetchTimestamps = new WeakMap<object, number>();
+const lastFetchTimestamps = new Map<GraphInstanceId, number>();
 
-type FetchGraphDataToAtomsParams = {
+type FetchGraphDataForReduxParams = {
     instanceId: GraphInstanceId;
     accounts: AccountItem[];
     eventsAccount?: AccountItem;
@@ -46,31 +38,6 @@ type FetchGraphDataToAtomsParams = {
     dispatch: ReturnType<typeof useDispatch>;
 };
 
-const getGraphAtomsForInstanceId = (instanceId: GraphInstanceId) => {
-    if (isPortfolioGraphInstanceId(instanceId)) {
-        return portfolioGraphAtoms;
-    }
-
-    return accountDetailGraphAtoms;
-};
-
-const setGraphPointsForInstanceId = (
-    instanceId: GraphInstanceId,
-    points: FiatGraphPoint[] | FiatGraphPointWithCryptoBalance[],
-) => {
-    // FIXME: Remove this atom-specific branch once graph points/events are stored in Redux graph instances.
-    if (isPortfolioGraphInstanceId(instanceId)) {
-        jotaiStore.set(portfolioGraphAtoms.graphPointsAtom, points as FiatGraphPoint[]);
-
-        return;
-    }
-
-    jotaiStore.set(
-        accountDetailGraphAtoms.graphPointsAtom,
-        points as FiatGraphPointWithCryptoBalance[],
-    );
-};
-
 const getGraphError = (error: unknown): Error => {
     if (error instanceof Error) {
         return error;
@@ -79,7 +46,7 @@ const getGraphError = (error: unknown): Error => {
     return new Error(String(error));
 };
 
-const fetchGraphDataToAtoms = async ({
+const fetchGraphDataForRedux = async ({
     instanceId,
     accounts,
     eventsAccount,
@@ -88,10 +55,9 @@ const fetchGraphDataToAtoms = async ({
     baseCurrencyCode,
     forceRefetch,
     dispatch,
-}: FetchGraphDataToAtomsParams): Promise<RefetchGraphThunkResult> => {
-    const atoms = getGraphAtomsForInstanceId(instanceId);
+}: FetchGraphDataForReduxParams): Promise<RefetchGraphThunkResult> => {
     const fetchTimestamp = Date.now();
-    lastFetchTimestamps.set(atoms, fetchTimestamp);
+    lastFetchTimestamps.set(instanceId, fetchTimestamp);
 
     const { startOfTimeFrameDate, endOfTimeFrameDate } =
         getTimeFrameForHistoryHours(timeframeHours);
@@ -107,20 +73,15 @@ const fetchGraphDataToAtoms = async ({
         dispatch,
     });
 
-    if (events) {
-        // We need to set events after graph points, othewise it will mess up events randomly
-        // because of strange useEffect in AnimatedLineGraph component.
-        jotaiStore.set(atoms.graphEventsAtom, events);
-    }
-
-    if (lastFetchTimestamps.get(atoms) !== fetchTimestamp) {
+    if (lastFetchTimestamps.get(instanceId) !== fetchTimestamp) {
         return { status: RefetchGraphThunkStatus.Interrupted };
     }
 
-    // The point type is determined by the accounts of the graph the bundle belongs to.
-    setGraphPointsForInstanceId(instanceId, points);
-
-    return { status: RefetchGraphThunkStatus.Fetched };
+    return {
+        status: RefetchGraphThunkStatus.Fetched,
+        points: serializeGraphPoints(points),
+        events: serializeGraphEvents(events),
+    };
 };
 
 export const refetchGraphThunk = createThunk<
@@ -150,7 +111,7 @@ export const refetchGraphThunk = createThunk<
     }
 
     try {
-        return await fetchGraphDataToAtoms({
+        return await fetchGraphDataForRedux({
             instanceId,
             accounts,
             eventsAccount,

--- a/suite-native/graph/src/slice.ts
+++ b/suite-native/graph/src/slice.ts
@@ -20,6 +20,14 @@ import {
 // Default is 720 hours (1 month).
 export const DEFAULT_GRAPH_TIMEFRAME_HOURS = 720;
 
+export const getGraphTimeframeOrDefault = (
+    timeframeHours: TimeframeHoursValue | undefined,
+): TimeframeHoursValue => {
+    if (timeframeHours === undefined) return DEFAULT_GRAPH_TIMEFRAME_HOURS;
+
+    return timeframeHours;
+};
+
 export type GraphInstanceState = {
     timeframeHours: TimeframeHoursValue;
     isLoading?: boolean;

--- a/suite-native/graph/src/slice.ts
+++ b/suite-native/graph/src/slice.ts
@@ -6,7 +6,9 @@ import { filterKeysByPartialMatch } from '@suite-native/storage';
 
 import {
     type GraphInstanceId,
+    type GraphInstanceStateKey,
     getAccountGraphInstanceId,
+    getGraphInstanceStateKey,
     getPortfolioGraphInstanceId,
     isGraphInstanceId,
 } from './graphInstances';
@@ -37,7 +39,7 @@ export type GraphInstanceState = {
     events?: StoredGroupedBalanceMovementEvent[];
 };
 
-type Graphs = Partial<Record<GraphInstanceId, GraphInstanceState>>;
+type Graphs = Partial<Record<GraphInstanceStateKey, GraphInstanceState>>;
 
 export type GraphState = {
     graphs: Graphs;
@@ -59,8 +61,9 @@ const getOrCreateGraphInstance = (
         throw new Error('Invalid graph instance ID.');
     }
 
-    const graph = state.graphs[instanceId] ?? getDefaultGraphInstanceState();
-    state.graphs[instanceId] = graph;
+    const stateKey = getGraphInstanceStateKey(instanceId);
+    const graph = state.graphs[stateKey] ?? getDefaultGraphInstanceState();
+    state.graphs[stateKey] = graph;
 
     return graph;
 };
@@ -105,7 +108,7 @@ const graphSlice = createSlice({
             state,
             { payload: { instanceId } }: PayloadAction<{ instanceId: GraphInstanceId }>,
         ) => {
-            const graph = state.graphs[instanceId];
+            const graph = state.graphs[getGraphInstanceStateKey(instanceId)];
 
             if (!graph) return;
 

--- a/suite-native/graph/src/slice.ts
+++ b/suite-native/graph/src/slice.ts
@@ -8,6 +8,7 @@ import {
     type GraphInstanceId,
     getAccountGraphInstanceId,
     getPortfolioGraphInstanceId,
+    isGraphInstanceId,
 } from './graphInstances';
 import { RefetchGraphThunkStatus } from './graphThunkTypes';
 import { refetchGraphThunk } from './graphThunks';
@@ -54,6 +55,10 @@ const getOrCreateGraphInstance = (
     state: GraphState,
     instanceId: GraphInstanceId,
 ): GraphInstanceState => {
+    if (!isGraphInstanceId(instanceId)) {
+        throw new Error('Invalid graph instance ID.');
+    }
+
     const graph = state.graphs[instanceId] ?? getDefaultGraphInstanceState();
     state.graphs[instanceId] = graph;
 
@@ -132,10 +137,7 @@ const graphSlice = createSlice({
             .addCase(refetchGraphThunk.fulfilled, (state, action) => {
                 const graphInstance = getOrCreateGraphInstance(state, action.meta.arg.instanceId);
 
-                if (
-                    action.payload.status === RefetchGraphThunkStatus.WaitingForDiscovery ||
-                    action.payload.status === RefetchGraphThunkStatus.Interrupted
-                ) {
+                if (action.payload.status !== RefetchGraphThunkStatus.Fetched) {
                     return;
                 }
 

--- a/suite-native/graph/src/slice.ts
+++ b/suite-native/graph/src/slice.ts
@@ -11,7 +11,11 @@ import {
 } from './graphInstances';
 import { RefetchGraphThunkStatus } from './graphThunkTypes';
 import { refetchGraphThunk } from './graphThunks';
-import { type TimeframeHoursValue } from './types';
+import {
+    type StoredFiatGraphPoint,
+    type StoredGroupedBalanceMovementEvent,
+    type TimeframeHoursValue,
+} from './types';
 
 // Default is 720 hours (1 month).
 export const DEFAULT_GRAPH_TIMEFRAME_HOURS = 720;
@@ -20,6 +24,8 @@ export type GraphInstanceState = {
     timeframeHours: TimeframeHoursValue;
     isLoading?: boolean;
     error?: string | null;
+    points?: StoredFiatGraphPoint[];
+    events?: StoredGroupedBalanceMovementEvent[];
 };
 
 type Graphs = Partial<Record<GraphInstanceId, GraphInstanceState>>;
@@ -127,6 +133,13 @@ const graphSlice = createSlice({
 
                 graphInstance.isLoading = false;
                 graphInstance.error = null;
+                graphInstance.points = action.payload.points;
+
+                if (action.payload.events) {
+                    graphInstance.events = action.payload.events;
+                } else {
+                    delete graphInstance.events;
+                }
             })
             .addCase(refetchGraphThunk.rejected, (state, action) => {
                 const graphInstance = getOrCreateGraphInstance(state, action.meta.arg.instanceId);

--- a/suite-native/graph/src/tests/graphDataUtils.test.ts
+++ b/suite-native/graph/src/tests/graphDataUtils.test.ts
@@ -1,0 +1,76 @@
+import {
+    type FiatGraphPointWithCryptoBalance,
+    type GroupedBalanceMovementEvent,
+} from '@suite-common/graph';
+import { type AccountKey } from '@suite-common/wallet-types';
+
+import {
+    deserializeGraphEvents,
+    deserializeGraphPoints,
+    serializeGraphEvents,
+    serializeGraphPoints,
+} from '../graphDataUtils';
+
+describe('graphDataUtils', () => {
+    it('serializes graph point dates as timestamps', () => {
+        const points: FiatGraphPointWithCryptoBalance[] = [
+            {
+                date: new Date(1000),
+                value: 12,
+                cryptoBalance: '0.42',
+            },
+        ];
+
+        expect(serializeGraphPoints(points)).toEqual([
+            {
+                date: 1000,
+                value: 12,
+                cryptoBalance: '0.42',
+            },
+        ]);
+    });
+
+    it('deserializes graph point timestamps as dates', () => {
+        const [point] = deserializeGraphPoints<FiatGraphPointWithCryptoBalance>([
+            {
+                date: 1000,
+                value: 12,
+                cryptoBalance: '0.42',
+            },
+        ]);
+
+        expect(point).toEqual({
+            date: new Date(1000),
+            value: 12,
+            cryptoBalance: '0.42',
+        });
+    });
+
+    it('serializes and deserializes graph event dates', () => {
+        const events: GroupedBalanceMovementEvent[] = [
+            {
+                date: new Date(2000),
+                payload: {
+                    received: 1,
+                    sent: 2,
+                    sentTransactionsCount: 1,
+                    receivedTransactionsCount: 1,
+                    symbol: 'eth',
+                    accountKey: 'account-key' as AccountKey,
+                },
+            },
+        ];
+
+        expect(deserializeGraphEvents(serializeGraphEvents(events))).toEqual([
+            {
+                ...events[0],
+                date: new Date(2000),
+            },
+        ]);
+    });
+
+    it('returns stable empty arrays', () => {
+        expect(deserializeGraphPoints(undefined)).toBe(deserializeGraphPoints(undefined));
+        expect(deserializeGraphEvents(undefined)).toBe(deserializeGraphEvents(undefined));
+    });
+});

--- a/suite-native/graph/src/tests/slice.test.ts
+++ b/suite-native/graph/src/tests/slice.test.ts
@@ -1,14 +1,18 @@
 import { type AccountItem } from '@suite-common/graph';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { type BaseCurrencyCode } from '@trezor/blockchain-link-types';
 
-import { getPortfolioGraphInstanceId } from '../graphInstances';
+import { type GraphInstanceId, getPortfolioGraphInstanceId } from '../graphInstances';
 import { graphPersistTransform } from '../graphPersistTransform';
 import { selectGraphTimeframe } from '../graphSelectors';
 import { RefetchGraphThunkStatus } from '../graphThunkTypes';
 import { refetchGraphThunk } from '../graphThunks';
-import { type GraphSliceRootState, graphInitialState, graphReducer } from '../slice';
+import {
+    type GraphSliceRootState,
+    graphInitialState,
+    graphReducer,
+    resetGraphRuntimeState,
+} from '../slice';
 
 const instanceId = getPortfolioGraphInstanceId();
 
@@ -23,7 +27,7 @@ const refetchGraphThunkArg = {
     ] satisfies AccountItem[],
     timeframeHours: 24,
     isElectrumBackend: false,
-    baseCurrencyCode: 'usd' as BaseCurrencyCode,
+    baseCurrencyCode: 'usd' as const,
 };
 
 describe('graphReducer', () => {
@@ -110,6 +114,41 @@ describe('graphReducer', () => {
             stateWithFetchedData.graphs[instanceId]?.events,
         );
         expect(state.graphs[instanceId]?.error).toBe('Fetch failed');
+    });
+
+    it('resets runtime status without removing fetched data', () => {
+        const state = graphReducer(
+            {
+                graphs: {
+                    [instanceId]: {
+                        timeframeHours: 24,
+                        isLoading: true,
+                        error: 'Fetch failed',
+                        points: [{ date: 1000, value: 1 }],
+                        events: [],
+                    },
+                },
+            },
+            resetGraphRuntimeState({ instanceId }),
+        );
+
+        expect(state.graphs[instanceId]).toEqual({
+            timeframeHours: 24,
+            points: [{ date: 1000, value: 1 }],
+            events: [],
+        });
+    });
+
+    it('rejects graph instance IDs that could access object prototypes', () => {
+        expect(() =>
+            graphReducer(
+                graphInitialState,
+                refetchGraphThunk.pending('request-id', {
+                    ...refetchGraphThunkArg,
+                    instanceId: '__proto__' as GraphInstanceId,
+                }),
+            ),
+        ).toThrow('Invalid graph instance ID.');
     });
 });
 

--- a/suite-native/graph/src/tests/slice.test.ts
+++ b/suite-native/graph/src/tests/slice.test.ts
@@ -1,0 +1,112 @@
+import { type AccountItem } from '@suite-common/graph';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type AccountKey } from '@suite-common/wallet-types';
+import { type BaseCurrencyCode } from '@trezor/blockchain-link-types';
+
+import { getPortfolioGraphInstanceId } from '../graphInstances';
+import { RefetchGraphThunkStatus } from '../graphThunkTypes';
+import { refetchGraphThunk } from '../graphThunks';
+import { graphInitialState, graphReducer } from '../slice';
+
+const instanceId = getPortfolioGraphInstanceId();
+
+const refetchGraphThunkArg = {
+    instanceId,
+    accounts: [
+        {
+            symbol: 'btc' as NetworkSymbol,
+            descriptor: 'descriptor',
+            accountKey: 'account-key' as AccountKey,
+        },
+    ] satisfies AccountItem[],
+    timeframeHours: 24,
+    isElectrumBackend: false,
+    baseCurrencyCode: 'usd' as BaseCurrencyCode,
+};
+
+describe('graphReducer', () => {
+    it('stores fetched graph points and events', () => {
+        const state = graphReducer(
+            graphInitialState,
+            refetchGraphThunk.fulfilled(
+                {
+                    status: RefetchGraphThunkStatus.Fetched,
+                    points: [{ date: 1000, value: 1 }],
+                    events: [
+                        {
+                            date: 2000,
+                            payload: {
+                                received: 1,
+                                sent: 0,
+                                sentTransactionsCount: 0,
+                                receivedTransactionsCount: 1,
+                                symbol: 'btc',
+                                accountKey: 'account-key' as AccountKey,
+                            },
+                        },
+                    ],
+                },
+                'request-id',
+                refetchGraphThunkArg,
+            ),
+        );
+
+        expect(state.graphs[instanceId]?.points).toEqual([{ date: 1000, value: 1 }]);
+        expect(state.graphs[instanceId]?.events).toEqual([
+            {
+                date: 2000,
+                payload: {
+                    received: 1,
+                    sent: 0,
+                    sentTransactionsCount: 0,
+                    receivedTransactionsCount: 1,
+                    symbol: 'btc',
+                    accountKey: 'account-key',
+                },
+            },
+        ]);
+    });
+
+    it('keeps last successful graph data when refetch fails', () => {
+        const stateWithFetchedData = graphReducer(
+            graphInitialState,
+            refetchGraphThunk.fulfilled(
+                {
+                    status: RefetchGraphThunkStatus.Fetched,
+                    points: [{ date: 1000, value: 1 }],
+                    events: [
+                        {
+                            date: 2000,
+                            payload: {
+                                received: 1,
+                                sent: 0,
+                                sentTransactionsCount: 0,
+                                receivedTransactionsCount: 1,
+                                symbol: 'btc',
+                                accountKey: 'account-key' as AccountKey,
+                            },
+                        },
+                    ],
+                },
+                'request-id',
+                refetchGraphThunkArg,
+            ),
+        );
+
+        const state = graphReducer(
+            stateWithFetchedData,
+            refetchGraphThunk.rejected(
+                new Error('Fetch failed'),
+                'request-id',
+                refetchGraphThunkArg,
+                'Fetch failed',
+            ),
+        );
+
+        expect(state.graphs[instanceId]?.points).toEqual([{ date: 1000, value: 1 }]);
+        expect(state.graphs[instanceId]?.events).toEqual(
+            stateWithFetchedData.graphs[instanceId]?.events,
+        );
+        expect(state.graphs[instanceId]?.error).toBe('Fetch failed');
+    });
+});

--- a/suite-native/graph/src/tests/slice.test.ts
+++ b/suite-native/graph/src/tests/slice.test.ts
@@ -2,7 +2,11 @@ import { type AccountItem } from '@suite-common/graph';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
 
-import { type GraphInstanceId, getPortfolioGraphInstanceId } from '../graphInstances';
+import {
+    type GraphInstanceId,
+    getGraphInstanceStateKey,
+    getPortfolioGraphInstanceId,
+} from '../graphInstances';
 import { graphPersistTransform } from '../graphPersistTransform';
 import { selectGraphTimeframe } from '../graphSelectors';
 import { RefetchGraphThunkStatus } from '../graphThunkTypes';
@@ -15,6 +19,7 @@ import {
 } from '../slice';
 
 const instanceId = getPortfolioGraphInstanceId();
+const stateKey = getGraphInstanceStateKey(instanceId);
 
 const refetchGraphThunkArg = {
     instanceId,
@@ -57,8 +62,8 @@ describe('graphReducer', () => {
             ),
         );
 
-        expect(state.graphs[instanceId]?.points).toEqual([{ date: 1000, value: 1 }]);
-        expect(state.graphs[instanceId]?.events).toEqual([
+        expect(state.graphs[stateKey]?.points).toEqual([{ date: 1000, value: 1 }]);
+        expect(state.graphs[stateKey]?.events).toEqual([
             {
                 date: 2000,
                 payload: {
@@ -109,18 +114,18 @@ describe('graphReducer', () => {
             ),
         );
 
-        expect(state.graphs[instanceId]?.points).toEqual([{ date: 1000, value: 1 }]);
-        expect(state.graphs[instanceId]?.events).toEqual(
-            stateWithFetchedData.graphs[instanceId]?.events,
+        expect(state.graphs[stateKey]?.points).toEqual([{ date: 1000, value: 1 }]);
+        expect(state.graphs[stateKey]?.events).toEqual(
+            stateWithFetchedData.graphs[stateKey]?.events,
         );
-        expect(state.graphs[instanceId]?.error).toBe('Fetch failed');
+        expect(state.graphs[stateKey]?.error).toBe('Fetch failed');
     });
 
     it('resets runtime status without removing fetched data', () => {
         const state = graphReducer(
             {
                 graphs: {
-                    [instanceId]: {
+                    [stateKey]: {
                         timeframeHours: 24,
                         isLoading: true,
                         error: 'Fetch failed',
@@ -132,7 +137,7 @@ describe('graphReducer', () => {
             resetGraphRuntimeState({ instanceId }),
         );
 
-        expect(state.graphs[instanceId]).toEqual({
+        expect(state.graphs[stateKey]).toEqual({
             timeframeHours: 24,
             points: [{ date: 1000, value: 1 }],
             events: [],
@@ -157,7 +162,7 @@ describe('all-time graph timeframe', () => {
         const state: GraphSliceRootState = {
             graph: {
                 graphs: {
-                    [instanceId]: { timeframeHours: null },
+                    [stateKey]: { timeframeHours: null },
                 },
             },
         };
@@ -172,6 +177,6 @@ describe('all-time graph timeframe', () => {
             {},
         );
 
-        expect(state.graphs[instanceId]?.timeframeHours).toBeNull();
+        expect(state.graphs[stateKey]?.timeframeHours).toBeNull();
     });
 });

--- a/suite-native/graph/src/tests/slice.test.ts
+++ b/suite-native/graph/src/tests/slice.test.ts
@@ -4,9 +4,11 @@ import { type AccountKey } from '@suite-common/wallet-types';
 import { type BaseCurrencyCode } from '@trezor/blockchain-link-types';
 
 import { getPortfolioGraphInstanceId } from '../graphInstances';
+import { graphPersistTransform } from '../graphPersistTransform';
+import { selectGraphTimeframe } from '../graphSelectors';
 import { RefetchGraphThunkStatus } from '../graphThunkTypes';
 import { refetchGraphThunk } from '../graphThunks';
-import { graphInitialState, graphReducer } from '../slice';
+import { type GraphSliceRootState, graphInitialState, graphReducer } from '../slice';
 
 const instanceId = getPortfolioGraphInstanceId();
 
@@ -108,5 +110,29 @@ describe('graphReducer', () => {
             stateWithFetchedData.graphs[instanceId]?.events,
         );
         expect(state.graphs[instanceId]?.error).toBe('Fetch failed');
+    });
+});
+
+describe('all-time graph timeframe', () => {
+    it('selects null as the all-time timeframe', () => {
+        const state: GraphSliceRootState = {
+            graph: {
+                graphs: {
+                    [instanceId]: { timeframeHours: null },
+                },
+            },
+        };
+
+        expect(selectGraphTimeframe(state, instanceId)).toBeNull();
+    });
+
+    it('rehydrates null as the all-time timeframe', () => {
+        const state = graphPersistTransform.out(
+            { graphs: { [instanceId]: { timeframeHours: null } } },
+            'graph',
+            {},
+        );
+
+        expect(state.graphs[instanceId]?.timeframeHours).toBeNull();
     });
 });

--- a/suite-native/graph/src/types.ts
+++ b/suite-native/graph/src/types.ts
@@ -1,1 +1,14 @@
+import { type GroupedBalanceMovementEventPayload } from '@suite-common/graph';
+
 export type TimeframeHoursValue = number | null;
+
+export type StoredFiatGraphPoint = {
+    date: number;
+    value: number;
+    cryptoBalance?: string;
+};
+
+export type StoredGroupedBalanceMovementEvent = {
+    date: number;
+    payload: GroupedBalanceMovementEventPayload;
+};

--- a/suite-native/module-accounts-management/src/components/AccountDetailGraph.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailGraph.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { useAtomValue, useSetAtom } from 'jotai';
-
 import { type FiatGraphPointWithCryptoBalance } from '@suite-common/graph';
 import { type AccountsRootState } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
@@ -19,7 +17,9 @@ import {
     getAccountGraphInstanceId,
     resetGraphRuntimeState,
     selectAccountGraphError,
+    selectAccountGraphEvents,
     selectAccountGraphIsLoading,
+    selectAccountGraphPoints,
     selectAccountGraphTimeframe,
     selectIsHistoryEnabledAccountByAccountKey,
     useGraphData,
@@ -37,7 +37,6 @@ type AccountDetailGraphProps = {
 
 export const AccountDetailGraph = ({ accountKey, tokenContract }: AccountDetailGraphProps) => {
     const dispatch = useDispatch();
-    const resetGraph = useSetAtom(accountDetailGraphAtoms.resetGraphAtom);
     const graphInstanceId = getAccountGraphInstanceId({ accountKey, tokenContract });
 
     const isHistoryEnabledAccount = useSelector((state: AccountsRootState) =>
@@ -64,14 +63,18 @@ export const AccountDetailGraph = ({ accountKey, tokenContract }: AccountDetailG
         backendSymbol: accountItem?.symbol ?? 'btc',
     });
 
-    const graphPoints = useAtomValue(accountDetailGraphAtoms.graphPointsAtom);
+    const graphPoints = useSelector((state: GraphSliceRootState) =>
+        selectAccountGraphPoints(state, accountKey, tokenContract),
+    );
     const isLoading = useSelector((state: GraphSliceRootState) =>
         selectAccountGraphIsLoading(state, accountKey, tokenContract),
     );
     const error = useSelector((state: GraphSliceRootState) =>
         selectAccountGraphError(state, accountKey, tokenContract),
     );
-    const graphEvents = useAtomValue(accountDetailGraphAtoms.graphEventsAtom);
+    const graphEvents = useSelector((state: GraphSliceRootState) =>
+        selectAccountGraphEvents(state, accountKey, tokenContract),
+    );
 
     const { setSelectedPoint, handleGestureEnd } = useGraphGestureHandlers(
         accountDetailGraphAtoms.selectedPointAtom,
@@ -80,9 +83,8 @@ export const AccountDetailGraph = ({ accountKey, tokenContract }: AccountDetailG
     useEffect(
         () => () => {
             dispatch(resetGraphRuntimeState({ instanceId: graphInstanceId }));
-            resetGraph();
         },
-        [dispatch, graphInstanceId, resetGraph],
+        [dispatch, graphInstanceId],
     );
 
     const isTokenPriceUnavailable = !isLoading && (!!error || graphPoints.length <= 1);
@@ -98,6 +100,7 @@ export const AccountDetailGraph = ({ accountKey, tokenContract }: AccountDetailG
                 accountKey={accountKey}
                 tokenAddress={tokenContract}
                 totalFiatBalance={totalFiatBalance}
+                graphPoints={graphPoints}
             />
 
             {isHistoryEnabledAccount && !isGraphHidden && (

--- a/suite-native/module-accounts-management/src/components/AccountDetailHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailHeader.tsx
@@ -2,7 +2,8 @@ import { useSelector } from 'react-redux';
 
 import { useAtomValue } from 'jotai';
 
-import type { DeviceRootState } from '@suite-common/device';
+import { type DeviceRootState } from '@suite-common/device';
+import { type FiatGraphPointWithCryptoBalance } from '@suite-common/graph';
 import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
@@ -36,6 +37,7 @@ type AccountBalanceProps = {
     accountKey: AccountKey;
     tokenAddress?: TokenAddress;
     totalFiatBalance: BaseCurrencyAmount;
+    graphPoints: FiatGraphPointWithCryptoBalance[];
 };
 
 const CryptoBalance = ({
@@ -61,6 +63,7 @@ export const AccountDetailHeader = ({
     accountKey,
     tokenAddress,
     totalFiatBalance,
+    graphPoints,
 }: AccountBalanceProps) => {
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
@@ -100,10 +103,8 @@ export const AccountDetailHeader = ({
             )}
 
             <GraphBaseCurrencyBalance
-                selectedPointFiatValueAtom={accountDetailGraphAtoms.selectedPointFiatValueAtom}
-                selectedPointTimestampAtom={accountDetailGraphAtoms.selectedPointTimestampAtom}
-                referencePointAtom={accountDetailGraphAtoms.referencePointAtom}
-                percentageChangeAtom={accountDetailGraphAtoms.percentageChangeAtom}
+                points={graphPoints}
+                selectedPointAtom={accountDetailGraphAtoms.selectedPointAtom}
                 isGestureActiveAtom={accountDetailGraphAtoms.isGestureActiveAtom}
                 showChange={isHistoryEnabledAccount}
                 totalBaseCurrencyBalance={totalFiatBalance}

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioHeader.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioHeader.tsx
@@ -8,6 +8,7 @@ import {
     selectHasDeviceHistoryEnabledAccounts,
     selectHasPortfolioGraphAccounts,
     selectPortfolioGraphIsLoading,
+    selectPortfolioGraphPoints,
 } from '@suite-native/graph';
 
 type PortfolioHeaderContentProps = {
@@ -17,15 +18,14 @@ type PortfolioHeaderContentProps = {
 const PortfolioHeaderContent = ({ isLoading }: PortfolioHeaderContentProps) => {
     const hasDeviceHistoryEnabledAccounts = useSelector(selectHasDeviceHistoryEnabledAccounts);
     const totalFiatBalance = useSelector(selectSelectedDeviceTotalFiatBalance);
+    const graphPoints = useSelector(selectPortfolioGraphPoints);
 
     return (
         <Box testID="@home/portfolio/header">
             <VStack spacing="sp4" alignItems="center">
                 <GraphBaseCurrencyBalance
-                    selectedPointFiatValueAtom={portfolioGraphAtoms.selectedPointFiatValueAtom}
-                    selectedPointTimestampAtom={portfolioGraphAtoms.selectedPointTimestampAtom}
-                    referencePointAtom={portfolioGraphAtoms.referencePointAtom}
-                    percentageChangeAtom={portfolioGraphAtoms.percentageChangeAtom}
+                    points={graphPoints}
+                    selectedPointAtom={portfolioGraphAtoms.selectedPointAtom}
                     isGestureActiveAtom={portfolioGraphAtoms.isGestureActiveAtom}
                     showChange={hasDeviceHistoryEnabledAccounts}
                     isLoading={isLoading}

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioLineGraph.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioLineGraph.tsx
@@ -1,8 +1,6 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
-import { useAtomValue } from 'jotai';
-
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { useIsDiscoveryDurationTooLong } from '@suite-native/discovery';
 import {
@@ -12,6 +10,7 @@ import {
     selectHasDeviceHistoryEnabledAccounts,
     selectPortfolioGraphError,
     selectPortfolioGraphIsLoading,
+    selectPortfolioGraphPoints,
     useGraphGestureHandlers,
 } from '@suite-native/graph';
 
@@ -24,7 +23,7 @@ export const PortfolioLineGraph = ({ refetchGraph }: PortfolioLineGraphProps) =>
     const hasDeviceHistoryEnabledAccounts = useSelector(selectHasDeviceHistoryEnabledAccounts);
     const loadingTakesLongerThanExpected = useIsDiscoveryDurationTooLong();
 
-    const graphPoints = useAtomValue(portfolioGraphAtoms.graphPointsAtom);
+    const graphPoints = useSelector(selectPortfolioGraphPoints);
     const isLoading = useSelector(selectPortfolioGraphIsLoading);
     const error = useSelector(selectPortfolioGraphError);
 


### PR DESCRIPTION
## Description

Moves fetched Suite Native Graph Points and Graph Events from module-global Jotai atoms into the
Redux graph instance that owns the corresponding request lifecycle.

Graph data is serialized at the thunk boundary, stored as timestamps and plain values, and restored
to the graph domain types by memoized selectors. Jotai remains responsible for the selected point
and other high-frequency gesture state, so swiping the graph does not dispatch Redux actions.

The base-currency balance display is split into focused components. Gesture-derived values are read
only by the components that display them, while loading, fallback, amount, date, and change rendering
remain isolated from unrelated updates.

The PR also fixes the `All` timeframe after the Redux migration. `null` is the intentional `All`
value, while `undefined` means that no timeframe has been stored and should use the default. Selectors
and persistence now preserve that distinction.

Account-detail unmount now resets only runtime loading and error state. Its latest fetched points and
events remain attached to that account-specific graph instance in memory, while gesture selection is
still cleared by the gesture hook. Points and events are not persisted across app restarts, and
forgetting a device removes its graph instances.

### Why this is useful

- Fetched graph results now follow one explicit data flow: thunk result, fulfilled action, graph
  instance state, and selectors.
- Portfolio and account graphs have independently addressable state instead of relying on writes to
  Jotai's global default store from outside React.
- Redux contains serializable data, which makes state inspection, lifecycle behavior, and future
  persistence decisions predictable.
- Runtime validation and constant-prefixed internal keys prevent graph instance IDs from addressing
  object prototype properties.
- High-frequency gesture interaction stays outside Redux, preserving the existing performance
  boundary.
- Memoized selectors deserialize dates only when stored graph data changes.
- Smaller balance components reduce the number of values each component subscribes to and therefore
  limit avoidable rerenders.

### Scope

This PR changes graph-result ownership, not graph-source acquisition. Transaction pagination,
historical-rate fetching, request concurrency, and cache reuse are intentionally unchanged. Those
performance changes will follow separately so their impact can be reviewed and measured in
isolation.

Each completed fetch publishes approximately 40 Graph Points and optional account Graph Events once.
Swipe updates remain in Jotai and do not add Redux dispatches. A matched `develop` versus PR
performance recording will be added before merge to verify that this ownership change does not
regress the `Day` to `All` interaction.

## Notes for QA

- Verify portfolio and account graphs load and retain independent results.
- Switch between `Day`, finite timeframes, and `All`.
- Restart the app with `All` selected and verify it remains selected.
- Swipe portfolio and account graphs and verify amount, date, percentage change, and account crypto
  balance update correctly.
- Verify account Graph Events and token account graphs.
- Verify loading, discovery, no-history fallback, error, and retry states.

## Validation

- `yarn workspace @suite-native/graph test:unit --coverage=0` - 26 tests passed.
- `yarn workspace @suite-native/graph depcheck` - passed.
- `yarn lint:js --no-tui` - 7 affected projects passed.
- CI type-check - passed.
- CI CodeQL analysis - passed with no open alert for the PR ref.

## Screenshots

Not applicable; this PR preserves the existing visual design.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/native-graph-redux-pr1&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->