### PR TITLE
refactor(connect-init): gate global UI-event swallow on a scoped-callId registry

### DIFF
--- a/suite-common/connect-init/src/connectInitThunks.test.ts
+++ b/suite-common/connect-init/src/connectInitThunks.test.ts
@@ -4,7 +4,6 @@ import {
     extraDependenciesCommonMock,
     testMocks,
 } from '@suite-common/test-utils';
-import { defaultTrezorUIEventHandlerThunk } from '@suite-common/wallet-core';
 import {
     BLOCKCHAIN_EVENT,
     DEVICE,
@@ -157,43 +156,6 @@ describe('TrezorConnect Actions', () => {
             type: extraDependenciesCommonMock.actions.lockDevice.type,
             payload: true,
         });
-    });
-
-    it('callId-bearing UI events are swallowed by the global listener', async () => {
-        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-        await store.dispatch(connectInitThunk());
-        const actionsBefore = store.getActions().length;
-        const { emitTestEvent } = testMocks.getTrezorConnectMock();
-
-        emitTestEvent(UI_EVENT, {
-            type: UI_REQUEST.REQUEST_BUTTON,
-            payload: { code: 'ButtonRequest_ProtectCall' },
-        });
-        emitTestEvent(UI_EVENT, {
-            type: UI_REQUEST.REQUEST_BUTTON,
-            payload: { code: 'ButtonRequest_ProtectCall' },
-            callId: 'scoped-call-id',
-        });
-        await new Promise(resolve => setImmediate(resolve));
-
-        const newActions = store.getActions().slice(actionsBefore);
-
-        const pendingCount = newActions.filter(
-            a => a.type === defaultTrezorUIEventHandlerThunk.pending.type,
-        ).length;
-        const fulfilledCount = newActions.filter(
-            a => a.type === defaultTrezorUIEventHandlerThunk.fulfilled.type,
-        ).length;
-        const buttonActionCount = newActions.filter(
-            a => a.type === UI_REQUEST.REQUEST_BUTTON,
-        ).length;
-
-        expect(pendingCount).toBe(1);
-        expect(fulfilledCount).toBe(1);
-        expect(buttonActionCount).toBe(1);
-        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('callId=scoped-call-id'));
-
-        warnSpy.mockRestore();
     });
 
     it('connectInitHooks.deviceEvent is called for DEVICE.CONNECT / DEVICE.CONNECT_UNACQUIRED', async () => {

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -15,6 +15,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import {
     defaultTrezorUIEventHandlerThunk,
     deviceConnectThunks,
+    isScopedCallId,
     selectEnabledNetworks,
 } from '@suite-common/wallet-core';
 import TrezorConnect, {
@@ -84,11 +85,9 @@ export const connectInitThunk = createThunk<void, void, void>(
         });
 
         TrezorConnect.on(UI_EVENT, ({ event: _, ...action }) => {
-            if ('callId' in action && action.callId) {
-                console.warn(
-                    `[connect-init] UI_EVENT ${action.type} (callId=${action.callId}) swallowed in global scope — handled by a scoped flow.`,
-                );
-
+            // A bare `callId` is not proof of ownership — it doubles as the
+            // cancellation token — so defer only events a scoped flow has registered.
+            if ('callId' in action && action.callId && isScopedCallId(action.callId)) {
                 return;
             }
             dispatch(defaultTrezorUIEventHandlerThunk(action));

--- a/suite-common/wallet-core/src/discovery/passphraseWalletThunks.ts
+++ b/suite-common/wallet-core/src/discovery/passphraseWalletThunks.ts
@@ -7,6 +7,7 @@ import { DISCOVERY_MODULE_PREFIX, discoveryActions } from './discoveryActions';
 import { isDiscoveryInProgress, selectDiscoveryByDevicePath } from './discoverySelectors';
 import { runDiscoveryThunk, startDiscoveryThunk } from './discoveryThunks';
 import { defaultTrezorUIEventHandlerThunk } from '../uiEvent/defaultTrezorUIEventHandlerThunk';
+import { registerScopedCallId, unregisterScopedCallId } from '../uiEvent/scopedCallIdRegistry';
 
 // The "run" step. Exported because for a *new* hidden wallet the run is deferred from
 // start — called from PassphraseWalletIsNotExistFlow's "Next" once the user confirms
@@ -23,11 +24,14 @@ export const runPassphraseWalletAddingDiscoveryThunk = createThunk(
             dispatch(defaultTrezorUIEventHandlerThunk(action));
         };
 
+        // Claim this callId so the global handler defers its events to the scoped listener.
+        registerScopedCallId(callId);
         TrezorConnect.on(UI_EVENT, onUiEvent);
         try {
             await dispatch(runDiscoveryThunk({ device, callId })).unwrap();
         } finally {
             TrezorConnect.off(UI_EVENT, onUiEvent);
+            unregisterScopedCallId(callId);
         }
     },
 );

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -109,4 +109,5 @@ export * from './phishing/phishingSelectors';
 export type * from './phishing/phishingReducerTypes';
 export * from './stake/stakeDataSlice';
 export * from './uiEvent/defaultTrezorUIEventHandlerThunk';
+export * from './uiEvent/scopedCallIdRegistry';
 export * from './discovery/passphraseWalletThunks';

--- a/suite-common/wallet-core/src/uiEvent/scopedCallIdRegistry.ts
+++ b/suite-common/wallet-core/src/uiEvent/scopedCallIdRegistry.ts
@@ -1,0 +1,16 @@
+// Process-wide set of `callId`s that a scoped UI flow currently owns. A `callId`
+// also doubles as the cancellation-correlation token, so its presence on an event
+// does not prove a scoped flow owns it — this registry is the explicit ownership
+// signal the global UI handler checks before deferring an event to a scoped flow.
+
+const scopedCallIds = new Set<string>();
+
+export const registerScopedCallId = (callId: string): void => {
+    scopedCallIds.add(callId);
+};
+
+export const unregisterScopedCallId = (callId: string): void => {
+    scopedCallIds.delete(callId);
+};
+
+export const isScopedCallId = (callId: string): boolean => scopedCallIds.has(callId);


### PR DESCRIPTION
## Description

The global `UI_EVENT` handler in connect-init swallowed **any** event that carried a `callId`, on the assumption that a scoped flow owned it. But `callId` is not only an ownership marker — it is already the cancellation-correlation token that Core matches in `abortRunningCall` (reached from `TrezorConnect.cancel({ callId })`), and Core stamps it onto every `ui-` event of the call.

Those two concerns were conflated in one line: the old guard swallowed on the *presence* of a `callId`, with no check that a scoped listener actually existed. "Has callId ⇒ owned by a scoped flow" is an assumption, not a fact — so an ordinary call made cancellable via a `callId` would have its PIN / passphrase / button-request modals silently dropped (swallowed by the global handler, with no scoped listener to render them).

## The change

Decouple the two concerns:

- `callId` stays purely a correlation / cancellation token. Core is untouched.
- A new process-wide `scopedCallIdRegistry` is the explicit ownership signal. A scoped flow registers its `callId`(s) for as long as it handles their UI events.
- The global handler now swallows an event only when its `callId` is **registered**; an unregistered `callId` falls through to the global handler.

Registration is always performed by Suite itself, never by a remote caller (an in-process `Set`, not a wire field), so "suppress the global handler" stays an internal-only decision — no 3rd-party caller can opt out of Suite's global UI handling.

The hidden-wallet discovery flow — the only scoped consumer on develop — registers its minted callId set around its scoped listener and releases it in `finally`. Its behavior is unchanged.

## Notes for QA

Behavioral blast radius is limited to the hidden-wallet ("add passphrase / hidden wallet") discovery flow, the only code path that mints a `callId` at runtime. Its device prompts (passphrase, discovery button requests) must appear and clear exactly as before; discovery completes normally. Regular flows that carry no `callId` (getAddress, sign, PIN, standard discovery) always fell through to the global handler and still do.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files sit in two broad global areas: TrezorConnect initialization (connectInitThunks.ts, scopedCallIdRegistry.ts) and wallet discovery/passphrase wallet handling (passphraseWalletThunks.ts, wallet-core/index.ts). Because the static mappers flag 135+ tests for each, we apply the broad-utility heuristic and select only the tests that directly exercise these paths: passphrase wallet flows, Connect popup/device-call flows, and wallet discovery. These give high confidence without running the whole suite.

<details><summary><b>Changed files (5)</b></summary>

- `suite-common/connect-init/src/connectInitThunks.test.ts`
- `suite-common/connect-init/src/connectInitThunks.ts`
- `suite-common/wallet-core/src/discovery/passphraseWalletThunks.ts`
- `suite-common/wallet-core/src/index.ts`
- `suite-common/wallet-core/src/uiEvent/scopedCallIdRegistry.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/passphrase/passphrase.test.ts` — Directly exercises hidden (passphrase-protected) wallet creation, switching, caching, and address verification — the core user flow impacted by passphraseWalletThunks.ts changes.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — End-to-end validation of TrezorConnect initialization, permissions, popup lifecycle, and call cancellation — the primary path affected by connectInitThunks.ts and scopedCallIdRegistry.ts changes.
- `suite/e2e/tests/wallet/discovery.test.ts` — Verifies multi-coin wallet discovery and recovery after reload, which relies on the discovery thunks in wallet-core and could regress if passphrase/discovery state handling changed.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Tests adding a standard wallet after eject and verifying BTC balance discovery, sharing the discovery thunk infrastructure with passphraseWalletThunks.ts.
- `suite/e2e/tests/passphrase/passphrase-cancel.test.ts` — Exercises the passphrase entry and cancellation flow, touching the same passphrase wallet thunk/state path as the main passphrase test.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — Validates duplicate passphrase detection when adding hidden wallets, which depends on passphrase wallet state management and discovery logic.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — Checks hidden wallet numbering and ordering after add/eject operations, directly relevant to passphrase wallet management thunks.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Tests passphrase wallet persistence and re-verification after device disconnect/reconnect, a key scenario for passphrase wallet thunk state handling.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Exercises TrezorConnect address export permissions, device confirmation, and verification states, all relying on the connect init and call-id tracking infrastructure.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests Connect permission grants, persistence, revocation, and the connected-apps settings page — directly tied to connect initialization and permission state.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/index.ts`

_Updated: 2026-08-07T12:28:44.404Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/scoped-callid-registry&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/scoped-callid-registry&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/scoped-callid-registry&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T12:30:04.666Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T12:29:58.436Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/scoped-callid-registry/web/](https://dev.suite.sldev.cz/suite-web/mroz22/scoped-callid-registry/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

