### PR TITLE
Optimize duration of downloadCryptoIcons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,5 @@ packages/suite-data/files/translations/master.json
 
 # coverage map and test analysis files
 coverage-map/
+
+suite-common/icons/files/cryptoicons

--- a/suite-common/icons/scripts/downloadCryptoIcons.ts
+++ b/suite-common/icons/scripts/downloadCryptoIcons.ts
@@ -10,7 +10,12 @@ import {
     RUN_LIMIT_SECONDS,
     UPDATED_ICONS_LIST_FILE,
 } from './constants';
-import { COIN_IMAGE_SIZES, createCoinImageName } from '../src/coinImages';
+import {
+    COIN_IMAGE_SIZES,
+    IMAGE_EXTENSION,
+    IMAGE_SIZE_SEPARATOR,
+    createCoinImageName,
+} from '../src/coinImages';
 import {
     fetchCoinList,
     fetchUpdatedIconsList,
@@ -50,21 +55,24 @@ function isValidUrl(url: string): boolean {
 // Returns true only if the icon was written successfully, so the caller can persist the
 // image-url fingerprint (and thereby skip this coin next run) exclusively on success.
 const updateIcon = async (
+    logPrefix: string,
     coinId: string,
     imageUrl: string,
     coinPlatforms: Record<string, string>,
 ): Promise<boolean> => {
     try {
         if (!isValidUrl(imageUrl)) {
-            console.error(`Invalid url (${coinId}):`, imageUrl);
+            console.error(logPrefix, `Invalid url:`, imageUrl);
 
             return false;
         }
 
+        console.log(logPrefix, `⏳ Fetching`, imageUrl);
         const originImage = await fetch(imageUrl);
         if (!originImage.ok) {
             console.error(
-                `Invalid image (${coinId}):`,
+                logPrefix,
+                `Invalid image:`,
                 imageUrl,
                 originImage.status,
                 originImage.statusText,
@@ -75,24 +83,37 @@ const updateIcon = async (
 
         const originImageBuffer = await originImage.arrayBuffer();
         const platforms = Object.entries(coinPlatforms);
+        const iconNames = new Set<string>();
 
         for (const size of COIN_IMAGE_SIZES) {
             const finalImageBuffer = await resizeImage(originImageBuffer, size);
 
             for (const [coingeckoId, contractAddress] of platforms) {
                 const fileName = createCoinImageName({ coingeckoId, contractAddress, size });
-                console.log(`Writing image (${coinId}):`, fileName);
                 await writeImage(fileName, finalImageBuffer);
+                iconNames.add(fileName.split(IMAGE_SIZE_SEPARATOR)[0]!);
             }
 
             const fileName = createCoinImageName({ coingeckoId: coinId, size });
-            console.log(`Writing image (${coinId}):`, fileName);
             await writeImage(fileName, finalImageBuffer);
+            iconNames.add(fileName.split(IMAGE_SIZE_SEPARATOR)[0]!);
         }
+
+        console.log(
+            logPrefix,
+            `🟢 Saved:\n`,
+            JSON.stringify(
+                Array.from(iconNames).map(iconName =>
+                    `${iconName}${IMAGE_SIZE_SEPARATOR}{${COIN_IMAGE_SIZES.join(',')}}${IMAGE_EXTENSION}`.trim(),
+                ),
+                null,
+                2,
+            ),
+        );
 
         return true;
     } catch (error) {
-        console.error(`Error (${coinId}):`, error);
+        console.error(logPrefix, `🔴 Error:`, error);
 
         return false;
     }
@@ -114,13 +135,13 @@ async function ensureDirectoryExists(path: string) {
     if (coins.length === 0) {
         throw new Error('No coins found');
     } else {
-        console.log('Total coins in coin list:', coins.length);
+        console.log(new Date().toISOString(), 'Total coins in coin list:', coins.length);
     }
 
     // Image urls in bulk (~250 coins/request) instead of one /coins/{id} request per coin.
     // Only coins with market data are covered here; the rest fall back to getCoinData below.
     const marketImageUrls = await getCoinMarketImageUrls();
-    console.log('Total market image urls fetched:', marketImageUrls.size);
+    console.log(new Date().toISOString(), 'Total market image urls fetched:', marketImageUrls.size);
 
     // process missing icons and icons updated the longest time ago first
     coins.sort(
@@ -136,8 +157,10 @@ async function ensureDirectoryExists(path: string) {
     await ensureDirectoryExists(FILES_CRYPTOICONS_PATH);
 
     for (let i = 0; i < coins.length; i++) {
+        const logPrefix = `${i + 1}/${coins.length} ${coins[i]?.id}:`;
+
         if (Date.now() - startedAt > RUN_LIMIT_SECONDS * 1000) {
-            console.log(`${i + 1}/${coins.length}: Run limit reached`);
+            console.log(logPrefix, `Run limit reached`);
             break;
         }
 
@@ -146,14 +169,13 @@ async function ensureDirectoryExists(path: string) {
             continue;
         }
 
-        console.log(`${i + 1}/${coins.length}: Start icon updating for ${coin.id}`);
-
         let imageUrl = marketImageUrls.get(coin.id);
         let platforms = coin.platforms ?? {};
 
         // Tail coins (no market data) are absent from /coins/markets — fall back to the
         // per-coin endpoint. This is the only remaining rate-limited call in the loop.
         if (!imageUrl) {
+            console.log(logPrefix, `No market image url, falling back to /coins/{id} endpoint`);
             const apiCallDelay = Math.ceil((60 / RATE_LIMIT_PER_MINUTE) * 1000);
 
             await sleep(apiCallDelay);
@@ -164,22 +186,22 @@ async function ensureDirectoryExists(path: string) {
                     platforms = coinData.platforms;
                 }
             } catch (error) {
-                console.error(`Failed to fetch coin data (${coin.id}):`, error);
+                console.error(logPrefix, `Failed to fetch coin data (${coin.id}):`, error);
             }
         }
 
         if (!imageUrl) {
-            console.error(`No image url for: ${coin.id}`);
+            console.error(logPrefix, `No image url.`);
             continue;
         }
 
         // Skip coins whose source image is unchanged since the last successful run.
         if (updatedIcons[coin.id]?.imageUrl === imageUrl) {
-            console.log(`${i + 1}/${coins.length}: Skipping unchanged icon for ${coin.id}`);
+            console.log(logPrefix, `Skipping unchanged icon.`);
             continue;
         }
 
-        const success = await updateIcon(coin.id, imageUrl, platforms);
+        const success = await updateIcon(logPrefix, coin.id, imageUrl, platforms);
 
         updatedIcons[coin.id] = {
             updatedAt: Math.floor(Date.now() / 1000),
@@ -188,5 +210,6 @@ async function ensureDirectoryExists(path: string) {
         };
     }
 
+    console.log('All icons processed, writing updated icons list');
     await fs.writeFile(UPDATED_ICONS_LIST_FILE, JSON.stringify(updatedIcons, null, 2));
 })();

--- a/suite-common/icons/scripts/downloadCryptoIcons.ts
+++ b/suite-common/icons/scripts/downloadCryptoIcons.ts
@@ -186,7 +186,7 @@ async function ensureDirectoryExists(path: string) {
             // Only fingerprint on success so a failed coin is retried on the next run.
             ...(success ? { imageUrl } : {}),
         };
-
-        await fs.writeFile(UPDATED_ICONS_LIST_FILE, JSON.stringify(updatedIcons, null, 2));
     }
+
+    await fs.writeFile(UPDATED_ICONS_LIST_FILE, JSON.stringify(updatedIcons, null, 2));
 })();

--- a/suite-common/icons/scripts/utils/fetchCoins.ts
+++ b/suite-common/icons/scripts/utils/fetchCoins.ts
@@ -23,11 +23,18 @@ import {
 const coinGeckoApi = createHttpClient({
     baseUrl: COINGECKO_API_BASE_URL,
     headers: { [COINGECKO_API_KEY_HEADER]: COINGECKO_API_KEY_VALUE },
+    onError: error => {
+        console.error('Error fetching from CoinGecko API:', error);
+    },
 });
 
 // The updated-icons checkpoint lives on the trezor CDN, not CoinGecko, so it must NOT carry the
 // CoinGecko API key — hence a separate headerless client.
-const trezorDataApi = createHttpClient({});
+const trezorDataApi = createHttpClient({
+    onError: error => {
+        console.error('Error fetching updated icons list:', error);
+    },
+});
 
 const fetchCoinMarketsPage = coinGeckoApi('/coins/markets', {
     method: 'GET',

--- a/suite-common/icons/src/coinImages.ts
+++ b/suite-common/icons/src/coinImages.ts
@@ -5,7 +5,8 @@ export const COIN_IMAGE_SIZES = [24, 40, 48, 80] as const satisfies number[];
 export type CoinImageSize = (typeof COIN_IMAGE_SIZES)[number];
 
 const CRYPTO_ID_SEPARATOR = '--';
-const IMAGE_SIZE_SEPARATOR = '@';
+export const IMAGE_SIZE_SEPARATOR = '@';
+export const IMAGE_EXTENSION = '.webp';
 
 function createCryptoId(coingeckoId: string, contractAddress?: string) {
     const cryptoId = contractAddress
@@ -28,5 +29,5 @@ export function createCoinImageName<Size extends CoinImageSize>({
 }: CreateCoinImageNameParams<Size>) {
     const cryptoId = createCryptoId(coingeckoId, contractAddress);
 
-    return `${cryptoId}${IMAGE_SIZE_SEPARATOR}${size}.webp` as const;
+    return `${cryptoId}${IMAGE_SIZE_SEPARATOR}${size}${IMAGE_EXTENSION}` as const;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Reduce file writes from O(n) to O(1).

## Related Issue

Resolve #30115

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files (downloadCryptoIcons.ts and fetchCoins.ts) are build-time/dev-tooling scripts under suite-common/icons/scripts used to fetch coin metadata and download crypto icon assets during the build or CI pipeline. They are not part of the runtime application code exercised by the Playwright E2E suite (no page objects, components, or Redux logic reference them), and none of the 107 cataloged tests exercise this icon-fetching script functionality directly or indirectly. Since these scripts run offline/at build time to generate static icon assets rather than affecting live app behavior tested by E2E flows, there is no meaningful E2E regression risk to target; the appropriate verification would be a build/lint check or a manual/script-level unit test rather than E2E test execution.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/icons/scripts/downloadCryptoIcons.ts`
- `suite-common/icons/scripts/utils/fetchCoins.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `suite-common/icons/scripts/downloadCryptoIcons.ts`
- `suite-common/icons/scripts/utils/fetchCoins.ts`

_Updated: 2026-07-21T12:16:15.627Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/icons-script-2&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/icons-script-2&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/icons-script-2&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-21T13:33:24.795Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-21T13:33:21.137Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/icons-script-2/web/](https://dev.suite.sldev.cz/suite-web/fix/icons-script-2/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->