### PR TITLE
fix(suite-native): derive account types from network type

### DIFF
--- a/suite-native/add-coin-account/jest.config.js
+++ b/suite-native/add-coin-account/jest.config.js
@@ -1,0 +1,11 @@
+/**
+ * Jest configuration for native packages.
+ * Keeping this file next to the package.json file instead of providing configuration
+ * with `-c ../../jest.config.native` option in package.json scripts
+ * allows us to run jest tests directly from IDEs.
+ */
+const baseConfig = require('../../jest.config.native');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-native/add-coin-account/package.json
+++ b/suite-native/add-coin-account/package.json
@@ -8,6 +8,9 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
+        "test:unit": "yarn g:jest:native",
+        "test:unit:coverage": "yarn g:jest:native --coverage",
+        "test:unit:watch": "yarn g:jest:native --watch",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "lint:js:fix": "yarn lint:js --fix"
     },

--- a/suite-native/add-coin-account/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/add-coin-account/src/hooks/useAddCoinAccount.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { A, pipe } from '@mobily/ts-belt';
@@ -13,7 +13,6 @@ import {
     type AccountType,
     NORMAL_ACCOUNT_TYPE,
     type NetworkSymbol,
-    networkSymbolCollection,
     networks,
 } from '@suite-common/wallet-config';
 import {
@@ -48,9 +47,10 @@ import {
     type StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
 import { exhaustive } from '@trezor/type-utils';
-import { resolveAfter, typedObjectKeys } from '@trezor/utils';
+import { resolveAfter } from '@trezor/utils';
 
 import { useAddCoinAccountAlerts } from './useAddCoinAccountAlerts';
+import { getAvailableAccountTypesForNetworkSymbol } from '../utils/getAvailableAccountTypesForNetworkSymbol';
 
 export type AddCoinAccountNavigationProps = StackToStackCompositeNavigationProps<
     AddCoinAccountStackParamList,
@@ -120,41 +120,6 @@ export const useAddCoinAccount = (networksSearchQuery?: string) => {
     const [networkSymbolWithTypeToBeAdded, setNetworkSymbolWithTypeToBeAdded] = useState<
         [NetworkSymbol, AddCoinEnabledAccountType] | null
     >(null);
-
-    const availableNetworkAccountTypes = useMemo(() => {
-        // first account type for every network is set to normal and represents default type
-        const availableTypes: Map<NetworkSymbol, [AccountType, ...AccountType[]]> = new Map();
-
-        networkSymbolCollection.forEach(symbol => {
-            // for Cardano and Ethereum only allow latest account type and coinjoin and ledger are not supported
-            const types = typedObjectKeys(networks[symbol].accountTypes).filter(
-                t => !['coinjoin', 'imported', 'ledger'].includes(t),
-            );
-            availableTypes.set(symbol, [
-                NORMAL_ACCOUNT_TYPE,
-                // For Cardano and EVMs allow only normal account type
-                ...([
-                    'ada',
-                    'eth',
-                    'pol',
-                    'bsc',
-                    'sol',
-                    'op',
-                    'base',
-                    'arb',
-                    'rhc',
-                    'avax',
-                ].includes(symbol)
-                    ? []
-                    : types),
-            ]);
-        });
-
-        return availableTypes;
-    }, []);
-
-    const getAvailableAccountTypesForNetworkSymbol = ({ symbol }: { symbol: NetworkSymbol }) =>
-        availableNetworkAccountTypes.get(symbol) ?? [NORMAL_ACCOUNT_TYPE];
 
     const getAccountTypeToBeAddedName = () =>
         networkSymbolWithTypeToBeAdded

--- a/suite-native/add-coin-account/src/utils/__tests__/getAvailableAccountTypesForNetworkSymbol.test.ts
+++ b/suite-native/add-coin-account/src/utils/__tests__/getAvailableAccountTypesForNetworkSymbol.test.ts
@@ -1,0 +1,39 @@
+import { NORMAL_ACCOUNT_TYPE, networkSymbolCollection } from '@suite-common/wallet-config';
+import { isEvmNetwork } from '@suite-common/wallet-utils';
+
+import { getAvailableAccountTypesForNetworkSymbol } from '../getAvailableAccountTypesForNetworkSymbol';
+
+describe('getAvailableAccountTypesForNetworkSymbol', () => {
+    it.each(networkSymbolCollection.filter(isEvmNetwork))(
+        'returns only the normal account type for EVM network %s',
+        symbol => {
+            expect(getAvailableAccountTypesForNetworkSymbol({ symbol })).toEqual([
+                NORMAL_ACCOUNT_TYPE,
+            ]);
+        },
+    );
+
+    it.each(['ada', 'sol'] as const)(
+        'returns only the normal account type for non-EVM exception %s',
+        symbol => {
+            expect(getAvailableAccountTypesForNetworkSymbol({ symbol })).toEqual([
+                NORMAL_ACCOUNT_TYPE,
+            ]);
+        },
+    );
+
+    it('returns supported account types for non-EVM networks', () => {
+        expect(getAvailableAccountTypesForNetworkSymbol({ symbol: 'btc' })).toEqual([
+            NORMAL_ACCOUNT_TYPE,
+            'taproot',
+            'segwit',
+            'legacy',
+        ]);
+    });
+
+    it('filters unsupported account types', () => {
+        expect(getAvailableAccountTypesForNetworkSymbol({ symbol: 'trx' })).toEqual([
+            NORMAL_ACCOUNT_TYPE,
+        ]);
+    });
+});

--- a/suite-native/add-coin-account/src/utils/getAvailableAccountTypesForNetworkSymbol.ts
+++ b/suite-native/add-coin-account/src/utils/getAvailableAccountTypesForNetworkSymbol.ts
@@ -1,0 +1,22 @@
+import {
+    type AccountType,
+    NORMAL_ACCOUNT_TYPE,
+    type NetworkSymbol,
+    networks,
+} from '@suite-common/wallet-config';
+import { isEvmNetwork } from '@suite-common/wallet-utils';
+import { typedObjectKeys } from '@trezor/utils';
+
+export const getAvailableAccountTypesForNetworkSymbol = ({
+    symbol,
+}: {
+    symbol: NetworkSymbol;
+}): [AccountType, ...AccountType[]] => {
+    const accountTypes = typedObjectKeys(networks[symbol].accountTypes).filter(
+        accountType => !['coinjoin', 'imported', 'ledger'].includes(accountType),
+    );
+    const supportsOnlyNormalAccountType =
+        isEvmNetwork(symbol) || symbol === 'ada' || symbol === 'sol';
+
+    return [NORMAL_ACCOUNT_TYPE, ...(supportsOnlyNormalAccountType ? [] : accountTypes)];
+};


### PR DESCRIPTION
## Description

### Summary

- Derive normal-only account availability for EVM networks using `isEvmNetwork` instead of a hard-coded symbol list.
- Keep Cardano (`ada`) and Solana (`sol`) as explicit normal-only exceptions.
- Preserve filtering of unsupported `coinjoin`, `imported`, and `ledger` account types.
- Extract the account-type policy into a testable helper and add Jest configuration for the package.

### Changelog

Suite Native now consistently exposes only the normal account type for every EVM network.

## Notes for QA

Please verify that:

- EVM networks expose only the normal account type.
- `ada` and `sol` remain normal-only.
- Bitcoin still exposes normal, Taproot, SegWit, and legacy account types.
- Unsupported account types remain filtered.

The intentional behavior change affects the `tsep` and `thod` debug EVM networks, which no longer expose their legacy account type. Production EVM behavior is unchanged.



## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30086


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=codex/issue-30086-normal-account-types&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->