### PR TITLE
feat(suite-common): wrapped-native token calldata and validation

### DIFF
--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
@@ -1,0 +1,217 @@
+import { openDeferredModal } from '@suite/modal';
+import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin/src/tx-simulation';
+import { createThunk } from '@suite-common/redux-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import {
+    getNetwork,
+    getNetworkDisplaySymbol,
+    getWrappedNativeAddress,
+} from '@suite-common/wallet-config';
+import { WETH_DEPOSIT_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
+import {
+    buildYieldUnsignedTransaction,
+    buildYieldWrapTransactionData,
+    estimateYieldFeeLevel,
+    ethereumGetCurrentNonceThunk,
+    selectRawNetworkFeeInfo,
+} from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { getAccountIdentity, getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
+
+import { sendYieldTransaction } from './stablecoin-yield/signingHelpers';
+
+// Standalone wrap flow for the debug "Wrap" action on the dashboard native-asset row. It reuses the
+// shared yield building blocks/signer but deliberately keeps its own thunks so the stablecoin-yield
+// flow thunks stay untouched.
+const WRAP_NATIVE_TOKEN_PREFIX = '@wallet/wrap-native-token';
+
+export type ComposeWrapNativeTokenErrorReason =
+    | 'unsupported-network'
+    | 'not-wrapped-native'
+    | 'missing-fee-level';
+
+export type ComposeWrapNativeTokenResult =
+    | {
+          type: 'action-ready';
+          unsignedTransaction: string;
+      }
+    | {
+          type: 'error';
+          reason: ComposeWrapNativeTokenErrorReason;
+      };
+
+type WrapNativeTokenPayload = {
+    account: Account;
+    /** Native coin amount to wrap — the value carried by the transaction. */
+    wrapAmount: string;
+};
+
+/**
+ * Composes an unsigned WETH `deposit()` (wrap) transaction that carries `wrapAmount` in its value.
+ * The target is always the chain's canonical wrapped-native contract.
+ */
+export const composeWrapNativeTokenThunk = createThunk<
+    ComposeWrapNativeTokenResult,
+    WrapNativeTokenPayload,
+    void
+>(
+    `${WRAP_NATIVE_TOKEN_PREFIX}/compose`,
+    async ({ account, wrapAmount }, { dispatch, getState }) => {
+        if (account.networkType !== 'ethereum') {
+            return { type: 'error', reason: 'unsupported-network' } as const;
+        }
+
+        const wethAddress = getWrappedNativeAddress(account.symbol);
+
+        if (!wethAddress) {
+            return { type: 'error', reason: 'not-wrapped-native' } as const;
+        }
+
+        const network = getNetwork(account.symbol);
+
+        if (!network.chainId) {
+            return { type: 'error', reason: 'unsupported-network' } as const;
+        }
+
+        const { data, value } = buildYieldWrapTransactionData({
+            wrapAmount,
+            decimals: network.decimals,
+        });
+
+        const [{ nonce }, estimatedFeeLevel] = await Promise.all([
+            dispatch(
+                ethereumGetCurrentNonceThunk({
+                    selectedAccount: account,
+                    fetchConfirmedNonce: true,
+                }),
+            ).unwrap(),
+            estimateYieldFeeLevel({
+                coin: account.symbol,
+                identity: getAccountIdentity(account),
+                from: account.descriptor,
+                to: wethAddress,
+                data,
+                value,
+            }),
+        ]);
+
+        // WETH deposit() is a fixed ~45k-gas call, so fall back to a known backup limit when
+        // estimation fails rather than blocking the wrap.
+        const gasLimit = estimatedFeeLevel.success
+            ? estimatedFeeLevel.payload.feeLimit
+            : WETH_DEPOSIT_BACKUP_GAS_LIMIT;
+
+        const feeInfo = getConvertedOrDefaultFeeInfo({
+            networkType: account.networkType,
+            feeInfo: selectRawNetworkFeeInfo(getState(), account.symbol),
+        });
+        const normalLevel =
+            feeInfo.levels.find(level => level.label === 'normal') ?? feeInfo.levels[0];
+
+        if (!normalLevel) {
+            return { type: 'error', reason: 'missing-fee-level' } as const;
+        }
+
+        const unsignedTransaction = JSON.stringify(
+            buildYieldUnsignedTransaction({
+                chainId: network.chainId,
+                data,
+                feeLevel: normalLevel,
+                from: account.descriptor,
+                gasLimit,
+                nonce: Number(nonce),
+                to: wethAddress,
+                value,
+            }),
+        );
+
+        return { type: 'action-ready', unsignedTransaction } as const;
+    },
+);
+
+/**
+ * Debug-only submit for the native-token wrap: composes the `deposit()` tx, shows the tx-simulation
+ * preview, then signs on the device and broadcasts. Reuses the shared `sendYieldTransaction` signer
+ * as-is — `flowType`/`flowKey` only feed the (flow-agnostic) precomposed-tx store and are inert for
+ * a standalone wrap.
+ */
+export const submitWrapNativeTokenThunk = createThunk(
+    `${WRAP_NATIVE_TOKEN_PREFIX}/submit`,
+    async ({ account, wrapAmount }: WrapNativeTokenPayload, { dispatch, getState }) => {
+        try {
+            const result = await dispatch(
+                composeWrapNativeTokenThunk({ account, wrapAmount }),
+            ).unwrap();
+
+            if (result.type === 'error') {
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'sign-tx-error',
+                        error: `Failed to compose wrap transaction (${result.reason}).`,
+                    }),
+                );
+
+                return;
+            }
+
+            const userAcceptedTxSimulation = await dispatch(
+                openDeferredModal({
+                    type: 'earn-yield-tx-simulation',
+                    data: {
+                        flow: 'wrap',
+                        unsignedTx: result.unsignedTransaction,
+                        account,
+                    } satisfies StablecoinYieldTxSimulationParams,
+                }),
+            );
+
+            if (userAcceptedTxSimulation?.value === false) {
+                return;
+            }
+
+            const network = getNetwork(account.symbol);
+
+            const sendResult = await sendYieldTransaction({
+                account,
+                amount: wrapAmount,
+                // Native display token (no contractAddress) ⇒ the review renders the wrap as a
+                // native value transfer to the WETH contract, which is what a deposit() call is.
+                token: {
+                    networkSymbol: account.symbol,
+                    symbol: getNetworkDisplaySymbol(account.symbol),
+                    decimals: network.decimals,
+                    contractAddress: null,
+                },
+                unsignedTransaction: result.unsignedTransaction,
+                flowKey: 'debug-wrap-native',
+                flowType: 'deposit',
+                dispatch,
+                getState,
+                selectedFee: userAcceptedTxSimulation?.selectedFee ?? null,
+            });
+
+            userAcceptedTxSimulation?.resolve();
+
+            if (!sendResult) {
+                return;
+            }
+
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'raw-tx-sent',
+                    descriptor: account.descriptor,
+                    symbol: account.symbol,
+                    txid: sendResult.txid,
+                }),
+            );
+        } catch (error) {
+            console.error(error);
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'sign-tx-error',
+                    error: error instanceof Error ? error.message : String(error),
+                }),
+            );
+        }
+    },
+);

--- a/packages/suite/src/components/earn/yield/__tests__/yieldFlowUtils.test.ts
+++ b/packages/suite/src/components/earn/yield/__tests__/yieldFlowUtils.test.ts
@@ -15,6 +15,8 @@ const withdrawWithUnwrapSequence = getYieldFlowStepSequence({
 
 describe('yieldFlowUtils', () => {
     describe('getYieldFlowSteps', () => {
+        // A normal deposit lists only approve + action (the leading `wrap` step is native-only and
+        // excluded from the list), so `wrap` shows as an out-of-flow (done, unnumbered) step.
         it('describes deposit steps on the approve step', () => {
             expect(getYieldFlowSteps(depositSequence, 'approve')).toEqual({
                 wrap: { state: 'done', indicator: { index: 0, total: 2 } },

--- a/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
@@ -19,9 +19,11 @@ const getPendingTransactionLabel = (kind: YieldPendingTransactionState['type']):
         case 'revoke':
             return 'TR_EXCHANGE_APPROVAL_FORM_REVOKING_APPROVAL';
         case 'deposit':
+        case 'wrap':
             return 'TR_EARN_YIELD_PENDING_DEPOSIT';
         case 'withdraw':
         case 'redeem':
+        case 'unwrap':
             return 'TR_EARN_YIELD_PENDING_WITHDRAW';
         case 'claim':
             return 'TR_EARN_YIELD_PENDING_CLAIM';

--- a/packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx
@@ -1,7 +1,6 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Row, Text } from '@trezor/components';
 import { TokenIcon } from '@trezor/product-components';
-import { BigNumber } from '@trezor/utils';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 
@@ -17,30 +16,25 @@ type YieldTokenValueProps = {
     'data-testid'?: string;
 };
 
-export const YieldTokenValue = ({
-    token,
-    amount,
-    'data-testid': dataTestId,
-}: YieldTokenValueProps) => {
-    const roundedAmount = new BigNumber(amount).decimalPlaces(2, BigNumber.ROUND_DOWN).toFixed();
-
-    return (
-        <Row alignItems="center" gap={8}>
-            <TokenIcon
-                size={24}
-                symbol={token.networkSymbol}
-                contractAddress={token.contractAddress}
-                placeholder={token.symbol}
-                showNetworkIcon
-                isBordered={false}
-            />
-            <Text typographyStyle="body-md-strong">
-                <FormattedCryptoAmount
-                    value={roundedAmount}
-                    symbol={token.symbol}
-                    data-testid={dataTestId}
-                />
-            </Text>
-        </Row>
-    );
-};
+export const YieldTokenValue = ({ token, amount }: YieldTokenValueProps) => (
+    <Row alignItems="center" gap={8}>
+        <TokenIcon
+            size={24}
+            symbol={token.networkSymbol}
+            contractAddress={token.contractAddress}
+            placeholder={token.symbol}
+            showNetworkIcon
+            isBordered={false}
+        />
+        <Text typographyStyle="body-md-strong">
+            {/*
+                `isBalance` runs the amount through `formatCoinBalance`, which keeps the leading
+                significant digits and appends an ellipsis (…) once the fractional part gets too
+                long. This keeps the rendered width bounded (no more layout jitter) while still
+                showing the meaningful digits of small stablecoin/WETH amounts — a fixed decimal
+                cap instead rounded those down to zeroes.
+            */}
+            <FormattedCryptoAmount value={amount} symbol={token.symbol} isBalance />
+        </Text>
+    </Row>
+);

--- a/packages/suite/src/components/suite/WrapTxAmount.tsx
+++ b/packages/suite/src/components/suite/WrapTxAmount.tsx
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+
+import { getWrappedNativeSymbol } from '@suite-common/wallet-config';
+import { type WalletAccountTransaction } from '@suite-common/wallet-types';
+import {
+    asAmountSubunit,
+    getNativeWrapTxKind,
+    getUnwrapAmountByEthereumDataHex,
+    subunitsToUnits,
+} from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { FormattedCryptoAmount } from './FormattedCryptoAmount';
+
+interface WrapTxAmountProps {
+    transaction: WalletAccountTransaction;
+    /** Render the wrapped-token symbol (e.g. WETH) instead of the native one (e.g. ETH). */
+    wrapped?: boolean;
+}
+
+export const WrapTxAmount = ({ transaction, wrapped }: WrapTxAmountProps) => {
+    const { symbol } = transaction;
+
+    const amount = useMemo(() => {
+        const kind = getNativeWrapTxKind(transaction);
+
+        if (!kind) return undefined;
+
+        // Wrapping is 1:1, so both legs show the same amount and only differ in symbol. The amount
+        // is the transaction value for a wrap and the withdraw(uint256) calldata for an unwrap.
+        const subunits =
+            kind === 'wrap'
+                ? transaction.amount
+                : getUnwrapAmountByEthereumDataHex(transaction.ethereumSpecific?.data);
+
+        return subunits
+            ? subunitsToUnits({ value: asAmountSubunit(new BigNumber(subunits)), symbol })
+            : undefined;
+    }, [transaction, symbol]);
+
+    if (!amount) return null;
+
+    return (
+        <FormattedCryptoAmount
+            value={amount}
+            symbol={wrapped ? (getWrappedNativeSymbol(symbol) ?? symbol) : symbol}
+        />
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -59,6 +59,7 @@ import { UnecoCoinjoinModal } from './UnecoCoinjoinModal';
 import { WalletConnectProposalModal } from './WalletConnectProposalModal';
 import { WalletConnectSwitchAccountModal } from './WalletConnectSwitchAccountModal';
 import { WipeDeviceSuccessModal } from './WipeDeviceSuccessModal';
+import { WrapNativeTokenModal } from './WrapNativeTokenModal';
 
 /** Modals opened as a result of user action */
 export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL_CONTEXT_USER>) => {
@@ -205,6 +206,16 @@ export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL_CONTE
             );
         case 'wipe-device-success':
             return <WipeDeviceSuccessModal />;
+        case 'wrap-native-token':
+            return (
+                <WrapNativeTokenModal
+                    account={payload.account}
+                    maxWrapAmount={payload.maxWrapAmount}
+                    nativeSymbol={payload.nativeSymbol}
+                    wrappedSymbol={payload.wrappedSymbol}
+                    onCancel={onCancel}
+                />
+            );
         default:
             return exhaustive(payload);
     }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WrapNativeTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WrapNativeTokenModal.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
+
+import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
+import { type Account } from '@suite-common/wallet-types';
+import { Button, Column, Input, Modal, Row } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { submitWrapNativeTokenThunk } from 'src/actions/wallet/wrapNativeTokenThunks';
+import { useDispatch } from 'src/hooks/suite';
+
+type WrapNativeTokenModalProps = {
+    account: Account;
+    /** Max native amount that can be wrapped (balance minus the gas reserve), display units. */
+    maxWrapAmount: string;
+    nativeSymbol: string;
+    wrappedSymbol: string;
+    onCancel: () => void;
+};
+
+type FormData = {
+    amount: string;
+};
+
+export const validateAmount =
+    (translate: (id: TranslationKey) => string, maxWrapAmount: string) => (value: string) => {
+        const amount = new BigNumber(value);
+
+        if (amount.isNaN() || amount.lte(0)) {
+            return translate('AMOUNT_IS_TOO_LOW');
+        }
+
+        if (amount.gt(maxWrapAmount)) {
+            return translate('AMOUNT_IS_NOT_ENOUGH');
+        }
+
+        return true;
+    };
+
+// Debug-only modal (opened from the dashboard native-asset "Wrap" button) that collects the amount
+// to wrap, then hands off to submitWrapNativeTokenThunk which drives the tx-simulation + signing.
+export const WrapNativeTokenModal = ({
+    account,
+    maxWrapAmount,
+    nativeSymbol,
+    wrappedSymbol,
+    onCancel,
+}: WrapNativeTokenModalProps) => {
+    const { translationString } = useTranslation();
+    const dispatch = useDispatch();
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const {
+        register,
+        handleSubmit,
+        setValue,
+        formState: { errors, isValid },
+        control,
+    } = useForm<FormData>({
+        mode: 'onChange',
+        defaultValues: { amount: '' },
+    });
+
+    // Watch the value so the Input's floating-label CSS animates in react-hook-form's uncontrolled
+    // mode (see StellarTokenInputModal for the same pattern). useWatch (a hook) rather than the
+    // useForm watch() function, which React Compiler can't memoize and flags as incompatible.
+    const amount = useWatch({ control, name: 'amount' });
+
+    const { ref: amountRef, ...amountField } = register('amount', {
+        required: translationString('AMOUNT_IS_NOT_SET'),
+        validate: validateAmount(translationString, maxWrapAmount),
+    });
+
+    const onContinue = handleSubmit(async ({ amount: wrapAmount }) => {
+        setIsSubmitting(true);
+        // On success the thunk replaces this modal with the tx-simulation modal; on failure it shows
+        // a toast and this modal stays open, so re-enable the button afterwards.
+        await dispatch(submitWrapNativeTokenThunk({ account, wrapAmount }));
+        setIsSubmitting(false);
+    });
+
+    return (
+        <Modal
+            onCancel={onCancel}
+            heading={
+                <Translation
+                    id="TR_WRAP_NATIVE_TOKEN_MODAL_TITLE"
+                    values={{ nativeSymbol, wrappedSymbol }}
+                />
+            }
+            bottomContent={
+                <Row gap={8}>
+                    <Button
+                        onClick={onContinue}
+                        isDisabled={!isValid}
+                        isLoading={isSubmitting}
+                        intent="brand"
+                    >
+                        <Translation id="TR_CONTINUE" />
+                    </Button>
+                    <Button onClick={onCancel} intent="neutral" priority="secondary">
+                        <Translation id="TR_CANCEL" />
+                    </Button>
+                </Row>
+            }
+        >
+            <Column gap={16} alignItems="stretch">
+                <Input
+                    label={<Translation id="TR_WRAP_NATIVE_TOKEN_AMOUNT_LABEL" />}
+                    value={amount}
+                    innerRef={amountRef}
+                    {...amountField}
+                    hasError={!!errors.amount}
+                    bottomText={errors.amount?.message || null}
+                />
+                <Row justifyContent="flex-end">
+                    <Button
+                        onClick={() => setValue('amount', maxWrapAmount, { shouldValidate: true })}
+                        intent="neutral"
+                        priority="secondary"
+                    >
+                        <Translation id="TR_WRAP_NATIVE_TOKEN_MAX" />
+                    </Button>
+                </Row>
+            </Column>
+        </Modal>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/__tests__/WrapNativeTokenModal.test.ts
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/__tests__/WrapNativeTokenModal.test.ts
@@ -1,0 +1,35 @@
+import { type TranslationKey } from '@suite/intl';
+
+// The modal pulls in the wrap submit thunk (and, transitively, TrezorConnect); stub it so this pure
+// validator test stays lightweight.
+jest.mock('src/actions/wallet/wrapNativeTokenThunks', () => ({
+    submitWrapNativeTokenThunk: jest.fn(),
+}));
+
+import { validateAmount } from '../WrapNativeTokenModal';
+
+// Identity translator so the returned message equals the message id under test.
+const translate = (id: TranslationKey) => id;
+
+describe('WrapNativeTokenModal validateAmount', () => {
+    const validate = validateAmount(translate, '1.495');
+
+    it('accepts an amount within the max', () => {
+        expect(validate('1')).toBe(true);
+        expect(validate('1.495')).toBe(true);
+    });
+
+    it('rejects an amount above the max', () => {
+        expect(validate('1.5')).toBe('AMOUNT_IS_NOT_ENOUGH');
+    });
+
+    it('rejects zero and negative amounts', () => {
+        expect(validate('0')).toBe('AMOUNT_IS_TOO_LOW');
+        expect(validate('-1')).toBe('AMOUNT_IS_TOO_LOW');
+    });
+
+    it('rejects a non-numeric amount', () => {
+        expect(validate('abc')).toBe('AMOUNT_IS_TOO_LOW');
+        expect(validate('')).toBe('AMOUNT_IS_TOO_LOW');
+    });
+});

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
@@ -4,6 +4,7 @@ import { getNetworkDisplaySymbol, isNetworkSymbol } from '@suite-common/wallet-c
 import { type TronTxContractType } from '@suite-common/wallet-constants';
 import { type StakeType } from '@suite-common/wallet-types';
 import {
+    getNativeWrapTxKind,
     getTxHeaderSymbol,
     isCardanoStakingTx,
     isSupportedEthStakingNetworkSymbol,
@@ -13,6 +14,7 @@ import { type AccountTransaction } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
 import { UnstakingTxAmount } from 'src/components/suite/UnstakingTxAmount';
+import { WrapTxAmount } from 'src/components/suite/WrapTxAmount';
 import { type WalletAccountTransaction } from 'src/types/wallet';
 import { BlurUrls } from 'src/views/wallet/tokens/common/BlurUrls';
 
@@ -126,6 +128,21 @@ export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderP
 
     if (isPending && (transaction.ethereumSpecific || transaction.cardanoSpecific)) {
         return <Translation id="TR_UNCONFIRMED_TX_LONG" />;
+    }
+
+    // WETH wrap/unwrap are shown as their own labels (with the amount) instead of the generic
+    // contract-call name ("deposit"/"withdraw") that the indexer parses.
+    const wrapKind = getNativeWrapTxKind(transaction);
+    if (wrapKind) {
+        return (
+            <Translation
+                id={wrapKind === 'wrap' ? 'TR_TX_WRAP' : 'TR_TX_UNWRAP'}
+                values={{
+                    nativeAmount: <WrapTxAmount transaction={transaction} />,
+                    wrappedAmount: <WrapTxAmount transaction={transaction} wrapped />,
+                }}
+            />
+        );
     }
 
     if (

--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
@@ -17,6 +17,8 @@ import { PriceTicker, TrendTicker } from 'src/components/suite';
 import { useDispatch, useLayoutSize } from 'src/hooks/suite';
 import { type Account } from 'src/types/wallet';
 
+import { WrapNativeTokenButton } from './WrapNativeTokenButton';
+
 type TradeBoxProps = {
     account: Account;
 };
@@ -185,6 +187,7 @@ export const TradeBox = ({ account }: TradeBoxProps) => {
                                 <Translation id="TR_TRADING_SWAP" />
                             </ActionButton>
                         )}
+                        <WrapNativeTokenButton account={account} />
                     </Row>
                 </Flex>
             </Card>

--- a/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx
@@ -1,0 +1,76 @@
+import { type MouseEvent } from 'react';
+
+import { selectIsDebugModeActive } from '@suite/debug';
+import { Translation } from '@suite/intl';
+import { openModal } from '@suite/modal';
+import {
+    getNetworkDisplaySymbol,
+    getNetworkType,
+    getWrappedNativeAddress,
+    getWrappedNativeSymbol,
+} from '@suite-common/wallet-config';
+import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
+import { Button } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { type Account } from 'src/types/wallet';
+
+type WrapNativeTokenButtonProps = {
+    account: Account;
+};
+
+/**
+ * Debug-only action to wrap the native coin into its wrapped-native token (e.g. ETH → WETH).
+ * Rendered in the account TradeBox; hidden outside debug mode, on non-EVM networks, or on networks
+ * without a wrapped-native contract configured.
+ */
+export const WrapNativeTokenButton = ({ account }: WrapNativeTokenButtonProps) => {
+    const dispatch = useDispatch();
+    const isDebugModeActive = useSelector(selectIsDebugModeActive);
+
+    const { symbol } = account;
+    const wrappedAddress = getWrappedNativeAddress(symbol);
+    const wrappedSymbol = getWrappedNativeSymbol(symbol);
+
+    if (
+        !isDebugModeActive ||
+        getNetworkType(symbol) !== 'ethereum' ||
+        !wrappedAddress ||
+        !wrappedSymbol
+    ) {
+        return null;
+    }
+
+    // Keep a native buffer for the wrap fee (and any follow-up approve/deposit), matching the
+    // reserve the shared wrap logic uses.
+    const maxWrapAmount = BigNumber.max(
+        0,
+        new BigNumber(account.formattedBalance).minus(WETH_WRAP_GAS_RESERVE),
+    ).toString();
+
+    const onClick = (e: MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation();
+
+        dispatch(
+            openModal({
+                type: 'wrap-native-token',
+                account,
+                maxWrapAmount,
+                nativeSymbol: getNetworkDisplaySymbol(symbol),
+                wrappedSymbol,
+            }),
+        );
+    };
+
+    return (
+        <Button
+            intent="accentViolet"
+            size="small"
+            onClick={onClick}
+            data-testid="@trading/menu/wrap-native-token"
+        >
+            <Translation id="TR_WRAP_NATIVE_TOKEN" />
+        </Button>
+    );
+};

--- a/packages/suite/src/views/wallet/transactions/TradeBox/__tests__/WrapNativeTokenButton.test.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/__tests__/WrapNativeTokenButton.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { ThemeProvider } from 'src/support/suite/ThemeProvider';
+import { type Account } from 'src/types/wallet';
+
+import { WrapNativeTokenButton } from '../WrapNativeTokenButton';
+
+const mockDispatch = jest.fn();
+
+jest.mock('src/hooks/suite', () => ({
+    useDispatch: () => mockDispatch,
+    // The component reads debug mode only through the (mocked) selector, so invoking it with no
+    // state is enough here.
+    useSelector: (selector: () => unknown) => selector(),
+}));
+
+jest.mock('@suite/intl', () => ({
+    ...jest.requireActual('@suite/intl'),
+    Translation: ({ id }: { id: string }) => <span>{id}</span>,
+}));
+
+const mockOpenModal = jest.fn((payload: unknown) => ({ type: 'MODAL_OPEN', payload }));
+jest.mock('@suite/modal', () => ({ openModal: (payload: unknown) => mockOpenModal(payload) }));
+
+const mockSelectIsDebugModeActive = jest.fn();
+jest.mock('@suite/debug', () => ({
+    selectIsDebugModeActive: () => mockSelectIsDebugModeActive(),
+}));
+
+const mockGetNetworkType = jest.fn();
+const mockGetWrappedNativeAddress = jest.fn();
+const mockGetWrappedNativeSymbol = jest.fn();
+jest.mock('@suite-common/wallet-config', () => ({
+    ...jest.requireActual('@suite-common/wallet-config'),
+    getNetworkType: (symbol: string) => mockGetNetworkType(symbol),
+    getWrappedNativeAddress: (symbol: string) => mockGetWrappedNativeAddress(symbol),
+    getWrappedNativeSymbol: (symbol: string) => mockGetWrappedNativeSymbol(symbol),
+    getNetworkDisplaySymbol: () => 'ETH',
+}));
+
+const account = {
+    symbol: 'eth',
+    formattedBalance: '1.5',
+    networkType: 'ethereum',
+} as unknown as Account;
+
+const WRAP_BUTTON_TESTID = '@trading/menu/wrap-native-token';
+
+const renderButton = () =>
+    render(
+        <ThemeProvider>
+            <WrapNativeTokenButton account={account} />
+        </ThemeProvider>,
+    );
+
+describe('WrapNativeTokenButton', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // Happy-path defaults; individual tests override one condition.
+        mockSelectIsDebugModeActive.mockReturnValue(true);
+        mockGetNetworkType.mockReturnValue('ethereum');
+        mockGetWrappedNativeAddress.mockReturnValue('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2');
+        mockGetWrappedNativeSymbol.mockReturnValue('WETH');
+    });
+
+    it('renders nothing when debug mode is off', () => {
+        mockSelectIsDebugModeActive.mockReturnValue(false);
+        renderButton();
+        expect(screen.queryByTestId(WRAP_BUTTON_TESTID)).not.toBeInTheDocument();
+    });
+
+    it('renders nothing on a non-EVM network', () => {
+        mockGetNetworkType.mockReturnValue('bitcoin');
+        renderButton();
+        expect(screen.queryByTestId(WRAP_BUTTON_TESTID)).not.toBeInTheDocument();
+    });
+
+    it('renders nothing when the network has no wrapped-native token', () => {
+        mockGetWrappedNativeAddress.mockReturnValue(undefined);
+        mockGetWrappedNativeSymbol.mockReturnValue(undefined);
+        renderButton();
+        expect(screen.queryByTestId(WRAP_BUTTON_TESTID)).not.toBeInTheDocument();
+    });
+
+    it('opens the wrap modal with the depositable max when all conditions are met', () => {
+        renderButton();
+
+        const button = screen.getByTestId(WRAP_BUTTON_TESTID);
+        expect(button).toBeInTheDocument();
+
+        fireEvent.click(button);
+
+        // 1.5 native balance minus the 0.005 gas reserve.
+        expect(mockOpenModal).toHaveBeenCalledWith({
+            type: 'wrap-native-token',
+            account,
+            maxWrapAmount: '1.495',
+            nativeSymbol: 'ETH',
+            wrappedSymbol: 'WETH',
+        });
+        expect(mockDispatch).toHaveBeenCalledTimes(1);
+    });
+});

--- a/suite-common/calldata/src/builder/evm/weth/deposit.ts
+++ b/suite-common/calldata/src/builder/evm/weth/deposit.ts
@@ -1,0 +1,9 @@
+import { EVM_ABI } from '../../../constants/evm';
+import { createEvmEncoder } from '../../../encoder/evm';
+import { createBuilder } from '../../createBuilder';
+
+// deposit() takes no calldata arguments — the wrapped amount rides in the transaction value.
+export const buildWethDeposit = createBuilder({
+    params: {},
+    encode: createEvmEncoder(EVM_ABI.weth.deposit),
+});

--- a/suite-common/calldata/src/builder/evm/weth/withdraw.ts
+++ b/suite-common/calldata/src/builder/evm/weth/withdraw.ts
@@ -1,0 +1,22 @@
+import { type BigNumber } from '@trezor/utils';
+
+import { EVM_ABI } from '../../../constants/evm';
+import { createEvmEncoder } from '../../../encoder/evm';
+import { createPolicy } from '../../../policy/createPolicy';
+import { validateUint256 } from '../../../validation/shared/uint256';
+import { createBuilder } from '../../createBuilder';
+import { createParam } from '../../createParam';
+
+type WethWithdrawContext = { balance?: bigint };
+
+const wadParam = createParam<BigNumber, bigint, WethWithdrawContext>({
+    validate: validateUint256,
+    policy: createPolicy({ ZERO_AMOUNT: 'error' }),
+});
+
+export const buildWethWithdraw = createBuilder({
+    params: {
+        wad: wadParam,
+    },
+    encode: createEvmEncoder(EVM_ABI.weth.withdraw),
+});

--- a/suite-common/calldata/src/calldata.ts
+++ b/suite-common/calldata/src/calldata.ts
@@ -7,6 +7,8 @@ import { buildStake } from './builder/evm/everstake/stake';
 import { buildUnstake } from './builder/evm/everstake/unstake';
 import { buildRedeem } from './builder/evm/redeem';
 import { buildTransfer } from './builder/evm/transfer';
+import { buildWethDeposit } from './builder/evm/weth/deposit';
+import { buildWethWithdraw } from './builder/evm/weth/withdraw';
 import { buildWithdraw } from './builder/evm/withdraw';
 import { buildTrc20Transfer } from './builder/tron/trc20/transfer';
 import { EVM_ABI } from './constants/evm';
@@ -49,6 +51,16 @@ export const Calldata = {
             stake: { encode: buildStake },
             unstake: { encode: buildUnstake },
             claimWithdrawRequest: { encode: buildClaimWithdrawRequest },
+        },
+        weth: {
+            deposit: {
+                encode: buildWethDeposit,
+                decode: createEvmDecoder(EVM_ABI.weth.deposit),
+            },
+            withdraw: {
+                encode: buildWethWithdraw,
+                decode: createEvmDecoder(EVM_ABI.weth.withdraw),
+            },
         },
     },
     tron: {

--- a/suite-common/calldata/src/constants/evm.ts
+++ b/suite-common/calldata/src/constants/evm.ts
@@ -25,4 +25,8 @@ export const EVM_ABI = {
         ]),
         claimWithdrawRequest: parseAbi(['function claimWithdrawRequest()']),
     },
+    weth: {
+        deposit: parseAbi(['function deposit() payable']),
+        withdraw: parseAbi(['function withdraw(uint256 wad)']),
+    },
 } as const;

--- a/suite-common/calldata/src/decoder/evm.ts
+++ b/suite-common/calldata/src/decoder/evm.ts
@@ -41,7 +41,8 @@ export const createEvmDecoder = <const T extends Abi>(abi: T): Decoder<T> => {
         ) as `0x${string}`;
         try {
             const { args } = decodeFunctionData({ abi, data: normalized });
-            const values = (args as readonly unknown[]).map((v, i) => {
+            // viem returns `args: undefined` for zero-input functions (e.g. `deposit()`).
+            const values = ((args ?? []) as readonly unknown[]).map((v, i) => {
                 const { inputs } = fn;
                 // @ts-expect-error: noUncheckedIndexedAccess
                 const inputIndexed: AbiFunction['inputs'][number] = inputs[i];

--- a/suite-common/calldata/src/tests/builder/evm/weth/deposit.test.ts
+++ b/suite-common/calldata/src/tests/builder/evm/weth/deposit.test.ts
@@ -1,0 +1,12 @@
+import { buildWethDeposit } from '../../../../builder/evm/weth/deposit';
+
+describe('buildWethDeposit', () => {
+    it('encodes the deposit selector with no args', () => {
+        const result = buildWethDeposit({});
+
+        expect(result.isValid).toBe(true);
+        expect(result.data).toBe('0xd0e30db0');
+        expect(result.errors).toEqual([]);
+        expect(result.warnings).toEqual([]);
+    });
+});

--- a/suite-common/calldata/src/tests/builder/evm/weth/withdraw.test.ts
+++ b/suite-common/calldata/src/tests/builder/evm/weth/withdraw.test.ts
@@ -1,0 +1,35 @@
+import { BigNumber } from '@trezor/utils';
+
+import { buildWethWithdraw } from '../../../../builder/evm/weth/withdraw';
+import { Calldata } from '../../../../calldata';
+
+describe('buildWethWithdraw', () => {
+    it('encodes valid withdraw calldata', () => {
+        const result = buildWethWithdraw({ wad: new BigNumber('1000000000000000000') });
+
+        expect(result.isValid).toBe(true);
+        expect(result.data).toBe(
+            '0x2e1a7d4d0000000000000000000000000000000000000000000000000de0b6b3a7640000',
+        );
+        expect(result.errors).toEqual([]);
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('decodes encoded calldata back to the wad amount', () => {
+        const result = buildWethWithdraw({ wad: new BigNumber('1507906') });
+
+        expect(result.data).not.toBe(null);
+        expect(Calldata.evm.weth.withdraw.decode(result.data ?? undefined)).toEqual({
+            wad: 1_507_906n,
+        });
+    });
+
+    it('returns error for zero wad', () => {
+        const result = buildWethWithdraw({ wad: new BigNumber('0') });
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.errors).toEqual([{ code: 'ZERO_AMOUNT', path: 'wad', severity: 'error' }]);
+        expect(result.warnings).toEqual([]);
+    });
+});

--- a/suite-common/calldata/src/tests/decoder/evm.test.ts
+++ b/suite-common/calldata/src/tests/decoder/evm.test.ts
@@ -56,6 +56,12 @@ describe('createEvmDecoder', () => {
         });
     });
 
+    it('decodes zero-input functions to an empty object', () => {
+        const depositDecode = createEvmDecoder(EVM_ABI.weth.deposit);
+        // `deposit()` calldata is just the 4-byte selector, no arguments.
+        expect(depositDecode('0xd0e30db0')).toEqual({});
+    });
+
     it('lowercases addresses inside address[] params', () => {
         const arrayDecode = createEvmDecoder(EVM_ABI.distributor.claim);
         const calldata = buildClaim(

--- a/suite-common/calldata/src/tests/verifier/evm/weth/deposit.test.ts
+++ b/suite-common/calldata/src/tests/verifier/evm/weth/deposit.test.ts
@@ -1,0 +1,28 @@
+import { buildWethDeposit } from '../../../../builder/evm/weth/deposit';
+import { Verifier } from '../../../../verifier';
+
+const depositHex = buildWethDeposit({}).data!;
+
+describe('verify weth deposit', () => {
+    it('returns isValid true for the deposit() selector', () => {
+        expect(Verifier.evm.weth.deposit(depositHex, {})).toEqual({ isValid: true, issues: [] });
+    });
+
+    it('rejects an ERC-4626 deposit(uint256,address) call (different selector)', () => {
+        // 0x6e553f65 = deposit(uint256,address); must NOT verify as the zero-arg WETH deposit().
+        const erc4626DepositHex =
+            '0x6e553f6500000000000000000000000000000000000000000000000000000000004c4b400000000000000000000000009ea3721b5bf3b64b4418c38b603154d2d597fae3';
+
+        expect(Verifier.evm.weth.deposit(erc4626DepositHex, {})).toEqual({
+            isValid: false,
+            issues: [{ code: 'SIGNATURE_MISMATCH', field: null }],
+        });
+    });
+
+    it('returns SIGNATURE_MISMATCH for unrelated calldata', () => {
+        expect(Verifier.evm.weth.deposit('0xdeadbeef', {})).toEqual({
+            isValid: false,
+            issues: [{ code: 'SIGNATURE_MISMATCH', field: null }],
+        });
+    });
+});

--- a/suite-common/calldata/src/tests/verifier/evm/weth/withdraw.test.ts
+++ b/suite-common/calldata/src/tests/verifier/evm/weth/withdraw.test.ts
@@ -1,0 +1,30 @@
+import { BigNumber } from '@trezor/utils';
+
+import { buildWethWithdraw } from '../../../../builder/evm/weth/withdraw';
+import { Verifier } from '../../../../verifier';
+
+const WAD = 1_000_000_000_000_000_000n;
+const withdrawHex = buildWethWithdraw({ wad: new BigNumber(WAD.toString()) }).data!;
+
+describe('verify weth withdraw', () => {
+    it('returns isValid true on matching wad', () => {
+        expect(Verifier.evm.weth.withdraw(withdrawHex, { wad: WAD })).toEqual({
+            isValid: true,
+            issues: [],
+        });
+    });
+
+    it('returns VALUE_MISMATCH on a different wad', () => {
+        expect(Verifier.evm.weth.withdraw(withdrawHex, { wad: 1n })).toEqual({
+            isValid: false,
+            issues: [{ code: 'VALUE_MISMATCH', field: 'wad' }],
+        });
+    });
+
+    it('returns SIGNATURE_MISMATCH for unrelated calldata', () => {
+        expect(Verifier.evm.weth.withdraw('0xdeadbeef', { wad: WAD })).toEqual({
+            isValid: false,
+            issues: [{ code: 'SIGNATURE_MISMATCH', field: null }],
+        });
+    });
+});

--- a/suite-common/calldata/src/verifier.ts
+++ b/suite-common/calldata/src/verifier.ts
@@ -20,5 +20,9 @@ export const Verifier = {
             unstake: createVerifier({ abi: EVM_ABI.everstake.unstake }),
             claimWithdrawRequest: createVerifier({ abi: EVM_ABI.everstake.claimWithdrawRequest }),
         },
+        weth: {
+            deposit: createVerifier({ abi: EVM_ABI.weth.deposit }),
+            withdraw: createVerifier({ abi: EVM_ABI.weth.withdraw }),
+        },
     },
 } as const;

--- a/suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.ts
+++ b/suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.ts
@@ -28,7 +28,13 @@ const claimUnsignedTxBase = {
 
 const stablecoinYieldTxSimulationParams = z.discriminatedUnion('flow', [
     z.strictObject({
-        flow: z.union([z.literal('deposit'), z.literal('withdraw'), z.literal('redeem')]),
+        flow: z.union([
+            z.literal('deposit'),
+            z.literal('withdraw'),
+            z.literal('redeem'),
+            z.literal('wrap'),
+            z.literal('unwrap'),
+        ]),
         account: partialAccount,
         unsignedTx: z.string(),
     }),
@@ -57,7 +63,9 @@ function composeUnsignedEvmTx(
     switch (params.flow) {
         case 'deposit':
         case 'redeem':
-        case 'withdraw': {
+        case 'withdraw':
+        case 'wrap':
+        case 'unwrap': {
             const {
                 to,
                 value = '0x0',

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -260,5 +260,13 @@ export type UserContextPayload =
           >;
       }
     | {
+          type: 'wrap-native-token';
+          account: Account;
+          /** Max native amount that can be wrapped (balance minus the gas reserve), display units. */
+          maxWrapAmount: string;
+          nativeSymbol: string;
+          wrappedSymbol: string;
+      }
+    | {
           type: 'wipe-device-success';
       };

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -77,6 +77,7 @@ export * from './stablecoin-yield/stablecoinYieldDeviceUtils';
 export * from './stablecoin-yield/stablecoinYieldFeeEstimation';
 export * from './stablecoin-yield/stablecoinYieldTypes';
 export * from './stablecoin-yield/stablecoinYieldUtils';
+export * from './stablecoin-yield/stablecoinYieldWrapThunks';
 export * from './stake/tron/tronStakeReducer';
 export * from './stake/tron/tronStakeSelectors';
 export { composeTronFreezeFeeLevelsThunk } from './stake/tron/actions/freeze/composeFreeze';

--- a/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldReducer.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldReducer.test.ts
@@ -15,10 +15,10 @@ const FLOW_KEY = 'account-key:yield-id:0xtoken';
 const getSession = (state: StablecoinYieldState, flowType: YieldFlowType) =>
     state[flowType][getStablecoinYieldSessionKey(FLOW_KEY)];
 
-const initSession = (flowType: YieldFlowType) =>
+const initSession = (flowType: YieldFlowType, isNativeDeposit?: boolean) =>
     stablecoinYieldReducer(
         initialStablecoinYieldState,
-        stablecoinYieldActions.initSession({ flowType, flowKey: FLOW_KEY }),
+        stablecoinYieldActions.initSession({ flowType, flowKey: FLOW_KEY, isNativeDeposit }),
     );
 
 describe('stablecoinYieldReducer', () => {
@@ -27,6 +27,34 @@ describe('stablecoinYieldReducer', () => {
             const state = initSession('deposit');
 
             expect(getSession(state, 'deposit')?.step).toBe('approve');
+        });
+
+        it('starts a native-token deposit at the wrap step', () => {
+            const state = initSession('deposit', true);
+
+            expect(getSession(state, 'deposit')?.step).toBe('wrap');
+        });
+
+        it('moves a native deposit from the wrap step to approve when it is skipped', () => {
+            const state = stablecoinYieldReducer(
+                initSession('deposit', true),
+                stablecoinYieldActions.skipWrapStep({ flowType: 'deposit', flowKey: FLOW_KEY }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('approve');
+        });
+
+        it('does not regress once the wrap step has been left', () => {
+            // skipWrapStep must only advance from the wrap step, so a repeat can't pull the
+            // flow back from approve/action.
+            const skipWrap = stablecoinYieldActions.skipWrapStep({
+                flowType: 'deposit',
+                flowKey: FLOW_KEY,
+            });
+            const once = stablecoinYieldReducer(initSession('deposit', true), skipWrap);
+            const twice = stablecoinYieldReducer(once, skipWrap);
+
+            expect(getSession(twice, 'deposit')?.step).toBe('approve');
         });
 
         it.each(['withdraw', 'redeem', 'claim'] as const)(

--- a/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts
@@ -5,9 +5,13 @@ import {
     buildEvmSelectedFee,
     buildYieldDepositCalldata,
     buildYieldUnsignedTransaction,
+    buildYieldUnwrapTransactionData,
     buildYieldWithdrawCalldata,
+    buildYieldWrapTransactionData,
     getNextYieldFlowStep,
+    getYieldDepositableBalance,
     getYieldFlowStepSequence,
+    getYieldWrapAmount,
     splitYieldPendingTransaction,
 } from '../stablecoinYieldUtils';
 
@@ -90,7 +94,8 @@ describe('stablecoinYieldUtils', () => {
     });
 
     describe('getNextYieldFlowStep', () => {
-        it('advances deposit through approve → action → complete', () => {
+        it('advances deposit through wrap → approve → action → complete', () => {
+            expect(getNextYieldFlowStep('deposit', 'wrap')).toBe('approve');
             expect(getNextYieldFlowStep('deposit', 'approve')).toBe('action');
             expect(getNextYieldFlowStep('deposit', 'action')).toBe('complete');
         });
@@ -301,6 +306,96 @@ describe('stablecoinYieldUtils', () => {
             maxFeePerGas: '0x165a0bc00',
             maxPriorityFeePerGas: '0x3b9aca00',
             type: 'eip1559',
+        });
+    });
+
+    describe('buildYieldWrapTransactionData', () => {
+        it('encodes the WETH deposit() selector and carries the amount in the value', () => {
+            expect(buildYieldWrapTransactionData({ wrapAmount: '1', decimals: 18 })).toEqual({
+                data: '0xd0e30db0',
+                value: '0xde0b6b3a7640000',
+            });
+        });
+    });
+
+    describe('buildYieldUnwrapTransactionData', () => {
+        it('encodes WETH withdraw(uint256) calldata for the amount', () => {
+            const { data } = buildYieldUnwrapTransactionData({ unwrapAmount: '1', decimals: 18 });
+
+            expect(Calldata.evm.weth.withdraw.decode(data)).toEqual({
+                wad: 1_000_000_000_000_000_000n,
+            });
+        });
+
+        it('throws for a zero amount', () => {
+            expect(() =>
+                buildYieldUnwrapTransactionData({ unwrapAmount: '0', decimals: 18 }),
+            ).toThrow('Failed to encode WETH withdraw calldata');
+        });
+    });
+
+    describe('getYieldDepositableBalance', () => {
+        const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+        const USDC_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+
+        it('returns only the matched token balance for a non-wrapped-native vault', () => {
+            expect(
+                getYieldDepositableBalance({
+                    networkSymbol: 'eth',
+                    nativeFormattedBalance: '5',
+                    vaultTokenAddress: USDC_ADDRESS,
+                    matchedTokenBalance: '100',
+                }),
+            ).toBe('100');
+        });
+
+        it('adds the native balance minus the gas reserve for a wrapped-native vault', () => {
+            expect(
+                getYieldDepositableBalance({
+                    networkSymbol: 'eth',
+                    nativeFormattedBalance: '0.2',
+                    vaultTokenAddress: WETH_ADDRESS,
+                    matchedTokenBalance: '1.5',
+                }),
+            ).toBe('1.695');
+        });
+
+        it('ignores native balance below the gas reserve', () => {
+            expect(
+                getYieldDepositableBalance({
+                    networkSymbol: 'eth',
+                    nativeFormattedBalance: '0.003',
+                    vaultTokenAddress: WETH_ADDRESS,
+                    matchedTokenBalance: '1',
+                }),
+            ).toBe('1');
+        });
+
+        it('returns the spendable native balance when no token is matched', () => {
+            expect(
+                getYieldDepositableBalance({
+                    networkSymbol: 'eth',
+                    nativeFormattedBalance: '1',
+                    vaultTokenAddress: WETH_ADDRESS,
+                    matchedTokenBalance: undefined,
+                }),
+            ).toBe('0.995');
+        });
+    });
+
+    describe('getYieldWrapAmount', () => {
+        it('wraps the shortfall between the deposit total and held WETH', () => {
+            expect(getYieldWrapAmount({ totalAmount: '2', matchedWethBalance: '1.5' })).toBe('0.5');
+        });
+
+        it('returns 0 when held WETH already covers the total', () => {
+            expect(getYieldWrapAmount({ totalAmount: '1', matchedWethBalance: '2' })).toBe('0');
+        });
+
+        it('wraps the whole total when no WETH is held', () => {
+            expect(getYieldWrapAmount({ totalAmount: '1', matchedWethBalance: undefined })).toBe(
+                '1',
+            );
         });
     });
 });

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldFeeEstimation.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldFeeEstimation.ts
@@ -14,6 +14,8 @@ type EstimateYieldFeeLevelParams = {
     from: string;
     to: string;
     data: string;
+    /** Native value carried by the transaction (hex). Non-zero for wraps. */
+    value?: string;
 };
 
 export const estimateYieldFeeLevel = async ({
@@ -22,6 +24,7 @@ export const estimateYieldFeeLevel = async ({
     from,
     to,
     data,
+    value = '0x0',
 }: EstimateYieldFeeLevelParams): Promise<
     Result<YieldEstimatedFeeLevel, YieldFeeEstimationError>
 > => {
@@ -34,7 +37,7 @@ export const estimateYieldFeeLevel = async ({
                 from,
                 to,
                 data,
-                value: '0x0',
+                value,
             },
         },
     });

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -162,9 +162,10 @@ export const initialStablecoinYieldState: StablecoinYieldState = {
 
 const createInitialStablecoinYieldSessionState = (
     flowType: YieldFlowType,
+    isNativeDeposit = false,
 ): StablecoinYieldSessionState => ({
     ...initialStablecoinYieldSessionState,
-    step: getYieldFlowStepSequence({ flowType })[0],
+    step: getYieldFlowStepSequence({ flowType, isWrappedNativeVault: isNativeDeposit })[0],
     approval: { ...initialStablecoinYieldSessionState.approval },
     action: { ...initialStablecoinYieldSessionState.action },
     result: {
@@ -199,9 +200,11 @@ const stablecoinYieldSlice = createSlice({
     reducers: {
         initSession(
             state: StablecoinYieldState,
-            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+            action: PayloadAction<
+                StablecoinYieldSessionActionPayload & { isNativeDeposit?: boolean }
+            >,
         ) {
-            const { flowType, flowKey } = action.payload;
+            const { flowType, flowKey, isNativeDeposit } = action.payload;
 
             if (!isSafeObjectKey(flowKey)) {
                 return;
@@ -210,7 +213,10 @@ const stablecoinYieldSlice = createSlice({
             const sessionKey = getStablecoinYieldSessionKey(flowKey);
 
             if (!state[flowType][sessionKey]) {
-                state[flowType][sessionKey] = createInitialStablecoinYieldSessionState(flowType);
+                state[flowType][sessionKey] = createInitialStablecoinYieldSessionState(
+                    flowType,
+                    isNativeDeposit,
+                );
             }
         },
         disposeSession(
@@ -379,6 +385,17 @@ const stablecoinYieldSlice = createSlice({
         ) {
             withSession(state, action.payload, session => {
                 session.step = getNextYieldFlowStep(action.payload.flowType, 'approve');
+            });
+        },
+        skipWrapStep(
+            state: StablecoinYieldState,
+            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+        ) {
+            withSession(state, action.payload, session => {
+                // Only advance from the wrap step, so repeated init calls can't regress the flow.
+                if (session.step === 'wrap') {
+                    session.step = getNextYieldFlowStep(action.payload.flowType, 'wrap');
+                }
             });
         },
         revokeSuccess(

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
@@ -68,7 +68,7 @@ export type YieldApproveModalState = {
 };
 
 export type YieldPendingTransactionState = {
-    type: 'approve' | 'revoke' | 'deposit' | 'withdraw' | 'redeem' | 'claim';
+    type: 'approve' | 'revoke' | 'deposit' | 'withdraw' | 'redeem' | 'claim' | 'wrap' | 'unwrap';
     txid: string;
     amount: string;
     fee?: string;

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -1,12 +1,14 @@
 import { Calldata, type EvmAddress } from '@suite-common/calldata';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
 import { type AccountKey, type EvmSelectedFee } from '@suite-common/wallet-types';
 import {
     asAmountUnit,
     fromGwei,
     fromIntegerString,
     getContractAddressForNetworkSymbol,
+    isWrappedNativeToken,
     unitsToSubunits,
 } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
@@ -94,6 +96,8 @@ type BuildYieldUnsignedTransactionParams = {
     gasLimit: string;
     nonce: number;
     to: string;
+    /** Native value carried by the transaction (hex). Non-zero for wraps; defaults to `0x0`. */
+    value?: string;
 };
 
 type BuildEvmFeeFieldsParams = {
@@ -143,19 +147,26 @@ export const getYieldFlowStepSequence = <TFlowType extends YieldFlowType>({
 /**
  * Returns the step that follows `step` in the flow's step sequence. Stays on `step`
  * when it is the last one or not part of the flow at all.
+ *
+ * The full sequence (wrap/unwrap included) is used to locate `step`, so an optional step
+ * such as `wrap` can be advanced from. Optional steps are skipped as *targets* though —
+ * they are entered explicitly (e.g. `wrap` is left via `skipWrapStep`), never as the
+ * automatic next step of the preceding one.
  */
 export const getNextYieldFlowStep = (
     flowType: YieldFlowType,
     step: YieldFlowStepId,
 ): YieldFlowStepId => {
-    const sequence = getYieldFlowStepSequence({ flowType });
+    const sequence = getYieldFlowStepSequence({ flowType, isWrappedNativeVault: true });
     const stepIndex = sequence.indexOf(step);
 
     if (stepIndex === -1) {
         return step;
     }
 
-    return sequence[stepIndex + 1] ?? step;
+    const nextStep = sequence.slice(stepIndex + 1).find(s => s !== 'wrap' && s !== 'unwrap');
+
+    return nextStep ?? step;
 };
 
 export const getYieldWithdrawInputToken = ({
@@ -282,13 +293,14 @@ export const buildYieldUnsignedTransaction = ({
     gasLimit,
     nonce,
     to,
+    value = '0x0',
 }: BuildYieldUnsignedTransactionParams) => {
     const feeFields = buildEvmFeeFields({ feeLevel, gasLimit });
     const commonFields = {
         from,
         to,
         data,
-        value: '0x0',
+        value,
         nonce,
         chainId,
         gasLimit: feeFields.gasLimit,
@@ -308,6 +320,106 @@ export const buildYieldUnsignedTransaction = ({
         gasPrice: feeFields.gasPrice,
     };
 };
+
+type BuildYieldWrapTransactionDataParams = {
+    wrapAmount: string;
+    decimals: number;
+};
+
+// WETH `deposit()` carries the wrapped amount in the transaction value, not in calldata.
+export const buildYieldWrapTransactionData = ({
+    wrapAmount,
+    decimals,
+}: BuildYieldWrapTransactionDataParams) => {
+    const builderResult = Calldata.evm.weth.deposit.encode({});
+
+    if (!builderResult.isValid || !builderResult.data) {
+        throw new Error('Failed to encode WETH deposit calldata.');
+    }
+
+    const valueSubunits = unitsToSubunits({
+        value: asAmountUnit(new BigNumber(wrapAmount)),
+        decimals,
+    });
+
+    return {
+        data: builderResult.data,
+        value: fromIntegerString(valueSubunits.toFixed(0)).toHex(),
+    };
+};
+
+type BuildYieldUnwrapTransactionDataParams = {
+    unwrapAmount: string;
+    decimals: number;
+};
+
+export const buildYieldUnwrapTransactionData = ({
+    unwrapAmount,
+    decimals,
+}: BuildYieldUnwrapTransactionDataParams) => {
+    const wadSubunits = unitsToSubunits({
+        value: asAmountUnit(new BigNumber(unwrapAmount)),
+        decimals,
+    });
+
+    const builderResult = Calldata.evm.weth.withdraw.encode({ wad: wadSubunits });
+
+    if (!builderResult.isValid || !builderResult.data) {
+        const issues = builderResult.errors.map(issue => issue.code).join(', ');
+
+        throw new Error(`Failed to encode WETH withdraw calldata${issues ? `: ${issues}` : '.'}`);
+    }
+
+    return { data: builderResult.data };
+};
+
+type GetYieldDepositableBalanceParams = {
+    networkSymbol: NetworkSymbol;
+    /** Native coin balance in display units, NOT subunits. */
+    nativeFormattedBalance: string;
+    vaultTokenAddress?: string | null;
+    matchedTokenBalance?: string | null;
+};
+
+/**
+ * Balance available for a yield deposit. For a wrapped-native (WETH) vault the native balance can
+ * be wrapped, so it counts in after keeping `WETH_WRAP_GAS_RESERVE` aside to cover the follow-up
+ * wrap + approve + deposit (+ exit) fees.
+ */
+export const getYieldDepositableBalance = ({
+    networkSymbol,
+    nativeFormattedBalance,
+    vaultTokenAddress,
+    matchedTokenBalance,
+}: GetYieldDepositableBalanceParams): string => {
+    // Normal deposit: only the already-held vault-token balance is spendable.
+    const tokenDepositBalance = matchedTokenBalance ?? '0';
+
+    if (!isWrappedNativeToken(networkSymbol, vaultTokenAddress)) {
+        return tokenDepositBalance;
+    }
+
+    // Native-asset deposit: the native balance can also be wrapped, after keeping the fee reserve
+    // aside for the follow-up wrap + approve + deposit (+ exit) transactions.
+    const wrappableNativeBalance = BigNumber.max(
+        0,
+        new BigNumber(nativeFormattedBalance || '0').minus(WETH_WRAP_GAS_RESERVE),
+    );
+
+    return new BigNumber(tokenDepositBalance).plus(wrappableNativeBalance).toString();
+};
+
+type GetYieldWrapAmountParams = {
+    totalAmount: string;
+    matchedWethBalance?: string | null;
+};
+
+/** Native portion of a deposit that must be wrapped — the total minus already-held WETH. */
+export const getYieldWrapAmount = ({
+    totalAmount,
+    matchedWethBalance,
+}: GetYieldWrapAmountParams): string =>
+    BigNumber.max(0, new BigNumber(totalAmount || '0').minus(matchedWethBalance || '0')).toString();
 
 type YieldTxReviewFlowIdentity = {
     accountKey?: AccountKey;

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldWrapThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldWrapThunks.ts
@@ -1,0 +1,217 @@
+import { createThunk } from '@suite-common/redux-utils';
+import { getNetwork } from '@suite-common/wallet-config';
+import { WETH_DEPOSIT_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
+import { type Account } from '@suite-common/wallet-types';
+import {
+    getAccountIdentity,
+    getConvertedOrDefaultFeeInfo,
+    isWrappedNativeToken,
+} from '@suite-common/wallet-utils';
+
+import { STABLECOIN_YIELD_PREFIX } from './stablecoinYieldConstants';
+import { estimateYieldFeeLevel } from './stablecoinYieldFeeEstimation';
+import type { YieldFlowDisplayToken, YieldFlowResolvedData } from './stablecoinYieldTypes';
+import {
+    buildYieldUnsignedTransaction,
+    buildYieldUnwrapTransactionData,
+    buildYieldWrapTransactionData,
+} from './stablecoinYieldUtils';
+import { selectRawNetworkFeeInfo } from '../fees/feesReducer';
+import { ethereumGetCurrentNonceThunk } from '../send/sendFormEthereumThunks';
+
+const YIELD_WRAP_THUNK_PREFIX = `${STABLECOIN_YIELD_PREFIX}/thunk`;
+
+export type ComposeYieldWrapErrorReason =
+    | 'unsupported-network'
+    | 'not-wrapped-native'
+    | 'vault-chain-mismatch'
+    | 'missing-fee-level'
+    | 'fee-estimation-failed';
+
+export type ComposeYieldWrapResult =
+    | {
+          type: 'action-ready';
+          unsignedTransaction: string;
+      }
+    | {
+          type: 'error';
+          reason: ComposeYieldWrapErrorReason;
+      };
+
+type ComposeYieldWrapTransactionPayload = {
+    flowData: YieldFlowResolvedData;
+    /** Native coin amount to wrap — the value carried by the transaction. */
+    wrapAmount: string;
+};
+
+type ComposeYieldUnwrapTransactionPayload = {
+    account: Account;
+    /** The wrapped-native (WETH) token being unwrapped. */
+    token: Pick<YieldFlowDisplayToken, 'contractAddress' | 'decimals'>;
+    unwrapAmount: string;
+};
+
+/**
+ * Composes an unsigned WETH `deposit()` (wrap) transaction that carries `wrapAmount` in its value.
+ * Refuses to build a value-carrying transaction to anything but the account network's canonical
+ * wrapped-native contract.
+ */
+export const composeYieldWrapTransactionThunk = createThunk<
+    ComposeYieldWrapResult,
+    ComposeYieldWrapTransactionPayload,
+    void
+>(
+    `${YIELD_WRAP_THUNK_PREFIX}/composeWrapTransaction`,
+    async ({ flowData, wrapAmount }, { dispatch, getState }) => {
+        const { account, token, vault } = flowData;
+
+        if (account.networkType !== 'ethereum') {
+            return { type: 'error', reason: 'unsupported-network' } as const;
+        }
+
+        const wethAddress = token.contractAddress;
+
+        if (!isWrappedNativeToken(account.symbol, wethAddress) || !wethAddress) {
+            return { type: 'error', reason: 'not-wrapped-native' } as const;
+        }
+
+        const network = getNetwork(account.symbol);
+
+        if (!network.chainId || vault.chainId !== network.chainId) {
+            return { type: 'error', reason: 'vault-chain-mismatch' } as const;
+        }
+
+        const { data, value } = buildYieldWrapTransactionData({
+            wrapAmount,
+            decimals: token.decimals,
+        });
+
+        const [{ nonce }, estimatedFeeLevel] = await Promise.all([
+            dispatch(
+                ethereumGetCurrentNonceThunk({
+                    selectedAccount: account,
+                    fetchConfirmedNonce: true,
+                }),
+            ).unwrap(),
+            estimateYieldFeeLevel({
+                coin: account.symbol,
+                identity: getAccountIdentity(account),
+                from: account.descriptor,
+                to: wethAddress,
+                data,
+                value,
+            }),
+        ]);
+
+        // WETH deposit() is a fixed ~45k-gas call, so fall back to a known backup limit when
+        // estimation fails rather than blocking the wrap.
+        const gasLimit = estimatedFeeLevel.success
+            ? estimatedFeeLevel.payload.feeLimit
+            : WETH_DEPOSIT_BACKUP_GAS_LIMIT;
+
+        const feeInfo = getConvertedOrDefaultFeeInfo({
+            networkType: account.networkType,
+            feeInfo: selectRawNetworkFeeInfo(getState(), account.symbol),
+        });
+        const normalLevel =
+            feeInfo.levels.find(level => level.label === 'normal') ?? feeInfo.levels[0];
+
+        if (!normalLevel) {
+            return { type: 'error', reason: 'missing-fee-level' } as const;
+        }
+
+        const unsignedTransaction = JSON.stringify(
+            buildYieldUnsignedTransaction({
+                chainId: network.chainId,
+                data,
+                feeLevel: normalLevel,
+                from: account.descriptor,
+                gasLimit,
+                nonce: Number(nonce),
+                to: wethAddress,
+                value,
+            }),
+        );
+
+        return { type: 'action-ready', unsignedTransaction } as const;
+    },
+);
+
+/**
+ * Composes an unsigned WETH `withdraw(uint256)` (unwrap) transaction — the standalone WETH→ETH
+ * action for the wrapped-native token.
+ */
+export const composeYieldUnwrapTransactionThunk = createThunk<
+    ComposeYieldWrapResult,
+    ComposeYieldUnwrapTransactionPayload,
+    void
+>(
+    `${YIELD_WRAP_THUNK_PREFIX}/composeUnwrapTransaction`,
+    async ({ account, token, unwrapAmount }, { dispatch, getState }) => {
+        if (account.networkType !== 'ethereum') {
+            return { type: 'error', reason: 'unsupported-network' } as const;
+        }
+
+        const wethAddress = token.contractAddress;
+
+        if (!isWrappedNativeToken(account.symbol, wethAddress) || !wethAddress) {
+            return { type: 'error', reason: 'not-wrapped-native' } as const;
+        }
+
+        const network = getNetwork(account.symbol);
+
+        if (!network.chainId) {
+            return { type: 'error', reason: 'vault-chain-mismatch' } as const;
+        }
+
+        const { data } = buildYieldUnwrapTransactionData({
+            unwrapAmount,
+            decimals: token.decimals,
+        });
+
+        const [{ nonce }, estimatedFeeLevel] = await Promise.all([
+            dispatch(
+                ethereumGetCurrentNonceThunk({
+                    selectedAccount: account,
+                    fetchConfirmedNonce: true,
+                }),
+            ).unwrap(),
+            estimateYieldFeeLevel({
+                coin: account.symbol,
+                identity: getAccountIdentity(account),
+                from: account.descriptor,
+                to: wethAddress,
+                data,
+            }),
+        ]);
+
+        if (!estimatedFeeLevel.success) {
+            return { type: 'error', reason: 'fee-estimation-failed' } as const;
+        }
+
+        const feeInfo = getConvertedOrDefaultFeeInfo({
+            networkType: account.networkType,
+            feeInfo: selectRawNetworkFeeInfo(getState(), account.symbol),
+        });
+        const normalLevel =
+            feeInfo.levels.find(level => level.label === 'normal') ?? feeInfo.levels[0];
+
+        if (!normalLevel) {
+            return { type: 'error', reason: 'missing-fee-level' } as const;
+        }
+
+        const unsignedTransaction = JSON.stringify(
+            buildYieldUnsignedTransaction({
+                chainId: network.chainId,
+                data,
+                feeLevel: normalLevel,
+                from: account.descriptor,
+                gasLimit: estimatedFeeLevel.payload.feeLimit,
+                nonce: Number(nonce),
+                to: wethAddress,
+            }),
+        );
+
+        return { type: 'action-ready', unsignedTransaction } as const;
+    },
+);

--- a/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
@@ -5,6 +5,9 @@ import { BigNumber } from '@trezor/utils';
 import {
     buildApprovalTransactionData,
     getEvmTransactionTextSignature,
+    getUnwrapAmountByEthereumDataHex,
+    isUnwrapNativeTx,
+    isWrapNativeTx,
     padLeftEven,
     sanitizeHex,
     strip,
@@ -156,6 +159,63 @@ describe('eth utils', () => {
 
         it('returns "unknown" for selector-only claim (too short)', () => {
             expect(getEvmTransactionTextSignature('0x71ee95c0')).toBe('unknown');
+        });
+    });
+
+    describe('wrapped-native tx detection', () => {
+        const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+        const OTHER = '0x1111111111111111111111111111111111111111';
+        const DEPOSIT = '0xd0e30db0'; // WETH deposit()
+        const WITHDRAW =
+            '0x2e1a7d4d0000000000000000000000000000000000000000000000000de0b6b3a7640000'; // withdraw(1e18)
+        const ERC4626_DEPOSIT =
+            '0x6e553f65' + // deposit(uint256,address) — different selector, must not be treated as a wrap
+            '00000000000000000000000000000000000000000000000000000000004c4b40' +
+            '0000000000000000000000009ea3721b5bf3b64b4418c38b603154d2d597fae3';
+
+        const wrap = (to: string | null, data: string | null) =>
+            isWrapNativeTx({ networkSymbol: 'eth', to, data });
+        const unwrap = (to: string | null, data: string | null) =>
+            isUnwrapNativeTx({ networkSymbol: 'eth', to, data });
+
+        it('isWrapNativeTx detects deposit() to the wrapped-native contract', () => {
+            expect(wrap(WETH, DEPOSIT)).toBe(true);
+        });
+
+        it('isWrapNativeTx ignores deposit() to a non-WETH contract (target guard)', () => {
+            expect(wrap(OTHER, DEPOSIT)).toBe(false);
+        });
+
+        it('isWrapNativeTx ignores other selectors on the WETH contract', () => {
+            expect(wrap(WETH, WITHDRAW)).toBe(false);
+            expect(wrap(WETH, ERC4626_DEPOSIT)).toBe(false);
+        });
+
+        it('isWrapNativeTx returns false for a missing target or data', () => {
+            expect(wrap(null, DEPOSIT)).toBe(false);
+            expect(wrap(WETH, null)).toBe(false);
+        });
+
+        it('isUnwrapNativeTx detects withdraw() to the wrapped-native contract', () => {
+            expect(unwrap(WETH, WITHDRAW)).toBe(true);
+        });
+
+        it('isUnwrapNativeTx ignores withdraw() to a non-WETH contract', () => {
+            expect(unwrap(OTHER, WITHDRAW)).toBe(false);
+        });
+
+        it('isUnwrapNativeTx ignores the deposit() selector', () => {
+            expect(unwrap(WETH, DEPOSIT)).toBe(false);
+        });
+
+        it('getUnwrapAmountByEthereumDataHex returns the wad amount for withdraw()', () => {
+            expect(getUnwrapAmountByEthereumDataHex(WITHDRAW)).toBe('1000000000000000000');
+        });
+
+        it('getUnwrapAmountByEthereumDataHex returns null for non-withdraw data', () => {
+            expect(getUnwrapAmountByEthereumDataHex(DEPOSIT)).toBe(null);
+            expect(getUnwrapAmountByEthereumDataHex('0xdeadbeef')).toBe(null);
+            expect(getUnwrapAmountByEthereumDataHex(undefined)).toBe(null);
         });
     });
 

--- a/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
@@ -1,10 +1,12 @@
 import { Calldata, asEvmAddress } from '@suite-common/calldata';
 import { UINT256_MAX } from '@suite-common/suite-constants';
+import { type WalletAccountTransaction } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils';
 
 import {
     buildApprovalTransactionData,
     getEvmTransactionTextSignature,
+    getNativeWrapTxKind,
     getUnwrapAmountByEthereumDataHex,
     isUnwrapNativeTx,
     isWrapNativeTx,
@@ -216,6 +218,58 @@ describe('eth utils', () => {
             expect(getUnwrapAmountByEthereumDataHex(DEPOSIT)).toBe(null);
             expect(getUnwrapAmountByEthereumDataHex('0xdeadbeef')).toBe(null);
             expect(getUnwrapAmountByEthereumDataHex(undefined)).toBe(null);
+        });
+    });
+
+    describe('getNativeWrapTxKind', () => {
+        const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+        const OTHER = '0x1111111111111111111111111111111111111111';
+        const DEPOSIT = '0xd0e30db0';
+        const WITHDRAW =
+            '0x2e1a7d4d0000000000000000000000000000000000000000000000000de0b6b3a7640000';
+
+        const tx = ({
+            targets = [],
+            internalTransfers = [],
+            data,
+        }: {
+            targets?: { addresses?: string[] }[];
+            internalTransfers?: { from: string }[];
+            data?: string;
+        }) =>
+            ({
+                symbol: 'eth',
+                targets,
+                internalTransfers,
+                ethereumSpecific: data ? { data } : undefined,
+            }) as unknown as WalletAccountTransaction;
+
+        it('detects a wrap when the WETH contract is the value target', () => {
+            expect(
+                getNativeWrapTxKind(tx({ targets: [{ addresses: [WETH] }], data: DEPOSIT })),
+            ).toBe('wrap');
+        });
+
+        it('detects an unwrap when the WETH contract is the internal ETH sender', () => {
+            expect(
+                getNativeWrapTxKind(tx({ internalTransfers: [{ from: WETH }], data: WITHDRAW })),
+            ).toBe('unwrap');
+        });
+
+        it('ignores a deposit() to a non-WETH contract', () => {
+            expect(
+                getNativeWrapTxKind(tx({ targets: [{ addresses: [OTHER] }], data: DEPOSIT })),
+            ).toBeUndefined();
+        });
+
+        it('ignores a WETH interaction with an unrelated selector', () => {
+            expect(
+                getNativeWrapTxKind(tx({ targets: [{ addresses: [WETH] }], data: '0xdeadbeef' })),
+            ).toBeUndefined();
+        });
+
+        it('returns undefined without a WETH target or data', () => {
+            expect(getNativeWrapTxKind(tx({}))).toBeUndefined();
         });
     });
 

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -1,7 +1,10 @@
 import { Calldata } from '@suite-common/calldata';
 import { UINT256_MAX } from '@suite-common/suite-constants';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type EvmTransactionPurpose } from '@suite-common/wallet-types';
+import {
+    type EvmTransactionPurpose,
+    type WalletAccountTransaction,
+} from '@suite-common/wallet-types';
 import { type TokenInfo } from '@trezor/blockchain-link-types';
 import { exhaustive } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils';
@@ -71,6 +74,30 @@ export const isUnwrapNativeTx = ({ networkSymbol, to, data }: WrappedNativeTxPar
 // Amount (in wei) unwrapped by a WETH withdraw(uint256) call, or null when data is not one.
 export const getUnwrapAmountByEthereumDataHex = (data?: string): string | null =>
     Calldata.evm.weth.withdraw.decode(data)?.wad.toString() ?? null;
+
+/**
+ * Classifies an EVM transaction as a native wrap/unwrap for display. The wrapped-native (WETH)
+ * contract shows up as the value recipient for a wrap and as the internal ETH sender for an
+ * unwrap, so both `targets` and `internalTransfers` are considered when resolving the target.
+ */
+export const getNativeWrapTxKind = (
+    transaction: WalletAccountTransaction,
+): 'wrap' | 'unwrap' | undefined => {
+    const { symbol } = transaction;
+    const data = transaction.ethereumSpecific?.data;
+
+    const candidateAddresses = [
+        ...transaction.targets.flatMap(target => target.addresses ?? []),
+        ...transaction.internalTransfers.map(transfer => transfer.from),
+    ];
+    const to = candidateAddresses.find(address => isWrappedNativeToken(symbol, address));
+
+    if (!to) return undefined;
+    if (isWrapNativeTx({ networkSymbol: symbol, to, data })) return 'wrap';
+    if (isUnwrapNativeTx({ networkSymbol: symbol, to, data })) return 'unwrap';
+
+    return undefined;
+};
 
 export const isEvmApprovalTx = (data?: string): boolean =>
     Calldata.evm.erc20.approve.decode(data) !== null;

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -1,5 +1,6 @@
 import { Calldata } from '@suite-common/calldata';
 import { UINT256_MAX } from '@suite-common/suite-constants';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type EvmTransactionPurpose } from '@suite-common/wallet-types';
 import { type TokenInfo } from '@trezor/blockchain-link-types';
 import { exhaustive } from '@trezor/type-utils';
@@ -7,6 +8,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { asAmountSubunit, asAmountUnit } from './AmountTypes';
 import { unitsToSubunits } from './amountUtils';
+import { isWrappedNativeToken } from './tokenUtils';
 
 export const isEip1559 = (
     tx: Record<string, any> | null | undefined,
@@ -49,6 +51,26 @@ export const getEvmTransactionTextSignature = (data?: string): EvmTransactionPur
 
     return 'unknown';
 };
+
+type WrappedNativeTxParams = {
+    networkSymbol: NetworkSymbol;
+    to?: string | null;
+    data?: string | null;
+};
+
+// deposit() (0xd0e30db0) is a generic selector shared by many contracts, so the selector alone is
+// not enough — the target must also be the chain's wrapped-native contract.
+export const isWrapNativeTx = ({ networkSymbol, to, data }: WrappedNativeTxParams): boolean =>
+    isWrappedNativeToken(networkSymbol, to) &&
+    Calldata.evm.weth.deposit.decode(data ?? undefined) !== null;
+
+export const isUnwrapNativeTx = ({ networkSymbol, to, data }: WrappedNativeTxParams): boolean =>
+    isWrappedNativeToken(networkSymbol, to) &&
+    Calldata.evm.weth.withdraw.decode(data ?? undefined) !== null;
+
+// Amount (in wei) unwrapped by a WETH withdraw(uint256) call, or null when data is not one.
+export const getUnwrapAmountByEthereumDataHex = (data?: string): string | null =>
+    Calldata.evm.weth.withdraw.decode(data)?.wad.toString() ?? null;
 
 export const isEvmApprovalTx = (data?: string): boolean =>
     Calldata.evm.erc20.approve.decode(data) !== null;

--- a/suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts
+++ b/suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts
@@ -123,6 +123,10 @@ const reportYieldTransactionResolution = ({
 
             return;
         }
+        case 'wrap':
+        case 'unwrap':
+            // Intermediate steps of the deposit/withdraw flows; they carry no analytics event of their own.
+            return;
         default:
             exhaustive(pendingTransactionType);
     }

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11324,6 +11324,22 @@ export const messages = defineMessages({
         id: 'TR_TX_UNWRAP',
         defaultMessage: 'Unwrap {wrappedAmount} into {nativeAmount}',
     },
+    TR_WRAP_NATIVE_TOKEN: {
+        id: 'TR_WRAP_NATIVE_TOKEN',
+        defaultMessage: 'Wrap',
+    },
+    TR_WRAP_NATIVE_TOKEN_MODAL_TITLE: {
+        id: 'TR_WRAP_NATIVE_TOKEN_MODAL_TITLE',
+        defaultMessage: 'Wrap {nativeSymbol} to {wrappedSymbol}',
+    },
+    TR_WRAP_NATIVE_TOKEN_AMOUNT_LABEL: {
+        id: 'TR_WRAP_NATIVE_TOKEN_AMOUNT_LABEL',
+        defaultMessage: 'Amount to wrap',
+    },
+    TR_WRAP_NATIVE_TOKEN_MAX: {
+        id: 'TR_WRAP_NATIVE_TOKEN_MAX',
+        defaultMessage: 'Max',
+    },
     TR_STAKE_STAKE: {
         id: 'TR_STAKE_STAKE',
         defaultMessage: 'Stake',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11316,6 +11316,14 @@ export const messages = defineMessages({
         id: 'TR_TX_STAKE_CLAIM',
         defaultMessage: 'Claim withdraw request',
     },
+    TR_TX_WRAP: {
+        id: 'TR_TX_WRAP',
+        defaultMessage: 'Wrap {nativeAmount} into {wrappedAmount}',
+    },
+    TR_TX_UNWRAP: {
+        id: 'TR_TX_UNWRAP',
+        defaultMessage: 'Unwrap {wrappedAmount} into {nativeAmount}',
+    },
     TR_STAKE_STAKE: {
         id: 'TR_STAKE_STAKE',
         defaultMessage: 'Stake',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->


## Scope
- [x] `weth/deposit` + `weth/withdraw` calldata builders (`suite-common/calldata`)
- [x] Decoder + constants for `0xd0e30db0` (deposit) / `0x2e1a7d4d` (withdraw)
- [x] `getUnwrapAmountByEthereumDataHex` decoder — single source of truth for selectors
- [x] Verifier allowlist entry — match **selector and target** (WETH contract) together
- [x] Confirm what the Trezor device screen shows for wrap 
- [x] Unit tests, incl. false-positive cases

## Notes for QA

To test this branch manual contract interaction wouldn't be enough as we need to test application's ability to build transaction data correctly, so it requires two buttons to be added: ETH->WETH and WETH->ETH.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29857

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/wrapped-native-calldata&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/wrapped-native-calldata&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/wrapped-native-calldata&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/wrapped-native-calldata/web/](https://dev.suite.sldev.cz/suite-web/feat/wrapped-native-calldata/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-24T10:35:42.790Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-24T10:36:06.696Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->