### PR TITLE
fix(native): show bootloader status in device switcher

### DIFF
--- a/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
@@ -73,7 +73,7 @@ export const DeviceItemContent = React.memo(
                 isConnected: d.connected,
                 label: selectDeviceLabelOrNameById(state, d.id),
                 walletNumber: d.walletNumber,
-                isDeviceInBootloaderMode: !state && selectShouldFactoryResetBeVisible(state),
+                isDeviceInBootloaderMode: !device && selectShouldFactoryResetBeVisible(state),
                 useEmptyPassphrase: d.useEmptyPassphrase,
                 staticSessionId: d.state?.staticSessionId,
             };


### PR DESCRIPTION
Show correct device status in the device switcher on native.

## Notes for QA

**Happy paths**
- Selected device in bootloader mode → open device switcher → header shows **"Bootloader mode"** (was "Connected")
- Succesfully connected / disconnected / pin locked / thp locked is shown correctly as well


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30111

## Screenshots:
<img width="449" height="553" alt="Screenshot 2026-07-20 at 14 47 36" src="https://github.com/user-attachments/assets/5abcb185-dd6a-4509-85a3-a63b668fb756" />
<img width="442" height="494" alt="Screenshot 2026-07-20 at 14 47 44" src="https://github.com/user-attachments/assets/9faa0095-275d-4875-ab7b-c686c77ba07e" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=native/fix-bootloader-connection-status&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->