### PR TITLE
Align staking progress-modal copy with design

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2581,6 +2581,14 @@ export const messages = {
                 stepWithdrawalPeriod:
                     'Withdrawal period (~{days, plural, one {# day} other {# days}})',
                 stepReadyToClaim: 'Ready to claim',
+                sol: {
+                    stepWarmUpPeriod:
+                        'Warm-up period (~{days, plural, one {# day} other {# days}})',
+                    stepStakedReceivingRewards: 'Staked & receiving rewards',
+                    stepCoolDownPeriod:
+                        'Cool-down period (~{days, plural, one {# day} other {# days}})',
+                    stepUnstakedReadyToClaim: 'Unstaked and ready to claim',
+                },
             },
         },
         yieldInsufficientBalance: {

--- a/suite-native/module-earn/src/components/StakingManagementPendingStakeModal.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementPendingStakeModal.tsx
@@ -7,6 +7,7 @@ import {
     useAccountsSelector,
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
+import { isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import {
     BottomSheetModal,
     type BottomSheetModalRef,
@@ -81,14 +82,23 @@ export const StakingManagementPendingStakeModal = ({
         return StakingDetailModalStep.Completed;
     })();
 
-    const inProgressLabel = (
+    const isSolanaStaking = !!symbol && isSupportedSolStakingNetworkSymbol(symbol);
+
+    const inProgressLabel = isSolanaStaking ? (
+        <Translation
+            id="earn.stakingManagementScreen.pendingItemModal.sol.stepWarmUpPeriod"
+            values={{ days: entryPeriodEstimateInDays }}
+        />
+    ) : (
         <Translation
             id="earn.stakingManagementScreen.pendingItemModal.stepEntryPeriod"
             values={{ days: entryPeriodEstimateInDays }}
         />
     );
 
-    const completedLabel = (
+    const completedLabel = isSolanaStaking ? (
+        <Translation id="earn.stakingManagementScreen.pendingItemModal.sol.stepStakedReceivingRewards" />
+    ) : (
         <Translation id="earn.stakingManagementScreen.pendingItemModal.stepStakedReceivingRewards" />
     );
 

--- a/suite-native/module-earn/src/components/StakingManagementUnstakingModal.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementUnstakingModal.tsx
@@ -1,7 +1,7 @@
 import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS } from '@suite-common/formatters';
 import { selectAccountNetworkSymbol, useAccountsSelector } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { isPositiveBalance } from '@suite-common/wallet-utils';
+import { isPositiveBalance, isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import {
     BottomSheetModal,
     type BottomSheetModalRef,
@@ -68,20 +68,29 @@ export const StakingManagementUnstakingModal = ({
     );
 
     const currentStep: StakingDetailModalStep = (() => {
-        if (isPositiveBalance(claimableAmount)) return StakingDetailModalStep.Completed;
         if (isPositiveBalance(unstakingBalance)) return StakingDetailModalStep.InProgress;
+        if (isPositiveBalance(claimableAmount)) return StakingDetailModalStep.Completed;
 
         return StakingDetailModalStep.TransactionConfirmed;
     })();
 
-    const inProgressLabel = (
+    const isSolanaStaking = !!symbol && isSupportedSolStakingNetworkSymbol(symbol);
+
+    const inProgressLabel = isSolanaStaking ? (
+        <Translation
+            id="earn.stakingManagementScreen.pendingItemModal.sol.stepCoolDownPeriod"
+            values={{ days: unstakingPeriodInDays }}
+        />
+    ) : (
         <Translation
             id="earn.stakingManagementScreen.pendingItemModal.stepWithdrawalPeriod"
             values={{ days: unstakingPeriodInDays }}
         />
     );
 
-    const completedLabel = (
+    const completedLabel = isSolanaStaking ? (
+        <Translation id="earn.stakingManagementScreen.pendingItemModal.sol.stepUnstakedReadyToClaim" />
+    ) : (
         <Translation id="earn.stakingManagementScreen.pendingItemModal.stepReadyToClaim" />
     );
 


### PR DESCRIPTION
## Description

Aligned the SOL staking pending-action modal copy with the reference design (cool-down/warm-up period, ready-to-claim wording).

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29840

## Screenshots:
<img width="371" height="683" alt="Screenshot 2026-07-21 at 16 29 29" src="https://github.com/user-attachments/assets/f2b3e32e-a722-458b-afec-32a8edca4672" />
<img width="369" height="686" alt="Screenshot 2026-07-21 at 16 29 46" src="https://github.com/user-attachments/assets/a625e1b4-53d0-46d4-8388-4c95d194a23b" />