### PR TITLE
fix(suite-native): derive normal-only account networks

### DIFF
--- a/suite-native/add-coin-account/src/utils/getAvailableAccountTypesForNetworkSymbol.ts
+++ b/suite-native/add-coin-account/src/utils/getAvailableAccountTypesForNetworkSymbol.ts
@@ -5,21 +5,10 @@ import {
     type NetworkSymbol,
     networks,
 } from '@suite-common/wallet-config';
+import { isEvmNetwork } from '@suite-common/wallet-utils';
 import { typedObjectKeys } from '@trezor/utils';
 
-const networkSymbolsWithOnlyNormalAccountType = new Set<NetworkSymbol>([
-    'ada',
-    'eth',
-    'pol',
-    'bsc',
-    'sol',
-    'op',
-    'base',
-    'arb',
-    'rhc',
-    'hype',
-    'avax',
-]);
+const normalOnlyNonEvmNetworkSymbols: NetworkSymbol[] = ['ada', 'sol'];
 
 export const getAvailableAccountTypesForNetworkSymbol = ({
     symbol,
@@ -31,10 +20,15 @@ export const getAvailableAccountTypesForNetworkSymbol = ({
         return [NORMAL_ACCOUNT_TYPE];
     }
 
+    const supportsOnlyNormalAccountType =
+        isEvmNetwork(symbol) || normalOnlyNonEvmNetworkSymbols.includes(symbol);
+    if (supportsOnlyNormalAccountType) {
+        return [NORMAL_ACCOUNT_TYPE];
+    }
+
     const accountTypes = typedObjectKeys(networkConfig.accountTypes).filter(
         accountType => !['coinjoin', 'imported', 'ledger'].includes(accountType),
     );
-    const supportsOnlyNormalAccountType = networkSymbolsWithOnlyNormalAccountType.has(symbol);
 
-    return [NORMAL_ACCOUNT_TYPE, ...(supportsOnlyNormalAccountType ? [] : accountTypes)];
+    return [NORMAL_ACCOUNT_TYPE, ...accountTypes];
 };


### PR DESCRIPTION
## Description

- Derive normal-only account availability for EVM networks from `isEvmNetwork` instead of maintaining a hard-coded symbol list.
- Keep Cardano and Solana as explicit non-EVM exceptions.
- Preserve filtering of unsupported account types for other networks.

This ensures newly added EVM networks automatically use the normal account type in the native add-coin-account flow.

## Notes for QA

- In Suite Native, verify EVM networks expose only the normal account type when adding an account. Please include Ethereum Classic (`etc`) and the Ethereum testnets (`tsep` and `thod`), which were missing from the previous hard-coded list.
- Verify Cardano (`ada`) and Solana (`sol`) still expose only the normal account type.
- Verify a non-EVM network with multiple account types, such as Bitcoin, continues to offer its applicable account types.
- Desktop/web behavior is unchanged.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30086

## Screenshots:

Not applicable.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=agent/derive-evm-account-types&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->