### PR TITLE
test(connect-init): document the global callId swallow leaving external-caller UI unreachable

### DIFF
--- a/suite-common/connect-init/src/connectInitThunks.test.ts
+++ b/suite-common/connect-init/src/connectInitThunks.test.ts
@@ -159,41 +159,48 @@ describe('TrezorConnect Actions', () => {
         });
     });
 
-    it('callId-bearing UI events are swallowed by the global listener', async () => {
-        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // Characterization test documenting the limitation this stack fixes.
+    //
+    // A connect call may carry a `callId`: a 3rd-party popup caller supplies its own
+    // (public `CommonParams.callId`), and the same field is the cancellation-correlation
+    // token Core matches in `abortRunningCall`. Core stamps that `callId` onto every
+    // `ui-` event of the call, and the global handler below swallows EVERY callId-bearing
+    // event on the assumption that a scoped flow owns it. When no scoped flow does — an
+    // external caller, or an ordinary call made cancellable via a `callId` — the event
+    // never reaches `defaultTrezorUIEventHandlerThunk`, so the device modal is unreachable
+    // and the call hangs. Presence of a `callId` is being used as an ownership signal it
+    // cannot actually prove.
+    //
+    // The follow-up PR replaces this blanket swallow with a scoped-callId registry, so the
+    // handler defers only events a scoped flow has explicitly claimed; this test flips to
+    // assert that fixed behavior there.
+    it('swallows every callId-bearing UI event, leaving an external caller UI unreachable', async () => {
+        // Suppress the swallow log; the asserted behavior is the (non-)dispatch, not the warning.
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
         await store.dispatch(connectInitThunk());
         const actionsBefore = store.getActions().length;
         const { emitTestEvent } = testMocks.getTrezorConnectMock();
 
+        // No callId -> reaches the global handler and would render.
         emitTestEvent(UI_EVENT, {
             type: UI_REQUEST.REQUEST_BUTTON,
             payload: { code: 'ButtonRequest_ProtectCall' },
         });
+        // An external caller's callId -> swallowed, never reaches the handler (the limitation).
         emitTestEvent(UI_EVENT, {
             type: UI_REQUEST.REQUEST_BUTTON,
             payload: { code: 'ButtonRequest_ProtectCall' },
-            callId: 'scoped-call-id',
+            callId: 'external-caller-call-id',
         });
         await new Promise(resolve => setImmediate(resolve));
 
-        const newActions = store.getActions().slice(actionsBefore);
+        const reachedHandler = store
+            .getActions()
+            .slice(actionsBefore)
+            .filter(a => a.type === defaultTrezorUIEventHandlerThunk.pending.type).length;
 
-        const pendingCount = newActions.filter(
-            a => a.type === defaultTrezorUIEventHandlerThunk.pending.type,
-        ).length;
-        const fulfilledCount = newActions.filter(
-            a => a.type === defaultTrezorUIEventHandlerThunk.fulfilled.type,
-        ).length;
-        const buttonActionCount = newActions.filter(
-            a => a.type === UI_REQUEST.REQUEST_BUTTON,
-        ).length;
-
-        expect(pendingCount).toBe(1);
-        expect(fulfilledCount).toBe(1);
-        expect(buttonActionCount).toBe(1);
-        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('callId=scoped-call-id'));
-
-        warnSpy.mockRestore();
+        // Only the callId-less event reached the handler; the callId-bearing one was swallowed.
+        expect(reachedHandler).toBe(1);
     });
 
     it('connectInitHooks.deviceEvent is called for DEVICE.CONNECT / DEVICE.CONNECT_UNACQUIRED', async () => {


### PR DESCRIPTION
## Description

First step of a three-PR stack. This PR adds nothing but a **characterization test** that documents a limitation in the global connect UI handler, so the fix that follows can be reviewed as a clean before/after.

The global `UI_EVENT` handler ([connectInitThunks.ts](https://github.com/trezor/trezor-suite/blob/01979130c7d6640c0ada9e8f53eec67db4d94756/suite-common/connect-init/src/connectInitThunks.ts#L84-L93)) swallows **every** UI event that carries a `callId`, on the assumption that a scoped flow owns it. But `callId` is also the cancellation-correlation token Core matches in `abortRunningCall`, so its mere presence cannot prove ownership. When an external caller (a 3rd-party popup passing its own `callId`) — or any ordinary call made cancellable via a `callId` — has no scoped flow to render its UI, the stamped events are swallowed and never reach `defaultTrezorUIEventHandlerThunk`: the device modal is unreachable and the call hangs (from UI perspective). 

The added test asserts exactly this current behavior (a callId-less event reaches the handler; a callId-bearing one is swallowed). It is green on develop.

## The stack

1. **This PR** — document the failing case as a test.
2. **#30125** — the fix: replace the blanket swallow with a scoped-callId registry, and flip this test to assert the fixed behavior (an unclaimed `callId` falls through to the global handler; only a scoped flow's claimed `callId` is swallowed).
3. **#29890** — the button-request-by-path changes, stacked on the fix.

## Notes for QA

Test-only change, no runtime behavior change — no QA needed.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to a unit test for connect initialization thunks, which are foundational for all TrezorConnect flows in Suite. No static E2E coverage was found, so recommendations are inferred from the LLM analysis and focus on the trezor-connect suite. These five tests cover core initialization, permissions, popup lifecycle, and silent mode—enough to catch regressions without running the entire connect folder.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/connect-init/src/connectInitThunks.test.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/error.test.ts` — Directly exercises TrezorConnect.init with coreMode 'suite-desktop', which is the primary output of the connect init thunks. A regression in initialization would fail this test immediately.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Covers the full Connect flow after initialization: permissions modal, address export, bundle export, device confirmation, and verification errors. This validates that init thunks correctly wire up Connect to the Suite UI and device layer.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests permission granting, remembering, revocation, and the Connect settings tab. connectInitThunks manages Connect permission state, so changes there could break this flow.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Validates the web popup lifecycle, including initialization, permissions, cancellation, and popup reuse. Inferred relevant because connect init thunks configure how Suite-web hosts the Connect popup.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests silent mode behavior and Connect permissions state managed through settings. connectInitThunks likely control how silent mode permissions are applied to subsequent Connect calls.

</details>

_Updated: 2026-08-03T14:10:45.732Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/callid-swallow-characterization/web/](https://dev.suite.sldev.cz/suite-web/mroz22/callid-swallow-characterization/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/callid-swallow-characterization&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/callid-swallow-characterization&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/callid-swallow-characterization&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T14:13:25.210Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T14:12:54.333Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->