### PR TITLE
fix(workflows): adjust aws session duration for icon workflow

### DIFF
--- a/.github/workflows/release-suite-coin-icons.yml
+++ b/.github/workflows/release-suite-coin-icons.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::538326561891:role/gh_actions_suite_production_icons
           aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: 14400 # 4 hours
 
       - name: Upload crypto icons
         run: |


### PR DESCRIPTION
## Summary

- Extend the AWS OIDC role session for the coin icon release workflow from the default one hour to four hours.
- Prevent the S3 synchronization from failing with `ExpiredToken` before all icons are uploaded and CloudFront invalidation runs.

The failed workflow generated 17,660 coin icons and then started uploading them to S3. The temporary AWS credentials expired exactly one hour into the upload, leaving S3 partially updated and preventing the subsequent CloudFront invalidation.


## Testing

- Confirmed from the failed job logs that the credentials expired after the default 3,600-second session.
- Verified that `aws-actions/configure-aws-credentials` supports `role-duration-seconds: 14400`.
- No automated tests were added because this only changes GitHub Actions configuration.
- After merging, verify that a scheduled or manually dispatched run completes the S3 sync and CloudFront invalidation.


## Risk and rollout notes

The `gh_actions_suite_production_icons` IAM role must allow a maximum session duration of at least four hours. If its configured maximum is lower, the credential configuration step will fail.

The workflow continues to use temporary OIDC credentials with the existing IAM role and permissions.

## Related context

- Closes #30090
- Failed job: https://github.com/trezor/trezor-suite/actions/runs/29709671667/job/88251791688