### PR TITLE
feat(suite-desktop): display wrap/unwrap label on tx list item

### DIFF
--- a/packages/suite/src/components/suite/WrapTxAmount.tsx
+++ b/packages/suite/src/components/suite/WrapTxAmount.tsx
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+
+import { getWrappedNativeSymbol } from '@suite-common/wallet-config';
+import { type WalletAccountTransaction } from '@suite-common/wallet-types';
+import {
+    asAmountSubunit,
+    getNativeWrapTxKind,
+    getUnwrapAmountByEthereumDataHex,
+    subunitsToUnits,
+} from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { FormattedCryptoAmount } from './FormattedCryptoAmount';
+
+interface WrapTxAmountProps {
+    transaction: WalletAccountTransaction;
+    /** Render the wrapped-token symbol (e.g. WETH) instead of the native one (e.g. ETH). */
+    wrapped?: boolean;
+}
+
+export const WrapTxAmount = ({ transaction, wrapped }: WrapTxAmountProps) => {
+    const { symbol } = transaction;
+
+    const amount = useMemo(() => {
+        const kind = getNativeWrapTxKind(transaction);
+
+        if (!kind) return undefined;
+
+        // Wrapping is 1:1, so both legs show the same amount and only differ in symbol. The amount
+        // is the transaction value for a wrap and the withdraw(uint256) calldata for an unwrap.
+        const subunits =
+            kind === 'wrap'
+                ? transaction.amount
+                : getUnwrapAmountByEthereumDataHex(transaction.ethereumSpecific?.data);
+
+        return subunits
+            ? subunitsToUnits({ value: asAmountSubunit(new BigNumber(subunits)), symbol })
+            : undefined;
+    }, [transaction, symbol]);
+
+    if (!amount) return null;
+
+    return (
+        <FormattedCryptoAmount
+            value={amount}
+            symbol={wrapped ? (getWrappedNativeSymbol(symbol) ?? symbol) : symbol}
+        />
+    );
+};

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
@@ -4,6 +4,7 @@ import { getNetworkDisplaySymbol, isNetworkSymbol } from '@suite-common/wallet-c
 import { type TronTxContractType } from '@suite-common/wallet-constants';
 import { type StakeType } from '@suite-common/wallet-types';
 import {
+    getNativeWrapTxKind,
     getTxHeaderSymbol,
     isCardanoStakingTx,
     isSupportedEthStakingNetworkSymbol,
@@ -13,6 +14,7 @@ import { type AccountTransaction } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
 import { UnstakingTxAmount } from 'src/components/suite/UnstakingTxAmount';
+import { WrapTxAmount } from 'src/components/suite/WrapTxAmount';
 import { type WalletAccountTransaction } from 'src/types/wallet';
 import { BlurUrls } from 'src/views/wallet/tokens/common/BlurUrls';
 
@@ -126,6 +128,21 @@ export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderP
 
     if (isPending && (transaction.ethereumSpecific || transaction.cardanoSpecific)) {
         return <Translation id="TR_UNCONFIRMED_TX_LONG" />;
+    }
+
+    // WETH wrap/unwrap are shown as their own labels (with the amount) instead of the generic
+    // contract-call name ("deposit"/"withdraw") that the indexer parses.
+    const wrapKind = getNativeWrapTxKind(transaction);
+    if (wrapKind) {
+        return (
+            <Translation
+                id={wrapKind === 'wrap' ? 'TR_TX_WRAP' : 'TR_TX_UNWRAP'}
+                values={{
+                    nativeAmount: <WrapTxAmount transaction={transaction} />,
+                    wrappedAmount: <WrapTxAmount transaction={transaction} wrapped />,
+                }}
+            />
+        );
     }
 
     if (

--- a/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
@@ -1,10 +1,12 @@
 import { Calldata, asEvmAddress } from '@suite-common/calldata';
 import { UINT256_MAX } from '@suite-common/suite-constants';
+import { type WalletAccountTransaction } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils';
 
 import {
     buildApprovalTransactionData,
     getEvmTransactionTextSignature,
+    getNativeWrapTxKind,
     getUnwrapAmountByEthereumDataHex,
     isUnwrapNativeTx,
     isWrapNativeTx,
@@ -216,6 +218,58 @@ describe('eth utils', () => {
             expect(getUnwrapAmountByEthereumDataHex(DEPOSIT)).toBe(null);
             expect(getUnwrapAmountByEthereumDataHex('0xdeadbeef')).toBe(null);
             expect(getUnwrapAmountByEthereumDataHex(undefined)).toBe(null);
+        });
+    });
+
+    describe('getNativeWrapTxKind', () => {
+        const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+        const OTHER = '0x1111111111111111111111111111111111111111';
+        const DEPOSIT = '0xd0e30db0';
+        const WITHDRAW =
+            '0x2e1a7d4d0000000000000000000000000000000000000000000000000de0b6b3a7640000';
+
+        const tx = ({
+            targets = [],
+            internalTransfers = [],
+            data,
+        }: {
+            targets?: { addresses?: string[] }[];
+            internalTransfers?: { from: string }[];
+            data?: string;
+        }) =>
+            ({
+                symbol: 'eth',
+                targets,
+                internalTransfers,
+                ethereumSpecific: data ? { data } : undefined,
+            }) as unknown as WalletAccountTransaction;
+
+        it('detects a wrap when the WETH contract is the value target', () => {
+            expect(
+                getNativeWrapTxKind(tx({ targets: [{ addresses: [WETH] }], data: DEPOSIT })),
+            ).toBe('wrap');
+        });
+
+        it('detects an unwrap when the WETH contract is the internal ETH sender', () => {
+            expect(
+                getNativeWrapTxKind(tx({ internalTransfers: [{ from: WETH }], data: WITHDRAW })),
+            ).toBe('unwrap');
+        });
+
+        it('ignores a deposit() to a non-WETH contract', () => {
+            expect(
+                getNativeWrapTxKind(tx({ targets: [{ addresses: [OTHER] }], data: DEPOSIT })),
+            ).toBeUndefined();
+        });
+
+        it('ignores a WETH interaction with an unrelated selector', () => {
+            expect(
+                getNativeWrapTxKind(tx({ targets: [{ addresses: [WETH] }], data: '0xdeadbeef' })),
+            ).toBeUndefined();
+        });
+
+        it('returns undefined without a WETH target or data', () => {
+            expect(getNativeWrapTxKind(tx({}))).toBeUndefined();
         });
     });
 

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -1,7 +1,10 @@
 import { Calldata } from '@suite-common/calldata';
 import { UINT256_MAX } from '@suite-common/suite-constants';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type EvmTransactionPurpose } from '@suite-common/wallet-types';
+import {
+    type EvmTransactionPurpose,
+    type WalletAccountTransaction,
+} from '@suite-common/wallet-types';
 import { type TokenInfo } from '@trezor/blockchain-link-types';
 import { exhaustive } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils';
@@ -71,6 +74,30 @@ export const isUnwrapNativeTx = ({ networkSymbol, to, data }: WrappedNativeTxPar
 // Amount (in wei) unwrapped by a WETH withdraw(uint256) call, or null when data is not one.
 export const getUnwrapAmountByEthereumDataHex = (data?: string): string | null =>
     Calldata.evm.weth.withdraw.decode(data)?.wad.toString() ?? null;
+
+/**
+ * Classifies an EVM transaction as a native wrap/unwrap for display. The wrapped-native (WETH)
+ * contract shows up as the value recipient for a wrap and as the internal ETH sender for an
+ * unwrap, so both `targets` and `internalTransfers` are considered when resolving the target.
+ */
+export const getNativeWrapTxKind = (
+    transaction: WalletAccountTransaction,
+): 'wrap' | 'unwrap' | undefined => {
+    const { symbol } = transaction;
+    const data = transaction.ethereumSpecific?.data;
+
+    const candidateAddresses = [
+        ...transaction.targets.flatMap(target => target.addresses ?? []),
+        ...transaction.internalTransfers.map(transfer => transfer.from),
+    ];
+    const to = candidateAddresses.find(address => isWrappedNativeToken(symbol, address));
+
+    if (!to) return undefined;
+    if (isWrapNativeTx({ networkSymbol: symbol, to, data })) return 'wrap';
+    if (isUnwrapNativeTx({ networkSymbol: symbol, to, data })) return 'unwrap';
+
+    return undefined;
+};
 
 export const isEvmApprovalTx = (data?: string): boolean =>
     Calldata.evm.erc20.approve.decode(data) !== null;

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11274,6 +11274,14 @@ export const messages = defineMessages({
         id: 'TR_TX_STAKE_CLAIM',
         defaultMessage: 'Claim withdraw request',
     },
+    TR_TX_WRAP: {
+        id: 'TR_TX_WRAP',
+        defaultMessage: 'Wrap {nativeAmount} into {wrappedAmount}',
+    },
+    TR_TX_UNWRAP: {
+        id: 'TR_TX_UNWRAP',
+        defaultMessage: 'Unwrap {wrappedAmount} into {nativeAmount}',
+    },
     TR_STAKE_STAKE: {
         id: 'TR_STAKE_STAKE',
         defaultMessage: 'Stake',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

## Scope
- [x] Title ("Wrapped ETH" / "Unwrapped ETH") + converted amount in `TransactionHeader`
- [x] `UnwrapTxAmount`; detection from #29858 (selector + target); i18n keys

## Notes for QA

You can use method described in https://github.com/trezor/trezor-suite/pull/30089 or debug interface to get such transaction

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29875

## Screenshots:

<img width="1195" height="442" alt="Screenshot 2026-07-21 at 12 07 23" src="https://github.com/user-attachments/assets/4db1733d-9518-4a3a-b8aa-f6d39d27e95c" />
<img width="1194" height="541" alt="Screenshot 2026-07-21 at 12 10 11" src="https://github.com/user-attachments/assets/96251de1-9cb8-4220-b4bd-efa15ba37b6c" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/wrapped-native-tx-label&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->