### PR TITLE
fix(suite-desktop): fix mac ARM develop build signing

### DIFF
--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -104,6 +104,7 @@ jobs:
 
       - name: Build ${{ matrix.platform }} suite-desktop
         env:
+          CSC_FOR_PULL_REQUEST: ${{ matrix.platform == 'mac' && 'true' || 'false' }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           yarn workspace @trezor/suite-desktop build:app

--- a/packages/suite-desktop/electron-builder-config.js
+++ b/packages/suite-desktop/electron-builder-config.js
@@ -94,6 +94,7 @@ module.exports = {
         ],
         icon: 'build/static/images/desktop/512x512.icns',
         artifactName: 'Trezor-Suite-${version}-mac-${arch}.${ext}',
+        identity: isCodesignBuild ? undefined : '-',
         hardenedRuntime: isCodesignBuild,
         gatekeeperAssess: false,
         darkModeSupport: true,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Set macOS identity for unsigned builds.

The issue was caused by the removal of the ad-hoc signing fallback in this electron-builder update: https://github.com/electron-userland/electron-builder/pull/9822/changes#diff-a02afd00a99aa11804505f2244d9fc1a343a29df14f6f5a5113738f7293d0714L59

Additionally,`electron-builder` skips macOS signing in PR builds unless `CSC_FOR_PULL_REQUEST=true`. Enabling it allows our explicit ad-hoc identity (`-`) to sign the fuses-modified Electron bundle and prevents invalid CI artifacts.

## Notes for QA

- If we can run the app on all platforms, we should be fine. But check all platforms, not only mac arm 🙏 

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/mac-arm-build-develop-signing/web/](https://dev.suite.sldev.cz/suite-web/fix/mac-arm-build-develop-signing/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/mac-arm-build-develop-signing&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/mac-arm-build-develop-signing&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-21T16:52:44.286Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect > Error screen | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.signTransaction > TrezorConnect.signTransaction | 🤖 auto |
| TrezorConnect.ethereumSignMessage > TrezorConnect.ethereumSignMessage | 🤖 auto |
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-21T16:51:47.548Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->