### PR TITLE
feat(eslint): enable @typescript-eslint/prefer-string-starts-ends-with

### DIFF
--- a/packages/blockchain-link-types/src/constants/errors.ts
+++ b/packages/blockchain-link-types/src/constants/errors.ts
@@ -27,7 +27,7 @@ export class CustomError extends Error {
         this.message = message;
 
         if (typeof codeOrMessage === 'string') {
-            const isPrefixed = codeOrMessage.indexOf(PREFIX) === 0;
+            const isPrefixed = codeOrMessage.startsWith(PREFIX);
             const code = isPrefixed ? codeOrMessage.substring(PREFIX.length) : codeOrMessage;
             const knownCode = Object.keys(ERROR).includes(code);
             if (isPrefixed || knownCode) {
@@ -36,7 +36,7 @@ export class CustomError extends Error {
                 if (codeMessage) {
                     if (this.message === '') {
                         this.message = codeMessage;
-                    } else if (message.indexOf('+') === 0) {
+                    } else if (message.startsWith('+')) {
                         this.message = `${codeMessage} ${message.substring(1)}`;
                     }
                 }

--- a/packages/connect/src/api/ethereum/ethereumSignTx.ts
+++ b/packages/connect/src/api/ethereum/ethereumSignTx.ts
@@ -141,7 +141,7 @@ export const serializeEthereumTx = (
     );
 
 const stripLeadingZeroes = (str: string) => {
-    while (/^00/.test(str)) {
+    while (str.startsWith('00')) {
         str = str.slice(2);
     }
 

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -142,6 +142,10 @@ export const typescriptConfig = [
             // Known limitation: the rule mis-reports some load-bearing widening assertions
             // (removing them breaks tsc); such spots carry a scoped disable with a justification.
             '@typescript-eslint/no-unnecessary-type-assertion': ['error'],
+
+            // Type-checked rule; the src override is the only block with type info. Prefer
+            // startsWith/endsWith over indexOf(x) === 0, slice(-1) === c and /^x/.test().
+            '@typescript-eslint/prefer-string-starts-ends-with': ['error'],
         },
     },
     {

--- a/packages/utxo-lib/src/bip32.ts
+++ b/packages/utxo-lib/src/bip32.ts
@@ -317,7 +317,7 @@ class BIP32 implements BIP32Interface {
 
         return splitPath.reduce((prevHd, indexStr) => {
             let index;
-            if (indexStr.slice(-1) === `'`) {
+            if (indexStr.endsWith(`'`)) {
                 index = parseInt(indexStr.slice(0, -1), 10);
 
                 return prevHd.deriveHardened(index);

--- a/suite-common/address/src/hasBitcoinCashAddressPrefix.ts
+++ b/suite-common/address/src/hasBitcoinCashAddressPrefix.ts
@@ -1,2 +1,2 @@
 export const hasBitcoinCashAddressPrefix = (address: string) =>
-    /^bitcoincash:/.test(address.toLowerCase());
+    address.toLowerCase().startsWith('bitcoincash:');

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -24,14 +24,14 @@ export const hasEip1559MaxPriorityFee = (
 export const padLeftEven = (hex: string): string => (hex.length % 2 !== 0 ? `0${hex}` : hex);
 
 export const sanitizeHex = ($hex: string): string => {
-    const hex = $hex.toLowerCase().substring(0, 2) === '0x' ? $hex.substring(2) : $hex;
+    const hex = $hex.toLowerCase().startsWith('0x') ? $hex.substring(2) : $hex;
     if (hex === '') return '';
 
     return `0x${padLeftEven(hex)}`;
 };
 
 export const strip = (str: string): string => {
-    if (str.indexOf('0x') === 0) {
+    if (str.startsWith('0x')) {
         return padLeftEven(str.substring(2, str.length));
     }
 

--- a/suite-common/wallet-utils/src/validationUtils.ts
+++ b/suite-common/wallet-utils/src/validationUtils.ts
@@ -22,7 +22,7 @@ export const isInteger = (value: string) =>
 
 export const isHexValid = (value: string, prefix?: string) => {
     // ethereum data/signedTx may start with prefix
-    if (prefix && value.indexOf(prefix) === 0) {
+    if (prefix && value.startsWith(prefix)) {
         const hex = value.substring(prefix.length, value.length);
         // pad left even, is it necessary in ETH?
         // TODO: investigate

--- a/suite/router/src/router.ts
+++ b/suite/router/src/router.ts
@@ -32,7 +32,7 @@ export type RouterPath = {
 export const getPrefixedURL = (url: string) => {
     // do not use object destructuring https://github.com/webpack/webpack/issues/5392
     const prefix = process.env.ASSET_PREFIX;
-    if (prefix && url.indexOf(prefix) !== 0) return prefix + url;
+    if (prefix && !url.startsWith(prefix)) return prefix + url;
 
     return url;
 };
@@ -40,7 +40,7 @@ export const getPrefixedURL = (url: string) => {
 export const stripPrefixedURL = (url: string) => {
     // do not use object destructuring https://github.com/webpack/webpack/issues/5392
     const prefix = process.env.ASSET_PREFIX;
-    if (typeof prefix === 'string' && url.indexOf(prefix) === 0) {
+    if (typeof prefix === 'string' && url.startsWith(prefix)) {
         url = url.slice(prefix.length);
     }
 


### PR DESCRIPTION
Enables the type-checked rule `@typescript-eslint/prefer-string-starts-ends-with` in the `**/src/**` block (the only one with type information) and fixes the occurrences it surfaces.

It steers `str.indexOf(x) === 0`, `str.slice(-1) === c` and `/^x/.test(str)` prefix/suffix checks to `startsWith`/`endsWith`. All fixes are behaviour-preserving (mostly autofix).

Part of a set that splits the original combined PR (#30096) into one rule per PR:
- #30135 — prefer-string-starts-ends-with
- #30136 — return-await
- #30137 — only-throw-error
- #30138 — no-non-null-asserted-nullish-coalescing

## Notes for QA
No user-facing or behavioural change. `startsWith`/`endsWith` are exact equivalents of the replaced expressions. No QA needed beyond CI going green.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is medium risk: ethereumSignTx.ts and ethUtils.ts affect all EVM signing paths, validationUtils.ts affects form validation across trading and wallet, bip32.ts affects key derivation, and router.ts affects all navigation. The recommended tests focus on direct EVM signing flows, route coverage, and validation, avoiding the broad 133-test mappings that are mostly transitive. Two changed files (errors.ts and hasBitcoinCashAddressPrefix.ts) lack specific E2E coverage for their functionality.

<details><summary><b>Changed files (7)</b></summary>

- `packages/blockchain-link-types/src/constants/errors.ts`
- `packages/connect/src/api/ethereum/ethereumSignTx.ts`
- `packages/utxo-lib/src/bip32.ts`
- `suite-common/address/src/hasBitcoinCashAddressPrefix.ts`
- `suite-common/wallet-utils/src/ethUtils.ts`
- `suite-common/wallet-utils/src/validationUtils.ts`
- `suite/router/src/router.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test enumerates every application route and verifies each page loads. Changes to suite/router/src/router.ts directly affect routing, so this is the most comprehensive regression test for navigation and route coverage.
- `suite/e2e/tests/trading/staking-form.test.ts` — Directly exercises ETH staking form validation including minimum amounts, decimal precision, insufficient funds, and fiat/crypto switching. These validations rely on validationUtils.ts and ethUtils.ts.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Directly calls TrezorConnect.ethereumSignTransaction and verifies the full device confirmation flow. This is the most targeted test for changes in packages/connect/src/api/ethereum/ethereumSignTx.ts.
- `suite/e2e/tests/wallet/send-eth.test.ts` — End-to-end ETH send flow with custom gas fees and device confirmation. Directly exercises ethereumSignTx.ts signing paths and ethUtils.ts for fee/amount formatting.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking transaction signing uses ethereumSignTx.ts and ethUtils.ts for amount/fee display. A regression in contract transaction signing or ETH formatting would be visible here.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Exercises sell form percentage calculations, decimal validation, max amount logic, and balance validation across BTC and SOL. These validations are handled by validationUtils.ts.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — ETH-to-USDC DEX swap confirms approval and swap transactions on device, using ethereumSignTx.ts and ethUtils.ts for gas limits, slippage, and amount formatting.
- `suite/e2e/tests/wallet/public-keys.test.ts` — Directly verifies XPUB derivation for BTC, LTC, and ADA accounts. XPUB derivation relies on bip32.ts, making this a focused test for key derivation changes.
- `suite/e2e/tests/wallet/send-base.test.ts` — Base is an EVM network and uses the same Ethereum transaction signing flow as ethereumSignTx.ts. This test covers an additional EVM chain beyond ETH itself. (Not present in the static ethereumSignTx mapping; inferred from chain type.)

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/blockchain-link-types/src/constants/errors.ts`
- `suite-common/address/src/hasBitcoinCashAddressPrefix.ts`

_Updated: 2026-07-29T13:33:27.163Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/eslint-prefer-string-starts-ends-with/web/](https://dev.suite.sldev.cz/suite-web/mroz22/eslint-prefer-string-starts-ends-with/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/eslint-prefer-string-starts-ends-with&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/eslint-prefer-string-starts-ends-with&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/eslint-prefer-string-starts-ends-with&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-21T07:48:11.274Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T13:35:12.598Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->