### PR TITLE
feat(suite-common): reusable thunks logic for wrapping and unwrapping

### DIFF
--- a/packages/suite/src/components/earn/yield/__tests__/yieldFlowUtils.test.ts
+++ b/packages/suite/src/components/earn/yield/__tests__/yieldFlowUtils.test.ts
@@ -2,8 +2,11 @@ import { getYieldFlowSteps } from '../yieldFlowUtils';
 
 describe('yieldFlowUtils', () => {
     describe('getYieldFlowSteps', () => {
+        // A normal deposit lists only approve + action (the leading `wrap` step is native-only and
+        // excluded from the list), so `wrap` shows as an out-of-flow (done, unnumbered) step.
         it('describes deposit steps on the approve step', () => {
-            expect(getYieldFlowSteps('deposit', 'approve')).toEqual({
+            expect(getYieldFlowSteps('deposit', 'approve', ['approve', 'action'])).toEqual({
+                wrap: { state: 'done', indicator: { index: 0, total: 2 } },
                 approve: { state: 'active', indicator: { index: 1, total: 2 } },
                 action: { state: 'pending', indicator: { index: 2, total: 2 } },
                 complete: { state: 'pending', indicator: { index: 0, total: 2 } },
@@ -11,7 +14,8 @@ describe('yieldFlowUtils', () => {
         });
 
         it('describes deposit steps on the action step', () => {
-            expect(getYieldFlowSteps('deposit', 'action')).toEqual({
+            expect(getYieldFlowSteps('deposit', 'action', ['approve', 'action'])).toEqual({
+                wrap: { state: 'done', indicator: { index: 0, total: 2 } },
                 approve: { state: 'done', indicator: { index: 1, total: 2 } },
                 action: { state: 'active', indicator: { index: 2, total: 2 } },
                 complete: { state: 'pending', indicator: { index: 0, total: 2 } },
@@ -19,7 +23,8 @@ describe('yieldFlowUtils', () => {
         });
 
         it('describes deposit steps on the complete step', () => {
-            expect(getYieldFlowSteps('deposit', 'complete')).toEqual({
+            expect(getYieldFlowSteps('deposit', 'complete', ['approve', 'action'])).toEqual({
+                wrap: { state: 'done', indicator: { index: 0, total: 2 } },
                 approve: { state: 'done', indicator: { index: 1, total: 2 } },
                 action: { state: 'done', indicator: { index: 2, total: 2 } },
                 complete: { state: 'active', indicator: { index: 0, total: 2 } },
@@ -30,6 +35,7 @@ describe('yieldFlowUtils', () => {
             expect(
                 getYieldFlowSteps('deposit', 'approve', ['approve', 'action', 'complete']),
             ).toEqual({
+                wrap: { state: 'done', indicator: { index: 0, total: 3 } },
                 approve: { state: 'active', indicator: { index: 1, total: 3 } },
                 action: { state: 'pending', indicator: { index: 2, total: 3 } },
                 complete: { state: 'pending', indicator: { index: 3, total: 3 } },
@@ -38,6 +44,7 @@ describe('yieldFlowUtils', () => {
 
         it('reports steps outside the flow as passed', () => {
             expect(getYieldFlowSteps('withdraw', 'action')).toEqual({
+                wrap: { state: 'done', indicator: { index: 0, total: 1 } },
                 approve: { state: 'done', indicator: { index: 0, total: 1 } },
                 action: { state: 'active', indicator: { index: 1, total: 1 } },
                 complete: { state: 'pending', indicator: { index: 0, total: 1 } },

--- a/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
@@ -19,9 +19,11 @@ const getPendingTransactionLabel = (kind: YieldPendingTransactionState['type']):
         case 'revoke':
             return 'TR_EXCHANGE_APPROVAL_FORM_REVOKING_APPROVAL';
         case 'deposit':
+        case 'wrap':
             return 'TR_EARN_YIELD_PENDING_DEPOSIT';
         case 'withdraw':
         case 'redeem':
+        case 'unwrap':
             return 'TR_EARN_YIELD_PENDING_WITHDRAW';
         case 'claim':
             return 'TR_EARN_YIELD_PENDING_CLAIM';

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -180,6 +180,12 @@ export const YieldDepositForm = () => {
                         currentStep={flow.currentStep}
                         hasStepList
                         steps={{
+                            // Wrap is a native-token-deposit-only step; inert here (isListItem:false
+                            // keeps it out of the step numbering). The wrap UI lands in #30104.
+                            wrap: {
+                                isListItem: false,
+                                content: () => null,
+                            },
                             approve: {
                                 title: <Translation id="TR_EARN_YIELD_SELECT_AMOUNT_AND_APPROVE" />,
                                 rightContent: view =>

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
@@ -82,6 +82,7 @@ export const getYieldFlowSteps = (
     });
 
     return {
+        wrap: getStepView('wrap'),
         approve: getStepView('approve'),
         action: getStepView('action'),
         complete: getStepView('complete'),

--- a/suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.ts
+++ b/suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.ts
@@ -28,7 +28,13 @@ const claimUnsignedTxBase = {
 
 const stablecoinYieldTxSimulationParams = z.discriminatedUnion('flow', [
     z.strictObject({
-        flow: z.union([z.literal('deposit'), z.literal('withdraw'), z.literal('redeem')]),
+        flow: z.union([
+            z.literal('deposit'),
+            z.literal('withdraw'),
+            z.literal('redeem'),
+            z.literal('wrap'),
+            z.literal('unwrap'),
+        ]),
         account: partialAccount,
         unsignedTx: z.string(),
     }),
@@ -57,7 +63,9 @@ function composeUnsignedEvmTx(
     switch (params.flow) {
         case 'deposit':
         case 'redeem':
-        case 'withdraw': {
+        case 'withdraw':
+        case 'wrap':
+        case 'unwrap': {
             const {
                 to,
                 value = '0x0',

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -77,6 +77,7 @@ export * from './stablecoin-yield/stablecoinYieldDeviceUtils';
 export * from './stablecoin-yield/stablecoinYieldFeeEstimation';
 export * from './stablecoin-yield/stablecoinYieldTypes';
 export * from './stablecoin-yield/stablecoinYieldUtils';
+export * from './stablecoin-yield/stablecoinYieldWrapThunks';
 export * from './stake/tron/tronStakeReducer';
 export * from './stake/tron/tronStakeSelectors';
 export { composeTronFreezeFeeLevelsThunk } from './stake/tron/actions/freeze/composeFreeze';

--- a/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldReducer.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldReducer.test.ts
@@ -15,10 +15,10 @@ const FLOW_KEY = 'account-key:yield-id:0xtoken';
 const getSession = (state: StablecoinYieldState, flowType: YieldFlowType) =>
     state[flowType][getStablecoinYieldSessionKey(FLOW_KEY)];
 
-const initSession = (flowType: YieldFlowType) =>
+const initSession = (flowType: YieldFlowType, isNativeDeposit?: boolean) =>
     stablecoinYieldReducer(
         initialStablecoinYieldState,
-        stablecoinYieldActions.initSession({ flowType, flowKey: FLOW_KEY }),
+        stablecoinYieldActions.initSession({ flowType, flowKey: FLOW_KEY, isNativeDeposit }),
     );
 
 describe('stablecoinYieldReducer', () => {
@@ -27,6 +27,34 @@ describe('stablecoinYieldReducer', () => {
             const state = initSession('deposit');
 
             expect(getSession(state, 'deposit')?.step).toBe('approve');
+        });
+
+        it('starts a native-token deposit at the wrap step', () => {
+            const state = initSession('deposit', true);
+
+            expect(getSession(state, 'deposit')?.step).toBe('wrap');
+        });
+
+        it('moves a native deposit from the wrap step to approve when it is skipped', () => {
+            const state = stablecoinYieldReducer(
+                initSession('deposit', true),
+                stablecoinYieldActions.skipWrapStep({ flowType: 'deposit', flowKey: FLOW_KEY }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('approve');
+        });
+
+        it('does not regress once the wrap step has been left', () => {
+            // skipWrapStep must only advance from the wrap step, so a repeat can't pull the
+            // flow back from approve/action.
+            const skipWrap = stablecoinYieldActions.skipWrapStep({
+                flowType: 'deposit',
+                flowKey: FLOW_KEY,
+            });
+            const once = stablecoinYieldReducer(initSession('deposit', true), skipWrap);
+            const twice = stablecoinYieldReducer(once, skipWrap);
+
+            expect(getSession(twice, 'deposit')?.step).toBe('approve');
         });
 
         it.each(['withdraw', 'redeem', 'claim'] as const)(

--- a/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts
@@ -5,8 +5,12 @@ import {
     buildEvmSelectedFee,
     buildYieldDepositCalldata,
     buildYieldUnsignedTransaction,
+    buildYieldUnwrapTransactionData,
     buildYieldWithdrawCalldata,
+    buildYieldWrapTransactionData,
     getNextYieldFlowStep,
+    getYieldDepositableBalance,
+    getYieldWrapAmount,
     splitYieldPendingTransaction,
 } from '../stablecoinYieldUtils';
 
@@ -89,7 +93,8 @@ describe('stablecoinYieldUtils', () => {
     });
 
     describe('getNextYieldFlowStep', () => {
-        it('advances deposit through approve → action → complete', () => {
+        it('advances deposit through wrap → approve → action → complete', () => {
+            expect(getNextYieldFlowStep('deposit', 'wrap')).toBe('approve');
             expect(getNextYieldFlowStep('deposit', 'approve')).toBe('action');
             expect(getNextYieldFlowStep('deposit', 'action')).toBe('complete');
         });
@@ -263,6 +268,96 @@ describe('stablecoinYieldUtils', () => {
             maxFeePerGas: '0x165a0bc00',
             maxPriorityFeePerGas: '0x3b9aca00',
             type: 'eip1559',
+        });
+    });
+
+    describe('buildYieldWrapTransactionData', () => {
+        it('encodes the WETH deposit() selector and carries the amount in the value', () => {
+            expect(buildYieldWrapTransactionData({ wrapAmount: '1', decimals: 18 })).toEqual({
+                data: '0xd0e30db0',
+                value: '0xde0b6b3a7640000',
+            });
+        });
+    });
+
+    describe('buildYieldUnwrapTransactionData', () => {
+        it('encodes WETH withdraw(uint256) calldata for the amount', () => {
+            const { data } = buildYieldUnwrapTransactionData({ unwrapAmount: '1', decimals: 18 });
+
+            expect(Calldata.evm.weth.withdraw.decode(data)).toEqual({
+                wad: 1_000_000_000_000_000_000n,
+            });
+        });
+
+        it('throws for a zero amount', () => {
+            expect(() =>
+                buildYieldUnwrapTransactionData({ unwrapAmount: '0', decimals: 18 }),
+            ).toThrow('Failed to encode WETH withdraw calldata');
+        });
+    });
+
+    describe('getYieldDepositableBalance', () => {
+        const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+        const USDC_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+
+        it('returns only the matched token balance for a non-wrapped-native vault', () => {
+            expect(
+                getYieldDepositableBalance({
+                    networkSymbol: 'eth',
+                    nativeFormattedBalance: '5',
+                    vaultTokenAddress: USDC_ADDRESS,
+                    matchedTokenBalance: '100',
+                }),
+            ).toBe('100');
+        });
+
+        it('adds the native balance minus the gas reserve for a wrapped-native vault', () => {
+            expect(
+                getYieldDepositableBalance({
+                    networkSymbol: 'eth',
+                    nativeFormattedBalance: '0.2',
+                    vaultTokenAddress: WETH_ADDRESS,
+                    matchedTokenBalance: '1.5',
+                }),
+            ).toBe('1.695');
+        });
+
+        it('ignores native balance below the gas reserve', () => {
+            expect(
+                getYieldDepositableBalance({
+                    networkSymbol: 'eth',
+                    nativeFormattedBalance: '0.003',
+                    vaultTokenAddress: WETH_ADDRESS,
+                    matchedTokenBalance: '1',
+                }),
+            ).toBe('1');
+        });
+
+        it('returns the spendable native balance when no token is matched', () => {
+            expect(
+                getYieldDepositableBalance({
+                    networkSymbol: 'eth',
+                    nativeFormattedBalance: '1',
+                    vaultTokenAddress: WETH_ADDRESS,
+                    matchedTokenBalance: undefined,
+                }),
+            ).toBe('0.995');
+        });
+    });
+
+    describe('getYieldWrapAmount', () => {
+        it('wraps the shortfall between the deposit total and held WETH', () => {
+            expect(getYieldWrapAmount({ totalAmount: '2', matchedWethBalance: '1.5' })).toBe('0.5');
+        });
+
+        it('returns 0 when held WETH already covers the total', () => {
+            expect(getYieldWrapAmount({ totalAmount: '1', matchedWethBalance: '2' })).toBe('0');
+        });
+
+        it('wraps the whole total when no WETH is held', () => {
+            expect(getYieldWrapAmount({ totalAmount: '1', matchedWethBalance: undefined })).toBe(
+                '1',
+            );
         });
     });
 });

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldConstants.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldConstants.ts
@@ -3,7 +3,10 @@ import type { YieldFlowStepId, YieldFlowType } from './stablecoinYieldTypes';
 export const STABLECOIN_YIELD_PREFIX = '@suite-common/wallet-core/stablecoin-yield';
 
 export const YIELD_FLOW_STEP_SEQUENCES = {
-    deposit: ['approve', 'action', 'complete'],
+    // The deposit flow carries a leading `wrap` step (ETH→WETH). It is used only for native-token
+    // deposits; normal token deposits start at `approve` — see
+    // `createInitialStablecoinYieldSessionState`.
+    deposit: ['wrap', 'approve', 'action', 'complete'],
     withdraw: ['action', 'complete'],
     redeem: ['action', 'complete'],
     claim: ['action', 'complete'],

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldFeeEstimation.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldFeeEstimation.ts
@@ -14,6 +14,8 @@ type EstimateYieldFeeLevelParams = {
     from: string;
     to: string;
     data: string;
+    /** Native value carried by the transaction (hex). Non-zero for wraps. */
+    value?: string;
 };
 
 export const estimateYieldFeeLevel = async ({
@@ -22,6 +24,7 @@ export const estimateYieldFeeLevel = async ({
     from,
     to,
     data,
+    value = '0x0',
 }: EstimateYieldFeeLevelParams): Promise<
     Result<YieldEstimatedFeeLevel, YieldFeeEstimationError>
 > => {
@@ -34,7 +37,7 @@ export const estimateYieldFeeLevel = async ({
                 from,
                 to,
                 data,
-                value: '0x0',
+                value,
             },
         },
     });

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -162,16 +162,24 @@ export const initialStablecoinYieldState: StablecoinYieldState = {
 
 const createInitialStablecoinYieldSessionState = (
     flowType: YieldFlowType,
-): StablecoinYieldSessionState => ({
-    ...initialStablecoinYieldSessionState,
-    step: YIELD_FLOW_STEP_SEQUENCES[flowType][0],
-    approval: { ...initialStablecoinYieldSessionState.approval },
-    action: { ...initialStablecoinYieldSessionState.action },
-    result: {
-        ...initialStablecoinYieldSessionState.result,
-        completedRewards: [...initialStablecoinYieldSessionState.result.completedRewards],
-    },
-});
+    isNativeDeposit = false,
+): StablecoinYieldSessionState => {
+    const sequence = YIELD_FLOW_STEP_SEQUENCES[flowType];
+    // Only native-token deposits start on the leading `wrap` step; everything else skips it.
+    const step =
+        sequence[0] === 'wrap' && !isNativeDeposit ? (sequence[1] ?? sequence[0]) : sequence[0];
+
+    return {
+        ...initialStablecoinYieldSessionState,
+        step,
+        approval: { ...initialStablecoinYieldSessionState.approval },
+        action: { ...initialStablecoinYieldSessionState.action },
+        result: {
+            ...initialStablecoinYieldSessionState.result,
+            completedRewards: [...initialStablecoinYieldSessionState.result.completedRewards],
+        },
+    };
+};
 
 export const getStablecoinYieldSessionKey = (flowKey: string) => `yield-session:${flowKey}`;
 
@@ -199,9 +207,11 @@ const stablecoinYieldSlice = createSlice({
     reducers: {
         initSession(
             state: StablecoinYieldState,
-            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+            action: PayloadAction<
+                StablecoinYieldSessionActionPayload & { isNativeDeposit?: boolean }
+            >,
         ) {
-            const { flowType, flowKey } = action.payload;
+            const { flowType, flowKey, isNativeDeposit } = action.payload;
 
             if (!isSafeObjectKey(flowKey)) {
                 return;
@@ -210,7 +220,10 @@ const stablecoinYieldSlice = createSlice({
             const sessionKey = getStablecoinYieldSessionKey(flowKey);
 
             if (!state[flowType][sessionKey]) {
-                state[flowType][sessionKey] = createInitialStablecoinYieldSessionState(flowType);
+                state[flowType][sessionKey] = createInitialStablecoinYieldSessionState(
+                    flowType,
+                    isNativeDeposit,
+                );
             }
         },
         disposeSession(
@@ -379,6 +392,17 @@ const stablecoinYieldSlice = createSlice({
         ) {
             withSession(state, action.payload, session => {
                 session.step = getNextYieldFlowStep(action.payload.flowType, 'approve');
+            });
+        },
+        skipWrapStep(
+            state: StablecoinYieldState,
+            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+        ) {
+            withSession(state, action.payload, session => {
+                // Only advance from the wrap step, so repeated init calls can't regress the flow.
+                if (session.step === 'wrap') {
+                    session.step = getNextYieldFlowStep(action.payload.flowType, 'wrap');
+                }
             });
         },
         revokeSuccess(

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
@@ -4,7 +4,8 @@ import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { Account } from '@suite-common/wallet-types';
 
 export const YIELD_FLOW_TYPES = ['deposit', 'withdraw', 'redeem', 'claim'] as const;
-export const YIELD_FLOW_STEPS = ['approve', 'action', 'complete'] as const;
+// `wrap` is a leading deposit step used only for native-token deposits (see YIELD_FLOW_STEP_SEQUENCES).
+export const YIELD_FLOW_STEPS = ['wrap', 'approve', 'action', 'complete'] as const;
 
 export type YieldFlowType = (typeof YIELD_FLOW_TYPES)[number];
 export type YieldPositionFlowType = Exclude<YieldFlowType, 'claim'>;
@@ -68,7 +69,7 @@ export type YieldApproveModalState = {
 };
 
 export type YieldPendingTransactionState = {
-    type: 'approve' | 'revoke' | 'deposit' | 'withdraw' | 'redeem' | 'claim';
+    type: 'approve' | 'revoke' | 'deposit' | 'withdraw' | 'redeem' | 'claim' | 'wrap' | 'unwrap';
     txid: string;
     amount: string;
     fee?: string;

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -1,12 +1,14 @@
 import { Calldata, type EvmAddress } from '@suite-common/calldata';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
 import { type AccountKey, type EvmSelectedFee } from '@suite-common/wallet-types';
 import {
     asAmountUnit,
     fromGwei,
     fromIntegerString,
     getContractAddressForNetworkSymbol,
+    isWrappedNativeToken,
     unitsToSubunits,
 } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
@@ -94,6 +96,8 @@ type BuildYieldUnsignedTransactionParams = {
     gasLimit: string;
     nonce: number;
     to: string;
+    /** Native value carried by the transaction (hex). Non-zero for wraps; defaults to `0x0`. */
+    value?: string;
 };
 
 type BuildEvmFeeFieldsParams = {
@@ -254,13 +258,14 @@ export const buildYieldUnsignedTransaction = ({
     gasLimit,
     nonce,
     to,
+    value = '0x0',
 }: BuildYieldUnsignedTransactionParams) => {
     const feeFields = buildEvmFeeFields({ feeLevel, gasLimit });
     const commonFields = {
         from,
         to,
         data,
-        value: '0x0',
+        value,
         nonce,
         chainId,
         gasLimit: feeFields.gasLimit,
@@ -280,6 +285,106 @@ export const buildYieldUnsignedTransaction = ({
         gasPrice: feeFields.gasPrice,
     };
 };
+
+type BuildYieldWrapTransactionDataParams = {
+    wrapAmount: string;
+    decimals: number;
+};
+
+// WETH `deposit()` carries the wrapped amount in the transaction value, not in calldata.
+export const buildYieldWrapTransactionData = ({
+    wrapAmount,
+    decimals,
+}: BuildYieldWrapTransactionDataParams) => {
+    const builderResult = Calldata.evm.weth.deposit.encode({});
+
+    if (!builderResult.isValid || !builderResult.data) {
+        throw new Error('Failed to encode WETH deposit calldata.');
+    }
+
+    const valueSubunits = unitsToSubunits({
+        value: asAmountUnit(new BigNumber(wrapAmount)),
+        decimals,
+    });
+
+    return {
+        data: builderResult.data,
+        value: fromIntegerString(valueSubunits.toFixed(0)).toHex(),
+    };
+};
+
+type BuildYieldUnwrapTransactionDataParams = {
+    unwrapAmount: string;
+    decimals: number;
+};
+
+export const buildYieldUnwrapTransactionData = ({
+    unwrapAmount,
+    decimals,
+}: BuildYieldUnwrapTransactionDataParams) => {
+    const wadSubunits = unitsToSubunits({
+        value: asAmountUnit(new BigNumber(unwrapAmount)),
+        decimals,
+    });
+
+    const builderResult = Calldata.evm.weth.withdraw.encode({ wad: wadSubunits });
+
+    if (!builderResult.isValid || !builderResult.data) {
+        const issues = builderResult.errors.map(issue => issue.code).join(', ');
+
+        throw new Error(`Failed to encode WETH withdraw calldata${issues ? `: ${issues}` : '.'}`);
+    }
+
+    return { data: builderResult.data };
+};
+
+type GetYieldDepositableBalanceParams = {
+    networkSymbol: NetworkSymbol;
+    /** Native coin balance in display units, NOT subunits. */
+    nativeFormattedBalance: string;
+    vaultTokenAddress?: string | null;
+    matchedTokenBalance?: string | null;
+};
+
+/**
+ * Balance available for a yield deposit. For a wrapped-native (WETH) vault the native balance can
+ * be wrapped, so it counts in after keeping `WETH_WRAP_GAS_RESERVE` aside to cover the follow-up
+ * wrap + approve + deposit (+ exit) fees.
+ */
+export const getYieldDepositableBalance = ({
+    networkSymbol,
+    nativeFormattedBalance,
+    vaultTokenAddress,
+    matchedTokenBalance,
+}: GetYieldDepositableBalanceParams): string => {
+    // Normal deposit: only the already-held vault-token balance is spendable.
+    const tokenDepositBalance = matchedTokenBalance ?? '0';
+
+    if (!isWrappedNativeToken(networkSymbol, vaultTokenAddress)) {
+        return tokenDepositBalance;
+    }
+
+    // Native-asset deposit: the native balance can also be wrapped, after keeping the fee reserve
+    // aside for the follow-up wrap + approve + deposit (+ exit) transactions.
+    const wrappableNativeBalance = BigNumber.max(
+        0,
+        new BigNumber(nativeFormattedBalance || '0').minus(WETH_WRAP_GAS_RESERVE),
+    );
+
+    return new BigNumber(tokenDepositBalance).plus(wrappableNativeBalance).toString();
+};
+
+type GetYieldWrapAmountParams = {
+    totalAmount: string;
+    matchedWethBalance?: string | null;
+};
+
+/** Native portion of a deposit that must be wrapped — the total minus already-held WETH. */
+export const getYieldWrapAmount = ({
+    totalAmount,
+    matchedWethBalance,
+}: GetYieldWrapAmountParams): string =>
+    BigNumber.max(0, new BigNumber(totalAmount || '0').minus(matchedWethBalance || '0')).toString();
 
 type YieldTxReviewFlowIdentity = {
     accountKey?: AccountKey;

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldWrapThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldWrapThunks.ts
@@ -1,0 +1,217 @@
+import { createThunk } from '@suite-common/redux-utils';
+import { getNetwork } from '@suite-common/wallet-config';
+import { WETH_DEPOSIT_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
+import { type Account } from '@suite-common/wallet-types';
+import {
+    getAccountIdentity,
+    getConvertedOrDefaultFeeInfo,
+    isWrappedNativeToken,
+} from '@suite-common/wallet-utils';
+
+import { STABLECOIN_YIELD_PREFIX } from './stablecoinYieldConstants';
+import { estimateYieldFeeLevel } from './stablecoinYieldFeeEstimation';
+import type { YieldFlowDisplayToken, YieldFlowResolvedData } from './stablecoinYieldTypes';
+import {
+    buildYieldUnsignedTransaction,
+    buildYieldUnwrapTransactionData,
+    buildYieldWrapTransactionData,
+} from './stablecoinYieldUtils';
+import { selectRawNetworkFeeInfo } from '../fees/feesReducer';
+import { ethereumGetCurrentNonceThunk } from '../send/sendFormEthereumThunks';
+
+const YIELD_WRAP_THUNK_PREFIX = `${STABLECOIN_YIELD_PREFIX}/thunk`;
+
+export type ComposeYieldWrapErrorReason =
+    | 'unsupported-network'
+    | 'not-wrapped-native'
+    | 'vault-chain-mismatch'
+    | 'missing-fee-level'
+    | 'fee-estimation-failed';
+
+export type ComposeYieldWrapResult =
+    | {
+          type: 'action-ready';
+          unsignedTransaction: string;
+      }
+    | {
+          type: 'error';
+          reason: ComposeYieldWrapErrorReason;
+      };
+
+type ComposeYieldWrapTransactionPayload = {
+    flowData: YieldFlowResolvedData;
+    /** Native coin amount to wrap — the value carried by the transaction. */
+    wrapAmount: string;
+};
+
+type ComposeYieldUnwrapTransactionPayload = {
+    account: Account;
+    /** The wrapped-native (WETH) token being unwrapped. */
+    token: Pick<YieldFlowDisplayToken, 'contractAddress' | 'decimals'>;
+    unwrapAmount: string;
+};
+
+/**
+ * Composes an unsigned WETH `deposit()` (wrap) transaction that carries `wrapAmount` in its value.
+ * Refuses to build a value-carrying transaction to anything but the account network's canonical
+ * wrapped-native contract.
+ */
+export const composeYieldWrapTransactionThunk = createThunk<
+    ComposeYieldWrapResult,
+    ComposeYieldWrapTransactionPayload,
+    void
+>(
+    `${YIELD_WRAP_THUNK_PREFIX}/composeWrapTransaction`,
+    async ({ flowData, wrapAmount }, { dispatch, getState }) => {
+        const { account, token, vault } = flowData;
+
+        if (account.networkType !== 'ethereum') {
+            return { type: 'error', reason: 'unsupported-network' } as const;
+        }
+
+        const wethAddress = token.contractAddress;
+
+        if (!isWrappedNativeToken(account.symbol, wethAddress) || !wethAddress) {
+            return { type: 'error', reason: 'not-wrapped-native' } as const;
+        }
+
+        const network = getNetwork(account.symbol);
+
+        if (!network.chainId || vault.chainId !== network.chainId) {
+            return { type: 'error', reason: 'vault-chain-mismatch' } as const;
+        }
+
+        const { data, value } = buildYieldWrapTransactionData({
+            wrapAmount,
+            decimals: token.decimals,
+        });
+
+        const [{ nonce }, estimatedFeeLevel] = await Promise.all([
+            dispatch(
+                ethereumGetCurrentNonceThunk({
+                    selectedAccount: account,
+                    fetchConfirmedNonce: true,
+                }),
+            ).unwrap(),
+            estimateYieldFeeLevel({
+                coin: account.symbol,
+                identity: getAccountIdentity(account),
+                from: account.descriptor,
+                to: wethAddress,
+                data,
+                value,
+            }),
+        ]);
+
+        // WETH deposit() is a fixed ~45k-gas call, so fall back to a known backup limit when
+        // estimation fails rather than blocking the wrap.
+        const gasLimit = estimatedFeeLevel.success
+            ? estimatedFeeLevel.payload.feeLimit
+            : WETH_DEPOSIT_BACKUP_GAS_LIMIT;
+
+        const feeInfo = getConvertedOrDefaultFeeInfo({
+            networkType: account.networkType,
+            feeInfo: selectRawNetworkFeeInfo(getState(), account.symbol),
+        });
+        const normalLevel =
+            feeInfo.levels.find(level => level.label === 'normal') ?? feeInfo.levels[0];
+
+        if (!normalLevel) {
+            return { type: 'error', reason: 'missing-fee-level' } as const;
+        }
+
+        const unsignedTransaction = JSON.stringify(
+            buildYieldUnsignedTransaction({
+                chainId: network.chainId,
+                data,
+                feeLevel: normalLevel,
+                from: account.descriptor,
+                gasLimit,
+                nonce: Number(nonce),
+                to: wethAddress,
+                value,
+            }),
+        );
+
+        return { type: 'action-ready', unsignedTransaction } as const;
+    },
+);
+
+/**
+ * Composes an unsigned WETH `withdraw(uint256)` (unwrap) transaction — the standalone WETH→ETH
+ * action for the wrapped-native token.
+ */
+export const composeYieldUnwrapTransactionThunk = createThunk<
+    ComposeYieldWrapResult,
+    ComposeYieldUnwrapTransactionPayload,
+    void
+>(
+    `${YIELD_WRAP_THUNK_PREFIX}/composeUnwrapTransaction`,
+    async ({ account, token, unwrapAmount }, { dispatch, getState }) => {
+        if (account.networkType !== 'ethereum') {
+            return { type: 'error', reason: 'unsupported-network' } as const;
+        }
+
+        const wethAddress = token.contractAddress;
+
+        if (!isWrappedNativeToken(account.symbol, wethAddress) || !wethAddress) {
+            return { type: 'error', reason: 'not-wrapped-native' } as const;
+        }
+
+        const network = getNetwork(account.symbol);
+
+        if (!network.chainId) {
+            return { type: 'error', reason: 'vault-chain-mismatch' } as const;
+        }
+
+        const { data } = buildYieldUnwrapTransactionData({
+            unwrapAmount,
+            decimals: token.decimals,
+        });
+
+        const [{ nonce }, estimatedFeeLevel] = await Promise.all([
+            dispatch(
+                ethereumGetCurrentNonceThunk({
+                    selectedAccount: account,
+                    fetchConfirmedNonce: true,
+                }),
+            ).unwrap(),
+            estimateYieldFeeLevel({
+                coin: account.symbol,
+                identity: getAccountIdentity(account),
+                from: account.descriptor,
+                to: wethAddress,
+                data,
+            }),
+        ]);
+
+        if (!estimatedFeeLevel.success) {
+            return { type: 'error', reason: 'fee-estimation-failed' } as const;
+        }
+
+        const feeInfo = getConvertedOrDefaultFeeInfo({
+            networkType: account.networkType,
+            feeInfo: selectRawNetworkFeeInfo(getState(), account.symbol),
+        });
+        const normalLevel =
+            feeInfo.levels.find(level => level.label === 'normal') ?? feeInfo.levels[0];
+
+        if (!normalLevel) {
+            return { type: 'error', reason: 'missing-fee-level' } as const;
+        }
+
+        const unsignedTransaction = JSON.stringify(
+            buildYieldUnsignedTransaction({
+                chainId: network.chainId,
+                data,
+                feeLevel: normalLevel,
+                from: account.descriptor,
+                gasLimit: estimatedFeeLevel.payload.feeLimit,
+                nonce: Number(nonce),
+                to: wethAddress,
+            }),
+        );
+
+        return { type: 'action-ready', unsignedTransaction } as const;
+    },
+);

--- a/suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts
+++ b/suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts
@@ -123,6 +123,10 @@ const reportYieldTransactionResolution = ({
 
             return;
         }
+        case 'wrap':
+        case 'unwrap':
+            // Intermediate steps of the deposit/withdraw flows; they carry no analytics event of their own.
+            return;
         default:
             exhaustive(pendingTransactionType);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

## Scope
- [x] Shared `composeYieldWrapTransaction` / ~submit~ + unwrap equivalents
- [x] Fee-reserve helper: wrap + approve + deposit + **exit-gas buffer** (uses the config constants)
- [x] Wrap phase in the yield state machine + tx-simulation hooks

## Notes for QA

Changes from this PR are intended to be tested in a separate PR that introduces 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29859

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/wrapped-native-thunks&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->