### PR TITLE
fix(suite-desktop): fix macOS desktop update

### DIFF
--- a/packages/suite-desktop-core/src/modules/auto-updater.ts
+++ b/packages/suite-desktop-core/src/modules/auto-updater.ts
@@ -186,7 +186,17 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
 
     autoUpdater.on('update-downloaded', async (info: UpdateDownloadedEvent) => {
         const { version, releaseDate, downloadedFile, releaseNotes } = info;
-        // Disable installation of the downloaded file before verification is complete
+
+        // Need to make the event handler async before setting `autoInstallOnAppQuit = false` here, because the Node.js
+        // EventEmitter is synchronous, and it would cause a macOS specific bug during app update, see upstream code:
+        // https://github.com/electron-userland/electron-builder/blob/a5121de49582eaa8870d4c05e6ae55eff160a592/packages/electron-updater/src/MacUpdater.ts#L253-L255
+        // autoInstallOnAppQuit is considered a permanent setting, not something that can toggle on/off during the process.
+        // → we need to make sure the MacUpdater code finishes with previous `autoInstallOnAppQuit` value.
+        await Promise.resolve();
+
+        // Disable installation of the downloaded file before our own verification is complete, it's quite hacky but
+        // electron-updater doesn't have an interface to delay the installation with an arbitrary async function.
+        // TODO refactor https://github.com/electron-userland/electron-builder/issues/10010
         const previousAutoInstallOnAppQuit = autoUpdater.autoInstallOnAppQuit;
         autoUpdater.autoInstallOnAppQuit = false;
 


### PR DESCRIPTION
## Description

Followup to https://github.com/trezor/trezor-suite/pull/29760 which introduced a bug on macOS, breaking the update flow.
The app wouldn't quit when `autoUpdater.quitAndInstall(true, true)` is called, because when we set the `autoInstallOnAppQuit = false` to prevent the unverified binary from installing, a sync/async bug causes electron-updater to evaluate it at wrong time.

Oneliner hacky fix for a hacky security hotfix → this shall be fixed by the proposed upstream issue, if it is accepted by the maintainers.

## Notes for QA

[Build desktop apps](https://github.com/trezor/trezor-suite/actions/runs/29741240218) from this branch rebased on `release/26.7` but that's not testable, because macOS cannot update from non-codesign to codesign, like you can on Linux and Windows :face_with_diagonal_mouth:  
I tested it myself with a local setup, see video :heavy_check_mark: 

## Screenshots:

Tested update from this build to 37.1 autoupdate testing version from last RC

https://github.com/user-attachments/assets/49f805d5-8d6e-4d63-bc77-02622f87e838

