### PR TITLE
Fix: retransmission on ThpTransportBusy error

### DIFF
--- a/packages/protocol/src/protocol-thp/ThpState.ts
+++ b/packages/protocol/src/protocol-thp/ThpState.ts
@@ -205,6 +205,7 @@ export class ThpState {
     sync(type: 'send' | 'recv', messageType: string) {
         // check if syncBit should be updated
         const updateSyncBit = ![
+            'ThpError',
             'ThpAck',
             'ThpCreateChannelRequest',
             'ThpCreateChannelResponse',

--- a/packages/protocol/src/protocol-thp/decode.ts
+++ b/packages/protocol/src/protocol-thp/decode.ts
@@ -6,7 +6,7 @@ import { type TransportProtocolDecode } from '../types';
 import { crc32 } from './crypto/crc32';
 import { getHandshakeHash, getTrezorState } from './crypto/pairing';
 import { getIvFromNonce } from './crypto/tools';
-import { type ThpDeviceProperties, type ThpError, type ThpMessageResponse } from './messages';
+import { type ThpDeviceProperties, type ThpMessageResponse } from './messages';
 
 type ThpMessage = ReturnType<TransportProtocolDecode> & {
     thpState: ThpState;
@@ -120,7 +120,7 @@ const decodeReadAck = (): ThpMessageResponse => ({
 // [magic | channel | len* | error | crc     ]
 // [42    | 1222    | 0005 | 02    | 70303cfa]
 // *len includes error+crc
-const decodeThpError = (payload: Buffer): ThpMessageResponse => {
+export const decodeThpError = (payload: Buffer): ThpMessageResponse<'ThpError'> => {
     const [errorType] = payload;
 
     const error = (() => {
@@ -138,14 +138,12 @@ const decodeThpError = (payload: Buffer): ThpMessageResponse => {
         }
     })();
 
-    const message: ThpError = {
-        code: error,
-        message: error ?? `Unknown ThpError ${errorType}`,
-    };
-
     return {
         type: 'ThpError',
-        message,
+        message: {
+            code: error,
+            message: error,
+        },
     };
 };
 

--- a/packages/transport-common/src/thp/loop.ts
+++ b/packages/transport-common/src/thp/loop.ts
@@ -1,5 +1,6 @@
 import { thp as protocolThp } from '@trezor/protocol';
 import { THP_CONTROL_BYTE } from '@trezor/protocol/src/protocol-v2/constants';
+import { getWeakRandomInt, resolveAfter } from '@trezor/utils';
 
 import {
     ATTEMPTS_LIMIT,
@@ -28,6 +29,8 @@ enum ThpLoopState {
     DONE,
 }
 
+const MAX_BUSY_BACKOFF_MS = 500;
+
 export const thpLoop = async ({
     chunks,
     thpState,
@@ -49,6 +52,8 @@ export const thpLoop = async ({
     const deadline = Date.now() + THP_ACK_DEADLINE;
     const isDeadlineReached = () => Date.now() >= deadline;
     const thpStateError = (message: string) => error({ code: THP_STATE_ERROR, message });
+    const isThpTransportBusy = (result: Buffer) =>
+        protocolThp.decodeThpError(result).message.code === 'ThpTransportBusy';
     let result;
 
     while (phase !== ThpLoopState.DONE) {
@@ -143,8 +148,16 @@ export const thpLoop = async ({
                         break;
                     }
                     case THP_CONTROL_BYTE.ERROR:
-                        result = ackResult;
-                        phase = ThpLoopState.DONE;
+                        if (isThpTransportBusy(ackResult.payload.payload)) {
+                            const backoff = getWeakRandomInt(0, MAX_BUSY_BACKOFF_MS);
+                            debug(`READ_ACK received ThpTransportBusy. retrying in ${backoff}ms`);
+                            await resolveAfter(backoff, signal);
+                            phase = ThpLoopState.WRITE_REQUEST;
+                        } else {
+                            result = ackResult;
+                            phase = ThpLoopState.DONE;
+                        }
+
                         break;
                     default:
                         if (
@@ -204,8 +217,18 @@ export const thpLoop = async ({
                     case THP_CONTROL_BYTE.ACK_MESSAGE:
                         break; // keep reading
                     case THP_CONTROL_BYTE.ERROR:
-                        result = receiveResult;
-                        phase = ThpLoopState.DONE;
+                        if (isThpTransportBusy(receiveResult.payload.payload)) {
+                            const backoff = getWeakRandomInt(0, MAX_BUSY_BACKOFF_MS);
+                            debug(
+                                `READ_RESPONSE received ThpTransportBusy. retrying in ${backoff}ms`,
+                            );
+                            await resolveAfter(backoff, signal);
+                            phase = ThpLoopState.WRITE_REQUEST;
+                        } else {
+                            result = receiveResult;
+                            phase = ThpLoopState.DONE;
+                        }
+
                         break;
                     default:
                         result = receiveResult;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

following THP specs: https://github.com/trezor/trezor-firmware/blob/main/docs/common/thp/specification.md

> When the sender receives a TRANSPORT_BUSY error, it should notify the segmenting layer to cease transmitting packets and notify the synchronization layer to increase the timeout for the next retransmission of the transport payload by a random value in the range [0, MAX_BUSY_BACKOFF_MS].

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-retry-thptranposrtbusy&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-retry-thptranposrtbusy&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-21T14:50:36.262Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-21T14:50:04.839Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/thp-retry-thptranposrtbusy/web/](https://dev.suite.sldev.cz/suite-web/fix/thp-retry-thptranposrtbusy/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->