### PR TITLE
fix(connect): cardanoGetPublicKey response v9 backward compatibility

### DIFF
--- a/suite-common/connect-popup/src/methodHooks/cardanoGetPublicKeyCompat.ts
+++ b/suite-common/connect-popup/src/methodHooks/cardanoGetPublicKeyCompat.ts
@@ -1,0 +1,42 @@
+import { type CallMethodKeys, type CardanoPublicKey } from '@trezor/connect';
+
+import { type PostCallHookParams } from './types';
+
+/**
+ * Connect v9 returned the Cardano extended public key (xpub) directly in the
+ * `publicKey` field of `cardanoGetPublicKey`. Connect v10 unified the
+ * `*GetPublicKey` response shape (trezor-suite#27299): `publicKey` now holds the
+ * raw 32-byte public key, and the extended key moved to the new `xpub` /
+ * `displayablePublicKey` fields.
+ *
+ * To keep host apps still pinned to a `9.x` version of `@trezor/connect`
+ * working, rewrite `publicKey` back to the extended key for those callers.
+ * Callers on a newer version receive the unified shape untouched.
+ */
+export function postCallHook<M extends CallMethodKeys>({
+    method,
+    response,
+    source,
+}: PostCallHookParams<M>) {
+    if (
+        method === 'cardanoGetPublicKey' &&
+        response.success &&
+        source.manifest.npmVersion?.startsWith('9.')
+    ) {
+        // `response` is resolved back to the calling app verbatim, so patch the
+        // payload in place. Both the single and bundled (array) forms are handled.
+        const bundledResponse = (
+            Array.isArray(response.payload) ? response.payload : [response.payload]
+        ) as CardanoPublicKey[];
+
+        bundledResponse.forEach(item => {
+            item.publicKey = item.xpub;
+        });
+    }
+
+    return false;
+}
+
+export const cardanoGetPublicKeyCompat = {
+    postCallHook,
+};

--- a/suite-common/connect-popup/src/methodHooks/index.ts
+++ b/suite-common/connect-popup/src/methodHooks/index.ts
@@ -2,6 +2,7 @@ import { type CallMethodKeys } from '@trezor/connect';
 
 import { addressConfirmationModalHooks } from './addressConfirmation';
 import { bitcoinSignTransaction } from './bitcoinSignTransaction';
+import { cardanoGetPublicKeyCompat } from './cardanoGetPublicKeyCompat';
 import { ethereumSignTransaction } from './ethereumSignTransaction';
 import { requestLoginHooks } from './requestLogin';
 import { selectAccountHooks } from './selectAccount';
@@ -31,6 +32,7 @@ export async function postCallHooks<M extends CallMethodKeys>(params: PostCallHo
         await solanaSignTransaction.postCallHook(params),
         await addressConfirmationModalHooks.postCallHook(params),
         await selectAccountHooks.postCallHook(params),
+        await cardanoGetPublicKeyCompat.postCallHook(params),
     ];
 
     return hooks.some(Boolean);


### PR DESCRIPTION
## Description

Connect v10 unified the *GetPublicKey response shape (#27299). As part of that, `cardanoGetPublicKey` was realigned with the other coins: publicKey changed meaning - it used to carry the Cardano extended public key (64-bytes), and now carries the raw 32-byte public key. 

This silently breaks third-party apps that use v9 and expect the original response shape. 

This PR adds a backward-compat shim in the connect-popup method hooks. For callers whose handshake reports a 9.x connect version, it rewrites cardanoGetPublicKey's publicKey back to the extended key, restoring the original behavior. 

## Notes for QA

Test account import in v9 apps, such as Nu.fi, Adalite

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are isolated to the TrezorConnect popup's methodHooks module, specifically the Cardano public key compatibility hook and the central hook index that wires all method hooks together. While index.ts statically maps to 133 tests (a broad-utility file), most of those tests do not exercise the TrezorConnect popup or Cardano public key flows directly, so they were excluded per the broad-utility heuristic. The recommended tests focus on TrezorConnect popup flows (getAddress, selectAccount, cardanoGetAddress) and Cardano-specific public key/address functionality, which are the areas most plausibly affected by these two files.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/connect-popup/src/methodHooks/cardanoGetPublicKeyCompat.ts`
- `suite-common/connect-popup/src/methodHooks/index.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test directly exercises the TrezorConnect popup flow including cardanoGetAddress, which relies on the connect-popup methodHooks module (index.ts) that dispatches per-method hooks such as cardanoGetPublicKeyCompat. Any regression in methodHooks/index.ts wiring would break this popup flow's method dispatch.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test exercises the same connect-popup getAddress/permissions flow through a webextension entry point, directly relying on methodHooks/index.ts to route TrezorConnect calls in the popup.
- `suite/e2e/tests/wallet/cardano.test.ts` — This test exercises Cardano public key reveal and address confirmation flows for a Cardano account, which is the direct functional area touched by cardanoGetPublicKeyCompat.ts — a change here could break public key retrieval/compatibility for Cardano.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Exercises the general TrezorConnect.getAddress popup flow (single and bundle) which shares the same methodHooks dispatch mechanism modified in index.ts, making it a good sanity check for regressions in method routing.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — selectAccount is another TrezorConnect popup method that flows through methodHooks/index.ts; verifying it still returns correct account data (without exposing xpub/publicKey) is relevant since public-key related hooks were touched.
- `suite/e2e/tests/wallet/public-keys.test.ts` — This test verifies displayed XPUB/public key values for ADA (and other coins) via device prompts, directly touching the public-key retrieval code path affected by cardanoGetPublicKeyCompat.ts changes.

</details>

_Updated: 2026-07-21T09:39:16.884Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/cardanogetpublickey-v9-backward-compat/web/](https://dev.suite.sldev.cz/suite-web/fix/cardanogetpublickey-v9-backward-compat/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/cardanogetpublickey-v9-backward-compat&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/cardanogetpublickey-v9-backward-compat&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-21T09:42:14.535Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->