### PR TITLE
feat(native): show device settings in native bootloader mode

### DIFF
--- a/suite-native/device-manager/src/components/DeviceManagerContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerContent.tsx
@@ -135,12 +135,12 @@ export const DeviceManagerContent = () => {
             >
                 <VStack spacing="sp24">
                     {isDeviceListVisible && <DeviceList onSelectDevice={handleSelectDevice} />}
-                    {!isPortfolioTrackerDevice && !shouldFactoryResetBeVisible && (
+                    {!isPortfolioTrackerDevice && (
                         <AnimatedVStack
                             layout={LinearTransition}
                             marginTop={!isDeviceListVisible ? 'sp12' : undefined}
                         >
-                            {deviceStaticSessionId && (
+                            {!shouldFactoryResetBeVisible && deviceStaticSessionId && (
                                 <WalletList onSelectDevice={handleSelectDevice} />
                             )}
                             <VStack paddingHorizontal="sp16" paddingBottom="sp16" spacing="sp12">

--- a/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
+++ b/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
@@ -1,5 +1,8 @@
+import { useSelector } from 'react-redux';
+
 import { useNavigation } from '@react-navigation/native';
 
+import { selectIsDeviceInBootloader } from '@suite-common/device';
 import { Translation } from '@suite-native/intl';
 import {
     type DeviceSettingsStackParamList,
@@ -16,16 +19,25 @@ type NavigationProp = StackNavigationProps<
 
 export const WipeDeviceCard = () => {
     const navigation = useNavigation<NavigationProp>();
+    const isDeviceInBootloader = useSelector(selectIsDeviceInBootloader);
 
     const handleRedirect = () => {
         navigation.navigate(DeviceSettingsStackRoutes.WipeDevice);
     };
 
+    // In bootloader mode wiping the device is presented as a factory reset, mirroring desktop.
+    const title = isDeviceInBootloader
+        ? 'moduleDeviceSettings.wipeDevice.factoryResetScreen.title'
+        : 'moduleDeviceSettings.wipeDevice.title';
+    const subtitle = isDeviceInBootloader
+        ? 'moduleDeviceSettings.wipeDevice.factoryResetScreen.description'
+        : 'moduleDeviceSettings.wipeDevice.subtitle';
+
     return (
         <DeviceSettingsItemCard
-            title={<Translation id="moduleDeviceSettings.wipeDevice.title" />}
+            title={<Translation id={title} />}
             icon="warningOctagon"
-            subtitle={<Translation id="moduleDeviceSettings.wipeDevice.subtitle" />}
+            subtitle={<Translation id={subtitle} />}
             onPress={handleRedirect}
             variant="danger"
             testID="@wipeDevice/redirectToWipeDeviceScreen"

--- a/suite-native/module-device-settings/src/screens/BackupAndPassphraseScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/BackupAndPassphraseScreen.tsx
@@ -1,6 +1,10 @@
 import { useSelector } from 'react-redux';
 
-import { selectIsDeviceBackupUnfinished, selectIsDeviceInitialized } from '@suite-common/device';
+import {
+    selectIsDeviceBackupUnfinished,
+    selectIsDeviceInBootloader,
+    selectIsDeviceInitialized,
+} from '@suite-common/device';
 import { VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
@@ -11,7 +15,10 @@ import { PassphraseCard } from '../components/PassphraseCard';
 export const BackupAndPassphraseScreen = () => {
     const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
     const isDeviceBackupUnfinished = useSelector(selectIsDeviceBackupUnfinished);
-    const isCheckBackupAvailable = isDeviceInitialized && !isDeviceBackupUnfinished;
+    const isDeviceInBootloader = useSelector(selectIsDeviceInBootloader);
+    // Backup can't be checked in bootloader mode, so only passphrase settings remain.
+    const isCheckBackupAvailable =
+        isDeviceInitialized && !isDeviceBackupUnfinished && !isDeviceInBootloader;
 
     return (
         <Screen

--- a/suite-native/module-device-settings/src/screens/DeviceSettingsScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/DeviceSettingsScreen.tsx
@@ -4,6 +4,7 @@ import {
     selectDeviceLabel,
     selectDeviceModel,
     selectDeviceName,
+    selectIsDeviceInBootloader,
     selectIsDeviceInitialized,
 } from '@suite-common/device';
 import { SUPPORTS_DEVICE_AUTHENTICITY_CHECK } from '@suite-common/suite-constants';
@@ -29,10 +30,20 @@ export const DeviceSettingsScreen = () => {
     const deviceName = useSelector(selectDeviceName);
     const deviceLabel = useSelector(selectDeviceLabel);
     const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
+    const isDeviceInBootloader = useSelector(selectIsDeviceInBootloader);
 
     if (!deviceModel || !deviceName) {
         return null;
     }
+
+    // In bootloader mode PIN protection and the authenticity check cannot run, so they are hidden
+    // (mirroring desktop). Backup & passphrase stays available for its passphrase settings.
+    const isPinProtectionVisible = isDeviceInitialized && !isDeviceInBootloader;
+    const isBackupAndPassphraseVisible = isDeviceInitialized;
+    const isAuthenticityCheckVisible =
+        SUPPORTS_DEVICE_AUTHENTICITY_CHECK[deviceModel] && !isDeviceInBootloader;
+    const isSecuritySectionVisible =
+        isPinProtectionVisible || isBackupAndPassphraseVisible || isAuthenticityCheckVisible;
 
     return (
         <Screen
@@ -46,13 +57,15 @@ export const DeviceSettingsScreen = () => {
                     <DeviceFirmwareCard />
                     <DeviceConnectionCard />
                 </TitledSection>
-                <TitledSection
-                    title={<Translation id="moduleDeviceSettings.sectionTitles.security" />}
-                >
-                    {isDeviceInitialized && <DevicePinProtectionCard />}
-                    {isDeviceInitialized && <BackupAndPassphraseCard />}
-                    {SUPPORTS_DEVICE_AUTHENTICITY_CHECK[deviceModel] && <DeviceAuthenticityCard />}
-                </TitledSection>
+                {isSecuritySectionVisible && (
+                    <TitledSection
+                        title={<Translation id="moduleDeviceSettings.sectionTitles.security" />}
+                    >
+                        {isPinProtectionVisible && <DevicePinProtectionCard />}
+                        {isBackupAndPassphraseVisible && <BackupAndPassphraseCard />}
+                        {isAuthenticityCheckVisible && <DeviceAuthenticityCard />}
+                    </TitledSection>
+                )}
                 <TitledSection
                     title={<Translation id="moduleDeviceSettings.sectionTitles.dangerZone" />}
                 >


### PR DESCRIPTION
Show limited device settings on mobile when device is in bootloader mode the same way as on desktop.

## Description
There are cases in which you are stuck in bootloader mode and you need to wipe / factory reset your device. Native did not have this settings available, so we need to show it.

## Notes for QA

**Happy paths**
- Connect device in bootloader mode → open device switcher → "Device settings" gear button visible (previously hidden)
- Bootloader mode → Device settings opens → shows General (Firmware, Connection), Passphrase, Danger sections
- Normal mode (regression) → Device settings unchanged: PIN, authenticity, backup all present

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28814

## Screenshots:
<img width="427" height="926" alt="Screenshot 2026-07-20 at 11 35 12" src="https://github.com/user-attachments/assets/513ae815-9251-4c3b-9dce-9bf4704df19f" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=native/device-settings-in-bootloader&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->