### PR TITLE
Update release suite coin icons

### DIFF
--- a/.github/workflows/release-suite-coin-icons.yml
+++ b/.github/workflows/release-suite-coin-icons.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::538326561891:role/gh_actions_suite_production_icons
           aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: 900 # The default 1h, 15min is enough for our use case
 
       - name: Upload crypto icons
         # The local folder contains only files produced by this run (fresh checkout, the script


### PR DESCRIPTION
## Description

- Decrease aws credentials validity from 1h to 15min for crypto icons.
- [The first successful run (uncached) with the improved script took ~11min](https://github.com/trezor/trezor-suite/actions/runs/29838431299/job/88660750576). The successive runs (cached) take a few seconds.   

## Related Issue

Resolve #30115
