### PR TITLE
fix(packages): declare workspace type entries

### DIFF
--- a/networks/cardano/network-cardano/package.json
+++ b/networks/cardano/network-cardano/package.json
@@ -6,10 +6,22 @@
     "main": "./src/index.ts",
     "type": "module",
     "exports": {
-        "./constants": "./src/constants/index.ts",
-        "./runtime": "./src/runtime/index.ts",
-        "./types": "./src/types/index.ts",
-        ".": "./src/index.ts"
+        "./constants": {
+            "types": "./libDev/src/constants/index.d.ts",
+            "default": "./src/constants/index.ts"
+        },
+        "./runtime": {
+            "types": "./libDev/src/runtime/index.d.ts",
+            "default": "./src/runtime/index.ts"
+        },
+        "./types": {
+            "types": "./libDev/src/types/index.d.ts",
+            "default": "./src/types/index.ts"
+        },
+        ".": {
+            "types": "./libDev/src/index.d.ts",
+            "default": "./src/index.ts"
+        }
     },
     "publishConfig": {
         "main": "./lib/index.js",
@@ -47,5 +59,6 @@
     "dependencies": {
         "@fivebinaries/coin-selection": "3.0.0",
         "cbor": "^10.0.12"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/networks/ripple/network-ripple/package.json
+++ b/networks/ripple/network-ripple/package.json
@@ -6,10 +6,22 @@
     "main": "./src/index.ts",
     "type": "module",
     "exports": {
-        "./constants": "./src/constants/index.ts",
-        "./runtime": "./src/runtime/index.ts",
-        "./types": "./src/types/index.ts",
-        ".": "./src/index.ts"
+        "./constants": {
+            "types": "./libDev/src/constants/index.d.ts",
+            "default": "./src/constants/index.ts"
+        },
+        "./runtime": {
+            "types": "./libDev/src/runtime/index.d.ts",
+            "default": "./src/runtime/index.ts"
+        },
+        "./types": {
+            "types": "./libDev/src/types/index.d.ts",
+            "default": "./src/types/index.ts"
+        },
+        ".": {
+            "types": "./libDev/src/index.d.ts",
+            "default": "./src/index.ts"
+        }
     },
     "publishConfig": {
         "main": "./lib/index.js",
@@ -46,5 +58,6 @@
     },
     "dependencies": {
         "xrpl": "4.6.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/networks/solana/network-solana/package.json
+++ b/networks/solana/network-solana/package.json
@@ -6,10 +6,22 @@
     "main": "./src/index.ts",
     "type": "module",
     "exports": {
-        "./constants": "./src/constants/index.ts",
-        "./runtime": "./src/runtime/index.ts",
-        "./types": "./src/types/index.ts",
-        ".": "./src/index.ts"
+        "./constants": {
+            "types": "./libDev/src/constants/index.d.ts",
+            "default": "./src/constants/index.ts"
+        },
+        "./runtime": {
+            "types": "./libDev/src/runtime/index.d.ts",
+            "default": "./src/runtime/index.ts"
+        },
+        "./types": {
+            "types": "./libDev/src/types/index.d.ts",
+            "default": "./src/types/index.ts"
+        },
+        ".": {
+            "types": "./libDev/src/index.d.ts",
+            "default": "./src/index.ts"
+        }
     },
     "publishConfig": {
         "main": "./lib/index.js",
@@ -56,5 +68,6 @@
         "@solana/rpc-types": "^6.9.0",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/networks/stellar/network-stellar/package.json
+++ b/networks/stellar/network-stellar/package.json
@@ -6,10 +6,22 @@
     "main": "./src/index.ts",
     "type": "module",
     "exports": {
-        "./constants": "./src/constants/index.ts",
-        "./runtime": "./src/runtime/index.ts",
-        "./types": "./src/types/index.ts",
-        ".": "./src/index.ts"
+        "./constants": {
+            "types": "./libDev/src/constants/index.d.ts",
+            "default": "./src/constants/index.ts"
+        },
+        "./runtime": {
+            "types": "./libDev/src/runtime/index.d.ts",
+            "default": "./src/runtime/index.ts"
+        },
+        "./types": {
+            "types": "./libDev/src/types/index.d.ts",
+            "default": "./src/types/index.ts"
+        },
+        ".": {
+            "types": "./libDev/src/index.d.ts",
+            "default": "./src/index.ts"
+        }
     },
     "publishConfig": {
         "main": "./lib/index.js",
@@ -47,5 +59,6 @@
     "dependencies": {
         "@stellar/stellar-sdk": "14.5.0",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/networks/tron/network-tron/package.json
+++ b/networks/tron/network-tron/package.json
@@ -6,9 +6,18 @@
     "main": "./src/index.ts",
     "type": "module",
     "exports": {
-        "./constants": "./src/constants/index.ts",
-        "./utils": "./src/utils/index.ts",
-        ".": "./src/index.ts"
+        "./constants": {
+            "types": "./libDev/src/constants/index.d.ts",
+            "default": "./src/constants/index.ts"
+        },
+        "./utils": {
+            "types": "./libDev/src/utils/index.d.ts",
+            "default": "./src/utils/index.ts"
+        },
+        ".": {
+            "types": "./libDev/src/index.d.ts",
+            "default": "./src/index.ts"
+        }
     },
     "publishConfig": {
         "main": "./lib/index.js",
@@ -41,5 +50,6 @@
     },
     "dependencies": {
         "@noble/hashes": "^2.0.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/address-validator/package.json
+++ b/packages/address-validator/package.json
@@ -21,5 +21,6 @@
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/analytics-log-server/package.json
+++ b/packages/analytics-log-server/package.json
@@ -3,10 +3,10 @@
     "private": true,
     "type": "module",
     "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
+    "types": "./libDev/index.d.ts",
     "exports": {
         ".": {
-            "types": "./dist/index.d.ts",
+            "types": "./libDev/index.d.ts",
             "default": "./dist/index.js"
         }
     },

--- a/packages/analytics-uploader/package.json
+++ b/packages/analytics-uploader/package.json
@@ -16,5 +16,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/asset-utils/package.json
+++ b/packages/asset-utils/package.json
@@ -12,5 +12,6 @@
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/auth-server/package.json
+++ b/packages/auth-server/package.json
@@ -22,5 +22,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -41,5 +41,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/blockchain-link-utils/package.json
+++ b/packages/blockchain-link-utils/package.json
@@ -41,5 +41,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -40,6 +40,38 @@
                 "types": "./lib/index.d.ts",
                 "default": "./lib/index.js"
             },
+            "./workers/baseWorker": {
+                "types": "./lib/workers/baseWorker.d.ts",
+                "default": "./lib/workers/baseWorker.js"
+            },
+            "./workers/blockbook": {
+                "types": "./lib/workers/blockbook/index.d.ts",
+                "default": "./lib/workers/blockbook/index.js"
+            },
+            "./workers/blockfrost": {
+                "types": "./lib/workers/blockfrost/index.d.ts",
+                "default": "./lib/workers/blockfrost/index.js"
+            },
+            "./workers/electrum": {
+                "types": "./lib/workers/electrum/index.d.ts",
+                "default": "./lib/workers/electrum/index.js"
+            },
+            "./workers/evm-rpc": {
+                "types": "./lib/workers/evm-rpc/index.d.ts",
+                "default": "./lib/workers/evm-rpc/index.js"
+            },
+            "./workers/ripple": {
+                "types": "./lib/workers/ripple/index.d.ts",
+                "default": "./lib/workers/ripple/index.js"
+            },
+            "./workers/solana": {
+                "types": "./lib/workers/solana/index.d.ts",
+                "default": "./lib/workers/solana/index.js"
+            },
+            "./workers/stellar": {
+                "types": "./lib/workers/stellar/index.d.ts",
+                "default": "./lib/workers/stellar/index.js"
+            },
             "./lib/*": "./lib/*"
         },
         "browser": {

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -122,5 +122,64 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
+    },
+    "types": "./libDev/src/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./libDev/src/index.d.ts",
+            "default": "./src/index.ts"
+        },
+        "./workers/baseWorker": {
+            "types": "./libDev/workers/baseWorker/index.d.ts",
+            "default": "./workers/baseWorker/index.ts"
+        },
+        "./workers/blockbook": {
+            "types": "./libDev/workers/blockbook/index.d.ts",
+            "default": "./workers/blockbook/index.ts"
+        },
+        "./workers/blockfrost": {
+            "types": "./libDev/workers/blockfrost/index.d.ts",
+            "default": "./workers/blockfrost/index.ts"
+        },
+        "./workers/electrum": {
+            "types": "./libDev/workers/electrum/index.d.ts",
+            "default": "./workers/electrum/index.ts"
+        },
+        "./workers/evm-rpc": {
+            "types": "./libDev/workers/evm-rpc/index.d.ts",
+            "default": "./workers/evm-rpc/index.ts"
+        },
+        "./workers/ripple": {
+            "types": "./libDev/workers/ripple/index.d.ts",
+            "default": "./workers/ripple/index.ts"
+        },
+        "./workers/solana": {
+            "types": "./libDev/workers/solana/index.d.ts",
+            "default": "./workers/solana/index.ts"
+        },
+        "./workers/stellar": {
+            "types": "./libDev/workers/stellar/index.d.ts",
+            "default": "./workers/stellar/index.ts"
+        },
+        "./src/workers/blockbook": {
+            "types": "./libDev/src/workers/blockbook/index.d.ts",
+            "default": "./src/workers/blockbook/index.ts"
+        },
+        "./src/workers/blockbook/websocket": {
+            "types": "./libDev/src/workers/blockbook/websocket.d.ts",
+            "default": "./src/workers/blockbook/websocket.ts"
+        },
+        "./src/workers/blockfrost": {
+            "types": "./libDev/src/workers/blockfrost/index.d.ts",
+            "default": "./src/workers/blockfrost/index.ts"
+        },
+        "./src/workers/ripple": {
+            "types": "./libDev/src/workers/ripple/index.d.ts",
+            "default": "./src/workers/ripple/index.ts"
+        },
+        "./src/utils/socks-proxy-agent.ts": {
+            "types": "./libDev/src/utils/socks-proxy-agent.d.ts",
+            "default": "./src/utils/socks-proxy-agent.ts"
+        }
     }
 }

--- a/packages/blockchain-link/src/workers/baseWorker.ts
+++ b/packages/blockchain-link/src/workers/baseWorker.ts
@@ -1,3 +1,5 @@
+/// <reference lib="webworker" />
+
 // Abstract class extended by WorkerModule (see /src/workers/*/index.ts)
 // Provides an interface of WorkerGlobalScope to behave as regular WebWorker (see /src/index.ts)
 // Goal is to Make no difference from the implementation point of view between:

--- a/packages/blockchain-link/workers/baseWorker/index.ts
+++ b/packages/blockchain-link/workers/baseWorker/index.ts
@@ -1,0 +1,1 @@
+export * from '../../src/workers/baseWorker';

--- a/packages/blockchain-link/workers/blockbook/index.ts
+++ b/packages/blockchain-link/workers/blockbook/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/blockbook';

--- a/packages/blockchain-link/workers/blockfrost/index.ts
+++ b/packages/blockchain-link/workers/blockfrost/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/blockfrost';

--- a/packages/blockchain-link/workers/electrum/index.ts
+++ b/packages/blockchain-link/workers/electrum/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/electrum';

--- a/packages/blockchain-link/workers/evm-rpc/index.ts
+++ b/packages/blockchain-link/workers/evm-rpc/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/evm-rpc';

--- a/packages/blockchain-link/workers/ripple/index.ts
+++ b/packages/blockchain-link/workers/ripple/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/ripple';

--- a/packages/blockchain-link/workers/solana/index.ts
+++ b/packages/blockchain-link/workers/solana/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/solana';

--- a/packages/blockchain-link/workers/stellar/index.ts
+++ b/packages/blockchain-link/workers/stellar/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/stellar';

--- a/packages/bundler-security/package.json
+++ b/packages/bundler-security/package.json
@@ -13,5 +13,6 @@
     },
     "dependencies": {
         "webpack": "5.108.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/coinjoin/package.json
+++ b/packages/coinjoin/package.json
@@ -41,5 +41,6 @@
         "node-fetch": "^3.3.2",
         "socks-proxy-agent": "8.0.5",
         "ws": "^8.20.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -61,5 +61,6 @@
         "stylelint": "^17.1.1",
         "stylelint-config-standard": "^40.0.0",
         "typescript-styled-plugin": "^0.18.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/connect-cli/package.json
+++ b/packages/connect-cli/package.json
@@ -23,5 +23,6 @@
     },
     "devDependencies": {
         "tsx": "^4.21.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -31,6 +31,10 @@
                 "types": "./lib/index.d.ts",
                 "default": "./lib/index.js"
             },
+            "./pathUtils": {
+                "types": "./lib/utils/pathUtils.d.ts",
+                "default": "./lib/utils/pathUtils.js"
+            },
             "./lib/*": "./lib/*",
             "./lib/constants": {
                 "types": "./lib/constants/index.d.ts",
@@ -80,5 +84,72 @@
         "@types/chrome": "^0.1.40",
         "@types/jest": "30.0.0",
         "@types/node": "22.13.10"
+    },
+    "types": "./libDev/src/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./libDev/src/index.d.ts",
+            "default": "./src/index.ts"
+        },
+        "./pathUtils": {
+            "types": "./libDev/src/utils/pathUtils.d.ts",
+            "default": "./src/utils/pathUtils.ts"
+        },
+        "./src/callableMethods": {
+            "types": "./libDev/src/callableMethods.d.ts",
+            "default": "./src/callableMethods.ts"
+        },
+        "./src/constants": {
+            "types": "./libDev/src/constants/index.d.ts",
+            "default": "./src/constants/index.ts"
+        },
+        "./src/constants/*": {
+            "types": "./libDev/src/constants/*.d.ts",
+            "default": "./src/constants/*.ts"
+        },
+        "./src/data": {
+            "types": "./libDev/src/data/index.d.ts",
+            "default": "./src/data/index.ts"
+        },
+        "./src/data/*": {
+            "types": "./libDev/src/data/*.d.ts",
+            "default": "./src/data/*.ts"
+        },
+        "./src/events": {
+            "types": "./libDev/src/events/index.d.ts",
+            "default": "./src/events/index.ts"
+        },
+        "./src/events/*": {
+            "types": "./libDev/src/events/*.d.ts",
+            "default": "./src/events/*.ts"
+        },
+        "./src/factory": {
+            "types": "./libDev/src/factory.d.ts",
+            "default": "./src/factory.ts"
+        },
+        "./src/impl/*": {
+            "types": "./libDev/src/impl/*.d.ts",
+            "default": "./src/impl/*.ts"
+        },
+        "./src/messageChannel/*": {
+            "types": "./libDev/src/messageChannel/*.d.ts",
+            "default": "./src/messageChannel/*.ts"
+        },
+        "./src/types": {
+            "types": "./libDev/src/types/index.d.ts",
+            "default": "./src/types/index.ts"
+        },
+        "./src/types/api": {
+            "types": "./libDev/src/types/api/index.d.ts",
+            "default": "./src/types/api/index.ts"
+        },
+        "./src/types/*": {
+            "types": "./libDev/src/types/*.d.ts",
+            "default": "./src/types/*.ts"
+        },
+        "./src/utils/*": {
+            "types": "./libDev/src/utils/*.d.ts",
+            "default": "./src/utils/*.ts"
+        }
     }
 }

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -17,6 +17,7 @@
     },
     "license": "MIT",
     "description": "Collection of assets and utils used by trezor-connect library.",
+    "sideEffects": false,
     "main": "./src/index.ts",
     "files": [
         "lib/",

--- a/packages/connect-common/src/index.ts
+++ b/packages/connect-common/src/index.ts
@@ -16,6 +16,7 @@ export {
     corsValidator,
 } from './data/connectSettings';
 export * from './utils/debug';
+export * from './utils/cancelParams';
 export * from './utils/urlUtils';
 export { getSerializedPath, getSlip44ByPath, validatePath } from './utils/pathUtils';
 export { connectCallableMethods } from './callableMethods';

--- a/packages/connect-common/src/index.ts
+++ b/packages/connect-common/src/index.ts
@@ -18,5 +18,7 @@ export {
 export * from './utils/debug';
 export * from './utils/cancelParams';
 export * from './utils/urlUtils';
+// Path helpers needed by shared consumers (Suite, connect-popup, trading). The rest of
+// utils/pathUtils stays connect-internal to keep this public barrel minimal (see #27376).
 export { getSerializedPath, getSlip44ByPath, validatePath } from './utils/pathUtils';
 export { connectCallableMethods } from './callableMethods';

--- a/packages/connect-common/src/utils/pathUtils.ts
+++ b/packages/connect-common/src/utils/pathUtils.ts
@@ -7,7 +7,6 @@ import {
     toHardenedPathPart,
 } from '@trezor/crypto-utils';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
-import { arrayPartition } from '@trezor/utils';
 
 import { ERRORS } from '../constants';
 import type { CoinInfo } from '../types/coinInfo';
@@ -208,54 +207,4 @@ export const getLabel = (label: string, coinInfo?: CoinInfo) => {
     }
 
     return label.replace('#NETWORK', '');
-};
-
-/** @deprecated Temporary diagnostic method */
-export const __btcUnknownTxDebug__ = (
-    description: string,
-    inputs: { address_n?: number[]; orig_hash?: any }[],
-    addresses:
-        | { used: { path: string }[]; unused: { path: string }[]; change: { path: string }[] }
-        | undefined,
-) => {
-    try {
-        if (inputs.some(i => i.orig_hash)) {
-            // In RBF, account's change addresses are modified so the right change address is selected,
-            // therefore it's expected that the inputs can't be found in account's addresses.
-            return;
-        }
-
-        const accountAddressPaths = new Set(
-            addresses
-                ? addresses.change.concat(addresses.used, addresses.unused).map(({ path }) => path)
-                : [],
-        );
-
-        const [matched, unmatched] = arrayPartition(
-            inputs
-                .map(input => input.address_n)
-                .filter((addr): addr is number[] => Array.isArray(addr) && addr.length > 0),
-            addr => accountAddressPaths.has(getSerializedPath(addr)),
-        );
-
-        const toReadable = (address_n: number[]) =>
-            `${address_n[address_n.length - 2] ? 'change' : 'receive'}/${address_n[address_n.length - 1]}`;
-
-        if (unmatched.length) {
-            // [btc-unknown-tx-debug] the selected account does not contain paths used by the tx inputs.
-            // This can make Connect build a pending tx with wrong or empty vin addresses, which can then
-            // classify the optimistic pending tx incorrectly before the backend response arrives.
-            // Intentionally no paths / addresses / descriptor / txid: these reach Sentry and could
-            // deanonymize the user. accountType + symbol are low-cardinality, non-PII.
-            console.error(`[btc-unknown-tx-debug-v2] ${description}`, {
-                knownUsedCount: addresses?.used.length,
-                knownUnusedCount: addresses?.unused.length,
-                knownChangeCount: addresses?.change.length,
-                matchedInputs: matched.map(toReadable),
-                unmatchedInputs: unmatched.map(toReadable),
-            });
-        }
-    } catch {
-        // empty
-    }
 };

--- a/packages/connect-data/package.json
+++ b/packages/connect-data/package.json
@@ -51,5 +51,6 @@
         "@types/chrome": "^0.1.40",
         "@types/jest": "30.0.0",
         "@types/node": "22.13.10"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/connect-electron/package.json
+++ b/packages/connect-electron/package.json
@@ -16,5 +16,6 @@
         "@trezor/connect-common": "workspace:*",
         "@trezor/ipc-proxy": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/connect-explorer-theme/package.json
+++ b/packages/connect-explorer-theme/package.json
@@ -60,5 +60,6 @@
     },
     "sideEffects": [
         "./src/polyfill.ts"
-    ]
+    ],
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/connect-explorer/src/pages/_app.tsx
+++ b/packages/connect-explorer/src/pages/_app.tsx
@@ -31,7 +31,7 @@ const ThemeComponent = ({ Component, pageProps }: AppProps) => {
     }, [router]);
 
     return (
-        <ThemeProvider theme={intermediaryTheme[theme]}>
+        <ThemeProvider theme={{ variant: theme, ...intermediaryTheme[theme] }}>
             <Provider store={store}>
                 <Component {...pageProps} />
             </Provider>

--- a/packages/connect-mobile/package.json
+++ b/packages/connect-mobile/package.json
@@ -31,5 +31,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/connect-plugin-ethereum/package.json
+++ b/packages/connect-plugin-ethereum/package.json
@@ -42,5 +42,6 @@
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib",
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/connect-plugin-stellar/package.json
+++ b/packages/connect-plugin-stellar/package.json
@@ -42,5 +42,6 @@
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib",
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -61,5 +61,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "types": "./libDev/connect-web/src/index.d.ts"
 }

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -18,6 +18,7 @@ const TrezorConnect: TrezorConnectPublicAPI<ConnectDynamicSettings> = factoryPub
 );
 
 export default TrezorConnect;
+export { CoreInSuiteDesktop, CoreInSuiteWeb };
 export * from '@trezor/connect-common/src/constants';
 export * from '@trezor/connect-common/src/events';
 export * from '@trezor/connect-common/src/types';

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -36,7 +36,7 @@
         "CHANGELOG.md",
         "!lib/proxy"
     ],
-    "types": "src/index.ts",
+    "types": "./libDev/src/index.d.ts",
     "scripts": {
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib && DTS_OUT_DIR=lib yarn build:dts:inline",
         "build:dts:inline": "node ../../scripts/inline-devdep-types.mjs",

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -1,18 +1,13 @@
-// note: at the moment, there is something in the root of @trezor/connect-common that pulls entire PROTO runtime, thus
-// these targeted imports
-import { CORE_CALL_CANCEL, POPUP } from '@trezor/connect-common/src/events';
-import { factoryPublic } from '@trezor/connect-common/src/factory';
-import { TrezorConnectDynamic } from '@trezor/connect-common/src/impl/dynamic';
-// Import as src not lib due to webpack issues with inlining content script later
-import { ServiceWorkerWindowChannel } from '@trezor/connect-common/src/messageChannel/serviceworker-window';
-import type {
-    ConnectDynamicSettings,
-    TrezorConnectPublicAPI,
-} from '@trezor/connect-common/src/types';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- intra-tier wiring: connect-webextension composes implementations from connect-web (see #27376)
-import { CoreInSuiteDesktop } from '@trezor/connect-web/src/impl/core-in-suite-desktop';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- intra-tier wiring: connect-webextension composes implementations from connect-web (see #27376)
-import { CoreInSuiteWeb } from '@trezor/connect-web/src/impl/core-in-suite-web';
+import {
+    CORE_CALL_CANCEL,
+    type ConnectDynamicSettings,
+    POPUP,
+    ServiceWorkerWindowChannel,
+    TrezorConnectDynamic,
+    type TrezorConnectPublicAPI,
+    factoryPublic,
+} from '@trezor/connect-common';
+import { CoreInSuiteDesktop, CoreInSuiteWeb } from '@trezor/connect-web';
 
 const impl = new TrezorConnectDynamic({
     implementations: {
@@ -106,6 +101,4 @@ initProxyChannel();
 
 // eslint-disable-next-line import/no-default-export
 export default TrezorConnect;
-export * from '@trezor/connect-common/src/constants';
-export * from '@trezor/connect-common/src/events';
-export type * from '@trezor/connect-common/src/types';
+export * from '@trezor/connect-common';

--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -1,15 +1,15 @@
-import { ERRORS } from '@trezor/connect-common/src/constants';
-import { CORE_CALL, POPUP, createErrorMessage } from '@trezor/connect-common/src/events';
-import { factoryPublic } from '@trezor/connect-common/src/factory';
-import { WindowServiceWorkerChannel } from '@trezor/connect-common/src/messageChannel/window-serviceworker';
-import type {
-    ConnectDynamicSettings,
-    TrezorConnectPublicAPI,
-} from '@trezor/connect-common/src/types';
 import {
+    CORE_CALL,
     type CancelParams,
+    type ConnectDynamicSettings,
+    ERRORS,
+    POPUP,
+    type TrezorConnectPublicAPI,
+    WindowServiceWorkerChannel,
     createCoreCallCancelMessage,
-} from '@trezor/connect-common/src/utils/cancelParams';
+    createErrorMessage,
+    factoryPublic,
+} from '@trezor/connect-common';
 
 let _channel: any;
 
@@ -82,6 +82,4 @@ const TrezorConnect: TrezorConnectPublicAPI<ConnectDynamicSettings> = factoryPub
 
 // eslint-disable-next-line import/no-default-export
 export default TrezorConnect;
-export * from '@trezor/connect-common/src/constants';
-export * from '@trezor/connect-common/src/events';
-export * from '@trezor/connect-common/src/types';
+export * from '@trezor/connect-common';

--- a/packages/connect-webextension/tsconfig.json
+++ b/packages/connect-webextension/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
         "isolatedModules": false,
-        "outDir": "./lib",
+        "outDir": "./libDev",
         "types": ["chrome", "w3c-web-usb"]
     },
     "include": ["**/*.ts", "**/*.js"],

--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
 import { UI_REQUEST, UI_RESPONSE } from '@trezor/connect-common';
 import type { ApplySettings } from '@trezor/protobuf/src/definitions';
 import { BridgeTransport } from '@trezor/transport-common';
@@ -9,7 +7,7 @@ import { versionUtils } from '@trezor/utils';
 
 import { THP_CREDENTIALS_AUTOCONNECT } from './common-thp-credentials';
 
-// import TrezorConnect from '../src';
+import TrezorConnect from '../src';
 
 // Read emulator start options from EMULATOR_START_OPTS env var (JSON string set by run.ts).
 // In browser mode, Vite's `define` replaces process.env.EMULATOR_START_OPTS at build time.

--- a/packages/connect/e2e/tests/api/init.test.ts
+++ b/packages/connect/e2e/tests/api/init.test.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect from '../../../src';
 
 // error thrown by .init()
 const INIT_ERROR = { code: 'Init_ManifestMissing' };

--- a/packages/connect/e2e/tests/device/authenticateDevice.test.ts
+++ b/packages/connect/e2e/tests/device/authenticateDevice.test.ts
@@ -1,9 +1,8 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
 import type { DeviceAuthenticityConfig } from '@trezor/device-authenticity';
 import { deviceAuthenticityConfig } from '@trezor/device-authenticity';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
+import TrezorConnect from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();

--- a/packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts
+++ b/packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts
@@ -1,8 +1,6 @@
 import { vi } from 'vitest';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
-
+import TrezorConnect from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();

--- a/packages/connect/e2e/tests/device/cancel.test.ts
+++ b/packages/connect/e2e/tests/device/cancel.test.ts
@@ -1,9 +1,8 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
 import type { CoinSymbol } from '@trezor/connect-common';
 import type { TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
 import { Model } from '@trezor/trezor-user-env-link';
 
+import TrezorConnect from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const getAddress = (showOnTrezor: boolean, coin: CoinSymbol = 'regtest') =>

--- a/packages/connect/e2e/tests/device/cancelCoinjoinAuthorization.test.ts
+++ b/packages/connect/e2e/tests/device/cancelCoinjoinAuthorization.test.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
-
+import TrezorConnect from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 describe('TrezorConnect.cancelCoinjoinAuthorization', () => {

--- a/packages/connect/e2e/tests/device/discoverAccounts.test.ts
+++ b/packages/connect/e2e/tests/device/discoverAccounts.test.ts
@@ -1,8 +1,7 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect, { type BundleProgress } from '@trezor/connect';
 import { UI_REQUEST } from '@trezor/connect-common';
 import type { DiscoverAccountsProgress } from '@trezor/connect-common/src/types/api/account/discoverAccounts';
 
+import TrezorConnect, { type BundleProgress } from '../../../src';
 import { getController, initTrezorConnect, setup } from '../../common.setup';
 
 let controller: ReturnType<typeof getController> | undefined;

--- a/packages/connect/e2e/tests/device/info.test.ts
+++ b/packages/connect/e2e/tests/device/info.test.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect, { connectCallableMethods } from '@trezor/connect';
-
+import TrezorConnect, { connectCallableMethods } from '../../../src';
 import { getController, initTrezorConnect, setup } from '../../common.setup';
 const controller = getController();
 

--- a/packages/connect/e2e/tests/device/keepSession.test.ts
+++ b/packages/connect/e2e/tests/device/keepSession.test.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect, { type StaticSessionId } from '@trezor/connect';
-
+import TrezorConnect, { type StaticSessionId } from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();

--- a/packages/connect/e2e/tests/device/methods.test.ts
+++ b/packages/connect/e2e/tests/device/methods.test.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
-
+import TrezorConnect from '../../../src';
 import * as fixtures from '../../__fixtures__';
 import {
     conditionalTest,

--- a/packages/connect/e2e/tests/device/passphrase.test.ts
+++ b/packages/connect/e2e/tests/device/passphrase.test.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
-
+import TrezorConnect from '../../../src';
 import {
     conditionalTest,
     getController,

--- a/packages/connect/e2e/tests/device/pingDevice.test.ts
+++ b/packages/connect/e2e/tests/device/pingDevice.test.ts
@@ -1,8 +1,6 @@
 import { vi } from 'vitest';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
-
+import TrezorConnect from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();

--- a/packages/connect/e2e/tests/device/resetDevice.test.ts
+++ b/packages/connect/e2e/tests/device/resetDevice.test.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
-
+import TrezorConnect from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();

--- a/packages/connect/e2e/tests/device/setBusy.test.ts
+++ b/packages/connect/e2e/tests/device/setBusy.test.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
-
+import TrezorConnect from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();

--- a/packages/connect/e2e/tests/device/thpPairing.test.ts
+++ b/packages/connect/e2e/tests/device/thpPairing.test.ts
@@ -1,8 +1,6 @@
 import { vi } from 'vitest';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect, { type Device, type ThpSettings, type UiEvent } from '@trezor/connect';
-
+import TrezorConnect, { type Device, type ThpSettings, type UiEvent } from '../../../src';
 import { THP_CREDENTIALS } from '../../common-thp-credentials';
 import { getController, initTrezorConnect, restartEmu, setup } from '../../common.setup';
 

--- a/packages/connect/e2e/tests/device/unlockPath.test.ts
+++ b/packages/connect/e2e/tests/device/unlockPath.test.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
-
+import TrezorConnect from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();

--- a/packages/connect/e2e/tests/device/updateConnectSettings.test.ts
+++ b/packages/connect/e2e/tests/device/updateConnectSettings.test.ts
@@ -1,7 +1,6 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import TrezorConnect from '@trezor/connect';
 import { BridgeTransport } from '@trezor/transport-common';
 
+import TrezorConnect from '../../../src';
 import { getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();

--- a/packages/connect/e2e/vitest.config.ts
+++ b/packages/connect/e2e/vitest.config.ts
@@ -17,7 +17,7 @@ const alias = [
     },
 ];
 
-// Plugin to resolve bare module specifiers (e.g. @trezor/blockchain-link/src/workers/blockbook)
+// Plugin to resolve bare module specifiers (e.g. @trezor/blockchain-link/workers/blockbook)
 // inside new Worker(new URL(..., import.meta.url)) calls.
 // In dev mode, Vite doesn't bundle — the browser constructs the URL at runtime and has no way to
 // resolve bare package specifiers, so we must expand them to /@fs/ paths that the dev server

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -129,5 +129,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/connect/src/api/bitcoin/createPendingTx.ts
+++ b/packages/connect/src/api/bitcoin/createPendingTx.ts
@@ -2,7 +2,7 @@ import type { AccountAddresses, PROTO } from '@trezor/connect-common';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import type { Transaction as BitcoinJsTransaction } from '@trezor/utxo-lib';
 
-import { __btcUnknownTxDebug__, getSerializedPath } from '../../utils/pathUtils';
+import { getSerializedPath } from '../../utils/pathUtils';
 
 export const createPendingTransaction = (
     tx: BitcoinJsTransaction,
@@ -32,8 +32,6 @@ export const createPendingTransaction = (
             .filter(address => address.path === path)
             .map(address => address.address);
     };
-
-    __btcUnknownTxDebug__('createPendingTransaction', inputs, addresses);
 
     return {
         txid: tx.getId(),

--- a/packages/connect/src/exports.ts
+++ b/packages/connect/src/exports.ts
@@ -1,4 +1,17 @@
+import type { TrezorConnectPrivilegedAPI } from '@trezor/connect-common';
+
 export * from '@trezor/connect-common';
+
+/**
+ * Connect API exposed by the browser entry, including its browser-only WebUSB device picker.
+ *
+ * Use this type instead of importing the browser implementation directly. The WebUSB action should
+ * eventually move behind an environment abstraction or dependency injection rather than becoming
+ * part of the shared Connect API.
+ */
+export type TrezorConnectWithBrowserAPI = TrezorConnectPrivilegedAPI & {
+    requestWebUSBDevice: () => Promise<void>;
+};
 
 // note: only @trezor/connect re-exports protobuf runtime
 export { MessagesSchema as PROTO } from '@trezor/protobuf';

--- a/packages/connect/src/utils/pathUtils.ts
+++ b/packages/connect/src/utils/pathUtils.ts
@@ -1,3 +1,3 @@
 // pathUtils moved to @trezor/connect-common so it can be shared without a deep import into
 // @trezor/connect (see #27376). Re-exported here to keep connect's internal call sites unchanged.
-export * from '@trezor/connect-common/src/utils/pathUtils';
+export * from '@trezor/connect-common/pathUtils';

--- a/packages/connect/src/workers/workers.browser.ts
+++ b/packages/connect/src/workers/workers.browser.ts
@@ -1,4 +1,4 @@
-import type { BaseWorker } from '@trezor/blockchain-link/src/workers/baseWorker';
+import type { BaseWorker } from '@trezor/blockchain-link/workers/baseWorker';
 
 type WorkerAsyncImporter = () => Promise<BaseWorker<unknown>>;
 
@@ -6,7 +6,7 @@ const BlockbookWorker = () =>
     new Worker(
         new URL(
             /* webpackChunkName: "workers/blockbook-worker" */
-            '@trezor/blockchain-link/src/workers/blockbook',
+            '@trezor/blockchain-link/workers/blockbook',
             import.meta.url,
         ),
         { type: 'module' },
@@ -16,7 +16,7 @@ const BlockfrostWorker = () =>
     new Worker(
         new URL(
             /* webpackChunkName: "workers/blockfrost-worker" */
-            '@trezor/blockchain-link/src/workers/blockfrost',
+            '@trezor/blockchain-link/workers/blockfrost',
             import.meta.url,
         ),
         { type: 'module' },
@@ -26,7 +26,7 @@ const RippleWorker = () =>
     new Worker(
         new URL(
             /* webpackChunkName: "workers/ripple-worker" */
-            '@trezor/blockchain-link/src/workers/ripple',
+            '@trezor/blockchain-link/workers/ripple',
             import.meta.url,
         ),
         { type: 'module' },
@@ -36,7 +36,7 @@ const StellarWorker = () =>
     new Worker(
         new URL(
             /* webpackChunkName: "workers/stellar-worker" */
-            '@trezor/blockchain-link/src/workers/stellar',
+            '@trezor/blockchain-link/workers/stellar',
             import.meta.url,
         ),
         { type: 'module' },
@@ -46,14 +46,14 @@ const StellarWorker = () =>
 const SolanaWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/solana-worker" */
-        '@trezor/blockchain-link/src/workers/solana'
+        '@trezor/blockchain-link/workers/solana'
     ).then(w => w.default());
 const ElectrumWorker = undefined;
 
 const EvmRpcWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/evm-rpc-worker" */
-        '@trezor/blockchain-link/src/workers/evm-rpc'
+        '@trezor/blockchain-link/workers/evm-rpc'
     ).then(w => w.default());
 
 export {

--- a/packages/connect/src/workers/workers.native.ts
+++ b/packages/connect/src/workers/workers.native.ts
@@ -1,9 +1,9 @@
-import BlockbookWorker from '@trezor/blockchain-link/src/workers/blockbook';
-import BlockfrostWorker from '@trezor/blockchain-link/src/workers/blockfrost';
-import ElectrumWorker from '@trezor/blockchain-link/src/workers/electrum';
-import RippleWorker from '@trezor/blockchain-link/src/workers/ripple';
-import SolanaWorker from '@trezor/blockchain-link/src/workers/solana';
-import StellarWorker from '@trezor/blockchain-link/src/workers/stellar';
+import BlockbookWorker from '@trezor/blockchain-link/workers/blockbook';
+import BlockfrostWorker from '@trezor/blockchain-link/workers/blockfrost';
+import ElectrumWorker from '@trezor/blockchain-link/workers/electrum';
+import RippleWorker from '@trezor/blockchain-link/workers/ripple';
+import SolanaWorker from '@trezor/blockchain-link/workers/solana';
+import StellarWorker from '@trezor/blockchain-link/workers/stellar';
 
 export {
     BlockbookWorker,

--- a/packages/connect/src/workers/workers.ts
+++ b/packages/connect/src/workers/workers.ts
@@ -1,42 +1,42 @@
-import type { BaseWorker } from '@trezor/blockchain-link/src/workers/baseWorker';
+import type { BaseWorker } from '@trezor/blockchain-link/workers/baseWorker';
 
 type WorkerAsyncImporter = () => Promise<BaseWorker<unknown>>;
 
 const BlockbookWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/blockbook-worker" */
-        '@trezor/blockchain-link/src/workers/blockbook'
+        '@trezor/blockchain-link/workers/blockbook'
     ).then(w => w.default());
 const RippleWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/ripple-worker" */
-        '@trezor/blockchain-link/src/workers/ripple'
+        '@trezor/blockchain-link/workers/ripple'
     ).then(w => w.default());
 const BlockfrostWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/blockfrost-worker" */
-        '@trezor/blockchain-link/src/workers/blockfrost'
+        '@trezor/blockchain-link/workers/blockfrost'
     ).then(w => w.default());
 const ElectrumWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/electrum-worker" */
-        '@trezor/blockchain-link/src/workers/electrum'
+        '@trezor/blockchain-link/workers/electrum'
     ).then(w => w.default());
 const SolanaWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/solana-worker" */
-        '@trezor/blockchain-link/src/workers/solana'
+        '@trezor/blockchain-link/workers/solana'
     ).then(w => w.default());
 const StellarWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/stellar-worker" */
-        '@trezor/blockchain-link/src/workers/stellar'
+        '@trezor/blockchain-link/workers/stellar'
     ).then(w => w.default());
 
 const EvmRpcWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/evm-rpc-worker" */
-        '@trezor/blockchain-link/src/workers/evm-rpc'
+        '@trezor/blockchain-link/workers/evm-rpc'
     ).then(w => w.default());
 
 export {

--- a/packages/crypto-utils/package.json
+++ b/packages/crypto-utils/package.json
@@ -46,5 +46,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/device-authenticity/package.json
+++ b/packages/device-authenticity/package.json
@@ -42,5 +42,6 @@
         "@trezor/protobuf": "workspace:*",
         "@trezor/schema-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/device-utils/package.json
+++ b/packages/device-utils/package.json
@@ -30,5 +30,6 @@
         "@trezor/protobuf": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/dom-utils/package.json
+++ b/packages/dom-utils/package.json
@@ -9,5 +9,6 @@
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/e2e-utils/package.json
+++ b/packages/e2e-utils/package.json
@@ -42,5 +42,6 @@
         "@playwright/test": "1.60.0",
         "@trezor/node-utils": "workspace:*",
         "tsx": "^4.21.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/env-utils/package.json
+++ b/packages/env-utils/package.json
@@ -51,5 +51,6 @@
         "react-native": {
             "optional": true
         }
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -22,5 +22,6 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^17.6.0",
         "typescript-eslint": "^8.62.0"
-    }
+    },
+    "types": "./libDev/src/index.d.mts"
 }

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -38,6 +38,14 @@ const connectDeepImportPatterns = [
     },
 ];
 
+const suiteDesktopApiDeepImportPattern = {
+    group: ['@trezor/suite-desktop-api/src/**'],
+    message:
+        'Import from "@trezor/suite-desktop-api" instead. Deep paths into "@trezor/suite-desktop-api/src/**" bypass the public API.',
+};
+
+const packageDeepImportPatterns = [...connectDeepImportPatterns, suiteDesktopApiDeepImportPattern];
+
 // Deny importing internal suite packages from outside the suite app itself.
 const suiteInternalPatterns = {
     group: ['@suite-common/**', '@suite-native/**'],
@@ -49,7 +57,7 @@ export const restrictedImportsPatterns = [
     buildArtifactPatterns,
     suiteInternalPatterns,
     networksPackagePattern,
-    ...connectDeepImportPatterns,
+    ...packageDeepImportPatterns,
 ];
 
 /** @type {import('typescript-eslint').ConfigArray} */
@@ -73,7 +81,7 @@ export const typescriptConfig = [
                     patterns: [
                         buildArtifactPatterns,
                         networksPackagePattern,
-                        ...connectDeepImportPatterns,
+                        ...packageDeepImportPatterns,
                     ],
                 },
             ],

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -5,7 +5,7 @@
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
     "main": "src/generated/icons/index",
-    "types": "src/index.ts",
+    "types": "./libDev/src/index.d.ts",
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",

--- a/packages/ipc-proxy/package.json
+++ b/packages/ipc-proxy/package.json
@@ -20,5 +20,6 @@
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/node-utils/package.json
+++ b/packages/node-utils/package.json
@@ -16,5 +16,6 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "ajv": "^8.20.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/product-components/package.json
+++ b/packages/product-components/package.json
@@ -62,5 +62,6 @@
         "stylelint-config-standard": "^40.0.0",
         "svgo": "^4.0.1",
         "typescript-styled-plugin": "^0.18.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -53,5 +53,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -48,5 +48,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/react-native-usb/package.json
+++ b/packages/react-native-usb/package.json
@@ -28,5 +28,6 @@
         "expo-modules-core": "*",
         "react": "*",
         "react-native": "*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/react-utils/package.json
+++ b/packages/react-utils/package.json
@@ -21,5 +21,6 @@
         "@testing-library/react": "^16.3.2",
         "@types/react": "19.2.14",
         "react-dom": "19.2.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -25,5 +25,6 @@
         "@trezor/e2e-utils": "workspace:*",
         "@trezor/eslint": "workspace:*",
         "tsx": "^4.21.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/requirements/package.json
+++ b/packages/requirements/package.json
@@ -20,5 +20,6 @@
     },
     "devDependencies": {
         "tsx": "^4.21.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/requirements/src/requirements/allRequirements.ts
+++ b/packages/requirements/src/requirements/allRequirements.ts
@@ -5,6 +5,7 @@ import { requireDocsSummary } from './docs-summary/requireDocsSummary';
 import { requireFirmwareReleaseVersionMonotonicity } from './firmware-releases/requireFirmwareReleaseVersionMonotonicity';
 import { requireForbiddenDeps } from './forbidden-deps/requireForbiddenDeps';
 import { requirePackageJsonScripts } from './package-json/requirePackageJsonScripts';
+import { requirePackageJsonTypes } from './package-json/requirePackageJsonTypes';
 import { requirePublishConfig } from './package-json/requirePublishConfig';
 import { requireConnectPublicDependencies } from './public-package-dependencies/requireConnectPublicDependencies';
 import { requireTypeDeclarationSize } from './type-declarations/requireTypeDeclarationSize';
@@ -17,6 +18,7 @@ export const requirements: ReadonlyArray<Requirement<RequirementScope>> = [
     requireFirmwareReleaseVersionMonotonicity,
     requireForbiddenDeps,
     requirePackageJsonScripts,
+    requirePackageJsonTypes,
     requirePublishConfig,
     requireTypeDeclarationSize,
 ];

--- a/packages/requirements/src/requirements/package-json/__tests__/requirePackageJsonTypes.test.ts
+++ b/packages/requirements/src/requirements/package-json/__tests__/requirePackageJsonTypes.test.ts
@@ -183,6 +183,39 @@ describe(requirePackageJsonTypes.name, () => {
         });
     });
 
+    it('configures the Tron network declaration entries', async () => {
+        context = { ...context, workspaceName: '@trezor/network-tron' };
+        writePackageJson({
+            name: '@trezor/network-tron',
+            exports: {
+                './constants': './src/constants/index.ts',
+                './utils': './src/utils/index.ts',
+                '.': './src/index.ts',
+            },
+        });
+
+        const errors = await requirePackageJsonTypes.fix!(context);
+
+        expect(errors).toEqual([]);
+        expect(readPackageJson()).toMatchObject({
+            types: './libDev/src/index.d.ts',
+            exports: {
+                './constants': {
+                    types: './libDev/src/constants/index.d.ts',
+                    default: './src/constants/index.ts',
+                },
+                './utils': {
+                    types: './libDev/src/utils/index.d.ts',
+                    default: './src/utils/index.ts',
+                },
+                '.': {
+                    types: './libDev/src/index.d.ts',
+                    default: './src/index.ts',
+                },
+            },
+        });
+    });
+
     it('reports a root export that shadows an unmodeled declaration entry', async () => {
         writePackageJson({
             types: './libDev/src/index.d.ts',
@@ -292,19 +325,22 @@ describe(requirePackageJsonTypes.name, () => {
                 },
             },
         ],
-    ])('configures the typed-only public subpaths exposed by %s', async (workspaceName, exports) => {
-        context = { ...context, workspaceName };
-        rmSync(join(workspaceDir, 'src'), { recursive: true });
-        writePackageJson({
-            name: workspaceName,
-            types: './libDev/src/index.d.ts',
-        });
+    ])(
+        'configures the typed-only public subpaths exposed by %s',
+        async (workspaceName, exports) => {
+            context = { ...context, workspaceName };
+            rmSync(join(workspaceDir, 'src'), { recursive: true });
+            writePackageJson({
+                name: workspaceName,
+                types: './libDev/src/index.d.ts',
+            });
 
-        const errors = await requirePackageJsonTypes.fix!(context);
+            const errors = await requirePackageJsonTypes.fix!(context);
 
-        expect(errors).toEqual([]);
-        expect(readPackageJson()).toEqual({ name: workspaceName, exports });
-    });
+            expect(errors).toEqual([]);
+            expect(readPackageJson()).toEqual({ name: workspaceName, exports });
+        },
+    );
 
     it('reports missing or invalid package.json', async () => {
         const errorsWithoutFile = await requirePackageJsonTypes.verify(context);

--- a/packages/requirements/src/requirements/package-json/__tests__/requirePackageJsonTypes.test.ts
+++ b/packages/requirements/src/requirements/package-json/__tests__/requirePackageJsonTypes.test.ts
@@ -1,0 +1,356 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { WorkspaceContext } from '../../Requirement';
+import { requirePackageJsonTypes } from '../requirePackageJsonTypes';
+
+const createTempWorkspace = (): string => mkdtempSync(join(tmpdir(), 'package-json-types-'));
+
+describe(requirePackageJsonTypes.name, () => {
+    let workspaceDir: string;
+    let context: WorkspaceContext;
+
+    const writePackageJson = (packageJson: Record<string, unknown>) =>
+        writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(packageJson));
+
+    const readPackageJson = () =>
+        JSON.parse(readFileSync(join(workspaceDir, 'package.json'), 'utf8')) as Record<
+            string,
+            unknown
+        >;
+
+    beforeEach(() => {
+        workspaceDir = createTempWorkspace();
+        context = {
+            repoRoot: '/repo',
+            workspaceDir,
+            workspaceName: '@trezor/example',
+        };
+        mkdirSync(join(workspaceDir, 'src'));
+        writeFileSync(join(workspaceDir, 'src/index.ts'), 'export {};\n');
+    });
+
+    afterEach(() => {
+        rmSync(workspaceDir, { recursive: true, force: true });
+    });
+
+    it('passes when types is configured correctly', async () => {
+        writePackageJson({ types: './libDev/src/index.d.ts' });
+
+        const errors = await requirePackageJsonTypes.verify(context);
+
+        expect(errors).toEqual([]);
+    });
+
+    it('reports missing or invalid types', async () => {
+        writePackageJson({ name: '@trezor/example', types: './lib/index.d.ts' });
+
+        const errors = await requirePackageJsonTypes.verify(context);
+
+        expect(errors).toEqual([
+            '@trezor/example: types must be "./libDev/src/index.d.ts" in package.json.',
+        ]);
+    });
+
+    it('fixes types', async () => {
+        writePackageJson({ name: '@trezor/example', types: './lib/index.d.ts' });
+
+        const errors = await requirePackageJsonTypes.fix!(context);
+
+        expect(errors).toEqual([]);
+        expect(readPackageJson()).toEqual({
+            name: '@trezor/example',
+            types: './libDev/src/index.d.ts',
+        });
+    });
+
+    it('accepts a conventional TSX entry', async () => {
+        rmSync(join(workspaceDir, 'src/index.ts'));
+        writeFileSync(join(workspaceDir, 'src/index.tsx'), 'export {};\n');
+        writePackageJson({ types: './libDev/src/index.d.ts' });
+
+        const errors = await requirePackageJsonTypes.verify(context);
+
+        expect(errors).toEqual([]);
+    });
+
+    it('does not invent an entry for an unclassified workspace', async () => {
+        rmSync(join(workspaceDir, 'src'), { recursive: true });
+        writePackageJson({ name: '@trezor/example' });
+
+        const errors = await requirePackageJsonTypes.fix!(context);
+
+        expect(errors).toEqual([
+            '@trezor/example: workspace without src/index.ts(x) must configure a declaration entry or exemption.',
+        ]);
+        expect(readPackageJson()).toEqual({ name: '@trezor/example' });
+    });
+
+    it.each([
+        ['@trezor/analytics-log-server', './libDev/index.d.ts'],
+        ['@trezor/connect-web', './libDev/connect-web/src/index.d.ts'],
+        ['@trezor/eslint', './libDev/src/index.d.mts'],
+        ['@trezor/suite', './libDev/index.d.ts'],
+        ['@trezor/suite-desktop-api', './libDev/src/types.d.ts'],
+    ])('uses the declaration entry emitted by %s', async (workspaceName, types) => {
+        context = { ...context, workspaceName };
+        writePackageJson({ types: './libDev/src/index.d.ts' });
+
+        const errors = await requirePackageJsonTypes.fix!(context);
+
+        expect(errors).toEqual([]);
+        expect(readPackageJson()).toMatchObject({ types });
+    });
+
+    it('configures a root and typed subpaths together', async () => {
+        context = { ...context, workspaceName: '@suite-common/test-utils' };
+        writePackageJson({
+            name: '@suite-common/test-utils',
+            exports: {
+                '.': './src/index.ts',
+            },
+        });
+
+        const errors = await requirePackageJsonTypes.fix!(context);
+
+        expect(errors).toEqual([]);
+        expect(readPackageJson()).toEqual({
+            name: '@suite-common/test-utils',
+            types: './libDev/src/index.d.ts',
+            exports: {
+                '.': {
+                    types: './libDev/src/index.d.ts',
+                    default: './src/index.ts',
+                },
+                './globalOverrides': {
+                    types: './libDev/globalOverrides/index.d.ts',
+                    default: './globalOverrides/index.ts',
+                },
+            },
+        });
+    });
+
+    it('configures React Query provider entries', async () => {
+        context = { ...context, workspaceName: '@suite-common/react-query' };
+        writePackageJson({ name: '@suite-common/react-query' });
+
+        const errors = await requirePackageJsonTypes.fix!(context);
+
+        expect(errors).toEqual([]);
+        expect(readPackageJson()).toMatchObject({
+            types: './libDev/src/index.d.ts',
+            exports: {
+                './react': {
+                    types: './libDev/react/index.d.ts',
+                    default: './react/index.ts',
+                },
+                './react-native': {
+                    types: './libDev/react-native/index.d.ts',
+                    default: './react-native/index.ts',
+                },
+            },
+        });
+    });
+
+    it('configures typed exports that would otherwise shadow network declarations', async () => {
+        context = { ...context, workspaceName: '@trezor/network-cardano' };
+        writePackageJson({
+            name: '@trezor/network-cardano',
+            exports: {
+                './constants': './src/constants/index.ts',
+                './runtime': './src/runtime/index.ts',
+                './types': './src/types/index.ts',
+                '.': './src/index.ts',
+            },
+        });
+
+        const errors = await requirePackageJsonTypes.fix!(context);
+
+        expect(errors).toEqual([]);
+        expect(readPackageJson()).toMatchObject({
+            types: './libDev/src/index.d.ts',
+            exports: {
+                './constants': {
+                    types: './libDev/src/constants/index.d.ts',
+                    default: './src/constants/index.ts',
+                },
+                '.': {
+                    types: './libDev/src/index.d.ts',
+                    default: './src/index.ts',
+                },
+            },
+        });
+    });
+
+    it('reports a root export that shadows an unmodeled declaration entry', async () => {
+        writePackageJson({
+            types: './libDev/src/index.d.ts',
+            exports: { '.': './src/index.ts' },
+        });
+
+        const errors = await requirePackageJsonTypes.verify(context);
+
+        expect(errors).toEqual([
+            '@trezor/example: exports["."] shadows the types field and must configure a typed root export contract.',
+        ]);
+    });
+
+    it('reports extensionless export declaration targets', async () => {
+        context = { ...context, workspaceName: '@trezor/blockchain-link' };
+        writePackageJson({
+            types: './libDev/src/index.d.ts',
+            exports: {
+                '.': {
+                    types: './libDev/src/index.d.ts',
+                    default: './src/index.ts',
+                },
+                './src/*': {
+                    types: './libDev/src/*',
+                    default: './src/*',
+                },
+            },
+        });
+
+        const errors = await requirePackageJsonTypes.verify(context);
+
+        expect(errors).toContain(
+            '@trezor/blockchain-link: exports["./src/*"].types must target a declaration file with an explicit extension in package.json.',
+        );
+    });
+
+    it('configures exact Blockchain Link legacy worker entries', async () => {
+        context = { ...context, workspaceName: '@trezor/blockchain-link' };
+        writePackageJson({ name: '@trezor/blockchain-link' });
+
+        const errors = await requirePackageJsonTypes.fix!(context);
+
+        expect(errors).toEqual([]);
+        expect(readPackageJson()).toMatchObject({
+            exports: {
+                './src/workers/blockbook': {
+                    types: './libDev/src/workers/blockbook/index.d.ts',
+                    default: './src/workers/blockbook/index.ts',
+                },
+                './src/workers/blockbook/websocket': {
+                    types: './libDev/src/workers/blockbook/websocket.d.ts',
+                    default: './src/workers/blockbook/websocket.ts',
+                },
+                './src/workers/blockfrost': {
+                    types: './libDev/src/workers/blockfrost/index.d.ts',
+                    default: './src/workers/blockfrost/index.ts',
+                },
+                './src/workers/ripple': {
+                    types: './libDev/src/workers/ripple/index.d.ts',
+                    default: './src/workers/ripple/index.ts',
+                },
+                './src/utils/socks-proxy-agent.ts': {
+                    types: './libDev/src/utils/socks-proxy-agent.d.ts',
+                    default: './src/utils/socks-proxy-agent.ts',
+                },
+            },
+        });
+    });
+
+    it.each([
+        [
+            '@suite-common/earn-stablecoin',
+            {
+                './src/allowance': {
+                    types: './libDev/src/allowance/index.d.ts',
+                    default: './src/allowance/index.ts',
+                },
+                './src/signing': {
+                    types: './libDev/src/signing/index.d.ts',
+                    default: './src/signing/index.ts',
+                },
+                './src/tx-simulation': {
+                    types: './libDev/src/tx-simulation/index.d.ts',
+                    default: './src/tx-simulation/index.ts',
+                },
+            },
+        ],
+        [
+            '@suite-common/schemas',
+            {
+                './src/evm': {
+                    types: './libDev/src/evm/index.d.ts',
+                    default: './src/evm/index.ts',
+                },
+            },
+        ],
+        [
+            '@suite/tx-simulation',
+            {
+                './src/common': {
+                    types: './libDev/src/common/index.d.ts',
+                    default: './src/common/index.ts',
+                },
+                './src/evm': {
+                    types: './libDev/src/evm/index.d.ts',
+                    default: './src/evm/index.ts',
+                },
+            },
+        ],
+    ])('configures the typed-only public subpaths exposed by %s', async (workspaceName, exports) => {
+        context = { ...context, workspaceName };
+        rmSync(join(workspaceDir, 'src'), { recursive: true });
+        writePackageJson({
+            name: workspaceName,
+            types: './libDev/src/index.d.ts',
+        });
+
+        const errors = await requirePackageJsonTypes.fix!(context);
+
+        expect(errors).toEqual([]);
+        expect(readPackageJson()).toEqual({ name: workspaceName, exports });
+    });
+
+    it('reports missing or invalid package.json', async () => {
+        const errorsWithoutFile = await requirePackageJsonTypes.verify(context);
+
+        expect(errorsWithoutFile).toEqual([
+            '@trezor/example: package.json is missing or contains invalid JSON.',
+        ]);
+
+        writeFileSync(join(workspaceDir, 'package.json'), '{ invalid json }');
+
+        const errorsInvalidJson = await requirePackageJsonTypes.verify(context);
+
+        expect(errorsInvalidJson).toEqual([
+            '@trezor/example: package.json is missing or contains invalid JSON.',
+        ]);
+    });
+
+    it('does not require types for exempt workspaces', async () => {
+        context = { ...context, workspaceName: '@trezor/analytics-docs' };
+        writePackageJson({ name: '@trezor/analytics-docs' });
+
+        const errors = await requirePackageJsonTypes.verify(context);
+
+        expect(errors).toEqual([]);
+    });
+
+    it('removes types from exempt workspaces', async () => {
+        context = { ...context, workspaceName: '@suite-native/app' };
+        writePackageJson({
+            name: '@suite-native/app',
+            types: './libDev/src/index.d.ts',
+        });
+
+        const verificationErrors = await requirePackageJsonTypes.verify(context);
+
+        expect(verificationErrors).toEqual([
+            '@suite-native/app: types must be omitted because the workspace does not expose a typed package root in package.json.',
+        ]);
+
+        const errors = await requirePackageJsonTypes.fix!(context);
+
+        expect(errors).toEqual([]);
+        expect(readPackageJson()).toEqual({ name: '@suite-native/app' });
+    });
+
+    it('has workspace scope', () => {
+        expect(requirePackageJsonTypes.scope).toBe('workspace');
+    });
+});

--- a/packages/requirements/src/requirements/package-json/requirePackageJsonTypes.ts
+++ b/packages/requirements/src/requirements/package-json/requirePackageJsonTypes.ts
@@ -103,6 +103,20 @@ const REQUIRED_TYPED_EXPORTS: Record<string, Record<string, PackageExport>> = {
     '@trezor/network-ripple': NETWORK_TYPED_EXPORTS,
     '@trezor/network-solana': NETWORK_TYPED_EXPORTS,
     '@trezor/network-stellar': NETWORK_TYPED_EXPORTS,
+    '@trezor/network-tron': {
+        './constants': {
+            types: './libDev/src/constants/index.d.ts',
+            default: './src/constants/index.ts',
+        },
+        './utils': {
+            types: './libDev/src/utils/index.d.ts',
+            default: './src/utils/index.ts',
+        },
+        '.': {
+            types: DEFAULT_TYPES_FIELD,
+            default: './src/index.ts',
+        },
+    },
     '@trezor/analytics-log-server': {
         '.': {
             types: './libDev/index.d.ts',
@@ -466,11 +480,7 @@ export const requirePackageJsonTypes: Requirement<'workspace'> = {
               }
             : packageJsonWithRequiredTypes;
 
-        writeFileSync(
-            packageJsonPath,
-            `${JSON.stringify(fixedPackageJson, null, 4)}\n`,
-            'utf-8',
-        );
+        writeFileSync(packageJsonPath, `${JSON.stringify(fixedPackageJson, null, 4)}\n`, 'utf-8');
 
         return Promise.resolve(getVerificationErrors(context));
     },

--- a/packages/requirements/src/requirements/package-json/requirePackageJsonTypes.ts
+++ b/packages/requirements/src/requirements/package-json/requirePackageJsonTypes.ts
@@ -1,0 +1,477 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { Requirement, WorkspaceContext } from '../Requirement';
+
+const PACKAGE_JSON_FILE = 'package.json';
+const DEFAULT_TYPES_FIELD = './libDev/src/index.d.ts';
+const DECLARATION_FILE_PATTERN = /\.d\.(?:ts|mts|cts)$/;
+
+const TYPES_FIELD_OVERRIDES: Record<string, string> = {
+    '@trezor/analytics-log-server': './libDev/index.d.ts',
+    '@trezor/connect-web': './libDev/connect-web/src/index.d.ts',
+    '@trezor/eslint': './libDev/src/index.d.mts',
+    '@trezor/suite': './libDev/index.d.ts',
+    '@trezor/suite-desktop-api': './libDev/src/types.d.ts',
+};
+
+type PackageExport = {
+    readonly types: string;
+    readonly default: string;
+};
+
+const NETWORK_TYPED_EXPORTS: Record<string, PackageExport> = {
+    './constants': {
+        types: './libDev/src/constants/index.d.ts',
+        default: './src/constants/index.ts',
+    },
+    './runtime': {
+        types: './libDev/src/runtime/index.d.ts',
+        default: './src/runtime/index.ts',
+    },
+    './types': {
+        types: './libDev/src/types/index.d.ts',
+        default: './src/types/index.ts',
+    },
+    '.': {
+        types: DEFAULT_TYPES_FIELD,
+        default: './src/index.ts',
+    },
+};
+
+const BLOCKCHAIN_LINK_TYPED_EXPORTS: Record<string, PackageExport> = {
+    '.': {
+        types: DEFAULT_TYPES_FIELD,
+        default: './src/index.ts',
+    },
+    './workers/baseWorker': {
+        types: './libDev/workers/baseWorker/index.d.ts',
+        default: './workers/baseWorker/index.ts',
+    },
+    './workers/blockbook': {
+        types: './libDev/workers/blockbook/index.d.ts',
+        default: './workers/blockbook/index.ts',
+    },
+    './workers/blockfrost': {
+        types: './libDev/workers/blockfrost/index.d.ts',
+        default: './workers/blockfrost/index.ts',
+    },
+    './workers/electrum': {
+        types: './libDev/workers/electrum/index.d.ts',
+        default: './workers/electrum/index.ts',
+    },
+    './workers/evm-rpc': {
+        types: './libDev/workers/evm-rpc/index.d.ts',
+        default: './workers/evm-rpc/index.ts',
+    },
+    './workers/ripple': {
+        types: './libDev/workers/ripple/index.d.ts',
+        default: './workers/ripple/index.ts',
+    },
+    './workers/solana': {
+        types: './libDev/workers/solana/index.d.ts',
+        default: './workers/solana/index.ts',
+    },
+    './workers/stellar': {
+        types: './libDev/workers/stellar/index.d.ts',
+        default: './workers/stellar/index.ts',
+    },
+    './src/workers/blockbook': {
+        types: './libDev/src/workers/blockbook/index.d.ts',
+        default: './src/workers/blockbook/index.ts',
+    },
+    './src/workers/blockbook/websocket': {
+        types: './libDev/src/workers/blockbook/websocket.d.ts',
+        default: './src/workers/blockbook/websocket.ts',
+    },
+    './src/workers/blockfrost': {
+        types: './libDev/src/workers/blockfrost/index.d.ts',
+        default: './src/workers/blockfrost/index.ts',
+    },
+    './src/workers/ripple': {
+        types: './libDev/src/workers/ripple/index.d.ts',
+        default: './src/workers/ripple/index.ts',
+    },
+    './src/utils/socks-proxy-agent.ts': {
+        types: './libDev/src/utils/socks-proxy-agent.d.ts',
+        default: './src/utils/socks-proxy-agent.ts',
+    },
+};
+
+const REQUIRED_TYPED_EXPORTS: Record<string, Record<string, PackageExport>> = {
+    '@trezor/network-cardano': NETWORK_TYPED_EXPORTS,
+    '@trezor/network-ripple': NETWORK_TYPED_EXPORTS,
+    '@trezor/network-solana': NETWORK_TYPED_EXPORTS,
+    '@trezor/network-stellar': NETWORK_TYPED_EXPORTS,
+    '@trezor/analytics-log-server': {
+        '.': {
+            types: './libDev/index.d.ts',
+            default: './dist/index.js',
+        },
+    },
+    '@trezor/blockchain-link': BLOCKCHAIN_LINK_TYPED_EXPORTS,
+    '@trezor/connect-common': {
+        '.': {
+            types: DEFAULT_TYPES_FIELD,
+            default: './src/index.ts',
+        },
+        './pathUtils': {
+            types: './libDev/src/utils/pathUtils.d.ts',
+            default: './src/utils/pathUtils.ts',
+        },
+        './src/callableMethods': {
+            types: './libDev/src/callableMethods.d.ts',
+            default: './src/callableMethods.ts',
+        },
+        './src/constants': {
+            types: './libDev/src/constants/index.d.ts',
+            default: './src/constants/index.ts',
+        },
+        './src/constants/*': {
+            types: './libDev/src/constants/*.d.ts',
+            default: './src/constants/*.ts',
+        },
+        './src/data': {
+            types: './libDev/src/data/index.d.ts',
+            default: './src/data/index.ts',
+        },
+        './src/data/*': {
+            types: './libDev/src/data/*.d.ts',
+            default: './src/data/*.ts',
+        },
+        './src/events': {
+            types: './libDev/src/events/index.d.ts',
+            default: './src/events/index.ts',
+        },
+        './src/events/*': {
+            types: './libDev/src/events/*.d.ts',
+            default: './src/events/*.ts',
+        },
+        './src/factory': {
+            types: './libDev/src/factory.d.ts',
+            default: './src/factory.ts',
+        },
+        './src/impl/*': {
+            types: './libDev/src/impl/*.d.ts',
+            default: './src/impl/*.ts',
+        },
+        './src/messageChannel/*': {
+            types: './libDev/src/messageChannel/*.d.ts',
+            default: './src/messageChannel/*.ts',
+        },
+        './src/types': {
+            types: './libDev/src/types/index.d.ts',
+            default: './src/types/index.ts',
+        },
+        './src/types/api': {
+            types: './libDev/src/types/api/index.d.ts',
+            default: './src/types/api/index.ts',
+        },
+        './src/types/*': {
+            types: './libDev/src/types/*.d.ts',
+            default: './src/types/*.ts',
+        },
+        './src/utils/*': {
+            types: './libDev/src/utils/*.d.ts',
+            default: './src/utils/*.ts',
+        },
+    },
+    '@trezor/suite': {
+        '.': {
+            types: './libDev/index.d.ts',
+            default: './index.ts',
+        },
+        './mocks': {
+            types: './libDev/mocks/index.d.ts',
+            default: './mocks/index.ts',
+        },
+    },
+    '@suite-common/earn-stablecoin': {
+        './src/allowance': {
+            types: './libDev/src/allowance/index.d.ts',
+            default: './src/allowance/index.ts',
+        },
+        './src/signing': {
+            types: './libDev/src/signing/index.d.ts',
+            default: './src/signing/index.ts',
+        },
+        './src/tx-simulation': {
+            types: './libDev/src/tx-simulation/index.d.ts',
+            default: './src/tx-simulation/index.ts',
+        },
+    },
+    '@suite-common/react-query': {
+        '.': {
+            types: DEFAULT_TYPES_FIELD,
+            default: './src/index.ts',
+        },
+        './react': {
+            types: './libDev/react/index.d.ts',
+            default: './react/index.ts',
+        },
+        './react-native': {
+            types: './libDev/react-native/index.d.ts',
+            default: './react-native/index.ts',
+        },
+    },
+    '@suite-common/schemas': {
+        './src/evm': {
+            types: './libDev/src/evm/index.d.ts',
+            default: './src/evm/index.ts',
+        },
+    },
+    '@suite-common/test-utils': {
+        '.': {
+            types: DEFAULT_TYPES_FIELD,
+            default: './src/index.ts',
+        },
+        './globalOverrides': {
+            types: './libDev/globalOverrides/index.d.ts',
+            default: './globalOverrides/index.ts',
+        },
+    },
+    '@suite/tx-simulation': {
+        './src/common': {
+            types: './libDev/src/common/index.d.ts',
+            default: './src/common/index.ts',
+        },
+        './src/evm': {
+            types: './libDev/src/evm/index.d.ts',
+            default: './src/evm/index.ts',
+        },
+    },
+};
+
+const TYPES_FIELD_EXEMPT_WORKSPACES = [
+    'connect-example-electron-main',
+    'connect-mobile-example',
+    'connect-example-node',
+    '@suite-native/app',
+    '@trezor/analytics-docs',
+    '@trezor/connect-explorer',
+    '@trezor/scripts',
+    '@trezor/suite-build',
+    '@trezor/suite-data',
+    '@trezor/suite-desktop',
+    '@trezor/suite-desktop-core',
+    '@trezor/suite-e2e',
+    '@trezor/transport-test',
+    '@trezor/webextension-mv3-sw-ts',
+];
+
+type PackageJson = {
+    readonly types?: string;
+    readonly exports?: Record<string, unknown>;
+    readonly [key: string]: unknown;
+};
+
+const readPackageJson = (packageJsonPath: string): PackageJson | undefined => {
+    try {
+        return JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as PackageJson;
+    } catch {
+        return undefined;
+    }
+};
+
+const getRequiredTypesField = ({
+    workspaceDir,
+    workspaceName,
+}: WorkspaceContext): string | undefined => {
+    const typesFieldOverride = TYPES_FIELD_OVERRIDES[workspaceName];
+
+    if (typesFieldOverride) {
+        return typesFieldOverride;
+    }
+
+    if (
+        existsSync(join(workspaceDir, 'src/index.ts')) ||
+        existsSync(join(workspaceDir, 'src/index.tsx'))
+    ) {
+        return DEFAULT_TYPES_FIELD;
+    }
+
+    return undefined;
+};
+
+const isTypesFieldExemptWorkspace = (workspaceName: string) =>
+    TYPES_FIELD_EXEMPT_WORKSPACES.some(packageName => packageName === workspaceName);
+
+const getPackageJsonWithoutTypes = (packageJson: PackageJson): PackageJson => {
+    const packageJsonWithoutTypes = { ...packageJson };
+
+    delete packageJsonWithoutTypes.types;
+
+    return packageJsonWithoutTypes;
+};
+
+const getTypedExportVerificationErrors = (
+    context: WorkspaceContext,
+    packageJson: PackageJson,
+    requiredExports: Record<string, PackageExport>,
+) => {
+    const errors: string[] = [];
+
+    Object.entries(requiredExports).forEach(([subpath, requiredExport]) => {
+        const actualExport = packageJson.exports?.[subpath];
+
+        if (
+            typeof actualExport !== 'object' ||
+            actualExport === null ||
+            !('types' in actualExport) ||
+            actualExport.types !== requiredExport.types ||
+            !('default' in actualExport) ||
+            actualExport.default !== requiredExport.default
+        ) {
+            errors.push(
+                `${context.workspaceName}: exports["${subpath}"] must define types "${requiredExport.types}" and default "${requiredExport.default}" in ${PACKAGE_JSON_FILE}.`,
+            );
+        }
+    });
+
+    return errors;
+};
+
+const getExportTypesConditionVerificationErrors = (
+    context: WorkspaceContext,
+    exports: Record<string, unknown> | undefined,
+) => {
+    const errors: string[] = [];
+
+    const verifyTypesConditions = (value: unknown, exportPath: string) => {
+        if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+            return;
+        }
+
+        Object.entries(value).forEach(([condition, conditionValue]) => {
+            const conditionPath = `${exportPath}.${condition}`;
+
+            if (
+                condition === 'types' &&
+                typeof conditionValue === 'string' &&
+                !DECLARATION_FILE_PATTERN.test(conditionValue)
+            ) {
+                errors.push(
+                    `${context.workspaceName}: ${conditionPath} must target a declaration file with an explicit extension in ${PACKAGE_JSON_FILE}.`,
+                );
+            }
+
+            verifyTypesConditions(conditionValue, conditionPath);
+        });
+    };
+
+    Object.entries(exports ?? {}).forEach(([subpath, value]) => {
+        verifyTypesConditions(value, `exports["${subpath}"]`);
+    });
+
+    return errors;
+};
+
+const getVerificationErrors = (context: WorkspaceContext) => {
+    const packageJsonPath = join(context.workspaceDir, PACKAGE_JSON_FILE);
+    const parsed = readPackageJson(packageJsonPath);
+
+    if (!parsed) {
+        return [
+            `${context.workspaceName}: ${PACKAGE_JSON_FILE} is missing or contains invalid JSON.`,
+        ];
+    }
+
+    if (isTypesFieldExemptWorkspace(context.workspaceName)) {
+        if (parsed.types !== undefined) {
+            return [
+                `${context.workspaceName}: types must be omitted because the workspace does not expose a typed package root in ${PACKAGE_JSON_FILE}.`,
+            ];
+        }
+
+        return [];
+    }
+
+    const requiredTypesField = getRequiredTypesField(context);
+    const requiredTypedExports = REQUIRED_TYPED_EXPORTS[context.workspaceName];
+
+    if (!requiredTypesField && !requiredTypedExports) {
+        return [
+            `${context.workspaceName}: workspace without src/index.ts(x) must configure a declaration entry or exemption.`,
+        ];
+    }
+
+    const errors: string[] = [];
+
+    if (requiredTypesField) {
+        if (parsed.types !== requiredTypesField) {
+            errors.push(
+                `${context.workspaceName}: types must be "${requiredTypesField}" in ${PACKAGE_JSON_FILE}.`,
+            );
+        }
+    } else if (parsed.types !== undefined) {
+        errors.push(
+            `${context.workspaceName}: types must be omitted when typed subpaths define the public API in ${PACKAGE_JSON_FILE}.`,
+        );
+    }
+
+    if (requiredTypedExports) {
+        errors.push(...getTypedExportVerificationErrors(context, parsed, requiredTypedExports));
+    } else if (parsed.exports?.['.'] !== undefined) {
+        errors.push(
+            `${context.workspaceName}: exports["."] shadows the types field and must configure a typed root export contract.`,
+        );
+    }
+
+    errors.push(...getExportTypesConditionVerificationErrors(context, parsed.exports));
+
+    return errors;
+};
+
+export const requirePackageJsonTypes: Requirement<'workspace'> = {
+    name: 'package-json-types',
+    scope: 'workspace',
+    verify: context => Promise.resolve(getVerificationErrors(context)),
+    fix: context => {
+        const packageJsonPath = join(context.workspaceDir, PACKAGE_JSON_FILE);
+        const parsed = readPackageJson(packageJsonPath);
+
+        if (!parsed) {
+            return Promise.resolve(getVerificationErrors(context));
+        }
+
+        if (isTypesFieldExemptWorkspace(context.workspaceName)) {
+            if (parsed.types !== undefined) {
+                writeFileSync(
+                    packageJsonPath,
+                    `${JSON.stringify(getPackageJsonWithoutTypes(parsed), null, 4)}\n`,
+                    'utf-8',
+                );
+            }
+
+            return Promise.resolve(getVerificationErrors(context));
+        }
+
+        const requiredTypesField = getRequiredTypesField(context);
+        const requiredTypedExports = REQUIRED_TYPED_EXPORTS[context.workspaceName];
+
+        if (!requiredTypesField && !requiredTypedExports) {
+            return Promise.resolve(getVerificationErrors(context));
+        }
+
+        const packageJsonWithRequiredTypes = requiredTypesField
+            ? { ...parsed, types: requiredTypesField }
+            : getPackageJsonWithoutTypes(parsed);
+        const fixedPackageJson = requiredTypedExports
+            ? {
+                  ...packageJsonWithRequiredTypes,
+                  exports: {
+                      ...packageJsonWithRequiredTypes.exports,
+                      ...requiredTypedExports,
+                  },
+              }
+            : packageJsonWithRequiredTypes;
+
+        writeFileSync(
+            packageJsonPath,
+            `${JSON.stringify(fixedPackageJson, null, 4)}\n`,
+            'utf-8',
+        );
+
+        return Promise.resolve(getVerificationErrors(context));
+    },
+};

--- a/packages/schema-utils/package.json
+++ b/packages/schema-utils/package.json
@@ -39,5 +39,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/styles-common/package.json
+++ b/packages/styles-common/package.json
@@ -15,5 +15,6 @@
         "@trezor/theme": "workspace:*",
         "polished": "^4.3.1",
         "react": "19.2.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/styles-native/package.json
+++ b/packages/styles-native/package.json
@@ -20,5 +20,6 @@
         "react": "19.2.3",
         "react-fela": "^12.2.1",
         "react-native": "0.85.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -9,5 +9,6 @@
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/suite-desktop-native/package.json
+++ b/packages/suite-desktop-native/package.json
@@ -19,5 +19,6 @@
     "devDependencies": {
         "@types/node": "22.13.10",
         "node-gyp": "12.2.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/suite-desktop-ui/package.json
+++ b/packages/suite-desktop-ui/package.json
@@ -44,5 +44,6 @@
         "postcss-styled-syntax": "^0.7.1",
         "stylelint": "^17.1.1",
         "stylelint-config-standard": "^40.0.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/suite-storage/package.json
+++ b/packages/suite-storage/package.json
@@ -21,5 +21,6 @@
         "@trezor/eslint": "workspace:*",
         "@trezor/utils": "workspace:*",
         "idb": "^8.0.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -46,5 +46,6 @@
         "stylelint-config-standard": "^40.0.0",
         "tsx": "^4.21.0",
         "vite": "^8.0.7"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -3,6 +3,7 @@
     "suiteVersion": "26.8.0",
     "version": "1.0.0",
     "private": true,
+    "types": "./libDev/index.d.ts",
     "exports": {
         ".": {
             "types": "./libDev/index.d.ts",

--- a/packages/suite/src/components/firmware/FirmwareInstallation.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInstallation.tsx
@@ -1,9 +1,7 @@
 import { FirmwareProgressBar, useFirmwareDesktopUpdate } from '@suite/firmware-upgrade';
 import { Translation } from '@suite/intl';
 import { Banner, Card, Column } from '@trezor/components';
-import TrezorConnect from '@trezor/connect';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: expose the browser-specific TrezorConnect type via the @trezor/connect barrel and remove this exception (see #27376)
-import type TrezorConnectBrowser from '@trezor/connect/src/index.browser';
+import TrezorConnect, { type TrezorConnectWithBrowserAPI } from '@trezor/connect';
 import { BluetoothIcon, TrezorDevicesFilledIcon } from '@trezor/icons';
 
 import { FirmwareOffer } from 'src/components/firmware/FirmwareOffer';
@@ -57,7 +55,7 @@ export const FirmwareInstallation = ({
                             <Banner.Button
                                 onClick={() => {
                                     (
-                                        TrezorConnect as typeof TrezorConnectBrowser
+                                        TrezorConnect as TrezorConnectWithBrowserAPI
                                     ).requestWebUSBDevice();
                                 }}
                             >

--- a/packages/suite/src/components/suite/WebUsbButton.tsx
+++ b/packages/suite/src/components/suite/WebUsbButton.tsx
@@ -1,13 +1,11 @@
 import { Translation } from '@suite/intl';
 import { Button, type ButtonProps } from '@trezor/components';
-import TrezorConnect from '@trezor/connect';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: expose the browser-specific TrezorConnect type via the @trezor/connect barrel and remove this exception (see #27376)
-import type TrezorConnectBrowser from '@trezor/connect/src/index.browser';
+import TrezorConnect, { type TrezorConnectWithBrowserAPI } from '@trezor/connect';
 import { MagnifyingGlassIcon } from '@trezor/icons';
 
 const handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.stopPropagation();
-    (TrezorConnect as typeof TrezorConnectBrowser).requestWebUSBDevice();
+    (TrezorConnect as TrezorConnectWithBrowserAPI).requestWebUSBDevice();
 };
 
 type WebUsbButtonProps = Omit<ButtonProps, 'onClick' | 'data-testid' | 'children' | 'iconRight'> & {

--- a/packages/suite/src/support/suite/Main.tsx
+++ b/packages/suite/src/support/suite/Main.tsx
@@ -1,7 +1,7 @@
 import { HelmetProvider } from 'react-helmet-async';
 
 import { FormatterProvider } from '@suite-common/formatters';
-import { ReactQueryProvider } from '@suite-common/react-query/src/components/ReactQueryProvider';
+import { ReactQueryProvider } from '@suite-common/react-query/react';
 import { SelectCacheProvider } from '@trezor/components';
 
 import { useFormattersConfig } from 'src/hooks/suite';

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -14,5 +14,6 @@
         "@mobily/ts-belt": "^3.13.1",
         "@suite-common/wallet-config": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/transport-bluetooth/package.json
+++ b/packages/transport-bluetooth/package.json
@@ -39,5 +39,6 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "webpack": "5.108.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/transport-bridge/package.json
+++ b/packages/transport-bridge/package.json
@@ -44,5 +44,6 @@
         "react-intl": "^8.1.3",
         "styled-components": "^6.3.9",
         "usb": "^2.17.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/transport-common/package.json
+++ b/packages/transport-common/package.json
@@ -69,5 +69,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/transport-native-bluetooth/package.json
+++ b/packages/transport-native-bluetooth/package.json
@@ -17,5 +17,6 @@
     },
     "devDependencies": {
         "@trezor/type-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/transport-native-usb/package.json
+++ b/packages/transport-native-usb/package.json
@@ -13,5 +13,6 @@
     "dependencies": {
         "@trezor/react-native-usb": "workspace:*",
         "@trezor/transport-common": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/transport-web/package.json
+++ b/packages/transport-web/package.json
@@ -48,5 +48,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -54,5 +54,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/trezor-user-env-link/package.json
+++ b/packages/trezor-user-env-link/package.json
@@ -17,5 +17,6 @@
     },
     "devDependencies": {
         "tsx": "^4.21.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -32,5 +32,6 @@
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/urls/package.json
+++ b/packages/urls/package.json
@@ -11,5 +11,6 @@
         "test:e2e": "yarn g:jest -c ../../jest.config.base.js --testPathPattern=tests/e2e",
         "test:unit": "yarn g:jest -c ../../jest.config.base.js --testPathIgnorePatterns tests/e2e",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -49,5 +49,6 @@
     },
     "browser": {
         "crypto": false
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -62,5 +62,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -62,5 +62,6 @@
         "@types/node": "22.13.10",
         "@types/web": "^0.0.345",
         "@types/ws": "^8.5.13"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/address/package.json
+++ b/suite-common/address/package.json
@@ -17,5 +17,6 @@
         "@trezor/address-validator": "workspace:*",
         "@trezor/crypto-utils": "workspace:*",
         "viem": "^2.54.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/analytics-redux/package.json
+++ b/suite-common/analytics-redux/package.json
@@ -15,5 +15,6 @@
         "@reduxjs/toolkit": "2.12.0",
         "@suite-common/redux-utils": "workspace:*",
         "react": "19.2.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/analytics/package.json
+++ b/suite-common/analytics/package.json
@@ -15,5 +15,6 @@
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "react": "19.2.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/assets/package.json
+++ b/suite-common/assets/package.json
@@ -14,5 +14,6 @@
     "dependencies": {
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/backup/package.json
+++ b/suite-common/backup/package.json
@@ -16,5 +16,6 @@
     },
     "devDependencies": {
         "@suite-common/suite-types": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/bip329-types/package.json
+++ b/suite-common/bip329-types/package.json
@@ -17,5 +17,6 @@
         "@trezor/device-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "yup": "1.7.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/bip329/package.json
+++ b/suite-common/bip329/package.json
@@ -20,5 +20,6 @@
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/bluetooth/package.json
+++ b/suite-common/bluetooth/package.json
@@ -19,5 +19,6 @@
         "@suite-common/test-utils": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/calldata/package.json
+++ b/suite-common/calldata/package.json
@@ -16,5 +16,6 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "viem": "^2.54.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/connect-init/package.json
+++ b/suite-common/connect-init/package.json
@@ -25,5 +25,6 @@
         "@trezor/env-utils": "workspace:*",
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/connect-popup/package.json
+++ b/suite-common/connect-popup/package.json
@@ -29,5 +29,6 @@
     },
     "devDependencies": {
         "@types/react": "19.2.14"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/delegated-identity-key-types/package.json
+++ b/suite-common/delegated-identity-key-types/package.json
@@ -13,5 +13,6 @@
     "dependencies": {
         "@suite-common/suite-types": "workspace:*",
         "@trezor/type-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/delegated-identity-key/package.json
+++ b/suite-common/delegated-identity-key/package.json
@@ -22,5 +22,6 @@
         "@trezor/connect": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/dependency-injection/package.json
+++ b/suite-common/dependency-injection/package.json
@@ -17,5 +17,6 @@
     },
     "devDependencies": {
         "@testing-library/react": "^16.3.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/device-authenticity/package.json
+++ b/suite-common/device-authenticity/package.json
@@ -20,5 +20,6 @@
         "@suite-common/toast-notifications": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/type-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/device/package.json
+++ b/suite-common/device/package.json
@@ -26,5 +26,6 @@
         "@trezor/utils": "workspace:*",
         "react": "19.2.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/discreet-mode/package.json
+++ b/suite-common/discreet-mode/package.json
@@ -15,5 +15,6 @@
         "@reduxjs/toolkit": "2.12.0",
         "react": "19.2.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/e2e-evolu-client/package.json
+++ b/suite-common/e2e-evolu-client/package.json
@@ -21,5 +21,6 @@
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/device-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/earn-stablecoin-api/package.json
+++ b/suite-common/earn-stablecoin-api/package.json
@@ -25,5 +25,6 @@
         "@trezor/utils": "workspace:^",
         "react": "19.2.3",
         "zod": "4.3.6"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/earn-stablecoin-defs/package.json
+++ b/suite-common/earn-stablecoin-defs/package.json
@@ -20,5 +20,6 @@
     },
     "dependencies": {
         "zod": "4.3.6"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/earn-stablecoin/package.json
+++ b/suite-common/earn-stablecoin/package.json
@@ -22,5 +22,19 @@
         "@trezor/utils": "workspace:*",
         "react": "19.2.3",
         "zod": "4.3.6"
+    },
+    "exports": {
+        "./src/allowance": {
+            "types": "./libDev/src/allowance/index.d.ts",
+            "default": "./src/allowance/index.ts"
+        },
+        "./src/signing": {
+            "types": "./libDev/src/signing/index.d.ts",
+            "default": "./src/signing/index.ts"
+        },
+        "./src/tx-simulation": {
+            "types": "./libDev/src/tx-simulation/index.d.ts",
+            "default": "./src/tx-simulation/index.ts"
+        }
     }
 }

--- a/suite-common/earn-staking-api/package.json
+++ b/suite-common/earn-staking-api/package.json
@@ -25,5 +25,6 @@
     "devDependencies": {
         "orval": "8.19.0",
         "prettier": "^3.8.4"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/feedback/package.json
+++ b/suite-common/feedback/package.json
@@ -18,5 +18,6 @@
         "@suite-common/toast-notifications": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/fiat-services/package.json
+++ b/suite-common/fiat-services/package.json
@@ -20,5 +20,6 @@
         "@trezor/network-stellar": "workspace:*",
         "@trezor/utils": "workspace:*",
         "date-fns": "^4.1.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/firmware-authenticity/package.json
+++ b/suite-common/firmware-authenticity/package.json
@@ -25,5 +25,6 @@
     "devDependencies": {
         "@suite-common/suite-types": "workspace:*",
         "@trezor/type-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/firmware/package.json
+++ b/suite-common/firmware/package.json
@@ -22,5 +22,6 @@
         "@trezor/utils": "workspace:*",
         "react": "19.2.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/flags/package.json
+++ b/suite-common/flags/package.json
@@ -15,5 +15,6 @@
     },
     "devDependencies": {
         "@types/invity-api": "^1.1.19"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/formatters/package.json
+++ b/suite-common/formatters/package.json
@@ -26,5 +26,6 @@
         "date-fns": "^4.1.0",
         "react": "19.2.3",
         "react-intl": "^8.1.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/geolocation/package.json
+++ b/suite-common/geolocation/package.json
@@ -14,5 +14,6 @@
         "@reduxjs/toolkit": "2.12.0",
         "@suite-common/redux-utils": "workspace:*",
         "@trezor/urls": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/graph/package.json
+++ b/suite-common/graph/package.json
@@ -26,5 +26,6 @@
         "date-fns": "^4.1.0",
         "react": "19.2.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/http-client/package.json
+++ b/suite-common/http-client/package.json
@@ -13,5 +13,6 @@
     "dependencies": {
         "up-fetch": "2.6.0",
         "zod": "4.3.6"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/icons/package.json
+++ b/suite-common/icons/package.json
@@ -23,5 +23,6 @@
     "dependencies": {
         "@suite-common/http-client": "workspace:^",
         "zod": "4.3.6"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/illustrations/package.json
+++ b/suite-common/illustrations/package.json
@@ -15,5 +15,6 @@
         "chalk": "^5.6.2",
         "prettier": "^3.8.4",
         "svgo": "^4.0.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/jsonl/package.json
+++ b/suite-common/jsonl/package.json
@@ -14,5 +14,6 @@
     "dependencies": {
         "@trezor/type-utils": "workspace:*",
         "yup": "1.7.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/logger/package.json
+++ b/suite-common/logger/package.json
@@ -30,5 +30,6 @@
         "@trezor/type-utils": "workspace:*",
         "react": "19.2.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/message-system/package.json
+++ b/suite-common/message-system/package.json
@@ -53,5 +53,6 @@
                 ]
             }
         }
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/metadata-types/package.json
+++ b/suite-common/metadata-types/package.json
@@ -12,5 +12,6 @@
     },
     "dependencies": {
         "@trezor/device-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/mev/package.json
+++ b/suite-common/mev/package.json
@@ -19,5 +19,6 @@
     "devDependencies": {
         "@suite-common/suite-types": "workspace:*",
         "@trezor/device-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/platform-encryption/package.json
+++ b/suite-common/platform-encryption/package.json
@@ -12,5 +12,6 @@
     },
     "dependencies": {
         "@trezor/type-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/react-query/package.json
+++ b/suite-common/react-query/package.json
@@ -14,5 +14,20 @@
         "@tanstack/react-query": "5.101.2",
         "@tanstack/react-query-devtools": "5.101.2",
         "react": "19.2.3"
+    },
+    "types": "./libDev/src/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./libDev/src/index.d.ts",
+            "default": "./src/index.ts"
+        },
+        "./react": {
+            "types": "./libDev/react/index.d.ts",
+            "default": "./react/index.ts"
+        },
+        "./react-native": {
+            "types": "./libDev/react-native/index.d.ts",
+            "default": "./react-native/index.ts"
+        }
     }
 }

--- a/suite-common/react-query/react-native/index.ts
+++ b/suite-common/react-query/react-native/index.ts
@@ -1,0 +1,1 @@
+export { ReactNativeQueryProvider } from '../src/components/ReactNativeQueryProvider';

--- a/suite-common/react-query/react/index.ts
+++ b/suite-common/react-query/react/index.ts
@@ -1,0 +1,1 @@
+export { ReactQueryProvider } from '../src/components/ReactQueryProvider';

--- a/suite-common/receive/package.json
+++ b/suite-common/receive/package.json
@@ -19,5 +19,6 @@
     },
     "devDependencies": {
         "@suite-common/test-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/redux-utils/package.json
+++ b/suite-common/redux-utils/package.json
@@ -34,5 +34,6 @@
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0",
         "reselect": "5.2.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/schemas/package.json
+++ b/suite-common/schemas/package.json
@@ -12,5 +12,11 @@
     },
     "dependencies": {
         "zod": "4.3.6"
+    },
+    "exports": {
+        "./src/evm": {
+            "types": "./libDev/src/evm/index.d.ts",
+            "default": "./src/evm/index.ts"
+        }
     }
 }

--- a/suite-common/sentry/package.json
+++ b/suite-common/sentry/package.json
@@ -12,5 +12,6 @@
     },
     "dependencies": {
         "@sentry/core": "10.62.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/staking/package.json
+++ b/suite-common/staking/package.json
@@ -24,5 +24,6 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "viem": "^2.54.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/suite-config/package.json
+++ b/suite-common/suite-config/package.json
@@ -9,5 +9,6 @@
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/suite-constants/package.json
+++ b/suite-common/suite-constants/package.json
@@ -14,5 +14,6 @@
         "@suite-common/wallet-config": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/protobuf": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/suite-rbf-labels-migrations-types/package.json
+++ b/suite-common/suite-rbf-labels-migrations-types/package.json
@@ -19,5 +19,6 @@
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/suite-rbf-labels-migrations/package.json
+++ b/suite-common/suite-rbf-labels-migrations/package.json
@@ -22,5 +22,6 @@
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/suite-sync-evolu/package.json
+++ b/suite-common/suite-sync-evolu/package.json
@@ -25,5 +25,6 @@
         "@evolu/nodejs": "3.0.0-next.3",
         "@trezor/eslint": "workspace:*",
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/suite-sync-quota-manager/package.json
+++ b/suite-common/suite-sync-quota-manager/package.json
@@ -33,5 +33,6 @@
     },
     "devDependencies": {
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/suite-sync-storage/package.json
+++ b/suite-common/suite-sync-storage/package.json
@@ -15,5 +15,6 @@
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/suite-sync-types/package.json
+++ b/suite-common/suite-sync-types/package.json
@@ -21,5 +21,6 @@
         "@trezor/connect-common": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/suite-sync/package.json
+++ b/suite-common/suite-sync/package.json
@@ -39,5 +39,6 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/suite-types/package.json
+++ b/suite-common/suite-types/package.json
@@ -22,5 +22,6 @@
         "@trezor/protocol": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/suite-utils/package.json
+++ b/suite-common/suite-utils/package.json
@@ -30,5 +30,6 @@
     },
     "devDependencies": {
         "@trezor/device-utils": "workspace:^"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/support/package.json
+++ b/suite-common/support/package.json
@@ -17,5 +17,6 @@
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/urls": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/test-utils/package.json
+++ b/suite-common/test-utils/package.json
@@ -46,5 +46,6 @@
         "react-redux": "9.3.0",
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/thp/package.json
+++ b/suite-common/thp/package.json
@@ -21,5 +21,6 @@
         "@trezor/device-utils": "workspace:*",
         "@trezor/protocol": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/toast-notifications/package.json
+++ b/suite-common/toast-notifications/package.json
@@ -21,5 +21,6 @@
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/connect": "workspace:*",
         "react": "19.2.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/token-definitions/package.json
+++ b/suite-common/token-definitions/package.json
@@ -32,5 +32,6 @@
         "ajv": "^8.20.0",
         "jws": "^4.0.1",
         "toml": "^4.1.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/trading/package.json
+++ b/suite-common/trading/package.json
@@ -46,5 +46,6 @@
         "@suite-common/test-utils": "workspace:*",
         "@testing-library/react": "^16.3.2",
         "@types/invity-api": "^1.1.19"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/transaction-search/package.json
+++ b/suite-common/transaction-search/package.json
@@ -19,5 +19,6 @@
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/utils": "workspace:*",
         "react": "19.2.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/transfer-uri/package.json
+++ b/suite-common/transfer-uri/package.json
@@ -17,5 +17,6 @@
         "@suite-common/wallet-config": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/tx-simulation/package.json
+++ b/suite-common/tx-simulation/package.json
@@ -20,5 +20,6 @@
         "@suite-common/wallet-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "react": "19.2.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/validators/package.json
+++ b/suite-common/validators/package.json
@@ -19,5 +19,6 @@
         "@trezor/network-solana": "workspace:*",
         "@trezor/utils": "workspace:*",
         "yup": "1.7.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/wallet-config/package.json
+++ b/suite-common/wallet-config/package.json
@@ -25,5 +25,6 @@
         "@trezor/network-tron": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/wallet-constants/package.json
+++ b/suite-common/wallet-constants/package.json
@@ -12,5 +12,6 @@
     },
     "dependencies": {
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -57,5 +57,6 @@
         "react": "19.2.3",
         "react-hook-form": "^7.77.0",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
@@ -27,8 +27,6 @@ import TrezorConnect, {
     type SignTransaction,
     type SignedTransaction,
 } from '@trezor/connect';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- temporary diagnostic
-import { __btcUnknownTxDebug__ } from '@trezor/connect/src/utils/pathUtils';
 import { BigNumber, isArrayMember } from '@trezor/utils';
 
 import { SEND_MODULE_PREFIX } from './sendFormConstants';
@@ -337,12 +335,6 @@ export const signBitcoinSendFormTransactionThunk = createThunk<
             // nVersion, use 2 as it enables BIP68 + seems to be the most commonly used (= harder to fingerprint the Trezor)
             signEnhancement.version = 2;
         }
-
-        __btcUnknownTxDebug__(
-            'signBitcoin',
-            (signEnhancement.inputs as { address_n?: number[] }[]) ?? precomposedTransaction.inputs,
-            selectedAccount.addresses,
-        );
 
         const signPayload: Params<SignTransaction> = {
             device: {

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -33,8 +33,6 @@ import TrezorConnect, {
     type AccountTransaction,
     type TokenTransfer,
 } from '@trezor/connect';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- temporary diagnostic
-import { __btcUnknownTxDebug__ } from '@trezor/connect/src/utils/pathUtils';
 
 import { TRANSACTIONS_MODULE_PREFIX, transactionsActions } from './transactionsActions';
 import {
@@ -181,13 +179,6 @@ export const addFakePendingTxThunk = createThunk(
                     signedTransaction,
                     affectedAccount.addresses ?? affectedAccount.descriptor,
                 );
-                if (affectedAccountTransaction.type === 'unknown') {
-                    __btcUnknownTxDebug__(
-                        'addFakePendingTxThunk',
-                        precomposedTransaction.inputs,
-                        affectedAccount.addresses,
-                    );
-                }
                 const prependingTx = { ...affectedAccountTransaction, deadline: blockHeight + 2 };
                 dispatch(
                     transactionsActions.addTransaction({

--- a/suite-common/wallet-types/package.json
+++ b/suite-common/wallet-types/package.json
@@ -21,5 +21,6 @@
         "@trezor/utils": "workspace:^",
         "@types/invity-api": "^1.1.19",
         "react": "19.2.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/wallet-utils/package.json
+++ b/suite-common/wallet-utils/package.json
@@ -38,5 +38,6 @@
         "date-fns": "^4.1.0",
         "react": "19.2.3",
         "react-hook-form": "^7.77.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-common/walletconnect/package.json
+++ b/suite-common/walletconnect/package.json
@@ -35,5 +35,6 @@
         "@walletconnect/core": "^2.23.9",
         "@walletconnect/types": "^2.23.9",
         "@walletconnect/utils": "^2.23.9"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/accounts/package.json
+++ b/suite-native/accounts/package.json
@@ -55,5 +55,6 @@
     "devDependencies": {
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/test-utils-store": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/add-coin-account/package.json
+++ b/suite-native/add-coin-account/package.json
@@ -35,5 +35,6 @@
         "react": "19.2.3",
         "react-native": "0.85.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/address/package.json
+++ b/suite-native/address/package.json
@@ -24,5 +24,6 @@
         "@trezor/connect": "workspace:*",
         "react": "19.2.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/alerts/package.json
+++ b/suite-native/alerts/package.json
@@ -21,5 +21,6 @@
         "react-native": "0.85.3",
         "react-native-reanimated": "4.3.1",
         "react-native-safe-area-context": "5.6.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/analytics-redux/package.json
+++ b/suite-native/analytics-redux/package.json
@@ -19,5 +19,6 @@
         "@suite-native/sentry": "workspace:*",
         "@trezor/analytics-uploader": "workspace:*",
         "@trezor/env-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/analytics/package.json
+++ b/suite-native/analytics/package.json
@@ -26,5 +26,6 @@
         "@trezor/env-utils": "workspace:*",
         "@trezor/utils": "workspace:^",
         "react-native": "0.85.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/app-init/package.json
+++ b/suite-native/app-init/package.json
@@ -22,5 +22,6 @@
         "@suite-native/analytics-redux": "workspace:*",
         "@suite-native/settings": "workspace:*",
         "@suite-native/state": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/app/src/App.tsx
+++ b/suite-native/app/src/App.tsx
@@ -10,7 +10,7 @@ import * as Sentry from '@sentry/react-native';
 import * as SplashScreen from 'expo-splash-screen';
 
 import { FormatterProvider } from '@suite-common/formatters';
-import { ReactNativeQueryProvider } from '@suite-common/react-query/src/components/ReactNativeQueryProvider';
+import { ReactNativeQueryProvider } from '@suite-common/react-query/react-native';
 import { applicationInit } from '@suite-native/app-init';
 import { selectShouldUserBeAuthenticated } from '@suite-native/biometrics';
 import { launchArguments } from '@suite-native/config';

--- a/suite-native/assets/package.json
+++ b/suite-native/assets/package.json
@@ -36,5 +36,6 @@
         "react-native": "0.85.3",
         "react-native-reanimated": "4.3.1",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/atoms/package.json
+++ b/suite-native/atoms/package.json
@@ -47,5 +47,6 @@
     },
     "devDependencies": {
         "@suite-native/test-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/banner-flags/package.json
+++ b/suite-native/banner-flags/package.json
@@ -13,5 +13,6 @@
     "dependencies": {
         "@reduxjs/toolkit": "2.12.0",
         "@trezor/connect": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/biometrics/package.json
+++ b/suite-native/biometrics/package.json
@@ -25,5 +25,6 @@
         "react-native": "0.85.3",
         "react-native-svg": "15.15.5",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/bip329/package.json
+++ b/suite-native/bip329/package.json
@@ -32,5 +32,6 @@
         "react": "19.2.3",
         "react-native": "0.85.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/blockchain/package.json
+++ b/suite-native/blockchain/package.json
@@ -21,5 +21,6 @@
         "react": "19.2.3",
         "react-native": "0.85.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/bluetooth/package.json
+++ b/suite-native/bluetooth/package.json
@@ -34,5 +34,6 @@
         "react-native": "0.85.3",
         "react-native-permissions": "5.4.4",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/clipboard/package.json
+++ b/suite-native/clipboard/package.json
@@ -15,5 +15,6 @@
         "@suite-native/toasts": "workspace:*",
         "expo-clipboard": "~56.0.3",
         "react": "19.2.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/coin-enabling/package.json
+++ b/suite-native/coin-enabling/package.json
@@ -35,5 +35,6 @@
         "react-native-reanimated": "4.3.1",
         "react-native-svg": "15.15.5",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/config/package.json
+++ b/suite-native/config/package.json
@@ -15,5 +15,6 @@
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
         "react-native-launch-arguments": "^4.1.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/confirm-on-trezor/package.json
+++ b/suite-native/confirm-on-trezor/package.json
@@ -27,5 +27,6 @@
         "react-native": "0.85.3",
         "react-native-gesture-handler": "2.31.1",
         "react-native-reanimated": "4.3.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/connection-status/package.json
+++ b/suite-native/connection-status/package.json
@@ -22,5 +22,6 @@
         "react": "19.2.3",
         "react-native": "0.85.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/device-authorization/package.json
+++ b/suite-native/device-authorization/package.json
@@ -42,5 +42,6 @@
     },
     "devDependencies": {
         "@suite-native/test-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/device-bootloader-mode/package.json
+++ b/suite-native/device-bootloader-mode/package.json
@@ -20,5 +20,6 @@
         "@trezor/styles-native": "workspace:*",
         "react": "19.2.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/device-manager/package.json
+++ b/suite-native/device-manager/package.json
@@ -40,5 +40,6 @@
         "react-native-reanimated": "4.3.1",
         "react-native-safe-area-context": "5.6.2",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/device-mutex/package.json
+++ b/suite-native/device-mutex/package.json
@@ -14,5 +14,6 @@
         "type-check": "yarn g:tsc --build",
         "test:unit": "yarn g:jest:native",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/device-onboarding/package.json
+++ b/suite-native/device-onboarding/package.json
@@ -12,5 +12,6 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.12.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/device/package.json
+++ b/suite-native/device/package.json
@@ -69,5 +69,6 @@
         "react-redux": "9.3.0",
         "semver": "^7.7.1",
         "type-fest": "5.5.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/discovery/package.json
+++ b/suite-native/discovery/package.json
@@ -39,5 +39,6 @@
     },
     "devDependencies": {
         "@suite-native/test-utils-store": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/experimental-features/package.json
+++ b/suite-native/experimental-features/package.json
@@ -14,5 +14,6 @@
         "@suite-native/intl": "workspace:*",
         "@suite-native/settings": "workspace:*",
         "react": "19.2.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/feature-feedback/package.json
+++ b/suite-native/feature-feedback/package.json
@@ -21,5 +21,6 @@
         "react": "19.2.3",
         "react-native": "0.85.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/feature-flags/package.json
+++ b/suite-native/feature-flags/package.json
@@ -17,5 +17,6 @@
         "@trezor/env-utils": "workspace:*",
         "react-native": "0.85.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/firmware/package.json
+++ b/suite-native/firmware/package.json
@@ -45,5 +45,6 @@
         "react-native": "0.85.3",
         "react-native-reanimated": "4.3.1",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/formatters-config/package.json
+++ b/suite-native/formatters-config/package.json
@@ -17,5 +17,6 @@
         "expo-localization": "~56.0.6",
         "react": "19.2.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/formatters/package.json
+++ b/suite-native/formatters/package.json
@@ -37,5 +37,6 @@
     "devDependencies": {
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/test-utils-store": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/forms/package.json
+++ b/suite-native/forms/package.json
@@ -20,5 +20,6 @@
         "react-hook-form": "^7.77.0",
         "react-native": "0.85.3",
         "react-native-reanimated": "4.3.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/graph/package.json
+++ b/suite-native/graph/package.json
@@ -50,5 +50,6 @@
         "react-native-reanimated": "4.3.1",
         "react-redux": "9.3.0",
         "redux-persist": "6.0.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/helpers/package.json
+++ b/suite-native/helpers/package.json
@@ -28,5 +28,6 @@
     },
     "devDependencies": {
         "@suite-native/test-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/icons/package.json
+++ b/suite-native/icons/package.json
@@ -34,5 +34,6 @@
     },
     "devDependencies": {
         "@suite-native/test-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/in-app-rating/package.json
+++ b/suite-native/in-app-rating/package.json
@@ -15,5 +15,6 @@
         "@suite-common/message-system": "workspace:*",
         "expo-store-review": "~56.0.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/intl/package.json
+++ b/suite-native/intl/package.json
@@ -38,5 +38,6 @@
     },
     "devDependencies": {
         "@crowdin/cli": "4.13.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/labeling/package.json
+++ b/suite-native/labeling/package.json
@@ -26,5 +26,6 @@
         "react": "19.2.3",
         "react-native": "0.85.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/link/package.json
+++ b/suite-native/link/package.json
@@ -24,5 +24,6 @@
     "peerDependencies": {
         "react-native": "*",
         "react-native-reanimated": "*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/message-system/package.json
+++ b/suite-native/message-system/package.json
@@ -36,5 +36,6 @@
     },
     "devDependencies": {
         "@suite-native/test-utils-store": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-accounts-import/package.json
+++ b/suite-native/module-accounts-import/package.json
@@ -57,5 +57,6 @@
     "devDependencies": {
         "@suite-native/test-utils-store": "workspace:*",
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-accounts-management/package.json
+++ b/suite-native/module-accounts-management/package.json
@@ -72,5 +72,6 @@
         "react-native": "0.85.3",
         "react-native-reanimated": "4.3.1",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-add-accounts/package.json
+++ b/suite-native/module-add-accounts/package.json
@@ -44,5 +44,6 @@
     },
     "devDependencies": {
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-authenticity-checks/package.json
+++ b/suite-native/module-authenticity-checks/package.json
@@ -29,5 +29,6 @@
     },
     "devDependencies": {
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-authorize-device/package.json
+++ b/suite-native/module-authorize-device/package.json
@@ -51,5 +51,6 @@
     },
     "devDependencies": {
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-check-backup/package.json
+++ b/suite-native/module-check-backup/package.json
@@ -38,5 +38,6 @@
     },
     "devDependencies": {
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-connect-popup/package.json
+++ b/suite-native/module-connect-popup/package.json
@@ -46,5 +46,6 @@
     },
     "devDependencies": {
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-demo-account-questionnaire/package.json
+++ b/suite-native/module-demo-account-questionnaire/package.json
@@ -28,5 +28,6 @@
     },
     "devDependencies": {
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-dev-utils/package.json
+++ b/suite-native/module-dev-utils/package.json
@@ -50,5 +50,6 @@
     },
     "devDependencies": {
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-device-onboarding/package.json
+++ b/suite-native/module-device-onboarding/package.json
@@ -66,5 +66,6 @@
     "devDependencies": {
         "@suite-native/test-utils-store": "workspace:*",
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-device-settings/package.json
+++ b/suite-native/module-device-settings/package.json
@@ -49,5 +49,6 @@
     },
     "devDependencies": {
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-earn/package.json
+++ b/suite-native/module-earn/package.json
@@ -81,5 +81,6 @@
     },
     "devDependencies": {
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-home/package.json
+++ b/suite-native/module-home/package.json
@@ -64,5 +64,6 @@
     "devDependencies": {
         "@suite-native/test-utils-store": "workspace:*",
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-onboarding/package.json
+++ b/suite-native/module-onboarding/package.json
@@ -45,5 +45,6 @@
         "@suite-native/feature-flags": "workspace:*",
         "@suite-native/test-utils-store": "workspace:*",
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-passphrase/package.json
+++ b/suite-native/module-passphrase/package.json
@@ -34,5 +34,6 @@
     },
     "devDependencies": {
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-receive/package.json
+++ b/suite-native/module-receive/package.json
@@ -47,5 +47,6 @@
     },
     "devDependencies": {
         "@suite-native/test-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-send/package.json
+++ b/suite-native/module-send/package.json
@@ -72,5 +72,6 @@
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/test-utils-store": "workspace:*",
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-settings/package.json
+++ b/suite-native/module-settings/package.json
@@ -73,5 +73,6 @@
     "devDependencies": {
         "@suite-native/test-utils-store": "workspace:*",
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-stellar-token-management/package.json
+++ b/suite-native/module-stellar-token-management/package.json
@@ -46,5 +46,6 @@
     "devDependencies": {
         "@suite-native/test-utils-store": "workspace:*",
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -105,5 +105,6 @@
         "@suite-native/trading-types": "workspace:*",
         "@trezor/requirements": "workspace:*",
         "@types/invity-api": "^1.1.19"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/module-transactions/package.json
+++ b/suite-native/module-transactions/package.json
@@ -46,5 +46,6 @@
     },
     "devDependencies": {
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/navigation/package.json
+++ b/suite-native/navigation/package.json
@@ -47,5 +47,6 @@
     },
     "devDependencies": {
         "@suite-native/test-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/passphrase/package.json
+++ b/suite-native/passphrase/package.json
@@ -33,5 +33,6 @@
         "react-native": "0.85.3",
         "react-native-reanimated": "4.3.1",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/platform-encryption-native/package.json
+++ b/suite-native/platform-encryption-native/package.json
@@ -14,5 +14,6 @@
         "@suite-common/platform-encryption": "workspace:*",
         "@suite-native/storage": "workspace:*",
         "@trezor/type-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/qr-code/package.json
+++ b/suite-native/qr-code/package.json
@@ -28,5 +28,6 @@
         "react-native": "0.85.3",
         "react-qr-code": "2.0.18",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/react-native-graph/package.json
+++ b/suite-native/react-native-graph/package.json
@@ -22,5 +22,6 @@
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/scrollview/package.json
+++ b/suite-native/scrollview/package.json
@@ -15,5 +15,6 @@
         "react": "19.2.3",
         "react-native": "0.85.3",
         "react-native-reanimated": "4.3.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/search/package.json
+++ b/suite-native/search/package.json
@@ -17,5 +17,6 @@
         "@trezor/styles-native": "workspace:*",
         "react": "19.2.3",
         "react-native-reanimated": "4.3.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/send/package.json
+++ b/suite-native/send/package.json
@@ -25,5 +25,6 @@
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/sentry/package.json
+++ b/suite-native/sentry/package.json
@@ -16,5 +16,6 @@
         "@suite-common/sentry": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-native/config": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/services/package.json
+++ b/suite-native/services/package.json
@@ -14,5 +14,6 @@
         "@suite-common/redux-utils": "workspace:*",
         "@suite-native/analytics": "workspace:*",
         "react-native-mmkv": "~4.3.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/settings/package.json
+++ b/suite-native/settings/package.json
@@ -16,5 +16,6 @@
         "@suite-native/config": "workspace:*",
         "@trezor/connect": "workspace:*",
         "react": "19.2.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/staking/package.json
+++ b/suite-native/staking/package.json
@@ -37,5 +37,6 @@
         "@suite-common/message-system": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/test-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -72,5 +72,6 @@
     "devDependencies": {
         "@rozenite/redux-devtools-plugin": "^1.4.0",
         "@types/redux-logger": "^3.0.13"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/storage/package.json
+++ b/suite-native/storage/package.json
@@ -38,5 +38,6 @@
         "react-native-mmkv": "~4.3.1",
         "react-native-restart": "0.0.27",
         "redux-persist": "6.0.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/storybook/package.json
+++ b/suite-native/storybook/package.json
@@ -5,6 +5,7 @@
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
     "main": ".rnstorybook/index",
+    "types": "./libDev/src/index.d.ts",
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",

--- a/suite-native/storybook/src/index.ts
+++ b/suite-native/storybook/src/index.ts
@@ -1,0 +1,1 @@
+export { StorybookUI } from '../.rnstorybook';

--- a/suite-native/storybook/tsconfig.json
+++ b/suite-native/storybook/tsconfig.json
@@ -1,6 +1,11 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
+    "include": [
+        ".",
+        ".rnstorybook/**/*.ts",
+        ".rnstorybook/**/*.tsx"
+    ],
     "references": [
         { "path": "../alerts" },
         { "path": "../intl" },

--- a/suite-native/suite-sync/package.json
+++ b/suite-native/suite-sync/package.json
@@ -37,5 +37,6 @@
         "react": "19.2.3",
         "react-native": "0.85.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/swipeable-walkthrough/package.json
+++ b/suite-native/swipeable-walkthrough/package.json
@@ -20,5 +20,6 @@
         "react-native-gesture-handler": "2.31.1",
         "react-native-reanimated": "4.3.1",
         "react-native-safe-area-context": "5.6.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/test-utils-store/package.json
+++ b/suite-native/test-utils-store/package.json
@@ -19,5 +19,6 @@
         "react": "19.2.3",
         "react-native": "0.85.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/test-utils/package.json
+++ b/suite-native/test-utils/package.json
@@ -32,5 +32,6 @@
         "react-native-reanimated": "4.3.1",
         "react-native-safe-area-context": "5.6.2",
         "react-native-worklets": "0.8.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/theme/package.json
+++ b/suite-native/theme/package.json
@@ -18,5 +18,6 @@
         "jotai": "2.17.1",
         "react": "19.2.3",
         "react-native": "0.85.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/thp/package.json
+++ b/suite-native/thp/package.json
@@ -24,5 +24,6 @@
         "react-native": "0.85.3",
         "react-native-keyboard-controller": "1.20.7",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/toasts/package.json
+++ b/suite-native/toasts/package.json
@@ -20,5 +20,6 @@
         "react": "19.2.3",
         "react-native-reanimated": "4.3.1",
         "react-native-safe-area-context": "5.6.2"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/tokens/package.json
+++ b/suite-native/tokens/package.json
@@ -22,5 +22,6 @@
         "@suite-common/wallet-utils": "workspace:*",
         "@trezor/blockchain-link": "workspace:*",
         "react": "19.2.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/trading-analytics/package.json
+++ b/suite-native/trading-analytics/package.json
@@ -27,5 +27,6 @@
         "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
         "@types/invity-api": "^1.1.19"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/trading-atoms/package.json
+++ b/suite-native/trading-atoms/package.json
@@ -46,5 +46,6 @@
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
         "@types/invity-api": "^1.1.19"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/trading-browser-auth/package.json
+++ b/suite-native/trading-browser-auth/package.json
@@ -45,5 +45,6 @@
         "@suite-native/trading-types": "workspace:*",
         "@suite-native/transaction-management": "workspace:*",
         "@types/invity-api": "^1.1.19"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/trading-consts/package.json
+++ b/suite-native/trading-consts/package.json
@@ -16,5 +16,6 @@
     },
     "devDependencies": {
         "@suite-native/trading-types": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/trading-debug/package.json
+++ b/suite-native/trading-debug/package.json
@@ -31,5 +31,6 @@
         "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/trading-consts": "workspace:*",
         "@suite-native/trading-types": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/trading-fixtures/package.json
+++ b/suite-native/trading-fixtures/package.json
@@ -26,5 +26,6 @@
     "devDependencies": {
         "@suite-native/trading-types": "workspace:*",
         "@types/invity-api": "^1.1.19"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/trading-history/package.json
+++ b/suite-native/trading-history/package.json
@@ -48,5 +48,6 @@
         "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
         "@types/invity-api": "^1.1.19"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/trading-provider-utils/package.json
+++ b/suite-native/trading-provider-utils/package.json
@@ -36,5 +36,6 @@
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
         "@types/invity-api": "^1.1.19"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/trading-quote-utils/package.json
+++ b/suite-native/trading-quote-utils/package.json
@@ -32,5 +32,6 @@
         "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
         "@types/invity-api": "^1.1.19"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/trading-residence/package.json
+++ b/suite-native/trading-residence/package.json
@@ -43,5 +43,6 @@
         "@suite-common/wallet-core": "workspace:*",
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/test-utils-store": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/trading-slippage/package.json
+++ b/suite-native/trading-slippage/package.json
@@ -39,5 +39,6 @@
         "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
         "@types/invity-api": "^1.1.19"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/trading-state/package.json
+++ b/suite-native/trading-state/package.json
@@ -45,5 +45,6 @@
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
         "@types/invity-api": "^1.1.19"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/trading-types/package.json
+++ b/suite-native/trading-types/package.json
@@ -21,5 +21,6 @@
         "@suite-native/navigation": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",
         "@types/invity-api": "^1.1.19"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/transaction-management/package.json
+++ b/suite-native/transaction-management/package.json
@@ -59,5 +59,6 @@
         "@suite-common/test-utils": "workspace:*",
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/test-utils-store": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/transactions/package.json
+++ b/suite-native/transactions/package.json
@@ -52,5 +52,6 @@
         "react-native": "0.85.3",
         "react-native-svg": "15.15.5",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/tx-simulation/package.json
+++ b/suite-native/tx-simulation/package.json
@@ -24,5 +24,6 @@
         "react": "19.2.3",
         "react-native": "0.85.3",
         "react-native-reanimated": "4.3.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/video-assets/package.json
+++ b/suite-native/video-assets/package.json
@@ -20,5 +20,6 @@
         "react": "19.2.3",
         "react-native": "0.85.3",
         "react-native-reanimated": "4.3.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite-native/wallet/package.json
+++ b/suite-native/wallet/package.json
@@ -18,5 +18,6 @@
         "@trezor/device-utils": "workspace:*",
         "react": "19.2.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/account/package.json
+++ b/suite/account/package.json
@@ -32,5 +32,6 @@
     },
     "devDependencies": {
         "@types/react": "19.2.14"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/address/package.json
+++ b/suite/address/package.json
@@ -37,5 +37,6 @@
     },
     "devDependencies": {
         "@types/react": "19.2.14"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/analytics/package.json
+++ b/suite/analytics/package.json
@@ -18,5 +18,6 @@
         "@suite/router-config": "workspace:*",
         "@trezor/analytics-uploader": "workspace:*",
         "@trezor/device-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/authenticity-checks/package.json
+++ b/suite/authenticity-checks/package.json
@@ -15,5 +15,6 @@
         "@suite-common/firmware-authenticity": "workspace:*",
         "@suite-common/message-system": "workspace:*",
         "@suite/settings": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/backup/package.json
+++ b/suite/backup/package.json
@@ -40,5 +40,6 @@
         "@suite-common/test-utils": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/protobuf": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/coinjoin/package.json
+++ b/suite/coinjoin/package.json
@@ -44,5 +44,6 @@
         "@suite-common/test-utils": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/eslint": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/debug/package.json
+++ b/suite/debug/package.json
@@ -22,5 +22,6 @@
         "react": "19.2.3",
         "react-redux": "9.3.0",
         "styled-components": "^6.3.9"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/desktop-update/package.json
+++ b/suite/desktop-update/package.json
@@ -32,5 +32,6 @@
         "react-redux": "9.3.0",
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/device/package.json
+++ b/suite/device/package.json
@@ -27,5 +27,6 @@
         "@types/react": "19.2.14",
         "redux-mock-store": "^1.5.5",
         "redux-thunk": "^3.1.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/discreet-mode/package.json
+++ b/suite/discreet-mode/package.json
@@ -15,5 +15,6 @@
         "react": "19.2.3",
         "react-redux": "9.3.0",
         "styled-components": "^6.3.9"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/experimental/package.json
+++ b/suite/experimental/package.json
@@ -12,5 +12,6 @@
     },
     "dependencies": {
         "@suite/intl": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/external-links/package.json
+++ b/suite/external-links/package.json
@@ -20,5 +20,6 @@
         "@trezor/utils": "workspace:*",
         "react": "19.2.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/feature-feedback/package.json
+++ b/suite/feature-feedback/package.json
@@ -26,5 +26,6 @@
     },
     "devDependencies": {
         "@types/react": "19.2.14"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/firmware-upgrade/package.json
+++ b/suite/firmware-upgrade/package.json
@@ -30,5 +30,6 @@
     },
     "devDependencies": {
         "@types/react": "19.2.14"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/flags/package.json
+++ b/suite/flags/package.json
@@ -16,5 +16,6 @@
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/test-utils": "workspace:*",
         "@trezor/connect": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/github/package.json
+++ b/suite/github/package.json
@@ -16,5 +16,6 @@
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/urls": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/idb-migration-utils/package.json
+++ b/suite/idb-migration-utils/package.json
@@ -15,5 +15,6 @@
     "dependencies": {
         "idb": "^8.0.3",
         "semver": "^7.7.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/intl/package.json
+++ b/suite/intl/package.json
@@ -26,5 +26,6 @@
         "@trezor/utils": "workspace:^",
         "react": "19.2.3",
         "react-intl": "^8.1.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/labeling/package.json
+++ b/suite/labeling/package.json
@@ -46,5 +46,6 @@
         "react-redux": "9.3.0",
         "react-select": "^5.10.2",
         "redux": "^5.0.1"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/locks/package.json
+++ b/suite/locks/package.json
@@ -14,5 +14,6 @@
     "dependencies": {
         "@reduxjs/toolkit": "2.12.0",
         "@suite-common/test-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/macos/package.json
+++ b/suite/macos/package.json
@@ -15,5 +15,6 @@
         "@trezor/theme": "workspace:*",
         "react": "19.2.3",
         "styled-components": "^6.3.9"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/message-system/package.json
+++ b/suite/message-system/package.json
@@ -34,5 +34,6 @@
         "react-redux": "9.3.0",
         "redux": "^5.0.1",
         "styled-components": "^6.3.9"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/metadata-migration/package.json
+++ b/suite/metadata-migration/package.json
@@ -39,5 +39,6 @@
         "react": "19.2.3",
         "react-redux": "9.3.0",
         "redux-thunk": "^3.1.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/metadata/package.json
+++ b/suite/metadata/package.json
@@ -53,5 +53,6 @@
     },
     "devDependencies": {
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/modal/package.json
+++ b/suite/modal/package.json
@@ -16,5 +16,6 @@
         "@suite-common/thp": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/nfc/package.json
+++ b/suite/nfc/package.json
@@ -17,5 +17,6 @@
         "@trezor/icons": "workspace:*",
         "react": "19.2.3",
         "styled-components": "^6.3.9"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/onboarding-components/package.json
+++ b/suite/onboarding-components/package.json
@@ -20,5 +20,6 @@
         "@trezor/theme": "workspace:*",
         "react": "19.2.3",
         "react-intl": "^8.1.3"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/platform-encryption-electron/package.json
+++ b/suite/platform-encryption-electron/package.json
@@ -14,5 +14,6 @@
         "@suite-common/platform-encryption": "workspace:*",
         "@trezor/suite-desktop-api": "workspace:*",
         "@trezor/type-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/platform-encryption-webauthn/package.json
+++ b/suite/platform-encryption-webauthn/package.json
@@ -13,5 +13,6 @@
     "dependencies": {
         "@suite-common/platform-encryption": "workspace:*",
         "@trezor/type-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/receive/package.json
+++ b/suite/receive/package.json
@@ -37,5 +37,6 @@
     },
     "devDependencies": {
         "@types/react": "19.2.14"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/recovery/package.json
+++ b/suite/recovery/package.json
@@ -20,5 +20,6 @@
         "@suite/analytics": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/router-config/package.json
+++ b/suite/router-config/package.json
@@ -9,5 +9,6 @@
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "type-check": "yarn g:tsc --build"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/router/package.json
+++ b/suite/router/package.json
@@ -25,5 +25,6 @@
         "history": "^5.3.0",
         "react": "19.2.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/sentry/package.json
+++ b/suite/sentry/package.json
@@ -17,5 +17,6 @@
         "@suite-common/suite-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/settings/package.json
+++ b/suite/settings/package.json
@@ -24,5 +24,6 @@
         "@trezor/connect-common": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/suite-desktop-api": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/suite-sync/package.json
+++ b/suite/suite-sync/package.json
@@ -48,5 +48,6 @@
     },
     "devDependencies": {
         "@trezor/requirements": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/test-utils/package.json
+++ b/suite/test-utils/package.json
@@ -25,5 +25,6 @@
         "history": "^5.3.0",
         "react": "19.2.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/thp/package.json
+++ b/suite/thp/package.json
@@ -29,5 +29,6 @@
     },
     "devDependencies": {
         "@types/react": "19.2.14"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/tor/package.json
+++ b/suite/tor/package.json
@@ -17,5 +17,6 @@
     },
     "devDependencies": {
         "@trezor/urls": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/trading/package.json
+++ b/suite/trading/package.json
@@ -30,5 +30,6 @@
     },
     "devDependencies": {
         "@types/invity-api": "^1.1.19"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/transfer-uri/package.json
+++ b/suite/transfer-uri/package.json
@@ -18,5 +18,6 @@
         "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/transfer-uri": "workspace:*",
         "@suite/analytics": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/tx-simulation/package.json
+++ b/suite/tx-simulation/package.json
@@ -23,5 +23,15 @@
     },
     "devDependencies": {
         "@types/react": "19.2.14"
+    },
+    "exports": {
+        "./src/common": {
+            "types": "./libDev/src/common/index.d.ts",
+            "default": "./src/common/index.ts"
+        },
+        "./src/evm": {
+            "types": "./libDev/src/evm/index.d.ts",
+            "default": "./src/evm/index.ts"
+        }
     }
 }

--- a/suite/ui-animations/package.json
+++ b/suite/ui-animations/package.json
@@ -14,5 +14,6 @@
     "dependencies": {
         "@suite-common/device": "workspace:*",
         "@suite/modal": "workspace:*"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }

--- a/suite/wallet/package.json
+++ b/suite/wallet/package.json
@@ -21,5 +21,6 @@
         "@trezor/device-utils": "workspace:*",
         "react": "19.2.3",
         "react-redux": "9.3.0"
-    }
+    },
+    "types": "./libDev/src/index.d.ts"
 }


### PR DESCRIPTION
## Description

Extracts phase 1 of #27060: declaration contracts only, with no isolated type-check configs and no disableSourceOfProjectReferenceRedirect. It adds libDev roots to 283 typed workspaces, 60 typed export conditions including three subpath-only workspaces, 14 explicit app/tool exemptions, and a Requirements guard for special paths and extensionless declaration targets. Pending fixes from #30063, #30065, #30066, #30068, #30069, #30070, #30071, #30072, #30074, #30075, #30094, #30098, and #30099 remain as individual commits for easy rebase; #30067 is already on develop.

Validated with immutable install, all 300 declaration-contract requirements, 23 focused tests, concrete declaration-target checks, lint across all 20 source-bearing projects plus ESLint rule/config files, and the full 296-project type-check with its two dependencies. This makes no type-check performance claim; isolated configs and source-redirect disabling remain phase 2.