### PR TITLE
chore(message-system): add message about Cardano network sync issues

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2026-07-14T12:00:00+00:00",
-    "sequence": 148,
+    "timestamp": "2026-07-20T00:00:00+00:00",
+    "sequence": 149,
     "actions": [
         {
             "conditions": [
@@ -1113,6 +1113,43 @@
                     }
                 },
                 "context": { "domain": ["accounts.coinjoin", "accounts.btc.coinjoin"] }
+            }
+        },
+        {
+            "conditions": [
+                {
+                    "settings": [
+                        {
+                            "ada": true
+                        }
+                    ],
+                    "environment": {
+                        "desktop": "*",
+                        "mobile": "*",
+                        "web": "*"
+                    }
+                }
+            ],
+            "message": {
+                "id": "17152a45-0802-4c7f-8165-e551e230688d",
+                "priority": 92,
+                "dismissible": true,
+                "variant": "warning",
+                "category": ["banner"],
+                "content": {
+                    "en": "We’re having temporary syncing issues with the Cardano network, which may cause delays or errors. Your Cardano assets are completely safe. Thanks for your patience.",
+                    "es": "Estamos teniendo problemas temporales de sincronización con la red Cardano, lo que puede causar retrasos o errores. Tus activos de Cardano están completamente seguros. Gracias por tu paciencia.",
+                    "cs": "Máme dočasné problémy se synchronizací sítě Cardano, což může způsobit zpoždění nebo chyby. Vaše prostředky v Cardano jsou zcela v bezpečí. Děkujeme za trpělivost.",
+                    "ru": "У нас возникли временные проблемы с синхронизацией сети Cardano, что может вызвать задержки или ошибки. Ваши активы Cardano находятся в полной безопасности. Спасибо за терпение.",
+                    "ja": "Cardano ネットワークで一時的な同期の問題が発生しており、遅延やエラーが発生する可能性があります。お客様の Cardano 資産は完全に安全です。しばらくお待ちください。",
+                    "hu": "Átmeneti szinkronizálási problémáink vannak a(z) Cardano hálózattal, ami késéseket vagy hibákat okozhat. A(z) Cardano eszközei teljes biztonságban vannak. Köszönjük türelmét.",
+                    "it": "Stiamo riscontrando problemi temporanei di sincronizzazione con la rete Cardano, che potrebbero causare ritardi o errori. I tuoi asset Cardano sono completamente al sicuro. Grazie per la pazienza.",
+                    "fr": "Nous rencontrons des problèmes de synchronisation temporaires avec le réseau Cardano, ce qui peut entraîner des retards ou des erreurs. Vos actifs Cardano sont en parfaite sécurité. Merci de votre patience.",
+                    "de": "Wir haben vorübergehende Synchronisierungsprobleme mit dem Cardano-Netzwerk, was zu Verzögerungen oder Fehlern führen kann. Deine Cardano-Assets sind vollkommen sicher. Danke für deine Geduld.",
+                    "tr": "Cardano ağıyla ilgili geçici senkronizasyon sorunları yaşıyoruz, bu da gecikmelere veya hatalara neden olabilir. Cardano varlıklarınız tamamen güvendedir. Sabrınız için teşekkürler.",
+                    "pt": "Estamos enfrentando problemas temporários de sincronização com a rede Cardano, o que pode causar atrasos ou erros. Seus ativos Cardano estão totalmente seguros. Obrigado pela sua paciência.",
+                    "uk": "У нас виникли тимчасові проблеми з синхронізацією мережі Cardano, що може спричинити затримки або помилки. Ваші активи Cardano у цілковитій безпеці. Дякуємо за терпіння."
+                }
             }
         },
         {


### PR DESCRIPTION
## Description

Display message about Cardano network sync issues.

## Notes for QA

Enable Cardano in the device settings and check that the banner is visible.

## Screenshots:
<img width="1457" height="166" alt="Screenshot 2026-07-20 at 13 29 22" src="https://github.com/user-attachments/assets/9db82343-767c-4585-a08b-31b61e2f2e71" />

<img width="1453" height="160" alt="Screenshot 2026-07-20 at 13 29 53" src="https://github.com/user-attachments/assets/b80299d2-7280-47f0-97ed-904565cb0488" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is limited to suite-common/message-system/config/config.v1.json, a data/config file for the in-app message system (used for banners, notifications, and feature flags delivered via the message system). None of the 118 candidate E2E tests analyzed reference or exercise the message-system config, its parsing, or its rendering (no test descriptions mention in-app messages, feature announcements, or the message-system banner infrastructure). Since there is no static or inferable coverage for this config file's consumers, no targeted E2E test can be confidently recommended; verification should rely on unit/schema validation tests for the message-system package and manual/visual QA of any banners driven by this config.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/message-system/config/config.v1.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-common/message-system/config/config.v1.json`

_Updated: 2026-07-20T12:09:34.865Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/message-system-add-ada-network-sync-issues/web/](https://dev.suite.sldev.cz/suite-web/chore/message-system-add-ada-network-sync-issues/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/message-system-add-ada-network-sync-issues&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/message-system-add-ada-network-sync-issues&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/message-system-add-ada-network-sync-issues&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-20T12:13:06.504Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-20T12:12:55.849Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->