### PR TITLE
feat(suite-native): stablecoin yield message system

### DIFF
--- a/packages/suite/src/hooks/suite/useMessageSystemEarnDashboard.ts
+++ b/packages/suite/src/hooks/suite/useMessageSystemEarnDashboard.ts
@@ -1,40 +1,15 @@
 import { selectLanguage } from '@suite/settings';
 import {
-    Context,
-    Feature,
-    selectContextMessageContent,
-    selectFeatureMessage,
-    selectFeatureMessageContent,
-    selectIsFeatureDisabled,
+    type EarnDashboardType,
+    useMessageSystemEarnDashboard as useMessageSystemEarnDashboardCore,
 } from '@suite-common/message-system';
 
 import { useSelector } from './useSelector';
 
-export type EarnDashboardType = keyof typeof Feature.earn.dashboard;
+export type { EarnDashboardType };
 
 export const useMessageSystemEarnDashboard = (type: EarnDashboardType) => {
-    const language = useSelector(selectLanguage);
+    const locale = useSelector(selectLanguage);
 
-    const isDisabled = useSelector(state =>
-        selectIsFeatureDisabled(state, Feature.earn.dashboard[type]),
-    );
-
-    const featureMessage = useSelector(state =>
-        selectFeatureMessage(state, Feature.earn.dashboard[type]),
-    );
-    const featureMessageContent = useSelector(state =>
-        selectFeatureMessageContent(state, Feature.earn.dashboard[type], language),
-    );
-    const contextMessage = useSelector(state =>
-        selectContextMessageContent(state, Context.getEarnDashboard(type), language),
-    );
-
-    const content = featureMessage ? featureMessageContent : contextMessage?.content;
-    const variant = featureMessage?.variant ?? contextMessage?.variant;
-
-    return {
-        isDisabled,
-        content,
-        variant,
-    };
+    return useMessageSystemEarnDashboardCore({ type, locale });
 };

--- a/packages/suite/src/hooks/suite/useMessageSystemYield.ts
+++ b/packages/suite/src/hooks/suite/useMessageSystemYield.ts
@@ -1,10 +1,5 @@
 import { selectLanguage } from '@suite/settings';
-import {
-    Feature,
-    selectIsYieldFeatureDisabled,
-    selectYieldFeatureMessage,
-    selectYieldFeatureMessageContent,
-} from '@suite-common/message-system';
+import { useMessageSystemYield as useMessageSystemYieldCore } from '@suite-common/message-system';
 import type { YieldFlowType } from '@suite-common/wallet-core';
 
 import { useSelector } from './useSelector';
@@ -17,31 +12,8 @@ export const useMessageSystemYield = (
     type: YieldFlowType,
     options: UseMessageSystemYieldOptions = {},
 ) => {
-    const language = useSelector(selectLanguage);
+    const locale = useSelector(selectLanguage);
     const { vaultContractAddress } = options;
 
-    const isDisabled = useSelector(state =>
-        selectIsYieldFeatureDisabled(state, Feature.earn.yield[type], vaultContractAddress),
-    );
-
-    const content = useSelector(state =>
-        selectYieldFeatureMessageContent(
-            state,
-            Feature.earn.yield[type],
-            vaultContractAddress,
-            language,
-        ),
-    );
-
-    const variant = useSelector(
-        state =>
-            selectYieldFeatureMessage(state, Feature.earn.yield[type], vaultContractAddress)
-                ?.variant,
-    );
-
-    return {
-        isDisabled,
-        content,
-        variant,
-    };
+    return useMessageSystemYieldCore({ type, vaultContractAddress, locale });
 };

--- a/suite-common/message-system/src/__tests__/useMessageSystemEarnDashboard.test.ts
+++ b/suite-common/message-system/src/__tests__/useMessageSystemEarnDashboard.test.ts
@@ -1,0 +1,107 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import {
+    configureMockStore,
+    extraDependenciesCommonMock,
+    renderHookWithStoreProvider,
+} from '@suite-common/test-utils';
+
+import { messageSystemInitialState, prepareMessageSystemReducer } from '../messageSystemReducer';
+import { type MessageSystemState } from '../messageSystemTypes';
+import { useMessageSystemEarnDashboard } from '../useMessageSystemEarnDashboard';
+
+const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
+
+const stateWithMessages = {
+    ...messageSystemInitialState,
+    config: {
+        version: 1,
+        timestamp: '2023-01-01',
+        sequence: 1,
+        actions: [
+            {
+                message: {
+                    id: 'yieldDashboardDisabledMsg',
+                    priority: 1,
+                    dismissible: false,
+                    category: ['feature'],
+                    variant: 'warning',
+                    content: { en: 'Yield dashboard disabled', cs: 'Yield dashboard vypnutý' },
+                    feature: [{ domain: 'earn.dashboard.yield', flag: false }],
+                },
+            },
+            {
+                message: {
+                    id: 'stakingDashboardContextMsg',
+                    priority: 1,
+                    dismissible: false,
+                    category: ['context'],
+                    variant: 'info',
+                    content: { en: 'Staking dashboard notice' },
+                    context: { domain: 'earn.dashboard.staking' },
+                },
+            },
+        ],
+        experiments: [],
+    },
+    validMessages: {
+        banner: [],
+        context: ['stakingDashboardContextMsg'],
+        modal: [],
+        feature: ['yieldDashboardDisabledMsg'],
+    },
+} as unknown as MessageSystemState;
+
+const createStore = (state: MessageSystemState = stateWithMessages) =>
+    configureMockStore({
+        extra: {},
+        reducer: combineReducers({ messageSystem: messageSystemReducer }),
+        preloadedState: { messageSystem: state } as { messageSystem: MessageSystemState },
+    });
+
+const renderHook = (props: Parameters<typeof useMessageSystemEarnDashboard>[0]) =>
+    renderHookWithStoreProvider(() => useMessageSystemEarnDashboard(props), {
+        store: createStore(),
+    });
+
+describe('useMessageSystemEarnDashboard', () => {
+    it('returns disabled state with feature message content and variant', () => {
+        const { result } = renderHook({ type: 'yield', locale: 'en' });
+
+        expect(result.current).toMatchObject({
+            isDisabled: true,
+            content: 'Yield dashboard disabled',
+            variant: 'warning',
+        });
+    });
+
+    it('returns localized feature message content', () => {
+        const { result } = renderHook({ type: 'yield', locale: 'cs' });
+
+        expect(result.current.content).toBe('Yield dashboard vypnutý');
+    });
+
+    it('falls back to context message content when no feature message is active', () => {
+        const { result } = renderHook({ type: 'staking', locale: 'en' });
+
+        expect(result.current).toMatchObject({
+            isDisabled: false,
+            content: 'Staking dashboard notice',
+            variant: 'info',
+        });
+    });
+
+    it('returns not disabled without content when no messages are configured', () => {
+        const store = createStore(messageSystemInitialState);
+        const { result } = renderHookWithStoreProvider(
+            () => useMessageSystemEarnDashboard({ type: 'yield', locale: 'en' }),
+            { store },
+        );
+
+        expect(result.current).toMatchObject({
+            isDisabled: false,
+            content: undefined,
+            variant: undefined,
+        });
+    });
+});

--- a/suite-common/message-system/src/__tests__/useMessageSystemYield.test.ts
+++ b/suite-common/message-system/src/__tests__/useMessageSystemYield.test.ts
@@ -1,0 +1,125 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import {
+    configureMockStore,
+    extraDependenciesCommonMock,
+    renderHookWithStoreProvider,
+} from '@suite-common/test-utils';
+
+import { messageSystemInitialState, prepareMessageSystemReducer } from '../messageSystemReducer';
+import { type MessageSystemState } from '../messageSystemTypes';
+import { useMessageSystemYield } from '../useMessageSystemYield';
+
+const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
+
+const VAULT_CONTRACT_ADDRESS = '0xAbCdEf0123456789abcdef0123456789ABCDEF01';
+
+const stateWithDisabledFeatures = {
+    ...messageSystemInitialState,
+    config: {
+        version: 1,
+        timestamp: '2023-01-01',
+        sequence: 1,
+        actions: [
+            {
+                message: {
+                    id: 'depositDisabledMsg',
+                    priority: 1,
+                    dismissible: false,
+                    category: ['feature'],
+                    variant: 'critical',
+                    content: { en: 'Deposit disabled', cs: 'Deposit vypnutý' },
+                    feature: [{ domain: 'earn.yield.deposit', flag: false }],
+                },
+            },
+            {
+                message: {
+                    id: 'withdrawVaultDisabledMsg',
+                    priority: 1,
+                    dismissible: false,
+                    category: ['feature'],
+                    content: { en: 'Vault withdrawal disabled' },
+                    feature: [
+                        {
+                            domain: 'earn.yield.withdraw',
+                            flag: false,
+                            payload: { vaultContractAddresses: [VAULT_CONTRACT_ADDRESS] },
+                        },
+                    ],
+                },
+            },
+        ],
+        experiments: [],
+    },
+    validMessages: {
+        banner: [],
+        context: [],
+        modal: [],
+        feature: ['depositDisabledMsg', 'withdrawVaultDisabledMsg'],
+    },
+} as unknown as MessageSystemState;
+
+const createStore = (state: MessageSystemState = stateWithDisabledFeatures) =>
+    configureMockStore({
+        extra: {},
+        reducer: combineReducers({ messageSystem: messageSystemReducer }),
+        preloadedState: { messageSystem: state } as { messageSystem: MessageSystemState },
+    });
+
+const renderHook = (props: Parameters<typeof useMessageSystemYield>[0]) =>
+    renderHookWithStoreProvider(() => useMessageSystemYield(props), {
+        store: createStore(),
+    });
+
+describe('useMessageSystemYield', () => {
+    it('returns disabled state, message content and variant when the feature is disabled', () => {
+        const { result } = renderHook({ type: 'deposit', locale: 'en' });
+
+        expect(result.current).toMatchObject({
+            isDisabled: true,
+            content: 'Deposit disabled',
+            variant: 'critical',
+        });
+    });
+
+    it('returns localized message content', () => {
+        const { result } = renderHook({ type: 'deposit', locale: 'cs' });
+
+        expect(result.current.content).toBe('Deposit vypnutý');
+    });
+
+    it('applies vault-targeted feature only to the matching vault', () => {
+        const { result: matchingVault } = renderHook({
+            type: 'withdraw',
+            vaultContractAddress: VAULT_CONTRACT_ADDRESS.toLowerCase(),
+            locale: 'en',
+        });
+        const { result: otherVault } = renderHook({
+            type: 'withdraw',
+            vaultContractAddress: '0x0000000000000000000000000000000000000000',
+            locale: 'en',
+        });
+        const { result: noVault } = renderHook({ type: 'withdraw', locale: 'en' });
+
+        expect(matchingVault.current).toMatchObject({
+            isDisabled: true,
+            content: 'Vault withdrawal disabled',
+        });
+        expect(otherVault.current.isDisabled).toBe(false);
+        expect(noVault.current.isDisabled).toBe(false);
+    });
+
+    it('returns not disabled when no feature messages are configured', () => {
+        const store = createStore(messageSystemInitialState);
+        const { result } = renderHookWithStoreProvider(
+            () => useMessageSystemYield({ type: 'deposit', locale: 'en' }),
+            { store },
+        );
+
+        expect(result.current).toMatchObject({
+            isDisabled: false,
+            content: undefined,
+            variant: undefined,
+        });
+    });
+});

--- a/suite-common/message-system/src/index.ts
+++ b/suite-common/message-system/src/index.ts
@@ -16,5 +16,7 @@ export * from './ExperimentWrapper';
 export * from './featureFlagUtils';
 export * from './useConditionControls';
 export * from './useExperiment';
+export * from './useMessageSystemEarnDashboard';
 export * from './useMessageSystemMessageForm';
 export * from './useMessageSystemStaking';
+export * from './useMessageSystemYield';

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -7,7 +7,7 @@ import type {
 } from '@suite-common/suite-types';
 import type { AccountType, NetworkSymbol, StakingNetworkSymbol } from '@suite-common/wallet-config';
 
-type EarnDashboardType = 'staking' | 'yield';
+export type EarnDashboardType = 'staking' | 'yield';
 
 export type MessageState = { [key in Category]: boolean };
 

--- a/suite-common/message-system/src/useMessageSystemEarnDashboard.ts
+++ b/suite-common/message-system/src/useMessageSystemEarnDashboard.ts
@@ -1,0 +1,47 @@
+import { useSelector } from 'react-redux';
+
+import {
+    selectContextMessageContent,
+    selectFeatureMessage,
+    selectFeatureMessageContent,
+    selectIsFeatureDisabled,
+} from './messageSystemSelectors';
+import {
+    Context,
+    type EarnDashboardType,
+    Feature,
+    type MessageSystemRootState,
+} from './messageSystemTypes';
+
+interface UseMessageSystemEarnDashboardProps {
+    type: EarnDashboardType;
+    locale: string;
+}
+
+export const useMessageSystemEarnDashboard = ({
+    type,
+    locale,
+}: UseMessageSystemEarnDashboardProps) => {
+    const isDisabled = useSelector((state: MessageSystemRootState) =>
+        selectIsFeatureDisabled(state, Feature.earn.dashboard[type]),
+    );
+
+    const featureMessage = useSelector((state: MessageSystemRootState) =>
+        selectFeatureMessage(state, Feature.earn.dashboard[type]),
+    );
+    const featureMessageContent = useSelector((state: MessageSystemRootState) =>
+        selectFeatureMessageContent(state, Feature.earn.dashboard[type], locale),
+    );
+    const contextMessage = useSelector((state: MessageSystemRootState) =>
+        selectContextMessageContent(state, Context.getEarnDashboard(type), locale),
+    );
+
+    const content = featureMessage ? featureMessageContent : contextMessage?.content;
+    const variant = featureMessage?.variant ?? contextMessage?.variant;
+
+    return {
+        isDisabled,
+        content,
+        variant,
+    };
+};

--- a/suite-common/message-system/src/useMessageSystemYield.ts
+++ b/suite-common/message-system/src/useMessageSystemYield.ts
@@ -1,0 +1,47 @@
+import { useSelector } from 'react-redux';
+
+import { type YieldFlowType } from '@suite-common/suite-types';
+
+import {
+    selectIsYieldFeatureDisabled,
+    selectYieldFeatureMessage,
+    selectYieldFeatureMessageContent,
+} from './messageSystemSelectors';
+import { Feature, type MessageSystemRootState } from './messageSystemTypes';
+
+interface UseMessageSystemYieldProps {
+    type: YieldFlowType;
+    vaultContractAddress?: string | null;
+    locale: string;
+}
+
+export const useMessageSystemYield = ({
+    type,
+    vaultContractAddress,
+    locale,
+}: UseMessageSystemYieldProps) => {
+    const isDisabled = useSelector((state: MessageSystemRootState) =>
+        selectIsYieldFeatureDisabled(state, Feature.earn.yield[type], vaultContractAddress),
+    );
+
+    const content = useSelector((state: MessageSystemRootState) =>
+        selectYieldFeatureMessageContent(
+            state,
+            Feature.earn.yield[type],
+            vaultContractAddress,
+            locale,
+        ),
+    );
+
+    const variant = useSelector(
+        (state: MessageSystemRootState) =>
+            selectYieldFeatureMessage(state, Feature.earn.yield[type], vaultContractAddress)
+                ?.variant,
+    );
+
+    return {
+        isDisabled,
+        content,
+        variant,
+    };
+};

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -3205,6 +3205,11 @@ export const messages = {
         apyPercentage: '~{apy}% APY',
         aprPercentage: '~{apy}% APR',
         notAvailableShort: 'N/A',
+        messageSystem: {
+            depositDisabled: 'Deposit is currently disabled.',
+            withdrawDisabled: 'Withdrawal is currently disabled.',
+            claimDisabled: 'Claim is currently disabled.',
+        },
         stakePendingCard: {
             totalStakePending: 'Total stake pending',
             addingToStakingPool: 'Adding to staking pool',

--- a/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
+++ b/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
@@ -4,7 +4,10 @@ import { useNavigation } from '@react-navigation/native';
 
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
-import { getConvertedOutputTokenBalanceToInputTokenAmount } from '@suite-common/wallet-core';
+import {
+    getConvertedOutputTokenBalanceToInputTokenAmount,
+    getYieldVaultContractAddress,
+} from '@suite-common/wallet-core';
 import {
     type AccountKey,
     type TokenAddress,
@@ -19,6 +22,7 @@ import {
     Card,
     CardDivider,
     HStack,
+    InlineAlertBox,
     PressableOpacity,
     Text,
     VStack,
@@ -28,6 +32,7 @@ import { Icon, TokenIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import {
     useApyBreakdownAlert,
+    useMessageSystemYield,
     useResolvedYieldFlowData,
     useStablecoinYieldFirmwareUpdateAlert,
 } from '@suite-native/module-earn';
@@ -70,6 +75,10 @@ export const StablecoinYieldTokenOverview = ({
     const apyValueText = apy && isApyAvailable(apy) ? `~${apy.toFixed(2)}%` : null;
 
     const apyBreakdownAlert = useApyBreakdownAlert({ account, vault, apy });
+
+    const vaultContractAddress = vault ? getYieldVaultContractAddress(vault) : undefined;
+    const depositMessageSystem = useMessageSystemYield('deposit', { vaultContractAddress });
+    const withdrawMessageSystem = useMessageSystemYield('withdraw', { vaultContractAddress });
 
     const handleDepositMorePress = useCallback(() => {
         if (!vault?.token.address) {
@@ -248,30 +257,46 @@ export const StablecoinYieldTokenOverview = ({
                         )}
                     </HStack>
                     {depositedPosition && (
-                        <HStack spacing="sp12">
-                            <Box flex={1}>
-                                <Button
-                                    onPress={handleDepositMorePress}
-                                    intent="brand"
-                                    priority="secondary"
-                                    size="medium"
-                                    testID="@account-detail/stablecoin-yield/deposit-more-button"
-                                >
-                                    <Translation id="moduleAccounts.accountDetail.stablecoinYield.depositMore" />
-                                </Button>
-                            </Box>
-                            <Box flex={1}>
-                                <Button
-                                    onPress={handleWithdrawPress}
-                                    intent="brand"
-                                    priority="secondary"
-                                    size="medium"
-                                    testID="@account-detail/stablecoin-yield/withdraw-button"
-                                >
-                                    <Translation id="moduleAccounts.accountDetail.stablecoinYield.withdraw" />
-                                </Button>
-                            </Box>
-                        </HStack>
+                        <>
+                            {depositMessageSystem.isDisabled && depositMessageSystem.content && (
+                                <InlineAlertBox
+                                    intent={depositMessageSystem.variant ?? 'warning'}
+                                    title={depositMessageSystem.content}
+                                />
+                            )}
+                            {withdrawMessageSystem.isDisabled && withdrawMessageSystem.content && (
+                                <InlineAlertBox
+                                    intent={withdrawMessageSystem.variant ?? 'warning'}
+                                    title={withdrawMessageSystem.content}
+                                />
+                            )}
+                            <HStack spacing="sp12">
+                                <Box flex={1}>
+                                    <Button
+                                        onPress={handleDepositMorePress}
+                                        isDisabled={depositMessageSystem.isDisabled}
+                                        intent="brand"
+                                        priority="secondary"
+                                        size="medium"
+                                        testID="@account-detail/stablecoin-yield/deposit-more-button"
+                                    >
+                                        <Translation id="moduleAccounts.accountDetail.stablecoinYield.depositMore" />
+                                    </Button>
+                                </Box>
+                                <Box flex={1}>
+                                    <Button
+                                        onPress={handleWithdrawPress}
+                                        isDisabled={withdrawMessageSystem.isDisabled}
+                                        intent="brand"
+                                        priority="secondary"
+                                        size="medium"
+                                        testID="@account-detail/stablecoin-yield/withdraw-button"
+                                    >
+                                        <Translation id="moduleAccounts.accountDetail.stablecoinYield.withdraw" />
+                                    </Button>
+                                </Box>
+                            </HStack>
+                        </>
                     )}
                 </VStack>
             </Card>

--- a/suite-native/module-earn/src/components/EarnDashboardDisabledRow.tsx
+++ b/suite-native/module-earn/src/components/EarnDashboardDisabledRow.tsx
@@ -1,0 +1,29 @@
+import { type EarnDashboardType } from '@suite-common/message-system';
+import { Box, InlineAlertBox } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+import { EarnPromoListRowContainer } from './EarnPromoListRow';
+import { useMessageSystemEarnDashboard } from '../hooks/useMessageSystemEarnDashboard';
+
+type EarnDashboardDisabledRowProps = {
+    type: EarnDashboardType;
+    isLastInSection: boolean;
+};
+
+export const EarnDashboardDisabledRow = ({
+    type,
+    isLastInSection,
+}: EarnDashboardDisabledRowProps) => {
+    const { content, variant } = useMessageSystemEarnDashboard(type);
+
+    return (
+        <EarnPromoListRowContainer isLastInSection={isLastInSection}>
+            <Box padding="sp16">
+                <InlineAlertBox
+                    intent={variant ?? 'warning'}
+                    title={content ?? <Translation id="earn.notAvailable" />}
+                />
+            </Box>
+        </EarnPromoListRowContainer>
+    );
+};

--- a/suite-native/module-earn/src/components/StablecoinYieldClaimRewardsCardSection.tsx
+++ b/suite-native/module-earn/src/components/StablecoinYieldClaimRewardsCardSection.tsx
@@ -6,10 +6,11 @@ import { useServices } from '@suite-common/dependency-injection';
 import { selectIsPortfolioTrackerDevice } from '@suite-common/device';
 import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
 import { selectNativeAnalyticsDep } from '@suite-native/analytics';
-import { Button, HStack, Text, VStack } from '@suite-native/atoms';
+import { Button, HStack, InlineAlertBox, Text, VStack } from '@suite-native/atoms';
 import { BaseCurrencyAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
 
+import { useMessageSystemYield } from '../hooks/useMessageSystemYield';
 import { type StablecoinYieldClaimSummary } from '../types';
 
 type StablecoinYieldClaimRewardsCardSectionProps = {
@@ -26,7 +27,12 @@ export const StablecoinYieldClaimRewardsCardSection = ({
     onPress,
 }: StablecoinYieldClaimRewardsCardSectionProps) => {
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
-    const isDisabled = claimRewards.length === 0 || isLoading;
+    const {
+        isDisabled: isClaimFeatureDisabled,
+        content: claimDisabledContent,
+        variant: claimDisabledVariant,
+    } = useMessageSystemYield('claim');
+    const isDisabled = claimRewards.length === 0 || isLoading || isClaimFeatureDisabled;
 
     const { analytics } = useServices(selectNativeAnalyticsDep);
 
@@ -50,28 +56,36 @@ export const StablecoinYieldClaimRewardsCardSection = ({
     }
 
     return (
-        <HStack spacing="sp24" alignItems="center">
-            <VStack spacing={2} flex={1}>
-                <Text variant="body-md" color="contentSecondary">
-                    <Translation id="earn.earnScreen.depositsCard.availableRewards" />
-                </Text>
-                <BaseCurrencyAmountFormatter
-                    value={totalFiatClaimableAmount}
-                    variant="headline-md"
-                    isDiscreetText={false}
-                    isLoading={isLoading}
+        <VStack spacing="sp12">
+            {isClaimFeatureDisabled && claimDisabledContent && (
+                <InlineAlertBox
+                    intent={claimDisabledVariant ?? 'warning'}
+                    title={claimDisabledContent}
                 />
-            </VStack>
-            <Button
-                size="medium"
-                intent="neutral"
-                priority="secondary"
-                isDisabled={isDisabled}
-                isLoading={isLoading}
-                onPress={handlePress}
-            >
-                <Translation id="earn.earnScreen.depositsCard.claimRewardsButton" />
-            </Button>
-        </HStack>
+            )}
+            <HStack spacing="sp24" alignItems="center">
+                <VStack spacing={2} flex={1}>
+                    <Text variant="body-md" color="contentSecondary">
+                        <Translation id="earn.earnScreen.depositsCard.availableRewards" />
+                    </Text>
+                    <BaseCurrencyAmountFormatter
+                        value={totalFiatClaimableAmount}
+                        variant="headline-md"
+                        isDiscreetText={false}
+                        isLoading={isLoading}
+                    />
+                </VStack>
+                <Button
+                    size="medium"
+                    intent="neutral"
+                    priority="secondary"
+                    isDisabled={isDisabled}
+                    isLoading={isLoading}
+                    onPress={handlePress}
+                >
+                    <Translation id="earn.earnScreen.depositsCard.claimRewardsButton" />
+                </Button>
+            </HStack>
+        </VStack>
     );
 };

--- a/suite-native/module-earn/src/components/YieldDisabledAlert.tsx
+++ b/suite-native/module-earn/src/components/YieldDisabledAlert.tsx
@@ -1,0 +1,26 @@
+import { type ReactNode } from 'react';
+
+import { type Variant } from '@suite-common/suite-types';
+import { type YieldFlowType } from '@suite-common/wallet-core';
+import { InlineAlertBox } from '@suite-native/atoms';
+import { Translation, type TxKeyPath } from '@suite-native/intl';
+
+const yieldDisabledTitleMap = {
+    deposit: 'earn.messageSystem.depositDisabled',
+    withdraw: 'earn.messageSystem.withdrawDisabled',
+    redeem: 'earn.messageSystem.withdrawDisabled',
+    claim: 'earn.messageSystem.claimDisabled',
+} as const satisfies Record<YieldFlowType, TxKeyPath>;
+
+type YieldDisabledAlertProps = {
+    type: YieldFlowType;
+    content?: ReactNode;
+    variant?: Variant;
+};
+
+export const YieldDisabledAlert = ({ type, content, variant }: YieldDisabledAlertProps) => (
+    <InlineAlertBox
+        intent={variant ?? 'warning'}
+        title={content ?? <Translation id={yieldDisabledTitleMap[type]} />}
+    />
+);

--- a/suite-native/module-earn/src/hooks/useMessageSystemEarnDashboard.ts
+++ b/suite-native/module-earn/src/hooks/useMessageSystemEarnDashboard.ts
@@ -1,0 +1,13 @@
+import { useSelector } from 'react-redux';
+
+import {
+    type EarnDashboardType,
+    useMessageSystemEarnDashboard as useMessageSystemEarnDashboardCore,
+} from '@suite-common/message-system';
+import { selectLocale } from '@suite-native/intl';
+
+export const useMessageSystemEarnDashboard = (type: EarnDashboardType) => {
+    const locale = useSelector(selectLocale);
+
+    return useMessageSystemEarnDashboardCore({ type, locale });
+};

--- a/suite-native/module-earn/src/hooks/useMessageSystemYield.ts
+++ b/suite-native/module-earn/src/hooks/useMessageSystemYield.ts
@@ -1,0 +1,19 @@
+import { useSelector } from 'react-redux';
+
+import { useMessageSystemYield as useMessageSystemYieldCore } from '@suite-common/message-system';
+import { type YieldFlowType } from '@suite-common/wallet-core';
+import { selectLocale } from '@suite-native/intl';
+
+type UseMessageSystemYieldOptions = {
+    vaultContractAddress?: string | null;
+};
+
+export const useMessageSystemYield = (
+    type: YieldFlowType,
+    options: UseMessageSystemYieldOptions = {},
+) => {
+    const locale = useSelector(selectLocale);
+    const { vaultContractAddress } = options;
+
+    return useMessageSystemYieldCore({ type, vaultContractAddress, locale });
+};

--- a/suite-native/module-earn/src/index.ts
+++ b/suite-native/module-earn/src/index.ts
@@ -1,6 +1,7 @@
 export { FiveBinariesHomeBanner } from './components/FiveBinariesHomeBanner';
 export { StablecoinYieldApyBreakdown } from './components/StablecoinYieldApyBreakdown';
 export { useApyBreakdownAlert } from './hooks/useApyBreakdownAlert';
+export { useMessageSystemYield } from './hooks/useMessageSystemYield';
 export { useResolvedYieldFlowData } from './hooks/useResolvedYieldFlowData';
 export { useStablecoinYieldFirmwareUpdateAlert } from './hooks/useStablecoinYieldFirmwareUpdateAlert';
 export { useStakingDetailNavigation } from './hooks/useStakingDetailNavigation';

--- a/suite-native/module-earn/src/screens/EarnScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnScreen.tsx
@@ -5,13 +5,16 @@ import { FlashList } from '@shopify/flash-list';
 
 import { events as sharedEvents } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
+import { Context } from '@suite-common/message-system';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { TitleHeader, VStack } from '@suite-native/atoms';
 import { DeviceManagerScreenHeader } from '@suite-native/device-manager';
 import { Translation } from '@suite-native/intl';
+import { ContextMessage } from '@suite-native/message-system';
 import { Screen } from '@suite-native/navigation';
 
 import { ChooseStakingAccountBottomSheet } from '../components/ChooseStakingAccountBottomSheet';
+import { EarnDashboardDisabledRow } from '../components/EarnDashboardDisabledRow';
 import { EarnItemInfoModal } from '../components/EarnItemInfoModal';
 import { EarnPortfolioTrackerGuard } from '../components/EarnPortfolioTrackerGuard';
 import { EarnPoweredByProvider } from '../components/EarnPoweredByProvider';
@@ -25,11 +28,28 @@ import { EarnScreenListHeader } from '../components/EarnScreenListHeader';
 import { EarnStakingProvidersInfo } from '../components/EarnStakingProvidersInfo';
 import { EnableNetworkForEarnBottomSheet } from '../components/EnableNetworkForEarnBottomSheet';
 import { StablecoinYieldLoadErrorAlert } from '../components/StablecoinYieldLoadErrorAlert';
+import { useMessageSystemEarnDashboard } from '../hooks/useMessageSystemEarnDashboard';
 import { useStablecoinYieldListData } from '../hooks/useStablecoinYieldListData';
 import { useStablecoinYieldPromoNavigation } from '../hooks/useStablecoinYieldPromoNavigation';
 import { useStakingListData } from '../hooks/useStakingListData';
 import { useStakingPromoNavigation } from '../hooks/useStakingPromoNavigation';
-import { type EarnPromoItem, type EarnPromoListDataItem } from '../types';
+import {
+    type EarnDashboardDisabledListItem,
+    type EarnPromoItem,
+    type EarnPromoListDataItem,
+} from '../types';
+
+const STAKING_DASHBOARD_DISABLED_ITEM = {
+    id: 'staking-dashboard-disabled',
+    type: 'dashboard-disabled',
+    dashboardType: 'staking',
+} as const satisfies EarnDashboardDisabledListItem;
+
+const YIELD_DASHBOARD_DISABLED_ITEM = {
+    id: 'yield-dashboard-disabled',
+    type: 'dashboard-disabled',
+    dashboardType: 'yield',
+} as const satisfies EarnDashboardDisabledListItem;
 
 const getEarnListItemType = (item: EarnPromoListDataItem) =>
     typeof item === 'string' ? 'section-header' : `row-${item.type}`;
@@ -66,10 +86,26 @@ const EarnScreenContent = () => {
     const { handleStakingPromoPress } = staking;
     const { handleStablecoinYieldPromoPress } = stablecoinYield;
 
-    const earnListData = useMemo(
-        (): EarnPromoListDataItem[] => [...stakingPromoItems, ...stablecoinYieldPromoItems],
-        [stablecoinYieldPromoItems, stakingPromoItems],
-    );
+    const stakingDashboard = useMessageSystemEarnDashboard('staking');
+    const yieldDashboard = useMessageSystemEarnDashboard('yield');
+    const isStakingDashboardDisabled = stakingDashboard.isDisabled;
+    const isYieldDashboardDisabled = yieldDashboard.isDisabled;
+
+    const earnListData = useMemo((): EarnPromoListDataItem[] => {
+        const stakingItems: EarnPromoListDataItem[] = isStakingDashboardDisabled
+            ? ['staking', STAKING_DASHBOARD_DISABLED_ITEM]
+            : stakingPromoItems;
+        const stablecoinYieldItems: EarnPromoListDataItem[] = isYieldDashboardDisabled
+            ? ['stablecoin-yield', YIELD_DASHBOARD_DISABLED_ITEM]
+            : stablecoinYieldPromoItems;
+
+        return [...stakingItems, ...stablecoinYieldItems];
+    }, [
+        isStakingDashboardDisabled,
+        isYieldDashboardDisabled,
+        stablecoinYieldPromoItems,
+        stakingPromoItems,
+    ]);
 
     useFocusEffect(
         useCallback(() => {
@@ -150,6 +186,15 @@ const EarnScreenContent = () => {
                 return <EarnPromoListSkeletonRow isLastInSection={isLastInSection} />;
             }
 
+            if (item.type === 'dashboard-disabled') {
+                return (
+                    <EarnDashboardDisabledRow
+                        type={item.dashboardType}
+                        isLastInSection={isLastInSection}
+                    />
+                );
+            }
+
             if (item.type === 'stablecoin-yield-load-error') {
                 return (
                     <EarnPromoListRowContainer isLastInSection={isLastInSection}>
@@ -183,17 +228,43 @@ const EarnScreenContent = () => {
                     data={earnListData}
                     getItemType={getEarnListItemType}
                     ListHeaderComponent={
-                        <EarnScreenListHeader
-                            isStablecoinYieldLoading={isYieldLoading}
-                            isStablecoinYieldClaimSummariesLoading={isClaimSummariesLoading}
-                            cardanoStakingAccountKey={accountStakedWithFiveBinaries?.key}
-                            stakingActiveItems={stakingActiveItems}
-                            stablecoinYieldActiveItems={stablecoinYieldActiveItems}
-                            stablecoinYieldClaimSummaries={stablecoinYieldClaimSummaries}
-                            stablecoinYieldTotalFiatClaimableAmount={
-                                stablecoinYieldTotalFiatClaimableAmount
-                            }
-                        />
+                        <>
+                            <ContextMessage
+                                context={Context.getEarnDashboard('staking')}
+                                marginBottom="sp16"
+                            />
+                            <ContextMessage
+                                context={Context.getEarnDashboard('yield')}
+                                marginBottom="sp16"
+                            />
+                            <EarnScreenListHeader
+                                isStablecoinYieldLoading={
+                                    !isYieldDashboardDisabled && isYieldLoading
+                                }
+                                isStablecoinYieldClaimSummariesLoading={
+                                    !isYieldDashboardDisabled && isClaimSummariesLoading
+                                }
+                                cardanoStakingAccountKey={
+                                    isStakingDashboardDisabled
+                                        ? undefined
+                                        : accountStakedWithFiveBinaries?.key
+                                }
+                                stakingActiveItems={
+                                    isStakingDashboardDisabled ? [] : stakingActiveItems
+                                }
+                                stablecoinYieldActiveItems={
+                                    isYieldDashboardDisabled ? [] : stablecoinYieldActiveItems
+                                }
+                                stablecoinYieldClaimSummaries={
+                                    isYieldDashboardDisabled ? [] : stablecoinYieldClaimSummaries
+                                }
+                                stablecoinYieldTotalFiatClaimableAmount={
+                                    isYieldDashboardDisabled
+                                        ? null
+                                        : stablecoinYieldTotalFiatClaimableAmount
+                                }
+                            />
+                        </>
                     }
                     keyExtractor={getEarnListItemKey}
                     renderItem={renderItem}

--- a/suite-native/module-earn/src/screens/HowYieldWorksScreen.tsx
+++ b/suite-native/module-earn/src/screens/HowYieldWorksScreen.tsx
@@ -2,6 +2,7 @@ import { type RouteProp, useNavigation, useRoute } from '@react-navigation/nativ
 
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
+import { getYieldVaultContractAddress } from '@suite-common/wallet-core';
 import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Button, TimelineDetailsCard, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -16,7 +17,9 @@ import {
 import { HowEarnWorksBenefitsSection } from '../components/HowEarnWorks/HowEarnWorksBenefitsSection';
 import { HowEarnWorksHeaderSection } from '../components/HowEarnWorks/HowEarnWorksHeaderSection';
 import { HowEarnWorksTimelineCard } from '../components/HowEarnWorks/HowEarnWorksTimelineCard';
+import { YieldDisabledAlert } from '../components/YieldDisabledAlert';
 import { useApyBreakdownAlert } from '../hooks/useApyBreakdownAlert';
+import { useMessageSystemYield } from '../hooks/useMessageSystemYield';
 import { useNavigateBackAnalytics } from '../hooks/useNavigateBackAnalytics';
 import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
 import { createHowYieldWorksPreset } from '../presets/HowEarnWorks/yieldPresets';
@@ -48,6 +51,13 @@ export const HowYieldWorksScreen = () => {
             vaultId: vault?.id,
         },
     });
+
+    const vaultContractAddress = vault ? getYieldVaultContractAddress(vault) : undefined;
+    const {
+        isDisabled: isDepositDisabled,
+        content: depositDisabledContent,
+        variant: depositDisabledVariant,
+    } = useMessageSystemYield('deposit', { vaultContractAddress });
 
     const handleNavigateToYieldConsents = () => {
         analytics.report({
@@ -114,9 +124,18 @@ export const HowYieldWorksScreen = () => {
                         ))}
                     </HowEarnWorksTimelineCard>
                 </VStack>
-                <Button onPress={handleNavigateToYieldConsents}>
-                    <Translation id="generic.buttons.continue" />
-                </Button>
+                <VStack spacing="sp16">
+                    {isDepositDisabled && (
+                        <YieldDisabledAlert
+                            type="deposit"
+                            content={depositDisabledContent}
+                            variant={depositDisabledVariant}
+                        />
+                    )}
+                    <Button onPress={handleNavigateToYieldConsents} isDisabled={isDepositDisabled}>
+                        <Translation id="generic.buttons.continue" />
+                    </Button>
+                </VStack>
             </VStack>
         </Screen>
     );

--- a/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
@@ -5,6 +5,7 @@ import { type RouteProp, useIsFocused, useNavigation, useRoute } from '@react-na
 
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
+import { Context } from '@suite-common/message-system';
 import { getNetwork } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
@@ -15,6 +16,7 @@ import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Box, FullAlertBox, Text, VStack, useBottomSheetModal } from '@suite-native/atoms';
 import { useFiatFromCryptoValue } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
+import { ContextMessage } from '@suite-native/message-system';
 import {
     Screen,
     ScreenHeader,
@@ -26,9 +28,11 @@ import { FeeSelector } from '@suite-native/transaction-management';
 
 import { YieldClaimFlowFooter } from '../components/YieldClaimFlowFooter';
 import { YieldClaimRewardsCard } from '../components/YieldClaimRewardsCard';
+import { YieldDisabledAlert } from '../components/YieldDisabledAlert';
 import { YieldFeeEstimationErrorAlert } from '../components/YieldFeeEstimationErrorAlert';
 import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
 import { YieldTxSimulationBottomSheet } from '../components/YieldTxSimulationBottomSheet';
+import { useMessageSystemYield } from '../hooks/useMessageSystemYield';
 import { useNavigateBackAnalytics } from '../hooks/useNavigateBackAnalytics';
 import { useShowYieldTransactionFailureAlert } from '../hooks/useShowYieldTransactionFailureAlert';
 import { type PreparedYieldClaimAction, useYieldClaimFees } from '../hooks/useYieldClaimFees';
@@ -60,6 +64,11 @@ export const YieldClaimScreen = () => {
         selectAccountByKey(state, accountKey),
     );
     const flowKey = account?.key ?? null;
+    const {
+        isDisabled: isClaimDisabled,
+        content: claimDisabledContent,
+        variant: claimDisabledVariant,
+    } = useMessageSystemYield('claim');
 
     useNavigateBackAnalytics({
         type: events.yieldNavigateEvent.name,
@@ -70,6 +79,7 @@ export const YieldClaimScreen = () => {
             networkSymbol: account?.symbol,
         },
     });
+
     const session = useYieldSession({
         flowKey,
         flowType: 'claim',
@@ -132,7 +142,8 @@ export const YieldClaimScreen = () => {
         claimFee.isPreparingClaimFee ||
         claimFee.isFeeUnavailable ||
         !accountRewards ||
-        !claimFee.preparedAction;
+        !claimFee.preparedAction ||
+        isClaimDisabled;
 
     useShowYieldTransactionFailureAlert({
         error: session?.error,
@@ -258,6 +269,14 @@ export const YieldClaimScreen = () => {
         >
             <Box paddingHorizontal="sp16" pointerEvents={isClaimPending ? 'none' : 'auto'}>
                 <VStack spacing="sp20">
+                    <ContextMessage context={Context.getEarnYield('claim')} />
+                    {isClaimDisabled && (
+                        <YieldDisabledAlert
+                            type="claim"
+                            content={claimDisabledContent}
+                            variant={claimDisabledVariant}
+                        />
+                    )}
                     <YieldClaimRewardsCard
                         accountRewards={accountRewards}
                         isFiatLoading={isClaimRewardsFiatLoading}

--- a/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
@@ -5,13 +5,19 @@ import { type RouteProp, useIsFocused, useNavigation, useRoute } from '@react-na
 
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
+import { Context } from '@suite-common/message-system';
 import { getNetwork } from '@suite-common/wallet-config';
-import { getYieldApprovalAction, stablecoinYieldActions } from '@suite-common/wallet-core';
+import {
+    getYieldApprovalAction,
+    getYieldVaultContractAddress,
+    stablecoinYieldActions,
+} from '@suite-common/wallet-core';
 import { isPositiveBalance } from '@suite-common/wallet-utils';
 import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Box, FullAlertBox, VStack, useBottomSheetModal } from '@suite-native/atoms';
 import { Form } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
+import { ContextMessage } from '@suite-native/message-system';
 import {
     Screen,
     type StackNavigationProps,
@@ -28,7 +34,9 @@ import { YieldDepositFlowFooter } from '../components/YieldDepositFlowFooter';
 import { YieldDepositFlowScreenHeader } from '../components/YieldDepositFlowScreenHeader';
 import { YieldDepositInfoBottomSheet } from '../components/YieldDepositInfoBottomSheet';
 import { YieldDepositStepCard } from '../components/YieldDepositStepCard';
+import { YieldDisabledAlert } from '../components/YieldDisabledAlert';
 import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
+import { useMessageSystemYield } from '../hooks/useMessageSystemYield';
 import { useRefreshYieldDepositAllowanceOnIdle } from '../hooks/useRefreshYieldDepositAllowanceOnIdle';
 import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
 import { useShowYieldTransactionFailureAlert } from '../hooks/useShowYieldTransactionFailureAlert';
@@ -75,10 +83,18 @@ export const YieldDepositApprovalScreen = () => {
         flowKey,
         token,
         tokenSymbol,
+        vault,
         vaultTokenSymbol,
         vaultTokenName,
         resolutionStatus,
     } = resolvedFlowData;
+
+    const vaultContractAddress = vault ? getYieldVaultContractAddress(vault) : undefined;
+    const {
+        isDisabled: isDepositDisabled,
+        content: depositDisabledContent,
+        variant: depositDisabledVariant,
+    } = useMessageSystemYield('deposit', { vaultContractAddress });
     const session = useYieldSession({
         flowKey,
         flowType: 'deposit',
@@ -157,7 +173,7 @@ export const YieldDepositApprovalScreen = () => {
         isApprovalSessionReady &&
         !isApprovalPending &&
         !isCheckingApproval;
-    const isSubmitDisabled = !canSubmitApproval;
+    const isSubmitDisabled = !canSubmitApproval || isDepositDisabled;
 
     useShowYieldTransactionFailureAlert({
         error: session?.error,
@@ -246,7 +262,7 @@ export const YieldDepositApprovalScreen = () => {
     }, [closeInfoBottomSheet, reopenPendingBottomSheet]);
 
     const handleSubmit = form.handleSubmit(async ({ amount }) => {
-        if (!canSubmitApproval) {
+        if (isSubmitDisabled) {
             return;
         }
 
@@ -318,6 +334,19 @@ export const YieldDepositApprovalScreen = () => {
             <Box pointerEvents={isApprovalPending ? 'none' : 'auto'}>
                 <Form form={form}>
                     <VStack spacing="sp16">
+                        <ContextMessage
+                            context={Context.getEarnYield('deposit')}
+                            marginHorizontal="sp16"
+                        />
+                        {isDepositDisabled && (
+                            <Box paddingHorizontal="sp16">
+                                <YieldDisabledAlert
+                                    type="deposit"
+                                    content={depositDisabledContent}
+                                    variant={depositDisabledVariant}
+                                />
+                            </Box>
+                        )}
                         <YieldDepositStepCard currentStepIndex={0} />
 
                         {shouldShowApprovedAmountCard && (

--- a/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
@@ -11,13 +11,15 @@ import {
 
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
+import { Context } from '@suite-common/message-system';
 import { getNetwork } from '@suite-common/wallet-config';
-import { stablecoinYieldActions } from '@suite-common/wallet-core';
+import { getYieldVaultContractAddress, stablecoinYieldActions } from '@suite-common/wallet-core';
 import { getApyBreakdown } from '@suite-common/wallet-utils';
 import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Box, FullAlertBox, VStack, useBottomSheetModal } from '@suite-native/atoms';
 import { Form } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
+import { ContextMessage } from '@suite-native/message-system';
 import {
     Screen,
     type StackNavigationProps,
@@ -34,9 +36,11 @@ import { YieldDepositFlowFooter } from '../components/YieldDepositFlowFooter';
 import { YieldDepositFlowScreenHeader } from '../components/YieldDepositFlowScreenHeader';
 import { YieldDepositInfoBottomSheet } from '../components/YieldDepositInfoBottomSheet';
 import { YieldDepositStepCard } from '../components/YieldDepositStepCard';
+import { YieldDisabledAlert } from '../components/YieldDisabledAlert';
 import { YieldFeeEstimationErrorAlert } from '../components/YieldFeeEstimationErrorAlert';
 import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
 import { YieldTxSimulationBottomSheet } from '../components/YieldTxSimulationBottomSheet';
+import { useMessageSystemYield } from '../hooks/useMessageSystemYield';
 import { useNavigateBackAnalytics } from '../hooks/useNavigateBackAnalytics';
 import { useRefreshYieldDepositAllowanceOnIdle } from '../hooks/useRefreshYieldDepositAllowanceOnIdle';
 import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
@@ -85,10 +89,18 @@ export const YieldDepositScreen = () => {
         flowKey,
         token,
         tokenSymbol,
+        vault,
         vaultTokenSymbol,
         vaultTokenName,
         resolutionStatus,
     } = resolvedFlowData;
+
+    const vaultContractAddress = vault ? getYieldVaultContractAddress(vault) : undefined;
+    const {
+        isDisabled: isDepositDisabled,
+        content: depositDisabledContent,
+        variant: depositDisabledVariant,
+    } = useMessageSystemYield('deposit', { vaultContractAddress });
 
     useNavigateBackAnalytics({
         type: events.yieldNavigateEvent.name,
@@ -100,6 +112,7 @@ export const YieldDepositScreen = () => {
             vaultId: resolvedFlowData.vault?.id,
         },
     });
+
     const session = useYieldSession({
         flowKey,
         flowType: 'deposit',
@@ -160,7 +173,10 @@ export const YieldDepositScreen = () => {
         isEnabled: canPrepareDepositFee,
     });
     const isSubmitDisabled =
-        !canContinueDepositFlow || isApprovalInsufficient || !depositFee.isDepositFeeReady;
+        !canContinueDepositFlow ||
+        isApprovalInsufficient ||
+        !depositFee.isDepositFeeReady ||
+        isDepositDisabled;
 
     useShowYieldTransactionFailureAlert({
         error: session?.error,
@@ -382,6 +398,19 @@ export const YieldDepositScreen = () => {
         >
             <Box pointerEvents={isDepositPending ? 'none' : 'auto'}>
                 <VStack spacing="sp16">
+                    <ContextMessage
+                        context={Context.getEarnYield('deposit')}
+                        marginHorizontal="sp16"
+                    />
+                    {isDepositDisabled && (
+                        <Box paddingHorizontal="sp16">
+                            <YieldDisabledAlert
+                                type="deposit"
+                                content={depositDisabledContent}
+                                variant={depositDisabledVariant}
+                            />
+                        </Box>
+                    )}
                     <YieldDepositStepCard currentStepIndex={1} />
 
                     <Box paddingHorizontal="sp16">

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -6,11 +6,13 @@ import { type RouteProp, useIsFocused, useNavigation, useRoute } from '@react-na
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
+import { Context } from '@suite-common/message-system';
 import { getNetwork } from '@suite-common/wallet-config';
 import {
     type YieldWithdrawFlowType,
     getConvertedOutputTokenBalanceToInputTokenAmount,
     getWithdrawRequestAmount,
+    getYieldVaultContractAddress,
     getYieldWithdrawInputToken,
     splitYieldPendingTransaction,
     stablecoinYieldActions,
@@ -35,6 +37,7 @@ import {
 import { useCryptoFiatConverters } from '@suite-native/formatters';
 import { decimalTransformer } from '@suite-native/helpers';
 import { Translation, useTranslate } from '@suite-native/intl';
+import { ContextMessage } from '@suite-native/message-system';
 import {
     Screen,
     type StackNavigationProps,
@@ -47,9 +50,11 @@ import { BigNumber } from '@trezor/utils';
 
 import { YieldDepositFlowScreenHeader } from '../components/YieldDepositFlowScreenHeader';
 import { YieldDepositInfoBottomSheet } from '../components/YieldDepositInfoBottomSheet';
+import { YieldDisabledAlert } from '../components/YieldDisabledAlert';
 import { YieldFeeEstimationErrorAlert } from '../components/YieldFeeEstimationErrorAlert';
 import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
 import { YieldWithdrawWarning } from '../components/YieldWithdrawWarning';
+import { useMessageSystemYield } from '../hooks/useMessageSystemYield';
 import { useNavigateBackAnalytics } from '../hooks/useNavigateBackAnalytics';
 import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
 import { useShowYieldTransactionFailureAlert } from '../hooks/useShowYieldTransactionFailureAlert';
@@ -124,6 +129,13 @@ export const YieldWithdrawScreen = () => {
         vaultTokenSymbol: resolvedVaultTokenSymbol,
         vaultTokenName,
     } = useResolvedYieldFlowData(route.params);
+
+    const vaultContractAddress = vault ? getYieldVaultContractAddress(vault) : undefined;
+    const {
+        isDisabled: isWithdrawDisabled,
+        content: withdrawDisabledContent,
+        variant: withdrawDisabledVariant,
+    } = useMessageSystemYield('withdraw', { vaultContractAddress });
 
     useNavigateBackAnalytics({
         type: events.yieldNavigateEvent.name,
@@ -261,7 +273,8 @@ export const YieldWithdrawScreen = () => {
         !!amountValidationError ||
         !isWithdrawReviewReady ||
         isComposingWithdrawFee ||
-        isFeeUnavailable;
+        isFeeUnavailable ||
+        isWithdrawDisabled;
 
     useShowYieldTransactionFailureAlert({
         error: session?.error,
@@ -416,7 +429,7 @@ export const YieldWithdrawScreen = () => {
     );
 
     const handleContinue = useCallback(() => {
-        if (!flowKey || !isWithdrawReviewReady || !preparedAction) {
+        if (!flowKey || !isWithdrawReviewReady || !preparedAction || isWithdrawDisabled) {
             return;
         }
 
@@ -454,6 +467,7 @@ export const YieldWithdrawScreen = () => {
         dispatch,
         flowType,
         flowKey,
+        isWithdrawDisabled,
         isWithdrawReviewReady,
         navigation,
         preparedAction,
@@ -531,6 +545,14 @@ export const YieldWithdrawScreen = () => {
                 paddingHorizontal="sp16"
                 pointerEvents={isWithdrawPending ? 'none' : 'auto'}
             >
+                <ContextMessage context={Context.getEarnYield('withdraw')} />
+                {isWithdrawDisabled && (
+                    <YieldDisabledAlert
+                        type="withdraw"
+                        content={withdrawDisabledContent}
+                        variant={withdrawDisabledVariant}
+                    />
+                )}
                 <Card style={applyStyle(withdrawFormCardStyle)}>
                     <VStack spacing="sp12">
                         <HStack justifyContent="space-between" alignItems="center">

--- a/suite-native/module-earn/src/types.ts
+++ b/suite-native/module-earn/src/types.ts
@@ -1,4 +1,5 @@
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import { type EarnDashboardType } from '@suite-common/message-system';
 import { type NetworkSymbol, type StakingNetworkSymbol } from '@suite-common/wallet-config';
 import {
     type Account,
@@ -109,13 +110,20 @@ export type EarnStakingProvidersInfoListItem = {
     id: string;
 };
 
+export type EarnDashboardDisabledListItem = {
+    type: 'dashboard-disabled';
+    id: string;
+    dashboardType: EarnDashboardType;
+};
+
 export type EarnPromoListDataItem =
     | EarnPromoItem
     | EarnPromoSectionType
     | SkeletonLoaderItem
     | StablecoinYieldLoadErrorListItem
     | EarnProviderListItem
-    | EarnStakingProvidersInfoListItem;
+    | EarnStakingProvidersInfoListItem
+    | EarnDashboardDisabledListItem;
 
 export type EarnDepositsCardActiveItem =
     | {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Mobile app now respects message system controls for stablecoin yield, mirroring desktop semantics. Until now, disabling e.g. `earn.yield.deposit` via message system config stopped the flow on desktop but mobile kept signing deposits.

## Notes for QA

```
{
    "conditions": [{}],
    "message": {
        "id": "test-earn-yield-deposit-killswitch",
        "priority": 100,
        "dismissible": false,
        "variant": "warning",
        "category": "feature",
        "content": {
            "en": "Deposits are temporarily paused. Your funds are safe.",
            "cs": "Vklady jsou dočasně pozastaveny. Vaše prostředky jsou v bezpečí.",
            "es": "Deposits are temporarily paused. Your funds are safe.",
            "de": "Deposits are temporarily paused. Your funds are safe.",
            "fr": "Deposits are temporarily paused. Your funds are safe.",
            "pt": "Deposits are temporarily paused. Your funds are safe."
        },
        "feature": [{ "domain": "earn.yield.deposit", "flag": false }]
    }
}
```

```
{
    "conditions": [{}],
    "message": {
        "id": "test-earn-yield-withdraw-killswitch",
        "priority": 100,
        "dismissible": false,
        "variant": "warning",
        "category": "feature",
        "content": {
            "en": "Deposits are temporarily paused. Your funds are safe.",
            "cs": "Vklady jsou dočasně pozastaveny. Vaše prostředky jsou v bezpečí.",
            "es": "Deposits are temporarily paused. Your funds are safe.",
            "de": "Deposits are temporarily paused. Your funds are safe.",
            "fr": "Deposits are temporarily paused. Your funds are safe.",
            "pt": "Deposits are temporarily paused. Your funds are safe."
        },
        "feature": [{ "domain": "earn.yield.withdraw", "flag": false }]
    }
}
```

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29969

## Screenshots:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-20 at 11 26 16" src="https://github.com/user-attachments/assets/7f24deaa-1917-4aa8-9cd3-47e2423494e2" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set is entirely focused on suite-native (React Native mobile app) message-system integration for the Earn/Yield/Staking dashboard features (useMessageSystemEarnDashboard, useMessageSystemYield hooks, related screens and components in suite-native/module-earn, suite-native/module-accounts-management, and suite-native/intl). The suite/e2e/tests directory covers only the web/desktop Trezor Suite application (Playwright tests against suite-web/suite-desktop), which does not share UI code, screens, or test infrastructure with suite-native. Although packages/suite/src/hooks/suite/useMessageSystemEarnDashboard.ts, useMessageSystemYield.ts, and suite-common/message-system/src/messageSystemTypes.ts statically map to 132 web e2e tests, this is because they are transitively imported through a shared common package — none of the LLM-analyzed e2e test behaviors, entry points, or assertions reference message-system-driven earn/yield dashboard banners, alerts, or disabled states in the web Suite UI, so no direct evidence supports including any of them. The suite-common/message-system unit tests (__tests__/useMessageSystemEarnDashboard.test.ts, __tests__/useMessageSystemYield.test.ts) are the appropriate and already-existing coverage for this logic, but these are Jest unit tests, not Playwright E2E tests, so they fall outside the recommendation set. Given the mismatch between the changed platform (suite-native) and the available e2e test suite (suite-web/desktop), no E2E test from the provided catalog can be recommended with concrete confidence; QA should instead rely on suite-native's own test suite (if any) and the existing message-system unit tests for this PR.

<details><summary><b>Changed files (23)</b></summary>

- `packages/suite/src/hooks/suite/useMessageSystemEarnDashboard.ts`
- `packages/suite/src/hooks/suite/useMessageSystemYield.ts`
- `suite-common/message-system/src/__tests__/useMessageSystemEarnDashboard.test.ts`
- `suite-common/message-system/src/__tests__/useMessageSystemYield.test.ts`
- `suite-common/message-system/src/index.ts`
- `suite-common/message-system/src/messageSystemTypes.ts`
- `suite-common/message-system/src/useMessageSystemEarnDashboard.ts`
- `suite-common/message-system/src/useMessageSystemYield.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx`
- `suite-native/module-earn/src/components/EarnDashboardDisabledRow.tsx`
- `suite-native/module-earn/src/components/StablecoinYieldClaimRewardsCardSection.tsx`
- `suite-native/module-earn/src/components/YieldDisabledAlert.tsx`
- `suite-native/module-earn/src/hooks/useMessageSystemEarnDashboard.ts`
- `suite-native/module-earn/src/hooks/useMessageSystemYield.ts`
- `suite-native/module-earn/src/index.ts`
- `suite-native/module-earn/src/screens/EarnScreen.tsx`
- `suite-native/module-earn/src/screens/HowYieldWorksScreen.tsx`
- `suite-native/module-earn/src/screens/YieldClaimScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx`
- `suite-native/module-earn/src/types.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (23)**
- `packages/suite/src/hooks/suite/useMessageSystemEarnDashboard.ts`
- `packages/suite/src/hooks/suite/useMessageSystemYield.ts`
- `suite-common/message-system/src/__tests__/useMessageSystemEarnDashboard.test.ts`
- `suite-common/message-system/src/__tests__/useMessageSystemYield.test.ts`
- `suite-common/message-system/src/index.ts`
- `suite-common/message-system/src/messageSystemTypes.ts`
- `suite-common/message-system/src/useMessageSystemEarnDashboard.ts`
- `suite-common/message-system/src/useMessageSystemYield.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx`
- `suite-native/module-earn/src/components/EarnDashboardDisabledRow.tsx`
- `suite-native/module-earn/src/components/StablecoinYieldClaimRewardsCardSection.tsx`
- `suite-native/module-earn/src/components/YieldDisabledAlert.tsx`
- `suite-native/module-earn/src/hooks/useMessageSystemEarnDashboard.ts`
- `suite-native/module-earn/src/hooks/useMessageSystemYield.ts`
- `suite-native/module-earn/src/index.ts`
- `suite-native/module-earn/src/screens/EarnScreen.tsx`
- `suite-native/module-earn/src/screens/HowYieldWorksScreen.tsx`
- `suite-native/module-earn/src/screens/YieldClaimScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx`
- `suite-native/module-earn/src/types.ts`

_Updated: 2026-07-20T15:45:20.744Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native/yield-message-system/web/](https://dev.suite.sldev.cz/suite-web/feat/native/yield-message-system/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/yield-message-system&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/yield-message-system&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/yield-message-system&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-20T15:49:12.759Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-20T15:48:54.471Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->