### PR TITLE
feat(suite-common): wrapped native token config and transaction helpers

### DIFF
--- a/suite-common/address/src/__tests__/evmChecksumUtils.test.ts
+++ b/suite-common/address/src/__tests__/evmChecksumUtils.test.ts
@@ -1,4 +1,4 @@
-import { checkAddressChecksum, toChecksumAddress } from '../evmChecksumUtils';
+import { areEvmAddressesEqual, checkAddressChecksum, toChecksumAddress } from '../evmChecksumUtils';
 
 // Test cases from https://eips.ethereum.org/EIPS/eip-55
 // [checksummed, lowercase, uppercase]
@@ -46,5 +46,25 @@ describe('evmChecksumUtils', () => {
 
     it.each(invalid)(`toChecksumAddress: '%s'`, addr => {
         expect(() => toChecksumAddress(addr)).toThrow();
+    });
+});
+
+describe('areEvmAddressesEqual', () => {
+    it.each(valid)(
+        `matches the same address regardless of case: '%s'`,
+        (checksum, lower, upper) => {
+            expect(areEvmAddressesEqual(checksum, lower)).toBe(true);
+            expect(areEvmAddressesEqual(lower, upper)).toBe(true);
+        },
+    );
+
+    it('does not match different addresses', () => {
+        expect(areEvmAddressesEqual(valid[0][0], valid[1][0])).toBe(false);
+    });
+
+    it('returns false for missing or invalid input', () => {
+        expect(areEvmAddressesEqual(undefined, valid[0][0])).toBe(false);
+        expect(areEvmAddressesEqual(valid[0][0], null)).toBe(false);
+        expect(areEvmAddressesEqual('0xabcd', '0xabcd')).toBe(false);
     });
 });

--- a/suite-common/address/src/evmChecksumUtils.ts
+++ b/suite-common/address/src/evmChecksumUtils.ts
@@ -1,4 +1,4 @@
-import { checksumAddress, getAddress, isAddress } from 'viem';
+import { checksumAddress, getAddress, isAddress, isAddressEqual } from 'viem';
 
 export const toChecksumAddress = (address: string) => getAddress(address);
 
@@ -6,3 +6,12 @@ export const toChecksumAddress = (address: string) => getAddress(address);
 // even strict mode doesn't check lowercase addresses (https://viem.sh/docs/utilities/isAddress)
 export const checkAddressChecksum = (address: string) =>
     isAddress(address, { strict: false }) && address === checksumAddress(address);
+
+// Checksum-agnostic EVM address equality. Missing or invalid input yields `false`, so callers
+// can compare untrusted addresses without pre-validating them.
+export const areEvmAddressesEqual = (a?: string | null, b?: string | null): boolean =>
+    !!a &&
+    !!b &&
+    isAddress(a, { strict: false }) &&
+    isAddress(b, { strict: false }) &&
+    isAddressEqual(a, b);

--- a/suite-common/wallet-config/package.json
+++ b/suite-common/wallet-config/package.json
@@ -11,6 +11,9 @@
         "type-check": "yarn g:tsc --build",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
+    "devDependencies": {
+        "viem": "^2.54.1"
+    },
     "dependencies": {
         "@suite-common/earn-stablecoin-defs": "workspace:*",
         "@suite-common/wallet-constants": "workspace:*",

--- a/suite-common/wallet-config/src/__tests__/wrappedNativeToken.test.ts
+++ b/suite-common/wallet-config/src/__tests__/wrappedNativeToken.test.ts
@@ -1,0 +1,48 @@
+import { checksumAddress, isAddress } from 'viem';
+
+import { typedObjectKeys } from '@trezor/utils';
+
+import { getNetworkType } from '../utils';
+import {
+    WRAPPED_NATIVE,
+    getWrappedNativeAddress,
+    getWrappedNativeSymbol,
+} from '../wrappedNativeToken';
+
+describe(getWrappedNativeAddress.name, () => {
+    it('returns the wrapped native address for a supported network', () => {
+        expect(getWrappedNativeAddress('eth')).toBe('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2');
+    });
+
+    it('returns the wrapped native address for a testnet', () => {
+        expect(getWrappedNativeAddress('tsep')).toBe('0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9');
+    });
+
+    it('returns undefined for a network without a wrapped native token', () => {
+        expect(getWrappedNativeAddress('btc')).toBeUndefined();
+    });
+});
+
+describe(getWrappedNativeSymbol.name, () => {
+    it('returns the wrapped native symbol for a supported network', () => {
+        expect(getWrappedNativeSymbol('bsc')).toBe('WBNB');
+        expect(getWrappedNativeSymbol('pol')).toBe('WPOL');
+    });
+
+    it('returns undefined for a network without a wrapped native token', () => {
+        expect(getWrappedNativeSymbol('btc')).toBeUndefined();
+    });
+});
+
+describe('WRAPPED_NATIVE', () => {
+    it('only maps EVM (ethereum) networks', () => {
+        typedObjectKeys(WRAPPED_NATIVE).forEach(networkSymbol => {
+            expect(getNetworkType(networkSymbol)).toBe('ethereum');
+        });
+    });
+
+    it.each(Object.entries(WRAPPED_NATIVE))('has a valid checksummed address: %s', (_, token) => {
+        expect(isAddress(token.address, { strict: false })).toBe(true);
+        expect(token.address).toBe(checksumAddress(token.address));
+    });
+});

--- a/suite-common/wallet-config/src/index.ts
+++ b/suite-common/wallet-config/src/index.ts
@@ -6,3 +6,4 @@ export * from './stakingProviders';
 export * from './types';
 export * from './utils';
 export * from './getExplorerUrls';
+export * from './wrappedNativeToken';

--- a/suite-common/wallet-config/src/wrappedNativeToken.ts
+++ b/suite-common/wallet-config/src/wrappedNativeToken.ts
@@ -1,0 +1,29 @@
+import { type NetworkSymbol } from './types';
+
+type WrappedNativeToken = {
+    address: `0x${string}`;
+    symbol: string;
+    decimals: number;
+};
+
+export const WRAPPED_NATIVE: Partial<Record<NetworkSymbol, WrappedNativeToken>> = {
+    eth: { address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', symbol: 'WETH', decimals: 18 },
+    op: { address: '0x4200000000000000000000000000000000000006', symbol: 'WETH', decimals: 18 },
+    bsc: { address: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c', symbol: 'WBNB', decimals: 18 },
+    etc: { address: '0x1953cab0E5bFa6D4a9BaD6E05fD46C1CC6527a5a', symbol: 'WETC', decimals: 18 },
+    // Polygon migration from WMATIC to WPOL is done only on the interface level. Contract symbol() still returns WMATIC.
+    pol: { address: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270', symbol: 'WPOL', decimals: 18 },
+    base: { address: '0x4200000000000000000000000000000000000006', symbol: 'WETH', decimals: 18 },
+    arb: { address: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1', symbol: 'WETH', decimals: 18 },
+    avax: { address: '0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7', symbol: 'WAVAX', decimals: 18 },
+
+    // --- testnets ---
+    tsep: { address: '0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9', symbol: 'WETH', decimals: 18 },
+    thod: { address: '0xE0decAa66aED871ac9eb924443D1Bf333Fdb062E', symbol: 'WETH', decimals: 18 },
+};
+
+export const getWrappedNativeAddress = (networkSymbol: NetworkSymbol) =>
+    WRAPPED_NATIVE[networkSymbol]?.address;
+
+export const getWrappedNativeSymbol = (networkSymbol: NetworkSymbol) =>
+    WRAPPED_NATIVE[networkSymbol]?.symbol;

--- a/suite-common/wallet-constants/src/earnConstants.ts
+++ b/suite-common/wallet-constants/src/earnConstants.ts
@@ -1,0 +1,9 @@
+import { MIN_ETH_BALANCE_FOR_FEE_BUFFER } from './ethereumStakingConstants';
+
+// Native balance kept aside when wrapping so the follow-up approve + deposit transactions
+// still have enough to cover their fees — the same buffer staking keeps for its exit fee.
+export const WETH_WRAP_GAS_RESERVE = MIN_ETH_BALANCE_FOR_FEE_BUFFER;
+
+// WETH deposit() consumes ~45k gas; the generic ~250k contract-call backup would over-reserve
+// the fee and could make a max-amount wrap fail.
+export const WETH_DEPOSIT_BACKUP_GAS_LIMIT = '60000';

--- a/suite-common/wallet-constants/src/index.ts
+++ b/suite-common/wallet-constants/src/index.ts
@@ -1,5 +1,6 @@
 export * from './formDraft';
 export * from './sendForm';
+export * from './earnConstants';
 export * from './ethereumStakingConstants';
 export * from './tronStakingConstants';
 export * from './cardanoConstants';

--- a/suite-common/wallet-utils/src/__tests__/tokenUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/tokenUtils.test.ts
@@ -5,6 +5,7 @@ import {
     getAssetLogoContractAddresses,
     getContractAddressForNetworkSymbol,
     getErc4626Contracts,
+    isWrappedNativeToken,
     sortTokensByName,
 } from '../tokenUtils';
 
@@ -17,6 +18,30 @@ describe('getContractAddressForNetworkSymbol', () => {
             });
         },
     );
+});
+
+describe('isWrappedNativeToken', () => {
+    const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+
+    it('matches the wrapped native token regardless of case', () => {
+        expect(isWrappedNativeToken('eth', WETH)).toBe(true);
+        expect(isWrappedNativeToken('eth', WETH.toLowerCase())).toBe(true);
+    });
+
+    it('does not match a different token', () => {
+        expect(isWrappedNativeToken('eth', '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')).toBe(
+            false,
+        );
+    });
+
+    it('does not match on a network without a wrapped native token', () => {
+        expect(isWrappedNativeToken('btc', WETH)).toBe(false);
+    });
+
+    it('returns false for a missing address', () => {
+        expect(isWrappedNativeToken('eth', null)).toBe(false);
+        expect(isWrappedNativeToken('eth', undefined)).toBe(false);
+    });
 });
 
 describe('getAssetLogoContractAddresses', () => {

--- a/suite-common/wallet-utils/src/tokenUtils.ts
+++ b/suite-common/wallet-utils/src/tokenUtils.ts
@@ -1,3 +1,4 @@
+import { areEvmAddressesEqual } from '@suite-common/address';
 import {
     type Explorer,
     type NetworkSymbol,
@@ -5,6 +6,7 @@ import {
     type NetworkType,
     getExplorerUrl,
     getNetworkType,
+    getWrappedNativeAddress,
 } from '@suite-common/wallet-config';
 import {
     type EthereumSpecific,
@@ -33,6 +35,11 @@ export const getContractAddressForNetworkSymbol = (
             return contractAddress;
     }
 };
+
+export const isWrappedNativeToken = (
+    networkSymbol: NetworkSymbol,
+    contractAddress?: string | null,
+): boolean => areEvmAddressesEqual(getWrappedNativeAddress(networkSymbol), contractAddress);
 
 export const getAssetLogoContractAddresses = async (
     symbol: NetworkSymbolExtended | undefined,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11196,6 +11196,7 @@ __metadata:
     "@trezor/network-tron": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
+    viem: "npm:^2.54.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

## Scope
- [x] Map native → wrapped, chain-keyed (ETH → WETH `0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2`, 18 decimals pinned)
- [x] `getWrappedNativeAddress` / `getWrappedNativeSymbol` / `isWrappedNativeToken`
- [ ] `isWrapNativeTx` / `isUnwrapNativeTx` — match selector **and** target (avoid `deposit()` false positives)
- [x] Reinstate `WETH_WRAP_GAS_RESERVE`, `WETH_DEPOSIT_BACKUP_GAS_LIMIT` + an exit-gas buffer
- [x] Testnet WETH (Sepolia / Holesky) so QA can exercise the flows

## Notes for QA


<details><summary>WETH9 Addresses</summary>
<p>

```
    eth: { address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', symbol: 'WETH', decimals: 18 },
    op: { address: '0x4200000000000000000000000000000000000006', symbol: 'WETH', decimals: 18 },
    bsc: { address: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c', symbol: 'WBNB', decimals: 18 },
    etc: { address: '0x1953cab0E5bFa6D4a9BaD6E05fD46C1CC6527a5a', symbol: 'WETC', decimals: 18 },
    // Polygon migration from WMATIC to WPOL is done only on the interface level. Contract symbol() still returns WMATIC.
    pol: { address: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270', symbol: 'WPOL', decimals: 18 },
    base: { address: '0x4200000000000000000000000000000000000006', symbol: 'WETH', decimals: 18 },
    arb: { address: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1', symbol: 'WETH', decimals: 18 },
    avax: { address: '0xB31f66AA3C1e785363F0875A1B74E27b85fD66c7', symbol: 'WAVAX', decimals: 18 },

    // --- testnets ---
    tsep: { address: '0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9', symbol: 'WETH', decimals: 18 },
    thod: { address: '0xE0decAa66aED871ac9eb924443D1Bf333Fdb062E', symbol: 'WETH', decimals: 18 },
```

</p>
</details> 

1) Native to chain explorer and open desired contract
2) Use wallet connect to write to contract
3) Use `deposit` function to trigger transaction

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29858

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies low-level EVM address checksum utilities, wallet-config exports (including a new wrappedNativeToken module), earn/staking constants, and token utilities used broadly across the wallet. Because these files are imported transitively by nearly all e2e tests, the recommendation focuses narrowly on tests that exercise Ethereum/EVM address display, ERC-20/SPL token handling, and staking flows referencing earnConstants or wrapped native tokens, where a regression would be directly observable. Unit tests for the changed files exist locally (evmChecksumUtils.test.ts, wrappedNativeToken.test.ts, tokenUtils.test.ts) but have no e2e coverage; broader smoke testing of ETH/token send, swap, and staking flows is recommended as the primary mitigation.

<details><summary><b>Changed files (9)</b></summary>

- `suite-common/address/src/__tests__/evmChecksumUtils.test.ts`
- `suite-common/address/src/evmChecksumUtils.ts`
- `suite-common/wallet-config/src/__tests__/wrappedNativeToken.test.ts`
- `suite-common/wallet-config/src/index.ts`
- `suite-common/wallet-config/src/wrappedNativeToken.ts`
- `suite-common/wallet-constants/src/earnConstants.ts`
- `suite-common/wallet-constants/src/index.ts`
- `suite-common/wallet-utils/src/__tests__/tokenUtils.test.ts`
- `suite-common/wallet-utils/src/tokenUtils.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — This test exercises Ethereum address formatting/checksumming and token/wallet-config logic during a send flow (EVM tetragrams address display, gas fee calc), directly touching evmChecksumUtils and tokenUtils code paths.
- `suite/e2e/tests/wallet/send-base.test.ts` — Base network sending relies on EVM address checksum formatting (evmTetragrams) and Ethereum-family fee/token utilities, directly covering the changed evmChecksumUtils and tokenUtils modules.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test explicitly verifies Ethereum address correctness both in Suite UI and on-device display, including EVM address indent/formatting logic that evmChecksumUtils implements.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This DEX swap test verifies ETH-to-USDC token swap details including gas limit, contract addresses, and token amounts, directly exercising tokenUtils and evmChecksumUtils for ERC-20 token handling and address verification.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Selling an ERC-20 token (USDC) requires correct token identification/formatting (tokenUtils) and destination address checksum verification (evmChecksumUtils), both changed in this PR.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking flow interacts with the Everstake contract address and wrapped/native token constants; changes to wrappedNativeToken and earnConstants could affect staking contract resolution or fee/token display.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Additional ETH staking exercises the same Everstake contract interaction and staking constants (earnConstants) that were modified, risking regression in fee/amount calculations.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Unstaking ETH also depends on earnConstants (staking pool config) and wrapped/native token identification, both changed in this PR.
- `suite/e2e/tests/staking/staking-form.test.ts` — The staking form test validates ETH amount calculations and withdrawal buffers, likely relying on earnConstants values that were modified in this PR.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Cross-chain coin-to-token swaps (SOL to USDC) rely on tokenUtils for token identification and evmChecksumUtils for the Ethereum-side receive address formatting.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-tokens.test.ts` — Solana SPL token-to-token swap exercises tokenUtils for token amount/symbol handling, though it does not touch EVM checksum logic directly.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Adding ETH/Base non-BTC accounts touches wallet-config network definitions which were modified (index.ts export changes), risking subtle regressions in account type/path resolution.

</details>

⚠️ **Changes with no test coverage (4)**
- `suite-common/address/src/__tests__/evmChecksumUtils.test.ts`
- `suite-common/wallet-config/src/__tests__/wrappedNativeToken.test.ts`
- `suite-common/wallet-constants/src/index.ts`
- `suite-common/wallet-utils/src/__tests__/tokenUtils.test.ts`

_Updated: 2026-07-20T10:24:12.317Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/wrapped-native-config/web/](https://dev.suite.sldev.cz/suite-web/feat/wrapped-native-config/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/wrapped-native-config&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/wrapped-native-config&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/wrapped-native-config&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-22T13:32:18.206Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect.ethereumSignMessage > TrezorConnect.ethereumSignMessage | 🤖 auto |
| TrezorConnect.signTransaction > TrezorConnect.signTransaction | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| TrezorConnect > Error screen | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-22T13:32:27.718Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->