### PR TITLE
Keep unstake review button fixed instead of tracking keyboard

### DIFF
--- a/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
@@ -107,6 +107,7 @@ export const UnstakeFlowScreen = () => {
     return (
         <Screen
             header={<UnstakeFlowScreenHeader />}
+            isFooterKeyboardAware={false}
             footer={
                 <>
                     <ScreenFooterGradient />

--- a/suite-native/navigation/src/components/Screen.tsx
+++ b/suite-native/navigation/src/components/Screen.tsx
@@ -31,6 +31,7 @@ export type ScreenProps = {
     noHorizontalPadding?: boolean;
     noBottomPadding?: boolean;
     focusedInputBottomOffset?: number;
+    isFooterKeyboardAware?: boolean;
     hasBottomInset?: boolean;
     refreshControl?: ScrollViewProps['refreshControl'];
     containerStyle?: ViewProps['style'];
@@ -93,6 +94,7 @@ export const Screen = ({
     noHorizontalPadding = false,
     noBottomPadding = false,
     focusedInputBottomOffset,
+    isFooterKeyboardAware = true,
     hasBottomInset = true,
     shouldKeepScrolledToEnd = false,
 }: ScreenProps) => {
@@ -166,6 +168,7 @@ export const Screen = ({
                 </ScreenContentWrapper>
                 {footer && (
                     <KeyboardStickyView
+                        enabled={isFooterKeyboardAware}
                         style={applyStyle(screenFooterStyle, { insets, applyBottomInset })}
                     >
                         {footer}


### PR DESCRIPTION
## Description

Fixed the unstake flow's "Review & sign" button overlapping the form content when the on-screen keyboard opens, it previously followed the keyboard via `KeyboardStickyView`, now it stays fixed at the bottom. Added an opt-in `isFooterKeyboardAware` prop (default `true`) to the shared `Screen` component so other screens are unaffected.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29842

## Screenshots:
<img width="372" height="683" alt="Screenshot 2026-07-21 at 09 54 31" src="https://github.com/user-attachments/assets/37deb7f3-d05c-486b-93f2-dda329bd51f9" />