### PR TITLE
feat(eslint): enable four low-noise type-checked safety rules

### DIFF
--- a/packages/blockchain-link-types/src/constants/errors.ts
+++ b/packages/blockchain-link-types/src/constants/errors.ts
@@ -27,7 +27,7 @@ export class CustomError extends Error {
         this.message = message;
 
         if (typeof codeOrMessage === 'string') {
-            const isPrefixed = codeOrMessage.indexOf(PREFIX) === 0;
+            const isPrefixed = codeOrMessage.startsWith(PREFIX);
             const code = isPrefixed ? codeOrMessage.substring(PREFIX.length) : codeOrMessage;
             const knownCode = Object.keys(ERROR).includes(code);
             if (isPrefixed || knownCode) {
@@ -36,7 +36,7 @@ export class CustomError extends Error {
                 if (codeMessage) {
                     if (this.message === '') {
                         this.message = codeMessage;
-                    } else if (message.indexOf('+') === 0) {
+                    } else if (message.startsWith('+')) {
                         this.message = `${codeMessage} ${message.substring(1)}`;
                     }
                 }

--- a/packages/connect-web/src/bootstrap/bootstrap.ts
+++ b/packages/connect-web/src/bootstrap/bootstrap.ts
@@ -1,3 +1,7 @@
+/* eslint-disable @typescript-eslint/only-throw-error --
+   This module intentionally throws the predefined string error codes from bootstrap-errors.ts.
+   They are matched by value and forwarded to Suite as the `connect-popup-err` URL param (see
+   redirectToSuite below and popup/web.ts), so the thrown value must be the bare code, not an Error. */
 import { BootstrapError } from './bootstrap-errors';
 
 const logger = (() => {

--- a/packages/connect/src/api/ethereum/ethereumSignTx.ts
+++ b/packages/connect/src/api/ethereum/ethereumSignTx.ts
@@ -141,7 +141,7 @@ export const serializeEthereumTx = (
     );
 
 const stripLeadingZeroes = (str: string) => {
-    while (/^00/.test(str)) {
+    while (str.startsWith('00')) {
         str = str.slice(2);
     }
 

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -140,6 +140,10 @@ export const typescriptConfig = [
             // Known limitation: the rule mis-reports some load-bearing widening assertions
             // (removing them breaks tsc); such spots carry a scoped disable with a justification.
             '@typescript-eslint/no-unnecessary-type-assertion': ['error'],
+
+            // Low-noise type-checked safety/hygiene rules (recommended/strict tiers), enabled
+            // here because the src override is the only block with type info.
+            '@typescript-eslint/prefer-string-starts-ends-with': ['error'],
         },
     },
     {

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -144,6 +144,11 @@ export const typescriptConfig = [
             // Low-noise type-checked safety/hygiene rules (recommended/strict tiers), enabled
             // here because the src override is the only block with type info.
             '@typescript-eslint/prefer-string-starts-ends-with': ['error'],
+            // `error-handling-correctness-only`: require `return await` inside try/catch/finally
+            // so the local catch sees the rejection and finally runs at the right time. Unlike
+            // `in-try-catch` it does NOT strip harmless awaits elsewhere, avoiding churn and a
+            // clash with `require-await` (removing the sole await of an async fn).
+            '@typescript-eslint/return-await': ['error', 'error-handling-correctness-only'],
         },
     },
     {

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -80,6 +80,9 @@ export const typescriptConfig = [
 
             // Additions from "plugin:@typescript-eslint/strict" (we may turn this on one day as a whole)
             '@typescript-eslint/no-useless-constructor': ['error'],
+            // `a! ?? b` is always a contradiction: the `!` asserts non-null, the `??` handles
+            // exactly that null. No type info needed, no current violations.
+            '@typescript-eslint/no-non-null-asserted-nullish-coalescing': ['error'],
             '@typescript-eslint/no-unused-vars': [
                 'error',
                 {

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -149,14 +149,16 @@ export const typescriptConfig = [
             // `in-try-catch` it does NOT strip harmless awaits elsewhere, avoiding churn and a
             // clash with `require-await` (removing the sole await of an async fn).
             '@typescript-eslint/return-await': ['error', 'error-handling-correctness-only'],
+            '@typescript-eslint/only-throw-error': ['error'],
         },
     },
     {
-        // Type assertions on partial mocks and fixtures are idiomatic in tests,
-        // so scope the rule out of test and fixture files.
+        // Type assertions on partial mocks and fixtures are idiomatic in tests, and throwing
+        // bare strings/values to assert error paths is common, so scope these out of tests.
         files: ['**/__tests__/**', '**/__fixtures__/**', '**/tests/**', '**/*.test.{ts,tsx}'],
         rules: {
             '@typescript-eslint/no-unnecessary-type-assertion': 'off',
+            '@typescript-eslint/only-throw-error': 'off',
         },
     },
 ];

--- a/packages/trezor-user-env-link/src/websocket-client.ts
+++ b/packages/trezor-user-env-link/src/websocket-client.ts
@@ -135,6 +135,6 @@ export class WebsocketClient extends WebsocketClientBase<WebsocketClientEvents> 
             }
         }
 
-        throw error;
+        throw new Error(error);
     }
 }

--- a/packages/utxo-lib/src/bip32.ts
+++ b/packages/utxo-lib/src/bip32.ts
@@ -317,7 +317,7 @@ class BIP32 implements BIP32Interface {
 
         return splitPath.reduce((prevHd, indexStr) => {
             let index;
-            if (indexStr.slice(-1) === `'`) {
+            if (indexStr.endsWith(`'`)) {
                 index = parseInt(indexStr.slice(0, -1), 10);
 
                 return prevHd.deriveHardened(index);

--- a/suite-common/address/src/hasBitcoinCashAddressPrefix.ts
+++ b/suite-common/address/src/hasBitcoinCashAddressPrefix.ts
@@ -1,2 +1,2 @@
 export const hasBitcoinCashAddressPrefix = (address: string) =>
-    /^bitcoincash:/.test(address.toLowerCase());
+    address.toLowerCase().startsWith('bitcoincash:');

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -156,7 +156,7 @@ const preCallHook = async <M extends CallMethodKeys>({
                     __precomposed: true,
                 });
                 if (!methodInfo.success) {
-                    throw methodInfo.error;
+                    throw new Error(methodInfo.error.message);
                 }
                 txSigningPrecomposed = (methodInfo.payload as any as MethodInfo).precomposed;
                 if (txSigningPrecomposed)

--- a/suite-common/fiat-services/src/coingecko.ts
+++ b/suite-common/fiat-services/src/coingecko.ts
@@ -36,7 +36,7 @@ const fetchCoinGecko = async (url: string, skipCache?: boolean) => {
             return;
         }
 
-        return res.json();
+        return await res.json();
     } catch (error) {
         // Do not report to Sentry to save the issues count limit.
         console.warn(error);

--- a/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
+++ b/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
@@ -31,7 +31,7 @@ export const createEvoluInstanceFactory =
         if (!owner.ok) {
             console.error(owner.error);
 
-            throw owner.error;
+            throw new Error(`Failed to create Evolu owner: ${JSON.stringify(owner.error)}`);
         }
 
         const appName = AppName.from(`trezor-suite-v${VERSION}`);
@@ -39,7 +39,7 @@ export const createEvoluInstanceFactory =
         if (!appName.ok) {
             console.error(appName.error);
 
-            throw appName.error;
+            throw new Error(`Invalid Evolu app name: ${JSON.stringify(appName.error)}`);
         }
 
         return getOrThrow(

--- a/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
+++ b/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
@@ -273,7 +273,7 @@ export const createPaymentRequestsThunk = createThunk<
             }
 
             default:
-                throw exhaustive(type);
+                return exhaustive(type);
         }
     },
 );

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -19,14 +19,14 @@ export const hasEip1559MaxPriorityFee = (
 export const padLeftEven = (hex: string): string => (hex.length % 2 !== 0 ? `0${hex}` : hex);
 
 export const sanitizeHex = ($hex: string): string => {
-    const hex = $hex.toLowerCase().substring(0, 2) === '0x' ? $hex.substring(2) : $hex;
+    const hex = $hex.toLowerCase().startsWith('0x') ? $hex.substring(2) : $hex;
     if (hex === '') return '';
 
     return `0x${padLeftEven(hex)}`;
 };
 
 export const strip = (str: string): string => {
-    if (str.indexOf('0x') === 0) {
+    if (str.startsWith('0x')) {
         return padLeftEven(str.substring(2, str.length));
     }
 

--- a/suite-common/wallet-utils/src/validationUtils.ts
+++ b/suite-common/wallet-utils/src/validationUtils.ts
@@ -25,7 +25,7 @@ export const isInteger = (value: string) =>
 
 export const isHexValid = (value: string, prefix?: string) => {
     // ethereum data/signedTx may start with prefix
-    if (prefix && value.indexOf(prefix) === 0) {
+    if (prefix && value.startsWith(prefix)) {
         const hex = value.substring(prefix.length, value.length);
         // pad left even, is it necessary in ETH?
         // TODO: investigate

--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -161,7 +161,9 @@ const sessionRequestThunk = createThunk<
 
         const result = await dispatch(adapter.requestThunk({ event }));
         if (!result || result.error) {
-            throw result?.error || new Error('Device request failed');
+            throw result?.error instanceof Error
+                ? result.error
+                : new Error(String(result?.error ?? 'Device request failed'));
         }
 
         await walletKit.respondSessionRequest({

--- a/suite-native/storage/src/createAsyncMigrate.ts
+++ b/suite-native/storage/src/createAsyncMigrate.ts
@@ -55,7 +55,7 @@ export const createAsyncMigrate =
                 }
             }
 
-            return Promise.resolve(migratedState);
+            return await Promise.resolve(migratedState);
         } catch (err) {
             console.error(err);
 

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.tsx
@@ -54,7 +54,7 @@ const OutputLabel = ({
                     return <Translation id="transactionManagement.review.outputs.addressLabel" />;
 
                 default:
-                    throw exhaustive(flowType);
+                    return exhaustive(flowType);
             }
         case 'amount':
             return <Translation id="transactionManagement.review.outputs.amountLabel" />;
@@ -81,7 +81,7 @@ const OutputLabel = ({
                     return <Translation id="transactionManagement.review.outputs.contractLabel" />;
 
                 default:
-                    throw exhaustive(flowType);
+                    return exhaustive(flowType);
             }
         case 'data':
             return <Translation id="transactionManagement.review.outputs.transactionDataLabel" />;

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx
@@ -94,7 +94,7 @@ export const ReviewOutputItemContent = ({
                     return <AddressFormatter value={value} format="full" variant="body-sm" />;
 
                 default:
-                    throw exhaustive(flowType);
+                    return exhaustive(flowType);
             }
 
         case 'contract':
@@ -108,7 +108,7 @@ export const ReviewOutputItemContent = ({
                 case undefined:
                     return <AddressFormatter value={value} format="full" variant="body-sm" />;
                 default:
-                    throw exhaustive(flowType);
+                    return exhaustive(flowType);
             }
 
         case 'signing-with':

--- a/suite/metadata/src/metadataLabelingActions.ts
+++ b/suite/metadata/src/metadataLabelingActions.ts
@@ -72,7 +72,7 @@ const fetchMetadata =
         const response = await providerInstance.getFileContent(fileName);
 
         if (!response.success) {
-            throw response;
+            throw new Error(response.error);
         }
 
         if (!response.payload) {

--- a/suite/router/src/router.ts
+++ b/suite/router/src/router.ts
@@ -32,7 +32,7 @@ export type RouterPath = {
 export const getPrefixedURL = (url: string) => {
     // do not use object destructuring https://github.com/webpack/webpack/issues/5392
     const prefix = process.env.ASSET_PREFIX;
-    if (prefix && url.indexOf(prefix) !== 0) return prefix + url;
+    if (prefix && !url.startsWith(prefix)) return prefix + url;
 
     return url;
 };
@@ -40,7 +40,7 @@ export const getPrefixedURL = (url: string) => {
 export const stripPrefixedURL = (url: string) => {
     // do not use object destructuring https://github.com/webpack/webpack/issues/5392
     const prefix = process.env.ASSET_PREFIX;
-    if (typeof prefix === 'string' && url.indexOf(prefix) === 0) {
+    if (typeof prefix === 'string' && url.startsWith(prefix)) {
         url = url.slice(prefix.length);
     }
 


### PR DESCRIPTION
## What

Enables four low-noise `@typescript-eslint` rules and fixes the violations they surface. All four rely on type information that is already available for `**/src/**` files (the shared config already sets `parserOptions.projectService: true` there), so there is no infrastructure change.

| Rule | Tier | What it catches |
| --- | --- | --- |
| `only-throw-error` | recommended (type-checked) | Throwing non-`Error` values (strings, plain objects) that lose stack traces and break Sentry grouping |
| `return-await` (`error-handling-correctness-only`) | strict | A `return <promise>` inside `try/catch/finally` without `await`, which escapes the local `catch` |
| `prefer-string-starts-ends-with` | stylistic (type-checked) | Prefix/suffix checks written as `indexOf(x) === 0`, `slice(-1) === c` or `/^x/.test()` |
| `no-non-null-asserted-nullish-coalescing` | strict | `a! ?? b`, which is self-contradictory (the `!` asserts non-null, the `??` handles exactly that null) |

## Why these four (and not more)

While preparing this I also trialled `await-thenable` (76 hits) and `no-unsafe-enum-comparison` (135 hits) by running them against the whole repo. Both turned out to be high-noise for structural reasons rather than genuine bugs, so they are intentionally left out:

- `no-unsafe-enum-comparison` is dominated by a `DeviceModelInternal` type-modeling gap — `internal_model` is typed as `string` in some message definitions, and there are two separate `DeviceModelInternal` declarations — so comparisons that are correct at runtime are flagged. The right fix is upstream type unification, not ~135 call-site edits.
- `await-thenable` is mostly `await` over values that are already synchronous (e.g. `Promise.all` over a sync mapper). Low bug value, high churn, and not autofixable.

Each of those deserves its own dedicated change.

`return-await` uses `error-handling-correctness-only` rather than `in-try-catch` on purpose: it enforces the correctness case (await inside try/catch) without stripping harmless awaits elsewhere, which avoids a large mechanical diff and a clash with `require-await` (removing the sole `await` of an async function).

## Notable fixes

- `only-throw-error` is scoped **off** for test/fixture files, mirroring the existing `no-unnecessary-type-assertion` test override — throwing bare values to drive error paths is idiomatic in tests.
- [`metadataLabelingActions.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/eslint-safety-rules/suite/metadata/src/metadataLabelingActions.ts#L75): `throw response` (a `{ success: false }` result object) → `throw new Error(response.error)`.
- `throw exhaustive(x)` → `return exhaustive(x)` in exhaustiveness `default:` branches. `exhaustive()` already throws internally and returns `never`, so the `return` is behaviourally identical and avoids the false positive.
- [`connect-web/src/bootstrap/bootstrap.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/eslint-safety-rules/packages/connect-web/src/bootstrap/bootstrap.ts#L1) carries a single file-scoped disable: it intentionally throws the predefined string error codes from `bootstrap-errors.ts`, which are matched by value and forwarded to Suite as the `connect-popup-err` URL param, so the thrown value must stay a bare code.
- The remaining edits are the rules' autofixes (`startsWith`/`endsWith` conversions) — behaviour-preserving.

## Notes for QA

No user-facing or behavioural change is expected. Every edit is one of: a lint-config addition, a behaviour-preserving autofix (`startsWith`/`endsWith`), a `throw <value>` → `throw new Error(...)` conversion on an already-failing path (the message content is preserved), or a `throw exhaustive()` → `return exhaustive()` swap (runtime-identical). Blast radius spans several packages but each change is trivial. No specific QA needed beyond CI going green.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes center on Ethereum transaction signing (ethereumSignTx.ts, ethUtils.ts, ethereumSignTransaction hook), wallet-utils validation logic, WalletConnect thunks, Evolu-based Suite Sync instance creation, metadata labeling actions, address prefix handling, and routing — most of which are exercised by dedicated E2E suites. Several changed files (blockchain-link errors, bip32.ts, coingecko.ts, connect-popup ethereumSignTransaction, wallet-utils files) are broad shared utilities imported by nearly all 132 tests, so recommendations were restricted to tests with concrete functional overlap (ETH signing/fee flows, validation-heavy forms, WalletConnect, Suite Sync, metadata labeling, and routing) rather than the full transitive set. Two suite-native files (ReviewOutputItem components) and connect-web bootstrap/websocket-client have no E2E coverage and should be validated via unit/component tests instead.

<details><summary><b>Changed files (18)</b></summary>

- `packages/blockchain-link-types/src/constants/errors.ts`
- `packages/connect-web/src/bootstrap/bootstrap.ts`
- `packages/connect/src/api/ethereum/ethereumSignTx.ts`
- `packages/trezor-user-env-link/src/websocket-client.ts`
- `packages/utxo-lib/src/bip32.ts`
- `suite-common/address/src/hasBitcoinCashAddressPrefix.ts`
- `suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts`
- `suite-common/fiat-services/src/coingecko.ts`
- `suite-common/suite-sync-evolu/src/createEvoluInstance.ts`
- `suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts`
- `suite-common/wallet-utils/src/ethUtils.ts`
- `suite-common/wallet-utils/src/validationUtils.ts`
- `suite-common/walletconnect/src/walletConnectThunks.ts`
- `suite-native/storage/src/createAsyncMigrate.ts`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.tsx`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx`
- `suite/metadata/src/metadataLabelingActions.ts`
- `suite/router/src/router.ts`

</details>

**Recommended tests (24)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — Directly exercises ethereumSignTx (packages/connect/src/api/ethereum/ethereumSignTx.ts) and ethUtils.ts through an ETH send flow with custom gas fees, device confirmation, and fee calculation - the core changed code paths.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — Ethereum message signing flow directly touches Ethereum signing infrastructure related to ethereumSignTx.ts changes, verifying signature output correctness.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Directly calls TrezorConnect.ethereumSignTransaction and exercises the connect-popup ethereumSignTransaction method hook that was changed, verifying signing succeeds end-to-end.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test exercises custom Ethereum fee parameters (gas limit, max fee per gas, priority fee) during a swap sign flow, directly hitting ethereumSignTx.ts and ethUtils.ts fee calculation logic changed in this PR.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking involves signing an Ethereum transaction with amount/fee/data verification on device, directly exercising the changed ethereumSignTx.ts code path.
- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — This test directly exercises WalletConnect pairing, proposal approval/rejection flows that are implemented in walletConnectThunks.ts, which was changed in this PR.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — Suite Sync labeling relies on the Evolu client instance created by createEvoluInstance.ts, and this test directly verifies syncing labels from the Evolu relay backend.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test creates and syncs labels via Suite Sync to the Evolu Relay backend, directly exercising createEvoluInstance.ts which manages the Evolu client instance that was modified.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — Extensively exercises Evolu-based label sync (update and removal for account/wallet/address/output), directly dependent on the changed createEvoluInstance.ts.

</details>

<details><summary>🟡 <b>Medium priority (11)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — Uses Evolu client and relay for multi-wallet Suite Sync scenarios, exercising the same createEvoluInstance.ts logic though with more complex setup that's less directly focused on the core instance creation change.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — Exercises Ethereum address handling/verification and touches hasBitcoinCashAddressPrefix.ts indirectly for address formatting logic; also includes ETH account creation and address reveal touching ethUtils paths.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test validates amount/address validation logic (large amount causing sign error) which directly touches validationUtils.ts changed in this PR, and address prefix logic from hasBitcoinCashAddressPrefix.ts.
- `suite/e2e/tests/staking/staking-form.test.ts` — Extensively tests staking form validation logic (min amount, decimals, insufficient funds) which is closely related to validationUtils.ts changes affecting amount validation across the app.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Validates crypto amount input decimal limits and insufficient funds errors, directly exercising validationUtils.ts logic that was changed.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests min/max amount validation errors in the buy form, directly exercising the validation logic in validationUtils.ts that was modified.
- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test exercises metadata labeling actions (add/edit/remove account labels) which are implemented in metadataLabelingActions.ts, a changed file with no static coverage but clear functional overlap.
- `suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — Exercises wallet label add/edit actions handled by metadataLabelingActions.ts, providing direct coverage of the changed labeling action logic.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — Exercises output label add/edit/cancel actions which are handled by metadataLabelingActions.ts, directly covering the changed labeling action logic.
- `suite/e2e/tests/general/check-links.test.ts` — This test explicitly validates that every route defined in router-config is covered, making it directly sensitive to changes in suite/router/src/router.ts.
- `suite/e2e/tests/trading/navigation.test.ts` — Extensively tests navigation to trading forms (buy/sell/swap) from various entry points across different routes, directly exercising routing logic likely affected by router.ts changes.

</details>

<details><summary>🟢 <b>Low priority (4)</b></summary>

- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — LTC send flow touches address prefix and BIP32-derived account paths; relevant but less directly tied to the specific changes than BTC/ETH-focused tests.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Exercises BTC send form validation and OP_RETURN handling which may touch validationUtils.ts logic, though less specifically than the direct validation-focused tests.
- `suite/e2e/tests/suite/db-migration.test.ts` — This test validates IndexedDB migration behavior across Suite versions, which is conceptually related to the changed createAsyncMigrate.ts storage migration utility, though it targets suite-native not suite-web storage specifically.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — Similar to db-migration.test.ts, this test covers persistence/migration behavior conceptually related to createAsyncMigrate.ts changes, though it targets suite-web not suite-native storage.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/connect-web/src/bootstrap/bootstrap.ts`
- `packages/trezor-user-env-link/src/websocket-client.ts`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.tsx`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx`

_Updated: 2026-07-20T13:20:12.536Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/eslint-safety-rules/web/](https://dev.suite.sldev.cz/suite-web/mroz22/eslint-safety-rules/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/eslint-safety-rules&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/eslint-safety-rules&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/eslint-safety-rules&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-20T13:22:42.071Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-20T13:22:55.116Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->