### PR TITLE
fix(suite-native-30085): correct ticker for native EVM assets

### DIFF
--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetListItem.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetListItem.tsx
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { type TradingRootState, selectTradingCoinInfoByCryptoId } from '@suite-common/trading';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { Text, VStack } from '@suite-native/atoms';
 import {
@@ -85,7 +86,7 @@ export const MyAssetListItem = ({ account, asset, onPress }: MyAssetListItemProp
     return (
         <AssetListItem
             name={name}
-            symbol={tokenSymbol ?? symbol}
+            symbol={tokenSymbol ?? getNetworkDisplaySymbol(symbol)}
             contractAddress={contract}
             networkSymbol={symbol}
             onPress={handlePress}

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetListItem.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '@suite-common/wallet-types';
 import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
-import { getBtcAccount, getEthAccount } from '@suite-native/trading-fixtures';
+import { base1NormalAccount, getBtcAccount, getEthAccount } from '@suite-native/trading-fixtures';
 import { type MyAsset } from '@suite-native/trading-types';
 import { BigNumber, getIndexOrThrow } from '@trezor/utils';
 
@@ -30,6 +30,15 @@ describe('MyAssetListItem', () => {
         balance: '1000000000000000000',
         fiatBalance: asBaseCurrencyAmount(new BigNumber(2500)),
         cryptoId: 'ethereum' as CryptoId,
+        isEnabled: true,
+    };
+
+    const mockBaseEthAsset: MyAsset = {
+        symbol: 'base' as NetworkSymbol,
+        name: 'Base Ethereum',
+        balance: '1000000000000000000',
+        fiatBalance: asBaseCurrencyAmount(new BigNumber(2500)),
+        cryptoId: 'base--0x0000000000000000000000000000000000000000' as CryptoId,
         isEnabled: true,
     };
 
@@ -128,6 +137,15 @@ describe('MyAssetListItem', () => {
         expect(getAllByText('Ethereum')[0]).toBeTruthy();
         expect(getAllByText('1,000,000,000,000,000,000 ETH')[0]).toBeTruthy();
         expect(getAllByText('$2,500.00')[0]).toBeTruthy();
+    });
+
+    it('should render the native asset symbol instead of the network symbol', () => {
+        const { getByText } = renderComponent({
+            asset: mockBaseEthAsset,
+            account: base1NormalAccount,
+        });
+
+        expect(getByText('ETH')).toBeTruthy();
     });
 
     it('should render token asset with token formatter', () => {

--- a/suite-native/trading-fixtures/src/__fixtures__/accounts.ts
+++ b/suite-native/trading-fixtures/src/__fixtures__/accounts.ts
@@ -1,5 +1,8 @@
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
-import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import {
+    mockWalletAccount,
+    networkSpecificDefaultEthereum,
+} from '@suite-common/wallet-types/mocks';
 import { type StaticSessionId } from '@trezor/device-utils';
 
 export const MOCK_ACCOUNT_DEVICE_SESSION_ID: StaticSessionId = '1@2:3';
@@ -116,6 +119,21 @@ export const eth3legacyAccount = mockWalletAccount({
     descriptor: asAccountDescriptor('eth3legacy'),
     visible: false,
 });
+
+export const base1NormalAccount = mockWalletAccount(
+    {
+        symbol: 'base',
+        accountLabel: 'Base Account #1',
+        deviceState: MOCK_ACCOUNT_DEVICE_SESSION_ID,
+        accountType: 'normal',
+        descriptor: asAccountDescriptor('base1normal'),
+        balance: '1000000000000000000',
+        availableBalance: '1000000000000000000',
+        formattedBalance: '1',
+        visible: true,
+    },
+    networkSpecificDefaultEthereum,
+);
 
 export const sol1normalAccount = mockWalletAccount({
     symbol: 'sol',


### PR DESCRIPTION
## Description

- Display the network-specific symbol for native EVM assets in the trading asset list.

## Notes for QA

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/30085

## Screenshots:
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-20 at 13 37 58" src="https://github.com/user-attachments/assets/89f33b16-922a-4d05-823b-533ea27ccef3" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/30085-incorect-ticker-for-native-evm-assets&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->