### PR TITLE
docs(protocol): update THP specification links

### DIFF
--- a/packages/connect/src/device/thp/handshake.ts
+++ b/packages/connect/src/device/thp/handshake.ts
@@ -24,8 +24,7 @@ const getPairingMethods = (
     });
 
 // State HH0
-// TODO: link-to-public-docs
-// https://www.notion.so/satoshilabs/THP-Specification-2-1-203dc5260606804192aecaa58fb961ca
+// https://github.com/trezor/trezor-firmware/blob/41692dc2cdb937564abe7fecd4bfc3e508adc8d4/docs/common/thp/specification.md#state-hh0
 export const createThpChannel = async (device: IDevice) => {
     const thpState = device.getThpState();
     if (!thpState) {
@@ -39,7 +38,7 @@ export const createThpChannel = async (device: IDevice) => {
 
     const { properties, ...resp } = createChannel.message;
 
-    // TODO: link-to-public-docs nonce validation is not mentioned by the docs
+    // NOTE: nonce validation is not mentioned by the docs
     if (nonce.compare(resp.nonce) !== 0) {
         throw new Error(
             'Nonce not meet' + nonce.toString('hex') + ' ' + resp.nonce.toString('hex'),
@@ -65,8 +64,7 @@ export const createThpChannel = async (device: IDevice) => {
 };
 
 // State HH1 and HH2
-// TODO: link-to-public-docs
-// https://www.notion.so/satoshilabs/THP-Specification-2-1-203dc5260606804192aecaa58fb961ca
+// https://github.com/trezor/trezor-firmware/blob/41692dc2cdb937564abe7fecd4bfc3e508adc8d4/docs/common/thp/specification.md#state-hh1
 export const thpHandshake = async (device: IDevice, unlockPin = false) => {
     const thpState = device.getThpState();
     if (!thpState?.handshakeCredentials) {

--- a/packages/connect/src/device/thp/pairing.ts
+++ b/packages/connect/src/device/thp/pairing.ts
@@ -257,8 +257,7 @@ export const thpPairingEnd = async (device: IDevice) => {
 
 // State HH2/HH3 -> HP0 -> HP1 -> HP2 -> HP3 -> HP4
 // Workflow will require user interaction
-// TODO: link-to-public-docs
-// https://www.notion.so/satoshilabs/THP-Specification-2-1-203dc5260606804192aecaa58fb961ca
+// https://github.com/trezor/trezor-firmware/blob/41692dc2cdb937564abe7fecd4bfc3e508adc8d4/docs/common/thp/specification.md#state-hh2
 export const thpPairing = async (device: IDevice) => {
     const thpState = device.getThpState();
     if (!thpState?.handshakeCredentials) {

--- a/packages/protocol/src/protocol-thp/crypto/pairing.ts
+++ b/packages/protocol/src/protocol-thp/crypto/pairing.ts
@@ -48,8 +48,7 @@ export const getTrezorState = (credentials: ThpHandshakeCredentials, payload: Bu
 type Curve25519KeyPair = ReturnType<typeof getCurve25519KeyPair>;
 
 // State HH1
-// TODO: link-to-public-docs
-// https://www.notion.so/satoshilabs/THP-Specification-2-0-18fdc5260606806ab573d0a7cba1897a#193dc526060681b4b871e6b761107fba
+// https://github.com/trezor/trezor-firmware/blob/41692dc2cdb937564abe7fecd4bfc3e508adc8d4/docs/common/thp/specification.md#state-hh1
 export const handleHandshakeInit = ({
     handshakeInitResponse,
     thpState,
@@ -185,8 +184,7 @@ export const handleHandshakeInit = ({
 };
 
 export const getCpaceHostKeys = (code: Buffer, handshakeHash: Buffer) => {
-    // TODO: link-to-public-docs
-    // https://www.notion.so/satoshilabs/Pairing-phase-996b0e879fff4ebd9460ae27376fce76
+    // https://github.com/trezor/trezor-firmware/blob/41692dc2cdb937564abe7fecd4bfc3e508adc8d4/docs/common/thp/specification.md#state-hp4
     // If the user enters code, take the following actions:
     // 2. Compute *pregenerator* as the first 32 bytes of SHA-512(*prefix* || *code* - 6 bytes || *padding || h*), where *prefix* is the byte-string  0x08 || 0x43 || 0x50 || 0x61 || 0x63 || 0x65 || 0x32 || 0x35 || 0x35 || 0x06 and *padding* is the byte-string 0x50 || 0x00 ^ 80 || 0x20.
     // 3. Set *generator =* ELLIGATOR2(*pregenerator*).

--- a/packages/protocol/src/protocol-thp/decode.ts
+++ b/packages/protocol/src/protocol-thp/decode.ts
@@ -31,8 +31,7 @@ const decipherMessage = (key: Buffer, recvNonce: number, payload: Buffer, tag: B
     return trezorMaskedStaticPubkey.subarray(1); // NOTE: remove session_id (first byte)
 };
 
-// TODO: link-to-public-docs
-// https://www.notion.so/satoshilabs/THP-Specification-2-0-18fdc5260606806ab573d0a7cba1897a
+// https://github.com/trezor/trezor-firmware/blob/41692dc2cdb937564abe7fecd4bfc3e508adc8d4/docs/common/thp/specification.md#allocation-layer
 // example: 41ffff0020639ba57ff4e0c2343c830a0454335731180220002802280328042801c0171551
 // [magic | channel | len* | nonce               | protobuf: messageType + message          | crc     ]
 // [41    | ffff    | 0020 | 639ba57ff4e0c234    | 3c830a0454335731180220002802280328042801 | c0171551]
@@ -114,8 +113,8 @@ const decodeReadAck = (): ThpMessageResponse => ({
     message: {},
 });
 
-// TODO: link-to-public-docs
-// https://www.notion.so/satoshilabs/THP-Specification-2-0-18fdc5260606806ab573d0a7cba1897a
+// transport error codes
+// https://github.com/trezor/trezor-firmware/blob/41692dc2cdb937564abe7fecd4bfc3e508adc8d4/docs/common/thp/specification.md#allocation-layer
 // example: 42122200050270303cfa
 // [magic | channel | len* | error | crc     ]
 // [42    | 1222    | 0005 | 02    | 70303cfa]

--- a/packages/protocol/src/protocol-thp/encode.ts
+++ b/packages/protocol/src/protocol-thp/encode.ts
@@ -85,8 +85,7 @@ export const encodePayload = (name: string, data: Record<string, unknown>, thpSt
     return Buffer.alloc(0);
 };
 
-// TODO: link-to-public-docs
-// https://www.notion.so/satoshilabs/THP-Specification-2-0-18fdc5260606806ab573d0a7cba1897a
+// https://github.com/trezor/trezor-firmware/blob/41692dc2cdb937564abe7fecd4bfc3e508adc8d4/docs/common/thp/specification.md#allocation-layer
 // example: 40ffff000c639ba57ff4e0c2348189a406
 // [magic | channel | len*  | nonce            | crc     ]
 // [40    | ffff    | 000c  | 639ba57ff4e0c234 | 8189a406]
@@ -127,8 +126,7 @@ const handshakeCompletionRequest = (data: Buffer, channel: Buffer, sendBit: numb
 
 const getPreviousAckBit = (thpState: ThpState) => (thpState.recvAckBit ? 0 : 1);
 
-// TODO: link-to-public-docs
-// https://www.notion.so/satoshilabs/THP-Specification-2-0-18fdc5260606806ab573d0a7cba1897a
+// https://github.com/trezor/trezor-firmware/blob/41692dc2cdb937564abe7fecd4bfc3e508adc8d4/docs/common/thp/specification.md#ack-message-structure
 // example: 2012340004d9fcce58
 // [magic | channel | len  | crc     ]
 // [20    | 1234    | 0004 | d9fcce58]
@@ -176,8 +174,6 @@ const encodeThpMessage = (
     throw new Error(`Unknown Thp message type ${messageType}`);
 };
 
-// TODO: link-to-public-docs
-// https://www.notion.so/satoshilabs/THP-Specification-2-0-18fdc5260606806ab573d0a7cba1897a
 export const encodeProtobufMessage = (
     messageType: number,
     data: Buffer,

--- a/packages/protocol/src/protocol-v2/decode.ts
+++ b/packages/protocol/src/protocol-v2/decode.ts
@@ -3,8 +3,7 @@ import { HEADER_SIZE, MESSAGE_LEN_SIZE, THP_CONTROL_BYTE } from './constants';
 import { getHeaders } from './encode';
 import { type TransportProtocolDecode } from '../types';
 
-// TODO: link-to-public-docs
-// https://github.com/trezor/trezor-firmware/blob/m1nd3r/thp-documentation/docs/common/thp/specification.md#transport-packet-structure
+// https://github.com/trezor/trezor-firmware/blob/41692dc2cdb937564abe7fecd4bfc3e508adc8d4/docs/common/thp/specification.md#transport-packet-structure
 export const decodeCtrlByte = (ctrlByte: number) => {
     // DATA message
     const dataType = ctrlByte & 0xe7;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

self descriptive


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/update-thp-docs/web/](https://dev.suite.sldev.cz/suite-web/chore/update-thp-docs/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/update-thp-docs&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/update-thp-docs&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/update-thp-docs&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect > Error screen | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.signTransaction > TrezorConnect.signTransaction | 🤖 auto |
| TrezorConnect.ethereumSignMessage > TrezorConnect.ethereumSignMessage | 🤖 auto |
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-21T16:54:22.344Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-21T16:54:07.908Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->