### PR TITLE
feat(eslint): enable @typescript-eslint/return-await

### DIFF
--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -142,6 +142,12 @@ export const typescriptConfig = [
             // Known limitation: the rule mis-reports some load-bearing widening assertions
             // (removing them breaks tsc); such spots carry a scoped disable with a justification.
             '@typescript-eslint/no-unnecessary-type-assertion': ['error'],
+
+            // `error-handling-correctness-only`: require `return await` inside try/catch/finally
+            // so the local catch sees the rejection and finally runs at the right time. Unlike
+            // `in-try-catch` it does NOT strip harmless awaits elsewhere, avoiding churn and a
+            // clash with `require-await` (removing the sole await of an async fn).
+            '@typescript-eslint/return-await': ['error', 'error-handling-correctness-only'],
         },
     },
     {

--- a/suite-common/fiat-services/src/coingecko.ts
+++ b/suite-common/fiat-services/src/coingecko.ts
@@ -36,7 +36,7 @@ const fetchCoinGecko = async (url: string, skipCache?: boolean) => {
             return;
         }
 
-        return res.json();
+        return await res.json();
     } catch (error) {
         // Do not report to Sentry to save the issues count limit.
         console.warn(error);

--- a/suite-native/storage/src/createAsyncMigrate.ts
+++ b/suite-native/storage/src/createAsyncMigrate.ts
@@ -55,7 +55,7 @@ export const createAsyncMigrate =
                 }
             }
 
-            return Promise.resolve(migratedState);
+            return await Promise.resolve(migratedState);
         } catch (err) {
             console.error(err);
 


### PR DESCRIPTION
Enables `@typescript-eslint/return-await` in mode `error-handling-correctness-only` in the `**/src/**` block (the only one with type information) and fixes the two occurrences it surfaces.

The rule requires `return await` inside `try/catch/finally` so a returned promise's rejection is caught by the local `catch` and `finally` runs at the right time. The `error-handling-correctness-only` mode (not `in-try-catch`) is deliberate: it only *adds* awaits where they matter for error handling and never strips harmless ones elsewhere, which avoids churn and a clash with `require-await` (removing the sole `await` of an async function).

The two fixes differ in impact:
- `coingecko.ts` — closes a latent bug. `return res.json()` inside the `try` returned the promise *unawaited*, so a JSON-parse rejection escaped the local `catch` and propagated to the caller instead of being logged and turned into `undefined`. `return await` lets the `catch` handle it as intended; all three callers already treat an `undefined` result as "skip this coin / return null", so the corrected error path is absorbed with no user-facing change.
- `createAsyncMigrate.ts` — behaviour-preserving. `Promise.resolve(migratedState)` wraps a plain value and can never reject, so the added `await` only satisfies the rule.

Part of a set that splits the original combined PR (#30096) into one rule per PR:
- #30135 — prefer-string-starts-ends-with
- #30136 — return-await
- #30137 — only-throw-error
- #30138 — no-non-null-asserted-nullish-coalescing

## Notes for QA
No user-facing change. The `createAsyncMigrate` fix is a no-op; the `coingecko` fix only tightens an error path — a failed fiat-rate fetch/parse is now logged and skipped locally (exactly as the surrounding `try/catch` already does for network errors), and callers already handle the resulting `undefined`. No QA needed beyond CI going green.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** suite-common/fiat-services/src/coingecko.ts is a broad fiat-rates utility statically referenced by 133 tests, so most references are transitive. Only tests that actually assert fiat-denominated UI behavior are worth running; settings/general and dashboard/discreet-mode are the strongest candidates. suite-native/storage/src/createAsyncMigrate.ts belongs to the mobile (suite-native) storage layer and has no inferred coverage in this web/desktop E2E suite.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/fiat-services/src/coingecko.ts`
- `suite-native/storage/src/createAsyncMigrate.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — This test directly changes the fiat currency (USD → EUR) and asserts that dashboard fiat amounts render with the new currency symbol. A regression in the CoinGecko fiat service could break fiat-denominated rendering or currency switching, which this test exercises end-to-end.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — The test renders fiat-denominated portfolio, asset, and wallet values across the dashboard and toggles their visibility. It exercises the same fiat-conversion display path that coingecko.ts feeds into, even though it focuses on masking rather than rate accuracy.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-native/storage/src/createAsyncMigrate.ts`

_Updated: 2026-07-29T13:31:43.656Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/eslint-return-await/web/](https://dev.suite.sldev.cz/suite-web/mroz22/eslint-return-await/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/eslint-return-await&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/eslint-return-await&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/eslint-return-await&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T13:33:35.651Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T13:33:17.455Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->
