### PR TITLE
28878 playwright perf tracking

### DIFF
--- a/packages/perf-e2e/eslint.config.mjs
+++ b/packages/perf-e2e/eslint.config.mjs
@@ -1,0 +1,3 @@
+import { eslint } from '@trezor/eslint';
+
+export default [...eslint];

--- a/packages/perf-e2e/jest.config.cjs
+++ b/packages/perf-e2e/jest.config.cjs
@@ -1,0 +1,8 @@
+const baseConfig = require('../../jest.config.base.swc');
+
+module.exports = {
+    ...baseConfig,
+    collectCoverage: true,
+    collectCoverageFrom: ['src/**/*.ts', '!src/instrumentation.ts', '!src/index.ts'],
+    testEnvironment: '../../JestCustomEnv.js',
+};

--- a/packages/perf-e2e/jest.config.cjs
+++ b/packages/perf-e2e/jest.config.cjs
@@ -3,6 +3,6 @@ const baseConfig = require('../../jest.config.base.swc');
 module.exports = {
     ...baseConfig,
     collectCoverage: true,
-    collectCoverageFrom: ['src/**/*.ts', '!src/instrumentation.ts', '!src/index.ts'],
+    collectCoverageFrom: ['src/**/*.ts', '!src/index.ts'],
     testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/perf-e2e/package.json
+++ b/packages/perf-e2e/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "@trezor/perf-e2e",
+    "version": "1.0.0",
+    "private": true,
+    "type": "module",
+    "description": "Frontend performance measurement for e2e tests: metric collection, comparison against limits, aggregation and reporting. Playwright-agnostic core.",
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index.ts",
+    "scripts": {
+        "test:unit": "yarn g:jest",
+        "type-check": "yarn g:tsc --build tsconfig.json",
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
+    },
+    "devDependencies": {
+        "@trezor/eslint": "workspace:*"
+    }
+}

--- a/packages/perf-e2e/src/aggregate.test.ts
+++ b/packages/perf-e2e/src/aggregate.test.ts
@@ -1,0 +1,62 @@
+import { aggregateSamples, median } from './aggregate';
+import { type PerfMetrics } from './types';
+
+const sample = (overrides: Partial<PerfMetrics> = {}): PerfMetrics => ({
+    totalBlockingTimeMs: 0,
+    longTaskCount: 0,
+    longestTaskMs: 0,
+    reactCommitCount: 0,
+    interactionDurationMs: 0,
+    ...overrides,
+});
+
+describe('median', () => {
+    it('returns the middle value for odd-length input', () => {
+        expect(median([90, 10, 50])).toBe(50);
+    });
+
+    it('averages the two middle values for even-length input', () => {
+        expect(median([10, 20, 30, 40])).toBe(25);
+    });
+
+    it('is robust to a single outlier', () => {
+        expect(median([100, 105, 110, 5000])).toBe(107.5);
+    });
+
+    it('throws on empty input', () => {
+        expect(() => median([])).toThrow();
+    });
+});
+
+describe('aggregateSamples', () => {
+    it('computes per-metric medians rounded to integers', () => {
+        const samples = [
+            sample({ totalBlockingTimeMs: 100, reactCommitCount: 6 }),
+            sample({ totalBlockingTimeMs: 120, reactCommitCount: 7 }),
+            sample({ totalBlockingTimeMs: 900, reactCommitCount: 8 }),
+        ];
+        const result = aggregateSamples(samples);
+        expect(result.totalBlockingTimeMs).toBe(120);
+        expect(result.reactCommitCount).toBe(7);
+    });
+
+    it('throws on empty input', () => {
+        expect(() => aggregateSamples([])).toThrow();
+    });
+
+    // A metric can read null where the environment cannot measure it, and a null must not be
+    // averaged in as a zero — that would report an unmeasured metric as a fast one.
+    it('yields null for a metric that is unavailable in every sample', () => {
+        const samples = [sample({ longestTaskMs: null }), sample({ longestTaskMs: null })];
+        expect(aggregateSamples(samples).longestTaskMs).toBeNull();
+    });
+
+    it('ignores null samples when some runs measured the metric', () => {
+        const samples = [
+            sample({ longestTaskMs: null }),
+            sample({ longestTaskMs: 100 }),
+            sample({ longestTaskMs: 200 }),
+        ];
+        expect(aggregateSamples(samples).longestTaskMs).toBe(150);
+    });
+});

--- a/packages/perf-e2e/src/aggregate.ts
+++ b/packages/perf-e2e/src/aggregate.ts
@@ -1,0 +1,46 @@
+import { METRIC_KEYS } from './config';
+import { type PerfMetrics } from './types';
+
+/**
+ * Median rather than mean: performance samples are skewed by occasional outliers (GC pauses,
+ * background CI load).
+ */
+export const median = (values: readonly number[]): number => {
+    if (values.length === 0) {
+        throw new Error('Cannot compute median of an empty sample set');
+    }
+
+    const sorted = [...values].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+
+    if (sorted.length % 2 === 0) {
+        const lower = sorted[mid - 1];
+        const upper = sorted[mid];
+
+        // Guarded for noUncheckedIndexedAccess; both are defined for a non-empty even-length array.
+        return lower !== undefined && upper !== undefined ? (lower + upper) / 2 : 0;
+    }
+
+    return sorted[mid] ?? 0;
+};
+
+/**
+ * Reduce N samples of a scenario into a single set of per-metric medians, so that a retried test is
+ * judged on its median rather than on its worst attempt.
+ */
+export const aggregateSamples = (samples: readonly PerfMetrics[]): PerfMetrics => {
+    if (samples.length === 0) {
+        throw new Error('Cannot aggregate an empty set of samples');
+    }
+
+    const aggregated = {} as PerfMetrics;
+    for (const key of METRIC_KEYS) {
+        // Drop unavailable (null) samples; a metric is null only if it was unavailable in every run.
+        const values = samples
+            .map(sample => sample[key])
+            .filter((value): value is number => value !== null);
+        aggregated[key] = values.length > 0 ? Math.round(median(values)) : null;
+    }
+
+    return aggregated;
+};

--- a/packages/perf-e2e/src/compare.test.ts
+++ b/packages/perf-e2e/src/compare.test.ts
@@ -94,10 +94,12 @@ describe(compareScenario.name, () => {
         ).toEqual(['reactCommitCount']);
     });
 
-    it('does not report a scenario whose every limited metric is within its limit', () => {
+    it('does not report a scenario whose measured metrics all stay under their limits', () => {
         const comparison = compareScenario('wallet-discovery', metrics(), undefined, limits);
 
-        expect(comparison.overLimit).toBe(false);
+        // `unlimited` tells this apart from a scenario that was never measured against anything,
+        // which would report the very same `overLimit`.
+        expect(comparison).toMatchObject({ overLimit: false, unlimited: false });
     });
 
     it('marks a scenario nothing is limited for, so that it cannot look measured against', () => {

--- a/packages/perf-e2e/src/compare.test.ts
+++ b/packages/perf-e2e/src/compare.test.ts
@@ -1,0 +1,127 @@
+import { compareMetric, compareScenario } from './compare';
+import { type MetricDefinition, type PerfMetrics } from './types';
+
+const blockingTime: MetricDefinition = {
+    key: 'totalBlockingTimeMs',
+    label: 'Total Blocking Time',
+    unit: 'ms',
+};
+
+const metrics = (overrides: Partial<PerfMetrics> = {}): PerfMetrics => ({
+    totalBlockingTimeMs: 100,
+    longTaskCount: 1,
+    longestTaskMs: 60,
+    reactCommitCount: 20,
+    interactionDurationMs: 500,
+    ...overrides,
+});
+
+describe(compareMetric.name, () => {
+    it('passes a metric that stays within its limit', () => {
+        const comparison = compareMetric(blockingTime, undefined, 1000, 999);
+
+        expect(comparison).toMatchObject({ exceededLimit: false, limit: 1000 });
+    });
+
+    it('passes a metric that reaches its limit exactly', () => {
+        const comparison = compareMetric(blockingTime, undefined, 1000, 1000);
+
+        expect(comparison.exceededLimit).toBe(false);
+    });
+
+    it('fails a metric that goes over its limit', () => {
+        const comparison = compareMetric(blockingTime, undefined, 1000, 1001);
+
+        expect(comparison.exceededLimit).toBe(true);
+    });
+
+    // The whole point of the limits: what the app used to cost has no say in what it may cost.
+    it('reports a metric over its limit even when it is at the baseline', () => {
+        const comparison = compareMetric(blockingTime, 1500, 1000, 1500);
+
+        expect(comparison.exceededLimit).toBe(true);
+    });
+
+    it('passes a metric within its limit however far above the baseline it is', () => {
+        const comparison = compareMetric(blockingTime, 100, 1000, 900);
+
+        expect(comparison.exceededLimit).toBe(false);
+    });
+
+    it('reports the share of the limit that was used', () => {
+        const comparison = compareMetric(blockingTime, undefined, 1000, 250);
+
+        expect(comparison.ratioToLimit).toBe(0.25);
+    });
+
+    it('never reports a metric the scenario sets no limit for', () => {
+        const comparison = compareMetric(blockingTime, 100, undefined, 100_000);
+
+        expect(comparison).toMatchObject({ limit: null, ratioToLimit: null, exceededLimit: false });
+    });
+
+    it('never reports a metric that could not be measured', () => {
+        const comparison = compareMetric(blockingTime, 100, 1000, null);
+
+        expect(comparison).toMatchObject({
+            current: null,
+            ratioToLimit: null,
+            exceededLimit: false,
+        });
+    });
+
+    it('keeps the baseline for the report even though it does not gate', () => {
+        const comparison = compareMetric(blockingTime, 400, 1000, 800);
+
+        expect(comparison.baseline).toBe(400);
+    });
+});
+
+describe(compareScenario.name, () => {
+    const limits = { totalBlockingTimeMs: 1000, reactCommitCount: 300 };
+
+    it('reports the scenario over limit when any metric goes over its limit', () => {
+        const comparison = compareScenario(
+            'wallet-discovery',
+            metrics({ reactCommitCount: 301 }),
+            undefined,
+            limits,
+        );
+
+        expect(comparison.overLimit).toBe(true);
+        expect(
+            comparison.metrics.filter(metric => metric.exceededLimit).map(metric => metric.key),
+        ).toEqual(['reactCommitCount']);
+    });
+
+    it('does not report a scenario whose every limited metric is within its limit', () => {
+        const comparison = compareScenario('wallet-discovery', metrics(), undefined, limits);
+
+        expect(comparison.overLimit).toBe(false);
+    });
+
+    it('marks a scenario nothing is limited for, so that it cannot look measured against', () => {
+        const comparison = compareScenario('wallet-discovery', metrics(), undefined, undefined);
+
+        expect(comparison).toMatchObject({ overLimit: false, unlimited: true });
+    });
+
+    it('treats a null limit the same as an absent one', () => {
+        const comparison = compareScenario('wallet-discovery', metrics(), undefined, {
+            totalBlockingTimeMs: undefined,
+        });
+
+        expect(comparison.metrics[0]).toMatchObject({ limit: null, exceededLimit: false });
+    });
+
+    it('carries the recorded baseline into the comparison', () => {
+        const comparison = compareScenario(
+            'wallet-discovery',
+            metrics(),
+            { totalBlockingTimeMs: 50 },
+            limits,
+        );
+
+        expect(comparison.metrics[0]?.baseline).toBe(50);
+    });
+});

--- a/packages/perf-e2e/src/compare.ts
+++ b/packages/perf-e2e/src/compare.ts
@@ -1,0 +1,65 @@
+import { METRIC_DEFINITIONS } from './config';
+import {
+    type MetricComparison,
+    type MetricDefinition,
+    type PerfMetrics,
+    type ScenarioComparison,
+    type ScenarioLimits,
+} from './types';
+
+/**
+ * Holds a metric against its limit. The baseline travels with the result for the report to show and
+ * has no say in it: a metric is over budget when it costs more than the app is allowed to cost, not
+ * when it costs more than it used to.
+ */
+export const compareMetric = (
+    definition: MetricDefinition,
+    baseline: number | undefined,
+    limit: number | undefined,
+    current: number | null,
+): MetricComparison => {
+    const comparison = {
+        key: definition.key,
+        label: definition.label,
+        unit: definition.unit,
+        baseline: baseline ?? null,
+        current,
+        limit: limit ?? null,
+    };
+
+    // Not measured this run, or no limit for it. Reported either way, never enforced.
+    if (current === null || limit === undefined) {
+        return { ...comparison, ratioToLimit: null, exceededLimit: false };
+    }
+
+    return {
+        ...comparison,
+        ratioToLimit: limit > 0 ? current / limit : null,
+        exceededLimit: current > limit,
+    };
+};
+
+export const compareScenario = (
+    scenario: string,
+    current: PerfMetrics,
+    baseline: Partial<PerfMetrics> | undefined,
+    limits: ScenarioLimits | undefined,
+    definitions: readonly MetricDefinition[] = METRIC_DEFINITIONS,
+): ScenarioComparison => {
+    const metrics = definitions.map(definition =>
+        // A null recorded baseline or limit means "none" for that metric, same as absent.
+        compareMetric(
+            definition,
+            baseline?.[definition.key] ?? undefined,
+            limits?.[definition.key] ?? undefined,
+            current[definition.key],
+        ),
+    );
+
+    return {
+        scenario,
+        metrics,
+        overLimit: metrics.some(metric => metric.exceededLimit),
+        unlimited: metrics.every(metric => metric.limit === null),
+    };
+};

--- a/packages/perf-e2e/src/config.ts
+++ b/packages/perf-e2e/src/config.ts
@@ -2,8 +2,8 @@ import { type MetricDefinition, type PerfMetricKey } from './types';
 
 /**
  * The metric registry. Order defines the order used in reports. Thresholds are per scenario, in
- * limits.json — the same metric means very different things in an account switch and in a
- * multi-account discovery.
+ * the app's `budgets.ts` — the same metric means very different things in an account switch and in
+ * a multi-account discovery.
  */
 export const METRIC_DEFINITIONS: readonly MetricDefinition[] = [
     {

--- a/packages/perf-e2e/src/config.ts
+++ b/packages/perf-e2e/src/config.ts
@@ -1,0 +1,36 @@
+import { type MetricDefinition, type PerfMetricKey } from './types';
+
+/**
+ * The metric registry. Order defines the order used in reports. Thresholds are per scenario, in
+ * limits.json — the same metric means very different things in an account switch and in a
+ * multi-account discovery.
+ */
+export const METRIC_DEFINITIONS: readonly MetricDefinition[] = [
+    {
+        key: 'totalBlockingTimeMs',
+        label: 'Total Blocking Time',
+        unit: 'ms',
+    },
+    {
+        key: 'longTaskCount',
+        label: 'Long tasks (>50ms)',
+        unit: 'count',
+    },
+    {
+        key: 'longestTaskMs',
+        label: 'Longest task',
+        unit: 'ms',
+    },
+    {
+        key: 'reactCommitCount',
+        label: 'React commits',
+        unit: 'count',
+    },
+    {
+        key: 'interactionDurationMs',
+        label: 'Interaction duration',
+        unit: 'ms',
+    },
+];
+
+export const METRIC_KEYS: readonly PerfMetricKey[] = METRIC_DEFINITIONS.map(def => def.key);

--- a/packages/perf-e2e/src/index.ts
+++ b/packages/perf-e2e/src/index.ts
@@ -1,0 +1,7 @@
+export type * from './types';
+export * from './config';
+export * from './compare';
+export * from './aggregate';
+export * from './report';
+export * from './suggestLimits';
+export * from './instrumentation';

--- a/packages/perf-e2e/src/index.ts
+++ b/packages/perf-e2e/src/index.ts
@@ -1,6 +1,7 @@
 export type * from './types';
 export * from './config';
 export * from './compare';
+export * from './measurement';
 export * from './aggregate';
 export * from './report';
 export * from './suggestLimits';

--- a/packages/perf-e2e/src/instrumentation.test.ts
+++ b/packages/perf-e2e/src/instrumentation.test.ts
@@ -1,0 +1,220 @@
+import {
+    PERF_GLOBAL_KEY,
+    endPerfInteraction,
+    installPerfInstrumentation,
+    readPerfMetrics,
+    startPerfMeasurement,
+} from './instrumentation';
+
+type LongTaskEntry = { startTime: number; duration: number };
+
+/**
+ * The instrumentation runs inside the page and reaches for browser globals only, so a test provides
+ * them rather than a DOM: a window that is its own top frame, and an observer whose entries the test
+ * delivers when it wants the engine to have seen them.
+ */
+const setupBrowserGlobals = ({ observesLongTasks = true } = {}) => {
+    const window = { top: null as unknown, self: null as unknown } as Record<string, unknown>;
+    window.top = window;
+    window.self = window;
+    (globalThis as any).window = window;
+
+    let deliver: ((entries: LongTaskEntry[]) => void) | undefined;
+
+    (globalThis as any).PerformanceObserver = class {
+        constructor(callback: (list: { getEntries: () => LongTaskEntry[] }) => void) {
+            deliver = entries => callback({ getEntries: () => entries });
+        }
+
+        observe() {
+            if (!observesLongTasks) {
+                // What an engine without long-task support does.
+                throw new Error('longtask is not a supported entry type');
+            }
+        }
+    };
+
+    return {
+        window,
+        deliverLongTasks: (entries: LongTaskEntry[]) => deliver?.(entries),
+    };
+};
+
+const reactHook = () =>
+    (globalThis as any).window.__REACT_DEVTOOLS_GLOBAL_HOOK__ as {
+        onCommitFiberRoot: (...args: unknown[]) => unknown;
+        inject: (renderer: unknown) => number;
+        supportsFiber: boolean;
+    };
+
+const commit = (times: number) => {
+    for (let index = 0; index < times; index++) {
+        reactHook().onCommitFiberRoot();
+    }
+};
+
+describe(installPerfInstrumentation.name, () => {
+    afterEach(() => {
+        delete (globalThis as any).window;
+        delete (globalThis as any).PerformanceObserver;
+    });
+
+    it('exposes the controller under the key the page is read through', () => {
+        const { window } = setupBrowserGlobals();
+
+        installPerfInstrumentation();
+
+        expect(window[PERF_GLOBAL_KEY]).toBeDefined();
+    });
+
+    it('leaves a frame that is not the top one alone, so the Connect iframe is never touched', () => {
+        const { window } = setupBrowserGlobals();
+        window.top = { different: true };
+
+        installPerfInstrumentation();
+
+        expect(window[PERF_GLOBAL_KEY]).toBeUndefined();
+    });
+
+    it('installs once, so a second run cannot reset a measurement in progress', () => {
+        const { window } = setupBrowserGlobals();
+
+        installPerfInstrumentation();
+        const controller = window[PERF_GLOBAL_KEY];
+        installPerfInstrumentation();
+
+        expect(window[PERF_GLOBAL_KEY]).toBe(controller);
+    });
+
+    it('counts the React commits made while the measurement is running', () => {
+        setupBrowserGlobals();
+        installPerfInstrumentation();
+
+        commit(2); // before the window
+        startPerfMeasurement();
+        commit(3);
+        const metrics = readPerfMetrics();
+        commit(4); // after the window
+
+        expect(metrics.reactCommitCount).toBe(3);
+    });
+
+    it('keeps counting commits between the end of the interaction and the read', () => {
+        setupBrowserGlobals();
+        installPerfInstrumentation();
+
+        startPerfMeasurement();
+        commit(1);
+        endPerfInteraction();
+        commit(2); // trailing renders, which the settle wait exists to catch
+
+        expect(readPerfMetrics().reactCommitCount).toBe(3);
+    });
+
+    it('keeps a React DevTools hook that is already there working', () => {
+        const { window } = setupBrowserGlobals();
+        const existing = jest.fn();
+        window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = { onCommitFiberRoot: existing };
+
+        installPerfInstrumentation();
+        startPerfMeasurement();
+        commit(1);
+
+        expect(existing).toHaveBeenCalledTimes(1);
+        expect(readPerfMetrics().reactCommitCount).toBe(1);
+    });
+
+    it('accepts the renderer React injects when no hook was there', () => {
+        setupBrowserGlobals();
+        installPerfInstrumentation();
+
+        expect(reactHook().supportsFiber).toBe(true);
+        expect(reactHook().inject({ renderer: true })).toBe(1);
+    });
+});
+
+describe('long task metrics', () => {
+    afterEach(() => {
+        delete (globalThis as any).window;
+        delete (globalThis as any).PerformanceObserver;
+    });
+
+    it('reports the blocking time and the longest task of the measured window', () => {
+        const { deliverLongTasks } = setupBrowserGlobals();
+        installPerfInstrumentation();
+
+        startPerfMeasurement();
+        deliverLongTasks([
+            { startTime: performance.now(), duration: 80 },
+            { startTime: performance.now(), duration: 120 },
+        ]);
+        const metrics = readPerfMetrics();
+
+        // Only what each task spends over 50ms blocks.
+        expect(metrics).toMatchObject({
+            totalBlockingTimeMs: 100,
+            longTaskCount: 2,
+            longestTaskMs: 120,
+        });
+    });
+
+    it('ignores a long task that started before the measurement did', () => {
+        const { deliverLongTasks } = setupBrowserGlobals();
+        installPerfInstrumentation();
+
+        const beforeTheWindow = performance.now();
+        startPerfMeasurement();
+        // Delivery is asynchronous, so an entry from before the window can arrive inside it.
+        deliverLongTasks([{ startTime: beforeTheWindow - 1, duration: 500 }]);
+
+        expect(readPerfMetrics()).toMatchObject({
+            totalBlockingTimeMs: 0,
+            longTaskCount: 0,
+            longestTaskMs: 0,
+        });
+    });
+
+    it('reports null where long tasks cannot be observed, rather than a flattering zero', () => {
+        setupBrowserGlobals({ observesLongTasks: false });
+        installPerfInstrumentation();
+
+        startPerfMeasurement();
+        const metrics = readPerfMetrics();
+
+        expect(metrics).toMatchObject({
+            totalBlockingTimeMs: null,
+            longTaskCount: null,
+            longestTaskMs: null,
+        });
+        // What does not depend on the observer is still measured.
+        expect(metrics.reactCommitCount).toBe(0);
+        expect(metrics.interactionDurationMs).not.toBeNull();
+    });
+});
+
+describe('measurement window', () => {
+    afterEach(() => {
+        delete (globalThis as any).window;
+        delete (globalThis as any).PerformanceObserver;
+    });
+
+    it('stops the interaction clock where the interaction ended, not where the metrics are read', async () => {
+        setupBrowserGlobals();
+        installPerfInstrumentation();
+
+        startPerfMeasurement();
+        endPerfInteraction();
+        const settled = new Promise(resolve => setTimeout(resolve, 50));
+        await settled;
+
+        expect(readPerfMetrics().interactionDurationMs).toBeLessThan(50);
+    });
+
+    it('refuses to measure before the instrumentation is installed', () => {
+        setupBrowserGlobals();
+
+        expect(() => startPerfMeasurement()).toThrow('not installed');
+        expect(() => endPerfInteraction()).toThrow('not installed');
+        expect(() => readPerfMetrics()).toThrow('not installed');
+    });
+});

--- a/packages/perf-e2e/src/instrumentation.test.ts
+++ b/packages/perf-e2e/src/instrumentation.test.ts
@@ -4,6 +4,7 @@ import {
     installPerfInstrumentation,
     readPerfMetrics,
     startPerfMeasurement,
+    waitForPageIdle,
 } from './instrumentation';
 
 type LongTaskEntry = { startTime: number; duration: number };
@@ -216,5 +217,45 @@ describe('measurement window', () => {
         expect(() => startPerfMeasurement()).toThrow('not installed');
         expect(() => endPerfInteraction()).toThrow('not installed');
         expect(() => readPerfMetrics()).toThrow('not installed');
+    });
+});
+
+describe(waitForPageIdle.name, () => {
+    afterEach(() => {
+        delete (globalThis as any).window;
+        jest.useRealTimers();
+    });
+
+    it('waits only as long as the page needs, not for the whole timeout', async () => {
+        const requestIdleCallback = jest.fn((callback: () => void) => setTimeout(callback, 5));
+        (globalThis as any).window = { requestIdleCallback };
+
+        const startedAt = performance.now();
+        await waitForPageIdle(5_000);
+
+        expect(performance.now() - startedAt).toBeLessThan(5_000);
+        expect(requestIdleCallback).toHaveBeenCalledWith(expect.any(Function), { timeout: 5_000 });
+    });
+
+    it('falls back to waiting out the timeout where the page cannot report being idle', async () => {
+        // Timers rather than the wall clock: `setTimeout` and `performance.now()` are not driven by
+        // the same clock, so a real 20ms wait can measure as 19.5 and fail a test that is about
+        // waiting for the timeout, not about how long a machine took to do it.
+        jest.useFakeTimers();
+        (globalThis as any).window = {};
+
+        let settled = false;
+        const idle = waitForPageIdle(20).then(() => {
+            settled = true;
+        });
+
+        jest.advanceTimersByTime(19);
+        await Promise.resolve();
+        expect(settled).toBe(false);
+
+        jest.advanceTimersByTime(1);
+        await idle;
+
+        expect(settled).toBe(true);
     });
 });

--- a/packages/perf-e2e/src/instrumentation.ts
+++ b/packages/perf-e2e/src/instrumentation.ts
@@ -1,0 +1,172 @@
+import { type PerfMetrics } from './types';
+
+/**
+ * Browser-side instrumentation.
+ *
+ * The functions below are executed inside the page, not in Node. They are handed verbatim to
+ * Playwright (`page.addInitScript` / `page.evaluate`), which serializes their source, so they MUST
+ * be fully self-contained: no imports, no closures over module state, only browser globals.
+ *
+ * `installPerfInstrumentation` must run at document start (before react-dom loads) so the React
+ * commit hook is installed before React probes `__REACT_DEVTOOLS_GLOBAL_HOOK__`.
+ */
+
+export const PERF_GLOBAL_KEY = '__trezorPerf__';
+
+type PerfController = {
+    start: () => void;
+    stop: () => PerfMetrics;
+};
+
+/**
+ * Idempotent.
+ *
+ * - React commit count: hooks `__REACT_DEVTOOLS_GLOBAL_HOOK__.onCommitFiberRoot`, which works on
+ *   any build — no profiling build needed.
+ * - Long tasks / TBT: a `longtask` PerformanceObserver buffers every entry; the window is applied
+ *   at `stop()` time so entries delivered late (observer callbacks are async) are not lost.
+ */
+export function installPerfInstrumentation(): void {
+    // Only instrument the top-level app frame. This init script runs in every frame (including the
+    // cross-origin Trezor Connect iframe/popup that handles device communication), and we must never
+    // touch those — measure only the main app. Comparing window references is same-origin-safe.
+    if (typeof window === 'undefined' || window.top !== window.self) {
+        return;
+    }
+
+    const w = window as unknown as Record<string, unknown>;
+    if (w.__trezorPerf__) {
+        return;
+    }
+
+    const state = {
+        enabled: false,
+        startTime: 0,
+        endTime: 0,
+        commitCount: 0,
+        longTasks: [] as Array<{ start: number; duration: number }>,
+    };
+
+    const onCommit = (): void => {
+        if (!state.enabled) {
+            return;
+        }
+        state.commitCount += 1;
+    };
+
+    const hookKey = '__REACT_DEVTOOLS_GLOBAL_HOOK__';
+    const existingHook = w[hookKey] as
+        { onCommitFiberRoot?: (...args: unknown[]) => unknown } | undefined;
+
+    if (existingHook) {
+        // Real DevTools hook already present (e.g. extension): wrap the existing callback.
+        const previous = existingHook.onCommitFiberRoot;
+        existingHook.onCommitFiberRoot = (...args: unknown[]) => {
+            try {
+                onCommit();
+            } catch {
+                // ignore instrumentation errors, never break the app
+            }
+
+            return typeof previous === 'function' ? previous.apply(existingHook, args) : undefined;
+        };
+    } else {
+        let nextRendererId = 1;
+        const renderers = new Map<number, unknown>();
+        w[hookKey] = {
+            renderers,
+            supportsFiber: true,
+            inject(renderer: unknown): number {
+                const id = nextRendererId;
+                nextRendererId += 1;
+                renderers.set(id, renderer);
+
+                return id;
+            },
+            onCommitFiberRoot: () => {
+                try {
+                    onCommit();
+                } catch {
+                    // ignore
+                }
+            },
+            onPostCommitFiberRoot: () => {},
+            onCommitFiberUnmount: () => {},
+            onScheduleFiberRoot: () => {},
+            setStrictMode: () => {},
+            registerInternalModuleStart: () => {},
+            registerInternalModuleStop: () => {},
+        };
+    }
+
+    try {
+        const observer = new PerformanceObserver(list => {
+            for (const entry of list.getEntries()) {
+                state.longTasks.push({ start: entry.startTime, duration: entry.duration });
+            }
+        });
+        observer.observe({ type: 'longtask', buffered: true });
+    } catch {
+        // 'longtask' is not supported in every engine; TBT/long-task metrics stay 0 there.
+    }
+
+    const controller: PerfController = {
+        start() {
+            state.enabled = true;
+            state.startTime = performance.now();
+            state.endTime = 0;
+            state.commitCount = 0;
+            state.longTasks = [];
+        },
+        stop() {
+            state.enabled = false;
+            state.endTime = performance.now();
+
+            // Keep only long tasks that started within the measured window.
+            const windowTasks = state.longTasks.filter(task => task.start >= state.startTime);
+
+            let totalBlockingTime = 0;
+            let longestTask = 0;
+            for (const task of windowTasks) {
+                const blocking = task.duration - 50;
+                if (blocking > 0) {
+                    totalBlockingTime += blocking;
+                }
+                if (task.duration > longestTask) {
+                    longestTask = task.duration;
+                }
+            }
+
+            return {
+                totalBlockingTimeMs: Math.round(totalBlockingTime),
+                longTaskCount: windowTasks.length,
+                longestTaskMs: Math.round(longestTask),
+                reactCommitCount: state.commitCount,
+                interactionDurationMs: Math.round(state.endTime - state.startTime),
+            };
+        },
+    };
+
+    w.__trezorPerf__ = controller;
+}
+
+export function startPerfMeasurement(): void {
+    const controller = (window as unknown as { __trezorPerf__?: PerfController }).__trezorPerf__;
+    if (!controller) {
+        throw new Error(
+            'Performance instrumentation is not installed. Call installPerfInstrumentation before page load.',
+        );
+    }
+    controller.start();
+}
+
+export function readPerfMetrics(): PerfMetrics {
+    const controller = (window as unknown as { __trezorPerf__?: PerfController }).__trezorPerf__;
+    if (!controller) {
+        throw new Error(
+            'Performance instrumentation is not installed. Call installPerfInstrumentation before page load.',
+        );
+    }
+
+    return controller.stop();
+}

--- a/packages/perf-e2e/src/instrumentation.ts
+++ b/packages/perf-e2e/src/instrumentation.ts
@@ -15,6 +15,7 @@ export const PERF_GLOBAL_KEY = '__trezorPerf__';
 
 type PerfController = {
     start: () => void;
+    endInteraction: () => void;
     stop: () => PerfMetrics;
 };
 
@@ -45,6 +46,7 @@ export function installPerfInstrumentation(): void {
         endTime: 0,
         commitCount: 0,
         longTasks: [] as Array<{ start: number; duration: number }>,
+        observesLongTasks: false,
     };
 
     const onCommit = (): void => {
@@ -106,8 +108,10 @@ export function installPerfInstrumentation(): void {
             }
         });
         observer.observe({ type: 'longtask', buffered: true });
+        state.observesLongTasks = true;
     } catch {
-        // 'longtask' is not supported in every engine; TBT/long-task metrics stay 0 there.
+        // 'longtask' is not supported in every engine. The metrics that come from it are reported
+        // as null there — zeros would make such an environment look artificially fast.
     }
 
     const controller: PerfController = {
@@ -118,9 +122,17 @@ export function installPerfInstrumentation(): void {
             state.commitCount = 0;
             state.longTasks = [];
         },
+        endInteraction() {
+            // Stamped when the interaction itself finishes, so the settle wait that follows does not
+            // end up in its duration. Anything landing during that wait still counts towards the
+            // other metrics, which is what the wait is for.
+            if (state.endTime === 0) {
+                state.endTime = performance.now();
+            }
+        },
         stop() {
             state.enabled = false;
-            state.endTime = performance.now();
+            const endTime = state.endTime === 0 ? performance.now() : state.endTime;
 
             // Keep only long tasks that started within the measured window.
             const windowTasks = state.longTasks.filter(task => task.start >= state.startTime);
@@ -138,11 +150,11 @@ export function installPerfInstrumentation(): void {
             }
 
             return {
-                totalBlockingTimeMs: Math.round(totalBlockingTime),
-                longTaskCount: windowTasks.length,
-                longestTaskMs: Math.round(longestTask),
+                totalBlockingTimeMs: state.observesLongTasks ? Math.round(totalBlockingTime) : null,
+                longTaskCount: state.observesLongTasks ? windowTasks.length : null,
+                longestTaskMs: state.observesLongTasks ? Math.round(longestTask) : null,
                 reactCommitCount: state.commitCount,
-                interactionDurationMs: Math.round(state.endTime - state.startTime),
+                interactionDurationMs: Math.round(endTime - state.startTime),
             };
         },
     };
@@ -158,6 +170,20 @@ export function startPerfMeasurement(): void {
         );
     }
     controller.start();
+}
+
+/**
+ * Ends the measured interaction without reading the metrics yet, so that whatever the page still
+ * does afterwards is measured but not counted as interaction time.
+ */
+export function endPerfInteraction(): void {
+    const controller = (window as unknown as { __trezorPerf__?: PerfController }).__trezorPerf__;
+    if (!controller) {
+        throw new Error(
+            'Performance instrumentation is not installed. Call installPerfInstrumentation before page load.',
+        );
+    }
+    controller.endInteraction();
 }
 
 export function readPerfMetrics(): PerfMetrics {

--- a/packages/perf-e2e/src/instrumentation.ts
+++ b/packages/perf-e2e/src/instrumentation.ts
@@ -173,6 +173,36 @@ export function startPerfMeasurement(): void {
 }
 
 /**
+ * Resolves as soon as the page has nothing left to do, and after `timeoutMs` at the latest.
+ *
+ * Long-task entries and React commits arrive after the interaction resolves, so the metrics must not
+ * be read straight away. Waiting for idle takes as long as the page actually needs instead of a
+ * fixed sleep, and the timeout is the ceiling — `requestIdleCallback` guarantees the callback runs
+ * once it expires, however busy the page still is.
+ */
+export function waitForPageIdle(timeoutMs: number): Promise<void> {
+    return new Promise<void>(resolve => {
+        const requestIdle = (
+            window as unknown as {
+                requestIdleCallback?: (
+                    callback: () => void,
+                    options?: { timeout: number },
+                ) => number;
+            }
+        ).requestIdleCallback;
+
+        if (typeof requestIdle !== 'function') {
+            // Not in every engine; there the ceiling is the whole wait.
+            setTimeout(resolve, timeoutMs);
+
+            return;
+        }
+
+        requestIdle(() => resolve(), { timeout: timeoutMs });
+    });
+}
+
+/**
  * Ends the measured interaction without reading the metrics yet, so that whatever the page still
  * does afterwards is measured but not counted as interaction time.
  */

--- a/packages/perf-e2e/src/measurement.test.ts
+++ b/packages/perf-e2e/src/measurement.test.ts
@@ -1,0 +1,34 @@
+import { measurementKey, resolveBudget } from './measurement';
+
+describe(measurementKey.name, () => {
+    it('names a measurement by the scenario and the model it ran on', () => {
+        expect(measurementKey('wallet-discovery', 'T3W1')).toBe('wallet-discovery [T3W1]');
+    });
+
+    it('is the scenario alone where there is no model to distinguish', () => {
+        expect(measurementKey('wallet-discovery', '')).toBe('wallet-discovery');
+    });
+});
+
+describe(resolveBudget.name, () => {
+    const budgets = {
+        'wallet-discovery': { totalBlockingTimeMs: 2000 },
+        'wallet-discovery [T3T1]': { totalBlockingTimeMs: 3000 },
+    };
+
+    it('prefers the budget of the model the scenario was measured on', () => {
+        expect(resolveBudget(budgets, 'wallet-discovery', 'T3T1')).toEqual({
+            totalBlockingTimeMs: 3000,
+        });
+    });
+
+    it('falls back to the scenario-wide budget for a model without one of its own', () => {
+        expect(resolveBudget(budgets, 'wallet-discovery', 'T3W1')).toEqual({
+            totalBlockingTimeMs: 2000,
+        });
+    });
+
+    it('is undefined for a scenario with no budget at all', () => {
+        expect(resolveBudget(budgets, 'account-switch', 'T3W1')).toBeUndefined();
+    });
+});

--- a/packages/perf-e2e/src/measurement.ts
+++ b/packages/perf-e2e/src/measurement.ts
@@ -1,0 +1,19 @@
+/**
+ * A scenario is measured once per device model, and the models are not equally fast: what is a
+ * comfortable budget for one can be out of reach for the other. A budget is therefore looked up per
+ * measurement — scenario *and* model — with the scenario-wide entry as the default.
+ */
+
+/** Names one measured run: a scenario on one device model. Used for both display and budget keys. */
+export const measurementKey = (scenario: string, model: string): string =>
+    model ? `${scenario} [${model}]` : scenario;
+
+/**
+ * The budget recorded for this model, or the scenario-wide one where the model has none of its own —
+ * which is what a scenario has before its first per-model numbers are recorded.
+ */
+export const resolveBudget = <T>(
+    budgets: Record<string, T>,
+    scenario: string,
+    model: string,
+): T | undefined => budgets[measurementKey(scenario, model)] ?? budgets[scenario];

--- a/packages/perf-e2e/src/report.test.ts
+++ b/packages/perf-e2e/src/report.test.ts
@@ -1,5 +1,5 @@
 import { compareScenario } from './compare';
-import { buildJsonReport, formatHumanReport } from './report';
+import { buildJsonReport, formatHumanReport, formatMetricValue } from './report';
 import { type PerfMetrics } from './types';
 
 const metrics = (overrides: Partial<PerfMetrics> = {}): PerfMetrics => ({
@@ -9,6 +9,21 @@ const metrics = (overrides: Partial<PerfMetrics> = {}): PerfMetrics => ({
     reactCommitCount: 0,
     interactionDurationMs: 0,
     ...overrides,
+});
+
+describe(formatMetricValue.name, () => {
+    it('writes a duration with its unit', () => {
+        expect(formatMetricValue(453.26, 'ms')).toBe('453.3 ms');
+    });
+
+    // `18 count` would read as neither English nor a measurement.
+    it('writes a count as the bare number', () => {
+        expect(formatMetricValue(18, 'count')).toBe('18');
+    });
+
+    it('writes an unmeasurable metric as n/a rather than as a zero', () => {
+        expect(formatMetricValue(null, 'ms')).toBe('n/a');
+    });
 });
 
 describe('formatHumanReport', () => {

--- a/packages/perf-e2e/src/report.test.ts
+++ b/packages/perf-e2e/src/report.test.ts
@@ -1,0 +1,95 @@
+import { compareScenario } from './compare';
+import { buildJsonReport, formatHumanReport } from './report';
+import { type PerfMetrics } from './types';
+
+const metrics = (overrides: Partial<PerfMetrics> = {}): PerfMetrics => ({
+    totalBlockingTimeMs: 0,
+    longTaskCount: 0,
+    longestTaskMs: 0,
+    reactCommitCount: 0,
+    interactionDurationMs: 0,
+    ...overrides,
+});
+
+describe('formatHumanReport', () => {
+    it('renders a report listing only the metrics that went over their limit', () => {
+        const comparison = compareScenario(
+            'product-filter',
+            metrics({
+                totalBlockingTimeMs: 640,
+                reactCommitCount: 147,
+                interactionDurationMs: 900,
+            }),
+            undefined,
+            { totalBlockingTimeMs: 500, reactCommitCount: 100, interactionDurationMs: 5000 },
+        );
+
+        const report = formatHumanReport(comparison);
+
+        expect(report).toContain('Performance OVER LIMIT');
+        expect(report).toContain('does not fail the run');
+        expect(report).toContain('product-filter');
+        expect(report).toContain('Total Blocking Time');
+        expect(report).toContain('React commits');
+        // A metric inside its limit is not part of the failure report.
+        expect(report).not.toContain('Interaction duration');
+    });
+
+    it('shows the baseline of an over-limit metric as not enforced', () => {
+        const comparison = compareScenario(
+            'product-filter',
+            metrics({ totalBlockingTimeMs: 640 }),
+            { totalBlockingTimeMs: 600 },
+            { totalBlockingTimeMs: 500 },
+        );
+
+        expect(formatHumanReport(comparison)).toContain('not enforced');
+    });
+
+    it('summarises a run that stayed within its limits', () => {
+        const comparison = compareScenario(
+            'product-filter',
+            metrics({ totalBlockingTimeMs: 100 }),
+            { totalBlockingTimeMs: 120 },
+            { totalBlockingTimeMs: 500 },
+        );
+
+        expect(formatHumanReport(comparison)).toContain('Performance within limits');
+    });
+
+    // Otherwise a scenario nobody set a budget for would read as if it had passed one.
+    it('says so when the scenario has no limits at all', () => {
+        const comparison = compareScenario(
+            'product-filter',
+            metrics({ totalBlockingTimeMs: 100 }),
+            undefined,
+            undefined,
+        );
+
+        expect(formatHumanReport(comparison)).toContain('no limits set for this scenario');
+    });
+});
+
+describe('buildJsonReport', () => {
+    it('captures the metrics, their limits and the baseline they are read against', () => {
+        const comparison = compareScenario(
+            'product-filter',
+            metrics({ totalBlockingTimeMs: 640 }),
+            { totalBlockingTimeMs: 120 },
+            { totalBlockingTimeMs: 500 },
+        );
+
+        const report = buildJsonReport(comparison);
+
+        expect(report.scenario).toBe('product-filter');
+        expect(report.overLimit).toBe(true);
+        const blockingTime = report.metrics.find(m => m.key === 'totalBlockingTimeMs');
+        expect(blockingTime).toMatchObject({
+            baseline: 120,
+            current: 640,
+            limit: 500,
+            exceededLimit: true,
+        });
+        expect(blockingTime?.ratioToLimit).toBeCloseTo(640 / 500);
+    });
+});

--- a/packages/perf-e2e/src/report.ts
+++ b/packages/perf-e2e/src/report.ts
@@ -1,20 +1,36 @@
-import { type MetricComparison, type ScenarioComparison } from './types';
+import {
+    type MetricComparison,
+    type MetricUnit,
+    type PerfMetricKey,
+    type ScenarioComparison,
+} from './types';
 
-const formatValue = (value: number | null, unit: string): string => {
+/**
+ * What each unit is written as after the number. A count is just the number — `20 count` reads as
+ * neither English nor a measurement. Keyed by unit so a new one cannot be left unhandled.
+ */
+const UNIT_SUFFIX: Record<MetricUnit, string> = {
+    ms: ' ms',
+    count: '',
+};
+
+/** `null` is a metric this environment could not measure, which is not the same as a zero. */
+export const formatMetricValue = (value: number | null, unit: MetricUnit): string => {
     if (value === null) {
         return 'n/a';
     }
+
     const rounded = Math.round(value * 10) / 10;
 
-    return unit === 'ms' ? `${rounded} ms` : `${rounded}`;
+    return `${rounded}${UNIT_SUFFIX[unit]}`;
 };
 
 const formatMetricBlock = (metric: MetricComparison): string =>
     [
         metric.label,
-        `limit   : ${formatValue(metric.limit, metric.unit)}`,
-        `current : ${formatValue(metric.current, metric.unit)}`,
-        `baseline: ${formatValue(metric.baseline, metric.unit)} (not enforced)`,
+        `limit   : ${formatMetricValue(metric.limit, metric.unit)}`,
+        `current : ${formatMetricValue(metric.current, metric.unit)}`,
+        `baseline: ${formatMetricValue(metric.baseline, metric.unit)} (not enforced)`,
     ].join('\n');
 
 /**
@@ -25,9 +41,9 @@ export const formatHumanReport = (comparison: ScenarioComparison): string => {
         const summary = comparison.metrics
             .map(
                 metric =>
-                    `  ${metric.label}: ${formatValue(metric.current, metric.unit)}` +
+                    `  ${metric.label}: ${formatMetricValue(metric.current, metric.unit)}` +
                     (metric.limit !== null
-                        ? ` (limit ${formatValue(metric.limit, metric.unit)})`
+                        ? ` (limit ${formatMetricValue(metric.limit, metric.unit)})`
                         : ' (no limit)'),
             )
             .join('\n');
@@ -52,9 +68,9 @@ export type PerfJsonReport = {
     overLimit: boolean;
     unlimited: boolean;
     metrics: Array<{
-        key: string;
+        key: PerfMetricKey;
         label: string;
-        unit: string;
+        unit: MetricUnit;
         baseline: number | null;
         current: number | null;
         limit: number | null;

--- a/packages/perf-e2e/src/report.ts
+++ b/packages/perf-e2e/src/report.ts
@@ -1,0 +1,85 @@
+import { type MetricComparison, type ScenarioComparison } from './types';
+
+const formatValue = (value: number | null, unit: string): string => {
+    if (value === null) {
+        return 'n/a';
+    }
+    const rounded = Math.round(value * 10) / 10;
+
+    return unit === 'ms' ? `${rounded} ms` : `${rounded}`;
+};
+
+const formatMetricBlock = (metric: MetricComparison): string =>
+    [
+        metric.label,
+        `limit   : ${formatValue(metric.limit, metric.unit)}`,
+        `current : ${formatValue(metric.current, metric.unit)}`,
+        `baseline: ${formatValue(metric.baseline, metric.unit)} (not enforced)`,
+    ].join('\n');
+
+/**
+ * Also returns a compact summary when nothing failed, so the numbers stay visible in passing runs.
+ */
+export const formatHumanReport = (comparison: ScenarioComparison): string => {
+    if (!comparison.overLimit) {
+        const summary = comparison.metrics
+            .map(
+                metric =>
+                    `  ${metric.label}: ${formatValue(metric.current, metric.unit)}` +
+                    (metric.limit !== null
+                        ? ` (limit ${formatValue(metric.limit, metric.unit)})`
+                        : ' (no limit)'),
+            )
+            .join('\n');
+
+        const heading = comparison.unlimited
+            ? 'Performance measured, no limits set for this scenario'
+            : 'Performance within limits';
+
+        return `${heading}\n\nScenario:\n${comparison.scenario}\n\nMetrics:\n${summary}`;
+    }
+
+    const body = comparison.metrics
+        .filter(metric => metric.exceededLimit)
+        .map(formatMetricBlock)
+        .join('\n\n');
+
+    return `Performance OVER LIMIT (reported, does not fail the run)\n\nScenario:\n${comparison.scenario}\n\nMetrics:\n\n${body}`;
+};
+
+export type PerfJsonReport = {
+    scenario: string;
+    overLimit: boolean;
+    unlimited: boolean;
+    metrics: Array<{
+        key: string;
+        label: string;
+        unit: string;
+        baseline: number | null;
+        current: number | null;
+        limit: number | null;
+        ratioToLimit: number | null;
+        exceededLimit: boolean;
+    }>;
+};
+
+/**
+ * The machine-readable artifact attached to the Playwright output. It contains everything needed to
+ * understand a verdict: the collected metrics, the limits they were held to, and the baseline they
+ * are read against.
+ */
+export const buildJsonReport = (comparison: ScenarioComparison): PerfJsonReport => ({
+    scenario: comparison.scenario,
+    overLimit: comparison.overLimit,
+    unlimited: comparison.unlimited,
+    metrics: comparison.metrics.map(metric => ({
+        key: metric.key,
+        label: metric.label,
+        unit: metric.unit,
+        baseline: metric.baseline,
+        current: metric.current,
+        limit: metric.limit,
+        ratioToLimit: metric.ratioToLimit,
+        exceededLimit: metric.exceededLimit,
+    })),
+});

--- a/packages/perf-e2e/src/suggestLimits.test.ts
+++ b/packages/perf-e2e/src/suggestLimits.test.ts
@@ -1,0 +1,65 @@
+import { compareScenario } from './compare';
+import { suggestLimits } from './suggestLimits';
+import { type PerfMetrics } from './types';
+
+const metrics = (overrides: Partial<PerfMetrics> = {}): PerfMetrics => ({
+    totalBlockingTimeMs: 0,
+    longTaskCount: 0,
+    longestTaskMs: 0,
+    reactCommitCount: 0,
+    interactionDurationMs: 0,
+    ...overrides,
+});
+
+const comparison = (current: Partial<PerfMetrics>, limits: Partial<Record<string, number>>) =>
+    compareScenario('wallet-discovery', metrics(current), undefined, limits);
+
+describe(suggestLimits.name, () => {
+    it('suggests a limit above the measured value, rounded to a number a human would pick', () => {
+        const suggested = suggestLimits([
+            comparison({ totalBlockingTimeMs: 1296 }, { totalBlockingTimeMs: 1000 }),
+        ]);
+
+        expect(suggested).toEqual({ 'wallet-discovery': { totalBlockingTimeMs: 2000 } });
+    });
+
+    // Otherwise a fast run would quietly ratchet the limit down, turning a lucky runner into the
+    // budget everyone else has to meet.
+    it('never suggests lowering a limit', () => {
+        const suggested = suggestLimits([
+            comparison({ totalBlockingTimeMs: 10 }, { totalBlockingTimeMs: 1000 }),
+        ]);
+
+        expect(suggested['wallet-discovery']?.totalBlockingTimeMs).toBe(1000);
+    });
+
+    // Otherwise every paste of the block would inflate budgets the run never came close to.
+    it('leaves a limit the run stayed inside untouched', () => {
+        const suggested = suggestLimits([
+            comparison({ totalBlockingTimeMs: 900 }, { totalBlockingTimeMs: 1000 }),
+        ]);
+
+        expect(suggested['wallet-discovery']?.totalBlockingTimeMs).toBe(1000);
+    });
+
+    it('leaves out metrics that have no limit', () => {
+        const suggested = suggestLimits([
+            comparison(
+                { totalBlockingTimeMs: 100, longTaskCount: 9 },
+                { totalBlockingTimeMs: 500 },
+            ),
+        ]);
+
+        expect(suggested['wallet-discovery']).toEqual({ totalBlockingTimeMs: 500 });
+    });
+
+    it('leaves out a scenario that has no limits at all', () => {
+        expect(suggestLimits([comparison({ totalBlockingTimeMs: 100 }, {})])).toEqual({});
+    });
+
+    it('rounds a small count up to a usable step', () => {
+        const suggested = suggestLimits([comparison({ longTaskCount: 3 }, { longTaskCount: 1 })]);
+
+        expect(suggested['wallet-discovery']?.longTaskCount).toBe(5);
+    });
+});

--- a/packages/perf-e2e/src/suggestLimits.test.ts
+++ b/packages/perf-e2e/src/suggestLimits.test.ts
@@ -62,4 +62,40 @@ describe(suggestLimits.name, () => {
 
         expect(suggested['wallet-discovery']?.longTaskCount).toBe(5);
     });
+
+    // The block the report prints replaces the scenario as a whole, so a metric left out of it
+    // would delete that budget from `budgets.ts` on the next paste.
+    it('keeps the limit of a metric this run could not measure', () => {
+        const suggested = suggestLimits([
+            comparison(
+                { totalBlockingTimeMs: null, reactCommitCount: 10 },
+                { totalBlockingTimeMs: 500, reactCommitCount: 100 },
+            ),
+        ]);
+
+        expect(suggested['wallet-discovery']).toEqual({
+            totalBlockingTimeMs: 500,
+            reactCommitCount: 100,
+        });
+    });
+
+    // One scenario is measured once per device model, so the pasted limit has to fit the slowest of
+    // them rather than whichever was reported last.
+    it('keeps the highest suggestion when a scenario was measured more than once', () => {
+        const suggested = suggestLimits([
+            comparison({ totalBlockingTimeMs: 1296 }, { totalBlockingTimeMs: 1000 }),
+            comparison({ totalBlockingTimeMs: 100 }, { totalBlockingTimeMs: 1000 }),
+        ]);
+
+        expect(suggested['wallet-discovery']?.totalBlockingTimeMs).toBe(2000);
+    });
+
+    it('keeps the highest suggestion whichever order the models are reported in', () => {
+        const suggested = suggestLimits([
+            comparison({ totalBlockingTimeMs: 100 }, { totalBlockingTimeMs: 1000 }),
+            comparison({ totalBlockingTimeMs: 1296 }, { totalBlockingTimeMs: 1000 }),
+        ]);
+
+        expect(suggested['wallet-discovery']?.totalBlockingTimeMs).toBe(2000);
+    });
 });

--- a/packages/perf-e2e/src/suggestLimits.ts
+++ b/packages/perf-e2e/src/suggestLimits.ts
@@ -1,0 +1,51 @@
+import { type Limits, type ScenarioComparison, type ScenarioLimits } from './types';
+
+/**
+ * Headroom over the measured value. CI runners are noisy, so a limit set exactly at what a run
+ * happened to cost would fail on the next slightly slower runner.
+ */
+export const SUGGESTED_LIMIT_HEADROOM = 1.5;
+
+/**
+ * Round up to two significant figures, so a pasted limit reads as a decision rather than as a
+ * measurement — 4.5 → 5, 94.5 → 95, 1944 → 2000 — while staying close to the value it came from.
+ * Rounding to one figure would add up to another 50% on top of the headroom.
+ */
+const roundUpToNiceNumber = (value: number): number => {
+    if (value <= 0) {
+        return 0;
+    }
+    const step = value <= 10 ? 1 : 10 ** (Math.floor(Math.log10(value)) - 1);
+
+    return Math.ceil(value / step) * step;
+};
+
+/**
+ * The limits this run would need, for the metrics that have one. Printed so raising a limit is a
+ * paste rather than arithmetic — and still an edit to a committed number, reviewed as the decision it
+ * is.
+ */
+export const suggestLimits = (comparisons: readonly ScenarioComparison[]): Limits =>
+    comparisons.reduce<Limits>((limits, comparison) => {
+        const scenarioLimits = comparison.metrics.reduce<ScenarioLimits>((metrics, metric) => {
+            if (metric.limit === null || metric.current === null) {
+                return metrics;
+            }
+
+            // Only a metric that went over gets a new number. Fitting a limit around a run that was
+            // already inside it would inflate every budget on every paste.
+            return {
+                ...metrics,
+                [metric.key]: metric.exceededLimit
+                    ? Math.max(
+                          metric.limit,
+                          roundUpToNiceNumber(metric.current * SUGGESTED_LIMIT_HEADROOM),
+                      )
+                    : metric.limit,
+            };
+        }, {});
+
+        return Object.keys(scenarioLimits).length > 0
+            ? { ...limits, [comparison.scenario]: scenarioLimits }
+            : limits;
+    }, {});

--- a/packages/perf-e2e/src/suggestLimits.ts
+++ b/packages/perf-e2e/src/suggestLimits.ts
@@ -25,27 +25,55 @@ const roundUpToNiceNumber = (value: number): number => {
  * paste rather than arithmetic — and still an edit to a committed number, reviewed as the decision it
  * is.
  */
+/**
+ * The higher of two suggestions per metric. A scenario is measured once per device model, so the
+ * pasted limit has to be the one that fits every model, not the one that happened to come last.
+ */
+const keepHigherLimits = (current: ScenarioLimits, incoming: ScenarioLimits): ScenarioLimits =>
+    Object.entries(incoming).reduce<ScenarioLimits>(
+        (merged, [key, limit]) => {
+            const existing = merged[key as keyof ScenarioLimits];
+
+            return {
+                ...merged,
+                [key]: existing === undefined ? limit : Math.max(existing, limit),
+            };
+        },
+        { ...current },
+    );
+
 export const suggestLimits = (comparisons: readonly ScenarioComparison[]): Limits =>
     comparisons.reduce<Limits>((limits, comparison) => {
         const scenarioLimits = comparison.metrics.reduce<ScenarioLimits>((metrics, metric) => {
-            if (metric.limit === null || metric.current === null) {
+            if (metric.limit === null) {
                 return metrics;
             }
 
-            // Only a metric that went over gets a new number. Fitting a limit around a run that was
-            // already inside it would inflate every budget on every paste.
-            return {
-                ...metrics,
-                [metric.key]: metric.exceededLimit
+            // A metric that could not be measured keeps the limit it already has. Leaving the key
+            // out would delete that budget from the block the report tells you to paste.
+            // Otherwise only a metric that went over gets a new number: fitting a limit around a run
+            // that was already inside it would inflate every budget on every paste.
+            const suggested =
+                metric.current !== null && metric.exceededLimit
                     ? Math.max(
                           metric.limit,
                           roundUpToNiceNumber(metric.current * SUGGESTED_LIMIT_HEADROOM),
                       )
-                    : metric.limit,
-            };
+                    : metric.limit;
+
+            return { ...metrics, [metric.key]: suggested };
         }, {});
 
-        return Object.keys(scenarioLimits).length > 0
-            ? { ...limits, [comparison.scenario]: scenarioLimits }
-            : limits;
+        if (Object.keys(scenarioLimits).length === 0) {
+            return limits;
+        }
+
+        const alreadySuggested = limits[comparison.scenario];
+
+        return {
+            ...limits,
+            [comparison.scenario]: alreadySuggested
+                ? keepHigherLimits(alreadySuggested, scenarioLimits)
+                : scenarioLimits,
+        };
     }, {});

--- a/packages/perf-e2e/src/suggestLimits.ts
+++ b/packages/perf-e2e/src/suggestLimits.ts
@@ -21,13 +21,8 @@ const roundUpToNiceNumber = (value: number): number => {
 };
 
 /**
- * The limits this run would need, for the metrics that have one. Printed so raising a limit is a
- * paste rather than arithmetic — and still an edit to a committed number, reviewed as the decision it
- * is.
- */
-/**
- * The higher of two suggestions per metric. A scenario is measured once per device model, so the
- * pasted limit has to be the one that fits every model, not the one that happened to come last.
+ * The higher of two suggestions per metric, for a key measured more than once in a run — the pasted
+ * limit has to be the one that fits every measurement of it, not the one that happened to come last.
  */
 const keepHigherLimits = (current: ScenarioLimits, incoming: ScenarioLimits): ScenarioLimits =>
     Object.entries(incoming).reduce<ScenarioLimits>(
@@ -42,6 +37,11 @@ const keepHigherLimits = (current: ScenarioLimits, incoming: ScenarioLimits): Sc
         { ...current },
     );
 
+/**
+ * The limits this run would need, for the metrics that have one. Printed so raising a limit is a
+ * paste rather than arithmetic — and still an edit to a committed number, reviewed as the decision it
+ * is.
+ */
 export const suggestLimits = (comparisons: readonly ScenarioComparison[]): Limits =>
     comparisons.reduce<Limits>((limits, comparison) => {
         const scenarioLimits = comparison.metrics.reduce<ScenarioLimits>((metrics, metric) => {

--- a/packages/perf-e2e/src/types.ts
+++ b/packages/perf-e2e/src/types.ts
@@ -1,4 +1,4 @@
-// Keep the keys stable: they are persisted in baselines.json and limits.json.
+// Keep the keys stable: they are persisted in the baselines and limits of `budgets.ts`.
 export type PerfMetricKey =
     | 'totalBlockingTimeMs'
     | 'longTaskCount'
@@ -22,8 +22,8 @@ export type MetricDefinition = {
 export type Baselines = Record<string, Partial<PerfMetrics>>;
 
 /**
- * The highest value each metric may reach before the run fails, keyed by metric. A metric without a
- * limit is reported but never enforced.
+ * The highest value each metric may reach before the run reports it as over limit, keyed by metric.
+ * Going over is reported, never failed; a metric without a limit is not even reported as over.
  */
 export type ScenarioLimits = Partial<Record<PerfMetricKey, number>>;
 

--- a/packages/perf-e2e/src/types.ts
+++ b/packages/perf-e2e/src/types.ts
@@ -1,0 +1,57 @@
+// Keep the keys stable: they are persisted in baselines.json and limits.json.
+export type PerfMetricKey =
+    | 'totalBlockingTimeMs'
+    | 'longTaskCount'
+    | 'longestTaskMs'
+    | 'reactCommitCount'
+    | 'interactionDurationMs';
+
+// `null` means the metric could not be measured in this environment. Such a metric is reported,
+// never enforced.
+export type PerfMetrics = Record<PerfMetricKey, number | null>;
+
+export type MetricUnit = 'ms' | 'count';
+
+export type MetricDefinition = {
+    key: PerfMetricKey;
+    label: string;
+    unit: MetricUnit;
+};
+
+/** What each scenario costs today, keyed by scenario name. Reported for reference, never enforced. */
+export type Baselines = Record<string, Partial<PerfMetrics>>;
+
+/**
+ * The highest value each metric may reach before the run fails, keyed by metric. A metric without a
+ * limit is reported but never enforced.
+ */
+export type ScenarioLimits = Partial<Record<PerfMetricKey, number>>;
+
+/** Limits keyed by scenario name. */
+export type Limits = Record<string, ScenarioLimits>;
+
+export type MetricComparison = {
+    key: PerfMetricKey;
+    label: string;
+    unit: MetricUnit;
+    /** Reference only, never enforced. */
+    baseline: number | null;
+    current: number | null;
+    /** null when the scenario sets none, which means this metric cannot fail. */
+    limit: number | null;
+    ratioToLimit: number | null;
+    exceededLimit: boolean;
+};
+
+export type ScenarioComparison = {
+    scenario: string;
+    metrics: MetricComparison[];
+    /**
+     * A metric went over its limit. Reported loudly, but never turned into a test failure: a
+     * performance number is not a reason to block a merge on its own, and a red report that everyone
+     * can see is worth more than a red build everyone learns to re-run.
+     */
+    overLimit: boolean;
+    /** No metric of this scenario has a limit, so there is nothing to report against. */
+    unlimited: boolean;
+};

--- a/packages/perf-e2e/tsconfig.json
+++ b/packages/perf-e2e/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [{ "path": "../eslint" }]
+}

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -57,6 +57,7 @@
         "@trezor/e2e-utils": "workspace:*",
         "@trezor/eslint": "workspace:*",
         "@trezor/network-solana": "workspace:*",
+        "@trezor/perf-e2e": "workspace:*",
         "@trezor/protobuf": "workspace:*",
         "@trezor/suite-data": "workspace:*",
         "@trezor/suite-desktop": "workspace:*",

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -72,6 +72,7 @@
         "@types/lodash": "^4.17.16",
         "@walletconnect/sign-client": "^2.23.10",
         "@walletconnect/types": "^2.23.10",
+        "chalk": "^6.0.0",
         "dotenv": "17.2.3",
         "fs-extra": "^11.3.1",
         "jest-diff": "^30.2.0",

--- a/suite/e2e/performance/budgets.ts
+++ b/suite/e2e/performance/budgets.ts
@@ -25,7 +25,7 @@ export const BASELINES: Baselines = {
     },
 };
 
-/** The highest value each metric may reach before the run fails. Raise deliberately. */
+/** The highest value each metric may reach before it is reported as over limit. Raise deliberately. */
 export const LIMITS: Limits = {
     'wallet-discovery': {
         totalBlockingTimeMs: 2000,

--- a/suite/e2e/performance/budgets.ts
+++ b/suite/e2e/performance/budgets.ts
@@ -1,5 +1,12 @@
 import { type Baselines, type Limits } from '@trezor/perf-e2e';
 
+/**
+ * Both maps below are keyed by measurement: `'wallet-discovery [T3W1]'` applies to that scenario on
+ * that device model only, while a bare `'wallet-discovery'` is the default for every model that has
+ * no entry of its own. The entries here predate the per-model split, so they are still scenario-wide;
+ * the end-of-run report prints per-model numbers to replace them with.
+ */
+
 /** What each scenario costs today, measured on CI. Reference only, never enforced. */
 export const BASELINES: Baselines = {
     'wallet-discovery': {

--- a/suite/e2e/performance/budgets.ts
+++ b/suite/e2e/performance/budgets.ts
@@ -1,0 +1,48 @@
+import { type Baselines, type Limits } from '@trezor/perf-e2e';
+
+/** What each scenario costs today, measured on CI. Reference only, never enforced. */
+export const BASELINES: Baselines = {
+    'wallet-discovery': {
+        totalBlockingTimeMs: 453,
+        longTaskCount: 18,
+        longestTaskMs: 185,
+        reactCommitCount: 270,
+        interactionDurationMs: 7506,
+    },
+    'account-switch': {
+        totalBlockingTimeMs: 217,
+        longTaskCount: 1,
+        longestTaskMs: 267,
+        reactCommitCount: 43,
+        interactionDurationMs: 915,
+    },
+    'multi-account-discovery': {
+        totalBlockingTimeMs: 4700,
+        longTaskCount: 62,
+        longestTaskMs: 543,
+        reactCommitCount: 237,
+        interactionDurationMs: 12125,
+    },
+};
+
+/** The highest value each metric may reach before the run fails. Raise deliberately. */
+export const LIMITS: Limits = {
+    'wallet-discovery': {
+        totalBlockingTimeMs: 2000,
+        longTaskCount: 45,
+        longestTaskMs: 400,
+        reactCommitCount: 410,
+    },
+    'account-switch': {
+        totalBlockingTimeMs: 700,
+        longTaskCount: 5,
+        longestTaskMs: 700,
+        reactCommitCount: 80,
+    },
+    'multi-account-discovery': {
+        totalBlockingTimeMs: 7000,
+        longTaskCount: 100,
+        longestTaskMs: 800,
+        reactCommitCount: 400,
+    },
+};

--- a/suite/e2e/performance/perfMeasure.ts
+++ b/suite/e2e/performance/perfMeasure.ts
@@ -4,6 +4,7 @@ import {
     PerfMetrics,
     buildJsonReport,
     compareScenario,
+    endPerfInteraction,
     formatHumanReport,
     readPerfMetrics,
     startPerfMeasurement,
@@ -45,6 +46,9 @@ export const measurePerformance = async (
 
     await page.evaluate(startPerfMeasurement);
     await interaction();
+    // The clock stops with the interaction; the settle wait below only lets trailing long tasks and
+    // renders arrive, and must not be reported as time the interaction took.
+    await page.evaluate(endPerfInteraction);
     await page.waitForTimeout(SETTLE_MS);
     const current = await page.evaluate(readPerfMetrics);
 

--- a/suite/e2e/performance/perfMeasure.ts
+++ b/suite/e2e/performance/perfMeasure.ts
@@ -6,14 +6,21 @@ import {
     compareScenario,
     endPerfInteraction,
     formatHumanReport,
+    measurementKey,
     readPerfMetrics,
+    resolveBudget,
     startPerfMeasurement,
+    waitForPageIdle,
 } from '@trezor/perf-e2e';
 
 import { BASELINES, LIMITS } from './budgets';
 
-// Lets the long-task observer flush and trailing renders settle before metrics are read.
-const SETTLE_MS = 400;
+/**
+ * The ceiling on the wait for the page to settle, not the wait itself: the metrics are read as soon
+ * as the page goes idle. It only has to be longer than the tail of an interaction that ends busy —
+ * a page still working after this long has trailing work no reading of ours would ever catch.
+ */
+const MAX_SETTLE_MS = 400;
 
 /**
  * Measures a single interaction and reports it against the limits of its scenario. Going over a
@@ -22,6 +29,10 @@ const SETTLE_MS = 400;
  * Instrumentation is installed globally at app load (see `electronSetup`), so no reload is needed
  * here. On a target where it was not installed, the interaction still runs and measurement is
  * skipped.
+ *
+ * The limits are those of this scenario on the device model the test is running on: the same
+ * interaction costs a different amount on each, so holding both models to one number would either
+ * let the slower one regress unnoticed or report the faster one as over budget.
  */
 export const measurePerformance = async (
     page: Page,
@@ -37,7 +48,7 @@ export const measurePerformance = async (
     if (!installed) {
         // eslint-disable-next-line no-console
         console.log(
-            `[perf] instrumentation not installed (non-web target?) — skipping "${scenario}"`,
+            `[perf] instrumentation not installed (web run, or PERF=0) — skipping "${scenario}"`,
         );
         await interaction();
 
@@ -46,13 +57,19 @@ export const measurePerformance = async (
 
     await page.evaluate(startPerfMeasurement);
     await interaction();
-    // The clock stops with the interaction; the settle wait below only lets trailing long tasks and
+    // The clock stops with the interaction; the settling below only lets trailing long tasks and
     // renders arrive, and must not be reported as time the interaction took.
     await page.evaluate(endPerfInteraction);
-    await page.waitForTimeout(SETTLE_MS);
+    await page.evaluate(waitForPageIdle, MAX_SETTLE_MS);
     const current = await page.evaluate(readPerfMetrics);
 
-    const comparison = compareScenario(scenario, current, BASELINES[scenario], LIMITS[scenario]);
+    const model = testInfo.project.name;
+    const comparison = compareScenario(
+        scenario,
+        current,
+        resolveBudget(BASELINES, scenario, model),
+        resolveBudget(LIMITS, scenario, model),
+    );
     const humanReport = formatHumanReport(comparison);
 
     await testInfo.attach(`perf-report-${scenario}.json`, {
@@ -61,14 +78,14 @@ export const measurePerformance = async (
     });
 
     // eslint-disable-next-line no-console
-    console.log(`\n${humanReport}\n`);
+    console.log(`\n[perf] ${measurementKey(scenario, model)}\n${humanReport}\n`);
 
     // Deliberately never thrown: going over a limit is reported, not turned into a test failure. A
     // performance number is not on its own a reason to block a merge, and the end-of-run report is
     // where a breach is meant to be noticed.
     if (comparison.overLimit) {
         console.warn(
-            `[perf] "${scenario}" went over its limit — see the report above. Raising the limit in ` +
+            `[perf] "${measurementKey(scenario, model)}" went over its limit — see the report above. Raising the limit in ` +
                 'performance/budgets.ts is a deliberate decision about what the app may cost.',
         );
     }

--- a/suite/e2e/performance/perfMeasure.ts
+++ b/suite/e2e/performance/perfMeasure.ts
@@ -1,0 +1,73 @@
+import { Page, TestInfo } from '@playwright/test';
+
+import {
+    PerfMetrics,
+    buildJsonReport,
+    compareScenario,
+    formatHumanReport,
+    readPerfMetrics,
+    startPerfMeasurement,
+} from '@trezor/perf-e2e';
+
+import { BASELINES, LIMITS } from './budgets';
+
+// Lets the long-task observer flush and trailing renders settle before metrics are read.
+const SETTLE_MS = 400;
+
+/**
+ * Measures a single interaction and reports it against the limits of its scenario. Going over a
+ * limit never fails the test.
+ *
+ * Instrumentation is installed globally at app load (see `electronSetup`), so no reload is needed
+ * here. On a target where it was not installed, the interaction still runs and measurement is
+ * skipped.
+ */
+export const measurePerformance = async (
+    page: Page,
+    testInfo: TestInfo,
+    scenario: string,
+    interaction: () => Promise<void>,
+): Promise<PerfMetrics | null> => {
+    const installed = await page.evaluate(
+        () =>
+            typeof (window as unknown as { __trezorPerf__?: unknown }).__trezorPerf__ !==
+            'undefined',
+    );
+    if (!installed) {
+        // eslint-disable-next-line no-console
+        console.log(
+            `[perf] instrumentation not installed (non-web target?) — skipping "${scenario}"`,
+        );
+        await interaction();
+
+        return null;
+    }
+
+    await page.evaluate(startPerfMeasurement);
+    await interaction();
+    await page.waitForTimeout(SETTLE_MS);
+    const current = await page.evaluate(readPerfMetrics);
+
+    const comparison = compareScenario(scenario, current, BASELINES[scenario], LIMITS[scenario]);
+    const humanReport = formatHumanReport(comparison);
+
+    await testInfo.attach(`perf-report-${scenario}.json`, {
+        body: JSON.stringify(buildJsonReport(comparison), null, 2),
+        contentType: 'application/json',
+    });
+
+    // eslint-disable-next-line no-console
+    console.log(`\n${humanReport}\n`);
+
+    // Deliberately never thrown: going over a limit is reported, not turned into a test failure. A
+    // performance number is not on its own a reason to block a merge, and the end-of-run report is
+    // where a breach is meant to be noticed.
+    if (comparison.overLimit) {
+        console.warn(
+            `[perf] "${scenario}" went over its limit — see the report above. Raising the limit in ` +
+                'performance/budgets.ts is a deliberate decision about what the app may cost.',
+        );
+    }
+
+    return current;
+};

--- a/suite/e2e/performance/perfReporter.ts
+++ b/suite/e2e/performance/perfReporter.ts
@@ -1,0 +1,230 @@
+import type { FullResult, Reporter, TestCase, TestResult } from '@playwright/test/reporter';
+
+import {
+    Baselines,
+    Limits,
+    PerfJsonReport,
+    PerfMetricKey,
+    PerfMetrics,
+    aggregateSamples,
+    buildJsonReport,
+    compareScenario,
+    suggestLimits,
+} from '@trezor/perf-e2e';
+
+import { BASELINES, LIMITS } from './budgets';
+
+const BUDGETS_MODULE_PATH = 'suite/e2e/performance/budgets.ts';
+
+// GitHub Actions logs render ANSI, so a failure is visible at a glance.
+const RED = '\x1b[31m';
+const GREEN = '\x1b[32m';
+const BOLD = '\x1b[1m';
+const RESET = '\x1b[0m';
+const paint = (text: string, ...codes: string[]) => `${codes.join('')}${text}${RESET}`;
+
+const pad = (value: string, width: number) => value.padEnd(width);
+
+const fmt = (value: number | null, unit: string) => {
+    if (value === null) {
+        return 'n/a';
+    }
+    const rounded = Math.round(value * 10) / 10;
+
+    return unit === 'ms' ? `${rounded}ms` : `${rounded}`;
+};
+
+type Metric = PerfJsonReport['metrics'][number];
+
+const fmtOfLimit = (metric: Metric) =>
+    metric.ratioToLimit === null ? 'n/a' : `${Math.round(metric.ratioToLimit * 100)}%`;
+
+const WELL_UNDER_LIMIT_RATIO = 0.5;
+
+const isWellUnderLimit = (metric: Metric) =>
+    metric.ratioToLimit !== null && metric.ratioToLimit <= WELL_UNDER_LIMIT_RATIO;
+
+const colorMetricRow = (row: string, metric: Metric) => {
+    if (metric.exceededLimit) {
+        return paint(row, RED);
+    }
+
+    return isWellUnderLimit(metric) ? paint(row, GREEN) : row;
+};
+
+/**
+ * The whole `budgets.ts` as it would look with this run's numbers in it, so refreshing the baseline
+ * or raising a limit is one paste from the CI log — no re-run, no hunting for the file.
+ */
+const formatBudgetsModule = (baselines: Baselines, limits: Limits) =>
+    [
+        "import { type Baselines, type Limits } from '@trezor/perf-e2e';",
+        '',
+        '/** What each scenario costs today, measured on CI. Reference only, never enforced. */',
+        `export const BASELINES: Baselines = ${JSON.stringify(baselines, null, 4)};`,
+        '',
+        '/** The highest value each metric may reach before the run fails. Raise deliberately. */',
+        `export const LIMITS: Limits = ${JSON.stringify(limits, null, 4)};`,
+    ].join('\n');
+
+const parseReport = (body: Buffer | undefined): PerfJsonReport | null => {
+    try {
+        return JSON.parse(String(body)) as PerfJsonReport;
+    } catch {
+        // A malformed attachment must not take the whole report down with it.
+        return null;
+    }
+};
+
+const toMetrics = (report: PerfJsonReport): PerfMetrics =>
+    report.metrics.reduce<PerfMetrics>(
+        (metrics, metric) => ({ ...metrics, [metric.key as PerfMetricKey]: metric.current }),
+        {} as PerfMetrics,
+    );
+
+const scenarioVerdict = (report: PerfJsonReport) => {
+    if (report.overLimit) {
+        return paint('OVER LIMIT', BOLD, RED);
+    }
+
+    return report.unlimited ? 'no limits set (nothing measured against)' : 'within limits';
+};
+
+/**
+ * Makes a breach visible on the run's summary page without failing anything: an `error` annotation
+ * renders red there, while the exit code stays the job's own. No-op outside GitHub Actions, where the
+ * console table is the whole report.
+ */
+const annotateOverLimit = (scenarios: string[]) => {
+    if (!process.env.GITHUB_ACTIONS || scenarios.length === 0) {
+        return;
+    }
+
+    // Scenario names go in the message, not in `title=`: workflow-command properties are
+    // comma-separated, so a comma in the title would start another property.
+    // eslint-disable-next-line no-console
+    console.log(
+        `::error title=Performance over limit::${scenarios.join(', ')} — see PERFORMANCE REPORT in this job's log. Does not fail the run.`,
+    );
+};
+
+/**
+ * End-of-run summary: collects the `perf-report-*.json` attachments, aggregates retries into one
+ * median block per scenario, and prints the table last.
+ */
+class PerfReporter implements Reporter {
+    private readonly reports: PerfJsonReport[] = [];
+
+    onTestEnd(_test: TestCase, result: TestResult) {
+        const reports = result.attachments
+            .filter(attachment => attachment.name.startsWith('perf-report-') && attachment.body)
+            .map(attachment => parseReport(attachment.body))
+            .filter((report): report is PerfJsonReport => report !== null);
+
+        this.reports.push(...reports);
+    }
+
+    onEnd(_result: FullResult) {
+        if (this.reports.length === 0) {
+            return;
+        }
+
+        // Aggregate retries: one median comparison per scenario (a test may run 2-3× on CI).
+        const samplesByScenario = this.reports.reduce<Record<string, PerfMetrics[]>>(
+            (samples, report) => ({
+                ...samples,
+                [report.scenario]: [...(samples[report.scenario] ?? []), toMetrics(report)],
+            }),
+            {},
+        );
+
+        const scenarios = Object.entries(samplesByScenario).map(([scenario, samples]) => {
+            const median = aggregateSamples(samples);
+            const comparison = compareScenario(
+                scenario,
+                median,
+                BASELINES[scenario],
+                LIMITS[scenario],
+            );
+
+            return {
+                scenario,
+                median,
+                comparison,
+                runs: samples.length,
+                report: buildJsonReport(comparison),
+            };
+        });
+
+        const overLimit = scenarios.filter(entry => entry.report.overLimit);
+        const headerColor = overLimit.length > 0 ? [BOLD, RED] : [BOLD, GREEN];
+
+        const lines: string[] = [
+            '',
+            paint('━'.repeat(72), ...headerColor),
+            paint('PERFORMANCE REPORT', ...headerColor),
+            paint('━'.repeat(72), ...headerColor),
+        ];
+
+        lines.push(
+            ...scenarios.flatMap(({ scenario, report, runs }) => [
+                '',
+                `Scenario: ${scenario}  (median of ${runs} run${runs === 1 ? '' : 's'})   →   ${scenarioVerdict(report)}`,
+                `  ${pad('metric', 24)}${pad('current', 12)}${pad('limit', 12)}${pad('% of limit', 12)}baseline`,
+                ...report.metrics.map(metric =>
+                    colorMetricRow(
+                        `  ${pad(metric.label, 24)}${pad(fmt(metric.current, metric.unit), 12)}` +
+                            `${pad(fmt(metric.limit, metric.unit), 12)}${pad(fmtOfLimit(metric), 12)}` +
+                            `${fmt(metric.baseline, metric.unit)}${metric.exceededLimit ? ' !!' : ''}`,
+                        metric,
+                    ),
+                ),
+            ]),
+            '',
+            paint('─'.repeat(72), ...headerColor),
+        );
+
+        if (overLimit.length > 0) {
+            lines.push(
+                paint(
+                    `Result: over limit — ${overLimit.map(e => e.scenario).join(', ')}. Reported only, the run is not failed.`,
+                    BOLD,
+                    RED,
+                ),
+            );
+        } else {
+            lines.push(paint('Result: within limits.', BOLD, GREEN));
+        }
+
+        // Both numbers in one paste: the baseline refreshed to this run, and every limit lifted to
+        // fit it where the run went over. Untouched scenarios are preserved.
+        const updatedBaselines: Baselines = {
+            ...BASELINES,
+            ...Object.fromEntries(scenarios.map(entry => [entry.scenario, entry.median])),
+        };
+        const updatedLimits: Limits = {
+            ...LIMITS,
+            ...suggestLimits(scenarios.map(entry => entry.comparison)),
+        };
+
+        lines.push(
+            '',
+            `To record this run's numbers, run from the repo root then commit`,
+            '(the baseline is reference only; a raised limit says the app may cost more):',
+            '',
+            `cat > ${BUDGETS_MODULE_PATH} <<'TS'`,
+            formatBudgetsModule(updatedBaselines, updatedLimits),
+            'TS',
+        );
+
+        lines.push(paint('━'.repeat(72), ...headerColor), '');
+
+        // eslint-disable-next-line no-console
+        console.log(lines.join('\n'));
+
+        annotateOverLimit(overLimit.map(entry => entry.scenario));
+    }
+}
+
+/* eslint-disable-next-line import/no-default-export */
+export default PerfReporter;

--- a/suite/e2e/performance/perfReporter.ts
+++ b/suite/e2e/performance/perfReporter.ts
@@ -28,6 +28,14 @@ const fmt = (value: number | null, unit: string) => {
 
 type Metric = PerfJsonReport['metrics'][number];
 
+type MeasuredRun = { project: string; testId: string; report: PerfJsonReport };
+
+type MeasurementSamples = { scenario: string; project: string; metrics: PerfMetrics[] };
+
+/** Names one measured run of a scenario, which is one scenario on one device model. */
+const measurementLabel = (scenario: string, project: string) =>
+    project ? `${scenario} [${project}]` : scenario;
+
 const fmtOfLimit = (metric: Metric) =>
     metric.ratioToLimit === null ? 'n/a' : `${Math.round(metric.ratioToLimit * 100)}%`;
 
@@ -42,7 +50,7 @@ const formatBudgetsModule = (baselines: Baselines, limits: Limits) =>
         '/** What each scenario costs today, measured on CI. Reference only, never enforced. */',
         `export const BASELINES: Baselines = ${JSON.stringify(baselines, null, 4)};`,
         '',
-        '/** The highest value each metric may reach before the run fails. Raise deliberately. */',
+        '/** The highest value each metric may reach before it is reported as over limit. Raise deliberately. */',
         `export const LIMITS: Limits = ${JSON.stringify(limits, null, 4)};`,
     ].join('\n');
 
@@ -92,15 +100,20 @@ const annotateOverLimit = (scenarios: string[]) => {
  * median block per scenario, and prints the table last.
  */
 class PerfReporter implements Reporter {
-    private readonly reports: PerfJsonReport[] = [];
+    private readonly reports: MeasuredRun[] = [];
 
-    onTestEnd(_test: TestCase, result: TestResult) {
-        const reports = result.attachments
+    onTestEnd(test: TestCase, result: TestResult) {
+        // A scenario is measured once per device model, and a retry repeats the very same test, so
+        // only the test and its project together say which runs are samples of one another.
+        const project = test.parent?.project()?.name ?? '';
+
+        const runs = result.attachments
             .filter(attachment => attachment.name.startsWith('perf-report-') && attachment.body)
             .map(attachment => parseReport(attachment.body))
-            .filter((report): report is PerfJsonReport => report !== null);
+            .filter((report): report is PerfJsonReport => report !== null)
+            .map(report => ({ project, testId: test.id, report }));
 
-        this.reports.push(...reports);
+        this.reports.push(...runs);
     }
 
     onEnd(_result: FullResult) {
@@ -108,32 +121,46 @@ class PerfReporter implements Reporter {
             return;
         }
 
-        // Aggregate retries: one median comparison per scenario (a test may run 2-3× on CI).
-        const samplesByScenario = this.reports.reduce<Record<string, PerfMetrics[]>>(
-            (samples, report) => ({
-                ...samples,
-                [report.scenario]: [...(samples[report.scenario] ?? []), toMetrics(report)],
-            }),
+        // Aggregate retries: one median comparison per measurement (a test may run 2-3× on CI).
+        // Grouping by scenario alone would average a slow device model with a fast one and hide a
+        // breach in the middle.
+        const samplesByMeasurement = this.reports.reduce<Record<string, MeasurementSamples>>(
+            (samples, { project, testId, report }) => {
+                const key = `${project}\u0000${testId}\u0000${report.scenario}`;
+                const existing = samples[key];
+
+                return {
+                    ...samples,
+                    [key]: {
+                        scenario: report.scenario,
+                        project,
+                        metrics: [...(existing?.metrics ?? []), toMetrics(report)],
+                    },
+                };
+            },
             {},
         );
 
-        const scenarios = Object.entries(samplesByScenario).map(([scenario, samples]) => {
-            const median = aggregateSamples(samples);
-            const comparison = compareScenario(
-                scenario,
-                median,
-                BASELINES[scenario],
-                LIMITS[scenario],
-            );
+        const scenarios = Object.values(samplesByMeasurement).map(
+            ({ scenario, project, metrics }) => {
+                const median = aggregateSamples(metrics);
+                const comparison = compareScenario(
+                    scenario,
+                    median,
+                    BASELINES[scenario],
+                    LIMITS[scenario],
+                );
 
-            return {
-                scenario,
-                median,
-                comparison,
-                runs: samples.length,
-                report: buildJsonReport(comparison),
-            };
-        });
+                return {
+                    scenario,
+                    project,
+                    median,
+                    comparison,
+                    runs: metrics.length,
+                    report: buildJsonReport(comparison),
+                };
+            },
+        );
 
         const overLimit = scenarios.filter(entry => entry.report.overLimit);
         // Chalk keeps its colors in GitHub Actions logs, so a failure is visible at a glance.
@@ -147,9 +174,9 @@ class PerfReporter implements Reporter {
         ];
 
         lines.push(
-            ...scenarios.flatMap(({ scenario, report, runs }) => [
+            ...scenarios.flatMap(({ scenario, project, report, runs }) => [
                 '',
-                `Scenario: ${scenario}  (median of ${runs} run${runs === 1 ? '' : 's'})   →   ${scenarioVerdict(report)}`,
+                `Scenario: ${measurementLabel(scenario, project)}  (median of ${runs} run${runs === 1 ? '' : 's'})   →   ${scenarioVerdict(report)}`,
                 `  ${'metric'.padEnd(24)}${'current'.padEnd(12)}${'limit'.padEnd(12)}${'% of limit'.padEnd(12)}baseline`,
                 ...report.metrics.map(metric => {
                     const row =
@@ -167,7 +194,7 @@ class PerfReporter implements Reporter {
         if (overLimit.length > 0) {
             lines.push(
                 chalk.bold.red(
-                    `Result: over limit — ${overLimit.map(e => e.scenario).join(', ')}. Reported only, the run is not failed.`,
+                    `Result: over limit — ${overLimit.map(e => measurementLabel(e.scenario, e.project)).join(', ')}. Reported only, the run is not failed.`,
                 ),
             );
         } else {
@@ -175,7 +202,9 @@ class PerfReporter implements Reporter {
         }
 
         // Both numbers in one paste: the baseline refreshed to this run, and every limit lifted to
-        // fit it where the run went over. Untouched scenarios are preserved.
+        // fit it where the run went over. Untouched scenarios are preserved. Where a scenario ran on
+        // more than one device model, the last one measured is the baseline recorded for it, while
+        // the limit fits them all (see `suggestLimits`).
         const updatedBaselines: Baselines = {
             ...BASELINES,
             ...Object.fromEntries(scenarios.map(entry => [entry.scenario, entry.median])),
@@ -200,7 +229,7 @@ class PerfReporter implements Reporter {
         // eslint-disable-next-line no-console
         console.log(lines.join('\n'));
 
-        annotateOverLimit(overLimit.map(entry => entry.scenario));
+        annotateOverLimit(overLimit.map(entry => measurementLabel(entry.scenario, entry.project)));
     }
 }
 

--- a/suite/e2e/performance/perfReporter.ts
+++ b/suite/e2e/performance/perfReporter.ts
@@ -1,4 +1,5 @@
 import type { FullResult, Reporter, TestCase, TestResult } from '@playwright/test/reporter';
+import chalk from 'chalk';
 
 import {
     Baselines,
@@ -16,15 +17,6 @@ import { BASELINES, LIMITS } from './budgets';
 
 const BUDGETS_MODULE_PATH = 'suite/e2e/performance/budgets.ts';
 
-// GitHub Actions logs render ANSI, so a failure is visible at a glance.
-const RED = '\x1b[31m';
-const GREEN = '\x1b[32m';
-const BOLD = '\x1b[1m';
-const RESET = '\x1b[0m';
-const paint = (text: string, ...codes: string[]) => `${codes.join('')}${text}${RESET}`;
-
-const pad = (value: string, width: number) => value.padEnd(width);
-
 const fmt = (value: number | null, unit: string) => {
     if (value === null) {
         return 'n/a';
@@ -38,19 +30,6 @@ type Metric = PerfJsonReport['metrics'][number];
 
 const fmtOfLimit = (metric: Metric) =>
     metric.ratioToLimit === null ? 'n/a' : `${Math.round(metric.ratioToLimit * 100)}%`;
-
-const WELL_UNDER_LIMIT_RATIO = 0.5;
-
-const isWellUnderLimit = (metric: Metric) =>
-    metric.ratioToLimit !== null && metric.ratioToLimit <= WELL_UNDER_LIMIT_RATIO;
-
-const colorMetricRow = (row: string, metric: Metric) => {
-    if (metric.exceededLimit) {
-        return paint(row, RED);
-    }
-
-    return isWellUnderLimit(metric) ? paint(row, GREEN) : row;
-};
 
 /**
  * The whole `budgets.ts` as it would look with this run's numbers in it, so refreshing the baseline
@@ -84,7 +63,7 @@ const toMetrics = (report: PerfJsonReport): PerfMetrics =>
 
 const scenarioVerdict = (report: PerfJsonReport) => {
     if (report.overLimit) {
-        return paint('OVER LIMIT', BOLD, RED);
+        return chalk.bold.red('OVER LIMIT');
     }
 
     return report.unlimited ? 'no limits set (nothing measured against)' : 'within limits';
@@ -157,43 +136,42 @@ class PerfReporter implements Reporter {
         });
 
         const overLimit = scenarios.filter(entry => entry.report.overLimit);
-        const headerColor = overLimit.length > 0 ? [BOLD, RED] : [BOLD, GREEN];
+        // Chalk keeps its colors in GitHub Actions logs, so a failure is visible at a glance.
+        const headerStyle = overLimit.length > 0 ? chalk.bold.red : chalk.bold.green;
 
         const lines: string[] = [
             '',
-            paint('━'.repeat(72), ...headerColor),
-            paint('PERFORMANCE REPORT', ...headerColor),
-            paint('━'.repeat(72), ...headerColor),
+            headerStyle('━'.repeat(72)),
+            headerStyle('PERFORMANCE REPORT'),
+            headerStyle('━'.repeat(72)),
         ];
 
         lines.push(
             ...scenarios.flatMap(({ scenario, report, runs }) => [
                 '',
                 `Scenario: ${scenario}  (median of ${runs} run${runs === 1 ? '' : 's'})   →   ${scenarioVerdict(report)}`,
-                `  ${pad('metric', 24)}${pad('current', 12)}${pad('limit', 12)}${pad('% of limit', 12)}baseline`,
-                ...report.metrics.map(metric =>
-                    colorMetricRow(
-                        `  ${pad(metric.label, 24)}${pad(fmt(metric.current, metric.unit), 12)}` +
-                            `${pad(fmt(metric.limit, metric.unit), 12)}${pad(fmtOfLimit(metric), 12)}` +
-                            `${fmt(metric.baseline, metric.unit)}${metric.exceededLimit ? ' !!' : ''}`,
-                        metric,
-                    ),
-                ),
+                `  ${'metric'.padEnd(24)}${'current'.padEnd(12)}${'limit'.padEnd(12)}${'% of limit'.padEnd(12)}baseline`,
+                ...report.metrics.map(metric => {
+                    const row =
+                        `  ${metric.label.padEnd(24)}${fmt(metric.current, metric.unit).padEnd(12)}` +
+                        `${fmt(metric.limit, metric.unit).padEnd(12)}${fmtOfLimit(metric).padEnd(12)}` +
+                        `${fmt(metric.baseline, metric.unit)}${metric.exceededLimit ? ' !!' : ''}`;
+
+                    return metric.exceededLimit ? chalk.red(row) : row;
+                }),
             ]),
             '',
-            paint('─'.repeat(72), ...headerColor),
+            headerStyle('─'.repeat(72)),
         );
 
         if (overLimit.length > 0) {
             lines.push(
-                paint(
+                chalk.bold.red(
                     `Result: over limit — ${overLimit.map(e => e.scenario).join(', ')}. Reported only, the run is not failed.`,
-                    BOLD,
-                    RED,
                 ),
             );
         } else {
-            lines.push(paint('Result: within limits.', BOLD, GREEN));
+            lines.push(chalk.bold.green('Result: within limits.'));
         }
 
         // Both numbers in one paste: the baseline refreshed to this run, and every limit lifted to
@@ -217,7 +195,7 @@ class PerfReporter implements Reporter {
             'TS',
         );
 
-        lines.push(paint('━'.repeat(72), ...headerColor), '');
+        lines.push(headerStyle('━'.repeat(72)), '');
 
         // eslint-disable-next-line no-console
         console.log(lines.join('\n'));

--- a/suite/e2e/performance/perfReporter.ts
+++ b/suite/e2e/performance/perfReporter.ts
@@ -5,11 +5,13 @@ import {
     Baselines,
     Limits,
     PerfJsonReport,
-    PerfMetricKey,
     PerfMetrics,
     aggregateSamples,
     buildJsonReport,
     compareScenario,
+    formatMetricValue,
+    measurementKey,
+    resolveBudget,
     suggestLimits,
 } from '@trezor/perf-e2e';
 
@@ -17,24 +19,11 @@ import { BASELINES, LIMITS } from './budgets';
 
 const BUDGETS_MODULE_PATH = 'suite/e2e/performance/budgets.ts';
 
-const fmt = (value: number | null, unit: string) => {
-    if (value === null) {
-        return 'n/a';
-    }
-    const rounded = Math.round(value * 10) / 10;
-
-    return unit === 'ms' ? `${rounded}ms` : `${rounded}`;
-};
-
 type Metric = PerfJsonReport['metrics'][number];
 
 type MeasuredRun = { project: string; testId: string; report: PerfJsonReport };
 
 type MeasurementSamples = { scenario: string; project: string; metrics: PerfMetrics[] };
-
-/** Names one measured run of a scenario, which is one scenario on one device model. */
-const measurementLabel = (scenario: string, project: string) =>
-    project ? `${scenario} [${project}]` : scenario;
 
 const fmtOfLimit = (metric: Metric) =>
     metric.ratioToLimit === null ? 'n/a' : `${Math.round(metric.ratioToLimit * 100)}%`;
@@ -65,7 +54,7 @@ const parseReport = (body: Buffer | undefined): PerfJsonReport | null => {
 
 const toMetrics = (report: PerfJsonReport): PerfMetrics =>
     report.metrics.reduce<PerfMetrics>(
-        (metrics, metric) => ({ ...metrics, [metric.key as PerfMetricKey]: metric.current }),
+        (metrics, metric) => ({ ...metrics, [metric.key]: metric.current }),
         {} as PerfMetrics,
     );
 
@@ -82,16 +71,16 @@ const scenarioVerdict = (report: PerfJsonReport) => {
  * renders red there, while the exit code stays the job's own. No-op outside GitHub Actions, where the
  * console table is the whole report.
  */
-const annotateOverLimit = (scenarios: string[]) => {
-    if (!process.env.GITHUB_ACTIONS || scenarios.length === 0) {
+const annotateOverLimit = (measurements: string[]) => {
+    if (!process.env.GITHUB_ACTIONS || measurements.length === 0) {
         return;
     }
 
-    // Scenario names go in the message, not in `title=`: workflow-command properties are
+    // Measurement names go in the message, not in `title=`: workflow-command properties are
     // comma-separated, so a comma in the title would start another property.
     // eslint-disable-next-line no-console
     console.log(
-        `::error title=Performance over limit::${scenarios.join(', ')} — see PERFORMANCE REPORT in this job's log. Does not fail the run.`,
+        `::error title=Performance over limit::${measurements.join(', ')} — see PERFORMANCE REPORT in this job's log. Does not fail the run.`,
     );
 };
 
@@ -147,8 +136,8 @@ class PerfReporter implements Reporter {
                 const comparison = compareScenario(
                     scenario,
                     median,
-                    BASELINES[scenario],
-                    LIMITS[scenario],
+                    resolveBudget(BASELINES, scenario, project),
+                    resolveBudget(LIMITS, scenario, project),
                 );
 
                 return {
@@ -176,13 +165,13 @@ class PerfReporter implements Reporter {
         lines.push(
             ...scenarios.flatMap(({ scenario, project, report, runs }) => [
                 '',
-                `Scenario: ${measurementLabel(scenario, project)}  (median of ${runs} run${runs === 1 ? '' : 's'})   →   ${scenarioVerdict(report)}`,
+                `Scenario: ${measurementKey(scenario, project)}  (median of ${runs} run${runs === 1 ? '' : 's'})   →   ${scenarioVerdict(report)}`,
                 `  ${'metric'.padEnd(24)}${'current'.padEnd(12)}${'limit'.padEnd(12)}${'% of limit'.padEnd(12)}baseline`,
                 ...report.metrics.map(metric => {
                     const row =
-                        `  ${metric.label.padEnd(24)}${fmt(metric.current, metric.unit).padEnd(12)}` +
-                        `${fmt(metric.limit, metric.unit).padEnd(12)}${fmtOfLimit(metric).padEnd(12)}` +
-                        `${fmt(metric.baseline, metric.unit)}${metric.exceededLimit ? ' !!' : ''}`;
+                        `  ${metric.label.padEnd(24)}${formatMetricValue(metric.current, metric.unit).padEnd(12)}` +
+                        `${formatMetricValue(metric.limit, metric.unit).padEnd(12)}${fmtOfLimit(metric).padEnd(12)}` +
+                        `${formatMetricValue(metric.baseline, metric.unit)}${metric.exceededLimit ? ' !!' : ''}`;
 
                     return metric.exceededLimit ? chalk.red(row) : row;
                 }),
@@ -194,7 +183,7 @@ class PerfReporter implements Reporter {
         if (overLimit.length > 0) {
             lines.push(
                 chalk.bold.red(
-                    `Result: over limit — ${overLimit.map(e => measurementLabel(e.scenario, e.project)).join(', ')}. Reported only, the run is not failed.`,
+                    `Result: over limit — ${overLimit.map(e => measurementKey(e.scenario, e.project)).join(', ')}. Reported only, the run is not failed.`,
                 ),
             );
         } else {
@@ -202,16 +191,24 @@ class PerfReporter implements Reporter {
         }
 
         // Both numbers in one paste: the baseline refreshed to this run, and every limit lifted to
-        // fit it where the run went over. Untouched scenarios are preserved. Where a scenario ran on
-        // more than one device model, the last one measured is the baseline recorded for it, while
-        // the limit fits them all (see `suggestLimits`).
+        // fit it where the run went over. Untouched entries are preserved. Each measurement is
+        // recorded under its own key, so two device models keep two sets of numbers instead of
+        // overwriting one another.
+        const measured = scenarios.map(entry => ({
+            ...entry,
+            key: measurementKey(entry.scenario, entry.project),
+        }));
+
+        // Nothing is removed, only added to: a run that covers one device model must not delete the
+        // scenario-wide entry the other one still falls back to, and CI is free to measure the models
+        // in separate jobs whose reports are pasted one after the other.
         const updatedBaselines: Baselines = {
             ...BASELINES,
-            ...Object.fromEntries(scenarios.map(entry => [entry.scenario, entry.median])),
+            ...Object.fromEntries(measured.map(entry => [entry.key, entry.median])),
         };
         const updatedLimits: Limits = {
             ...LIMITS,
-            ...suggestLimits(scenarios.map(entry => entry.comparison)),
+            ...suggestLimits(measured.map(entry => ({ ...entry.comparison, scenario: entry.key }))),
         };
 
         lines.push(
@@ -229,7 +226,7 @@ class PerfReporter implements Reporter {
         // eslint-disable-next-line no-console
         console.log(lines.join('\n'));
 
-        annotateOverLimit(overLimit.map(entry => measurementLabel(entry.scenario, entry.project)));
+        annotateOverLimit(overLimit.map(entry => measurementKey(entry.scenario, entry.project)));
     }
 }
 

--- a/suite/e2e/playwright-config/playwright-base.config.ts
+++ b/suite/e2e/playwright-config/playwright-base.config.ts
@@ -40,7 +40,6 @@ export const baseConfig: PlaywrightTestConfig = defineConfig<
         currentsFixturesEnabled: isDefaultGithubAction,
     },
     reportSlowTests: null,
-    // A no-op unless a perf-measured test ran.
     // Orchestrated CI runs use `pwc-p run --pwc-skip-reporter-injection`, so reporters must be
     // declared here rather than injected by the CLI. The GitHub reporter is opt-in via env.
     reporter: isDefaultGithubAction
@@ -53,11 +52,13 @@ export const baseConfig: PlaywrightTestConfig = defineConfig<
                         ] as ReporterDescription,
                     ]
                   : []),
+              // A no-op unless a perf-measured test ran.
               [path.join(__dirname, '../performance/perfReporter.ts')] as ReporterDescription,
           ] // CI run
         : [
               ['list'],
               ['html', { open: 'never' }],
+              // A no-op unless a perf-measured test ran.
               [path.join(__dirname, '../performance/perfReporter.ts')] as ReporterDescription,
           ], // Local run or Fix Agent CI run
     timeout: getTimeout(),

--- a/suite/e2e/playwright-config/playwright-base.config.ts
+++ b/suite/e2e/playwright-config/playwright-base.config.ts
@@ -40,6 +40,7 @@ export const baseConfig: PlaywrightTestConfig = defineConfig<
         currentsFixturesEnabled: isDefaultGithubAction,
     },
     reportSlowTests: null,
+    // A no-op unless a perf-measured test ran.
     // Orchestrated CI runs use `pwc-p run --pwc-skip-reporter-injection`, so reporters must be
     // declared here rather than injected by the CLI. The GitHub reporter is opt-in via env.
     reporter: isDefaultGithubAction
@@ -52,8 +53,13 @@ export const baseConfig: PlaywrightTestConfig = defineConfig<
                         ] as ReporterDescription,
                     ]
                   : []),
+              [path.join(__dirname, '../performance/perfReporter.ts')] as ReporterDescription,
           ] // CI run
-        : [['list'], ['html', { open: 'never' }]], // Local run or Fix Agent CI run
+        : [
+              ['list'],
+              ['html', { open: 'never' }],
+              [path.join(__dirname, '../performance/perfReporter.ts')] as ReporterDescription,
+          ], // Local run or Fix Agent CI run
     timeout: getTimeout(),
     outputDir: path.join(__dirname, '../test-results'),
 });

--- a/suite/e2e/support/fixtures.ts
+++ b/suite/e2e/support/fixtures.ts
@@ -1,7 +1,9 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { checkEvoluRelayServerRunning } from '@suite-common/e2e-evolu-client';
+import type { PerfMetrics } from '@trezor/perf-e2e';
 
 import { AnalyticsFixture, AnalyticsHelper } from './analytics';
+import { measurePerformance } from '../performance/perfMeasure';
 import { EvoluClient } from './helpers/evoluClient';
 import { IndexedDbFixture } from './indexedDb';
 import { BlockbookMock } from './mocks/blockBookMock';
@@ -71,6 +73,16 @@ type Fixtures = {
     paginationControl: PaginationControl;
     toastSection: ToastSection;
     evoluClient: EvoluClient;
+    perf: {
+        /**
+         * Wraps an interaction a desktop test already performs and holds it to the limits of its
+         * scenario. Returns null where instrumentation is not installed (e.g. web).
+         */
+        measure: (
+            scenario: string,
+            interaction: () => Promise<void>,
+        ) => Promise<PerfMetrics | null>;
+    };
 };
 
 const test = suiteBaseTest.extend<Fixtures>({
@@ -189,6 +201,12 @@ const test = suiteBaseTest.extend<Fixtures>({
         const evoluClient = new EvoluClient();
         await use(evoluClient);
         await evoluClient.dispose();
+    },
+    perf: async ({ page }, use, testInfo) => {
+        await use({
+            measure: (scenario, interaction) =>
+                measurePerformance(page, testInfo, scenario, interaction),
+        });
     },
 });
 

--- a/suite/e2e/support/setup.ts
+++ b/suite/e2e/support/setup.ts
@@ -1,6 +1,7 @@
 import { BrowserContext, TestInfo, expect } from '@playwright/test';
 import { execSync } from 'child_process';
 
+import { installPerfInstrumentation } from '@trezor/perf-e2e';
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { BRIDGE_VERSION } from './bridge';
@@ -26,6 +27,13 @@ export const electronSetup = async (
         viewport: testInfo.project.use.viewport!,
         ...electronConf,
     });
+
+    // The reload puts the init script in place before the renderer's React loads; the window is
+    // still on its initial screen, so no state is lost. Passive until a test opts in. PERF=0 skips it.
+    if (process.env.PERF !== '0') {
+        await suite.window.addInitScript(installPerfInstrumentation);
+        await suite.window.reload();
+    }
 
     // Mocks shell.openExternal to prevent opening real browser windows.
     await suite.electronApp.evaluate(({ shell }) => {

--- a/suite/e2e/tests/general/wallet-discovery.test.ts
+++ b/suite/e2e/tests/general/wallet-discovery.test.ts
@@ -10,7 +10,8 @@ test.beforeEach(async ({ onboardingPage, settingsPage }) => {
     await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
 });
 
-test.describe('Wallet discover tests', { tag: ['@T3W1', '@T3T1'] }, () => {
+// The @perf tag marks this as a performance-measurement host.
+test.describe('Wallet discover tests', { tag: ['@T3W1', '@T3T1', '@perf'] }, () => {
     test(
         'Discover a standard wallet',
         {
@@ -20,11 +21,20 @@ test.describe('Wallet discover tests', { tag: ['@T3W1', '@T3T1'] }, () => {
                 priority: TestPriority.Critical,
             }),
         },
-        async ({ dashboardPage, walletPage }) => {
+        async ({ dashboardPage, walletPage, perf }) => {
             await dashboardPage.openDeviceSwitcher();
             await dashboardPage.ejectWallet();
-            await dashboardPage.addStandardWallet();
+
+            await perf.measure('wallet-discovery', async () => {
+                await dashboardPage.addStandardWallet();
+            });
+
             await expect(walletPage.balanceOfAccount({ symbol: 'btc', atIndex: 0 })).toBeVisible();
+
+            // A natural spot for rerender loops: selected-account change plus account view re-render.
+            await perf.measure('account-switch', async () => {
+                await walletPage.openAccount({ symbol: 'btc' });
+            });
         },
     );
 });

--- a/suite/e2e/tests/wallet/multi-account-discovery-perf.test.ts
+++ b/suite/e2e/tests/wallet/multi-account-discovery-perf.test.ts
@@ -4,6 +4,11 @@ import { expect, test } from '../../support/fixtures';
  * `mnemonic_all` is funded across many coins, so enabling btc + eth + ltc updates many account
  * entities at once — far more account churn than the single-account `wallet-discovery` scenario,
  * while needing no passphrase and no THP so it still runs on Safe 5.
+ *
+ * Unlike the other scenarios, which ride along inside tests that exist anyway, this one is a test of
+ * its own and therefore costs the desktop suite one extra run per device model it is tagged for. No
+ * existing test discovers several funded networks at once, and measuring a flow the suite does not
+ * already perform is what that run buys.
  */
 test.describe('Performance', { tag: ['@T3W1', '@T3T1', '@perf'] }, () => {
     test.use({ deviceSetup: { mnemonic: 'mnemonic_all' } });

--- a/suite/e2e/tests/wallet/multi-account-discovery-perf.test.ts
+++ b/suite/e2e/tests/wallet/multi-account-discovery-perf.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '../../support/fixtures';
+
+/**
+ * `mnemonic_all` is funded across many coins, so enabling btc + eth + ltc updates many account
+ * entities at once — far more account churn than the single-account `wallet-discovery` scenario,
+ * while needing no passphrase and no THP so it still runs on Safe 5.
+ */
+test.describe('Performance', { tag: ['@T3W1', '@T3T1', '@perf'] }, () => {
+    test.use({ deviceSetup: { mnemonic: 'mnemonic_all' } });
+
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
+        await onboardingPage.completeOnboarding();
+        await settingsPage.changeNetworks({ enableNetworks: ['btc', 'eth', 'ltc'] });
+    });
+
+    test('multi-account discovery stays within its performance limits', async ({
+        dashboardPage,
+        walletPage,
+        perf,
+    }) => {
+        await dashboardPage.openDeviceSwitcher();
+        await dashboardPage.ejectWallet();
+
+        await perf.measure('multi-account-discovery', async () => {
+            await dashboardPage.addStandardWallet();
+        });
+
+        await expect(walletPage.balanceOfAccount({ symbol: 'btc', atIndex: 0 })).toBeVisible();
+    });
+});

--- a/suite/e2e/tsconfig.json
+++ b/suite/e2e/tsconfig.json
@@ -7,6 +7,7 @@
         "snapshots",
         "tests",
         "support",
+        "performance",
         "playwright-config",
         "scripts/**/*.ts"
     ],
@@ -67,6 +68,7 @@
         {
             "path": "../../networks/solana/network-solana"
         },
+        { "path": "../../packages/perf-e2e" },
         { "path": "../../packages/protobuf" },
         { "path": "../../packages/suite-data" },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16900,6 +16900,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@trezor/perf-e2e@workspace:*, @trezor/perf-e2e@workspace:packages/perf-e2e":
+  version: 0.0.0-use.local
+  resolution: "@trezor/perf-e2e@workspace:packages/perf-e2e"
+  dependencies:
+    "@trezor/eslint": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
 "@trezor/product-components@workspace:*, @trezor/product-components@workspace:packages/product-components":
   version: 0.0.0-use.local
   resolution: "@trezor/product-components@workspace:packages/product-components"
@@ -17326,6 +17334,7 @@ __metadata:
     "@trezor/e2e-utils": "workspace:*"
     "@trezor/eslint": "workspace:*"
     "@trezor/network-solana": "workspace:*"
+    "@trezor/perf-e2e": "workspace:*"
     "@trezor/protobuf": "workspace:*"
     "@trezor/suite-data": "workspace:*"
     "@trezor/suite-desktop": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17349,6 +17349,7 @@ __metadata:
     "@types/lodash": "npm:^4.17.16"
     "@walletconnect/sign-client": "npm:^2.23.10"
     "@walletconnect/types": "npm:^2.23.10"
+    chalk: "npm:^6.0.0"
     dotenv: "npm:17.2.3"
     fs-extra: "npm:^11.3.1"
     jest-diff: "npm:^30.2.0"


### PR DESCRIPTION
## Description

Frontend performance measurement for Suite, reported on every desktop e2e run.

Measurement rides **inside existing desktop e2e tests** — no dedicated CI run, no extra minutes. A
`perf` fixture installs browser instrumentation at app load, and three scenarios are measured:
`wallet-discovery`, `account-switch`, `multi-account-discovery`.

**Going over a limit never fails a test or a job — deliberately, in this PR.** It is reported: the
offending row is red in the end-of-run table, the verdict reads `OVER LIMIT`, and an `::error`
annotation makes it visible on the run's summary page. The exit code is unaffected, so nobody is
blocked and nobody has to re-run a red build over a performance number.

The point of starting this way is calibration: the limits here are first guesses derived from a
handful of CI runs, and they need real traffic before they are worth blocking a merge on. **Turning a
breach into a failing check is a follow-up PR**, once the numbers have been watched for a while and
the limits have been tightened to fit them.

### How it works

**1. Collection** — `@trezor/perf-e2e` is a Playwright-agnostic core that instruments the page:

| metric | source |
| --- | --- |
| Total Blocking Time, long task count, longest task | `PerformanceObserver` on `longtask` |
| React commits | React DevTools global hook |
| Interaction duration | wall clock around the measured interaction |

Instrumentation touches no production code: it is installed from the test at app load, and only in
the top-level app frame (never the Connect iframe).

**2. Limits decide, baselines only inform** — both live side by side in
[`suite/e2e/performance/budgets.ts`](../blob/28878-playwright-perf-tracking/suite/e2e/performance/budgets.ts):

- `LIMITS` — the highest value each metric may reach, **per scenario**, because the same metric means
  very different things in an account switch and in a multi-account discovery. Limits are absolute: a
  decision about what the app is allowed to cost, not a function of what it costs today. A creep
  therefore cannot be accepted one baseline bump at a time, and a noisy runner cannot flag a run that
  is well inside budget.
- `BASELINES` — what each scenario costs today. Printed in the report, marked as not enforced,
  deciding nothing. Recording a new baseline can never accept a regression; only editing a limit can,
  deliberately, in a diff where the number is the subject of the review.

A metric with no limit is measured and reported but never flagged, and a scenario with no limits at
all says so, so nothing can be mistaken for a check that is not one. Retries are aggregated to a
median before comparing.

**3. Reporting** — an end-of-run reporter prints one coloured table per scenario showing current,
limit, **% of limit** and the baseline, followed by the whole `budgets.ts` as it would look with this
run's numbers in it — ready to paste, with only the limits the run exceeded lifted to fit it
(rounded up to two significant figures over a 1.5× headroom). Shards that measured nothing stay
silent. Because the spec→shard mapping is decided per run, a breach also emits a GitHub annotation so
the right job is one click away.

## Where to see the report

Desktop e2e job → shard that ran a `@perf` host → step `Run Playwright E2E Tests` → search
`PERFORMANCE REPORT`. Example from a real run (numbers as measured on CI):

```
Scenario: multi-account-discovery  (median of 1 run)   →   within limits
  metric                  current     limit       % of limit  baseline
  Total Blocking Time     3226ms      7000ms      46%         4700ms
  Long tasks (>50ms)      56          100         56%         62
  Longest task            402ms       800ms       50%         543ms
  React commits           247         400         62%         237
  Interaction duration    9365ms      n/a         n/a         12125ms
```

## Commands

```bash
# Run the measured tests locally (needs the emulator)
yarn workspace @trezor/suite-e2e test:e2e:desktop --grep @perf

# Unit tests of the core
yarn workspace @trezor/perf-e2e test:unit
```

To change what the app may cost, edit `LIMITS` in `budgets.ts` — or paste the block the report
prints. To refresh the reference numbers, paste the same block's `BASELINES`.

## Notes for QA

Nothing user-facing: no production code is touched, and no test outcome changes. The only visible
effect is extra output in the desktop e2e logs and, on a breach, a red annotation on the run summary
that does not fail the run.

## Known limitations

- **Nothing is enforced yet.** By design, see above: a breach is reported, never fatal. Enforcement
  is a separate PR.
- **Catastrophic-class detection, not fine-grained.** The limits carry headroom for CI noise, so this
  reliably catches step changes (a rerender loop, a busy main thread), not a few percent of drift.
- **React render duration was dropped.** It needs React's profiling build, which would slow the
  artifact every desktop e2e test shares and shift every number measured with it. Rerender loops are
  still caught through the commit count, which works on any build.
- **Measurement rides inside a functional test**, so Playwright tracing/video overhead is present —
  present in the baseline too, so it cancels out.
- **Numbers are machine-dependent**: the committed numbers come from CI runners, so a local run will
  not match them.

## Related Issue

Resolve #28878
<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/28878-playwright-perf-tracking/web/](https://dev.suite.sldev.cz/suite-web/28878-playwright-perf-tracking/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=28878-playwright-perf-tracking&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=28878-playwright-perf-tracking&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-19T07:41:10.179Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |

</details>

_Updated: 2026-08-19T08:31:57.147Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->
