### PR TITLE
chore(eslint): forbid desktop api deep imports

### DIFF
--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -38,6 +38,14 @@ const connectDeepImportPatterns = [
     },
 ];
 
+const suiteDesktopApiDeepImportPattern = {
+    group: ['@trezor/suite-desktop-api/src/**'],
+    message:
+        'Import from "@trezor/suite-desktop-api" instead. Deep paths into "@trezor/suite-desktop-api/src/**" bypass the public API.',
+};
+
+const packageDeepImportPatterns = [...connectDeepImportPatterns, suiteDesktopApiDeepImportPattern];
+
 // Deny importing internal suite packages from outside the suite app itself.
 const suiteInternalPatterns = {
     group: ['@suite-common/**', '@suite-native/**'],
@@ -49,7 +57,7 @@ export const restrictedImportsPatterns = [
     buildArtifactPatterns,
     suiteInternalPatterns,
     networksPackagePattern,
-    ...connectDeepImportPatterns,
+    ...packageDeepImportPatterns,
 ];
 
 /** @type {import('typescript-eslint').ConfigArray} */
@@ -73,7 +81,7 @@ export const typescriptConfig = [
                     patterns: [
                         buildArtifactPatterns,
                         networksPackagePattern,
-                        ...connectDeepImportPatterns,
+                        ...packageDeepImportPatterns,
                     ],
                 },
             ],

--- a/packages/suite-desktop-api/src/index.ts
+++ b/packages/suite-desktop-api/src/index.ts
@@ -1,0 +1,2 @@
+export * from './main';
+export { desktopApi } from './renderer';


### PR DESCRIPTION
## Description

Deep imports into `@trezor/suite-desktop-api/src/**` bypass the package public declaration entry and can silently reintroduce the dependency removed by the prerequisite PR. The existing generic workspace deep-import rule does not cover `packages/**`, so this adds an explicit `no-restricted-imports` pattern to both relevant TypeScript ESLint configurations. Consumers must use `@trezor/suite-desktop-api` or carry a justified inline ESLint suppression.

This PR is stacked on https://github.com/trezor/trezor-suite/pull/30067. The web and desktop UI shells intentionally compose `packages/suite` through bare `src/*` aliases; those aliases are not package deep imports and remain allowed.

- Desktop API source imports in consumer code: **4 -> 0**
- Intentional shell `src/*` references affected: **0 of 112**
- Enforcement: **Suite code and `packages/**` consumers**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to packages/suite-desktop-api/src/index.ts, which has no static test coverage mapping, but based on its role as the API surface bridging the Electron desktop app and TrezorConnect/Suite UI, it most plausibly affects the suite of trezor-connect E2E tests that explicitly use coreMode 'suite-desktop' and the Electron WebSocket bridge (exposeConnectWs). These tests directly exercise the desktop API contract and are the most likely to catch regressions. Secondary, lower-confidence candidates are the bridge daemon/spawn tests which touch adjacent desktop/Electron infrastructure. Recommend running the medium-priority trezor-connect suite as the primary verification, with the bridge spawn tests as an optional secondary check.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite-desktop-api/src/index.ts`

</details>

**Recommended tests (13)**

<details><summary>🟡 <b>Medium priority (11)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises the TrezorConnect popup API surface (getAddress, cardanoGetAddress, permissions, cancellation flows) which is the kind of public API surface that packages/suite-desktop-api typically exposes/types; changes to the desktop API index could affect how these calls are wired between the popup and the app.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Similar to the web popup test, this validates TrezorConnect flows from a webextension context; any change to the desktop API contract (index.ts) could impact how connect requests are handled or exposed across contexts.
- `suite/e2e/tests/trezor-connect/error.test.ts` — This test explicitly initializes TrezorConnect with coreMode 'suite-desktop' and relies on the desktop core mode integration, which is the most direct exercised path likely affected by changes to the suite-desktop-api package's exported index.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Uses TrezorConnect.init with coreMode 'suite-desktop' and exposeConnectWs, directly depending on the desktop API bridge that packages/suite-desktop-api/src/index.ts likely defines or exports.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Relies on the suite-desktop core mode Electron WebSocket bridge (exposeConnectWs) to sign transactions, which is the functional area a change to the desktop API index file would most likely touch.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Depends on TrezorConnect.init with coreMode 'suite-desktop', directly exercising the desktop API integration surface that could be impacted by the changed index.ts.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Uses suite-desktop core mode for address export flows (single and bundle), a direct consumer of the desktop API bridge potentially affected by this change.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests app permission management (remember/forget) through the suite-desktop core mode integration, exercising the desktop API surface that may be defined or modified in index.ts.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Signs a Bitcoin transaction via TrezorConnect using coreMode 'suite-desktop', directly exercising the Electron desktop API bridge that is the subject of the change.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests silent mode behavior which relies on IPC (app/focus) events between the Electron main process and the Suite desktop app — functionality that is plausibly part of the suite-desktop-api's exposed interface.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — Uses TrezorConnect.selectAccount with coreMode 'suite-desktop', directly depending on the desktop API bridge configuration that could be affected by changes to index.ts.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — Involves Electron main process behavior and desktop app lifecycle (bridge daemon spawning), which could share underlying desktop API/IPC infrastructure exposed by the changed index.ts, though the connection is less direct than trezor-connect flows.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Exercises Electron app bridge lifecycle management, which may rely on similar desktop API/IPC exports as those changed, though the direct connection to trezor-connect functionality is weaker.

</details>

_Updated: 2026-07-21T09:57:19.585Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/eslint-desktop-api-deep-imports/web/](https://dev.suite.sldev.cz/suite-web/fix/eslint-desktop-api-deep-imports/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/eslint-desktop-api-deep-imports&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/eslint-desktop-api-deep-imports&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-21T09:56:54.021Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-21T10:00:08.282Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->