### PR TITLE
fix(suite): Fix shortcut collision

### DIFF
--- a/packages/suite/src/components/guide/GuideShortcuts.tsx
+++ b/packages/suite/src/components/guide/GuideShortcuts.tsx
@@ -92,11 +92,11 @@ const walletsSection: ShortcutSection = {
         },
         {
             labelId: 'TR_GUIDE_KEYBOARD_SHORTCUTS_DASHBOARD',
-            keys: ['ALT', 'KEY_0'],
+            keys: ['MOD', 'ALT', 'KEY_0'],
         },
         {
             labelId: 'TR_GUIDE_KEYBOARD_SHORTCUTS_SWITCH_ACCOUNT',
-            keys: ['ALT', 'KEY_1'],
+            keys: ['MOD', 'ALT', 'KEY_1'],
         },
         {
             labelId: 'TR_GUIDE_KEYBOARD_SHORTCUTS_PREV_ACCOUNT',

--- a/packages/suite/src/hooks/suite/useAppShortcuts.tsx
+++ b/packages/suite/src/hooks/suite/useAppShortcuts.tsx
@@ -52,6 +52,7 @@ export const useAppShortcuts = () => {
         const cmdOrCtrl = metaKey || ctrlKey;
         // Most shortcuts use ALT alone; exclude the other modifiers to avoid clashes.
         const altOnly = altKey && !shiftKey && !cmdOrCtrl;
+        const cmdOrCtrlAndAlt = cmdOrCtrl && altKey && !shiftKey;
 
         const gotoAccount = (account: ListedAccount | undefined) =>
             dispatch(
@@ -198,8 +199,8 @@ export const useAppShortcuts = () => {
                 ?.click();
         }
 
-        // press ALT + 0 to open the Dashboard, ALT + 1-9 to quick-switch between accounts
-        if (altOnly && isDeviceSelected) {
+        // press CMD/CTRL + ALT + 0 to open the Dashboard, CMD/CTRL + ALT + 1-9 to quick-switch between accounts
+        if (cmdOrCtrlAndAlt && isDeviceSelected) {
             if (e.code === KEYBOARD_CODE.DIGIT_ZERO) {
                 e.preventDefault();
                 dispatch(goto({ routeName: 'suite-index' }));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

changes shortcuts `OPT + number` for `OPT + CMD + number` 

related to following shortcuts:
- switch accounts
- dashboard

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="320" height="75" alt="image" src="https://github.com/user-attachments/assets/04bcffe5-7e50-420e-b47f-226f0e90a457" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-shortcut-collision&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-22T09:36:21.094Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->