### PR TITLE
feat(suite-native-29808): remove radio from provider selector

### DIFF
--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.tsx
@@ -8,7 +8,7 @@ import {
     type TradingType,
     selectTradingProviderByNameAndTradeType,
 } from '@suite-common/trading';
-import { Card, CardDivider, HStack, Radio, Text, VStack } from '@suite-native/atoms';
+import { Card, CardDivider, HStack, Text, VStack } from '@suite-native/atoms';
 import { ProviderLogo } from '@suite-native/trading-atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
@@ -28,7 +28,6 @@ const wrapperStyle = prepareNativeStyle(({ spacings }) => ({
 }));
 
 export const ProviderListItem = <T extends TradingTradeType>({
-    isSelected,
     onPress,
     quote,
     shouldShowExchangeType,
@@ -52,18 +51,11 @@ export const ProviderListItem = <T extends TradingTradeType>({
         <Pressable onPress={() => onPress(quote)} style={applyStyle(wrapperStyle)}>
             <Card>
                 <VStack>
-                    <HStack alignItems="center" justifyContent="space-between" paddingBottom="sp2">
-                        <HStack>
-                            <ProviderLogo logo={logo} />
-                            <Text variant="body-md" color="contentPrimary">
-                                {companyName}
-                            </Text>
-                        </HStack>
-                        <Radio
-                            value={orderId}
-                            onPress={() => onPress(quote)}
-                            isChecked={isSelected}
-                        />
+                    <HStack alignItems="center" paddingBottom="sp2">
+                        <ProviderLogo logo={logo} />
+                        <Text variant="body-md" color="contentPrimary">
+                            {companyName}
+                        </Text>
                     </HStack>
                     <ProviderListItemInfo
                         provider={provider}


### PR DESCRIPTION
## Description

- Remove the radio button from trading provider list items.

## Notes for QA

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/29808

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/29808-remove-radio-from-provider-selector&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->