### PR TITLE
fix(analytics): fix analytics endpoint for local debug builds

### DIFF
--- a/suite-native/analytics-redux/src/analyticsThunks.ts
+++ b/suite-native/analytics-redux/src/analyticsThunks.ts
@@ -9,7 +9,7 @@ import {
 } from '@suite-common/analytics-redux';
 import { createThunk } from '@suite-common/redux-utils';
 import { asTypedNativeAnalytics, events } from '@suite-native/analytics';
-import { isDevelopEnv } from '@suite-native/config';
+import { isProduction } from '@suite-native/config';
 import { allowSentryReport, setSentryUser } from '@suite-native/sentry';
 import { type InitOptions, getTrackingRandomId } from '@trezor/analytics-uploader';
 import { getCommitHash } from '@trezor/env-utils';
@@ -63,7 +63,7 @@ export const initAnalyticsThunk = createThunk(
             url: customAnalyticsUrl,
             loggerEnabled,
             commitId: getCommitHash(),
-            isDev: isDevelopEnv(),
+            isDev: !isProduction(),
             callbacks: {
                 onEnable: () => dispatch(enableAnalyticsThunk()),
                 onDisable: () => dispatch(disableAnalyticsThunk()),


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

We used a check for develop environment, but debug environment is separate and `isDevelopOrDebugEnv` or `!isProduction` should be used instead. Negative `!isProduction()` is used as more defensive, but it should be the same.

## Notes for QA

Double check on each environment (debug, dev, preview, production) if the correct analytics endpoint is used.



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native-analytic-debug-endpoint&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->