### PR TITLE
feat(suite): unify Add Account network list

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -362,6 +362,8 @@ export const AddAccountModal = ({
         account: NetworkAccount;
         accountTypes: NetworkAccount[];
     }) {
+        onCancel();
+
         const newAccount = await prepareNewAccountPayload({
             accountType: account.accountType,
             networkSymbol: network.symbol,
@@ -383,7 +385,6 @@ export const AddAccountModal = ({
             return;
         }
 
-        onCancel();
         dispatch(accountsActions.createAccount(newAccount));
         resetAccountSearch(newAccount.symbol);
         reportNewAccountAnalytics(newAccount);
@@ -540,7 +541,6 @@ export const AddAccountModal = ({
                               <>
                                   {showSupportedNetworks && (
                                       <SelectNetwork
-                                          heading={<Translation id="TR_COINS" />}
                                           networks={filteredSupportedNetworks}
                                           handleNetworkSelection={handleNetworkSelection}
                                           onSettings={setAdvancedSettingsSymbol}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -25,7 +25,6 @@ import {
 import { getAvailableAccountTypes, prepareNewAccountPayload } from '@suite-common/wallet-utils';
 import { Box, Column, Modal } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
-import { arrayPartition } from '@trezor/utils';
 
 import { useAvailableNetworkSymbols } from 'src/components/wallet/WalletLayout/AccountsMenu/useAvailableNetworkSymbols';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
@@ -74,10 +73,10 @@ export const AddAccountModal = ({
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { setCoinFilter, setSearchString, coinFilter } = useAccountSearch();
 
-    const resetAccountSearch = (symbol: NetworkSymbol) => {
+    const resetAccountSearch = (networkSymbol: NetworkSymbol) => {
         // reset search string in account search box so the new account is visible in the list
         setSearchString(undefined);
-        if (coinFilter && !coinFilter.includes(symbol)) {
+        if (coinFilter && !coinFilter.includes(networkSymbol)) {
             // if coinFilter is active then reset it only if added account doesn't belong to selected/filtered coin
             setCoinFilter([]);
         }
@@ -153,21 +152,12 @@ export const AddAccountModal = ({
     const enabledNetworks = availableNetworksSymbols.map(networkSymbol =>
         getNetwork(networkSymbol),
     );
-    const [enabledMainnetNetworks, enabledTestnetNetworks] = useMemo(
-        () => arrayPartition(enabledNetworks, network => !network?.testnet),
-        [enabledNetworks],
-    );
     const disabledNetworks = supportedNetworks.filter(
         network => !availableNetworksSymbols.includes(network.symbol),
     );
-
-    const [disabledMainnetNetworks, disabledTestnetNetworks] = useMemo(
-        () => arrayPartition(disabledNetworks, network => !network?.testnet),
-        [disabledNetworks],
-    );
-    const testnetNetworks = useMemo(
-        () => [...enabledTestnetNetworks, ...disabledTestnetNetworks],
-        [enabledTestnetNetworks, disabledTestnetNetworks],
+    const displayedSupportedNetworks = useMemo(
+        () => [...supportedMainnets, ...(useTestnetNetworks ? supportedTestnets : [])],
+        [supportedMainnets, supportedTestnets, useTestnetNetworks],
     );
 
     const allSearchableNetworks = useMemo(() => {
@@ -176,20 +166,10 @@ export const AddAccountModal = ({
         }
 
         return [
-            ...enabledMainnetNetworks,
-            ...disabledMainnetNetworks,
-            ...(useTestnetNetworks ? testnetNetworks : []),
+            ...displayedSupportedNetworks,
             ...(showUnsupportedCoins ? unsupportedMainnets : []),
         ];
-    }, [
-        disabledMainnetNetworks,
-        enabledMainnetNetworks,
-        showUnsupportedCoins,
-        symbol,
-        testnetNetworks,
-        unsupportedMainnets,
-        useTestnetNetworks,
-    ]);
+    }, [displayedSupportedNetworks, showUnsupportedCoins, symbol, unsupportedMainnets]);
 
     const {
         searchQuery,
@@ -200,17 +180,10 @@ export const AddAccountModal = ({
         handleSearchClear,
     } = useNetworkSettingsSearch(allSearchableNetworks, { origin: 'add-account' });
 
-    const filteredEnabledMainnetNetworks = filterNetworks(enabledMainnetNetworks);
-    const filteredDisabledMainnetNetworks = filterNetworks(disabledMainnetNetworks);
-    const filteredTestnetNetworks = filterNetworks(testnetNetworks);
+    const filteredSupportedNetworks = filterNetworks(displayedSupportedNetworks);
     const filteredUnsupportedMainnets = filterNetworks(unsupportedMainnets);
 
-    const showEnabledMainnets = !hasActiveSearch || filteredEnabledMainnetNetworks.length > 0;
-    const showDisabledMainnets = !hasActiveSearch || filteredDisabledMainnetNetworks.length > 0;
-    const showTestnetsSection =
-        useTestnetNetworks &&
-        testnetNetworks.length > 0 &&
-        (!hasActiveSearch || filteredTestnetNetworks.length > 0);
+    const showSupportedNetworks = !hasActiveSearch || filteredSupportedNetworks.length > 0;
     const showUnsupportedSection =
         showUnsupportedCoins &&
         unsupportedMainnets.length > 0 &&
@@ -242,10 +215,7 @@ export const AddAccountModal = ({
     const filterNetworksBySymbol = (items: Network[], networkSymbol?: NetworkSymbol) =>
         networkSymbol ? items.filter(network => network.symbol === networkSymbol) : items;
 
-    const filteredDisabledNetworks = filterNetworksBySymbol(
-        symbol ? disabledNetworks : disabledMainnetNetworks,
-        symbol,
-    );
+    const filteredDisabledNetworks = filterNetworksBySymbol(disabledNetworks, symbol);
     const filteredEnabledNetworks = filterNetworksBySymbol(enabledNetworks, symbol);
 
     const visibleNetworks =
@@ -568,29 +538,10 @@ export const AddAccountModal = ({
                               </Box>
                           ) : (
                               <>
-                                  {showEnabledMainnets && (
+                                  {showSupportedNetworks && (
                                       <SelectNetwork
-                                          heading={<Translation id="TR_ACTIVATED_COINS" />}
-                                          networks={filteredEnabledMainnetNetworks}
-                                          handleNetworkSelection={handleNetworkSelection}
-                                          onSettings={setAdvancedSettingsSymbol}
-                                          getAddDisabledMessage={getAddDisabledMessage}
-                                      />
-                                  )}
-                                  {showDisabledMainnets && (
-                                      <SelectNetwork
-                                          heading={<Translation id="TR_INACTIVE_COINS" />}
-                                          networks={filteredDisabledMainnetNetworks}
-                                          handleNetworkSelection={handleNetworkSelection}
-                                          onSettings={setAdvancedSettingsSymbol}
-                                          getAddDisabledMessage={getAddDisabledMessage}
-                                      />
-                                  )}
-                                  {showTestnetsSection && (
-                                      <SelectNetwork
-                                          heading={<Translation id="TR_TESTNET_COINS" />}
-                                          data-testid="@modal/account/activate_more_coins"
-                                          networks={filteredTestnetNetworks}
+                                          heading={<Translation id="TR_COINS" />}
+                                          networks={filteredSupportedNetworks}
                                           handleNetworkSelection={handleNetworkSelection}
                                           onSettings={setAdvancedSettingsSymbol}
                                           getAddDisabledMessage={getAddDisabledMessage}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
@@ -5,7 +5,7 @@ import { Button, Column, H4, Tooltip } from '@trezor/components';
 import { NetworkList } from 'src/components/suite/NetworkList/NetworkList';
 
 type SelectNetworkProps = {
-    heading: React.ReactNode;
+    heading?: React.ReactNode;
     networks: Network[];
     handleNetworkSelection?: (symbol?: NetworkSymbol) => void;
     onSettings?: (symbol: NetworkSymbol) => void;
@@ -27,9 +27,11 @@ export const SelectNetwork = ({
 
     return (
         <Column gap={12} data-testid={dataTestId}>
-            <H4 intent="neutral" priority="secondary" typographyStyle="body-sm">
-                {heading}
-            </H4>
+            {heading && (
+                <H4 intent="neutral" priority="secondary" typographyStyle="body-sm">
+                    {heading}
+                </H4>
+            )}
             <NetworkList
                 onClick={handleNetworkSelection}
                 networks={networks}


### PR DESCRIPTION
## Description

Unifies active and inactive supported networks into one ordered list in the Desktop/Web Add Account modal. Existing network activation, account discovery, account-type handling, firmware filtering, search, and Add button behavior remain unchanged.

## Notes for QA

- Open Add Account with at least one active network and confirm active and inactive networks appear in one list under **Networks**.
- Add an account on an active network and confirm the existing account-addition flow is unchanged.
- Select an inactive network and confirm the existing activation and discovery flow is unchanged.
- Verify search filters the unified list correctly.
- Verify testnet visibility follows the Testnet networks setting.
- Verify Bitcoin-only firmware only shows supported networks.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30079

## Screenshots:

### Before
<img width="1280" height="720" alt="add-account-before" src="https://github.com/user-attachments/assets/e2491c45-31b6-47e8-ab3d-bd53c140558c" />

### After
<img width="1280" height="720" alt="add-account-after" src="https://github.com/user-attachments/assets/6d1002c0-a8ac-4adc-bef0-d4ef519b544a" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to the AddAccountModal component, a UI modal used when users manually add new wallet accounts. Since this maps broadly to 133 tests (mostly via shared onboarding/settings scaffolding), most of those are irrelevant transitive dependents; only tests that actually exercise the 'add account' flow (selecting account type, confirming, or adding accounts via asset picker) are meaningfully at risk. Recommended strategy: run add-account-types.test.ts as the primary regression check, plus account-metadata and global-receive-send tests which touch the same modal in secondary flows.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test directly exercises the Add Account modal flow (opening the modal, selecting account type, confirming) across multiple coins - the exact component that was changed (AddAccountModal.tsx).

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test adds a new Bitcoin account and immediately assigns a custom label to it, exercising the add-account flow (via AddAccountModal) combined with labeling right after account creation.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test opens the global receive flow and adds a new ETH account via the asset picker/add account modal, directly exercising the add-account UI path affected by the change.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coins and triggers account discovery, which shares underlying account-creation logic with the AddAccountModal, though it does not directly interact with the modal itself.

</details>

_Updated: 2026-07-21T11:54:09.895Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/agent/unify-add-account-network-list/web/](https://dev.suite.sldev.cz/suite-web/agent/unify-add-account-network-list/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=agent/unify-add-account-network-list&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=agent/unify-add-account-network-list&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-22T08:06:22.162Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| TrezorConnect > Error screen | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.signTransaction > TrezorConnect.signTransaction | 🤖 auto |
| TrezorConnect.ethereumSignMessage > TrezorConnect.ethereumSignMessage | 🤖 auto |
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-22T08:06:18.869Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->