### PR TITLE
Fix/ci update trezor-user-env workflow

### DIFF
--- a/.github/workflows/update-protobuf.yml
+++ b/.github/workflows/update-protobuf.yml
@@ -62,6 +62,8 @@ jobs:
           branch: chore/update-protobuf-definitions
           title: "Update protobuf definitions"
           body: |
+            ## Description
+
             **Firmware commit:** [`${{ steps.firmware.outputs.commit }}`](https://github.com/trezor/trezor-firmware/commit/${{ steps.firmware.outputs.commit }})
           base: develop
           delete-branch: true

--- a/.github/workflows/update-trezor-user-env.yml
+++ b/.github/workflows/update-trezor-user-env.yml
@@ -27,10 +27,8 @@ jobs:
 
       - name: Get latest commit from trezor-user-env
         id: latest
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          latest=$(gh api repos/trezor/trezor-user-env/commits/main --jq '.sha')
+          latest=$(git ls-remote https://github.com/trezor/trezor-user-env.git HEAD | awk '{print $1}')
           if ! [[ "$latest" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error::Failed to fetch latest trezor-user-env commit: $latest"
             exit 1
@@ -72,6 +70,8 @@ jobs:
           branch: chore/update-trezor-user-env
           title: "Update trezor-user-env to ${{ steps.latest.outputs.commit }}"
           body: |
+            ## Description
+
             Updates `ghcr.io/trezor/trezor-user-env` image tag.
 
             **Commit:** [`${{ steps.latest.outputs.commit }}`](https://github.com/trezor/trezor-user-env/commit/${{ steps.latest.outputs.commit }})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. fix `update trezor-user-env` workflow
2. fix `update-protobuf` PR description (required by https://github.com/trezor/trezor-suite/pull/28516)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/ci-update-tenv/web/](https://dev.suite.sldev.cz/suite-web/fix/ci-update-tenv/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ci-update-tenv&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ci-update-tenv&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-20T10:11:48.735Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-20T10:11:19.040Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->