### PR TITLE
test(suite): fixes the incorect locator in electorn teardown

### DIFF
--- a/suite/e2e/support/setup.ts
+++ b/suite/e2e/support/setup.ts
@@ -77,7 +77,7 @@ export const electronTeardown = async (
     const closePromise = suite.electronApp.close();
     // Handle modal that asks to enable auto-start
     if (electronConf.exposeConnectWs) {
-        const autoStartQuitButton = suite.window.getByTestId('auto-start-quit-button');
+        const autoStartQuitButton = suite.window.getByTestId('@auto-start-before-quit/button-quit');
         await expect(
             autoStartQuitButton,
             'expected the AutoStart Quit button to be enabled',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fixes a broken locator

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-fix-21-7/web/](https://dev.suite.sldev.cz/suite-web/test-fix-21-7/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-fix-21-7&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-fix-21-7&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-21T17:12:21.986Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.signTransaction > TrezorConnect.signTransaction | 🤖 auto |
| TrezorConnect.ethereumSignMessage > TrezorConnect.ethereumSignMessage | 🤖 auto |
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-21T17:12:13.065Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->