### PR TITLE
feat(suite-sync): enable Suite Sync on Model T with custom relays

### DIFF
--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -229,7 +229,12 @@ export const config: Config = {
             ],
             min: {
                 T1B1: '0',
-                T2T1: '0',
+                // PoC: Model T firmware ships the evolu commands, so the methods are no longer
+                // `no-support`. The secure-element-only `evoluSignRegistrationRequest` is never
+                // invoked on Model T because Suite restricts it to custom relays (see
+                // `canDeviceSignEvoluRegistrationRequest` gate in suite-sync). Replace with the exact
+                // Model T firmware version that introduced evolu.
+                T2T1: '2.11.0',
                 T2B1: '2.11.0',
                 T3B1: '2.11.0',
                 T3T1: '2.11.0',

--- a/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOn.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOn.ts
@@ -12,10 +12,16 @@ import {
 } from '@suite-common/suite-sync-types';
 import { err } from '@trezor/type-utils';
 
-import { isFwUpgradeNeededForSuiteSync, isSuiteSyncSupportedByDevice } from '../suiteSyncUtils';
+import { selectSuiteSyncCustomRelayUrl } from '../relay/relayUrl';
+import { type WithSuiteSyncState } from '../suiteSyncSlice';
+import {
+    canDeviceSignEvoluRegistrationRequest,
+    isFwUpgradeNeededForSuiteSync,
+    isSuiteSyncSupportedByDevice,
+} from '../suiteSyncUtils';
 
 export type EnsureWalletSuiteSyncOnDeps = {
-    getState: () => DeviceRootState;
+    getState: () => DeviceRootState & WithSuiteSyncState;
 } & EnsureSubscribedStorageDep &
     EnsureSuiteSyncKeysDep &
     SubscriptionStorageDep &
@@ -38,6 +44,17 @@ export const createEnsureWalletSuiteSyncOn =
             device && isTrezorDeviceWithState(device) && isSuiteSyncSupportedByDevice(device);
 
         if (!canTurnOnSuiteSync) {
+            return err({ type: 'SuiteSyncUnavailableOnDeviceError' });
+        }
+
+        // Devices that cannot sign the evolu registration request (e.g. Model T) cannot register
+        // with the Quota Manager, so they may only turn on Suite Sync against a custom relay (which
+        // skips QM registration). This prevents a confusing device error from
+        // `evoluSignRegistrationRequest` on the default Trezor relay.
+        if (
+            !canDeviceSignEvoluRegistrationRequest(device) &&
+            selectSuiteSyncCustomRelayUrl(deps.getState()) === null
+        ) {
             return err({ type: 'SuiteSyncUnavailableOnDeviceError' });
         }
 

--- a/suite-common/suite-sync/src/suiteSyncSelectors.ts
+++ b/suite-common/suite-sync/src/suiteSyncSelectors.ts
@@ -8,9 +8,14 @@ import { type EncryptedHex } from '@suite-common/platform-encryption';
 import { type SuiteSyncOwnerSerialized } from '@suite-common/suite-sync-storage';
 import { type StaticSessionId } from '@trezor/connect';
 
+import { selectSuiteSyncCustomRelayUrl } from './relay/relayUrl';
 import { type WithSuiteSyncState } from './suiteSyncSlice';
 import { type SuiteSyncInteraction } from './suiteSyncTypes';
-import { isFwUpgradeNeededForSuiteSync, isSuiteSyncSupportedByDevice } from './suiteSyncUtils';
+import {
+    canDeviceSignEvoluRegistrationRequest,
+    isFwUpgradeNeededForSuiteSync,
+    isSuiteSyncSupportedByDevice,
+} from './suiteSyncUtils';
 
 export type WithSuiteSyncAndDeviceState = WithSuiteSyncState & DeviceRootState;
 
@@ -40,7 +45,14 @@ export const selectIsSuiteSyncInitPossible = (
         return false;
     }
 
-    return device.connected && isSuiteSyncSupportedByDevice(device);
+    return (
+        device.connected &&
+        isSuiteSyncSupportedByDevice(device) &&
+        // Devices that cannot sign the evolu registration request (e.g. Model T) can only sync
+        // against a custom relay, since Quota Manager registration is not possible for them.
+        (canDeviceSignEvoluRegistrationRequest(device) ||
+            selectSuiteSyncCustomRelayUrl(state) !== null)
+    );
 };
 
 export const selectSuiteSyncOwnerForDeviceStaticId = (
@@ -68,6 +80,16 @@ export const selectSuiteSyncInteraction = (
     // IMPORTANT: Order is very important here!
 
     if (!isSuiteSyncSupportedByDevice(device)) {
+        return 'unsupported';
+    }
+
+    // Devices that cannot sign the evolu registration request (e.g. Model T) cannot register with
+    // the Quota Manager, so Suite Sync is only offered when a custom relay is configured
+    // (custom relays skip QM registration).
+    if (
+        !canDeviceSignEvoluRegistrationRequest(device) &&
+        selectSuiteSyncCustomRelayUrl(state) === null
+    ) {
         return 'unsupported';
     }
 

--- a/suite-common/suite-sync/src/suiteSyncUtils.ts
+++ b/suite-common/suite-sync/src/suiteSyncUtils.ts
@@ -1,8 +1,26 @@
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { type Device } from '@trezor/connect';
+import { DeviceModelInternal } from '@trezor/device-utils';
 import { exhaustive } from '@trezor/type-utils';
 
 import { type SuiteSyncInteraction } from './suiteSyncTypes';
+
+// Signing the evolu registration request produces a secure-element attestation certificate chain,
+// which is what the Quota Manager verifies. Devices without a secure element cannot produce it, so
+// they cannot register with the Quota Manager. They can still derive Suite Sync keys (evoluGetNode /
+// evoluGetDelegatedIdentityKey) and sync against a custom relay, which does not require QM registration.
+const MODELS_WITHOUT_EVOLU_REGISTRATION_SUPPORT: DeviceModelInternal[] = [
+    DeviceModelInternal.T1B1,
+    DeviceModelInternal.T2T1,
+];
+
+export const canDeviceSignEvoluRegistrationRequest = (
+    device: Device | TrezorDevice | undefined,
+): boolean => {
+    const model = device?.features?.internal_model;
+
+    return model === undefined || !MODELS_WITHOUT_EVOLU_REGISTRATION_SUPPORT.includes(model);
+};
 
 export const isFwUpgradeNeededForSuiteSync = (device: Device | TrezorDevice | undefined): boolean =>
     device?.unavailableCapabilities?.evolu !== undefined &&


### PR DESCRIPTION
## Description

Allow Model T (no secure element) to use Suite Sync against custom relays by unblocking the evolu key methods in Connect and gating Quota Manager registration behind devices that can sign the evolu registration request.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/suite-sync-devices/web/](https://dev.suite.sldev.cz/suite-web/suite-sync-devices/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=suite-sync-devices&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=suite-sync-devices&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=suite-sync-devices&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.signTransaction > TrezorConnect.signTransaction | 🤖 auto |
| TrezorConnect.ethereumSignMessage > TrezorConnect.ethereumSignMessage | 🤖 auto |
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-21T20:17:15.558Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-21T20:16:17.962Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->