### PR TITLE
Swap stake/unstake CTA order on staking dashboard

### DIFF
--- a/suite-native/module-earn/src/components/StakingManagementStakedCard.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementStakedCard.tsx
@@ -177,16 +177,6 @@ export const StakingManagementStakedCard = ({
                     <InlineAlertBox intent="warning" title={stakingMessageContent} />
                 )}
                 <HStack spacing="sp12">
-                    {hasStakedBalance && (
-                        <Button
-                            flex={1}
-                            priority="secondary"
-                            onPress={handleUnstake}
-                            isDisabled={isUnstakingDisabled}
-                        >
-                            <Translation id="earn.stakingManagementScreen.unstakeButton" />
-                        </Button>
-                    )}
                     <Button
                         flex={1}
                         priority="secondary"
@@ -201,6 +191,16 @@ export const StakingManagementStakedCard = ({
                             }
                         />
                     </Button>
+                    {hasStakedBalance && (
+                        <Button
+                            flex={1}
+                            priority="secondary"
+                            onPress={handleUnstake}
+                            isDisabled={isUnstakingDisabled}
+                        >
+                            <Translation id="earn.stakingManagementScreen.unstakeButton" />
+                        </Button>
+                    )}
                 </HStack>
             </VStack>
         </Card>


### PR DESCRIPTION
## Description

The native staking dashboard had Unstake on the left and Stake more on the right, inconsistent with desktop. This swaps the order to match desktop's convention for both ETH and SOL: Stake/Stake more on the left, Unstake on the right.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29803

## Screenshots:
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2026-07-21 at 15 26 36" src="https://github.com/user-attachments/assets/9009deb9-23b9-466c-8354-75bd63adbc4d" />
