### PR TITLE
feat(suite-desktop): wrap native token debug button

### DIFF
--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
@@ -1,0 +1,217 @@
+import { openDeferredModal } from '@suite/modal';
+import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin/src/tx-simulation';
+import { createThunk } from '@suite-common/redux-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import {
+    getNetwork,
+    getNetworkDisplaySymbol,
+    getWrappedNativeAddress,
+} from '@suite-common/wallet-config';
+import { WETH_DEPOSIT_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
+import {
+    buildYieldUnsignedTransaction,
+    buildYieldWrapTransactionData,
+    estimateYieldFeeLevel,
+    ethereumGetCurrentNonceThunk,
+    selectRawNetworkFeeInfo,
+} from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { getAccountIdentity, getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
+
+import { sendYieldTransaction } from './stablecoin-yield/signingHelpers';
+
+// Standalone wrap flow for the debug "Wrap" action on the dashboard native-asset row. It reuses the
+// shared yield building blocks/signer but deliberately keeps its own thunks so the stablecoin-yield
+// flow thunks stay untouched.
+const WRAP_NATIVE_TOKEN_PREFIX = '@wallet/wrap-native-token';
+
+export type ComposeWrapNativeTokenErrorReason =
+    | 'unsupported-network'
+    | 'not-wrapped-native'
+    | 'missing-fee-level';
+
+export type ComposeWrapNativeTokenResult =
+    | {
+          type: 'action-ready';
+          unsignedTransaction: string;
+      }
+    | {
+          type: 'error';
+          reason: ComposeWrapNativeTokenErrorReason;
+      };
+
+type WrapNativeTokenPayload = {
+    account: Account;
+    /** Native coin amount to wrap — the value carried by the transaction. */
+    wrapAmount: string;
+};
+
+/**
+ * Composes an unsigned WETH `deposit()` (wrap) transaction that carries `wrapAmount` in its value.
+ * The target is always the chain's canonical wrapped-native contract.
+ */
+export const composeWrapNativeTokenThunk = createThunk<
+    ComposeWrapNativeTokenResult,
+    WrapNativeTokenPayload,
+    void
+>(
+    `${WRAP_NATIVE_TOKEN_PREFIX}/compose`,
+    async ({ account, wrapAmount }, { dispatch, getState }) => {
+        if (account.networkType !== 'ethereum') {
+            return { type: 'error', reason: 'unsupported-network' } as const;
+        }
+
+        const wethAddress = getWrappedNativeAddress(account.symbol);
+
+        if (!wethAddress) {
+            return { type: 'error', reason: 'not-wrapped-native' } as const;
+        }
+
+        const network = getNetwork(account.symbol);
+
+        if (!network.chainId) {
+            return { type: 'error', reason: 'unsupported-network' } as const;
+        }
+
+        const { data, value } = buildYieldWrapTransactionData({
+            wrapAmount,
+            decimals: network.decimals,
+        });
+
+        const [{ nonce }, estimatedFeeLevel] = await Promise.all([
+            dispatch(
+                ethereumGetCurrentNonceThunk({
+                    selectedAccount: account,
+                    fetchConfirmedNonce: true,
+                }),
+            ).unwrap(),
+            estimateYieldFeeLevel({
+                coin: account.symbol,
+                identity: getAccountIdentity(account),
+                from: account.descriptor,
+                to: wethAddress,
+                data,
+                value,
+            }),
+        ]);
+
+        // WETH deposit() is a fixed ~45k-gas call, so fall back to a known backup limit when
+        // estimation fails rather than blocking the wrap.
+        const gasLimit = estimatedFeeLevel.success
+            ? estimatedFeeLevel.payload.feeLimit
+            : WETH_DEPOSIT_BACKUP_GAS_LIMIT;
+
+        const feeInfo = getConvertedOrDefaultFeeInfo({
+            networkType: account.networkType,
+            feeInfo: selectRawNetworkFeeInfo(getState(), account.symbol),
+        });
+        const normalLevel =
+            feeInfo.levels.find(level => level.label === 'normal') ?? feeInfo.levels[0];
+
+        if (!normalLevel) {
+            return { type: 'error', reason: 'missing-fee-level' } as const;
+        }
+
+        const unsignedTransaction = JSON.stringify(
+            buildYieldUnsignedTransaction({
+                chainId: network.chainId,
+                data,
+                feeLevel: normalLevel,
+                from: account.descriptor,
+                gasLimit,
+                nonce: Number(nonce),
+                to: wethAddress,
+                value,
+            }),
+        );
+
+        return { type: 'action-ready', unsignedTransaction } as const;
+    },
+);
+
+/**
+ * Debug-only submit for the native-token wrap: composes the `deposit()` tx, shows the tx-simulation
+ * preview, then signs on the device and broadcasts. Reuses the shared `sendYieldTransaction` signer
+ * as-is — `flowType`/`flowKey` only feed the (flow-agnostic) precomposed-tx store and are inert for
+ * a standalone wrap.
+ */
+export const submitWrapNativeTokenThunk = createThunk(
+    `${WRAP_NATIVE_TOKEN_PREFIX}/submit`,
+    async ({ account, wrapAmount }: WrapNativeTokenPayload, { dispatch, getState }) => {
+        try {
+            const result = await dispatch(
+                composeWrapNativeTokenThunk({ account, wrapAmount }),
+            ).unwrap();
+
+            if (result.type === 'error') {
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'sign-tx-error',
+                        error: `Failed to compose wrap transaction (${result.reason}).`,
+                    }),
+                );
+
+                return;
+            }
+
+            const userAcceptedTxSimulation = await dispatch(
+                openDeferredModal({
+                    type: 'earn-yield-tx-simulation',
+                    data: {
+                        flow: 'wrap',
+                        unsignedTx: result.unsignedTransaction,
+                        account,
+                    } satisfies StablecoinYieldTxSimulationParams,
+                }),
+            );
+
+            if (userAcceptedTxSimulation?.value === false) {
+                return;
+            }
+
+            const network = getNetwork(account.symbol);
+
+            const sendResult = await sendYieldTransaction({
+                account,
+                amount: wrapAmount,
+                // Native display token (no contractAddress) ⇒ the review renders the wrap as a
+                // native value transfer to the WETH contract, which is what a deposit() call is.
+                token: {
+                    networkSymbol: account.symbol,
+                    symbol: getNetworkDisplaySymbol(account.symbol),
+                    decimals: network.decimals,
+                    contractAddress: null,
+                },
+                unsignedTransaction: result.unsignedTransaction,
+                flowKey: 'debug-wrap-native',
+                flowType: 'deposit',
+                dispatch,
+                getState,
+                selectedFee: userAcceptedTxSimulation?.selectedFee ?? null,
+            });
+
+            userAcceptedTxSimulation?.resolve();
+
+            if (!sendResult) {
+                return;
+            }
+
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'raw-tx-sent',
+                    descriptor: account.descriptor,
+                    symbol: account.symbol,
+                    txid: sendResult.txid,
+                }),
+            );
+        } catch (error) {
+            console.error(error);
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'sign-tx-error',
+                    error: error instanceof Error ? error.message : String(error),
+                }),
+            );
+        }
+    },
+);

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -59,6 +59,7 @@ import { UnecoCoinjoinModal } from './UnecoCoinjoinModal';
 import { WalletConnectProposalModal } from './WalletConnectProposalModal';
 import { WalletConnectSwitchAccountModal } from './WalletConnectSwitchAccountModal';
 import { WipeDeviceSuccessModal } from './WipeDeviceSuccessModal';
+import { WrapNativeTokenModal } from './WrapNativeTokenModal';
 
 /** Modals opened as a result of user action */
 export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL_CONTEXT_USER>) => {
@@ -205,6 +206,16 @@ export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL_CONTE
             );
         case 'wipe-device-success':
             return <WipeDeviceSuccessModal />;
+        case 'wrap-native-token':
+            return (
+                <WrapNativeTokenModal
+                    account={payload.account}
+                    maxWrapAmount={payload.maxWrapAmount}
+                    nativeSymbol={payload.nativeSymbol}
+                    wrappedSymbol={payload.wrappedSymbol}
+                    onCancel={onCancel}
+                />
+            );
         default:
             return exhaustive(payload);
     }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WrapNativeTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WrapNativeTokenModal.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
+
+import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
+import { type Account } from '@suite-common/wallet-types';
+import { Button, Column, Input, Modal, Row } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { submitWrapNativeTokenThunk } from 'src/actions/wallet/wrapNativeTokenThunks';
+import { useDispatch } from 'src/hooks/suite';
+
+type WrapNativeTokenModalProps = {
+    account: Account;
+    /** Max native amount that can be wrapped (balance minus the gas reserve), display units. */
+    maxWrapAmount: string;
+    nativeSymbol: string;
+    wrappedSymbol: string;
+    onCancel: () => void;
+};
+
+type FormData = {
+    amount: string;
+};
+
+export const validateAmount =
+    (translate: (id: TranslationKey) => string, maxWrapAmount: string) => (value: string) => {
+        const amount = new BigNumber(value);
+
+        if (amount.isNaN() || amount.lte(0)) {
+            return translate('AMOUNT_IS_TOO_LOW');
+        }
+
+        if (amount.gt(maxWrapAmount)) {
+            return translate('AMOUNT_IS_NOT_ENOUGH');
+        }
+
+        return true;
+    };
+
+// Debug-only modal (opened from the dashboard native-asset "Wrap" button) that collects the amount
+// to wrap, then hands off to submitWrapNativeTokenThunk which drives the tx-simulation + signing.
+export const WrapNativeTokenModal = ({
+    account,
+    maxWrapAmount,
+    nativeSymbol,
+    wrappedSymbol,
+    onCancel,
+}: WrapNativeTokenModalProps) => {
+    const { translationString } = useTranslation();
+    const dispatch = useDispatch();
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const {
+        register,
+        handleSubmit,
+        setValue,
+        formState: { errors, isValid },
+        control,
+    } = useForm<FormData>({
+        mode: 'onChange',
+        defaultValues: { amount: '' },
+    });
+
+    // Watch the value so the Input's floating-label CSS animates in react-hook-form's uncontrolled
+    // mode (see StellarTokenInputModal for the same pattern). useWatch (a hook) rather than the
+    // useForm watch() function, which React Compiler can't memoize and flags as incompatible.
+    const amount = useWatch({ control, name: 'amount' });
+
+    const { ref: amountRef, ...amountField } = register('amount', {
+        required: translationString('AMOUNT_IS_NOT_SET'),
+        validate: validateAmount(translationString, maxWrapAmount),
+    });
+
+    const onContinue = handleSubmit(async ({ amount: wrapAmount }) => {
+        setIsSubmitting(true);
+        // On success the thunk replaces this modal with the tx-simulation modal; on failure it shows
+        // a toast and this modal stays open, so re-enable the button afterwards.
+        await dispatch(submitWrapNativeTokenThunk({ account, wrapAmount }));
+        setIsSubmitting(false);
+    });
+
+    return (
+        <Modal
+            onCancel={onCancel}
+            heading={
+                <Translation
+                    id="TR_WRAP_NATIVE_TOKEN_MODAL_TITLE"
+                    values={{ nativeSymbol, wrappedSymbol }}
+                />
+            }
+            bottomContent={
+                <Row gap={8}>
+                    <Button
+                        onClick={onContinue}
+                        isDisabled={!isValid}
+                        isLoading={isSubmitting}
+                        intent="brand"
+                    >
+                        <Translation id="TR_CONTINUE" />
+                    </Button>
+                    <Button onClick={onCancel} intent="neutral" priority="secondary">
+                        <Translation id="TR_CANCEL" />
+                    </Button>
+                </Row>
+            }
+        >
+            <Column gap={16} alignItems="stretch">
+                <Input
+                    label={<Translation id="TR_WRAP_NATIVE_TOKEN_AMOUNT_LABEL" />}
+                    value={amount}
+                    innerRef={amountRef}
+                    {...amountField}
+                    hasError={!!errors.amount}
+                    bottomText={errors.amount?.message || null}
+                />
+                <Row justifyContent="flex-end">
+                    <Button
+                        onClick={() => setValue('amount', maxWrapAmount, { shouldValidate: true })}
+                        intent="neutral"
+                        priority="secondary"
+                    >
+                        <Translation id="TR_WRAP_NATIVE_TOKEN_MAX" />
+                    </Button>
+                </Row>
+            </Column>
+        </Modal>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/__tests__/WrapNativeTokenModal.test.ts
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/__tests__/WrapNativeTokenModal.test.ts
@@ -1,0 +1,35 @@
+import { type TranslationKey } from '@suite/intl';
+
+// The modal pulls in the wrap submit thunk (and, transitively, TrezorConnect); stub it so this pure
+// validator test stays lightweight.
+jest.mock('src/actions/wallet/wrapNativeTokenThunks', () => ({
+    submitWrapNativeTokenThunk: jest.fn(),
+}));
+
+import { validateAmount } from '../WrapNativeTokenModal';
+
+// Identity translator so the returned message equals the message id under test.
+const translate = (id: TranslationKey) => id;
+
+describe('WrapNativeTokenModal validateAmount', () => {
+    const validate = validateAmount(translate, '1.495');
+
+    it('accepts an amount within the max', () => {
+        expect(validate('1')).toBe(true);
+        expect(validate('1.495')).toBe(true);
+    });
+
+    it('rejects an amount above the max', () => {
+        expect(validate('1.5')).toBe('AMOUNT_IS_NOT_ENOUGH');
+    });
+
+    it('rejects zero and negative amounts', () => {
+        expect(validate('0')).toBe('AMOUNT_IS_TOO_LOW');
+        expect(validate('-1')).toBe('AMOUNT_IS_TOO_LOW');
+    });
+
+    it('rejects a non-numeric amount', () => {
+        expect(validate('abc')).toBe('AMOUNT_IS_TOO_LOW');
+        expect(validate('')).toBe('AMOUNT_IS_TOO_LOW');
+    });
+});

--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
@@ -18,6 +18,8 @@ import { PriceTicker, TrendTicker } from 'src/components/suite';
 import { useDispatch, useLayoutSize } from 'src/hooks/suite';
 import { type Account } from 'src/types/wallet';
 
+import { WrapNativeTokenButton } from './WrapNativeTokenButton';
+
 type TradeBoxProps = {
     account: Account;
 };
@@ -186,6 +188,7 @@ export const TradeBox = ({ account }: TradeBoxProps) => {
                                 <Translation id="TR_TRADING_SWAP" />
                             </ActionButton>
                         )}
+                        <WrapNativeTokenButton account={account} />
                     </Row>
                 </Flex>
             </Card>

--- a/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx
@@ -1,0 +1,76 @@
+import { type MouseEvent } from 'react';
+
+import { selectIsDebugModeActive } from '@suite/debug';
+import { Translation } from '@suite/intl';
+import { openModal } from '@suite/modal';
+import {
+    getNetworkDisplaySymbol,
+    getNetworkType,
+    getWrappedNativeAddress,
+    getWrappedNativeSymbol,
+} from '@suite-common/wallet-config';
+import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
+import { Button } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { type Account } from 'src/types/wallet';
+
+type WrapNativeTokenButtonProps = {
+    account: Account;
+};
+
+/**
+ * Debug-only action to wrap the native coin into its wrapped-native token (e.g. ETH → WETH).
+ * Rendered in the account TradeBox; hidden outside debug mode, on non-EVM networks, or on networks
+ * without a wrapped-native contract configured.
+ */
+export const WrapNativeTokenButton = ({ account }: WrapNativeTokenButtonProps) => {
+    const dispatch = useDispatch();
+    const isDebugModeActive = useSelector(selectIsDebugModeActive);
+
+    const { symbol } = account;
+    const wrappedAddress = getWrappedNativeAddress(symbol);
+    const wrappedSymbol = getWrappedNativeSymbol(symbol);
+
+    if (
+        !isDebugModeActive ||
+        getNetworkType(symbol) !== 'ethereum' ||
+        !wrappedAddress ||
+        !wrappedSymbol
+    ) {
+        return null;
+    }
+
+    // Keep a native buffer for the wrap fee (and any follow-up approve/deposit), matching the
+    // reserve the shared wrap logic uses.
+    const maxWrapAmount = BigNumber.max(
+        0,
+        new BigNumber(account.formattedBalance).minus(WETH_WRAP_GAS_RESERVE),
+    ).toString();
+
+    const onClick = (e: MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation();
+
+        dispatch(
+            openModal({
+                type: 'wrap-native-token',
+                account,
+                maxWrapAmount,
+                nativeSymbol: getNetworkDisplaySymbol(symbol),
+                wrappedSymbol,
+            }),
+        );
+    };
+
+    return (
+        <Button
+            intent="accentViolet"
+            size="small"
+            onClick={onClick}
+            data-testid="@trading/menu/wrap-native-token"
+        >
+            <Translation id="TR_WRAP_NATIVE_TOKEN" />
+        </Button>
+    );
+};

--- a/packages/suite/src/views/wallet/transactions/TradeBox/__tests__/WrapNativeTokenButton.test.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/__tests__/WrapNativeTokenButton.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { ThemeProvider } from 'src/support/suite/ThemeProvider';
+import { type Account } from 'src/types/wallet';
+
+import { WrapNativeTokenButton } from '../WrapNativeTokenButton';
+
+const mockDispatch = jest.fn();
+
+jest.mock('src/hooks/suite', () => ({
+    useDispatch: () => mockDispatch,
+    // The component reads debug mode only through the (mocked) selector, so invoking it with no
+    // state is enough here.
+    useSelector: (selector: () => unknown) => selector(),
+}));
+
+jest.mock('@suite/intl', () => ({
+    ...jest.requireActual('@suite/intl'),
+    Translation: ({ id }: { id: string }) => <span>{id}</span>,
+}));
+
+const mockOpenModal = jest.fn((payload: unknown) => ({ type: 'MODAL_OPEN', payload }));
+jest.mock('@suite/modal', () => ({ openModal: (payload: unknown) => mockOpenModal(payload) }));
+
+const mockSelectIsDebugModeActive = jest.fn();
+jest.mock('@suite/debug', () => ({
+    selectIsDebugModeActive: () => mockSelectIsDebugModeActive(),
+}));
+
+const mockGetNetworkType = jest.fn();
+const mockGetWrappedNativeAddress = jest.fn();
+const mockGetWrappedNativeSymbol = jest.fn();
+jest.mock('@suite-common/wallet-config', () => ({
+    ...jest.requireActual('@suite-common/wallet-config'),
+    getNetworkType: (symbol: string) => mockGetNetworkType(symbol),
+    getWrappedNativeAddress: (symbol: string) => mockGetWrappedNativeAddress(symbol),
+    getWrappedNativeSymbol: (symbol: string) => mockGetWrappedNativeSymbol(symbol),
+    getNetworkDisplaySymbol: () => 'ETH',
+}));
+
+const account = {
+    symbol: 'eth',
+    formattedBalance: '1.5',
+    networkType: 'ethereum',
+} as unknown as Account;
+
+const WRAP_BUTTON_TESTID = '@trading/menu/wrap-native-token';
+
+const renderButton = () =>
+    render(
+        <ThemeProvider>
+            <WrapNativeTokenButton account={account} />
+        </ThemeProvider>,
+    );
+
+describe('WrapNativeTokenButton', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // Happy-path defaults; individual tests override one condition.
+        mockSelectIsDebugModeActive.mockReturnValue(true);
+        mockGetNetworkType.mockReturnValue('ethereum');
+        mockGetWrappedNativeAddress.mockReturnValue('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2');
+        mockGetWrappedNativeSymbol.mockReturnValue('WETH');
+    });
+
+    it('renders nothing when debug mode is off', () => {
+        mockSelectIsDebugModeActive.mockReturnValue(false);
+        renderButton();
+        expect(screen.queryByTestId(WRAP_BUTTON_TESTID)).not.toBeInTheDocument();
+    });
+
+    it('renders nothing on a non-EVM network', () => {
+        mockGetNetworkType.mockReturnValue('bitcoin');
+        renderButton();
+        expect(screen.queryByTestId(WRAP_BUTTON_TESTID)).not.toBeInTheDocument();
+    });
+
+    it('renders nothing when the network has no wrapped-native token', () => {
+        mockGetWrappedNativeAddress.mockReturnValue(undefined);
+        mockGetWrappedNativeSymbol.mockReturnValue(undefined);
+        renderButton();
+        expect(screen.queryByTestId(WRAP_BUTTON_TESTID)).not.toBeInTheDocument();
+    });
+
+    it('opens the wrap modal with the depositable max when all conditions are met', () => {
+        renderButton();
+
+        const button = screen.getByTestId(WRAP_BUTTON_TESTID);
+        expect(button).toBeInTheDocument();
+
+        fireEvent.click(button);
+
+        // 1.5 native balance minus the 0.005 gas reserve.
+        expect(mockOpenModal).toHaveBeenCalledWith({
+            type: 'wrap-native-token',
+            account,
+            maxWrapAmount: '1.495',
+            nativeSymbol: 'ETH',
+            wrappedSymbol: 'WETH',
+        });
+        expect(mockDispatch).toHaveBeenCalledTimes(1);
+    });
+});

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -260,5 +260,13 @@ export type UserContextPayload =
           >;
       }
     | {
+          type: 'wrap-native-token';
+          account: Account;
+          /** Max native amount that can be wrapped (balance minus the gas reserve), display units. */
+          maxWrapAmount: string;
+          nativeSymbol: string;
+          wrappedSymbol: string;
+      }
+    | {
           type: 'wipe-device-success';
       };

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11282,6 +11282,22 @@ export const messages = defineMessages({
         id: 'TR_TX_UNWRAP',
         defaultMessage: 'Unwrap {wrappedAmount} into {nativeAmount}',
     },
+    TR_WRAP_NATIVE_TOKEN: {
+        id: 'TR_WRAP_NATIVE_TOKEN',
+        defaultMessage: 'Wrap',
+    },
+    TR_WRAP_NATIVE_TOKEN_MODAL_TITLE: {
+        id: 'TR_WRAP_NATIVE_TOKEN_MODAL_TITLE',
+        defaultMessage: 'Wrap {nativeSymbol} to {wrappedSymbol}',
+    },
+    TR_WRAP_NATIVE_TOKEN_AMOUNT_LABEL: {
+        id: 'TR_WRAP_NATIVE_TOKEN_AMOUNT_LABEL',
+        defaultMessage: 'Amount to wrap',
+    },
+    TR_WRAP_NATIVE_TOKEN_MAX: {
+        id: 'TR_WRAP_NATIVE_TOKEN_MAX',
+        defaultMessage: 'Max',
+    },
     TR_STAKE_STAKE: {
         id: 'TR_STAKE_STAKE',
         defaultMessage: 'Stake',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a debug button to the dashboard

## Notes for QA

1) Enable debug mode
2) Navigate to dashboard
3) Start wrapping flow

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30104

## Screenshots:
<img width="1251" height="747" alt="Screenshot 2026-07-21 at 14 58 46" src="https://github.com/user-attachments/assets/4fa343f5-42e6-42f7-849f-b7ca0d90bb52" />
<img width="817" height="347" alt="Screenshot 2026-07-21 at 14 58 51" src="https://github.com/user-attachments/assets/380f9e0a-1100-4bf3-b25f-f630d2371ee5" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/wrapped-native-debug&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->