### PR TITLE
feat(eslint): enable @typescript-eslint/only-throw-error

### DIFF
--- a/packages/connect-web/src/bootstrap/bootstrap.ts
+++ b/packages/connect-web/src/bootstrap/bootstrap.ts
@@ -1,3 +1,7 @@
+/* eslint-disable @typescript-eslint/only-throw-error --
+   This module intentionally throws the predefined string error codes from bootstrap-errors.ts.
+   They are matched by value and forwarded to Suite as the `connect-popup-err` URL param (see
+   redirectToSuite below and popup/web.ts), so the thrown value must be the bare code, not an Error. */
 import { BootstrapError } from './bootstrap-errors';
 
 const logger = (() => {

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -140,14 +140,20 @@ export const typescriptConfig = [
             // Known limitation: the rule mis-reports some load-bearing widening assertions
             // (removing them breaks tsc); such spots carry a scoped disable with a justification.
             '@typescript-eslint/no-unnecessary-type-assertion': ['error'],
+
+            // Type-checked recommended rule (the src override is the only block with type info):
+            // throw Error instances, not bare strings/objects, to preserve stack traces and
+            // Sentry grouping.
+            '@typescript-eslint/only-throw-error': ['error'],
         },
     },
     {
-        // Type assertions on partial mocks and fixtures are idiomatic in tests,
-        // so scope the rule out of test and fixture files.
+        // Type assertions on partial mocks and fixtures are idiomatic in tests, and throwing
+        // bare strings/values to assert error paths is common, so scope these out of tests.
         files: ['**/__tests__/**', '**/__fixtures__/**', '**/tests/**', '**/*.test.{ts,tsx}'],
         rules: {
             '@typescript-eslint/no-unnecessary-type-assertion': 'off',
+            '@typescript-eslint/only-throw-error': 'off',
         },
     },
 ];

--- a/packages/trezor-user-env-link/src/websocket-client.ts
+++ b/packages/trezor-user-env-link/src/websocket-client.ts
@@ -135,6 +135,6 @@ export class WebsocketClient extends WebsocketClientBase<WebsocketClientEvents> 
             }
         }
 
-        throw error;
+        throw new Error(error);
     }
 }

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -156,6 +156,9 @@ const preCallHook = async <M extends CallMethodKeys>({
                     __precomposed: true,
                 });
                 if (!methodInfo.success) {
+                    // The catch below inspects `error.code === 'Method_Cancel'`, so preserve the
+                    // code-bearing connect error rather than flattening it to a plain Error.
+                    // eslint-disable-next-line @typescript-eslint/only-throw-error
                     throw methodInfo.error;
                 }
                 txSigningPrecomposed = (methodInfo.payload as any as MethodInfo).precomposed;

--- a/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
+++ b/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
@@ -31,7 +31,7 @@ export const createEvoluInstanceFactory =
         if (!owner.ok) {
             console.error(owner.error);
 
-            throw owner.error;
+            throw new Error(`Failed to create Evolu owner: ${JSON.stringify(owner.error)}`);
         }
 
         const appName = AppName.from(`trezor-suite-v${VERSION}`);
@@ -39,7 +39,7 @@ export const createEvoluInstanceFactory =
         if (!appName.ok) {
             console.error(appName.error);
 
-            throw appName.error;
+            throw new Error(`Invalid Evolu app name: ${JSON.stringify(appName.error)}`);
         }
 
         return getOrThrow(

--- a/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
+++ b/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
@@ -273,7 +273,7 @@ export const createPaymentRequestsThunk = createThunk<
             }
 
             default:
-                throw exhaustive(type);
+                return exhaustive(type);
         }
     },
 );

--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -161,7 +161,9 @@ const sessionRequestThunk = createThunk<
 
         const result = await dispatch(adapter.requestThunk({ event }));
         if (!result || result.error) {
-            throw result?.error || new Error('Device request failed');
+            throw result?.error instanceof Error
+                ? result.error
+                : new Error(String(result?.error ?? 'Device request failed'));
         }
 
         await walletKit.respondSessionRequest({

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.tsx
@@ -54,7 +54,7 @@ const OutputLabel = ({
                     return <Translation id="transactionManagement.review.outputs.addressLabel" />;
 
                 default:
-                    throw exhaustive(flowType);
+                    return exhaustive(flowType);
             }
         case 'amount':
             return <Translation id="transactionManagement.review.outputs.amountLabel" />;
@@ -81,7 +81,7 @@ const OutputLabel = ({
                     return <Translation id="transactionManagement.review.outputs.contractLabel" />;
 
                 default:
-                    throw exhaustive(flowType);
+                    return exhaustive(flowType);
             }
         case 'data':
             return <Translation id="transactionManagement.review.outputs.transactionDataLabel" />;

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx
@@ -94,7 +94,7 @@ export const ReviewOutputItemContent = ({
                     return <AddressFormatter value={value} format="full" variant="body-sm" />;
 
                 default:
-                    throw exhaustive(flowType);
+                    return exhaustive(flowType);
             }
 
         case 'contract':
@@ -108,7 +108,7 @@ export const ReviewOutputItemContent = ({
                 case undefined:
                     return <AddressFormatter value={value} format="full" variant="body-sm" />;
                 default:
-                    throw exhaustive(flowType);
+                    return exhaustive(flowType);
             }
 
         case 'signing-with':

--- a/suite/metadata/src/metadataLabelingActions.ts
+++ b/suite/metadata/src/metadataLabelingActions.ts
@@ -72,6 +72,9 @@ const fetchMetadata =
         const response = await providerInstance.getFileContent(fileName);
 
         if (!response.success) {
+            // Legacy code: the thrown value is the code-bearing provider error object; handleProviderError
+            // routes on `error.code` (dispose/disconnect on AUTH/ACCESS errors), so it must stay an object.
+            // eslint-disable-next-line @typescript-eslint/only-throw-error
             throw response;
         }
 


### PR DESCRIPTION
Enables the type-checked recommended rule `@typescript-eslint/only-throw-error` in the `**/src/**` block and fixes the violations it surfaces. Throwing non-`Error` values (bare strings, plain objects) loses stack traces and breaks Sentry grouping.

Scoped **off** in test/fixture files (throwing bare values to drive error paths is idiomatic there), mirroring the existing `no-unnecessary-type-assertion` test override.

Notable fixes:
- `throw new Error(...)` instead of throwing a bare value or a result/connect error where nothing downstream reads the thrown value's structure (`websocket-client`, `createEvoluInstance`, `walletConnectThunks`).
- `throw exhaustive(x)` → `return exhaustive(x)` in exhaustiveness `default:` branches. `exhaustive()` already throws internally and returns `never`, so this is runtime-identical.

Three spots keep a scoped `eslint-disable` because the thrown value is inspected by structure downstream, so flattening it to an `Error` would change runtime behaviour:
- `connect-web/src/bootstrap/bootstrap.ts` intentionally throws the predefined string error codes from `bootstrap-errors.ts`, matched by value and forwarded to Suite as the `connect-popup-err` URL param.
- `metadataLabelingActions` throws the code-bearing provider error object; `handleProviderError` routes on `error.code` (dispose/disconnect on `AUTH`/`ACCESS` errors).
- `ethereumSignTransaction` throws the connect error whose `code` the local `catch` checks against `'Method_Cancel'`.

Part of a set that splits the original combined PR (#30096) into one rule per PR:
- #30135 — prefer-string-starts-ends-with
- #30136 — return-await
- #30137 — only-throw-error
- #30138 — no-non-null-asserted-nullish-coalescing

## Notes for QA
No user-facing change expected. Edits are `throw <value>` → `throw new Error(...)` on already-failing paths (message content preserved) or runtime-identical `throw exhaustive()` → `return exhaustive()`. No QA needed beyond CI going green.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set spans TrezorConnect's Ethereum sign-transaction hook and its bootstrap init, WalletConnect thunks, Suite Sync (Evolu) instance creation, metadata labeling actions, trading payment-request thunks, the Trezor user-env websocket client, and native-only transaction review output components. The highest risk areas are TrezorConnect Ethereum signing (packages/connect-web bootstrap + ethereumSignTransaction hook), WalletConnect proposal/pairing flows, and Suite Sync label synchronization (Evolu instance + metadataLabelingActions), since these have direct, well-covered e2e tests exercising their exact code paths. Trading payment-request thunk changes warrant medium-priority coverage via buy/sell/swap flows that construct payment/send requests. The native ReviewOutputItem components and trezor-user-env-link websocket client have no direct e2e coverage in this suite (websocket-client is infrastructure used broadly but not tested at a granular level, and the native components are outside this Playwright suite's scope), so recommend targeted manual/unit verification for those.

<details><summary><b>Changed files (9)</b></summary>

- `packages/connect-web/src/bootstrap/bootstrap.ts`
- `packages/trezor-user-env-link/src/websocket-client.ts`
- `suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts`
- `suite-common/suite-sync-evolu/src/createEvoluInstance.ts`
- `suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts`
- `suite-common/walletconnect/src/walletConnectThunks.ts`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.tsx`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx`
- `suite/metadata/src/metadataLabelingActions.ts`

</details>

**Recommended tests (18)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This test directly exercises TrezorConnect.ethereumSignTransaction end-to-end, which is precisely the method hook changed in suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts, and also depends on connect-web bootstrap initialization (packages/connect-web/src/bootstrap/bootstrap.ts) used to init TrezorConnect in suite-desktop mode.
- `suite/e2e/tests/trezor-connect/error.test.ts` — This test initializes TrezorConnect via connect-web bootstrap and exercises ethereumGetAddress error handling in suite-desktop core mode, directly touching the bootstrap.ts initialization path that was changed.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Sends an Ethereum transaction with custom gas fees and confirms via device prompt, closely mirroring the ethereumSignTransaction method hook logic that was changed; any regression in transaction construction/signing would surface here.
- `suite/e2e/tests/wallet/send-base.test.ts` — Performs a full ETH-compatible send on the Base (EVM L2) network with custom fees and device confirmation, exercising the same Ethereum sign-transaction code path affected by the changed method hook.
- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — This test directly exercises WalletConnect pairing, proposal approval/rejection, and analytics events, which are the exact flows implemented in the changed suite-common/walletconnect/src/walletConnectThunks.ts file.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test exercises Suite Sync labeling creation and verifies syncing to the Evolu Relay backend, directly touching the createEvoluInstance.ts changes and the metadataLabelingActions.ts logic used for label CRUD.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — Covers updating and removing labels via Suite Sync with verification against the Evolu relay tables, directly exercising both the Evolu instance creation and metadata labeling action logic that changed.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — Tests initial Suite Sync setup and label syncing from a seeded Evolu relay server, directly exercising the Evolu client instantiation code that was modified.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — Tests label removal syncing to null across the Evolu relay for account/wallet/address/output, directly exercising both the Evolu instance and metadata labeling action code paths changed.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — Covers Suite Sync enablement across multiple passphrase wallets with separate Evolu owner secrets, which could be impacted by changes to Evolu instance creation logic.
- `suite/e2e/tests/metadata/suite-sync/unsupported-device.test.ts` — Exercises Suite Sync enablement flow (via metadata quota manager and banners) that depends on the metadata labeling action and Evolu instance setup being changed.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — Tests migration from legacy Dropbox labeling to Suite Sync, touching both the metadata labeling actions and the Evolu client seeding/instance logic that changed.
- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — Verifies migration of legacy local labels (account, output, address) to Suite Sync with Evolu relay verification, directly relevant to changes in both createEvoluInstance.ts and metadataLabelingActions.ts.
- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — Covers account label CRUD operations (add, edit, remove) which are core behaviors implemented in metadataLabelingActions.ts, even though this uses the legacy Dropbox provider rather than Suite Sync.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This buy/trading flow test involves trade confirmation and payment-related requests, plausibly touching the createPaymentRequestsThunk.ts logic that was changed for payment request creation in the trading module.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Sell flow constructs a payment/send request to a provider destination address and fee, which relates to the createPaymentRequestsThunk.ts logic that was modified.
- `suite/e2e/tests/trading-poc/passthru-swap-eth-to-btc.test.ts` — This test verifies live-trade swap composed transaction info and payment/send request construction end-to-end, directly relevant to changes in the payment requests thunk used for trading.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — Staking transactions involve device-review of transaction outputs, which could be affected by the changed ReviewOutputItem/ReviewOutputItemContent components on native platforms, though this is a web/e2e test not directly the native component.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/trezor-user-env-link/src/websocket-client.ts`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.tsx`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx`

_Updated: 2026-07-21T09:19:07.617Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/eslint-only-throw-error/web/](https://dev.suite.sldev.cz/suite-web/mroz22/eslint-only-throw-error/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/eslint-only-throw-error&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/eslint-only-throw-error&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/eslint-only-throw-error&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-21T09:21:26.165Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-21T09:21:53.610Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->