### PR TITLE
Prevent stacked crypto/fiat amount inputs from overlapping

### DIFF
--- a/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleInput.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleInput.tsx
@@ -21,6 +21,8 @@ export type AnimatedDoubleInputProps = {
     onInputSwitch?: (activeView: ActiveView) => void;
     switchLabel?: string;
     activeView?: ActiveView;
+    unfocusedOffset?: number;
+    wrapperHeight?: number;
 };
 
 export const AnimatedDoubleInput = ({
@@ -29,6 +31,8 @@ export const AnimatedDoubleInput = ({
     onInputSwitch = noop,
     switchLabel,
     activeView,
+    unfocusedOffset,
+    wrapperHeight,
 }: AnimatedDoubleInputProps) => {
     const primaryInputRef = useRef<InputType | null>(null);
     const secondaryInputRef = useRef<InputType | null>(null);
@@ -76,6 +80,8 @@ export const AnimatedDoubleInput = ({
             onViewSwitch={focusInput}
             switchLabel={switchLabel}
             activeView={activeView}
+            unfocusedOffset={unfocusedOffset}
+            wrapperHeight={wrapperHeight}
         />
     );
 };

--- a/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleView.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleView.tsx
@@ -21,13 +21,17 @@ export type AnimatedDoubleViewProps = {
     onViewSwitch?: (activeView: ActiveView) => void;
     switchLabel?: string;
     activeView?: ActiveView;
+    // Layout overrides for taller views (e.g. the stacked amount inputs) that
+    // would otherwise overlap at the default spacing. See AnimatedViewWrapper.
+    unfocusedOffset?: number;
+    wrapperHeight?: number;
 };
 
 export const ANIMATED_DOUBLE_VIEW_SWITCH_ANIMATION_DURATION = ANIMATION_DURATION;
 export const ANIMATED_DOUBLE_VIEW_WRAPPER_HEIGHT = 108;
 
-const viewsWrapperStyle = prepareNativeStyle(() => ({
-    height: ANIMATED_DOUBLE_VIEW_WRAPPER_HEIGHT,
+const viewsWrapperStyle = prepareNativeStyle<{ wrapperHeight: number }>((_, { wrapperHeight }) => ({
+    height: wrapperHeight,
     justifyContent: 'space-between',
 }));
 
@@ -37,6 +41,8 @@ export const AnimatedDoubleView = ({
     onViewSwitch = noop,
     switchLabel,
     activeView: controlledActiveView,
+    unfocusedOffset,
+    wrapperHeight = ANIMATED_DOUBLE_VIEW_WRAPPER_HEIGHT,
 }: AnimatedDoubleViewProps) => {
     const { applyStyle } = useNativeStyles();
 
@@ -54,17 +60,22 @@ export const AnimatedDoubleView = ({
     }, [activeView, controlledActiveView, onViewSwitch]);
 
     return (
-        <Animated.View layout={LinearTransition} style={applyStyle(viewsWrapperStyle)}>
+        <Animated.View
+            layout={LinearTransition}
+            style={applyStyle(viewsWrapperStyle, { wrapperHeight })}
+        >
             <AnimatedViewWrapper
                 renderView={renderPrimary}
                 focused={activeView === 'primary'}
                 handleViewSwitch={handleViewSwitch}
+                unfocusedOffset={unfocusedOffset}
             />
             <SwitchViewsButton onPress={handleViewSwitch} label={switchLabel} />
             <AnimatedViewWrapper
                 renderView={renderSecondary}
                 focused={activeView === 'secondary'}
                 handleViewSwitch={handleViewSwitch}
+                unfocusedOffset={unfocusedOffset}
             />
         </Animated.View>
     );

--- a/suite-native/atoms/src/AnimatedDoubleView/AnimatedViewWrapper.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/AnimatedViewWrapper.tsx
@@ -18,6 +18,9 @@ export type AnimatedViewWrapperProps = {
     renderView: (props: RenderViewProps) => ReactNode;
     focused: boolean;
     handleViewSwitch: () => void;
+    // Vertical offset of the unfocused view. Taller views (e.g. the stacked
+    // amount inputs) pass a larger value so the two views do not overlap.
+    unfocusedOffset?: number;
 };
 
 export const ANIMATION_DURATION = 300;
@@ -30,7 +33,8 @@ const withPredefinedTiming = (toValue: number) =>
     withTiming(toValue, { duration: ANIMATION_DURATION });
 
 const getScale = (focused: boolean) => (focused ? SCALE_FOCUSED : SCALE_UNFOCUSED);
-const getTranslateY = (focused: boolean) => (focused ? TRANSLATE_Y_FOCUSED : TRANSLATE_Y_UNFOCUSED);
+const getTranslateY = (focused: boolean, unfocusedOffset: number) =>
+    focused ? TRANSLATE_Y_FOCUSED : unfocusedOffset;
 
 export const wrapperStyle = prepareNativeStyle<{ focused: boolean }>((_, { focused }) => ({
     position: 'absolute',
@@ -43,21 +47,22 @@ export const AnimatedViewWrapper = ({
     renderView,
     focused,
     handleViewSwitch,
+    unfocusedOffset = TRANSLATE_Y_UNFOCUSED,
 }: AnimatedViewWrapperProps) => {
     const { applyStyle } = useNativeStyles();
 
     const scale = useSharedValue(getScale(focused));
-    const translateY = useSharedValue(getTranslateY(focused));
+    const translateY = useSharedValue(getTranslateY(focused, unfocusedOffset));
 
     useEffect(() => {
         scale.value = withPredefinedTiming(getScale(focused));
-        translateY.value = withPredefinedTiming(getTranslateY(focused));
+        translateY.value = withPredefinedTiming(getTranslateY(focused, unfocusedOffset));
 
         return () => {
             cancelAnimation(scale);
             cancelAnimation(translateY);
         };
-    }, [focused, scale, translateY]);
+    }, [focused, scale, translateY, unfocusedOffset]);
 
     const animatedStyle = useAnimatedStyle(
         () => ({

--- a/suite-native/atoms/src/BaseAmountInputs.tsx
+++ b/suite-native/atoms/src/BaseAmountInputs.tsx
@@ -19,6 +19,8 @@ export type BaseAmountInputsProps = {
     renderCryptoInput: (props: RenderInputProps) => ReactNode;
     renderFiatInput: (props: RenderInputProps) => ReactNode;
     renderErrorMessage?: (isFiatDisplayed: boolean) => ReactNode;
+    unfocusedOffset?: number;
+    wrapperHeight?: number;
 };
 
 export const BaseAmountInputs = ({
@@ -28,6 +30,8 @@ export const BaseAmountInputs = ({
     renderCryptoInput,
     renderFiatInput,
     renderErrorMessage,
+    unfocusedOffset,
+    wrapperHeight,
 }: BaseAmountInputsProps) => {
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(symbol);
     const singleInputRef = useRef<InputType | null>(null);
@@ -44,6 +48,8 @@ export const BaseAmountInputs = ({
                     renderPrimary={props => renderCryptoInput(props)}
                     renderSecondary={props => renderFiatInput(props)}
                     onInputSwitch={onInputSwitch}
+                    unfocusedOffset={unfocusedOffset}
+                    wrapperHeight={wrapperHeight}
                 />
             ) : (
                 renderCryptoInput({ inputRef: singleInputRef })

--- a/suite-native/module-earn/src/components/EarnAmountInputs.tsx
+++ b/suite-native/module-earn/src/components/EarnAmountInputs.tsx
@@ -5,6 +5,7 @@ import { type AccountKey } from '@suite-common/wallet-types';
 import { type ActiveView, BaseAmountInputs, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
+import { AMOUNT_INPUT_UNFOCUSED_OFFSET, AMOUNT_INPUT_WRAPPER_HEIGHT } from '../constants';
 import { EarnAmountErrorMessage } from './EarnAmountErrorMessage';
 import { EarnCryptoAmountInput } from './EarnCryptoAmountInput';
 import { EarnFiatAmountInput } from './EarnFiatAmountInput';
@@ -33,6 +34,8 @@ export const EarnAmountInputs = ({
             <BaseAmountInputs
                 symbol={symbol}
                 onInputSwitch={onCurrencyChange}
+                unfocusedOffset={AMOUNT_INPUT_UNFOCUSED_OFFSET}
+                wrapperHeight={AMOUNT_INPUT_WRAPPER_HEIGHT}
                 renderTopRow={() => (
                     <>
                         <Text variant="body-sm">

--- a/suite-native/module-earn/src/components/EarnFormScreenFooter.tsx
+++ b/suite-native/module-earn/src/components/EarnFormScreenFooter.tsx
@@ -15,22 +15,19 @@ const screenFooterStyle = prepareNativeStyle(utils => ({
     backgroundColor: utils.colors.surfaceFillPage,
 }));
 
-const rewardsBoxStyle = prepareNativeStyle<{ hasValidationError: boolean }>(
-    (utils, { hasValidationError }) => ({
-        backgroundColor: utils.colors.legacyBackgroundPrimarySubtleOnElevationNegative,
-        borderTopLeftRadius: utils.borders.radii.r16,
-        borderTopRightRadius: utils.borders.radii.r16,
-        borderBottomLeftRadius: utils.borders.radii.r24,
-        borderBottomRightRadius: utils.borders.radii.r24,
-        paddingBottom: utils.spacings.sp48,
-        opacity: hasValidationError ? 0 : 1,
-    }),
-);
+const rewardsBoxStyle = prepareNativeStyle(utils => ({
+    backgroundColor: utils.colors.legacyBackgroundPrimarySubtleOnElevationNegative,
+    borderTopLeftRadius: utils.borders.radii.r16,
+    borderTopRightRadius: utils.borders.radii.r16,
+    borderBottomLeftRadius: utils.borders.radii.r24,
+    borderBottomRightRadius: utils.borders.radii.r24,
+    paddingBottom: utils.spacings.sp48,
+}));
 
-const continueButtonStyle = prepareNativeStyle<{ isEstimatedRewardsVisible: boolean }>(
-    (utils, { isEstimatedRewardsVisible }) => ({
+const continueButtonStyle = prepareNativeStyle<{ isRewardsBoxVisible: boolean }>(
+    (utils, { isRewardsBoxVisible }) => ({
         borderRadius: utils.borders.radii.round,
-        marginTop: isEstimatedRewardsVisible ? -utils.spacings.sp32 : 0,
+        marginTop: isRewardsBoxVisible ? -utils.spacings.sp32 : 0,
     }),
 );
 
@@ -38,7 +35,6 @@ type EarnFormScreenFooterProps = {
     symbol: NetworkSymbol;
     amountValue: string;
     isDisabled: boolean;
-    isDirty: boolean;
     onPress: () => void;
 };
 
@@ -46,7 +42,6 @@ export const EarnFormScreenFooter = ({
     symbol,
     amountValue,
     isDisabled,
-    isDirty,
     onPress,
 }: EarnFormScreenFooterProps) => {
     const { applyStyle } = useNativeStyles();
@@ -71,15 +66,14 @@ export const EarnFormScreenFooter = ({
 
     const buttonIntent = isDisabled ? 'neutral' : 'brand';
     const buttonPriority = isDisabled ? 'secondary' : 'primary';
-    const hasValidationError = isDirty && isDisabled;
-    const isEstimatedRewardsVisible = estimatedRewards !== null;
+    const isRewardsBoxVisible = estimatedRewards !== null && !isDisabled;
 
     return (
         <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
             <ScreenFooterGradient />
             <Box style={applyStyle(screenFooterStyle)}>
-                {isEstimatedRewardsVisible && (
-                    <Box style={applyStyle(rewardsBoxStyle, { hasValidationError })}>
+                {isRewardsBoxVisible && (
+                    <Box style={applyStyle(rewardsBoxStyle)}>
                         <VStack spacing="sp4" paddingTop="sp12" alignItems="center">
                             <Text variant="body-sm" color="contentPrimary">
                                 <Translation id="earn.earnFormScreen.estimatedRewardsLabel" />
@@ -98,7 +92,7 @@ export const EarnFormScreenFooter = ({
                     priority={buttonPriority}
                     onPress={onPress}
                     isDisabled={isDisabled}
-                    style={applyStyle(continueButtonStyle, { isEstimatedRewardsVisible })}
+                    style={applyStyle(continueButtonStyle, { isRewardsBoxVisible })}
                 >
                     <Translation id="generic.buttons.continue" />
                 </Button>

--- a/suite-native/module-earn/src/components/EarnFormScreenFooter.tsx
+++ b/suite-native/module-earn/src/components/EarnFormScreenFooter.tsx
@@ -11,7 +11,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 const screenFooterStyle = prepareNativeStyle(utils => ({
     paddingHorizontal: utils.spacings.sp16,
-    paddingBottom: 0,
+    paddingBottom: utils.spacings.sp16,
     backgroundColor: utils.colors.surfaceFillPage,
 }));
 

--- a/suite-native/module-earn/src/constants.ts
+++ b/suite-native/module-earn/src/constants.ts
@@ -4,6 +4,12 @@ export const STABLECOIN_YIELD_NATIVE_SOURCE_ORIGIN = 'trezor-suite-native://stab
 export const CRYPTO_BALANCE_DECIMALS = 5;
 export const NETWORK_FEE_WARNING_MULTIPLIER = 4;
 
+// The stacked crypto/fiat amount inputs are taller than the shared double-view's
+// default spacing accounts for, so they overlap at the default unfocused offset.
+// Earn screens push the unfocused input down further and grow the wrapper to fit.
+export const AMOUNT_INPUT_UNFOCUSED_OFFSET = 64;
+export const AMOUNT_INPUT_WRAPPER_HEIGHT = 128;
+
 export const USER_CANCELLED_ERROR_CODES = [
     'Failure_PinCancelled',
     'Method_Cancel',

--- a/suite-native/module-earn/src/screens/EarnFormScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnFormScreen.tsx
@@ -64,7 +64,7 @@ export const EarnFormScreen = () => {
         updateFeeLevelThunk,
     } = earnForm;
     const {
-        formState: { isValid, isDirty },
+        formState: { isValid },
     } = form;
 
     const handleSubmit = form.handleSubmit(() => {
@@ -93,7 +93,6 @@ export const EarnFormScreen = () => {
                     symbol={account.symbol}
                     amountValue={amountValue}
                     isDisabled={!isValid || isFeeUnavailable || isPrecomposeError}
-                    isDirty={isDirty}
                     onPress={() => handleSubmit()}
                 />
             }

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -54,6 +54,7 @@ import { YieldDisabledAlert } from '../components/YieldDisabledAlert';
 import { YieldFeeEstimationErrorAlert } from '../components/YieldFeeEstimationErrorAlert';
 import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
 import { YieldWithdrawWarning } from '../components/YieldWithdrawWarning';
+import { AMOUNT_INPUT_UNFOCUSED_OFFSET, AMOUNT_INPUT_WRAPPER_HEIGHT } from '../constants';
 import { useMessageSystemYield } from '../hooks/useMessageSystemYield';
 import { useNavigateBackAnalytics } from '../hooks/useNavigateBackAnalytics';
 import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
@@ -572,6 +573,8 @@ export const YieldWithdrawScreen = () => {
                         <AnimatedDoubleInput
                             activeView={isSharesInput ? 'secondary' : 'primary'}
                             onInputSwitch={handleInputSwitch}
+                            unfocusedOffset={AMOUNT_INPUT_UNFOCUSED_OFFSET}
+                            wrapperHeight={AMOUNT_INPUT_WRAPPER_HEIGHT}
                             renderPrimary={({ inputRef, isDisabled, onPress }) => (
                                 <Input
                                     ref={inputRef}


### PR DESCRIPTION
## Description

Fixed the stacked crypto/fiat amount input (native Send/Earn flows) overlapping on iOS by increasing the unfocused input's offset and container height.
Also fixed the Earn form's rewards box staying mounted when invalid, overlapping the continue button. It now only renders when the form is valid.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29833

## Screenshots:


<img width="402" height="874" alt="Simulator Screenshot - iPhone 17 - 2026-07-28 at 17 40 19" src="https://github.com/user-attachments/assets/2d1b954f-6a7c-410b-8cd3-6cbce6ccf5cd" />

<img width="402" height="874" alt="Simulator Screenshot - iPhone 17 - 2026-07-28 at 17 41 22" src="https://github.com/user-attachments/assets/7c2e768c-89ef-4037-84a5-f6bcd9993c2c" />




