### PR TITLE
feat(suite-desktop): displaying of wrap tx on toast

### DIFF
--- a/packages/product-components/src/components/Notifications/TransactionIcon.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionIcon.tsx
@@ -1,6 +1,10 @@
 import { type ReactNode } from 'react';
 
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type NetworkSymbol,
+    getWrappedNativeAddress,
+    getWrappedNativeSymbol,
+} from '@suite-common/wallet-config';
 
 import {
     type TransactionNotificationToken,
@@ -40,6 +44,24 @@ export const TransactionIcon = ({
 }: TransactionIconProps) => {
     if (icon) {
         return icon;
+    }
+
+    // A wrap (ETH→WETH) is denominated in the wrapped-native token, so show its logo (e.g. WETH) to
+    // match the amount. An unwrap is denominated in the native coin and uses the native icon below.
+    if (notificationType === 'tx-wrap') {
+        const wrappedNativeAddress = getWrappedNativeAddress(symbol);
+
+        if (wrappedNativeAddress) {
+            return (
+                <TokenIcon
+                    symbol={symbol}
+                    contractAddress={wrappedNativeAddress}
+                    placeholder={getWrappedNativeSymbol(symbol) ?? symbol}
+                    size={20}
+                    shouldTryToFetch
+                />
+            );
+        }
     }
 
     if (shouldDisplayAssetLogo({ notificationType, token }) && token) {

--- a/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
@@ -181,6 +181,26 @@ const transactionNotificationConfig: Record<
             },
         },
     },
+    'tx-wrap': {
+        toastIcon: ArrowUpIcon,
+        intent: 'brand',
+        message: 'Wrap transaction from Ethereum #1 has been broadcast',
+        amount: '1.495 WETH',
+        transaction: {
+            notificationType: 'tx-wrap',
+            symbol: 'eth',
+        },
+    },
+    'tx-unwrap': {
+        toastIcon: ArrowUpIcon,
+        intent: 'brand',
+        message: 'Unwrap transaction from Ethereum #1 has been broadcast',
+        amount: '1.495 ETH',
+        transaction: {
+            notificationType: 'tx-unwrap',
+            symbol: 'eth',
+        },
+    },
 };
 
 export const Default: Story = {

--- a/packages/product-components/src/components/Notifications/notificationsTypes.ts
+++ b/packages/product-components/src/components/Notifications/notificationsTypes.ts
@@ -28,7 +28,9 @@ export type TransactionNotificationType =
     | 'tx-revoked'
     | 'tx-yield-deposit'
     | 'tx-yield-withdraw'
-    | 'tx-yield-claim';
+    | 'tx-yield-claim'
+    | 'tx-wrap'
+    | 'tx-unwrap';
 
 type TransactionNotificationWithToken = Extract<
     NotificationEntry,

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
@@ -6,6 +6,7 @@ import {
     getNetwork,
     getNetworkDisplaySymbol,
     getWrappedNativeAddress,
+    getWrappedNativeSymbol,
 } from '@suite-common/wallet-config';
 import { WETH_DEPOSIT_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import {
@@ -20,9 +21,9 @@ import { getAccountIdentity, getConvertedOrDefaultFeeInfo } from '@suite-common/
 
 import { sendYieldTransaction } from './stablecoin-yield/signingHelpers';
 
-// Standalone wrap flow for the debug "Wrap" action on the dashboard native-asset row. It reuses the
-// shared yield building blocks/signer but deliberately keeps its own thunks so the stablecoin-yield
-// flow thunks stay untouched.
+// Standalone wrap flow for the debug "Wrap" action in the account TradeBox. It reuses the shared
+// yield building blocks/signer but deliberately keeps its own thunks so the stablecoin-yield flow
+// thunks stay untouched.
 const WRAP_NATIVE_TOKEN_PREFIX = '@wallet/wrap-native-token';
 
 export type ComposeWrapNativeTokenErrorReason =
@@ -196,9 +197,14 @@ export const submitWrapNativeTokenThunk = createThunk(
                 return;
             }
 
+            const wrappedSymbol =
+                getWrappedNativeSymbol(account.symbol) ?? getNetworkDisplaySymbol(account.symbol);
+
             dispatch(
                 notificationsActions.addToast({
-                    type: 'raw-tx-sent',
+                    type: 'tx-wrap',
+                    // Amount shown in the destination unit — the wrapped-native token (e.g. WETH).
+                    formattedAmount: `${wrapAmount} ${wrappedSymbol}`,
                     descriptor: account.descriptor,
                     symbol: account.symbol,
                     txid: sendResult.txid,

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -652,6 +652,34 @@ export const NotificationRenderer = ({
                 />
             );
 
+        case 'tx-wrap':
+            return (
+                <TransactionRenderer
+                    render={render}
+                    notification={notification}
+                    icon={ArrowUpIcon}
+                    variant="success"
+                    message="TOAST_TX_WRAP"
+                    messageValues={{
+                        account: notification.descriptor,
+                    }}
+                />
+            );
+
+        case 'tx-unwrap':
+            return (
+                <TransactionRenderer
+                    render={render}
+                    notification={notification}
+                    icon={ArrowUpIcon}
+                    variant="success"
+                    message="TOAST_TX_UNWRAP"
+                    messageValues={{
+                        account: notification.descriptor,
+                    }}
+                />
+            );
+
         case 'successful-claim':
             return renderNotificationView(render, notification, {
                 variant: 'success',

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -81,6 +81,17 @@ type YieldClaimTransactionNotification = {
     type: 'tx-yield-claim';
 } & BaseTransactionNotificationPayload;
 
+// Wrap/unwrap toasts show the amount in the destination unit: the wrapped-native token (WETH) for
+// a wrap, the native coin (ETH) for an unwrap. That destination unit is baked into `formattedAmount`
+// by the dispatcher.
+type WrapNativeTokenTransactionNotification = {
+    type: 'tx-wrap';
+} & TransactionNotificationPayload;
+
+type UnwrapNativeTokenTransactionNotification = {
+    type: 'tx-unwrap';
+} & TransactionNotificationPayload;
+
 export type ErrorToastPayload = {
     type:
         | 'error'
@@ -207,6 +218,8 @@ export type ToastPayload<TranslationKey extends UnknownTranslationKey = UnknownT
     | YieldDepositTransactionNotification
     | YieldWithdrawTransactionNotification
     | YieldClaimTransactionNotification
+    | WrapNativeTokenTransactionNotification
+    | UnwrapNativeTokenTransactionNotification
     | {
           type: 'cannot-open-bluetooth-settings-error';
       }

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11524,6 +11524,14 @@ export const messages = defineMessages({
         id: 'TOAST_TX_YIELD_CLAIM',
         defaultMessage: 'Claim transaction from {account} has been broadcast',
     },
+    TOAST_TX_WRAP: {
+        id: 'TOAST_TX_WRAP',
+        defaultMessage: 'Wrap transaction from {account} has been broadcast',
+    },
+    TOAST_TX_UNWRAP: {
+        id: 'TOAST_TX_UNWRAP',
+        defaultMessage: 'Unwrap transaction from {account} has been broadcast',
+    },
     TOAST_SUCCESSFUL_CLAIM: {
         id: 'TOAST_SUCCESSFUL_CLAIM',
         defaultMessage: '{networkDisplaySymbol} claimed successfully',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds definitions for wrapping and unwrapping transactions.

## Notes for QA

When sending a transaction for wrapping or onwrapping text on a toast should match the one on the screenshot

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29877

## Screenshots:

<img width="478" height="136" alt="Screenshot 2026-07-23 at 11 52 10" src="https://github.com/user-attachments/assets/43b66006-6733-4e7f-89af-9e7a762bf7bc" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/wrapped-native-tx-toast&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->