### PR TITLE
fix(suite-desktop): precision for eth deposits

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx
@@ -1,7 +1,6 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Row, Text } from '@trezor/components';
 import { TokenIcon } from '@trezor/product-components';
-import { BigNumber } from '@trezor/utils';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 
@@ -17,30 +16,25 @@ type YieldTokenValueProps = {
     'data-testid'?: string;
 };
 
-export const YieldTokenValue = ({
-    token,
-    amount,
-    'data-testid': dataTestId,
-}: YieldTokenValueProps) => {
-    const roundedAmount = new BigNumber(amount).decimalPlaces(2, BigNumber.ROUND_DOWN).toFixed();
-
-    return (
-        <Row alignItems="center" gap={8}>
-            <TokenIcon
-                size={24}
-                symbol={token.networkSymbol}
-                contractAddress={token.contractAddress}
-                placeholder={token.symbol}
-                showNetworkIcon
-                isBordered={false}
-            />
-            <Text typographyStyle="body-md-strong">
-                <FormattedCryptoAmount
-                    value={roundedAmount}
-                    symbol={token.symbol}
-                    data-testid={dataTestId}
-                />
-            </Text>
-        </Row>
-    );
-};
+export const YieldTokenValue = ({ token, amount }: YieldTokenValueProps) => (
+    <Row alignItems="center" gap={8}>
+        <TokenIcon
+            size={24}
+            symbol={token.networkSymbol}
+            contractAddress={token.contractAddress}
+            placeholder={token.symbol}
+            showNetworkIcon
+            isBordered={false}
+        />
+        <Text typographyStyle="body-md-strong">
+            {/*
+                `isBalance` runs the amount through `formatCoinBalance`, which keeps the leading
+                significant digits and appends an ellipsis (…) once the fractional part gets too
+                long. This keeps the rendered width bounded (no more layout jitter) while still
+                showing the meaningful digits of small stablecoin/WETH amounts — a fixed decimal
+                cap instead rounded those down to zeroes.
+            */}
+            <FormattedCryptoAmount value={amount} symbol={token.symbol} isBalance />
+        </Text>
+    </Row>
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Straightforward fix with specific formatting for detected wrapped native token used.

## Notes for QA



## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29883

## Screenshots


<img width="592" height="491" alt="Screenshot 2026-07-23 at 14 36 12" src="https://github.com/user-attachments/assets/f33ca29d-7e75-4eb6-8259-35691edf422b" />
<img width="605" height="481" alt="Screenshot 2026-07-23 at 14 35 24" src="https://github.com/user-attachments/assets/a3fa1314-8f07-41b8-840e-4c749c797cc0" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/yield-weth-precision&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->