### PR TITLE
Fix `composeTransaction` in popup

### DIFF
--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -126,6 +126,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
     }
 
     discovery?: Discovery;
+    private disposed = false;
 
     get requiredPermissions(): PermissionRequest[] {
         const permissions: PermissionRequest[] = [this.coinPerm('sign', this.params.coinInfo)];
@@ -216,7 +217,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         // wait for fee selection
         const response = await this.selectFee(account, utxo, context);
         // check for interruption
-        if (!this.discovery) {
+        if (this.disposed) {
             throw ERRORS.TypedError(
                 'Runtime',
                 'ComposeTransaction: selectFee response received after dispose',
@@ -531,6 +532,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
     }
 
     dispose() {
+        this.disposed = true;
         const { discovery } = this;
         if (discovery) {
             discovery.stop();

--- a/suite-common/connect-popup/src/connectPopupMiddleware.ts
+++ b/suite-common/connect-popup/src/connectPopupMiddleware.ts
@@ -96,7 +96,7 @@ export const prepareConnectPopupMiddleware = createMiddlewareWithExtraDeps(
         if (action.type === UI_REQUEST.REQUEST_DISCOVERY_ACCOUNTS) {
             const discovery = selectDiscoveryForSelectedDevice(getState());
 
-            if (discovery?.status !== 'complete') {
+            if (discovery && discovery.status !== 'complete') {
                 // Discovery hasn't completed — send null so Connect falls back
                 // to its own on-device discovery instead of using partial data.
                 TrezorConnect.uiResponse({


### PR DESCRIPTION
## Description

As a prerequisite for removing account discovery from `composeTransaction` method, two minibugs were fixed:

- In case of `discovery?.status !== 'complete'`, already discovered accounts weren't used as discovery may have been incomplete. But if Suite was started with remembered wallet, discovery object isn't there at all, therefore accounts weren't used even when they could.
  - changed to `discovery && discovery.status !== 'complete'`
- In `composeTransaction` method, `this.discovery` was used as a dispose flag, which incorrectly threw `ComposeTransaction: selectFee response received after dispose` in case no discovery was needed.
  - switched to dedicated `disposed` flag

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect core transaction composition logic (composeTransaction.ts) and the connect-popup middleware. composeTransaction.ts has a small, well-defined set of statically-mapped tests covering send/sell/swap flows with fee and amount calculations across BTC, LTC, DOGE, and regtest — these are prioritized highly since regressions here would directly break transaction building and fee estimation. connectPopupMiddleware.ts maps to 132 tests (essentially the entire suite), indicating it's a broad shared dependency; none of the LLM-derived behavior descriptions show direct interaction with connect-popup-specific functionality (e.g., popup window communication, iframe messaging), so no tests were promoted for that change beyond what's already covered via composeTransaction overlap. Recommended strategy: run the composeTransaction-related send/sell/swap tests as the primary regression gate, and rely on broader CI smoke coverage separately for the connect-popup middleware since no specific test demonstrates targeted coverage of its logic.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect/src/api/composeTransaction.ts`
- `suite-common/connect-popup/src/connectPopupMiddleware.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — composeTransaction.ts is the core transaction composition logic used by the send form; this test exercises multiple outputs, locktime, OP_RETURN, and unit switching—all paths that rely on composeTransaction to build valid transactions.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Directly tests composing and sending a max-amount LTC transaction including a MimbleWimble peg-out output, which depends heavily on composeTransaction's output/fee calculation logic.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Tests composeTransaction error handling for an amount exceeding MAX_SAFE_INTEGER, directly validating that composeTransaction correctly rejects invalid inputs and surfaces a sign-tx error.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Extensively validates fee/balance-based amount calculations (percentage buttons, max button, custom fee) for BTC and SOL, which rely on composeTransaction's fee and balance computation logic.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Verifies custom fee rate calculation and total amount composition for a BTC swap, directly exercising composeTransaction's fee/amount computation and device confirmation of the composed transaction.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Sell flow computes and displays Bitcoin fee and composes a send transaction to the sell provider, exercising composeTransaction indirectly during the send confirmation step.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/without-device.test.ts` — Uses the send form on regtest which internally calls composeTransaction when a review is attempted, but the test's main focus is on device disconnection handling rather than composition logic itself.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/connect-popup/src/connectPopupMiddleware.ts`

_Updated: 2026-07-20T15:27:10.486Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/compose-transaction-popup/web/](https://dev.suite.sldev.cz/suite-web/fix/compose-transaction-popup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/compose-transaction-popup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/compose-transaction-popup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/compose-transaction-popup&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-20T15:30:41.998Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-20T15:30:28.408Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->