### PR TITLE
fix(suite-native-30176): fix multiple trade form issues after enabling React Compiler

### DIFF
--- a/suite-native/forms/src/Form.tsx
+++ b/suite-native/forms/src/Form.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, createContext } from 'react';
 import { type FieldValues, type UseFormReturn } from 'react-hook-form';
 
-export type { FieldValues, Path, UseFormReturn, FieldPathValue } from 'react-hook-form';
+export type { FieldValues, Path, UseFormReturn, FieldPathValue, Control } from 'react-hook-form';
 
 export interface FormProps<TFieldValues extends FieldValues> {
     children?: ReactNode;

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -87,7 +87,6 @@
         "@trezor/utils": "workspace:*",
         "expo-linear-gradient": "~56.0.4",
         "react": "19.2.3",
-        "react-hook-form": "^7.77.0",
         "react-intl": "^8.1.3",
         "react-native": "0.85.3",
         "react-native-gesture-handler": "2.31.1",

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -87,6 +87,7 @@
         "@trezor/utils": "workspace:*",
         "expo-linear-gradient": "~56.0.4",
         "react": "19.2.3",
+        "react-hook-form": "^7.77.0",
         "react-intl": "^8.1.3",
         "react-native": "0.85.3",
         "react-native-gesture-handler": "2.31.1",

--- a/suite-native/module-trading/src/components/buy/BuyAlert.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyAlert.tsx
@@ -1,9 +1,11 @@
+import { useWatch } from '@suite-native/forms';
+
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
 import { GeneralAlert } from '../general/GeneralAlert';
 
 export const BuyAlert = () => {
-    const { watch } = useBuyFormContext();
-    const text = watch('generalAlert');
+    const { control } = useBuyFormContext();
+    const text = useWatch({ control, name: 'generalAlert' });
 
     return <GeneralAlert text={text} />;
 };

--- a/suite-native/module-trading/src/components/buy/BuyCard.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyCard.tsx
@@ -1,4 +1,5 @@
 import { Box, HStack } from '@suite-native/atoms';
+import { useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 import { CryptoToFiatValueBadge } from '@suite-native/trading-quote-utils';
 
@@ -19,9 +20,8 @@ type BuyCardProps = {
 const BUY_CARD_TEST_ID = '@trading/buyCard';
 
 export const BuyCard = ({ isAmountInputActive, shouldAnimateEntering }: BuyCardProps) => {
-    const { watch } = useBuyFormContext();
-
-    const [cryptoValue, asset] = watch(['cryptoValue', 'asset']);
+    const { control } = useBuyFormContext();
+    const [cryptoValue, asset] = useWatch({ control, name: ['cryptoValue', 'asset'] });
 
     return (
         <TradingCard

--- a/suite-native/module-trading/src/components/buy/BuyConfirmation.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyConfirmation.tsx
@@ -1,6 +1,7 @@
 import { type AnimatedProps, FadeIn, FadeOutDown } from 'react-native-reanimated';
 
 import { AnimatedBox, Button } from '@suite-native/atoms';
+import { useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 
 import { useBuyFlow } from '../../hooks/buy/useBuyFlow';
@@ -28,7 +29,10 @@ const ContinueButton = ({ selectQuote }: ContinueButtonProps) => (
 export const BuyConfirmation = ({ enteringAnimation }: ConfirmationProps) => {
     const form = useBuyFormContext();
     const { canProceed, selectQuote } = useBuyFlow(form);
-    const [receiveCryptoId, quote] = form.watch(['asset.cryptoId', 'quote']);
+    const [receiveCryptoId, quote] = useWatch({
+        control: form.control,
+        name: ['asset.cryptoId', 'quote'],
+    });
 
     const { isReceivingInactiveStellarToken, activateButtonElement } =
         useTradingStellarActivateToken({

--- a/suite-native/module-trading/src/components/buy/BuyCryptoAmountInput.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyCryptoAmountInput.tsx
@@ -3,6 +3,7 @@ import { type TextInput } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import { selectTradingBuyIsLoading } from '@suite-common/trading';
+import { useWatch } from '@suite-native/forms';
 import { useAmountInputTransformers } from '@suite-native/helpers';
 import { useTranslate } from '@suite-native/intl';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
@@ -21,8 +22,11 @@ const CRYPTO_AMOUNT_TEST_ID = '@trading/buy/crypto-amount-input';
 export const BuyCryptoAmountInput = forwardRef<TextInput, CryptoAmountInputProps>(
     ({ showAssetsSheet }, ref) => {
         const { translate } = useTranslate();
-        const { watch } = useBuyFormContext();
-        const [amountInCrypto, asset] = watch(['amountInCrypto', 'asset']);
+        const { control } = useBuyFormContext();
+        const [amountInCrypto, asset] = useWatch({
+            control,
+            name: ['amountInCrypto', 'asset'],
+        });
         const symbol = getSymbolFromTradeableAsset(asset);
         const { cryptoAmountTransformer } = useAmountInputTransformers(symbol);
         const isLoading = useSelector(selectTradingBuyIsLoading);

--- a/suite-native/module-trading/src/components/buy/BuyFiatAmountInput.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFiatAmountInput.tsx
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { selectTradingBuyIsLoading } from '@suite-common/trading';
+import { useWatch } from '@suite-native/forms';
 import { useAmountInputTransformers } from '@suite-native/helpers';
 import { useTranslate } from '@suite-native/intl';
 import { MAX_FIAT_DECIMALS } from '@suite-native/trading-consts';
@@ -13,12 +14,12 @@ const FIAT_AMOUNT_TEST_ID = '@trading/buy/fiat-amount-input';
 
 export const BuyFiatAmountInput = () => {
     const { translate } = useTranslate();
-    const { watch } = useBuyFormContext();
+    const { control } = useBuyFormContext();
     const { fiatAmountTransformer } = useAmountInputTransformers(undefined);
     const isLoading = useSelector(selectTradingBuyIsLoading);
     const inputControls = useBuyInputFormControls('fiatValue');
 
-    const amountInCrypto = watch('amountInCrypto');
+    const amountInCrypto = useWatch({ control, name: 'amountInCrypto' });
 
     return (
         <AmountInput

--- a/suite-native/module-trading/src/components/buy/BuyFiatCurrencyPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFiatCurrencyPicker.tsx
@@ -1,4 +1,11 @@
+import { useDispatch } from 'react-redux';
+
+import type { FiatCurrencyCode } from 'invity-api';
+
+import { useServices } from '@suite-common/dependency-injection';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { HStack } from '@suite-native/atoms';
+import { buyActions } from '@suite-native/trading-state';
 
 import { BuyFiatAmountInput } from './BuyFiatAmountInput';
 import { BuyFiatCurrencySheet } from './BuyFiatCurrencySheet';
@@ -9,9 +16,29 @@ import { FiatCurrencyButton } from '../general/FiatCurrencyButton';
 const FIAT_CURRENCY_PICKER_TEST_ID = '@trading/buy/fiat-button';
 
 export const BuyFiatCurrencyPicker = () => {
+    const dispatch = useDispatch();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const form = useBuyFormContext();
     const { isSheetVisible, hideSheet, showSheet, setSelectedValue, selectedValue } =
         useSheetControls(form, 'fiatCurrency');
+
+    const handleFiatSelect = (fiatCurrency: FiatCurrencyCode) => {
+        if (fiatCurrency === selectedValue) {
+            return;
+        }
+
+        setSelectedValue(fiatCurrency);
+        form.setValue('fiatValue', undefined, { shouldValidate: true });
+        form.setValue('cryptoValue', undefined, { shouldValidate: true });
+        dispatch(buyActions.fiatCurrencyChanged());
+        analytics.report({
+            type: events.tradingParameterChangedEvent.name,
+            payload: {
+                type: 'buy',
+                parameter: 'fiat',
+            },
+        });
+    };
 
     return (
         <>
@@ -26,7 +53,7 @@ export const BuyFiatCurrencyPicker = () => {
             <BuyFiatCurrencySheet
                 isVisible={isSheetVisible}
                 onClose={hideSheet}
-                onFiatSelect={setSelectedValue}
+                onFiatSelect={handleFiatSelect}
                 searchInputTestId="@trading/buy/fiat-search-input"
             />
         </>

--- a/suite-native/module-trading/src/components/buy/BuyForm.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyForm.tsx
@@ -78,7 +78,7 @@ const BuyFormMemoized = memo(
 
 export const BuyForm = ({ shouldAnimateEntering }: BuyFormProps) => {
     const buyForm = useBuyFormContext();
-    const isAmountInputActiveDebounced = useFocusedValueWatch(buyForm.watch);
+    const isAmountInputActiveDebounced = useFocusedValueWatch(buyForm.control);
     useBuyQuotes(buyForm);
 
     return (

--- a/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.tsx
@@ -5,7 +5,7 @@ import { useFormatters } from '@suite-common/formatters';
 import { selectTradingBuyIsLoading } from '@suite-common/trading';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { Badge } from '@suite-native/atoms';
-import { useField } from '@suite-native/forms';
+import { useField, useWatch } from '@suite-native/forms';
 import { truncateDecimals } from '@suite-native/helpers';
 import { useTranslate } from '@suite-native/intl';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
@@ -23,17 +23,15 @@ export type BuyFormFieldErrorBadgeProps = PropsWithChildren<{
 const asNonEmptyStringValue = (value: unknown): string => (value as string) ?? '0';
 
 const useMismatchedAmountMessage = (fieldName: keyof BuyFormValues) => {
-    const { watch } = useBuyFormContext();
+    const { control } = useBuyFormContext();
     const { translate } = useTranslate();
     const { CryptoAmountFormatter, BaseCurrencyAmountFormatter } = useFormatters();
     const { convertStrToBaseUnit } = useConvertFormValueToBaseUnit();
 
-    const [asset, quote, amountInCrypto, value] = watch([
-        'asset',
-        'quote',
-        'amountInCrypto',
-        fieldName,
-    ]);
+    const [asset, quote, amountInCrypto, value] = useWatch({
+        control,
+        name: ['asset', 'quote', 'amountInCrypto', fieldName],
+    });
     const symbol = getSymbolFromTradeableAsset(asset);
 
     if (!quote) {

--- a/suite-native/module-trading/src/components/buy/BuyReceiveAccountCryptoBalance.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyReceiveAccountCryptoBalance.tsx
@@ -1,11 +1,16 @@
+import { useWatch } from '@suite-native/forms';
+
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
 import { TradeableAssetAccountBalance } from '../general/TradeableAssetAccountBalance';
 
 export const RECEIVE_ACCOUNT_BALANCE_TEST_ID = '@trading/buy/receive-account-balance';
 
 export const BuyReceiveAccountCryptoBalance = () => {
-    const { watch } = useBuyFormContext();
-    const [asset, receiveAccount] = watch(['asset', 'receiveAccount']);
+    const { control } = useBuyFormContext();
+    const [asset, receiveAccount] = useWatch({
+        control,
+        name: ['asset', 'receiveAccount'],
+    });
 
     return (
         <TradeableAssetAccountBalance

--- a/suite-native/module-trading/src/components/buy/BuyReceiveAccountPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyReceiveAccountPicker.tsx
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux';
 
+import { useWatch } from '@suite-native/forms';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import { selectBuySelectedReceiveAccount } from '@suite-native/trading-state';
 
@@ -9,10 +10,10 @@ import { ReceiveAccountPicker } from '../general/ReceiveAccount/ReceiveAccountPi
 const RECEIVE_ACCOUNT_PICKER_TEST_ID = '@trading/buy/receive-account';
 
 export const BuyReceiveAccountPicker = () => {
-    const { watch } = useBuyFormContext();
+    const { control } = useBuyFormContext();
     const selectedReceiveAccount = useSelector(selectBuySelectedReceiveAccount);
 
-    const asset = watch('asset');
+    const asset = useWatch({ control, name: 'asset' });
     const selectedSymbol = getSymbolFromTradeableAsset(asset);
 
     return (

--- a/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.tsx
@@ -1,10 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { type TextInput } from 'react-native';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { selectHasBitcoinOnlyFirmware } from '@suite-common/device';
+import { cryptoIdToSymbol } from '@suite-common/trading';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { HStack } from '@suite-native/atoms';
-import { selectBuyTradeableAssets } from '@suite-native/trading-state';
+import { buyActions, selectBuyTradeableAssets } from '@suite-native/trading-state';
 import { type TradeableAsset } from '@suite-native/trading-types';
 import { noop } from '@trezor/utils';
 
@@ -17,6 +20,8 @@ import { SelectTradeableAssetButton } from '../general/SelectTradeableAssetButto
 const ASSET_PICKER_TEST_ID = '@trading/buy/asset-receive-button';
 
 export const BuyTradeableAssetPicker = () => {
+    const dispatch = useDispatch();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const inputRef = useRef<TextInput>(null);
     const form = useBuyFormContext();
     const [shouldFocusInput, setShouldFocusInput] = useState<boolean>(false);
@@ -27,15 +32,51 @@ export const BuyTradeableAssetPicker = () => {
 
     const btcAsset = useMemo(() => assets.find(asset => asset.cryptoId === 'bitcoin'), [assets]);
 
+    const changeAsset = useCallback(
+        ({
+            asset,
+            shouldReportAnalytics,
+        }: {
+            asset: TradeableAsset;
+            shouldReportAnalytics: boolean;
+        }) => {
+            if (asset.cryptoId === selectedValue?.cryptoId) {
+                return;
+            }
+
+            const previousSymbol = cryptoIdToSymbol(selectedValue?.cryptoId);
+            const symbol = cryptoIdToSymbol(asset.cryptoId);
+
+            setSelectedValue(asset);
+            form.setValue('cryptoValue', undefined, { shouldValidate: true });
+            dispatch(
+                previousSymbol === symbol
+                    ? buyActions.assetTokenChanged()
+                    : buyActions.assetChanged(),
+            );
+
+            if (shouldReportAnalytics) {
+                analytics.report({
+                    type: events.tradingParameterChangedEvent.name,
+                    payload: {
+                        type: 'buy',
+                        parameter: 'cryptoTo',
+                    },
+                });
+            }
+        },
+        [analytics, dispatch, form, selectedValue?.cryptoId, setSelectedValue],
+    );
+
     useEffect(() => {
-        if (hasBitcoinOnlyFirmware && selectedValue?.cryptoId !== btcAsset?.cryptoId) {
-            setSelectedValue(btcAsset);
+        if (hasBitcoinOnlyFirmware && btcAsset) {
+            changeAsset({ asset: btcAsset, shouldReportAnalytics: false });
         }
-    }, [hasBitcoinOnlyFirmware, btcAsset, selectedValue, setSelectedValue]);
+    }, [hasBitcoinOnlyFirmware, btcAsset, changeAsset]);
 
     const onAssetSelect = useCallback(
         (asset: TradeableAsset) => {
-            setSelectedValue(asset);
+            changeAsset({ asset, shouldReportAnalytics: true });
             if (shouldFocusInput) {
                 setShouldFocusInput(false);
                 // CryptoAmountInput is rendered disabled allow changes to propagate
@@ -44,7 +85,7 @@ export const BuyTradeableAssetPicker = () => {
                 }, 0);
             }
         },
-        [shouldFocusInput, setSelectedValue],
+        [changeAsset, shouldFocusInput],
     );
 
     const showAssetsSheet = useCallback(() => {

--- a/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.tsx
@@ -1,11 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { type TextInput } from 'react-native';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
-import { useServices } from '@suite-common/dependency-injection';
 import { selectHasBitcoinOnlyFirmware } from '@suite-common/device';
-import { cryptoIdToSymbol } from '@suite-common/trading';
-import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { HStack } from '@suite-native/atoms';
 import { buyActions, selectBuyTradeableAssets } from '@suite-native/trading-state';
 import { type TradeableAsset } from '@suite-native/trading-types';
@@ -14,14 +11,13 @@ import { noop } from '@trezor/utils';
 import { BuyCryptoAmountInput } from './BuyCryptoAmountInput';
 import { BuyTradeableAssetsSheet } from './BuyTradeableAssetsSheet';
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
+import { useTradeableAssetChange } from '../../hooks/general/form/useTradeableAssetChange';
 import { useSheetControls } from '../../hooks/general/useSheetControls';
 import { SelectTradeableAssetButton } from '../general/SelectTradeableAssetButton';
 
 const ASSET_PICKER_TEST_ID = '@trading/buy/asset-receive-button';
 
 export const BuyTradeableAssetPicker = () => {
-    const dispatch = useDispatch();
-    const { analytics } = useServices(selectNativeAnalyticsDep);
     const inputRef = useRef<TextInput>(null);
     const form = useBuyFormContext();
     const [shouldFocusInput, setShouldFocusInput] = useState<boolean>(false);
@@ -32,51 +28,26 @@ export const BuyTradeableAssetPicker = () => {
 
     const btcAsset = useMemo(() => assets.find(asset => asset.cryptoId === 'bitcoin'), [assets]);
 
-    const changeAsset = useCallback(
-        ({
-            asset,
-            shouldReportAnalytics,
-        }: {
-            asset: TradeableAsset;
-            shouldReportAnalytics: boolean;
-        }) => {
-            if (asset.cryptoId === selectedValue?.cryptoId) {
-                return;
-            }
-
-            const previousSymbol = cryptoIdToSymbol(selectedValue?.cryptoId);
-            const symbol = cryptoIdToSymbol(asset.cryptoId);
-
-            setSelectedValue(asset);
-            form.setValue('cryptoValue', undefined, { shouldValidate: true });
-            dispatch(
-                previousSymbol === symbol
-                    ? buyActions.assetTokenChanged()
-                    : buyActions.assetChanged(),
-            );
-
-            if (shouldReportAnalytics) {
-                analytics.report({
-                    type: events.tradingParameterChangedEvent.name,
-                    payload: {
-                        type: 'buy',
-                        parameter: 'cryptoTo',
-                    },
-                });
-            }
-        },
-        [analytics, dispatch, form, selectedValue?.cryptoId, setSelectedValue],
-    );
+    const changeAsset = useTradeableAssetChange({
+        form,
+        tradingType: 'buy',
+        selectedValue,
+        setSelectedValue,
+        analyticsParameter: 'cryptoTo',
+        amountField: 'cryptoValue',
+        getAssetChangedAction: buyActions.assetChanged,
+        getAssetTokenChangedAction: buyActions.assetTokenChanged,
+    });
 
     useEffect(() => {
         if (hasBitcoinOnlyFirmware && btcAsset) {
-            changeAsset({ asset: btcAsset, shouldReportAnalytics: false });
+            changeAsset(btcAsset, undefined, { shouldReportAnalytics: false });
         }
     }, [hasBitcoinOnlyFirmware, btcAsset, changeAsset]);
 
     const onAssetSelect = useCallback(
         (asset: TradeableAsset) => {
-            changeAsset({ asset, shouldReportAnalytics: true });
+            changeAsset(asset);
             if (shouldFocusInput) {
                 setShouldFocusInput(false);
                 // CryptoAmountInput is rendered disabled allow changes to propagate

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyConfirmation.test.tsx
@@ -11,9 +11,14 @@ jest.mock('../../../hooks/buy/useBuyFlow', () => ({
     useBuyFlow: jest.fn(),
 }));
 
+jest.mock('@suite-native/forms', () => ({
+    ...jest.requireActual('@suite-native/forms'),
+    useWatch: () => [undefined, undefined],
+}));
+
 jest.mock('../../../hooks/buy/useBuyFormContext', () => ({
     useBuyFormContext: () => ({
-        watch: jest.fn().mockReturnValue([undefined, undefined]),
+        control: undefined,
     }),
 }));
 

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyCryptoAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyCryptoAmountInput.test.tsx
@@ -106,6 +106,20 @@ describe('BuyCryptoAmountInput', () => {
         ).toHaveDisplayValue('1.123');
     });
 
+    it('should preserve a leading-zero decimal while typing', async () => {
+        const form = renderUseTradingBuyForm();
+        act(() => {
+            form.setValue('asset', btcAsset);
+        });
+        const { getByLabelText } = renderCryptoAmountInput({}, form);
+        const input = getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel'));
+
+        await userEvent.type(input, '0.0001');
+
+        expect(form.getValues('cryptoValue')).toEqual('0.0001');
+        expect(input).toHaveDisplayValue('0.0001');
+    });
+
     it('should format input value to be integer when BTC asset is selected and value should be displayed in sats', async () => {
         const preloadedState = {
             wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencyPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencyPicker.test.tsx
@@ -1,20 +1,28 @@
-import { deviceInitialState } from '@suite-common/device';
 import { type useListDataFilter } from '@suite-common/trading';
+import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { Form } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
 import {
+    type TestStore,
     act,
     fireEvent,
     renderHookWithStoreProvider,
     renderWithStoreProvider,
     screen,
 } from '@suite-native/test-utils-store';
-import { getInitializedTradingState } from '@suite-native/trading-fixtures';
+import { buyActions } from '@suite-native/trading-state';
+import { type BuyFormType } from '@suite-native/trading-types';
 
+import { createTradingLightStore } from '../../../__tests__/tradingTestUtils';
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
 import { BuyFiatCurrencyPicker } from '../BuyFiatCurrencyPicker';
 
 let mockUseListDataFilter: typeof useListDataFilter;
+const reportMock = jest.fn();
+const services: NativeAnalyticsDep = {
+    analytics: mockNativeAnalytics(reportMock),
+};
 
 jest.mock('@suite-common/trading', () => ({
     ...jest.requireActual('@suite-common/trading'),
@@ -23,28 +31,30 @@ jest.mock('@suite-common/trading', () => ({
 }));
 
 describe('BuyFiatCurrencyPicker', () => {
+    let form: BuyFormType;
+    let store: TestStore;
+
     beforeEach(() => {
         mockUseListDataFilter = jest.requireActual('@suite-common/trading').useListDataFilter;
+        reportMock.mockClear();
+        store = createTradingLightStore({ tradeType: 'buy' });
+        const { result } = renderHookWithStoreProvider(() => useBuyForm(), {
+            services,
+            store,
+        });
+        form = result.current;
     });
 
-    const renderFiatCurrencyPicker = () => {
-        const preloadedState = {
-            device: deviceInitialState,
-            wallet: { trading: getInitializedTradingState() },
-        };
-        const { result } = renderHookWithStoreProvider(() => useBuyForm(), {
-            preloadedState,
-        });
-
-        return renderWithStoreProvider(
-            <Form form={result.current}>
+    const renderFiatCurrencyPicker = () =>
+        renderWithStoreProvider(
+            <Form form={form}>
                 <BuyFiatCurrencyPicker />
             </Form>,
             {
-                preloadedState,
+                services,
+                store,
             },
         );
-    };
 
     afterEach(() => {
         screen.unmount();
@@ -70,6 +80,28 @@ describe('BuyFiatCurrencyPicker', () => {
         expect(
             getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')),
         ).toHaveTextContent(/USD/);
+    });
+
+    it('should apply buy fiat currency change effects on selection', async () => {
+        form.setValue('fiatValue', '100');
+        form.setValue('cryptoValue', '0.1');
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+        const { getByText, getByLabelText } = renderFiatCurrencyPicker();
+
+        fireEvent.press(getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')));
+        fireEvent.press(getByText('USD'));
+        await act(() => Promise.resolve());
+
+        expect(form.getValues('fiatValue')).toBeUndefined();
+        expect(form.getValues('cryptoValue')).toBeUndefined();
+        expect(dispatchSpy).toHaveBeenCalledWith(buyActions.fiatCurrencyChanged());
+        expect(reportMock).toHaveBeenCalledWith({
+            type: events.tradingParameterChangedEvent.name,
+            payload: {
+                type: 'buy',
+                parameter: 'fiat',
+            },
+        });
     });
 
     it('should display empty component when filtered data is empty', () => {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyTradeableAssetPicker.test.tsx
@@ -4,6 +4,7 @@ import { Form } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
 import { act } from '@suite-native/test-utils';
 import { type TestStore, fireEvent, screen } from '@suite-native/test-utils-store';
+import { ethAsset } from '@suite-native/trading-fixtures';
 import { buyActions } from '@suite-native/trading-state';
 import { type BuyFormType } from '@suite-native/trading-types';
 import { FirmwareType } from '@trezor/connect';
@@ -84,15 +85,35 @@ describe('BuyTradeableAssetPicker', () => {
             expect(getByLabelText('USDC')).toBeTruthy();
         });
 
-        it('should apply buy asset change effects on item press', () => {
+        it('should apply buy asset change effects on cross-network item press', async () => {
             form.setValue('cryptoValue', '0.1');
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { getByLabelText } = renderTradeableAssetPicker();
+            const { getByLabelText } = await renderTradeableAssetPicker();
 
             fireEvent.press(getByLabelText('Bitcoin'));
 
             expect(form.getValues('cryptoValue')).toBeUndefined();
             expect(dispatchSpy).toHaveBeenCalledWith(buyActions.assetChanged());
+            expect(reportMock).toHaveBeenCalledWith({
+                type: events.tradingParameterChangedEvent.name,
+                payload: {
+                    type: 'buy',
+                    parameter: 'cryptoTo',
+                },
+            });
+        });
+
+        it('should dispatch assetTokenChanged when switching between assets on the same network', async () => {
+            form.setValue('asset', ethAsset);
+            form.setValue('cryptoValue', '0.1');
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const { getByLabelText } = await renderTradeableAssetPicker();
+
+            fireEvent.press(getByLabelText('USDC'));
+
+            expect(form.getValues('cryptoValue')).toBeUndefined();
+            expect(dispatchSpy).toHaveBeenCalledWith(buyActions.assetTokenChanged());
+            expect(dispatchSpy).not.toHaveBeenCalledWith(buyActions.assetChanged());
             expect(reportMock).toHaveBeenCalledWith({
                 type: events.tradingParameterChangedEvent.name,
                 payload: {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyTradeableAssetPicker.test.tsx
@@ -1,7 +1,10 @@
+import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { Form } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
 import { act } from '@suite-native/test-utils';
 import { type TestStore, fireEvent, screen } from '@suite-native/test-utils-store';
+import { buyActions } from '@suite-native/trading-state';
 import { type BuyFormType } from '@suite-native/trading-types';
 import { FirmwareType } from '@trezor/connect';
 
@@ -12,6 +15,11 @@ import {
 } from '../../../__tests__/tradingTestUtils';
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
 import { BuyTradeableAssetPicker } from '../BuyTradeableAssetPicker';
+
+const reportMock = jest.fn();
+const services: NativeAnalyticsDep = {
+    analytics: mockNativeAnalytics(reportMock),
+};
 
 describe('BuyTradeableAssetPicker', () => {
     let store: TestStore;
@@ -27,6 +35,7 @@ describe('BuyTradeableAssetPicker', () => {
 
     const renderFormHook = () => {
         const { result } = renderHookWithTradingProvider(() => useBuyForm(), {
+            services,
             store,
         });
 
@@ -38,7 +47,7 @@ describe('BuyTradeableAssetPicker', () => {
             <Form form={form}>
                 <BuyTradeableAssetPicker />
             </Form>,
-            { store },
+            { services, store },
         );
         await act(async () => {
             await act(() => Promise.resolve());
@@ -53,6 +62,7 @@ describe('BuyTradeableAssetPicker', () => {
 
     describe('with regular firmware', () => {
         beforeEach(() => {
+            reportMock.mockClear();
             store = initPreloadedStore(FirmwareType.Universal);
             form = renderFormHook();
         });
@@ -73,10 +83,29 @@ describe('BuyTradeableAssetPicker', () => {
             expect(getByLabelText('Bitcoin')).toBeTruthy();
             expect(getByLabelText('USDC')).toBeTruthy();
         });
+
+        it('should apply buy asset change effects on item press', () => {
+            form.setValue('cryptoValue', '0.1');
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const { getByLabelText } = renderTradeableAssetPicker();
+
+            fireEvent.press(getByLabelText('Bitcoin'));
+
+            expect(form.getValues('cryptoValue')).toBeUndefined();
+            expect(dispatchSpy).toHaveBeenCalledWith(buyActions.assetChanged());
+            expect(reportMock).toHaveBeenCalledWith({
+                type: events.tradingParameterChangedEvent.name,
+                payload: {
+                    type: 'buy',
+                    parameter: 'cryptoTo',
+                },
+            });
+        });
     });
 
     describe('with BTC-only firmware', () => {
         beforeEach(() => {
+            reportMock.mockClear();
             store = initPreloadedStore(FirmwareType.BitcoinOnly);
             form = renderFormHook();
         });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyTradeableAssetPicker.test.tsx
@@ -1,10 +1,16 @@
+import { tradingBuyActions } from '@suite-common/trading';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { Form } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
 import { act } from '@suite-native/test-utils';
-import { type TestStore, fireEvent, screen } from '@suite-native/test-utils-store';
-import { ethAsset } from '@suite-native/trading-fixtures';
+import { type TestStore, fireEvent, screen, waitFor } from '@suite-native/test-utils-store';
+import {
+    MOCK_ACCOUNT_DEVICE_SESSION_ID,
+    eth1NormalAccount,
+    eth2legacyAccount,
+    ethAsset,
+} from '@suite-native/trading-fixtures';
 import { buyActions } from '@suite-native/trading-state';
 import { type BuyFormType } from '@suite-native/trading-types';
 import { FirmwareType } from '@trezor/connect';
@@ -22,6 +28,9 @@ const services: NativeAnalyticsDep = {
     analytics: mockNativeAnalytics(reportMock),
 };
 
+const eth1AccountKey = eth1NormalAccount.key;
+const eth2AccountKey = eth2legacyAccount.key;
+
 describe('BuyTradeableAssetPicker', () => {
     let store: TestStore;
     let form: BuyFormType;
@@ -31,6 +40,21 @@ describe('BuyTradeableAssetPicker', () => {
             tradeType: 'buy',
             overrides: {
                 device: { selectedDevice: { firmwareType } },
+            },
+        });
+
+    // Account preselection needs a device session that the mock accounts belong to,
+    // otherwise they are not treated as visible device accounts.
+    const initPreloadedStoreWithAccounts = () =>
+        createTradingLightStore({
+            tradeType: 'buy',
+            overrides: {
+                device: {
+                    selectedDevice: {
+                        firmwareType: FirmwareType.Universal,
+                        state: { staticSessionId: MOCK_ACCOUNT_DEVICE_SESSION_ID },
+                    },
+                },
             },
         });
 
@@ -108,7 +132,6 @@ describe('BuyTradeableAssetPicker', () => {
             form.setValue('cryptoValue', '0.1');
             const dispatchSpy = jest.spyOn(store, 'dispatch');
             const { getByLabelText } = await renderTradeableAssetPicker();
-
             fireEvent.press(getByLabelText('USDC'));
 
             expect(form.getValues('cryptoValue')).toBeUndefined();
@@ -120,6 +143,44 @@ describe('BuyTradeableAssetPicker', () => {
                     type: 'buy',
                     parameter: 'cryptoTo',
                 },
+            });
+        });
+    });
+
+    describe('receiveAccount preselection', () => {
+        beforeEach(() => {
+            reportMock.mockClear();
+            store = initPreloadedStoreWithAccounts();
+            form = renderFormHook();
+        });
+
+        it('should keep the selected receiveAccount when switching to another asset on the same network', async () => {
+            form.setValue('asset', ethAsset);
+            const { getByLabelText } = await renderTradeableAssetPicker();
+
+            await waitFor(() => {
+                expect(form.getValues('receiveAccount')).toEqual({
+                    account: expect.objectContaining({ key: eth1AccountKey }),
+                });
+            });
+
+            act(() => {
+                store.dispatch(tradingBuyActions.setTradingAccountKey(eth2AccountKey));
+                store.dispatch(tradingBuyActions.setReceiveAccountKey(eth2AccountKey));
+            });
+
+            await waitFor(() => {
+                expect(form.getValues('receiveAccount')).toEqual({
+                    account: expect.objectContaining({ key: eth2AccountKey }),
+                });
+            });
+
+            fireEvent.press(getByLabelText('USDC'));
+
+            await waitFor(() => {
+                expect(form.getValues('receiveAccount')).toEqual({
+                    account: expect.objectContaining({ key: eth2AccountKey }),
+                });
             });
         });
     });

--- a/suite-native/module-trading/src/components/exchange/ExchangeAlert.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeAlert.tsx
@@ -1,9 +1,11 @@
+import { useWatch } from '@suite-native/forms';
+
 import { useExchangeFormContext } from '../../hooks/exchange/useExchangeFormContext';
 import { GeneralAlert } from '../general/GeneralAlert';
 
 export const ExchangeAlert = () => {
-    const { watch } = useExchangeFormContext();
-    const text = watch('generalAlert');
+    const { control } = useExchangeFormContext();
+    const text = useWatch({ control, name: 'generalAlert' });
 
     return <GeneralAlert text={text} />;
 };

--- a/suite-native/module-trading/src/components/exchange/ExchangeCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeCard.tsx
@@ -1,3 +1,4 @@
+import { useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 import { CryptoToFiatValueBadge } from '@suite-native/trading-quote-utils';
 
@@ -15,8 +16,11 @@ type ExchangeCardProps = {
 const EXCHANGE_CARD_TEST_ID = '@trading/exchangeCard';
 
 export const ExchangeCard = ({ isAmountInputActive }: ExchangeCardProps) => {
-    const { watch } = useExchangeFormContext();
-    const [receiveAsset, receiveCryptoAmount] = watch(['receiveAsset', 'receiveCryptoAmount']);
+    const { control } = useExchangeFormContext();
+    const [receiveAsset, receiveCryptoAmount] = useWatch({
+        name: ['receiveAsset', 'receiveCryptoAmount'],
+        control,
+    });
 
     return (
         <TradingCard isAmountInputActive={isAmountInputActive}>

--- a/suite-native/module-trading/src/components/exchange/ExchangeForm.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeForm.tsx
@@ -40,7 +40,7 @@ const ExchangeFormMemoized = memo(({ isAmountInputActive }: ExchangeFormMemoized
 
 export const ExchangeForm = () => {
     const exchangeForm = useExchangeFormContext();
-    const isAmountInputActiveDebounced = useFocusedValueWatch(exchangeForm.watch);
+    const isAmountInputActiveDebounced = useFocusedValueWatch(exchangeForm.control);
     useExchangeQuotes(exchangeForm);
 
     return <ExchangeFormMemoized isAmountInputActive={isAmountInputActiveDebounced} />;

--- a/suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.tsx
@@ -1,14 +1,15 @@
 import { cryptoIdToNetworkAndContractAddress, getApprovalStatus } from '@suite-common/trading';
 import { findToken, isAllowanceUnlimited } from '@suite-common/wallet-utils';
 import { HStack, Text } from '@suite-native/atoms';
+import { useWatch } from '@suite-native/forms';
 import { DebugModeView } from '@suite-native/trading-debug';
 
 import { ExchangeUsdcPresetButton } from './ExchangeUsdcPresetButton';
 import { useExchangeFormContext } from '../../hooks/exchange/useExchangeFormContext';
 
 export const ExchangeFormQuoteDebugView = () => {
-    const { watch } = useExchangeFormContext();
-    const [quote, sendAccount] = watch(['quote', 'sendAccount']);
+    const { control } = useExchangeFormContext();
+    const [quote, sendAccount] = useWatch({ control, name: ['quote', 'sendAccount'] });
 
     const approvalStatus = getApprovalStatus(quote);
     const { contractAddress } = cryptoIdToNetworkAndContractAddress(quote?.send);

--- a/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.tsx
@@ -1,9 +1,10 @@
 import { useDispatch, useSelector } from 'react-redux';
 
-import { tradingExchangeActions } from '@suite-common/trading';
+import { cryptoIdToSymbol, tradingExchangeActions } from '@suite-common/trading';
 import { type AccountsRootState, selectAccounts } from '@suite-common/wallet-core';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { Text, TextButton } from '@suite-native/atoms';
+import { exchangeActions } from '@suite-native/trading-state';
 import { type TradeableAsset } from '@suite-native/trading-types';
 
 import { useExchangeFormContext } from '../../hooks/exchange/useExchangeFormContext';
@@ -27,7 +28,7 @@ const USDT_ETH: TradeableAsset = {
 };
 
 export const ExchangeUsdcPresetButton = () => {
-    const { setValue } = useExchangeFormContext();
+    const { getValues, setValue } = useExchangeFormContext();
     const dispatch = useDispatch();
     const debugAccount = useSelector((state: AccountsRootState) =>
         selectAccounts(state).find(
@@ -46,11 +47,20 @@ export const ExchangeUsdcPresetButton = () => {
     }
 
     const handlePress = () => {
+        const previousReceiveSymbol = cryptoIdToSymbol(getValues('receiveAsset')?.cryptoId);
+        const receiveSymbol = cryptoIdToSymbol(USDT_ETH.cryptoId);
+
         setValue('sendAsset', USDC_ETH);
         setValue('sendAccount', debugAccount);
         dispatch(tradingExchangeActions.setTradingAccountKey(debugAccount.key));
         setValue('sendCryptoAmount', '1');
         setValue('receiveAsset', USDT_ETH);
+        dispatch(exchangeActions.sendAssetChanged());
+        dispatch(
+            previousReceiveSymbol === receiveSymbol
+                ? exchangeActions.receiveTokenChanged()
+                : exchangeActions.receiveAssetChanged(),
+        );
     };
 
     return (

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeFormQuoteDebugView.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeFormQuoteDebugView.test.tsx
@@ -21,15 +21,14 @@ let mockSendAccount:
       }
     | undefined;
 
+jest.mock('@suite-native/forms', () => ({
+    ...jest.requireActual('@suite-native/forms'),
+    useWatch: () => [mockQuote, mockSendAccount],
+}));
+
 jest.mock('../../../hooks/exchange/useExchangeFormContext', () => ({
     useExchangeFormContext: () => ({
-        watch: (field: string | string[]) => {
-            if (Array.isArray(field)) {
-                return [mockQuote, mockSendAccount];
-            }
-
-            return mockQuote;
-        },
+        control: undefined,
     }),
 }));
 

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeUsdcPresetButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeUsdcPresetButton.test.tsx
@@ -10,9 +10,10 @@ import {
 import { ExchangeUsdcPresetButton } from '../ExchangeUsdcPresetButton';
 
 const mockSetValue = jest.fn();
+const mockGetValues = jest.fn();
 
 jest.mock('../../../hooks/exchange/useExchangeFormContext', () => ({
-    useExchangeFormContext: () => ({ setValue: mockSetValue }),
+    useExchangeFormContext: () => ({ getValues: mockGetValues, setValue: mockSetValue }),
 }));
 
 const ethAccountWithUsdc = mockWalletAccount({
@@ -34,6 +35,7 @@ const ethAccountWithUsdc = mockWalletAccount({
 
 describe('ExchangeUsdcPresetButton', () => {
     beforeEach(() => {
+        mockGetValues.mockReset();
         mockSetValue.mockClear();
     });
 

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAccountCryptoBalance.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAccountCryptoBalance.tsx
@@ -1,11 +1,16 @@
+import { useWatch } from '@suite-native/forms';
+
 import { useExchangeFormContext } from '../../../hooks/exchange/useExchangeFormContext';
 import { TradeableAssetAccountBalance } from '../../general/TradeableAssetAccountBalance';
 
 export const RECEIVE_ACCOUNT_BALANCE_TEST_ID = '@trading/exchange/receive-account-balance';
 
 export const ExchangeReceiveAccountCryptoBalance = () => {
-    const { watch } = useExchangeFormContext();
-    const [receiveAsset, receiveAccount] = watch(['receiveAsset', 'receiveAccount']);
+    const { control } = useExchangeFormContext();
+    const [receiveAsset, receiveAccount] = useWatch({
+        control,
+        name: ['receiveAsset', 'receiveAccount'],
+    });
 
     return (
         <TradeableAssetAccountBalance

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAmountInput.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAmountInput.tsx
@@ -3,6 +3,7 @@ import { type TextInput } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import { selectTradingExchangeIsLoading } from '@suite-common/trading';
+import { useWatch } from '@suite-native/forms';
 import { useAmountInputTransformers } from '@suite-native/helpers';
 import { useTranslate } from '@suite-native/intl';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
@@ -21,8 +22,11 @@ export const ExchangeReceiveAmountInput = forwardRef<TextInput, ExchangeReceiveA
     ({ showAssetsSheet }, ref) => {
         const { translate } = useTranslate();
         const isLoading = useSelector(selectTradingExchangeIsLoading);
-        const { watch } = useExchangeFormContext();
-        const [asset, amount] = watch(['receiveAsset', 'receiveCryptoAmount']);
+        const { control } = useExchangeFormContext();
+        const [asset, amount] = useWatch({
+            control,
+            name: ['receiveAsset', 'receiveCryptoAmount'],
+        });
         const symbol = getSymbolFromTradeableAsset(asset);
         const { cryptoAmountTransformer } = useAmountInputTransformers(symbol);
 

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveContent.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveContent.tsx
@@ -1,4 +1,5 @@
 import { HStack } from '@suite-native/atoms';
+import { useWatch } from '@suite-native/forms';
 
 import { ExchangeReceiveAccountCryptoBalance } from './ExchangeReceiveAccountCryptoBalance';
 import { ExchangeTradeableAssetPicker } from './ExchangeTradeableAssetPicker';
@@ -6,9 +7,9 @@ import { useExchangeFormContext } from '../../../hooks/exchange/useExchangeFormC
 import { TradeableAssetNetworkInfo } from '../../general/TradeableAssetNetworkInfo';
 
 export const ExchangeReceiveContent = () => {
-    const { watch } = useExchangeFormContext();
+    const { control } = useExchangeFormContext();
 
-    const asset = watch('receiveAsset');
+    const asset = useWatch({ control, name: 'receiveAsset' });
 
     return (
         <>

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeTradeableAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeTradeableAssetPicker.tsx
@@ -1,62 +1,39 @@
-import { useDispatch } from 'react-redux';
-
-import { useServices } from '@suite-common/dependency-injection';
-import { cryptoIdToSymbol } from '@suite-common/trading';
-import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { HStack } from '@suite-native/atoms';
 import { exchangeActions } from '@suite-native/trading-state';
-import { type TradeableAsset } from '@suite-native/trading-types';
 
 import { ExchangeReceiveAmountInput } from './ExchangeReceiveAmountInput';
 import { ExchangeTradeableAssetsSheet } from './ExchangeTradeableAssetsSheet';
 import { useExchangeFormContext } from '../../../hooks/exchange/useExchangeFormContext';
+import { useTradeableAssetChange } from '../../../hooks/general/form/useTradeableAssetChange';
 import { useSheetControls } from '../../../hooks/general/useSheetControls';
 import { SelectTradeableAssetButton } from '../../general/SelectTradeableAssetButton';
 
 const ASSET_PICKER_TEST_ID = '@trading/exchange/asset-receive-button';
 
+// Selecting a receive asset that equals the send asset clears the send side. The receive change
+// action dispatched afterwards already resets a superset of the send state, so no counterpart
+// action is needed here.
+const RECEIVE_ASSET_COLLISION = {
+    counterpartAssetField: 'sendAsset',
+    counterpartAmountField: 'sendCryptoAmount',
+    counterpartAnalyticsParameter: 'cryptoFrom',
+} as const;
+
 export const ExchangeTradeableAssetPicker = () => {
-    const dispatch = useDispatch();
-    const { analytics } = useServices(selectNativeAnalyticsDep);
     const form = useExchangeFormContext();
     const { isSheetVisible, hideSheet, showSheet, setSelectedValue, selectedValue } =
         useSheetControls(form, 'receiveAsset');
 
-    const handleAssetSelect = (asset: TradeableAsset) => {
-        if (asset.cryptoId === selectedValue?.cryptoId) {
-            return;
-        }
-
-        if (asset.cryptoId === form.getValues('sendAsset')?.cryptoId) {
-            form.setValue('sendAsset', undefined);
-            form.setValue('sendCryptoAmount', undefined, { shouldValidate: true });
-            analytics.report({
-                type: events.tradingParameterChangedEvent.name,
-                payload: {
-                    type: 'exchange',
-                    parameter: 'cryptoFrom',
-                },
-            });
-        }
-
-        const previousSymbol = cryptoIdToSymbol(selectedValue?.cryptoId);
-        const symbol = cryptoIdToSymbol(asset.cryptoId);
-
-        setSelectedValue(asset);
-
-        dispatch(
-            previousSymbol === symbol
-                ? exchangeActions.receiveTokenChanged()
-                : exchangeActions.receiveAssetChanged(),
-        );
-        analytics.report({
-            type: events.tradingParameterChangedEvent.name,
-            payload: {
-                type: 'exchange',
-                parameter: 'cryptoTo',
-            },
-        });
-    };
+    const handleAssetSelect = useTradeableAssetChange({
+        form,
+        tradingType: 'exchange',
+        selectedValue,
+        setSelectedValue,
+        analyticsParameter: 'cryptoTo',
+        getAssetChangedAction: exchangeActions.receiveAssetChanged,
+        getAssetTokenChangedAction: exchangeActions.receiveTokenChanged,
+        collision: RECEIVE_ASSET_COLLISION,
+    });
 
     return (
         <>

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeTradeableAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeTradeableAssetPicker.tsx
@@ -1,4 +1,11 @@
+import { useDispatch } from 'react-redux';
+
+import { useServices } from '@suite-common/dependency-injection';
+import { cryptoIdToSymbol } from '@suite-common/trading';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { HStack } from '@suite-native/atoms';
+import { exchangeActions } from '@suite-native/trading-state';
+import { type TradeableAsset } from '@suite-native/trading-types';
 
 import { ExchangeReceiveAmountInput } from './ExchangeReceiveAmountInput';
 import { ExchangeTradeableAssetsSheet } from './ExchangeTradeableAssetsSheet';
@@ -9,9 +16,34 @@ import { SelectTradeableAssetButton } from '../../general/SelectTradeableAssetBu
 const ASSET_PICKER_TEST_ID = '@trading/exchange/asset-receive-button';
 
 export const ExchangeTradeableAssetPicker = () => {
+    const dispatch = useDispatch();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const form = useExchangeFormContext();
     const { isSheetVisible, hideSheet, showSheet, setSelectedValue, selectedValue } =
         useSheetControls(form, 'receiveAsset');
+
+    const handleAssetSelect = (asset: TradeableAsset) => {
+        if (asset.cryptoId === selectedValue?.cryptoId) {
+            return;
+        }
+
+        const previousSymbol = cryptoIdToSymbol(selectedValue?.cryptoId);
+        const symbol = cryptoIdToSymbol(asset.cryptoId);
+
+        setSelectedValue(asset);
+        dispatch(
+            previousSymbol === symbol
+                ? exchangeActions.receiveTokenChanged()
+                : exchangeActions.receiveAssetChanged(),
+        );
+        analytics.report({
+            type: events.tradingParameterChangedEvent.name,
+            payload: {
+                type: 'exchange',
+                parameter: 'cryptoTo',
+            },
+        });
+    };
 
     return (
         <>
@@ -26,7 +58,7 @@ export const ExchangeTradeableAssetPicker = () => {
                 <ExchangeReceiveAmountInput showAssetsSheet={showSheet} />
             </HStack>
             <ExchangeTradeableAssetsSheet
-                onAssetSelect={setSelectedValue}
+                onAssetSelect={handleAssetSelect}
                 onClose={hideSheet}
                 isVisible={isSheetVisible}
             />

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeTradeableAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeTradeableAssetPicker.tsx
@@ -27,10 +27,15 @@ export const ExchangeTradeableAssetPicker = () => {
             return;
         }
 
+        if (asset.cryptoId === form.getValues('sendAsset')?.cryptoId) {
+            form.setValue('sendAsset', undefined);
+        }
+
         const previousSymbol = cryptoIdToSymbol(selectedValue?.cryptoId);
         const symbol = cryptoIdToSymbol(asset.cryptoId);
 
         setSelectedValue(asset);
+
         dispatch(
             previousSymbol === symbol
                 ? exchangeActions.receiveTokenChanged()

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeTradeableAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeTradeableAssetPicker.tsx
@@ -29,6 +29,14 @@ export const ExchangeTradeableAssetPicker = () => {
 
         if (asset.cryptoId === form.getValues('sendAsset')?.cryptoId) {
             form.setValue('sendAsset', undefined);
+            form.setValue('sendCryptoAmount', undefined, { shouldValidate: true });
+            analytics.report({
+                type: events.tradingParameterChangedEvent.name,
+                payload: {
+                    type: 'exchange',
+                    parameter: 'cryptoFrom',
+                },
+            });
         }
 
         const previousSymbol = cryptoIdToSymbol(selectedValue?.cryptoId);

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeTradeableAssetPicker.test.tsx
@@ -1,7 +1,10 @@
+import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { featureFlagsInitialState } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
-import { type TestStore, screen } from '@suite-native/test-utils-store';
+import { type TestStore, fireEvent, screen } from '@suite-native/test-utils-store';
+import { exchangeActions } from '@suite-native/trading-state';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 import { FirmwareType } from '@trezor/connect';
 
@@ -12,6 +15,11 @@ import {
 } from '../../../../__tests__/tradingTestUtils';
 import { useExchangeForm } from '../../../../hooks/exchange/useExchangeForm';
 import { ExchangeTradeableAssetPicker } from '../ExchangeTradeableAssetPicker';
+
+const reportMock = jest.fn();
+const services: NativeAnalyticsDep = {
+    analytics: mockNativeAnalytics(reportMock),
+};
 
 describe('ExchangeTradeableAssetPicker', () => {
     let store: TestStore;
@@ -30,6 +38,7 @@ describe('ExchangeTradeableAssetPicker', () => {
 
     const renderFormHook = () => {
         const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
+            services,
             store,
         });
 
@@ -38,11 +47,13 @@ describe('ExchangeTradeableAssetPicker', () => {
 
     const renderTradeableAssetPicker = () =>
         renderWithTradingProvider(<ExchangeTradeableAssetPicker />, {
+            services,
             store,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
     beforeEach(() => {
+        reportMock.mockClear();
         store = initPreloadedStore(FirmwareType.Universal);
         form = renderFormHook();
     });
@@ -66,5 +77,21 @@ describe('ExchangeTradeableAssetPicker', () => {
 
         expect(getAllByText('Bitcoin')).toBeTruthy();
         expect(getAllByText('USDC')).toBeTruthy();
+    });
+
+    it('should apply receive asset change effects on item press', () => {
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+        const { getByLabelText } = renderTradeableAssetPicker();
+
+        fireEvent.press(getByLabelText('Bitcoin'));
+
+        expect(dispatchSpy).toHaveBeenCalledWith(exchangeActions.receiveAssetChanged());
+        expect(reportMock).toHaveBeenCalledWith({
+            type: events.tradingParameterChangedEvent.name,
+            payload: {
+                type: 'exchange',
+                parameter: 'cryptoTo',
+            },
+        });
     });
 });

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeTradeableAssetPicker.test.tsx
@@ -1,10 +1,18 @@
+import { tradingExchangeActions } from '@suite-common/trading';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { featureFlagsInitialState } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
-import { type TestStore, fireEvent, screen } from '@suite-native/test-utils-store';
-import { btcAsset } from '@suite-native/trading-fixtures';
+import { act } from '@suite-native/test-utils';
+import { type TestStore, fireEvent, screen, waitFor } from '@suite-native/test-utils-store';
+import {
+    MOCK_ACCOUNT_DEVICE_SESSION_ID,
+    btc1NormalAccount,
+    btcAsset,
+    eth1NormalAccount,
+    eth2legacyAccount,
+} from '@suite-native/trading-fixtures';
 import { exchangeActions } from '@suite-native/trading-state';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 import { FirmwareType } from '@trezor/connect';
@@ -22,6 +30,10 @@ const services: NativeAnalyticsDep = {
     analytics: mockNativeAnalytics(reportMock),
 };
 
+const btc1AccountKey = btc1NormalAccount.key;
+const eth1AccountKey = eth1NormalAccount.key;
+const eth2AccountKey = eth2legacyAccount.key;
+
 describe('ExchangeTradeableAssetPicker', () => {
     let store: TestStore;
     let form: ExchangeFormType;
@@ -31,6 +43,24 @@ describe('ExchangeTradeableAssetPicker', () => {
             tradeType: 'exchange',
             overrides: {
                 device: { selectedDevice: { firmwareType } },
+                featureFlags: {
+                    ...featureFlagsInitialState,
+                },
+            },
+        });
+
+    // Account preselection needs a device session that the mock accounts belong to,
+    // otherwise they are not treated as visible device accounts.
+    const initPreloadedStoreWithAccounts = () =>
+        createTradingLightStore({
+            tradeType: 'exchange',
+            overrides: {
+                device: {
+                    selectedDevice: {
+                        firmwareType: FirmwareType.Universal,
+                        state: { staticSessionId: MOCK_ACCOUNT_DEVICE_SESSION_ID },
+                    },
+                },
                 featureFlags: {
                     ...featureFlagsInitialState,
                 },
@@ -111,6 +141,74 @@ describe('ExchangeTradeableAssetPicker', () => {
                 type: 'exchange',
                 parameter: 'cryptoFrom',
             },
+        });
+    });
+
+    describe('receiveAccount preselection', () => {
+        beforeEach(() => {
+            reportMock.mockClear();
+            store = initPreloadedStoreWithAccounts();
+            form = renderFormHook();
+        });
+
+        it('should preselect a new receiveAccount for the new asset network after a cross-network change', async () => {
+            const { getByLabelText } = renderTradeableAssetPicker();
+
+            fireEvent.press(getByLabelText('Bitcoin'));
+
+            await waitFor(() => {
+                expect(form.getValues('receiveAccount')).toEqual(
+                    expect.objectContaining({
+                        account: expect.objectContaining({ key: btc1AccountKey }),
+                    }),
+                );
+            });
+
+            fireEvent.press(getByLabelText('USDC'));
+
+            await waitFor(() => {
+                expect(form.getValues('receiveAccount')).toEqual(
+                    expect.objectContaining({
+                        account: expect.objectContaining({ key: eth1AccountKey }),
+                    }),
+                );
+            });
+        });
+
+        it('should keep the selected receiveAccount when switching to another asset on the same network', async () => {
+            const { getByLabelText } = renderTradeableAssetPicker();
+
+            fireEvent.press(getByLabelText('Ethereum'));
+
+            await waitFor(() => {
+                expect(form.getValues('receiveAccount')).toEqual(
+                    expect.objectContaining({
+                        account: expect.objectContaining({ key: eth1AccountKey }),
+                    }),
+                );
+            });
+
+            act(() => {
+                store.dispatch(tradingExchangeActions.setReceiveAccountKey(eth2AccountKey));
+            });
+
+            await waitFor(() => {
+                expect(form.getValues('receiveAccount')).toEqual(
+                    expect.objectContaining({
+                        account: expect.objectContaining({ key: eth2AccountKey }),
+                    }),
+                );
+            });
+
+            fireEvent.press(getByLabelText('USDC'));
+
+            await waitFor(() => {
+                expect(form.getValues('receiveAccount')).toEqual(
+                    expect.objectContaining({
+                        account: expect.objectContaining({ key: eth2AccountKey }),
+                    }),
+                );
+            });
         });
     });
 });

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeTradeableAssetPicker.test.tsx
@@ -4,6 +4,7 @@ import { featureFlagsInitialState } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
 import { type TestStore, fireEvent, screen } from '@suite-native/test-utils-store';
+import { btcAsset } from '@suite-native/trading-fixtures';
 import { exchangeActions } from '@suite-native/trading-state';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 import { FirmwareType } from '@trezor/connect';
@@ -91,6 +92,24 @@ describe('ExchangeTradeableAssetPicker', () => {
             payload: {
                 type: 'exchange',
                 parameter: 'cryptoTo',
+            },
+        });
+    });
+
+    it('should clear the send asset and its typed amount when it collides with the newly selected receive asset', () => {
+        form.setValue('sendAsset', btcAsset);
+        form.setValue('sendCryptoAmount', '1');
+        const { getByLabelText } = renderTradeableAssetPicker();
+
+        fireEvent.press(getByLabelText('Bitcoin'));
+
+        expect(form.getValues('sendAsset')).toBeUndefined();
+        expect(form.getValues('sendCryptoAmount')).toBeUndefined();
+        expect(reportMock).toHaveBeenCalledWith({
+            type: events.tradingParameterChangedEvent.name,
+            payload: {
+                type: 'exchange',
+                parameter: 'cryptoFrom',
             },
         });
     });

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAccountCryptoBalance.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAccountCryptoBalance.tsx
@@ -1,11 +1,16 @@
+import { useWatch } from '@suite-native/forms';
+
 import { useExchangeFormContext } from '../../../hooks/exchange/useExchangeFormContext';
 import { TradeableAssetAccountBalance } from '../../general/TradeableAssetAccountBalance';
 
 export const SEND_ACCOUNT_BALANCE_TEST_ID = '@trading/exchange/send-account-balance';
 
 export const ExchangeSendAccountCryptoBalance = () => {
-    const { watch } = useExchangeFormContext();
-    const [sendAsset, sendAccount] = watch(['sendAsset', 'sendAccount']);
+    const { control } = useExchangeFormContext();
+    const [sendAsset, sendAccount] = useWatch({
+        name: ['sendAsset', 'sendAccount'],
+        control,
+    });
 
     return (
         <TradeableAssetAccountBalance

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountBadge.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountBadge.tsx
@@ -34,28 +34,19 @@ const ExchangeSendFiatAmountBadge = ({ amount, asset }: ExchangeSendFiatAmountBa
     return <FiatAmountBadge amount={fiatAmount} />;
 };
 
-const ExchangeSendFiatAmountBadgeContainer = ({ amount }: { amount: string }) => {
-    const { control } = useExchangeFormContext();
-    const asset = useWatch({ control, name: 'sendAsset' });
-
-    if (!asset) {
-        return null;
-    }
-
-    return <ExchangeSendFiatAmountBadge amount={amount} asset={asset} />;
-};
-
 export const ExchangeSendAmountBadge = () => {
     const isLoading = useSelector(selectTradingExchangeIsLoading);
+    const { control } = useExchangeFormContext();
+    const asset = useWatch({ control, name: 'sendAsset' });
 
     const { errorMessage, hasError, value } = useField({ name: 'sendCryptoAmount' });
     if (!isLoading && hasError) {
         return <Badge label={errorMessage} intent="critical" size="small" />;
     }
 
-    if (!value) {
+    if (!value || !asset) {
         return null;
     }
 
-    return <ExchangeSendFiatAmountBadgeContainer amount={value} />;
+    return <ExchangeSendFiatAmountBadge amount={value} asset={asset} />;
 };

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountBadge.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountBadge.tsx
@@ -4,7 +4,7 @@ import { invariant } from '@suite-common/suite-utils';
 import { selectTradingExchangeIsLoading } from '@suite-common/trading';
 import { type FiatRatesRootState, type WalletSettingsRootState } from '@suite-common/wallet-core';
 import { Badge } from '@suite-native/atoms';
-import { useField } from '@suite-native/forms';
+import { useField, useWatch } from '@suite-native/forms';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import { type TradingRootState, selectAmountInBaseFiatCurrency } from '@suite-native/trading-state';
 import { type TradeableAsset } from '@suite-native/trading-types';
@@ -34,8 +34,18 @@ const ExchangeSendFiatAmountBadge = ({ amount, asset }: ExchangeSendFiatAmountBa
     return <FiatAmountBadge amount={fiatAmount} />;
 };
 
+const ExchangeSendFiatAmountBadgeContainer = ({ amount }: { amount: string }) => {
+    const { control } = useExchangeFormContext();
+    const asset = useWatch({ control, name: 'sendAsset' });
+
+    if (!asset) {
+        return null;
+    }
+
+    return <ExchangeSendFiatAmountBadge amount={amount} asset={asset} />;
+};
+
 export const ExchangeSendAmountBadge = () => {
-    const { watch } = useExchangeFormContext();
     const isLoading = useSelector(selectTradingExchangeIsLoading);
 
     const { errorMessage, hasError, value } = useField({ name: 'sendCryptoAmount' });
@@ -43,10 +53,9 @@ export const ExchangeSendAmountBadge = () => {
         return <Badge label={errorMessage} intent="critical" size="small" />;
     }
 
-    const asset = watch('sendAsset');
-    if (!asset || !value) {
+    if (!value) {
         return null;
     }
 
-    return <ExchangeSendFiatAmountBadge amount={value} asset={asset} />;
+    return <ExchangeSendFiatAmountBadgeContainer amount={value} />;
 };

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountInput.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountInput.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react';
 import { type TextInput } from 'react-native';
 
+import { useWatch } from '@suite-native/forms';
 import { useAmountInputTransformers } from '@suite-native/helpers';
 import { useTranslate } from '@suite-native/intl';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
@@ -19,8 +20,11 @@ const EXCHANGE_SEND_INPUT_TEST_ID = '@trading/exchange/send-amount-input';
 export const ExchangeSendAmountInput = forwardRef<TextInput, ExchangeSendAmountInputProps>(
     ({ showAssetsSheet }, ref) => {
         const { translate } = useTranslate();
-        const { watch, setValue } = useExchangeFormContext();
-        const [asset, amount, account] = watch(['sendAsset', 'sendCryptoAmount', 'sendAccount']);
+        const { control, setValue } = useExchangeFormContext();
+        const [asset, amount, account] = useWatch({
+            control,
+            name: ['sendAsset', 'sendCryptoAmount', 'sendAccount'],
+        });
         const symbol = getSymbolFromTradeableAsset(asset);
         const { cryptoAmountTransformer } = useAmountInputTransformers(symbol);
         const inputControls = useInputFieldControls('sendCryptoAmount', amount, setValue);

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAssetPicker.tsx
@@ -2,9 +2,12 @@ import { useCallback, useRef, useState } from 'react';
 import { type TextInput } from 'react-native';
 import { useDispatch } from 'react-redux';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { tradingExchangeActions } from '@suite-common/trading';
 import { type Account } from '@suite-common/wallet-types';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { HStack } from '@suite-native/atoms';
+import { exchangeActions } from '@suite-native/trading-state';
 import { type TradeableAsset } from '@suite-native/trading-types';
 
 import { ExchangeSendAmountInput } from './ExchangeSendAmountInput';
@@ -18,6 +21,7 @@ const ASSET_SHEET_TEST_ID = '@trading/exchange/send-asset-sheet';
 
 export const ExchangeSendAssetPicker = () => {
     const dispatch = useDispatch();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const inputRef = useRef<TextInput>(null);
     const form = useExchangeFormContext();
     const [shouldFocusInput, setShouldFocusInput] = useState<boolean>(false);
@@ -26,8 +30,26 @@ export const ExchangeSendAssetPicker = () => {
 
     const onAssetSelect = useCallback(
         (asset: TradeableAsset, account: Account) => {
-            setSelectedValue(asset);
             dispatch(tradingExchangeActions.setTradingAccountKey(account.key));
+
+            if (asset.cryptoId !== selectedValue?.cryptoId) {
+                setSelectedValue(asset);
+                form.setValue('sendCryptoAmount', undefined, { shouldValidate: true });
+
+                if (asset.cryptoId === form.getValues('receiveAsset')?.cryptoId) {
+                    form.setValue('receiveAsset', undefined);
+                }
+
+                dispatch(exchangeActions.sendAssetChanged());
+                analytics.report({
+                    type: events.tradingParameterChangedEvent.name,
+                    payload: {
+                        type: 'exchange',
+                        parameter: 'cryptoFrom',
+                    },
+                });
+            }
+
             if (shouldFocusInput) {
                 setShouldFocusInput(false);
                 // CryptoAmountInput is rendered disabled allow changes to propagate.
@@ -36,7 +58,7 @@ export const ExchangeSendAssetPicker = () => {
                 }, 0);
             }
         },
-        [shouldFocusInput, setSelectedValue, dispatch],
+        [analytics, dispatch, form, selectedValue?.cryptoId, setSelectedValue, shouldFocusInput],
     );
 
     const showAssetsSheet = useCallback(() => {

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAssetPicker.tsx
@@ -1,17 +1,15 @@
 import { useCallback, useRef, useState } from 'react';
 import { type TextInput } from 'react-native';
-import { useDispatch } from 'react-redux';
 
-import { useServices } from '@suite-common/dependency-injection';
 import { tradingExchangeActions } from '@suite-common/trading';
 import { type Account } from '@suite-common/wallet-types';
-import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { HStack } from '@suite-native/atoms';
 import { exchangeActions } from '@suite-native/trading-state';
 import { type TradeableAsset } from '@suite-native/trading-types';
 
 import { ExchangeSendAmountInput } from './ExchangeSendAmountInput';
 import { useExchangeFormContext } from '../../../hooks/exchange/useExchangeFormContext';
+import { useTradeableAssetChange } from '../../../hooks/general/form/useTradeableAssetChange';
 import { useSheetControls } from '../../../hooks/general/useSheetControls';
 import { MyAssetSheet } from '../../general/MyAssetSheet/MyAssetSheet';
 import { SelectTradeableAssetButton } from '../../general/SelectTradeableAssetButton';
@@ -19,44 +17,36 @@ import { SelectTradeableAssetButton } from '../../general/SelectTradeableAssetBu
 const ASSET_PICKER_TEST_ID = '@trading/exchange/asset-send-button';
 const ASSET_SHEET_TEST_ID = '@trading/exchange/send-asset-sheet';
 
+// Selecting a send asset that equals the receive asset clears the receive side. `sendAssetChanged`
+// alone would leave the stale receive account behind, so the collision resets the receive asset too.
+const SEND_ASSET_COLLISION = {
+    counterpartAssetField: 'receiveAsset',
+    counterpartAnalyticsParameter: 'cryptoTo',
+    getCounterpartChangedAction: exchangeActions.receiveAssetChanged,
+} as const;
+
 export const ExchangeSendAssetPicker = () => {
-    const dispatch = useDispatch();
-    const { analytics } = useServices(selectNativeAnalyticsDep);
     const inputRef = useRef<TextInput>(null);
     const form = useExchangeFormContext();
     const [shouldFocusInput, setShouldFocusInput] = useState<boolean>(false);
     const { isSheetVisible, hideSheet, showSheet, setSelectedValue, selectedValue } =
         useSheetControls(form, 'sendAsset');
 
+    const changeAsset = useTradeableAssetChange({
+        form,
+        tradingType: 'exchange',
+        selectedValue,
+        setSelectedValue,
+        analyticsParameter: 'cryptoFrom',
+        amountField: 'sendCryptoAmount',
+        getAssetChangedAction: exchangeActions.sendAssetChanged,
+        getSetTradingAccountKeyAction: tradingExchangeActions.setTradingAccountKey,
+        collision: SEND_ASSET_COLLISION,
+    });
+
     const onAssetSelect = useCallback(
         (asset: TradeableAsset, account: Account) => {
-            dispatch(tradingExchangeActions.setTradingAccountKey(account.key));
-
-            if (asset.cryptoId !== selectedValue?.cryptoId) {
-                setSelectedValue(asset);
-                form.setValue('sendCryptoAmount', undefined, { shouldValidate: true });
-
-                if (asset.cryptoId === form.getValues('receiveAsset')?.cryptoId) {
-                    form.setValue('receiveAsset', undefined);
-                    dispatch(exchangeActions.receiveAssetChanged());
-                    analytics.report({
-                        type: events.tradingParameterChangedEvent.name,
-                        payload: {
-                            type: 'exchange',
-                            parameter: 'cryptoTo',
-                        },
-                    });
-                }
-
-                dispatch(exchangeActions.sendAssetChanged());
-                analytics.report({
-                    type: events.tradingParameterChangedEvent.name,
-                    payload: {
-                        type: 'exchange',
-                        parameter: 'cryptoFrom',
-                    },
-                });
-            }
+            changeAsset(asset, account);
 
             if (shouldFocusInput) {
                 setShouldFocusInput(false);
@@ -66,7 +56,7 @@ export const ExchangeSendAssetPicker = () => {
                 }, 0);
             }
         },
-        [analytics, dispatch, form, selectedValue?.cryptoId, setSelectedValue, shouldFocusInput],
+        [changeAsset, shouldFocusInput],
     );
 
     const showAssetsSheet = useCallback(() => {

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAssetPicker.tsx
@@ -38,6 +38,14 @@ export const ExchangeSendAssetPicker = () => {
 
                 if (asset.cryptoId === form.getValues('receiveAsset')?.cryptoId) {
                     form.setValue('receiveAsset', undefined);
+                    dispatch(exchangeActions.receiveAssetChanged());
+                    analytics.report({
+                        type: events.tradingParameterChangedEvent.name,
+                        payload: {
+                            type: 'exchange',
+                            parameter: 'cryptoTo',
+                        },
+                    });
                 }
 
                 dispatch(exchangeActions.sendAssetChanged());

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendContent.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendContent.tsx
@@ -15,13 +15,15 @@ import { ExchangeSendAssetPicker } from './ExchangeSendAssetPicker';
 import { useExchangeFormContext } from '../../../hooks/exchange/useExchangeFormContext';
 import { TradeableAssetNetworkInfo } from '../../general/TradeableAssetNetworkInfo';
 
+type ExchangeNetworkReserveBannerProps = {
+    symbol: NetworkSymbol;
+    contractAddress?: string;
+};
+
 const ExchangeNetworkReserveBanner = ({
     symbol,
     contractAddress,
-}: {
-    symbol: NetworkSymbol;
-    contractAddress?: string;
-}) => {
+}: ExchangeNetworkReserveBannerProps) => {
     const { control } = useExchangeFormContext();
     const [sendCryptoAmount, sendAccount] = useWatch({
         name: ['sendCryptoAmount', 'sendAccount'],
@@ -59,7 +61,7 @@ export const ExchangeSendContent = () => {
                 <TradeableAssetNetworkInfo asset={asset} />
                 <ExchangeSendAccountCryptoBalance />
             </HStack>
-            {symbol && (
+            {!!symbol && (
                 <ExchangeNetworkReserveBanner
                     symbol={symbol}
                     contractAddress={asset?.contractAddress}

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendContent.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendContent.tsx
@@ -1,8 +1,10 @@
 import { useSelector } from 'react-redux';
 
 import { cryptoIdToSymbol } from '@suite-common/trading';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountFormattedBalance } from '@suite-common/wallet-core';
 import { HStack } from '@suite-native/atoms';
+import { useWatch } from '@suite-native/forms';
 import {
     NetworkReserveBanner,
     useIsNetworkReserveBannerVisible,
@@ -13,13 +15,18 @@ import { ExchangeSendAssetPicker } from './ExchangeSendAssetPicker';
 import { useExchangeFormContext } from '../../../hooks/exchange/useExchangeFormContext';
 import { TradeableAssetNetworkInfo } from '../../general/TradeableAssetNetworkInfo';
 
-export const ExchangeSendContent = () => {
-    const { watch } = useExchangeFormContext();
-
-    const asset = watch('sendAsset');
-    const sendCryptoAmount = watch('sendCryptoAmount');
-    const sendAccount = watch('sendAccount');
-    const symbol = asset ? cryptoIdToSymbol(asset.cryptoId) : undefined;
+const ExchangeNetworkReserveBanner = ({
+    symbol,
+    contractAddress,
+}: {
+    symbol: NetworkSymbol;
+    contractAddress?: string;
+}) => {
+    const { control } = useExchangeFormContext();
+    const [sendCryptoAmount, sendAccount] = useWatch({
+        name: ['sendCryptoAmount', 'sendAccount'],
+        control,
+    });
 
     const formattedBalance = useSelector((state: AccountsRootState) =>
         selectAccountFormattedBalance(state, sendAccount?.key),
@@ -27,10 +34,23 @@ export const ExchangeSendContent = () => {
 
     const shouldShowBanner = useIsNetworkReserveBannerVisible({
         symbol,
-        contractAddress: asset?.contractAddress,
+        contractAddress,
         amount: sendCryptoAmount,
         balance: formattedBalance,
     });
+
+    if (!shouldShowBanner) {
+        return null;
+    }
+
+    return <NetworkReserveBanner symbol={symbol} contractAddress={contractAddress} />;
+};
+
+export const ExchangeSendContent = () => {
+    const { control } = useExchangeFormContext();
+
+    const asset = useWatch({ name: 'sendAsset', control });
+    const symbol = cryptoIdToSymbol(asset?.cryptoId);
 
     return (
         <>
@@ -39,8 +59,11 @@ export const ExchangeSendContent = () => {
                 <TradeableAssetNetworkInfo asset={asset} />
                 <ExchangeSendAccountCryptoBalance />
             </HStack>
-            {symbol && shouldShowBanner && (
-                <NetworkReserveBanner symbol={symbol} contractAddress={asset?.contractAddress} />
+            {symbol && (
+                <ExchangeNetworkReserveBanner
+                    symbol={symbol}
+                    contractAddress={asset?.contractAddress}
+                />
             )}
         </>
     );

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAssetPicker.test.tsx
@@ -7,6 +7,8 @@ import { initialSuiteSyncDataState, initialSuiteSyncState } from '@suite-common/
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
+import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { featureFlagsInitialState } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
 import { localeReducer } from '@suite-native/intl';
@@ -19,12 +21,14 @@ import {
     userEvent,
 } from '@suite-native/test-utils-store';
 import {
+    btcAsset,
     getBtcAccount,
     getEthAccount,
     getInitializedTradingState,
     getWalletState,
 } from '@suite-native/trading-fixtures';
 import {
+    exchangeActions,
     selectAccountsWithTokensToSellSectionCondensedListByTradingType,
     tradingSlice,
 } from '@suite-native/trading-state';
@@ -41,6 +45,10 @@ jest.mock('@suite-native/trading-state', () => ({
 
 const mockedSelectAccountsWithTokensToSellSectionListByTradingType =
     selectAccountsWithTokensToSellSectionCondensedListByTradingType as unknown as jest.Mock;
+const reportMock = jest.fn();
+const services: NativeAnalyticsDep = {
+    analytics: mockNativeAnalytics(reportMock),
+};
 
 describe('ExchangeSendAssetPicker', () => {
     let form: ExchangeFormType;
@@ -88,15 +96,17 @@ describe('ExchangeSendAssetPicker', () => {
     });
 
     const renderExchangeForm = () =>
-        renderHookWithStoreProvider(() => useExchangeForm(), { store });
+        renderHookWithStoreProvider(() => useExchangeForm(), { services, store });
 
     const renderExchangeSendAssetPicker = () =>
         renderWithStoreProvider(<ExchangeSendAssetPicker />, {
+            services,
             store,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
     beforeEach(() => {
+        reportMock.mockClear();
         const walletState = getWalletState({ tradeType: 'exchange' });
         store = createLightStore({
             reducer: {
@@ -149,5 +159,25 @@ describe('ExchangeSendAssetPicker', () => {
 
         expect(accountForm).toEqual(btcAccount);
         expect(accountKeyStore).toBe(btcAccount.key);
+    });
+
+    it('should apply exchange send asset change effects on item press', async () => {
+        form.setValue('sendCryptoAmount', '1');
+        form.setValue('receiveAsset', btcAsset);
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+        const { getByText } = renderExchangeSendAssetPicker();
+
+        await userEvent.press(getByText('BTC'));
+
+        expect(form.getValues('sendCryptoAmount')).toBeUndefined();
+        expect(form.getValues('receiveAsset')).toBeUndefined();
+        expect(dispatchSpy).toHaveBeenCalledWith(exchangeActions.sendAssetChanged());
+        expect(reportMock).toHaveBeenCalledWith({
+            type: events.tradingParameterChangedEvent.name,
+            payload: {
+                type: 'exchange',
+                parameter: 'cryptoFrom',
+            },
+        });
     });
 });

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAssetPicker.test.tsx
@@ -163,20 +163,55 @@ describe('ExchangeSendAssetPicker', () => {
 
     it('should apply exchange send asset change effects on item press', async () => {
         form.setValue('sendCryptoAmount', '1');
-        form.setValue('receiveAsset', btcAsset);
         const dispatchSpy = jest.spyOn(store, 'dispatch');
         const { getByText } = renderExchangeSendAssetPicker();
 
         await userEvent.press(getByText('BTC'));
 
         expect(form.getValues('sendCryptoAmount')).toBeUndefined();
-        expect(form.getValues('receiveAsset')).toBeUndefined();
         expect(dispatchSpy).toHaveBeenCalledWith(exchangeActions.sendAssetChanged());
         expect(reportMock).toHaveBeenCalledWith({
             type: events.tradingParameterChangedEvent.name,
             payload: {
                 type: 'exchange',
                 parameter: 'cryptoFrom',
+            },
+        });
+    });
+
+    it('should clear the receive asset and apply its change effects when it collides with the newly selected send asset', async () => {
+        form.setValue('sendCryptoAmount', '1');
+        form.setValue('receiveAsset', btcAsset);
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+        const { getByText } = renderExchangeSendAssetPicker();
+
+        await userEvent.press(getByText('BTC'));
+
+        expect(form.getValues('receiveAsset')).toBeUndefined();
+        expect(dispatchSpy).toHaveBeenCalledWith(exchangeActions.receiveAssetChanged());
+        expect(reportMock).toHaveBeenCalledWith({
+            type: events.tradingParameterChangedEvent.name,
+            payload: {
+                type: 'exchange',
+                parameter: 'cryptoTo',
+            },
+        });
+    });
+
+    it('should not apply receive asset change effects when there is no collision', async () => {
+        form.setValue('sendCryptoAmount', '1');
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+        const { getByText } = renderExchangeSendAssetPicker();
+
+        await userEvent.press(getByText('BTC'));
+
+        expect(form.getValues('receiveAsset')).toBeUndefined();
+        expect(dispatchSpy).not.toHaveBeenCalledWith(exchangeActions.receiveAssetChanged());
+        expect(reportMock).not.toHaveBeenCalledWith({
+            type: events.tradingParameterChangedEvent.name,
+            payload: {
+                type: 'exchange',
+                parameter: 'cryptoTo',
             },
         });
     });

--- a/suite-native/module-trading/src/components/general/TradingCountrySubdivisionPickerButton.tsx
+++ b/suite-native/module-trading/src/components/general/TradingCountrySubdivisionPickerButton.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { isCountrySubdivisionEmpty } from '@suite-common/trading';
 import { Button, Text, VStack } from '@suite-native/atoms';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 import { useCountrySubdivisionPickerControls } from '@suite-native/trading-residence';
 import { selectIsTradingResidenceCheckEnabled } from '@suite-native/trading-state';
@@ -17,10 +17,11 @@ export const TradingCountrySubdivisionPickerButton = ({
 }: TradingCountrySubdivisionPickerButtonProps) => {
     const isTradingResidenceCheckEnabled = useSelector(selectIsTradingResidenceCheckEnabled);
     const { showSheet } = useCountrySubdivisionPickerControls();
-    const { watch } = useFormContext<FormWithFiatCurrencyValues>();
-
-    const country = watch('country');
-    const countrySubdivision = watch('countrySubdivision');
+    const { control } = useFormContext<FormWithFiatCurrencyValues>();
+    const [country, countrySubdivision] = useWatch({
+        control,
+        name: ['country', 'countrySubdivision'],
+    });
 
     if (
         isTradingResidenceCheckEnabled ||

--- a/suite-native/module-trading/src/components/sell/SellAlert.tsx
+++ b/suite-native/module-trading/src/components/sell/SellAlert.tsx
@@ -1,9 +1,11 @@
+import { useWatch } from '@suite-native/forms';
+
 import { useSellFormContext } from '../../hooks/sell/useSellFormContext';
 import { GeneralAlert } from '../general/GeneralAlert';
 
 export const SellAlert = () => {
-    const { watch } = useSellFormContext();
-    const text = watch('generalAlert');
+    const { control } = useSellFormContext();
+    const text = useWatch({ control, name: 'generalAlert' });
 
     return <GeneralAlert text={text} />;
 };

--- a/suite-native/module-trading/src/components/sell/SellCard.tsx
+++ b/suite-native/module-trading/src/components/sell/SellCard.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { cryptoIdToSymbol } from '@suite-common/trading';
 import { type AccountsRootState, selectAccountFormattedBalance } from '@suite-common/wallet-core';
 import { Box, HStack } from '@suite-native/atoms';
+import { useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 import {
     NetworkReserveBanner,
@@ -26,11 +27,11 @@ type SellCardProps = {
 const SELL_CARD_TEST_ID = '@trading/sellCard';
 
 export const SellCard = ({ isAmountInputActive, shouldAnimateEntering }: SellCardProps) => {
-    const { watch } = useSellFormContext();
-
-    const asset = watch('sendAsset');
-    const cryptoStringAmount = watch('cryptoStringAmount');
-    const sendAccount = watch('sendAccount');
+    const { control } = useSellFormContext();
+    const [asset, cryptoStringAmount, sendAccount] = useWatch({
+        control,
+        name: ['sendAsset', 'cryptoStringAmount', 'sendAccount'],
+    });
     const symbol = asset ? cryptoIdToSymbol(asset.cryptoId) : undefined;
 
     const formattedBalance = useSelector((state: AccountsRootState) =>

--- a/suite-native/module-trading/src/components/sell/SellConfirmation.tsx
+++ b/suite-native/module-trading/src/components/sell/SellConfirmation.tsx
@@ -6,6 +6,7 @@ import {
     selectTradingProviderByNameAndTradeType,
 } from '@suite-common/trading';
 import { AnimatedBox, Button } from '@suite-native/atoms';
+import { useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 
 import { useSellFormContext } from '../../hooks/sell/useSellFormContext';
@@ -21,7 +22,7 @@ export const SellConfirmation = ({ enteringAnimation }: ConfirmationProps) => {
     const form = useSellFormContext();
     const { canProceed, selectQuote } = useSellSelectQuote(form);
 
-    const quote = form.watch('quote');
+    const quote = useWatch({ control: form.control, name: 'quote' });
     const providerInfo = useSelector((state: TradingRootState) =>
         selectTradingProviderByNameAndTradeType(state, quote?.exchange, 'sell'),
     );

--- a/suite-native/module-trading/src/components/sell/SellForm.tsx
+++ b/suite-native/module-trading/src/components/sell/SellForm.tsx
@@ -79,7 +79,7 @@ const SellFormMemoized = memo(
 
 export const SellForm = ({ shouldAnimateEntering }: SellFormProps) => {
     const sellForm = useSellFormContext();
-    const isAmountInputActiveDebounced = useFocusedValueWatch(sellForm.watch);
+    const isAmountInputActiveDebounced = useFocusedValueWatch(sellForm.control);
     const reportToAnalytics = useSellAnalyticReportCallback();
 
     useSellQuotes(sellForm);

--- a/suite-native/module-trading/src/components/sell/SellFormFieldErrorBadge.tsx
+++ b/suite-native/module-trading/src/components/sell/SellFormFieldErrorBadge.tsx
@@ -106,9 +106,19 @@ const SellSendFiatAmountBadge = ({ amount, asset }: SellSendFiatAmountBadgeProps
     return <FiatAmountBadge amount={fiatAmount} />;
 };
 
+const SellSendFiatAmountBadgeContainer = ({ amount }: { amount: string }) => {
+    const { control } = useSellFormContext();
+    const asset = useWatch({ control, name: 'sendAsset' });
+
+    if (!asset) {
+        return null;
+    }
+
+    return <SellSendFiatAmountBadge amount={amount} asset={asset} />;
+};
+
 export const SellFormFieldErrorBadge = ({ fieldName }: SellFormFieldErrorBadgeProps) => {
     const isLoading = useSelector(selectTradingSellIsLoading);
-    const { watch } = useSellFormContext();
 
     const { errorMessage, hasError, value } = useField({ name: fieldName });
     const mismatchedAmountMessage = useMismatchedAmountMessage(fieldName);
@@ -124,12 +134,11 @@ export const SellFormFieldErrorBadge = ({ fieldName }: SellFormFieldErrorBadgePr
     }
 
     if (fieldName === 'cryptoStringAmount') {
-        const asset = watch('sendAsset');
-        if (!asset || !value) {
+        if (!value) {
             return null;
         }
 
-        return <SellSendFiatAmountBadge amount={value} asset={asset} />;
+        return <SellSendFiatAmountBadgeContainer amount={value} />;
     }
 
     return null;

--- a/suite-native/module-trading/src/components/sell/SellFormFieldErrorBadge.tsx
+++ b/suite-native/module-trading/src/components/sell/SellFormFieldErrorBadge.tsx
@@ -6,7 +6,7 @@ import { selectTradingSellIsLoading } from '@suite-common/trading';
 import { type FiatRatesRootState, type WalletSettingsRootState } from '@suite-common/wallet-core';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { Badge } from '@suite-native/atoms';
-import { useField } from '@suite-native/forms';
+import { useField, useWatch } from '@suite-native/forms';
 import { truncateDecimals } from '@suite-native/helpers';
 import { useTranslate } from '@suite-native/intl';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
@@ -31,17 +31,15 @@ type SellSendFiatAmountBadgeProps = {
 const asNonEmptyStringValue = (value: unknown): string => (value as string) ?? '0';
 
 const useMismatchedAmountMessage = (fieldName: keyof SellFormValues) => {
-    const { watch } = useSellFormContext();
+    const { control } = useSellFormContext();
     const { translate } = useTranslate();
     const { CryptoAmountFormatter, BaseCurrencyAmountFormatter } = useFormatters();
     const { convertStrToBaseUnit } = useConvertFormValueToBaseUnit();
 
-    const [asset, quote, amountInCrypto, value] = watch([
-        'sendAsset',
-        'quote',
-        'amountInCrypto',
-        fieldName,
-    ]);
+    const [asset, quote, amountInCrypto, value] = useWatch({
+        control,
+        name: ['sendAsset', 'quote', 'amountInCrypto', fieldName],
+    });
     const symbol = getSymbolFromTradeableAsset(asset);
 
     if (!quote) {

--- a/suite-native/module-trading/src/components/sell/SellFormFieldErrorBadge.tsx
+++ b/suite-native/module-trading/src/components/sell/SellFormFieldErrorBadge.tsx
@@ -106,19 +106,10 @@ const SellSendFiatAmountBadge = ({ amount, asset }: SellSendFiatAmountBadgeProps
     return <FiatAmountBadge amount={fiatAmount} />;
 };
 
-const SellSendFiatAmountBadgeContainer = ({ amount }: { amount: string }) => {
-    const { control } = useSellFormContext();
-    const asset = useWatch({ control, name: 'sendAsset' });
-
-    if (!asset) {
-        return null;
-    }
-
-    return <SellSendFiatAmountBadge amount={amount} asset={asset} />;
-};
-
 export const SellFormFieldErrorBadge = ({ fieldName }: SellFormFieldErrorBadgeProps) => {
     const isLoading = useSelector(selectTradingSellIsLoading);
+    const { control } = useSellFormContext();
+    const asset = useWatch({ control, name: 'sendAsset' });
 
     const { errorMessage, hasError, value } = useField({ name: fieldName });
     const mismatchedAmountMessage = useMismatchedAmountMessage(fieldName);
@@ -134,11 +125,11 @@ export const SellFormFieldErrorBadge = ({ fieldName }: SellFormFieldErrorBadgePr
     }
 
     if (fieldName === 'cryptoStringAmount') {
-        if (!value) {
+        if (!value || !asset) {
             return null;
         }
 
-        return <SellSendFiatAmountBadgeContainer amount={value} />;
+        return <SellSendFiatAmountBadge amount={value} asset={asset} />;
     }
 
     return null;

--- a/suite-native/module-trading/src/components/sell/__tests__/SellConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellConfirmation.test.tsx
@@ -13,25 +13,14 @@ jest.mock('../../../hooks/sell/useSellSelectQuote', () => ({
     useSellSelectQuote: jest.fn(),
 }));
 
+jest.mock('@suite-native/forms', () => ({
+    ...jest.requireActual('@suite-native/forms'),
+    useWatch: () => ({ exchange: 'test-provider' }),
+}));
+
 jest.mock('../../../hooks/sell/useSellFormContext', () => ({
     useSellFormContext: () => ({
-        watch: (fields: any) => {
-            if (Array.isArray(fields)) {
-                return fields.map((field: string) => {
-                    if (field === 'quote') return { exchange: EXCHANGE_NAME };
-
-                    if (field === 'sendAsset') return { symbol: 'btc' };
-
-                    return null;
-                });
-            }
-
-            if (fields === 'quote') {
-                return { exchange: EXCHANGE_NAME };
-            }
-
-            return null;
-        },
+        control: undefined,
     }),
 }));
 

--- a/suite-native/module-trading/src/components/sell/fiat/SellFiatAmountInput.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/SellFiatAmountInput.tsx
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { selectTradingSellIsLoading } from '@suite-common/trading';
+import { useWatch } from '@suite-native/forms';
 import { useAmountInputTransformers } from '@suite-native/helpers';
 import { useTranslate } from '@suite-native/intl';
 import { MAX_FIAT_DECIMALS } from '@suite-native/trading-consts';
@@ -13,12 +14,12 @@ const FIAT_AMOUNT_TEST_ID = '@trading/sell/fiat-amount-input';
 
 export const SellFiatAmountInput = () => {
     const { translate } = useTranslate();
-    const { watch } = useSellFormContext();
+    const { control } = useSellFormContext();
     const { fiatAmountTransformer } = useAmountInputTransformers(undefined);
     const isLoading = useSelector(selectTradingSellIsLoading);
     const inputControls = useSellInputFormControls('fiatStringAmount');
 
-    const amountInCrypto = watch('amountInCrypto');
+    const amountInCrypto = useWatch({ control, name: 'amountInCrypto' });
 
     return (
         <AmountInput

--- a/suite-native/module-trading/src/components/sell/fiat/SellFiatCurrencyPicker.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/SellFiatCurrencyPicker.tsx
@@ -1,4 +1,11 @@
+import { useDispatch } from 'react-redux';
+
+import type { FiatCurrencyCode } from 'invity-api';
+
+import { useServices } from '@suite-common/dependency-injection';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { HStack } from '@suite-native/atoms';
+import { sellActions } from '@suite-native/trading-state';
 
 import { SellFiatAmountInput } from './SellFiatAmountInput';
 import { SellFiatCurrencySheet } from './SellFiatCurrencySheet';
@@ -9,9 +16,28 @@ import { FiatCurrencyButton } from '../../general/FiatCurrencyButton';
 const FIAT_CURRENCY_PICKER_TEST_ID = '@trading/sell/fiat-button';
 
 export const SellFiatCurrencyPicker = () => {
+    const dispatch = useDispatch();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const form = useSellFormContext();
     const { isSheetVisible, hideSheet, showSheet, setSelectedValue, selectedValue } =
         useSheetControls(form, 'fiatCurrency');
+
+    const handleFiatSelect = (fiatCurrency: FiatCurrencyCode) => {
+        if (fiatCurrency === selectedValue) {
+            return;
+        }
+
+        setSelectedValue(fiatCurrency);
+        form.setValue('fiatStringAmount', undefined, { shouldValidate: true });
+        dispatch(sellActions.fiatCurrencyChanged());
+        analytics.report({
+            type: events.tradingParameterChangedEvent.name,
+            payload: {
+                type: 'sell',
+                parameter: 'fiat',
+            },
+        });
+    };
 
     return (
         <>
@@ -26,7 +52,7 @@ export const SellFiatCurrencyPicker = () => {
             <SellFiatCurrencySheet
                 isVisible={isSheetVisible}
                 onClose={hideSheet}
-                onFiatSelect={setSelectedValue}
+                onFiatSelect={handleFiatSelect}
                 searchInputTestId="@trading/sell/fiat-search-input"
             />
         </>

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencyPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencyPicker.test.tsx
@@ -1,19 +1,28 @@
 import { type useListDataFilter } from '@suite-common/trading';
+import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { Form } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
 import {
+    type TestStore,
     act,
     fireEvent,
     renderHookWithStoreProvider,
     renderWithStoreProvider,
     screen,
 } from '@suite-native/test-utils-store';
-import { getWalletState } from '@suite-native/trading-fixtures';
+import { sellActions } from '@suite-native/trading-state';
+import { type SellFormType } from '@suite-native/trading-types';
 
+import { createTradingLightStore } from '../../../../__tests__/tradingTestUtils';
 import { useSellForm } from '../../../../hooks/sell/useSellForm';
 import { SellFiatCurrencyPicker } from '../SellFiatCurrencyPicker';
 
 let mockUseListDataFilter: typeof useListDataFilter;
+const reportMock = jest.fn();
+const services: NativeAnalyticsDep = {
+    analytics: mockNativeAnalytics(reportMock),
+};
 
 jest.mock('@suite-common/trading', () => ({
     ...jest.requireActual('@suite-common/trading'),
@@ -22,29 +31,34 @@ jest.mock('@suite-common/trading', () => ({
 }));
 
 describe('SellFiatCurrencyPicker', () => {
+    let form: SellFormType;
+    let store: TestStore;
+
     beforeEach(() => {
         mockUseListDataFilter = jest.requireActual('@suite-common/trading').useListDataFilter;
+        reportMock.mockClear();
+        store = createTradingLightStore({ tradeType: 'sell' });
+        const { result } = renderHookWithStoreProvider(() => useSellForm(), {
+            services,
+            store,
+        });
+        form = result.current;
     });
 
     afterEach(() => {
         screen.unmount();
     });
 
-    const renderFiatCurrencyPicker = () => {
-        const preloadedState = { wallet: getWalletState({ tradeType: 'sell' }) };
-        const { result } = renderHookWithStoreProvider(() => useSellForm(), {
-            preloadedState,
-        });
-
-        return renderWithStoreProvider(
-            <Form form={result.current}>
+    const renderFiatCurrencyPicker = () =>
+        renderWithStoreProvider(
+            <Form form={form}>
                 <SellFiatCurrencyPicker />
             </Form>,
             {
-                preloadedState,
+                services,
+                store,
             },
         );
-    };
 
     it('should display selected currency', () => {
         const { getByLabelText } = renderFiatCurrencyPicker();
@@ -66,6 +80,26 @@ describe('SellFiatCurrencyPicker', () => {
         expect(
             getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')),
         ).toHaveTextContent(/PLN/);
+    });
+
+    it('should apply sell fiat currency change effects on selection', async () => {
+        form.setValue('fiatStringAmount', '100');
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+        const { getByText, getByLabelText } = renderFiatCurrencyPicker();
+
+        fireEvent.press(getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')));
+        fireEvent.press(getByText('PLN'));
+        await act(() => Promise.resolve());
+
+        expect(form.getValues('fiatStringAmount')).toBeUndefined();
+        expect(dispatchSpy).toHaveBeenCalledWith(sellActions.fiatCurrencyChanged());
+        expect(reportMock).toHaveBeenCalledWith({
+            type: events.tradingParameterChangedEvent.name,
+            payload: {
+                type: 'sell',
+                parameter: 'fiat',
+            },
+        });
     });
 
     it('should display empty component when filtered data is empty', () => {

--- a/suite-native/module-trading/src/components/sell/send/SellSendAccountCryptoBalance.tsx
+++ b/suite-native/module-trading/src/components/sell/send/SellSendAccountCryptoBalance.tsx
@@ -1,11 +1,16 @@
+import { useWatch } from '@suite-native/forms';
+
 import { useSellFormContext } from '../../../hooks/sell/useSellFormContext';
 import { TradeableAssetAccountBalance } from '../../general/TradeableAssetAccountBalance';
 
 export const SEND_ACCOUNT_BALANCE_TEST_ID = '@trading/sell/send-account-balance';
 
 export const SellSendAccountCryptoBalance = () => {
-    const { watch } = useSellFormContext();
-    const [sendAsset, sendAccount] = watch(['sendAsset', 'sendAccount']);
+    const { control } = useSellFormContext();
+    const [sendAsset, sendAccount] = useWatch({
+        control,
+        name: ['sendAsset', 'sendAccount'],
+    });
 
     return (
         <TradeableAssetAccountBalance

--- a/suite-native/module-trading/src/components/sell/send/SellSendAmountInput.tsx
+++ b/suite-native/module-trading/src/components/sell/send/SellSendAmountInput.tsx
@@ -3,6 +3,7 @@ import { type TextInput } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import { selectTradingSellIsLoading } from '@suite-common/trading';
+import { useWatch } from '@suite-native/forms';
 import { useAmountInputTransformers } from '@suite-native/helpers';
 import { useTranslate } from '@suite-native/intl';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
@@ -21,13 +22,11 @@ const SELL_SEND_INPUT_TEST_ID = '@trading/sell/send-amount-input';
 export const SellSendAmountInput = forwardRef<TextInput, SellSendAmountInputProps>(
     ({ showAssetsSheet }, ref) => {
         const { translate } = useTranslate();
-        const { watch, setValue } = useSellFormContext();
-        const [asset, amount, account, amountInCrypto] = watch([
-            'sendAsset',
-            'cryptoStringAmount',
-            'sendAccount',
-            'amountInCrypto',
-        ]);
+        const { control, setValue } = useSellFormContext();
+        const [asset, amount, account, amountInCrypto] = useWatch({
+            control,
+            name: ['sendAsset', 'cryptoStringAmount', 'sendAccount', 'amountInCrypto'],
+        });
         const symbol = getSymbolFromTradeableAsset(asset);
         const { cryptoAmountTransformer } = useAmountInputTransformers(symbol);
         const inputControls = useInputFieldControls('cryptoStringAmount', amount, setValue);

--- a/suite-native/module-trading/src/components/sell/send/SellSendAmountInput.tsx
+++ b/suite-native/module-trading/src/components/sell/send/SellSendAmountInput.tsx
@@ -9,8 +9,8 @@ import { useTranslate } from '@suite-native/intl';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 
 import { useAmountInputDecimals } from '../../../hooks/general/useAmountInputDecimals';
-import { useInputFieldControls } from '../../../hooks/general/useInputFieldControls';
 import { useSellFormContext } from '../../../hooks/sell/useSellFormContext';
+import { useSellInputFormControls } from '../../../hooks/sell/useSellInputFormControls';
 import { AmountInput } from '../../general/Input/AmountInput';
 
 export type SellSendAmountInputProps = {
@@ -22,15 +22,16 @@ const SELL_SEND_INPUT_TEST_ID = '@trading/sell/send-amount-input';
 export const SellSendAmountInput = forwardRef<TextInput, SellSendAmountInputProps>(
     ({ showAssetsSheet }, ref) => {
         const { translate } = useTranslate();
-        const { control, setValue } = useSellFormContext();
-        const [asset, amount, account, amountInCrypto] = useWatch({
+        const { control } = useSellFormContext();
+        const [asset, account, amountInCrypto] = useWatch({
             control,
-            name: ['sendAsset', 'cryptoStringAmount', 'sendAccount', 'amountInCrypto'],
+            name: ['sendAsset', 'sendAccount', 'amountInCrypto'],
         });
         const symbol = getSymbolFromTradeableAsset(asset);
         const { cryptoAmountTransformer } = useAmountInputTransformers(symbol);
-        const inputControls = useInputFieldControls('cryptoStringAmount', amount, setValue);
+        const inputControls = useSellInputFormControls('cryptoStringAmount');
         const decimals = useAmountInputDecimals(account, asset?.contractAddress);
+
         const isLoading = useSelector(selectTradingSellIsLoading);
 
         const isAssetSelected = !!asset;

--- a/suite-native/module-trading/src/components/sell/send/SellSendAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/sell/send/SellSendAssetPicker.tsx
@@ -2,9 +2,12 @@ import { useCallback, useRef, useState } from 'react';
 import { type TextInput } from 'react-native';
 import { useDispatch } from 'react-redux';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { tradingSellActions } from '@suite-common/trading';
 import { type Account } from '@suite-common/wallet-types';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { HStack } from '@suite-native/atoms';
+import { sellActions } from '@suite-native/trading-state';
 import { type TradeableAsset } from '@suite-native/trading-types';
 
 import { SellSendAmountInput } from './SellSendAmountInput';
@@ -18,6 +21,7 @@ const ASSET_SHEET_TEST_ID = '@trading/sell/send-asset-sheet';
 
 export const SellSendAssetPicker = () => {
     const dispatch = useDispatch();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const inputRef = useRef<TextInput>(null);
     const form = useSellFormContext();
     const [shouldFocusInput, setShouldFocusInput] = useState<boolean>(false);
@@ -26,8 +30,21 @@ export const SellSendAssetPicker = () => {
 
     const onAssetSelect = useCallback(
         (asset: TradeableAsset, account: Account) => {
-            setSelectedValue(asset);
             dispatch(tradingSellActions.setTradingAccountKey(account.key));
+
+            if (asset.cryptoId !== selectedValue?.cryptoId) {
+                setSelectedValue(asset);
+                form.setValue('cryptoStringAmount', undefined, { shouldValidate: true });
+                dispatch(sellActions.sendAssetChanged());
+                analytics.report({
+                    type: events.tradingParameterChangedEvent.name,
+                    payload: {
+                        type: 'sell',
+                        parameter: 'cryptoFrom',
+                    },
+                });
+            }
+
             if (shouldFocusInput) {
                 setShouldFocusInput(false);
                 // CryptoAmountInput is rendered disabled allow changes to propagate.
@@ -36,7 +53,7 @@ export const SellSendAssetPicker = () => {
                 }, 0);
             }
         },
-        [shouldFocusInput, setSelectedValue, dispatch],
+        [analytics, dispatch, form, selectedValue?.cryptoId, setSelectedValue, shouldFocusInput],
     );
 
     const showAssetsSheet = useCallback(() => {

--- a/suite-native/module-trading/src/components/sell/send/SellSendAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/sell/send/SellSendAssetPicker.tsx
@@ -1,16 +1,14 @@
 import { useCallback, useRef, useState } from 'react';
 import { type TextInput } from 'react-native';
-import { useDispatch } from 'react-redux';
 
-import { useServices } from '@suite-common/dependency-injection';
 import { tradingSellActions } from '@suite-common/trading';
 import { type Account } from '@suite-common/wallet-types';
-import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { HStack } from '@suite-native/atoms';
 import { sellActions } from '@suite-native/trading-state';
 import { type TradeableAsset } from '@suite-native/trading-types';
 
 import { SellSendAmountInput } from './SellSendAmountInput';
+import { useTradeableAssetChange } from '../../../hooks/general/form/useTradeableAssetChange';
 import { useSheetControls } from '../../../hooks/general/useSheetControls';
 import { useSellFormContext } from '../../../hooks/sell/useSellFormContext';
 import { MyAssetSheet } from '../../general/MyAssetSheet/MyAssetSheet';
@@ -20,30 +18,26 @@ const ASSET_PICKER_TEST_ID = '@trading/sell/asset-send-button';
 const ASSET_SHEET_TEST_ID = '@trading/sell/send-asset-sheet';
 
 export const SellSendAssetPicker = () => {
-    const dispatch = useDispatch();
-    const { analytics } = useServices(selectNativeAnalyticsDep);
     const inputRef = useRef<TextInput>(null);
     const form = useSellFormContext();
     const [shouldFocusInput, setShouldFocusInput] = useState<boolean>(false);
     const { isSheetVisible, hideSheet, showSheet, setSelectedValue, selectedValue } =
         useSheetControls(form, 'sendAsset');
 
+    const changeAsset = useTradeableAssetChange({
+        form,
+        tradingType: 'sell',
+        selectedValue,
+        setSelectedValue,
+        analyticsParameter: 'cryptoFrom',
+        amountField: 'cryptoStringAmount',
+        getAssetChangedAction: sellActions.sendAssetChanged,
+        getSetTradingAccountKeyAction: tradingSellActions.setTradingAccountKey,
+    });
+
     const onAssetSelect = useCallback(
         (asset: TradeableAsset, account: Account) => {
-            dispatch(tradingSellActions.setTradingAccountKey(account.key));
-
-            if (asset.cryptoId !== selectedValue?.cryptoId) {
-                setSelectedValue(asset);
-                form.setValue('cryptoStringAmount', undefined, { shouldValidate: true });
-                dispatch(sellActions.sendAssetChanged());
-                analytics.report({
-                    type: events.tradingParameterChangedEvent.name,
-                    payload: {
-                        type: 'sell',
-                        parameter: 'cryptoFrom',
-                    },
-                });
-            }
+            changeAsset(asset, account);
 
             if (shouldFocusInput) {
                 setShouldFocusInput(false);
@@ -53,7 +47,7 @@ export const SellSendAssetPicker = () => {
                 }, 0);
             }
         },
-        [analytics, dispatch, form, selectedValue?.cryptoId, setSelectedValue, shouldFocusInput],
+        [changeAsset, shouldFocusInput],
     );
 
     const showAssetsSheet = useCallback(() => {

--- a/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAmountInput.test.tsx
@@ -123,6 +123,20 @@ describe('SellSendAmountInput', () => {
         ).toHaveDisplayValue('1.123');
     });
 
+    it('should preserve a leading-zero decimal while typing', async () => {
+        const form = renderUseTradingSellForm();
+        act(() => {
+            form.setValue('sendAsset', btcAsset);
+        });
+        const { getByLabelText } = renderCryptoAmountInput({}, form);
+        const input = getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel'));
+
+        await userEvent.type(input, '0.0001');
+
+        expect(form.getValues('cryptoStringAmount')).toEqual('0.0001');
+        expect(input).toHaveDisplayValue('0.0001');
+    });
+
     it('should format input value to be integer when BTC asset is selected and value should be displayed in sats', async () => {
         const overrides = {
             wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },

--- a/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAssetPicker.test.tsx
@@ -1,6 +1,8 @@
 import type { CryptoId } from 'invity-api';
 
 import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
+import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { Form } from '@suite-native/forms';
 import {
     type TestStore,
@@ -13,7 +15,10 @@ import {
     getEthAccount,
     getInitializedTradingState,
 } from '@suite-native/trading-fixtures';
-import { selectAccountsWithTokensToSellSectionCondensedListByTradingType } from '@suite-native/trading-state';
+import {
+    selectAccountsWithTokensToSellSectionCondensedListByTradingType,
+    sellActions,
+} from '@suite-native/trading-state';
 import { type MyAssetTradeable, type SellFormType } from '@suite-native/trading-types';
 import { BigNumber } from '@trezor/utils';
 
@@ -27,6 +32,10 @@ jest.mock('@suite-native/trading-state', () => ({
 }));
 const mockedSelectAccountsWithTokensToSellSectionListByTradingType =
     selectAccountsWithTokensToSellSectionCondensedListByTradingType as unknown as jest.Mock;
+const reportMock = jest.fn();
+const services: NativeAnalyticsDep = {
+    analytics: mockNativeAnalytics(reportMock),
+};
 
 describe('SellSendAssetPicker', () => {
     let form: SellFormType;
@@ -59,15 +68,18 @@ describe('SellSendAssetPicker', () => {
         },
     ];
 
-    const renderSellForm = () => renderHookWithStoreProvider(() => useSellForm(), { store });
+    const renderSellForm = () =>
+        renderHookWithStoreProvider(() => useSellForm(), { services, store });
 
     const renderSellSendAssetPicker = () =>
         renderWithStoreProvider(<SellSendAssetPicker />, {
+            services,
             store,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
     beforeEach(() => {
+        reportMock.mockClear();
         store = createTradingLightStore({
             tradeType: 'sell',
             overrides: {
@@ -106,5 +118,23 @@ describe('SellSendAssetPicker', () => {
 
         const accountKeyStore = store.getState().wallet.trading.sell.tradingAccountKey;
         expect(accountKeyStore).toBe(btcAccount.key);
+    });
+
+    it('should apply sell asset change effects on item press', async () => {
+        form.setValue('cryptoStringAmount', '1');
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+        const { getByText } = renderSellSendAssetPicker();
+
+        await userEvent.press(getByText('BTC'));
+
+        expect(form.getValues('cryptoStringAmount')).toBeUndefined();
+        expect(dispatchSpy).toHaveBeenCalledWith(sellActions.sendAssetChanged());
+        expect(reportMock).toHaveBeenCalledWith({
+            type: events.tradingParameterChangedEvent.name,
+            payload: {
+                type: 'sell',
+                parameter: 'cryptoFrom',
+            },
+        });
     });
 });

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
@@ -4,11 +4,9 @@ import { type EnhancedStore } from '@reduxjs/toolkit';
 import type { BuyTrade, CryptoId } from 'invity-api';
 
 import { selectTradingProviderMetadata, tradingBuyActions } from '@suite-common/trading';
-import { Form, useField } from '@suite-native/forms';
 import {
     type TestStore,
     act,
-    renderHook,
     renderHookWithStoreProvider,
     waitFor,
 } from '@suite-native/test-utils-store';
@@ -24,10 +22,8 @@ import {
     getInitializedTradingState,
     mercuryoApplePayBuyQuote,
     mercuryoCreditCardBuyQuote,
-    usdcAsset,
-    usdtAsset,
 } from '@suite-native/trading-fixtures';
-import { buyActions, selectTradingResidenceCountry } from '@suite-native/trading-state';
+import { selectTradingResidenceCountry } from '@suite-native/trading-state';
 import { type BuyFormType, type TradeableAsset } from '@suite-native/trading-types';
 import { PROTO } from '@trezor/connect';
 
@@ -45,8 +41,6 @@ jest.mock('@trezor/react-utils', () => {
 
 const btc1AccountKey = btc1NormalAccount.key;
 const btc2AccountKey = btc2legacyAccount.key;
-const eth1AccountKey = eth1NormalAccount.key;
-const eth2AccountKey = eth2legacyAccount.key;
 const accountDeviceState = btc1NormalAccount.deviceState;
 
 describe('useBuyForm', () => {
@@ -135,73 +129,6 @@ describe('useBuyForm', () => {
         });
     });
 
-    it('should dispatch tradingBuy/assetChanged on asset change', () => {
-        const store = getInitializedStore();
-        const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseTradingBuyForm(store);
-
-        dispatchSpy.mockClear();
-        act(() => {
-            result.current.setValue('asset', usdcAsset);
-        });
-        expect(dispatchSpy).toHaveBeenCalledWith(buyActions.assetChanged());
-    });
-
-    it('should dispatch tradingBuy/assetTokenChanged when asset changes within the same network', () => {
-        const store = getInitializedStore();
-        const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseTradingBuyForm(store);
-
-        act(() => {
-            result.current.setValue('asset', usdcAsset);
-        });
-
-        dispatchSpy.mockClear();
-
-        act(() => {
-            result.current.setValue('asset', usdtAsset);
-        });
-
-        expect(dispatchSpy).toHaveBeenCalledWith(buyActions.assetTokenChanged());
-        expect(dispatchSpy).not.toHaveBeenCalledWith(buyActions.assetChanged());
-    });
-
-    it('should keep selected receiveAccount when asset changes within the same network', async () => {
-        const store = getInitializedStore();
-        const { result } = renderUseTradingBuyForm(store);
-
-        act(() => {
-            result.current.setValue('asset', usdcAsset);
-        });
-
-        await waitFor(() => {
-            expect(result.current.getValues('receiveAccount')).toEqual({
-                account: expect.objectContaining({ key: eth1AccountKey }),
-            });
-        });
-
-        act(() => {
-            store.dispatch(tradingBuyActions.setTradingAccountKey(eth2AccountKey));
-            store.dispatch(tradingBuyActions.setReceiveAccountKey(eth2AccountKey));
-        });
-
-        await waitFor(() => {
-            expect(result.current.getValues('receiveAccount')).toEqual({
-                account: expect.objectContaining({ key: eth2AccountKey }),
-            });
-        });
-
-        act(() => {
-            result.current.setValue('asset', usdtAsset);
-        });
-
-        await waitFor(() => {
-            expect(result.current.getValues('receiveAccount')).toEqual({
-                account: expect.objectContaining({ key: eth2AccountKey }),
-            });
-        });
-    });
-
     it('should not clear selected account when asset is set to undefined', () => {
         const store = getInitializedStore();
         const { result } = renderUseTradingBuyForm(store);
@@ -214,146 +141,6 @@ describe('useBuyForm', () => {
         expect(result.current.getValues('receiveAccount')).toEqual({
             account: expect.objectContaining({ key: btc1AccountKey }),
         });
-    });
-
-    it('should clear crypto amount on coin change', () => {
-        const store = getInitializedStore();
-        const { result } = renderUseTradingBuyForm(store);
-
-        act(() => {
-            result.current.setValue('asset', btcAsset);
-            result.current.setValue('cryptoValue', '10');
-            result.current.setValue('asset', usdcAsset);
-        });
-
-        expect(result.current.getValues('cryptoValue')).toBeUndefined();
-    });
-
-    it('should clear crypto amount on fiat currency change', () => {
-        const store = getInitializedStore();
-        const { result } = renderUseTradingBuyForm(store);
-
-        act(() => {
-            result.current.setValue('cryptoValue', '10');
-            result.current.setValue('fiatCurrency', 'eur');
-        });
-
-        expect(result.current.getValues('cryptoValue')).toBeUndefined();
-    });
-
-    it('should clear fiat amount on fiat currency change', () => {
-        const store = getInitializedStore();
-        const { result } = renderUseTradingBuyForm(store);
-
-        act(() => {
-            result.current.setValue('fiatValue', '10');
-            result.current.setValue('fiatCurrency', 'eur');
-        });
-
-        expect(result.current.getValues('fiatValue')).toBeUndefined();
-    });
-
-    it('should dispatch fiatCurrencyChanged action on fiat currency change', () => {
-        const store = getInitializedStore();
-        const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseTradingBuyForm(store);
-
-        dispatchSpy.mockClear();
-        act(() => {
-            result.current.setValue('fiatCurrency', 'eur');
-        });
-
-        expect(dispatchSpy).toHaveBeenCalledTimes(1);
-        expect(dispatchSpy).toHaveBeenCalledWith(buyActions.fiatCurrencyChanged());
-    });
-
-    it('should clear cryptoValue when user edits fiatValue', () => {
-        const store = getInitializedStore();
-        const { result, unmount } = renderUseTradingBuyForm(store);
-        const { result: fieldResult, unmount: unmountField } = renderHook(
-            () => useField({ name: 'fiatValue' }),
-            {
-                wrapper: ({ children }) => <Form form={result.current}>{children}</Form>,
-            },
-        );
-
-        act(() => {
-            result.current.setValue('cryptoValue', '10');
-            result.current.setValue('focusedValue', 'fiatValue');
-            fieldResult.current.onChange('10');
-        });
-
-        expect(result.current.getValues('cryptoValue')).toBeUndefined();
-        expect(result.current.getValues('fiatValue')).toEqual('10');
-
-        unmountField();
-        unmount();
-    });
-
-    it('should clear fiatValue when user edits cryptoValue', () => {
-        const store = getInitializedStore();
-        const { result, unmount } = renderUseTradingBuyForm(store);
-        const { result: fieldResult, unmount: unmountField } = renderHook(
-            () => useField({ name: 'cryptoValue' }),
-            {
-                wrapper: ({ children }) => <Form form={result.current}>{children}</Form>,
-            },
-        );
-
-        act(() => {
-            result.current.setValue('fiatValue', '10');
-            result.current.setValue('focusedValue', 'cryptoValue');
-            fieldResult.current.onChange('10');
-        });
-
-        expect(result.current.getValues('fiatValue')).toBeUndefined();
-        expect(result.current.getValues('cryptoValue')).toEqual('10');
-
-        unmountField();
-        unmount();
-    });
-
-    it('should set amountInCrypto to true when user edits cryptoValue', () => {
-        const store = getInitializedStore();
-        const { result, unmount } = renderUseTradingBuyForm(store);
-        const { result: fieldResult, unmount: unmountField } = renderHook(
-            () => useField({ name: 'cryptoValue' }),
-            {
-                wrapper: ({ children }) => <Form form={result.current}>{children}</Form>,
-            },
-        );
-
-        act(() => {
-            result.current.setValue('focusedValue', 'cryptoValue');
-            fieldResult.current.onChange('10');
-        });
-
-        expect(result.current.getValues('amountInCrypto')).toBe(true);
-
-        unmountField();
-        unmount();
-    });
-
-    it('should set amountInCrypto to false when user edits fiatValue', () => {
-        const store = getInitializedStore();
-        const { result, unmount } = renderUseTradingBuyForm(store);
-        const { result: fieldResult, unmount: unmountField } = renderHook(
-            () => useField({ name: 'fiatValue' }),
-            {
-                wrapper: ({ children }) => <Form form={result.current}>{children}</Form>,
-            },
-        );
-
-        act(() => {
-            result.current.setValue('amountInCrypto', true);
-            result.current.setValue('focusedValue', 'fiatValue');
-            fieldResult.current.onChange('10');
-        });
-
-        expect(result.current.getValues('amountInCrypto')).toBe(false);
-
-        unmountField();
-        unmount();
     });
 
     describe('on quotes change', () => {

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyInputFormControls.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyInputFormControls.test.tsx
@@ -1,5 +1,5 @@
 import { Form } from '@suite-native/forms';
-import { renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
 import { type BuyFormType } from '@suite-native/trading-types';
 
 import { renderHookWithTradingProvider } from '../../../__tests__/tradingTestUtils';
@@ -11,8 +11,8 @@ describe('useBuyInputFormControls', () => {
 
     const renderBuyFormHook = () => renderHookWithTradingProvider(() => useBuyForm());
 
-    const renderUseBuyInputFormControls = () =>
-        renderHookWithBasicProvider(() => useBuyInputFormControls('fiatValue'), {
+    const renderUseBuyInputFormControls = (name: 'fiatValue' | 'cryptoValue' = 'fiatValue') =>
+        renderHookWithBasicProvider(() => useBuyInputFormControls(name), {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
@@ -40,5 +40,38 @@ describe('useBuyInputFormControls', () => {
                 hasError: false,
             }),
         );
+    });
+
+    it('should keep onChangeText stable when the value changes', () => {
+        const { result } = renderUseBuyInputFormControls();
+        const initialOnChangeText = result.current.onChangeText;
+
+        act(() => form.setValue('fiatValue', '123'));
+
+        expect(result.current.onChangeText).toBe(initialOnChangeText);
+    });
+
+    it('should switch to fiat amount and clear crypto amount on fiat input change', () => {
+        form.setValue('amountInCrypto', true);
+        form.setValue('cryptoValue', '0.1');
+        const { result } = renderUseBuyInputFormControls('fiatValue');
+
+        act(() => result.current.onChangeText('100'));
+
+        expect(form.getValues('fiatValue')).toBe('100');
+        expect(form.getValues('cryptoValue')).toBeUndefined();
+        expect(form.getValues('amountInCrypto')).toBe(false);
+    });
+
+    it('should switch to crypto amount and clear fiat amount on crypto input change', () => {
+        form.setValue('amountInCrypto', false);
+        form.setValue('fiatValue', '100');
+        const { result } = renderUseBuyInputFormControls('cryptoValue');
+
+        act(() => result.current.onChangeText('0.1'));
+
+        expect(form.getValues('cryptoValue')).toBe('0.1');
+        expect(form.getValues('fiatValue')).toBeUndefined();
+        expect(form.getValues('amountInCrypto')).toBe(true);
     });
 });

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
@@ -165,12 +165,6 @@ describe('useBuyQuotes', () => {
         [
             'receiveAccount',
             {
-                account: eth1NormalAccount,
-            },
-        ],
-        [
-            'receiveAccount',
-            {
                 account: btc1NormalAccount,
                 address: btc1NormalAccount.addresses!.unused[0],
             },
@@ -214,6 +208,9 @@ describe('useBuyQuotes', () => {
             result.current.setValue('fiatValue', '100');
         });
 
+        act(() => {
+            result.current.setValue('receiveAccount', undefined);
+        });
         dispatchSpy.mockClear();
         act(() => {
             result.current.setValue('receiveAccount', {
@@ -244,7 +241,11 @@ describe('useBuyQuotes', () => {
             result.current.setValue('fiatValue', '100');
         });
 
-        expect(dispatchSpy).toHaveBeenCalledTimes(3);
+        expect(dispatchSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'handleRequestThunkMock',
+            }),
+        );
 
         act(() => {
             store.dispatch(tradingActions.setRefetchQuotesTimestamp(Date.now()));

--- a/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
@@ -12,6 +12,7 @@ import {
     tradingBuyActions,
 } from '@suite-common/trading';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
+import { useWatch } from '@suite-native/forms';
 import {
     type RootStackParamList,
     RootStackRoutes,
@@ -39,11 +40,10 @@ export const useBuyFlow = (form: BuyFormType) => {
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const dispatch = useDispatch();
     const isLoading = useSelector(selectTradingBuyIsLoading);
-    const [asset, candidateQuote, receiveAccount] = form.watch([
-        'asset',
-        'quote',
-        'receiveAccount',
-    ]);
+    const [asset, candidateQuote, receiveAccount] = useWatch({
+        control: form.control,
+        name: ['asset', 'quote', 'receiveAccount'],
+    });
 
     const navigation = useNavigation<NavigationProps>();
 

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -166,8 +166,8 @@ const useBuyQuotesChangeEffect = ({ getValues, setValue }: BuyFormType) => {
     }, [quotes, getValues, setValue]);
 };
 
-const useBuyQuoteChangeEffect = ({ getValues, setValue, watch }: BuyFormType) => {
-    const [asset, quote] = watch(['asset', 'quote']);
+const useBuyQuoteChangeEffect = ({ control, getValues, setValue }: BuyFormType) => {
+    const [asset, quote] = useWatch({ control, name: ['asset', 'quote'] });
     const symbol = getSymbolFromTradeableAsset(asset);
 
     const isAmountInSats = useSelector((state: WalletSettingsRootState) =>

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -1,26 +1,19 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { Platform } from 'react-native';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
-import type { BuyCryptoPaymentMethod, BuyTrade, CryptoId, FiatCurrencyCode } from 'invity-api';
+import type { BuyCryptoPaymentMethod, BuyTrade } from 'invity-api';
 
-import { useServices } from '@suite-common/dependency-injection';
-import {
-    type TradingAmountLimitProps,
-    cryptoIdToSymbol,
-    selectTradingBuyQuotesRequest,
-} from '@suite-common/trading';
+import { type TradingAmountLimitProps, selectTradingBuyQuotesRequest } from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
-import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { useForm, useWatch } from '@suite-native/forms';
 import { truncateDecimals } from '@suite-native/helpers';
 import { useTranslate } from '@suite-native/intl';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import { MAX_CRYPTO_DECIMALS, MAX_FIAT_DECIMALS } from '@suite-native/trading-consts';
 import {
-    buyActions,
     selectBuyAmountLimits,
     selectBuyFormDefaultValues,
     selectBuySelectedReceiveAccount,
@@ -34,83 +27,6 @@ import { useCountryChangeEffect } from '../general/form/useCountryChangeEffect';
 import { useProviderMetadataChangeEffect } from '../general/form/useProviderMetadataChangeEffect';
 import { useReceiveAccountChangeEffect } from '../general/form/useReceiveAccountChangeEffect';
 import { useReceiveAccountPreselectionEffect } from '../general/form/useReceiveAccountPreselectionEffect';
-
-const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: BuyFormType) => {
-    const dispatch = useDispatch();
-    const prevCryptoId = useRef<CryptoId | undefined>(undefined);
-    const prevFiatCurrency = useRef<FiatCurrencyCode | undefined>(getValues('fiatCurrency'));
-    const { analytics } = useServices(selectNativeAnalyticsDep);
-    useEffect(() => {
-        const { unsubscribe } = watch(
-            ({ focusedValue, asset, amountInCrypto, fiatCurrency }, { name, type }) => {
-                switch (name) {
-                    case 'fiatValue':
-                        if (focusedValue === 'fiatValue' && type === 'change') {
-                            setValue('cryptoValue', undefined, { shouldValidate: true });
-                            if (amountInCrypto) {
-                                setValue('amountInCrypto', false);
-                            }
-                        }
-                        break;
-
-                    case 'cryptoValue':
-                        if (focusedValue === 'cryptoValue' && type === 'change') {
-                            setValue('fiatValue', undefined, { shouldValidate: true });
-                            if (!amountInCrypto) {
-                                setValue('amountInCrypto', true);
-                            }
-                        }
-                        break;
-
-                    case 'fiatCurrency':
-                        if (fiatCurrency !== prevFiatCurrency.current) {
-                            analytics.report({
-                                type: events.tradingParameterChangedEvent.name,
-                                payload: {
-                                    type: 'buy',
-                                    parameter: 'fiat',
-                                },
-                            });
-                            prevFiatCurrency.current = fiatCurrency;
-                            setValue('fiatValue', undefined, { shouldValidate: true });
-                            setValue('cryptoValue', undefined, { shouldValidate: true });
-                            dispatch(buyActions.fiatCurrencyChanged());
-                        }
-                        break;
-
-                    case 'asset': {
-                        if (asset?.cryptoId !== prevCryptoId.current) {
-                            const prevSymbol = cryptoIdToSymbol(prevCryptoId.current);
-                            const symbol = cryptoIdToSymbol(asset?.cryptoId);
-
-                            analytics.report({
-                                type: events.tradingParameterChangedEvent.name,
-                                payload: {
-                                    type: 'buy',
-                                    parameter: 'cryptoTo',
-                                },
-                            });
-                            prevCryptoId.current = asset?.cryptoId;
-                            setValue('cryptoValue', undefined, { shouldValidate: true });
-                            dispatch(
-                                prevSymbol === symbol
-                                    ? buyActions.assetTokenChanged()
-                                    : buyActions.assetChanged(),
-                            );
-                        }
-                        break;
-                    }
-
-                    default:
-                        // do nothing
-                        break;
-                }
-            },
-        );
-
-        return unsubscribe;
-    }, [dispatch, analytics, setValue, watch]);
-};
 
 const useBuyQuotesChangeEffect = ({ getValues, setValue }: BuyFormType) => {
     const quotes = useSelector(selectValidTradingBuyQuotesNative);
@@ -236,10 +152,9 @@ export const useBuyForm = (): BuyFormType => {
         validation: buyFormValidationSchema,
         context,
     });
-    const { control, setValue, watch } = form;
+    const { control, setValue } = form;
     const asset = useWatch({ control, name: 'asset' });
 
-    useAmountAndCurrencyFieldsChangeEffect(form);
     useReceiveAccountChangeEffect(setValue, selectBuySelectedReceiveAccount);
     useReceiveAccountPreselectionEffect({
         receiveAsset: asset,
@@ -249,8 +164,8 @@ export const useBuyForm = (): BuyFormType => {
     useBuyQuotesChangeEffect(form);
     useBuyQuoteChangeEffect(form);
     useValidations(form, limits);
-    useCountryChangeEffect(watch);
-    useProviderMetadataChangeEffect(watch, 'buy');
+    useCountryChangeEffect(control);
+    useProviderMetadataChangeEffect(control, 'buy');
 
     return form;
 };

--- a/suite-native/module-trading/src/hooks/buy/useBuyInputFormControls.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyInputFormControls.ts
@@ -1,9 +1,42 @@
+import { useCallback } from 'react';
+
+import { useWatch } from '@suite-native/forms';
+
 import { useBuyFormContext } from './useBuyFormContext';
 import { useInputFieldControls } from '../general/useInputFieldControls';
 
 export const useBuyInputFormControls = (name: 'fiatValue' | 'cryptoValue') => {
-    const { getValues, setValue } = useBuyFormContext();
-    const value = getValues(name);
+    const { control, getValues, setValue } = useBuyFormContext();
+    const value = useWatch({ control, name });
+    const { onChangeText: updateFieldValue, ...inputControls } = useInputFieldControls(
+        name,
+        value,
+        setValue,
+    );
 
-    return useInputFieldControls(name, value, setValue);
+    const onChangeText = useCallback(
+        (nextValue: string | undefined) => {
+            updateFieldValue(nextValue);
+
+            if (name === 'fiatValue') {
+                setValue('cryptoValue', undefined, { shouldValidate: true });
+
+                if (getValues('amountInCrypto')) {
+                    setValue('amountInCrypto', false);
+                }
+            } else {
+                setValue('fiatValue', undefined, { shouldValidate: true });
+
+                if (!getValues('amountInCrypto')) {
+                    setValue('amountInCrypto', true);
+                }
+            }
+        },
+        [getValues, name, setValue, updateFieldValue],
+    );
+
+    return {
+        ...inputControls,
+        onChangeText,
+    };
 };

--- a/suite-native/module-trading/src/hooks/buy/useBuyQuotes.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyQuotes.ts
@@ -17,6 +17,7 @@ import {
 } from '@suite-common/trading';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
+import { useWatch } from '@suite-native/forms';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import { buyActions, selectValidTradingBuyQuotesNative } from '@suite-native/trading-state';
 import { type AbortablePromise, type BuyFormType } from '@suite-native/trading-types';
@@ -61,16 +62,19 @@ const useShouldFetchBuyQuotes = (form: BuyFormType): ShouldFetchBuyQuotes => {
         country,
         countrySubdivision,
         receiveAccount,
-    ] = form.watch([
-        'asset',
-        'fiatCurrency',
-        'fiatValue',
-        'cryptoValue',
-        'amountInCrypto',
-        'country',
-        'countrySubdivision',
-        'receiveAccount',
-    ]);
+    ] = useWatch({
+        control: form.control,
+        name: [
+            'asset',
+            'fiatCurrency',
+            'fiatValue',
+            'cryptoValue',
+            'amountInCrypto',
+            'country',
+            'countrySubdivision',
+            'receiveAccount',
+        ],
+    });
 
     const amount = amountInCrypto ? cryptoValue : fiatValue;
     const isFetchAllowed = !!(asset && fiatCurrency && amount && parseFloat(amount) > 0);
@@ -135,7 +139,7 @@ const useBuyQuotesThunk = (
 ) => {
     const dispatch = useDispatch();
     const { analytics } = useServices(selectNativeAnalyticsDep);
-    const asset = form.watch('asset');
+    const asset = useWatch({ control: form.control, name: 'asset' });
     const symbol = getSymbolFromTradeableAsset(asset);
     const shouldSendInSats = useSelector((state: WalletSettingsRootState) =>
         selectIsAmountInSats(state, symbol),

--- a/suite-native/module-trading/src/hooks/buy/useBuyQuotes.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyQuotes.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useCallback, useEffect, useRef } from 'react';
+import { type RefObject, useCallback, useEffect, useEffectEvent, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { isFulfilled } from '@reduxjs/toolkit';
@@ -27,7 +27,8 @@ import { tradingBuyFormToTradingBuyFormProps } from '../../utils/buy/quotesUtils
 import { getReceiveAccountAddressText } from '../../utils/general/receiveAccountUtils';
 import { useQuotesInvalidator } from '../general/useQuotesInvalidator';
 
-type ShouldFetchBuyQuotesRef = {
+type BuyQuoteRequestState = {
+    isFetchAllowed: boolean;
     cryptoId: string | undefined;
     fiatCurrency: string | undefined;
     amount: string | undefined;
@@ -37,22 +38,7 @@ type ShouldFetchBuyQuotesRef = {
     receiveAccountAddress: string | undefined;
 };
 
-type ShouldFetchBuyQuotes = {
-    isFetchAllowed: boolean;
-    shouldFetchQuotes: boolean;
-};
-
-const useShouldFetchBuyQuotes = (form: BuyFormType): ShouldFetchBuyQuotes => {
-    const prevState = useRef<ShouldFetchBuyQuotesRef>({
-        cryptoId: undefined,
-        fiatCurrency: undefined,
-        amount: undefined,
-        amountInCrypto: false,
-        country: undefined,
-        countrySubdivision: undefined,
-        receiveAccountAddress: undefined,
-    });
-
+const useBuyQuoteRequestState = ({ control }: BuyFormType): BuyQuoteRequestState => {
     const [
         asset,
         fiatCurrency,
@@ -63,7 +49,7 @@ const useShouldFetchBuyQuotes = (form: BuyFormType): ShouldFetchBuyQuotes => {
         countrySubdivision,
         receiveAccount,
     ] = useWatch({
-        control: form.control,
+        control,
         name: [
             'asset',
             'fiatCurrency',
@@ -78,36 +64,16 @@ const useShouldFetchBuyQuotes = (form: BuyFormType): ShouldFetchBuyQuotes => {
 
     const amount = amountInCrypto ? cryptoValue : fiatValue;
     const isFetchAllowed = !!(asset && fiatCurrency && amount && parseFloat(amount) > 0);
-    const receiveAccountAddress = getReceiveAccountAddressText(receiveAccount);
 
-    if (
-        asset?.cryptoId === prevState.current.cryptoId &&
-        fiatCurrency === prevState.current.fiatCurrency &&
-        amount === prevState.current.amount &&
-        amountInCrypto === prevState.current.amountInCrypto &&
-        country?.value === prevState.current.country &&
-        countrySubdivision?.value === prevState.current.countrySubdivision &&
-        receiveAccountAddress === prevState.current.receiveAccountAddress
-    ) {
-        return {
-            isFetchAllowed,
-            shouldFetchQuotes: false,
-        };
-    }
-
-    prevState.current = {
+    return {
+        isFetchAllowed,
         cryptoId: asset?.cryptoId,
         fiatCurrency,
         amount,
         amountInCrypto,
         country: country?.value,
         countrySubdivision: countrySubdivision?.value,
-        receiveAccountAddress,
-    };
-
-    return {
-        isFetchAllowed,
-        shouldFetchQuotes: true,
+        receiveAccountAddress: getReceiveAccountAddressText(receiveAccount),
     };
 };
 
@@ -132,8 +98,7 @@ const useBuyQuotesInvalidator = (
 
 const useBuyQuotesThunk = (
     form: BuyFormType,
-    isFetchAllowed: boolean,
-    shouldFetchQuotes: boolean,
+    requestState: BuyQuoteRequestState,
     quotesPromiseRef: RefObject<AbortablePromise | undefined>,
     debounce: ReturnType<typeof useDebounce>,
 ) => {
@@ -150,6 +115,16 @@ const useBuyQuotesThunk = (
     const platformInfo = useSelector((state: TradingRootState) =>
         selectTradingPlatformByCryptoId(state, asset?.cryptoId),
     );
+    const {
+        isFetchAllowed,
+        cryptoId,
+        fiatCurrency,
+        amount,
+        amountInCrypto,
+        country,
+        countrySubdivision,
+        receiveAccountAddress,
+    } = requestState;
 
     const fetchQuotes = useCallback(async () => {
         const selectedAsset = form.getValues('asset');
@@ -175,15 +150,30 @@ const useBuyQuotesThunk = (
         }
     }, [form, coinInfo, platformInfo, shouldSendInSats, quotesPromiseRef, dispatch, analytics]);
 
-    useEffect(() => {
-        if (!isFetchAllowed || !shouldFetchQuotes) return;
-
+    const requestQuotes = useEffectEvent(() => {
         if (quotesPromiseRef.current?.abort) {
             quotesPromiseRef.current.abort('Request was replaced by another one.');
         }
 
         debounce(fetchQuotes);
-    }, [isFetchAllowed, shouldFetchQuotes, quotesPromiseRef, debounce, fetchQuotes]);
+    });
+
+    useEffect(() => {
+        if (!isFetchAllowed) {
+            return;
+        }
+
+        requestQuotes();
+    }, [
+        isFetchAllowed,
+        cryptoId,
+        fiatCurrency,
+        amount,
+        amountInCrypto,
+        country,
+        countrySubdivision,
+        receiveAccountAddress,
+    ]);
 
     useTradingRefetchScheduler({
         onRefetch: () => {
@@ -197,8 +187,8 @@ export const useBuyQuotes = (form: BuyFormType) => {
     const debounce = useDebounce();
     const promiseRef = useRef<AbortablePromise | undefined>(undefined);
 
-    const { isFetchAllowed, shouldFetchQuotes } = useShouldFetchBuyQuotes(form);
+    const requestState = useBuyQuoteRequestState(form);
 
-    useBuyQuotesInvalidator(isFetchAllowed, promiseRef, debounce);
-    useBuyQuotesThunk(form, isFetchAllowed, shouldFetchQuotes, promiseRef, debounce);
+    useBuyQuotesInvalidator(requestState.isFetchAllowed, promiseRef, debounce);
+    useBuyQuotesThunk(form, requestState, promiseRef, debounce);
 };

--- a/suite-native/module-trading/src/hooks/concierge/useConciergeForm.ts
+++ b/suite-native/module-trading/src/hooks/concierge/useConciergeForm.ts
@@ -23,9 +23,7 @@ export const useConciergeForm = ({ defaultCountryCode }: ConciergeFormProps) => 
         },
         validation: yup.object({}),
     });
-    const { watch } = form;
-
-    useCountryChangeEffect(watch);
+    useCountryChangeEffect(form.control);
 
     return form;
 };

--- a/suite-native/module-trading/src/hooks/concierge/useConciergeProviders.ts
+++ b/suite-native/module-trading/src/hooks/concierge/useConciergeProviders.ts
@@ -1,15 +1,17 @@
 import { useCallback, useMemo } from 'react';
 
 import { type OtcProviderType, getOtcProvidersByCountry, useFetchOtc } from '@suite-common/trading';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 import { type ConciergeFormValues } from '@suite-native/trading-types';
 
 export const useConciergeProviders = () => {
     const { data: otcData } = useFetchOtc();
 
-    const { setValue, watch } = useFormContext<ConciergeFormValues>();
-    const country = watch('country');
-    const providerUrl = watch('providerUrl');
+    const { control, setValue } = useFormContext<ConciergeFormValues>();
+    const [country, providerUrl] = useWatch({
+        control,
+        name: ['country', 'providerUrl'],
+    });
 
     const providers = useMemo(
         () => getOtcProvidersByCountry(otcData, country.value),

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeBuyTradeableAssetsFilteredData.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeBuyTradeableAssetsFilteredData.test.ts
@@ -40,21 +40,6 @@ describe('useExchangeBuyTradeableAssetsFilteredData', () => {
         ]);
     });
 
-    it('should exclude sendAsset from the filtered list', () => {
-        mockUseWatch.mockReturnValue(btcAsset);
-
-        const { result } = renderUseExchangeBuyTradeableAssetsFilteredData();
-
-        expect(result.current.filteredData).toHaveLength(2);
-        expect(result.current.filteredData).toEqual([
-            expect.objectContaining({ cryptoId: usdcAsset.cryptoId }),
-            expect.objectContaining({ cryptoId: ethAsset.cryptoId }),
-        ]);
-        expect(result.current.filteredData).not.toContainEqual(
-            expect.objectContaining({ cryptoId: btcAsset.cryptoId }),
-        );
-    });
-
     it('should filter assets by search text', () => {
         mockUseWatch.mockReturnValue(undefined);
 

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeBuyTradeableAssetsFilteredData.test.tsx
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeBuyTradeableAssetsFilteredData.test.tsx
@@ -4,12 +4,17 @@ import { btcAsset, ethAsset, usdcAsset } from '@suite-native/trading-fixtures';
 import { renderHookWithTradingProvider } from '../../../__tests__/tradingTestUtils';
 import { useExchangeBuyTradeableAssetsFilteredData } from '../useExchangeBuyTradeableAssetsFilteredData';
 
-const mockWatch = jest.fn();
+const mockUseWatch = jest.fn();
+
+jest.mock('@suite-native/forms', () => ({
+    ...jest.requireActual('@suite-native/forms'),
+    useWatch: (...args: unknown[]) => mockUseWatch(...args),
+}));
 
 jest.mock('../useExchangeFormContext', () => ({
     ...jest.requireActual('../useExchangeFormContext'),
     useExchangeFormContext: () => ({
-        watch: mockWatch,
+        control: undefined,
     }),
 }));
 
@@ -24,7 +29,7 @@ describe('useExchangeBuyTradeableAssetsFilteredData', () => {
     });
 
     it('should return all available exchange buy assets when sendAsset is not selected', () => {
-        mockWatch.mockReturnValue(undefined);
+        mockUseWatch.mockReturnValue(undefined);
 
         const { result } = renderUseExchangeBuyTradeableAssetsFilteredData();
 
@@ -36,7 +41,7 @@ describe('useExchangeBuyTradeableAssetsFilteredData', () => {
     });
 
     it('should exclude sendAsset from the filtered list', () => {
-        mockWatch.mockReturnValue(btcAsset);
+        mockUseWatch.mockReturnValue(btcAsset);
 
         const { result } = renderUseExchangeBuyTradeableAssetsFilteredData();
 
@@ -51,7 +56,7 @@ describe('useExchangeBuyTradeableAssetsFilteredData', () => {
     });
 
     it('should filter assets by search text', () => {
-        mockWatch.mockReturnValue(undefined);
+        mockUseWatch.mockReturnValue(undefined);
 
         const { result } = renderUseExchangeBuyTradeableAssetsFilteredData();
 

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
@@ -5,8 +5,6 @@ import {
     selectTradingProviderMetadata,
     tradingExchangeActions,
 } from '@suite-common/trading';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
-import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import {
     type TestStore,
     act,
@@ -19,26 +17,19 @@ import {
     btcAsset,
     cexdirectFloatingQuote,
     eth1NormalAccount,
-    eth2legacyAccount,
     exchangeCexdirect,
     exchangeQuotes,
     invityDexQuote,
     mercuryoFixedBestQuote,
     mercuryoFixedWorstQuote,
     usdcAsset,
-    usdtAsset,
 } from '@suite-native/trading-fixtures';
-import { exchangeActions } from '@suite-native/trading-state';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 import { PROTO } from '@trezor/connect';
 
 import { createTradingLightStore } from '../../../__tests__/tradingTestUtils';
 import { clearExchangeFormQuoteData, useExchangeForm } from '../useExchangeForm';
 
-const mockReport = jest.fn();
-const services: NativeAnalyticsDep = {
-    analytics: mockNativeAnalytics(mockReport),
-};
 type PrefetchDexQuoteApprovalThunk = typeof exchangeThunks.prefetchDexQuoteApprovalThunk;
 
 jest.mock('@suite-native/transaction-management', () => ({
@@ -81,14 +72,13 @@ const createPrefetchDexQuoteApprovalThunkMock = (
 
 const btc1AccountKey = btc1NormalAccount.key;
 const eth1AccountKey = eth1NormalAccount.key;
-const eth2AccountKey = eth2legacyAccount.key;
 const accountDeviceState = btc1NormalAccount.deviceState;
 
 describe('useExchangeForm', () => {
     let store: TestStore;
 
     const renderUseExchangeForm = () =>
-        renderHookWithStoreProvider(() => useExchangeForm(), { services, store });
+        renderHookWithStoreProvider(() => useExchangeForm(), { store });
 
     const getInitializedStore = (bitcoinAmountUnit = PROTO.AmountUnit.BITCOIN) =>
         createTradingLightStore({
@@ -378,60 +368,6 @@ describe('useExchangeForm', () => {
         });
     });
 
-    describe('sendAsset', () => {
-        it('should clear crypto amount on change', () => {
-            const { result } = renderUseExchangeForm();
-            act(() => {
-                result.current.setValue('sendAsset', btcAsset);
-                result.current.setValue('sendCryptoAmount', '100');
-            });
-
-            act(() => {
-                result.current.setValue('sendAsset', usdcAsset);
-            });
-
-            expect(result.current.getValues('sendCryptoAmount')).toBeUndefined();
-        });
-
-        it('should report change to analytics', () => {
-            const { result } = renderUseExchangeForm();
-
-            act(() => {
-                result.current.setValue('sendAsset', btcAsset);
-            });
-
-            expect(mockReport).toHaveBeenCalledWith({
-                type: events.tradingParameterChangedEvent.name,
-                payload: {
-                    type: 'exchange',
-                    parameter: 'cryptoFrom',
-                },
-            });
-        });
-
-        it('should dispatch sendAssetChanged action', () => {
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseExchangeForm();
-
-            act(() => {
-                result.current.setValue('sendAsset', btcAsset);
-            });
-
-            expect(dispatchSpy).toHaveBeenCalledWith(exchangeActions.sendAssetChanged());
-        });
-
-        it('should clear receiveAsset when sendAsset has same cryptoId as receiveAsset', () => {
-            const { result } = renderUseExchangeForm();
-
-            act(() => {
-                result.current.setValue('receiveAsset', btcAsset);
-                result.current.setValue('sendAsset', btcAsset);
-            });
-
-            expect(result.current.getValues('receiveAsset')).toBeUndefined();
-        });
-    });
-
     describe('receiveAccount', () => {
         it('should be undefined by default', () => {
             const { result } = renderUseExchangeForm();
@@ -467,121 +403,6 @@ describe('useExchangeForm', () => {
                     }),
                 );
             });
-        });
-
-        it('should preselect receiveAccount for the new receiveAsset after receiveAsset changes', async () => {
-            const { result } = renderUseExchangeForm();
-
-            act(() => {
-                result.current.setValue('receiveAsset', btcAsset);
-            });
-
-            await waitFor(() => {
-                expect(result.current.getValues('receiveAccount')).toEqual(
-                    expect.objectContaining({
-                        account: btc1NormalAccount,
-                    }),
-                );
-            });
-
-            act(() => {
-                result.current.setValue('receiveAsset', usdcAsset);
-            });
-
-            await waitFor(() => {
-                expect(result.current.getValues('receiveAccount')).toEqual(
-                    expect.objectContaining({
-                        account: eth1NormalAccount,
-                    }),
-                );
-            });
-        });
-
-        it('should keep selected receiveAccount when receiveAsset changes within the same network', async () => {
-            const { result } = renderUseExchangeForm();
-
-            act(() => {
-                result.current.setValue('receiveAsset', usdcAsset);
-            });
-
-            await waitFor(() => {
-                expect(result.current.getValues('receiveAccount')).toEqual(
-                    expect.objectContaining({
-                        account: eth1NormalAccount,
-                    }),
-                );
-            });
-
-            act(() => {
-                store.dispatch(tradingExchangeActions.setReceiveAccountKey(eth2AccountKey));
-            });
-
-            await waitFor(() => {
-                expect(result.current.getValues('receiveAccount')).toEqual(
-                    expect.objectContaining({
-                        account: eth2legacyAccount,
-                    }),
-                );
-            });
-
-            act(() => {
-                result.current.setValue('receiveAsset', usdtAsset);
-            });
-
-            await waitFor(() => {
-                expect(result.current.getValues('receiveAccount')).toEqual(
-                    expect.objectContaining({
-                        account: eth2legacyAccount,
-                    }),
-                );
-            });
-        });
-    });
-
-    describe('receiveAsset', () => {
-        it('should report change to analytics', () => {
-            const { result } = renderUseExchangeForm();
-
-            act(() => {
-                result.current.setValue('receiveAsset', btcAsset);
-            });
-
-            expect(mockReport).toHaveBeenCalledWith({
-                type: events.tradingParameterChangedEvent.name,
-                payload: {
-                    type: 'exchange',
-                    parameter: 'cryptoTo',
-                },
-            });
-        });
-
-        it('should dispatch receiveAssetChanged action', () => {
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseExchangeForm();
-
-            act(() => {
-                result.current.setValue('receiveAsset', btcAsset);
-            });
-
-            expect(dispatchSpy).toHaveBeenCalledWith(exchangeActions.receiveAssetChanged());
-        });
-
-        it('should dispatch receiveTokenChanged action when receiveAsset changes within the same network', () => {
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseExchangeForm();
-
-            act(() => {
-                result.current.setValue('receiveAsset', usdcAsset);
-            });
-
-            dispatchSpy.mockClear();
-
-            act(() => {
-                result.current.setValue('receiveAsset', usdtAsset);
-            });
-
-            expect(dispatchSpy).toHaveBeenCalledWith(exchangeActions.receiveTokenChanged());
-            expect(dispatchSpy).not.toHaveBeenCalledWith(exchangeActions.receiveAssetChanged());
         });
     });
 

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeBuyTradeableAssetsFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeBuyTradeableAssetsFilteredData.ts
@@ -1,17 +1,11 @@
 import { useSelector } from 'react-redux';
 
-import type { FeatureFlagsRootState } from '@suite-native/feature-flags';
-import {
-    type TradingRootState,
-    selectExchangeBuyTradeableAssets,
-} from '@suite-native/trading-state';
+import { selectExchangeBuyTradeableAssets } from '@suite-native/trading-state';
 
 import { useTradeableAssetsFilteredData } from '../general/useTradeableAssetsFilteredData';
 
 export const useExchangeBuyTradeableAssetsFilteredData = () => {
-    const assets = useSelector((state: TradingRootState & FeatureFlagsRootState) =>
-        selectExchangeBuyTradeableAssets(state),
-    );
+    const assets = useSelector(selectExchangeBuyTradeableAssets);
 
     return useTradeableAssetsFilteredData({ assets });
 };

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeBuyTradeableAssetsFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeBuyTradeableAssetsFilteredData.ts
@@ -1,20 +1,16 @@
 import { useSelector } from 'react-redux';
 
 import type { FeatureFlagsRootState } from '@suite-native/feature-flags';
-import { useWatch } from '@suite-native/forms';
 import {
     type TradingRootState,
     selectExchangeBuyTradeableAssets,
 } from '@suite-native/trading-state';
 
-import { useExchangeFormContext } from './useExchangeFormContext';
 import { useTradeableAssetsFilteredData } from '../general/useTradeableAssetsFilteredData';
 
 export const useExchangeBuyTradeableAssetsFilteredData = () => {
-    const { control } = useExchangeFormContext();
-    const sendAsset = useWatch({ control, name: 'sendAsset' });
     const assets = useSelector((state: TradingRootState & FeatureFlagsRootState) =>
-        selectExchangeBuyTradeableAssets(state, sendAsset?.cryptoId),
+        selectExchangeBuyTradeableAssets(state),
     );
 
     return useTradeableAssetsFilteredData({ assets });

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeBuyTradeableAssetsFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeBuyTradeableAssetsFilteredData.ts
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import type { FeatureFlagsRootState } from '@suite-native/feature-flags';
+import { useWatch } from '@suite-native/forms';
 import {
     type TradingRootState,
     selectExchangeBuyTradeableAssets,
@@ -10,8 +11,8 @@ import { useExchangeFormContext } from './useExchangeFormContext';
 import { useTradeableAssetsFilteredData } from '../general/useTradeableAssetsFilteredData';
 
 export const useExchangeBuyTradeableAssetsFilteredData = () => {
-    const { watch } = useExchangeFormContext();
-    const sendAsset = watch('sendAsset');
+    const { control } = useExchangeFormContext();
+    const sendAsset = useWatch({ control, name: 'sendAsset' });
     const assets = useSelector((state: TradingRootState & FeatureFlagsRootState) =>
         selectExchangeBuyTradeableAssets(state, sendAsset?.cryptoId),
     );

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
@@ -1,12 +1,10 @@
 import { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import type { CryptoId, ExchangeTrade } from 'invity-api';
+import type { ExchangeTrade } from 'invity-api';
 
-import { useServices } from '@suite-common/dependency-injection';
 import {
     type TradingExchangeAmountLimitProps,
-    cryptoIdToSymbol,
     exchangeThunks,
     requiresTokenApproval,
     selectTradingExchangeProviders,
@@ -15,12 +13,10 @@ import {
 import { getNetwork } from '@suite-common/wallet-config';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
-import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { useForm, useWatch } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import {
-    exchangeActions,
     selectExchangeAmountLimits,
     selectExchangeQuotes,
     selectExchangeSelectedReceiveAccount,
@@ -114,65 +110,6 @@ const useExchangeQuoteChangeEffect = ({ control, setValue }: ExchangeFormType) =
                 : amount;
         setValue('receiveCryptoAmount', value, { shouldValidate: true });
     }, [selectedQuote, isAmountInSats, symbol, setValue]);
-};
-
-const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, watch }: ExchangeFormType) => {
-    const dispatch = useDispatch();
-    const prevSendCryptoId = useRef<CryptoId | undefined>(undefined);
-    const prevReceiveCryptoId = useRef<CryptoId | undefined>(undefined);
-    const { analytics } = useServices(selectNativeAnalyticsDep);
-
-    useEffect(() => {
-        const { unsubscribe } = watch(({ sendAsset, receiveAsset }, { name }) => {
-            switch (name) {
-                case 'sendAsset':
-                    if (sendAsset?.cryptoId !== prevSendCryptoId.current) {
-                        analytics.report({
-                            type: events.tradingParameterChangedEvent.name,
-                            payload: {
-                                type: 'exchange',
-                                parameter: 'cryptoFrom',
-                            },
-                        });
-
-                        prevSendCryptoId.current = sendAsset?.cryptoId;
-                        setValue('sendCryptoAmount', undefined, { shouldValidate: true });
-                        if (sendAsset?.cryptoId === receiveAsset?.cryptoId) {
-                            setValue('receiveAsset', undefined);
-                        }
-                        dispatch(exchangeActions.sendAssetChanged());
-                    }
-                    break;
-
-                case 'receiveAsset':
-                    if (receiveAsset?.cryptoId !== prevReceiveCryptoId.current) {
-                        const prevReceiveSymbol = cryptoIdToSymbol(prevReceiveCryptoId.current);
-                        const receiveSymbol = cryptoIdToSymbol(receiveAsset?.cryptoId);
-
-                        analytics.report({
-                            type: events.tradingParameterChangedEvent.name,
-                            payload: {
-                                type: 'exchange',
-                                parameter: 'cryptoTo',
-                            },
-                        });
-
-                        prevReceiveCryptoId.current = receiveAsset?.cryptoId;
-                        dispatch(
-                            prevReceiveSymbol === receiveSymbol
-                                ? exchangeActions.receiveTokenChanged()
-                                : exchangeActions.receiveAssetChanged(),
-                        );
-                    }
-                    break;
-
-                default:
-                // do nothing
-            }
-        });
-
-        return unsubscribe;
-    }, [setValue, watch, dispatch, analytics]);
 };
 
 const useDexQuoteApprovalInfoChangeEffect = ({
@@ -270,7 +207,7 @@ export const useExchangeForm = () => {
         validation: exchangeFormValidationSchema,
         context,
     });
-    const { control, setValue, watch } = form;
+    const { control, setValue } = form;
     const receiveAsset = useWatch({ control, name: 'receiveAsset' });
 
     useExchangeQuotesChangeEffect(form);
@@ -283,11 +220,16 @@ export const useExchangeForm = () => {
         selectReceiveAccount: selectExchangeSelectedReceiveAccount,
         tradingType: 'exchange',
     });
-    useAmountAndCurrencyFieldsChangeEffect(form);
     useDexQuoteApprovalInfoChangeEffect(form);
-    useSendAccountAssetBalance(form, setBalance, setSendSymbol, setContractAddress, setAccountKey);
+    useSendAccountAssetBalance({
+        control,
+        setBalance,
+        setSendSymbol,
+        setContractAddress,
+        setAccountKey,
+    });
     useValidations(form, limits);
-    useProviderMetadataChangeEffect(watch, 'exchange');
+    useProviderMetadataChangeEffect(control, 'exchange');
 
     return form;
 };

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
@@ -89,8 +89,11 @@ const useExchangeQuotesChangeEffect = ({ getValues, setValue }: ExchangeFormType
     }, [providers, quoteGroups, setValue, getValues]);
 };
 
-const useExchangeQuoteChangeEffect = ({ watch, setValue }: ExchangeFormType) => {
-    const [selectedQuote, receiveAsset] = watch(['quote', 'receiveAsset']);
+const useExchangeQuoteChangeEffect = ({ control, setValue }: ExchangeFormType) => {
+    const [selectedQuote, receiveAsset] = useWatch({
+        control,
+        name: ['quote', 'receiveAsset'],
+    });
     const symbol = getSymbolFromTradeableAsset(receiveAsset);
 
     const isAmountInSats = useSelector((state: WalletSettingsRootState) =>
@@ -172,10 +175,14 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, watch }: ExchangeFor
     }, [setValue, watch, dispatch, analytics]);
 };
 
-const useDexQuoteApprovalInfoChangeEffect = ({ getValues, setValue, watch }: ExchangeFormType) => {
+const useDexQuoteApprovalInfoChangeEffect = ({
+    control,
+    getValues,
+    setValue,
+}: ExchangeFormType) => {
     const dispatch = useDispatch();
     const sendAccount = useSelector(selectExchangeSelectedSendAccount);
-    const [quote] = watch(['quote']);
+    const quote = useWatch({ control, name: 'quote' });
 
     const lastProcessedQuoteId = useRef<string | undefined>(undefined);
     const pendingPrefetchQuoteIds = useRef(new Set<string>());

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import type { ExchangeTrade } from 'invity-api';
@@ -17,6 +17,7 @@ import { useForm, useWatch } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import {
+    exchangeActions,
     selectExchangeAmountLimits,
     selectExchangeQuotes,
     selectExchangeSelectedReceiveAccount,
@@ -208,11 +209,17 @@ export const useExchangeForm = () => {
         context,
     });
     const { control, setValue } = form;
+    const dispatch = useDispatch();
     const receiveAsset = useWatch({ control, name: 'receiveAsset' });
+
+    const onSendAssetCleared = useCallback(() => {
+        setValue('sendCryptoAmount', undefined, { shouldValidate: true });
+        dispatch(exchangeActions.sendAssetChanged());
+    }, [dispatch, setValue]);
 
     useExchangeQuotesChangeEffect(form);
     useExchangeQuoteChangeEffect(form);
-    useSendAccountChangeEffect(setValue, selectExchangeSelectedSendAccount);
+    useSendAccountChangeEffect(setValue, selectExchangeSelectedSendAccount, onSendAssetCleared);
     useReceiveAccountChangeEffect(setValue, selectExchangeSelectedReceiveAccount);
     useReceiveAccountPreselectionEffect({
         receiveAsset,

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useCallback, useEffect, useRef } from 'react';
+import { type RefObject, useCallback, useEffect, useEffectEvent, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { isFulfilled } from '@reduxjs/toolkit';
@@ -19,7 +19,7 @@ import {
     events,
     selectNativeAnalyticsDep,
 } from '@suite-native/analytics';
-import { useFormState } from '@suite-native/forms';
+import { useFormState, useWatch } from '@suite-native/forms';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import { exchangeActions, selectExchangeQuotes } from '@suite-native/trading-state';
 import { type AbortablePromise, type ExchangeFormType } from '@suite-native/trading-types';
@@ -31,7 +31,8 @@ import { tradingExchangeFormToTradingExchangeFormProps } from '../../utils/excha
 import { getReceiveAccountAddressText } from '../../utils/general/receiveAccountUtils';
 import { useQuotesInvalidator } from '../general/useQuotesInvalidator';
 
-type ShouldFetchExchangeQuotesRef = {
+type ExchangeQuoteRequestState = {
+    isFetchAllowed: boolean;
     sendAsset: string | undefined;
     receiveAsset: string | undefined;
     sendCryptoAmount: string | undefined;
@@ -39,67 +40,31 @@ type ShouldFetchExchangeQuotesRef = {
     receiveAccountAddress: string | undefined;
 };
 
-const defaultState = {
-    sendAsset: undefined,
-    receiveAsset: undefined,
-    sendCryptoAmount: undefined,
-    sendAccountDescriptor: undefined,
-    receiveAccountAddress: undefined,
-} as const;
-
-const useShouldFetchExchangeQuotes = (
-    watch: ExchangeFormType['watch'],
+const useExchangeQuoteRequestState = (
     control: ExchangeFormType['control'],
-): { isFetchAllowed: boolean; shouldFetchQuotes: boolean } => {
-    const prevState = useRef<ShouldFetchExchangeQuotesRef>(defaultState);
-
+): ExchangeQuoteRequestState => {
+    const [sendAsset, receiveAsset, sendCryptoAmount, sendAccount, receiveAccount] = useWatch({
+        control,
+        name: ['sendAsset', 'receiveAsset', 'sendCryptoAmount', 'sendAccount', 'receiveAccount'],
+    });
     const { isValid } = useFormState({ control });
-    if (!isValid) {
-        prevState.current = defaultState;
-
-        return {
-            isFetchAllowed: false,
-            shouldFetchQuotes: false,
-        };
-    }
-
-    const [sendAsset, receiveAsset, sendCryptoAmount, sendAccount, receiveAccount] = watch([
-        'sendAsset',
-        'receiveAsset',
-        'sendCryptoAmount',
-        'sendAccount',
-        'receiveAccount',
-    ]);
 
     const isFetchAllowed =
-        !!sendAsset && !!receiveAsset && !!sendCryptoAmount && parseFloat(sendCryptoAmount) > 0;
+        isValid &&
+        !!sendAsset &&
+        !!receiveAsset &&
+        !!sendCryptoAmount &&
+        parseFloat(sendCryptoAmount) > 0;
 
     const receiveAccountAddress = getReceiveAccountAddressText(receiveAccount);
 
-    if (
-        sendAsset?.cryptoId === prevState.current.sendAsset &&
-        receiveAsset?.cryptoId === prevState.current.receiveAsset &&
-        sendCryptoAmount === prevState.current.sendCryptoAmount &&
-        sendAccount?.descriptor === prevState.current.sendAccountDescriptor &&
-        receiveAccountAddress === prevState.current.receiveAccountAddress
-    ) {
-        return {
-            isFetchAllowed,
-            shouldFetchQuotes: false,
-        };
-    }
-
-    prevState.current = {
+    return {
+        isFetchAllowed,
         sendAsset: sendAsset?.cryptoId,
         receiveAsset: receiveAsset?.cryptoId,
         sendCryptoAmount,
         sendAccountDescriptor: sendAccount?.descriptor,
         receiveAccountAddress,
-    };
-
-    return {
-        isFetchAllowed,
-        shouldFetchQuotes: true,
     };
 };
 
@@ -124,8 +89,7 @@ const waitForPromiseAndReport = async (
 
 const useExchangeQuotesThunk = (
     getValues: ExchangeFormType['getValues'],
-    isFetchAllowed: boolean,
-    shouldFetchQuotes: boolean,
+    requestState: ExchangeQuoteRequestState,
     quotesPromiseRef: RefObject<AbortablePromise | undefined>,
     debounce: ReturnType<typeof useDebounce>,
 ) => {
@@ -136,6 +100,14 @@ const useExchangeQuotesThunk = (
     const shouldSendInSats = useSelector((state: WalletSettingsRootState) =>
         selectIsAmountInSats(state, symbol),
     );
+    const {
+        isFetchAllowed,
+        sendAsset,
+        receiveAsset,
+        sendCryptoAmount,
+        sendAccountDescriptor,
+        receiveAccountAddress,
+    } = requestState;
 
     const fetchQuotes = useCallback(async () => {
         const selectedAsset = getValues('sendAsset');
@@ -154,15 +126,28 @@ const useExchangeQuotesThunk = (
         await waitForPromiseAndReport(quotesPromiseRef.current, analytics);
     }, [getValues, shouldSendInSats, quotesPromiseRef, dispatch, analytics]);
 
-    useEffect(() => {
-        if (!isFetchAllowed || !shouldFetchQuotes) return;
-
+    const requestQuotes = useEffectEvent(() => {
         if (quotesPromiseRef.current?.abort) {
             quotesPromiseRef.current.abort('Request was replaced by another one.');
         }
 
         debounce(fetchQuotes);
-    }, [isFetchAllowed, shouldFetchQuotes, quotesPromiseRef, debounce, fetchQuotes]);
+    });
+
+    useEffect(() => {
+        if (!isFetchAllowed) {
+            return;
+        }
+
+        requestQuotes();
+    }, [
+        isFetchAllowed,
+        sendAsset,
+        receiveAsset,
+        sendCryptoAmount,
+        sendAccountDescriptor,
+        receiveAccountAddress,
+    ]);
 
     useTradingRefetchScheduler({
         onRefetch: () => {
@@ -191,12 +176,12 @@ const useExchangeQuotesInvalidator = (
     });
 };
 
-export const useExchangeQuotes = ({ watch, getValues, control }: ExchangeFormType) => {
+export const useExchangeQuotes = ({ getValues, control }: ExchangeFormType) => {
     const debounce = useDebounce();
     const promiseRef = useRef<AbortablePromise | undefined>(undefined);
 
-    const { isFetchAllowed, shouldFetchQuotes } = useShouldFetchExchangeQuotes(watch, control);
+    const requestState = useExchangeQuoteRequestState(control);
 
-    useExchangeQuotesInvalidator(isFetchAllowed, promiseRef, debounce);
-    useExchangeQuotesThunk(getValues, isFetchAllowed, shouldFetchQuotes, promiseRef, debounce);
+    useExchangeQuotesInvalidator(requestState.isFetchAllowed, promiseRef, debounce);
+    useExchangeQuotesThunk(getValues, requestState, promiseRef, debounce);
 };

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.ts
@@ -88,14 +88,14 @@ const waitForPromiseAndReport = async (
 };
 
 const useExchangeQuotesThunk = (
-    getValues: ExchangeFormType['getValues'],
+    { getValues, control }: ExchangeFormType,
     requestState: ExchangeQuoteRequestState,
     quotesPromiseRef: RefObject<AbortablePromise | undefined>,
     debounce: ReturnType<typeof useDebounce>,
 ) => {
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const dispatch = useDispatch();
-    const asset = getValues('sendAsset');
+    const asset = useWatch({ control, name: 'sendAsset' });
     const symbol = getSymbolFromTradeableAsset(asset);
     const shouldSendInSats = useSelector((state: WalletSettingsRootState) =>
         selectIsAmountInSats(state, symbol),
@@ -176,12 +176,12 @@ const useExchangeQuotesInvalidator = (
     });
 };
 
-export const useExchangeQuotes = ({ getValues, control }: ExchangeFormType) => {
+export const useExchangeQuotes = (form: ExchangeFormType) => {
     const debounce = useDebounce();
     const promiseRef = useRef<AbortablePromise | undefined>(undefined);
 
-    const requestState = useExchangeQuoteRequestState(control);
+    const requestState = useExchangeQuoteRequestState(form.control);
 
     useExchangeQuotesInvalidator(requestState.isFetchAllowed, promiseRef, debounce);
-    useExchangeQuotesThunk(getValues, requestState, promiseRef, debounce);
+    useExchangeQuotesThunk(form, requestState, promiseRef, debounce);
 };

--- a/suite-native/module-trading/src/hooks/general/__tests__/useFocusedValueWatch.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useFocusedValueWatch.test.tsx
@@ -3,7 +3,6 @@ import { combineReducers } from '@reduxjs/toolkit';
 import { deviceInitialState } from '@suite-common/device';
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
-import { Form } from '@suite-native/forms';
 import { localeReducer } from '@suite-native/intl';
 import {
     type TestStore,
@@ -48,10 +47,9 @@ describe('useFocusedValueWatch', () => {
         });
 
     const renderUseFocusedValueWatch = () =>
-        renderHookWithStoreProvider(({ watch }) => useFocusedValueWatch(watch), {
-            initialProps: { watch: form.watch },
+        renderHookWithStoreProvider(({ control }) => useFocusedValueWatch(control), {
+            initialProps: { control: form.control },
             store,
-            wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
     beforeEach(() => {
@@ -69,11 +67,10 @@ describe('useFocusedValueWatch', () => {
     });
 
     it('should be false right after input is focused', async () => {
-        const { result, rerender } = renderUseFocusedValueWatch();
+        const { result } = renderUseFocusedValueWatch();
 
         act(() => {
             form.setValue('focusedValue', 'fiatValue');
-            rerender({ watch: form.watch });
         });
 
         // make sure state is updated
@@ -84,12 +81,11 @@ describe('useFocusedValueWatch', () => {
     });
 
     it('should be true after 300ms of input focus', async () => {
-        const { result, rerender } = renderUseFocusedValueWatch();
+        const { result } = renderUseFocusedValueWatch();
 
         await act(() => {
             form.setValue('focusedValue', 'fiatValue');
         });
-        rerender({ watch: form.watch });
         await act(async () => {
             // temporary: find the proper async timer handling
             // https://github.com/trezor/trezor-suite/issues/19553
@@ -101,11 +97,10 @@ describe('useFocusedValueWatch', () => {
     });
 
     it('should set isAmountInputActive to false on unmount', async () => {
-        const { rerender, unmount } = renderUseFocusedValueWatch();
+        const { unmount } = renderUseFocusedValueWatch();
         await act(() => {
             form.setValue('focusedValue', 'fiatValue');
         });
-        rerender({ watch: form.watch });
         await act(async () => {
             // temporary: find the proper async timer handling
             // https://github.com/trezor/trezor-suite/issues/19553

--- a/suite-native/module-trading/src/hooks/general/__tests__/useInputFieldControls.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useInputFieldControls.test.ts
@@ -90,4 +90,20 @@ describe('useInputFieldControls', () => {
 
         expect(result.current.hasError).toBe(true);
     });
+
+    it('should keep focus callbacks stable when the value changes', () => {
+        const mockSetValue = jest.fn();
+        const { result, rerender } = renderHook(
+            ({ value }: { value: string }) =>
+                useInputFieldControls('testField', value, mockSetValue),
+            { initialProps: { value: '1' } },
+        );
+        const initialOnFocus = result.current.onFocus;
+        const initialOnBlur = result.current.onBlur;
+
+        rerender({ value: '2' });
+
+        expect(result.current.onFocus).toBe(initialOnFocus);
+        expect(result.current.onBlur).toBe(initialOnBlur);
+    });
 });

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useCountryChangeEffect.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useCountryChangeEffect.test.tsx
@@ -6,8 +6,11 @@ import {
     type TradingCountryOption,
     type TradingCountrySubdivisionOption,
 } from '@suite-common/trading';
+import { yup } from '@suite-common/validators';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import { useForm } from '@suite-native/forms';
 import { localeReducer } from '@suite-native/intl';
+import { act } from '@suite-native/test-utils';
 import {
     type TestStore,
     createLightStore,
@@ -20,10 +23,12 @@ import {
     tradingSlice,
 } from '@suite-native/trading-state';
 
-import {
-    type CountrySubdivisionFormWatch,
-    useCountryChangeEffect,
-} from '../useCountryChangeEffect';
+import { useCountryChangeEffect } from '../useCountryChangeEffect';
+
+type CountryFormValues = {
+    country: TradingCountryOption | undefined;
+    countrySubdivision: TradingCountrySubdivisionOption | undefined;
+};
 
 const buildCountryOption = (value: TradingCountryCode): TradingCountryOption => ({
     codeAlpha3: 'USA',
@@ -45,65 +50,73 @@ describe('useCountryChangeEffect', () => {
         }),
     } as const;
 
-    const renderUseCountryChangeEffect = (watch: CountrySubdivisionFormWatch) =>
-        renderHookWithStoreProvider(() => useCountryChangeEffect(watch), { store });
+    const renderUseCountryChangeEffect = (defaultValues: CountryFormValues) =>
+        renderHookWithStoreProvider(
+            () => {
+                const form = useForm<CountryFormValues>({
+                    defaultValues,
+                    validation: yup.object({}),
+                });
+                useCountryChangeEffect(form.control);
+
+                return form;
+            },
+            { store },
+        );
 
     beforeEach(() => {
         store = createLightStore({ reducer });
     });
 
     it('should do nothing on mount', () => {
-        renderUseCountryChangeEffect(() => [buildCountryOption('US'), undefined]);
+        renderUseCountryChangeEffect({
+            country: buildCountryOption('US'),
+            countrySubdivision: undefined,
+        });
 
         expect(selectTradingResidenceCountry(store.getState())).toBeUndefined();
     });
 
     it('should update trading residence country on country change', () => {
-        let countryValue: TradingCountryCode = 'US';
-        const watch: CountrySubdivisionFormWatch = () => [
-            buildCountryOption(countryValue),
-            undefined,
-        ];
+        const { result } = renderUseCountryChangeEffect({
+            country: buildCountryOption('US'),
+            countrySubdivision: undefined,
+        });
 
-        const { rerender } = renderUseCountryChangeEffect(watch);
-
-        countryValue = 'CA';
-        rerender({});
+        act(() => result.current.setValue('country', buildCountryOption('CA')));
 
         expect(selectTradingResidenceCountry(store.getState())).toBe('CA');
         expect(selectTradingResidenceCountrySubdivision(store.getState())).toBeUndefined();
     });
 
     it('should not update when country becomes undefined', () => {
-        let countryOption: TradingCountryOption | undefined = buildCountryOption('US');
-        const watch: CountrySubdivisionFormWatch = () => [countryOption, undefined];
-        const { rerender } = renderUseCountryChangeEffect(watch);
+        const { result } = renderUseCountryChangeEffect({
+            country: buildCountryOption('US'),
+            countrySubdivision: undefined,
+        });
 
-        countryOption = undefined;
-        rerender({});
+        act(() => result.current.setValue('country', undefined));
 
         expect(selectTradingResidenceCountry(store.getState())).toBeUndefined();
     });
 
     it('should update trading residence country subdivision on subdivision change', () => {
-        let countrySubdivision: TradingCountrySubdivisionOption | undefined = {
-            value: 'CA',
-            label: 'California',
-            name: 'California',
-        };
-        const watch: CountrySubdivisionFormWatch = () => [
-            buildCountryOption('US'),
-            countrySubdivision,
-        ];
+        const { result } = renderUseCountryChangeEffect({
+            country: buildCountryOption('US'),
+            countrySubdivision: {
+                value: 'CA',
+                label: 'California',
+                name: 'California',
+            },
+        });
 
-        const { rerender } = renderUseCountryChangeEffect(watch);
-
-        countrySubdivision = {
-            value: 'NY',
-            label: 'New York',
-            name: 'New York',
-        };
-        rerender({});
+        act(() =>
+            result.current.setValue('countrySubdivision', {
+                value: 'NY',
+                label: 'New York',
+                name: 'New York',
+            }),
+        );
 
         expect(selectTradingResidenceCountry(store.getState())).toBe('US');
         expect(selectTradingResidenceCountrySubdivision(store.getState())).toBe('NY');

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useProviderMetadataChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useProviderMetadataChangeEffect.test.ts
@@ -1,4 +1,6 @@
 import { selectTradingProviderMetadata } from '@suite-common/trading';
+import { yup } from '@suite-common/validators';
+import { useForm } from '@suite-native/forms';
 import { type TestStore } from '@suite-native/test-utils-store';
 import { buyMercuryo } from '@suite-native/trading-fixtures';
 
@@ -6,10 +8,13 @@ import {
     createTradingLightStore,
     renderHookWithTradingProvider,
 } from '../../../../__tests__/tradingTestUtils';
-import {
-    type QuoteProviderFormWatch,
-    useProviderMetadataChangeEffect,
-} from '../useProviderMetadataChangeEffect';
+import { useProviderMetadataChangeEffect } from '../useProviderMetadataChangeEffect';
+
+type ProviderFormValues = {
+    quote: {
+        exchange: string | undefined;
+    };
+};
 
 let mockIsFocused = true;
 
@@ -25,11 +30,18 @@ jest.mock('@react-navigation/native', () => {
 describe('useProviderMetadataChangeEffect', () => {
     let store: TestStore;
 
-    const renderUseProviderMetadataChangeEffect = (watch: QuoteProviderFormWatch) =>
-        renderHookWithTradingProvider(() => useProviderMetadataChangeEffect(watch, 'buy'), {
-            store,
-            tradeType: 'buy',
-        });
+    const renderUseProviderMetadataChangeEffect = (exchange: string | undefined) =>
+        renderHookWithTradingProvider(
+            () => {
+                const form = useForm<ProviderFormValues>({
+                    defaultValues: { quote: { exchange } },
+                    validation: yup.object({}),
+                });
+
+                return useProviderMetadataChangeEffect(form.control, 'buy');
+            },
+            { store, tradeType: 'buy' },
+        );
 
     beforeEach(() => {
         store = createTradingLightStore({ tradeType: 'buy' });
@@ -37,14 +49,14 @@ describe('useProviderMetadataChangeEffect', () => {
     });
 
     it('should set currentProviderMetadata when quote is set', () => {
-        const { result } = renderUseProviderMetadataChangeEffect(_ => 'mercuryo');
+        const { result } = renderUseProviderMetadataChangeEffect('mercuryo');
 
         expect(selectTradingProviderMetadata(store.getState())).toEqual(buyMercuryo);
         expect(result.current).toEqual(buyMercuryo);
     });
 
     it('should clear currentProviderMetadata on unmount', () => {
-        const { unmount } = renderUseProviderMetadataChangeEffect(_ => 'mercuryo');
+        const { unmount } = renderUseProviderMetadataChangeEffect('mercuryo');
 
         unmount();
 
@@ -53,7 +65,7 @@ describe('useProviderMetadataChangeEffect', () => {
 
     it('should not change provider metadata when screen is not focused', () => {
         mockIsFocused = false;
-        renderUseProviderMetadataChangeEffect(_ => 'mercuryo');
+        renderUseProviderMetadataChangeEffect('mercuryo');
 
         expect(selectTradingProviderMetadata(store.getState())).toBeUndefined();
     });

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useSendAccountAssetBalance.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useSendAccountAssetBalance.test.ts
@@ -1,16 +1,15 @@
+import { yup } from '@suite-common/validators';
 import { type Account, type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
+import { useForm } from '@suite-native/forms';
 import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import { btcAsset, getBtcAccount, getWalletState } from '@suite-native/trading-fixtures';
-import {
-    type ExchangeFormType,
-    type SellFormType,
-    type TradeableAsset,
-} from '@suite-native/trading-types';
+import { type SellFormValues, type TradeableAsset } from '@suite-native/trading-types';
 
 import { useSendAccountAssetBalance } from '../useSendAccountAssetBalance';
 
 type HookProps = {
-    form: ExchangeFormType | SellFormType;
+    sendAccount: Account | undefined;
+    sendAsset: TradeableAsset | undefined;
     setBalance: (balance: string | undefined) => unknown;
     setSendSymbol: (currency: string | undefined) => unknown;
     setContractAddress: (contractAddress: TokenAddress | undefined) => unknown;
@@ -19,24 +18,31 @@ type HookProps = {
 describe('useSendAccountAssetBalance', () => {
     const renderUseSendAccountAssetBalance = (initialProps: HookProps) =>
         renderHookWithStoreProvider(
-            ({ form, setBalance, setSendSymbol, setContractAddress, setAccountKey }) =>
-                useSendAccountAssetBalance(
-                    form,
+            ({
+                sendAccount,
+                sendAsset,
+                setBalance,
+                setSendSymbol,
+                setContractAddress,
+                setAccountKey,
+            }) => {
+                const form = useForm<SellFormValues>({
+                    defaultValues: { sendAccount, sendAsset },
+                    validation: yup.object({}),
+                });
+                useSendAccountAssetBalance({
+                    control: form.control,
                     setBalance,
                     setSendSymbol,
                     setContractAddress,
                     setAccountKey,
-                ),
+                });
+            },
             {
                 preloadedState: { wallet: getWalletState({ tradeType: 'sell' }) },
                 initialProps,
             },
         );
-
-    const getFormMock = (sendAccount: Account | undefined, sendAsset: TradeableAsset | undefined) =>
-        ({
-            watch: () => [sendAccount, sendAsset],
-        }) as unknown as SellFormType;
 
     it('should watch for balance and asset symbol', () => {
         const setBalance = jest.fn();
@@ -44,7 +50,8 @@ describe('useSendAccountAssetBalance', () => {
         const setContractAddress = jest.fn();
         const setAccountKey = jest.fn();
         renderUseSendAccountAssetBalance({
-            form: getFormMock(getBtcAccount(), btcAsset),
+            sendAccount: getBtcAccount(),
+            sendAsset: btcAsset,
             setBalance,
             setSendSymbol,
             setContractAddress,
@@ -62,7 +69,8 @@ describe('useSendAccountAssetBalance', () => {
         const setAccountKey = jest.fn();
 
         renderUseSendAccountAssetBalance({
-            form: getFormMock(undefined, btcAsset),
+            sendAccount: undefined,
+            sendAsset: btcAsset,
             setBalance,
             setSendSymbol,
             setContractAddress,
@@ -79,7 +87,8 @@ describe('useSendAccountAssetBalance', () => {
         const setAccountKey = jest.fn();
 
         renderUseSendAccountAssetBalance({
-            form: getFormMock(getBtcAccount(), undefined),
+            sendAccount: getBtcAccount(),
+            sendAsset: undefined,
             setBalance,
             setSendSymbol,
             setContractAddress,

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useSendAccountChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useSendAccountChangeEffect.test.ts
@@ -23,6 +23,7 @@ const btc2Account = getBtcAccount({ descriptor: asAccountDescriptor('btc2legacy'
 describe('useSendAccountChangeEffect', () => {
     let store: TestStore;
     let setValue: jest.Mock;
+    let onSendAssetCleared: jest.Mock;
 
     const reducer = {
         locale: localeReducer,
@@ -36,7 +37,11 @@ describe('useSendAccountChangeEffect', () => {
     const renderUseSendAccountChangeEffect = () =>
         renderHookWithStoreProvider(
             () => {
-                useSendAccountChangeEffect(setValue, selectExchangeSelectedSendAccount);
+                useSendAccountChangeEffect(
+                    setValue,
+                    selectExchangeSelectedSendAccount,
+                    onSendAssetCleared,
+                );
             },
             { store },
         );
@@ -51,6 +56,7 @@ describe('useSendAccountChangeEffect', () => {
             },
         });
         setValue = jest.fn();
+        onSendAssetCleared = jest.fn();
     });
 
     it('should set sendAccount and sendAsset to undefined initially', () => {
@@ -59,6 +65,26 @@ describe('useSendAccountChangeEffect', () => {
         expect(setValue).toHaveBeenCalledTimes(2);
         expect(setValue).toHaveBeenCalledWith('sendAccount', undefined);
         expect(setValue).toHaveBeenCalledWith('sendAsset', undefined);
+    });
+
+    it('should not fire onSendAssetCleared on initial mount when there was no account', () => {
+        renderUseSendAccountChangeEffect();
+
+        expect(onSendAssetCleared).not.toHaveBeenCalled();
+    });
+
+    it('should fire onSendAssetCleared when a previously selected account disappears', () => {
+        renderUseSendAccountChangeEffect();
+        act(() => {
+            store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1Account.key));
+        });
+
+        onSendAssetCleared.mockClear();
+        act(() => {
+            store.dispatch(tradingExchangeActions.setTradingAccountKey(undefined));
+        });
+
+        expect(onSendAssetCleared).toHaveBeenCalledTimes(1);
     });
 
     it('should set sendAccount when account is changed in store', () => {

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useTradeableAssetChange.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useTradeableAssetChange.test.ts
@@ -1,0 +1,193 @@
+import { tradingExchangeActions } from '@suite-common/trading';
+import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
+import { type UseFormReturn } from '@suite-native/forms';
+import { type TestStore, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+import { btcAsset, ethAsset, getBtcAccount, usdcAsset } from '@suite-native/trading-fixtures';
+import { buyActions, exchangeActions } from '@suite-native/trading-state';
+
+import { createTradingLightStore } from '../../../../__tests__/tradingTestUtils';
+import { useTradeableAssetChange } from '../useTradeableAssetChange';
+
+const reportMock = jest.fn();
+const services: NativeAnalyticsDep = {
+    analytics: mockNativeAnalytics(reportMock),
+};
+
+const btcAccount = getBtcAccount();
+
+type MockForm = {
+    setValue: jest.Mock;
+    getValues: jest.Mock;
+};
+
+const createMockForm = (counterpartAsset?: unknown): MockForm => ({
+    setValue: jest.fn(),
+    getValues: jest.fn().mockReturnValue(counterpartAsset),
+});
+
+describe('useTradeableAssetChange', () => {
+    let store: TestStore;
+    let setSelectedValue: jest.Mock;
+
+    beforeEach(() => {
+        reportMock.mockClear();
+        store = createTradingLightStore({ tradeType: 'exchange' });
+        setSelectedValue = jest.fn();
+    });
+
+    const renderChangeAsset = (
+        config: Omit<Partial<Parameters<typeof useTradeableAssetChange>[0]>, 'form'> & {
+            form: MockForm;
+        },
+    ) => {
+        const { result } = renderHookWithStoreProvider(
+            () =>
+                useTradeableAssetChange({
+                    tradingType: 'exchange',
+                    selectedValue: undefined,
+                    setSelectedValue,
+                    analyticsParameter: 'cryptoFrom',
+                    getAssetChangedAction: exchangeActions.sendAssetChanged,
+                    ...config,
+                    form: config.form as unknown as UseFormReturn<never>,
+                }),
+            { store, services },
+        );
+
+        return result.current;
+    };
+
+    it('should not apply any change effects when the selected asset is unchanged (dedup guard)', () => {
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+        const changeAsset = renderChangeAsset({
+            form: createMockForm(),
+            selectedValue: btcAsset,
+        });
+
+        changeAsset(btcAsset);
+
+        expect(setSelectedValue).not.toHaveBeenCalled();
+        expect(dispatchSpy).not.toHaveBeenCalled();
+        expect(reportMock).not.toHaveBeenCalled();
+    });
+
+    it('should still set the trading account key before the dedup guard returns', () => {
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+        const changeAsset = renderChangeAsset({
+            form: createMockForm(),
+            selectedValue: btcAsset,
+            getSetTradingAccountKeyAction: tradingExchangeActions.setTradingAccountKey,
+        });
+
+        changeAsset(btcAsset, btcAccount);
+
+        expect(dispatchSpy).toHaveBeenCalledWith(
+            tradingExchangeActions.setTradingAccountKey(btcAccount.key),
+        );
+        expect(setSelectedValue).not.toHaveBeenCalled();
+    });
+
+    it('should clear the amount and dispatch the base action on a cross-network change', () => {
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+        const form = createMockForm();
+        const changeAsset = renderChangeAsset({
+            form,
+            selectedValue: btcAsset,
+            amountField: 'sendCryptoAmount',
+            getAssetChangedAction: exchangeActions.sendAssetChanged,
+            getAssetTokenChangedAction: exchangeActions.receiveTokenChanged,
+        });
+
+        changeAsset(usdcAsset);
+
+        expect(setSelectedValue).toHaveBeenCalledWith(usdcAsset);
+        expect(form.setValue).toHaveBeenCalledWith('sendCryptoAmount', undefined, {
+            shouldValidate: true,
+        });
+        expect(dispatchSpy).toHaveBeenCalledWith(exchangeActions.sendAssetChanged());
+        expect(dispatchSpy).not.toHaveBeenCalledWith(exchangeActions.receiveTokenChanged());
+    });
+
+    it('should dispatch the token action when the network symbol is unchanged', () => {
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+        const changeAsset = renderChangeAsset({
+            form: createMockForm(),
+            tradingType: 'buy',
+            selectedValue: ethAsset,
+            getAssetChangedAction: buyActions.assetChanged,
+            getAssetTokenChangedAction: buyActions.assetTokenChanged,
+        });
+
+        // usdcAsset is an Ethereum token, so switching from native ETH is a same-network change.
+        changeAsset(usdcAsset);
+
+        expect(dispatchSpy).toHaveBeenCalledWith(buyActions.assetTokenChanged());
+        expect(dispatchSpy).not.toHaveBeenCalledWith(buyActions.assetChanged());
+    });
+
+    it('should not report analytics when shouldReportAnalytics is false', () => {
+        const changeAsset = renderChangeAsset({
+            form: createMockForm(),
+            selectedValue: btcAsset,
+        });
+
+        changeAsset(usdcAsset, undefined, { shouldReportAnalytics: false });
+
+        expect(setSelectedValue).toHaveBeenCalledWith(usdcAsset);
+        expect(reportMock).not.toHaveBeenCalled();
+    });
+
+    it('should clear the counterpart asset and dispatch its action on collision', () => {
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+        const form = createMockForm(usdcAsset);
+        const changeAsset = renderChangeAsset({
+            form,
+            selectedValue: btcAsset,
+            analyticsParameter: 'cryptoFrom',
+            getAssetChangedAction: exchangeActions.sendAssetChanged,
+            collision: {
+                counterpartAssetField: 'receiveAsset',
+                counterpartAnalyticsParameter: 'cryptoTo',
+                getCounterpartChangedAction: exchangeActions.receiveAssetChanged,
+            },
+        });
+
+        changeAsset(usdcAsset);
+
+        expect(form.setValue).toHaveBeenCalledWith('receiveAsset', undefined, undefined);
+        expect(dispatchSpy).toHaveBeenCalledWith(exchangeActions.receiveAssetChanged());
+        expect(reportMock).toHaveBeenCalledWith({
+            type: events.tradingParameterChangedEvent.name,
+            payload: { type: 'exchange', parameter: 'cryptoTo' },
+        });
+    });
+
+    it('should clear the counterpart amount without a counterpart action when omitted', () => {
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+        const form = createMockForm(usdcAsset);
+        const changeAsset = renderChangeAsset({
+            form,
+            selectedValue: btcAsset,
+            analyticsParameter: 'cryptoTo',
+            getAssetChangedAction: exchangeActions.receiveAssetChanged,
+            collision: {
+                counterpartAssetField: 'sendAsset',
+                counterpartAmountField: 'sendCryptoAmount',
+                counterpartAnalyticsParameter: 'cryptoFrom',
+            },
+        });
+
+        changeAsset(usdcAsset);
+
+        expect(form.setValue).toHaveBeenCalledWith('sendAsset', undefined, undefined);
+        expect(form.setValue).toHaveBeenCalledWith('sendCryptoAmount', undefined, {
+            shouldValidate: true,
+        });
+        expect(dispatchSpy).not.toHaveBeenCalledWith(exchangeActions.sendAssetChanged());
+        expect(reportMock).toHaveBeenCalledWith({
+            type: events.tradingParameterChangedEvent.name,
+            payload: { type: 'exchange', parameter: 'cryptoFrom' },
+        });
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/form/useCountryChangeEffect.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useCountryChangeEffect.ts
@@ -1,12 +1,11 @@
 import { useEffect, useRef } from 'react';
-import { type Control, type FieldValues, type Path } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
 
 import {
     type TradingCountryOption,
     type TradingCountrySubdivisionOption,
 } from '@suite-common/trading';
-import { useWatch } from '@suite-native/forms';
+import { type Control, type FieldValues, type Path, useWatch } from '@suite-native/forms';
 import { residenceActions } from '@suite-native/trading-state';
 
 export const useCountryChangeEffect = <TFieldValues extends FieldValues>(

--- a/suite-native/module-trading/src/hooks/general/form/useCountryChangeEffect.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useCountryChangeEffect.ts
@@ -1,20 +1,26 @@
 import { useEffect, useRef } from 'react';
+import { type Control, type FieldValues, type Path } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
 
 import {
     type TradingCountryOption,
     type TradingCountrySubdivisionOption,
 } from '@suite-common/trading';
+import { useWatch } from '@suite-native/forms';
 import { residenceActions } from '@suite-native/trading-state';
 
-export type CountrySubdivisionFormWatch = (
-    keys: ['country', 'countrySubdivision'],
-) => [TradingCountryOption | undefined, TradingCountrySubdivisionOption | undefined];
-
-export const useCountryChangeEffect = (watch: CountrySubdivisionFormWatch) => {
+export const useCountryChangeEffect = <TFieldValues extends FieldValues>(
+    control: Control<TFieldValues>,
+) => {
     const dispatch = useDispatch();
 
-    const [countryOption, countrySubdivisionOption] = watch(['country', 'countrySubdivision']);
+    const [countryOption, countrySubdivisionOption] = useWatch({
+        control,
+        name: ['country', 'countrySubdivision'] as Path<TFieldValues>[],
+    }) as unknown as [
+        TradingCountryOption | undefined,
+        TradingCountrySubdivisionOption | undefined,
+    ];
     const country = countryOption?.value;
     const countrySubdivision = countrySubdivisionOption?.value;
 

--- a/suite-native/module-trading/src/hooks/general/form/useProviderMetadataChangeEffect.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useProviderMetadataChangeEffect.ts
@@ -1,17 +1,21 @@
+import { type Control, type FieldValues, type Path } from 'react-hook-form';
+
 import { useIsFocused } from '@react-navigation/native';
 
 import {
     type TradingType,
     useProviderMetadataChangeEffect as useCommonProviderMetadataChangeEffect,
 } from '@suite-common/trading';
+import { useWatch } from '@suite-native/forms';
 
-export type QuoteProviderFormWatch = (key: 'quote.exchange') => string | undefined;
-
-export const useProviderMetadataChangeEffect = (
-    watch: QuoteProviderFormWatch,
+export const useProviderMetadataChangeEffect = <TFieldValues extends FieldValues>(
+    control: Control<TFieldValues>,
     tradingType: TradingType,
 ) => {
-    const exchange = watch('quote.exchange');
+    const exchange = useWatch({
+        control,
+        name: 'quote.exchange' as Path<TFieldValues>,
+    }) as string | undefined;
     const isFocused = useIsFocused();
 
     return useCommonProviderMetadataChangeEffect(tradingType, exchange, isFocused);

--- a/suite-native/module-trading/src/hooks/general/form/useProviderMetadataChangeEffect.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useProviderMetadataChangeEffect.ts
@@ -1,12 +1,10 @@
-import { type Control, type FieldValues, type Path } from 'react-hook-form';
-
 import { useIsFocused } from '@react-navigation/native';
 
 import {
     type TradingType,
     useProviderMetadataChangeEffect as useCommonProviderMetadataChangeEffect,
 } from '@suite-common/trading';
-import { useWatch } from '@suite-native/forms';
+import { type Control, type FieldValues, type Path, useWatch } from '@suite-native/forms';
 
 export const useProviderMetadataChangeEffect = <TFieldValues extends FieldValues>(
     control: Control<TFieldValues>,

--- a/suite-native/module-trading/src/hooks/general/form/useSendAccountAssetBalance.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useSendAccountAssetBalance.ts
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import { type Control, type FieldValues, type Path } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 
 import type { DeviceRootState } from '@suite-common/device';
@@ -10,7 +9,7 @@ import {
     selectAccountFormattedBalance,
 } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
-import { useWatch } from '@suite-native/forms';
+import { type Control, type FieldValues, type Path, useWatch } from '@suite-native/forms';
 import { selectAccountTokenBalance } from '@suite-native/tokens';
 import { type ExchangeFormValues } from '@suite-native/trading-types';
 

--- a/suite-native/module-trading/src/hooks/general/form/useSendAccountAssetBalance.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useSendAccountAssetBalance.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { type Control, type FieldValues, type Path } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 
 import type { DeviceRootState } from '@suite-common/device';
@@ -9,24 +10,29 @@ import {
     selectAccountFormattedBalance,
 } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
-import type { UseFormReturn } from '@suite-native/forms';
+import { useWatch } from '@suite-native/forms';
 import { selectAccountTokenBalance } from '@suite-native/tokens';
-import {
-    type ExchangeFormType,
-    type ExchangeFormValues,
-    type SellFormType,
-    type SellFormValues,
-} from '@suite-native/trading-types';
+import { type ExchangeFormValues } from '@suite-native/trading-types';
 
-export const useSendAccountAssetBalance = (
-    form: ExchangeFormType | SellFormType,
-    setBalance: (balance: string | undefined) => unknown,
-    setSendSymbol: (currency: string | undefined) => unknown,
-    setContractAddress: (contractAddress: TokenAddress | undefined) => unknown,
-    setAccountKey: (accountKey: AccountKey | undefined) => void,
-) => {
-    const { watch } = form as UseFormReturn<ExchangeFormValues | SellFormValues>;
-    const [sendAccount, sendAsset] = watch(['sendAccount', 'sendAsset']);
+type UseSendAccountAssetBalanceParams<TFieldValues extends FieldValues> = {
+    control: Control<TFieldValues>;
+    setBalance: (balance: string | undefined) => unknown;
+    setSendSymbol: (currency: string | undefined) => unknown;
+    setContractAddress: (contractAddress: TokenAddress | undefined) => unknown;
+    setAccountKey: (accountKey: AccountKey | undefined) => void;
+};
+
+export const useSendAccountAssetBalance = <TFieldValues extends FieldValues>({
+    control,
+    setBalance,
+    setSendSymbol,
+    setContractAddress,
+    setAccountKey,
+}: UseSendAccountAssetBalanceParams<TFieldValues>) => {
+    const [sendAccount, sendAsset] = useWatch({
+        control,
+        name: ['sendAccount', 'sendAsset'] as Path<TFieldValues>[],
+    }) as unknown as [ExchangeFormValues['sendAccount'], ExchangeFormValues['sendAsset']];
     const accountKey = sendAccount?.key;
 
     const balance = useSelector(

--- a/suite-native/module-trading/src/hooks/general/form/useSendAccountChangeEffect.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useSendAccountChangeEffect.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 
 import type { AccountsRootState } from '@suite-common/wallet-core';
@@ -18,13 +18,21 @@ type SendAccountSelector = (state: TradingRootState & AccountsRootState) => Acco
 export const useSendAccountChangeEffect = (
     setValue: FormSetValue,
     selectSendAccount: SendAccountSelector,
+    // Fires when a previously selected account disappears (e.g. device forgotten/hidden)
+    // and the send asset is cleared, so callers can reset the typed amount and stale limits.
+    onSendAssetCleared?: () => void,
 ) => {
     const sendAccount = useSelector(selectSendAccount);
+    const hadSendAccountRef = useRef(false);
 
     useEffect(() => {
         setValue('sendAccount', sendAccount);
         if (!sendAccount) {
             setValue('sendAsset', undefined);
+            if (hadSendAccountRef.current) {
+                onSendAssetCleared?.();
+            }
         }
-    }, [sendAccount, setValue]);
+        hadSendAccountRef.current = !!sendAccount;
+    }, [sendAccount, setValue, onSendAssetCleared]);
 };

--- a/suite-native/module-trading/src/hooks/general/form/useTradeableAssetChange.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useTradeableAssetChange.ts
@@ -1,0 +1,139 @@
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { type UnknownAction } from '@reduxjs/toolkit';
+
+import { useServices } from '@suite-common/dependency-injection';
+import { type TradingType, cryptoIdToSymbol } from '@suite-common/trading';
+import { type Account, type AccountKey } from '@suite-common/wallet-types';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
+import { type FieldValues, type Path, type UseFormReturn } from '@suite-native/forms';
+import { type TradeableAsset } from '@suite-native/trading-types';
+
+type TradingParameter = 'cryptoFrom' | 'cryptoTo';
+
+type CollisionConfig = {
+    counterpartAssetField: string;
+    counterpartAmountField?: string;
+    counterpartAnalyticsParameter: TradingParameter;
+    getCounterpartChangedAction?: () => UnknownAction;
+};
+
+type UseTradeableAssetChangeConfig<TFieldValues extends FieldValues> = {
+    form: UseFormReturn<TFieldValues>;
+    tradingType: TradingType;
+    selectedValue: TradeableAsset | undefined;
+    setSelectedValue: (asset: TradeableAsset) => void;
+    analyticsParameter: TradingParameter;
+    amountField?: string;
+    getAssetChangedAction: () => UnknownAction;
+    getAssetTokenChangedAction?: () => UnknownAction;
+    getSetTradingAccountKeyAction?: (accountKey: AccountKey) => UnknownAction;
+    collision?: CollisionConfig;
+};
+
+type ChangeAssetOptions = {
+    shouldReportAnalytics?: boolean;
+};
+
+export const useTradeableAssetChange = <TFieldValues extends FieldValues>({
+    form,
+    tradingType,
+    selectedValue,
+    setSelectedValue,
+    analyticsParameter,
+    amountField,
+    getAssetChangedAction,
+    getAssetTokenChangedAction,
+    getSetTradingAccountKeyAction,
+    collision,
+}: UseTradeableAssetChangeConfig<TFieldValues>) => {
+    const dispatch = useDispatch();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
+    const { setValue, getValues } = form;
+
+    const reportParameterChanged = useCallback(
+        (parameter: TradingParameter) => {
+            analytics.report({
+                type: events.tradingParameterChangedEvent.name,
+                payload: { type: tradingType, parameter },
+            });
+        },
+        [analytics, tradingType],
+    );
+
+    const clearField = useCallback(
+        (field: string, shouldValidate: boolean) => {
+            setValue(
+                field as Path<TFieldValues>,
+                undefined as never,
+                shouldValidate ? { shouldValidate: true } : undefined,
+            );
+        },
+        [setValue],
+    );
+
+    return useCallback(
+        (asset: TradeableAsset, account?: Account, options?: ChangeAssetOptions) => {
+            const { shouldReportAnalytics = true } = options ?? {};
+
+            if (account && getSetTradingAccountKeyAction) {
+                dispatch(getSetTradingAccountKeyAction(account.key));
+            }
+
+            if (asset.cryptoId === selectedValue?.cryptoId) {
+                return;
+            }
+
+            const isTokenChange =
+                cryptoIdToSymbol(selectedValue?.cryptoId) === cryptoIdToSymbol(asset.cryptoId);
+
+            setSelectedValue(asset);
+
+            if (amountField) {
+                clearField(amountField, true);
+            }
+
+            const counterpartAsset = collision
+                ? (getValues(collision.counterpartAssetField as Path<TFieldValues>) as
+                      | TradeableAsset
+                      | undefined)
+                : undefined;
+
+            if (collision && asset.cryptoId === counterpartAsset?.cryptoId) {
+                clearField(collision.counterpartAssetField, false);
+                if (collision.counterpartAmountField) {
+                    clearField(collision.counterpartAmountField, true);
+                }
+                if (collision.getCounterpartChangedAction) {
+                    dispatch(collision.getCounterpartChangedAction());
+                }
+                reportParameterChanged(collision.counterpartAnalyticsParameter);
+            }
+
+            dispatch(
+                isTokenChange && getAssetTokenChangedAction
+                    ? getAssetTokenChangedAction()
+                    : getAssetChangedAction(),
+            );
+
+            if (shouldReportAnalytics) {
+                reportParameterChanged(analyticsParameter);
+            }
+        },
+        [
+            dispatch,
+            selectedValue?.cryptoId,
+            setSelectedValue,
+            getValues,
+            clearField,
+            amountField,
+            collision,
+            analyticsParameter,
+            getAssetChangedAction,
+            getAssetTokenChangedAction,
+            getSetTradingAccountKeyAction,
+            reportParameterChanged,
+        ],
+    );
+};

--- a/suite-native/module-trading/src/hooks/general/useFocusedValueWatch.ts
+++ b/suite-native/module-trading/src/hooks/general/useFocusedValueWatch.ts
@@ -1,8 +1,7 @@
 import { useEffect } from 'react';
-import { type Control, type FieldValues, type Path } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
 
-import { useWatch } from '@suite-native/forms';
+import { type Control, type FieldValues, type Path, useWatch } from '@suite-native/forms';
 import { tradingActions } from '@suite-native/trading-state';
 import { useDebouncedValue } from '@trezor/react-utils';
 

--- a/suite-native/module-trading/src/hooks/general/useFocusedValueWatch.ts
+++ b/suite-native/module-trading/src/hooks/general/useFocusedValueWatch.ts
@@ -1,15 +1,18 @@
 import { useEffect } from 'react';
+import { type Control, type FieldValues, type Path } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
 
+import { useWatch } from '@suite-native/forms';
 import { tradingActions } from '@suite-native/trading-state';
 import { useDebouncedValue } from '@trezor/react-utils';
 
-export const useFocusedValueWatch = <T extends string | undefined>(
-    watch: (field: 'focusedValue') => T,
+export const useFocusedValueWatch = <TFieldValues extends FieldValues>(
+    control: Control<TFieldValues>,
 ) => {
     const dispatch = useDispatch();
 
-    const isAmountInputActive = !!watch('focusedValue');
+    const focusedValue = useWatch({ control, name: 'focusedValue' as Path<TFieldValues> });
+    const isAmountInputActive = !!focusedValue;
     const isAmountInputActiveDebounced = useDebouncedValue(isAmountInputActive);
 
     useEffect(() => {

--- a/suite-native/module-trading/src/hooks/general/useInputFieldControls.ts
+++ b/suite-native/module-trading/src/hooks/general/useInputFieldControls.ts
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { useField } from '@suite-native/forms';
 
 export const useInputFieldControls = <T extends string>(
@@ -8,14 +10,14 @@ export const useInputFieldControls = <T extends string>(
     // do not use `value` from `useField` here, because it does not work properly with `undefined`
     const { onChange, onBlur, hasError } = useField({ name });
 
-    const setFocusedValue = () => {
+    const setFocusedValue = useCallback(() => {
         setValue('focusedValue', name);
-    };
+    }, [name, setValue]);
 
-    const clearFocusedValueAndBlur = () => {
+    const clearFocusedValueAndBlur = useCallback(() => {
         onBlur();
         setValue('focusedValue', undefined);
-    };
+    }, [onBlur, setValue]);
 
     return {
         value: value ?? '',

--- a/suite-native/module-trading/src/hooks/general/useSheetControls.ts
+++ b/suite-native/module-trading/src/hooks/general/useSheetControls.ts
@@ -1,6 +1,6 @@
 import { type Dispatch, useCallback } from 'react';
 
-import type { FieldPathValue, Path, UseFormReturn } from '@suite-native/forms';
+import { type FieldPathValue, type Path, type UseFormReturn, useWatch } from '@suite-native/forms';
 import { useBottomSheetControls } from '@suite-native/trading-atoms';
 import {
     type BuyFormValues,
@@ -21,12 +21,12 @@ type SheetControls<
 };
 
 export const useSheetControls = <FormValues extends FormUnion, Key extends Path<FormValues>>(
-    { setValue, watch }: UseFormReturn<FormValues>,
+    { setValue, control }: UseFormReturn<FormValues>,
     key: Key,
 ): SheetControls<FormValues, Key> => {
     const bottomSheetControls = useBottomSheetControls();
 
-    const selectedValue = watch(key);
+    const selectedValue = useWatch({ name: key, control });
 
     const setSelectedValue = useCallback(
         (value: typeof selectedValue) => setValue(key, value),

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
@@ -2,13 +2,9 @@ import type { SellFiatTrade } from 'invity-api';
 
 import { tradingSellActions } from '@suite-common/trading';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
-import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
-import { Form, useField } from '@suite-native/forms';
 import {
     type TestStore,
     act,
-    renderHook,
     renderHookWithStoreProvider,
     screen,
     waitFor,
@@ -23,17 +19,12 @@ import {
     sellQuotes,
     usdcAsset,
 } from '@suite-native/trading-fixtures';
-import { selectTradingResidenceCountry, sellActions } from '@suite-native/trading-state';
+import { selectTradingResidenceCountry } from '@suite-native/trading-state';
 import { type SellFormType } from '@suite-native/trading-types';
 import { PROTO } from '@trezor/connect';
 
 import { createTradingLightStore } from '../../../__tests__/tradingTestUtils';
 import { useSellForm } from '../useSellForm';
-
-const mockReport = jest.fn();
-const services: NativeAnalyticsDep = {
-    analytics: mockNativeAnalytics(mockReport),
-};
 
 const btc1Account = getBtcAccount({ descriptor: asAccountDescriptor('btc1normal') });
 const eth1Account = getEthAccount({ descriptor: asAccountDescriptor('eth1normal') });
@@ -41,8 +32,7 @@ const eth1Account = getEthAccount({ descriptor: asAccountDescriptor('eth1normal'
 describe('useSellForm', () => {
     let store: TestStore;
 
-    const renderUseSellForm = () =>
-        renderHookWithStoreProvider(() => useSellForm(), { services, store });
+    const renderUseSellForm = () => renderHookWithStoreProvider(() => useSellForm(), { store });
 
     const getInitializedStore = (bitcoinAmountUnit = PROTO.AmountUnit.BITCOIN) =>
         createTradingLightStore({
@@ -75,180 +65,6 @@ describe('useSellForm', () => {
             });
 
             expect(result.current.getValues('sendAccount')).toEqual(btc1Account);
-        });
-    });
-
-    describe('sendAsset', () => {
-        it('should clear crypto amount on change', () => {
-            const { result } = renderUseSellForm();
-            act(() => {
-                result.current.setValue('sendAsset', btcAsset);
-                result.current.setValue('cryptoStringAmount', '100');
-            });
-
-            act(() => {
-                result.current.setValue('sendAsset', usdcAsset);
-            });
-
-            expect(result.current.getValues('cryptoStringAmount')).toBeUndefined();
-        });
-
-        it('should report change to analytics', () => {
-            const { result } = renderUseSellForm();
-
-            act(() => {
-                result.current.setValue('sendAsset', btcAsset);
-            });
-
-            expect(mockReport).toHaveBeenCalledWith({
-                type: events.tradingParameterChangedEvent.name,
-                payload: {
-                    type: 'sell',
-                    parameter: 'cryptoFrom',
-                },
-            });
-        });
-
-        it('should dispatch sendAssetChanged action', () => {
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseSellForm();
-
-            act(() => {
-                result.current.setValue('sendAsset', btcAsset);
-            });
-
-            expect(dispatchSpy).toHaveBeenCalledWith(sellActions.sendAssetChanged());
-        });
-    });
-
-    describe('fiatCurrency', () => {
-        it('should clear fiat amount on change', () => {
-            const { result } = renderUseSellForm();
-            act(() => {
-                result.current.setValue('fiatCurrency', 'czk');
-                result.current.setValue('fiatStringAmount', '100');
-            });
-
-            act(() => {
-                result.current.setValue('fiatCurrency', 'pln');
-            });
-
-            expect(result.current.getValues('fiatStringAmount')).toBeUndefined();
-        });
-
-        it('should report change to analytics', () => {
-            const { result } = renderUseSellForm();
-
-            act(() => {
-                result.current.setValue('fiatCurrency', 'pln');
-            });
-
-            expect(mockReport).toHaveBeenCalledWith({
-                type: events.tradingParameterChangedEvent.name,
-                payload: {
-                    type: 'sell',
-                    parameter: 'fiat',
-                },
-            });
-        });
-
-        it('should dispatch fiatCurrencyChanged action', () => {
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseSellForm();
-
-            act(() => {
-                result.current.setValue('fiatCurrency', 'pln');
-            });
-
-            expect(dispatchSpy).toHaveBeenCalledWith(sellActions.fiatCurrencyChanged());
-        });
-    });
-
-    describe('cryptoStringAmount', () => {
-        const renderUseCryptoStringAmountField = (form: SellFormType) => {
-            const { result: fieldResult, unmount: fieldUnmount } = renderHook(
-                () => useField({ name: 'cryptoStringAmount' }),
-                {
-                    wrapper: ({ children }) => <Form form={form}>{children}</Form>,
-                },
-            );
-
-            return { fieldResult, fieldUnmount };
-        };
-
-        it('should set amountInCrypto to true when user edits cryptoStringAmount', () => {
-            const { result } = renderUseSellForm();
-            const { fieldResult, fieldUnmount } = renderUseCryptoStringAmountField(result.current);
-
-            act(() => {
-                result.current.setValue('amountInCrypto', false);
-                result.current.setValue('focusedValue', 'cryptoStringAmount');
-                fieldResult.current.onChange('50');
-            });
-
-            expect(result.current.getValues('amountInCrypto')).toBe(true);
-
-            fieldUnmount();
-        });
-
-        it('should clear fiatStringAmount when user edits cryptoStringAmount', () => {
-            const { result } = renderUseSellForm();
-            const { fieldResult, fieldUnmount } = renderUseCryptoStringAmountField(result.current);
-
-            act(() => {
-                result.current.setValue('fiatStringAmount', '100');
-                result.current.setValue('focusedValue', 'cryptoStringAmount');
-                fieldResult.current.onChange('50');
-            });
-
-            expect(result.current.getValues('fiatStringAmount')).toBeUndefined();
-            expect(result.current.getValues('cryptoStringAmount')).toBe('50');
-
-            fieldUnmount();
-        });
-    });
-
-    describe('fiatStringAmount', () => {
-        const renderUseFiatStringAmountField = (form: SellFormType) => {
-            const { result: fieldResult, unmount: fieldUnmount } = renderHook(
-                () => useField({ name: 'fiatStringAmount' }),
-                {
-                    wrapper: ({ children }) => <Form form={form}>{children}</Form>,
-                },
-            );
-
-            return { fieldResult, fieldUnmount };
-        };
-
-        it('should set amountInCrypto to false when user edits fiatStringAmount', () => {
-            const { result } = renderUseSellForm();
-            const { fieldResult, fieldUnmount } = renderUseFiatStringAmountField(result.current);
-
-            act(() => {
-                result.current.setValue('amountInCrypto', true);
-                result.current.setValue('focusedValue', 'fiatStringAmount');
-                fieldResult.current.onChange('50');
-            });
-
-            expect(result.current.getValues('amountInCrypto')).toBe(false);
-
-            fieldUnmount();
-        });
-
-        it('should clear cryptoStringAmount when user edits fiatStringAmount', () => {
-            const { result } = renderUseSellForm();
-            const { fieldResult, fieldUnmount } = renderUseFiatStringAmountField(result.current);
-
-            act(() => {
-                result.current.setValue('cryptoStringAmount', '100');
-                result.current.setValue('focusedValue', 'fiatStringAmount');
-                fieldResult.current.onChange('50');
-            });
-
-            expect(result.current.getValues('cryptoStringAmount')).toBeUndefined();
-            expect(result.current.getValues('fiatStringAmount')).toBe('50');
-
-            fieldUnmount();
         });
     });
 

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellInputFormControls.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellInputFormControls.test.tsx
@@ -1,5 +1,5 @@
 import { Form } from '@suite-native/forms';
-import { renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
 import { type SellFormType } from '@suite-native/trading-types';
 
 import { renderHookWithTradingProvider } from '../../../__tests__/tradingTestUtils';
@@ -12,8 +12,10 @@ describe('useSellInputFormControls', () => {
     const renderSellFormHook = () =>
         renderHookWithTradingProvider(() => useSellForm(), { tradeType: 'sell' });
 
-    const renderUseSellInputFormControls = () =>
-        renderHookWithBasicProvider(() => useSellInputFormControls('fiatStringAmount'), {
+    const renderUseSellInputFormControls = (
+        name: 'fiatStringAmount' | 'cryptoStringAmount' = 'fiatStringAmount',
+    ) =>
+        renderHookWithBasicProvider(() => useSellInputFormControls(name), {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
@@ -41,5 +43,38 @@ describe('useSellInputFormControls', () => {
                 hasError: false,
             }),
         );
+    });
+
+    it('should keep onChangeText stable when the value changes', () => {
+        const { result } = renderUseSellInputFormControls();
+        const initialOnChangeText = result.current.onChangeText;
+
+        act(() => form.setValue('fiatStringAmount', '123'));
+
+        expect(result.current.onChangeText).toBe(initialOnChangeText);
+    });
+
+    it('should switch to fiat amount and clear crypto amount on fiat input change', () => {
+        form.setValue('amountInCrypto', true);
+        form.setValue('cryptoStringAmount', '0.1');
+        const { result } = renderUseSellInputFormControls('fiatStringAmount');
+
+        act(() => result.current.onChangeText('100'));
+
+        expect(form.getValues('fiatStringAmount')).toBe('100');
+        expect(form.getValues('cryptoStringAmount')).toBeUndefined();
+        expect(form.getValues('amountInCrypto')).toBe(false);
+    });
+
+    it('should switch to crypto amount and clear fiat amount on crypto input change', () => {
+        form.setValue('amountInCrypto', false);
+        form.setValue('fiatStringAmount', '100');
+        const { result } = renderUseSellInputFormControls('cryptoStringAmount');
+
+        act(() => result.current.onChangeText('0.1'));
+
+        expect(form.getValues('cryptoStringAmount')).toBe('0.1');
+        expect(form.getValues('fiatStringAmount')).toBeUndefined();
+        expect(form.getValues('amountInCrypto')).toBe(true);
     });
 });

--- a/suite-native/module-trading/src/hooks/sell/useSellForm.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellForm.ts
@@ -1,9 +1,8 @@
-import { useEffect, useRef } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 
-import type { CryptoId, FiatCurrencyCode, SellFiatTrade } from 'invity-api';
+import type { SellFiatTrade } from 'invity-api';
 
-import { useServices } from '@suite-common/dependency-injection';
 import {
     type TradingAmountLimitProps,
     selectTradingSellQuotesRequest,
@@ -12,7 +11,6 @@ import {
 import { getNetwork } from '@suite-common/wallet-config';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
-import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { useForm, useWatch } from '@suite-native/forms';
 import { truncateDecimals } from '@suite-native/helpers';
 import { useTranslate } from '@suite-native/intl';
@@ -22,7 +20,6 @@ import {
     selectSellAmountLimits,
     selectSellFormDefaultValues,
     selectSellSelectedSendAccount,
-    sellActions,
 } from '@suite-native/trading-state';
 import { type SellFormType, type SellFormValues } from '@suite-native/trading-types';
 
@@ -32,75 +29,6 @@ import { useCountryChangeEffect } from '../general/form/useCountryChangeEffect';
 import { useProviderMetadataChangeEffect } from '../general/form/useProviderMetadataChangeEffect';
 import { useSendAccountAssetBalance } from '../general/form/useSendAccountAssetBalance';
 import { useSendAccountChangeEffect } from '../general/form/useSendAccountChangeEffect';
-
-const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: SellFormType) => {
-    const dispatch = useDispatch();
-    const prevCryptoId = useRef<CryptoId | undefined>(undefined);
-    const prevFiatCurrency = useRef<FiatCurrencyCode | undefined>(getValues('fiatCurrency'));
-    const { analytics } = useServices(selectNativeAnalyticsDep);
-
-    useEffect(() => {
-        const { unsubscribe } = watch(
-            ({ fiatCurrency, sendAsset, amountInCrypto, focusedValue }, { name, type }) => {
-                switch (name) {
-                    case 'fiatStringAmount':
-                        if (type === 'change' && focusedValue === 'fiatStringAmount') {
-                            setValue('cryptoStringAmount', undefined, { shouldValidate: true });
-                            if (amountInCrypto) {
-                                setValue('amountInCrypto', false);
-                            }
-                        }
-                        break;
-
-                    case 'cryptoStringAmount':
-                        if (type === 'change' && focusedValue === 'cryptoStringAmount') {
-                            setValue('fiatStringAmount', undefined, { shouldValidate: true });
-                            if (!amountInCrypto) {
-                                setValue('amountInCrypto', true);
-                            }
-                        }
-                        break;
-
-                    case 'sendAsset':
-                        if (sendAsset?.cryptoId !== prevCryptoId.current) {
-                            analytics.report({
-                                type: events.tradingParameterChangedEvent.name,
-                                payload: {
-                                    type: 'sell',
-                                    parameter: 'cryptoFrom',
-                                },
-                            });
-                            prevCryptoId.current = sendAsset?.cryptoId;
-                            setValue('cryptoStringAmount', undefined, { shouldValidate: true });
-                            dispatch(sellActions.sendAssetChanged());
-                        }
-                        break;
-
-                    case 'fiatCurrency':
-                        if (fiatCurrency !== prevFiatCurrency.current) {
-                            analytics.report({
-                                type: events.tradingParameterChangedEvent.name,
-                                payload: {
-                                    type: 'sell',
-                                    parameter: 'fiat',
-                                },
-                            });
-                            prevFiatCurrency.current = fiatCurrency;
-                            setValue('fiatStringAmount', undefined, { shouldValidate: true });
-                            dispatch(sellActions.fiatCurrencyChanged());
-                        }
-                        break;
-
-                    default:
-                        // do nothing
-                        break;
-                }
-            },
-        );
-
-        return unsubscribe;
-    }, [setValue, watch, dispatch, analytics]);
-};
 
 const useSellQuotesChangeEffect = ({ getValues, setValue }: SellFormType) => {
     const quotes = useSelector(selectValidTradingSellQuotes);
@@ -215,16 +143,21 @@ export const useSellForm = (): SellFormType => {
         context,
     });
 
-    const { watch } = form;
+    const { control } = form;
 
     useSendAccountChangeEffect(form.setValue, selectSellSelectedSendAccount);
-    useAmountAndCurrencyFieldsChangeEffect(form);
-    useSendAccountAssetBalance(form, setBalance, setSendSymbol, setContractAddress, setAccountKey);
+    useSendAccountAssetBalance({
+        control,
+        setBalance,
+        setSendSymbol,
+        setContractAddress,
+        setAccountKey,
+    });
     useSellQuotesChangeEffect(form);
     useSellQuoteChangeEffect(form);
     useValidations(form, limits);
-    useCountryChangeEffect(watch);
-    useProviderMetadataChangeEffect(watch, 'sell');
+    useCountryChangeEffect(control);
+    useProviderMetadataChangeEffect(control, 'sell');
 
     return form;
 };

--- a/suite-native/module-trading/src/hooks/sell/useSellForm.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellForm.ts
@@ -13,7 +13,7 @@ import { getNetwork } from '@suite-common/wallet-config';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
-import { useForm } from '@suite-native/forms';
+import { useForm, useWatch } from '@suite-native/forms';
 import { truncateDecimals } from '@suite-native/helpers';
 import { useTranslate } from '@suite-native/intl';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
@@ -143,8 +143,8 @@ const useSellQuotesChangeEffect = ({ getValues, setValue }: SellFormType) => {
     }, [quotes, getValues, setValue]);
 };
 
-const useSellQuoteChangeEffect = ({ getValues, setValue, watch }: SellFormType) => {
-    const [sendAsset, quote] = watch(['sendAsset', 'quote']);
+const useSellQuoteChangeEffect = ({ control, getValues, setValue }: SellFormType) => {
+    const [sendAsset, quote] = useWatch({ control, name: ['sendAsset', 'quote'] });
     const symbol = getSymbolFromTradeableAsset(sendAsset);
 
     const isAmountInSats = useSelector((state: WalletSettingsRootState) =>

--- a/suite-native/module-trading/src/hooks/sell/useSellForm.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellForm.ts
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useCallback, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
 import type { SellFiatTrade } from 'invity-api';
 
@@ -20,6 +20,7 @@ import {
     selectSellAmountLimits,
     selectSellFormDefaultValues,
     selectSellSelectedSendAccount,
+    sellActions,
 } from '@suite-native/trading-state';
 import { type SellFormType, type SellFormValues } from '@suite-native/trading-types';
 
@@ -144,8 +145,14 @@ export const useSellForm = (): SellFormType => {
     });
 
     const { control } = form;
+    const dispatch = useDispatch();
 
-    useSendAccountChangeEffect(form.setValue, selectSellSelectedSendAccount);
+    const onSendAssetCleared = useCallback(() => {
+        form.setValue('cryptoStringAmount', undefined, { shouldValidate: true });
+        dispatch(sellActions.sendAssetChanged());
+    }, [dispatch, form]);
+
+    useSendAccountChangeEffect(form.setValue, selectSellSelectedSendAccount, onSendAssetCleared);
     useSendAccountAssetBalance({
         control,
         setBalance,

--- a/suite-native/module-trading/src/hooks/sell/useSellInputFormControls.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellInputFormControls.ts
@@ -1,9 +1,42 @@
+import { useCallback } from 'react';
+
+import { useWatch } from '@suite-native/forms';
+
 import { useSellFormContext } from './useSellFormContext';
 import { useInputFieldControls } from '../general/useInputFieldControls';
 
 export const useSellInputFormControls = (name: 'fiatStringAmount' | 'cryptoStringAmount') => {
-    const { getValues, setValue } = useSellFormContext();
-    const value = getValues(name);
+    const { control, getValues, setValue } = useSellFormContext();
+    const value = useWatch({ control, name });
+    const { onChangeText: updateFieldValue, ...inputControls } = useInputFieldControls(
+        name,
+        value,
+        setValue,
+    );
 
-    return useInputFieldControls(name, value, setValue);
+    const onChangeText = useCallback(
+        (nextValue: string | undefined) => {
+            updateFieldValue(nextValue);
+
+            if (name === 'fiatStringAmount') {
+                setValue('cryptoStringAmount', undefined, { shouldValidate: true });
+
+                if (getValues('amountInCrypto')) {
+                    setValue('amountInCrypto', false);
+                }
+            } else {
+                setValue('fiatStringAmount', undefined, { shouldValidate: true });
+
+                if (!getValues('amountInCrypto')) {
+                    setValue('amountInCrypto', true);
+                }
+            }
+        },
+        [getValues, name, setValue, updateFieldValue],
+    );
+
+    return {
+        ...inputControls,
+        onChangeText,
+    };
 };

--- a/suite-native/module-trading/src/hooks/sell/useSellQuotes.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellQuotes.ts
@@ -105,13 +105,13 @@ const useSellQuotesInvalidator = (
 };
 
 const useSellQuotesThunk = (
-    getValues: SellFormType['getValues'],
+    { getValues, control }: SellFormType,
     requestState: SellQuoteRequestState,
     quotesPromiseRef: RefObject<AbortablePromise | undefined>,
     debounce: ReturnType<typeof useDebounce>,
 ) => {
     const dispatch = useDispatch();
-    const asset = getValues('sendAsset');
+    const asset = useWatch({ control, name: 'sendAsset' });
     const symbol = getSymbolFromTradeableAsset(asset);
     const shouldSendInSats = useSelector((state: WalletSettingsRootState) =>
         selectIsAmountInSats(state, symbol),
@@ -182,5 +182,5 @@ export const useSellQuotes = (form: SellFormType) => {
     const requestState = useSellQuoteRequestState(form);
 
     useSellQuotesInvalidator(requestState.isFetchAllowed, promiseRef, debounce);
-    useSellQuotesThunk(form.getValues, requestState, promiseRef, debounce);
+    useSellQuotesThunk(form, requestState, promiseRef, debounce);
 };

--- a/suite-native/module-trading/src/hooks/sell/useSellQuotes.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellQuotes.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useCallback, useEffect, useRef } from 'react';
+import { type RefObject, useCallback, useEffect, useEffectEvent, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { invariant } from '@suite-common/suite-utils';
@@ -11,7 +11,7 @@ import {
     useTradingRefetchScheduler,
 } from '@suite-common/trading';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
-import { useFormState } from '@suite-native/forms';
+import { useFormState, useWatch } from '@suite-native/forms';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import { sellActions } from '@suite-native/trading-state';
 import { type AbortablePromise, type SellFormType } from '@suite-native/trading-types';
@@ -21,12 +21,8 @@ import { noop } from '@trezor/utils';
 import { tradingSellFormToTradingSellFormProps } from '../../utils/sell/quotesUtils';
 import { useQuotesInvalidator } from '../general/useQuotesInvalidator';
 
-type ShouldFetchSellQuotes = {
+type SellQuoteRequestState = {
     isFetchAllowed: boolean;
-    shouldFetchQuotes: boolean;
-};
-
-type ShouldFetchSellQuotesRef = {
     sendAsset: string | undefined;
     amount: string | undefined;
     amountInCrypto: boolean | undefined;
@@ -36,48 +32,15 @@ type ShouldFetchSellQuotesRef = {
     accountDescriptor: string | undefined;
 };
 
-const defaultState: ShouldFetchSellQuotesRef = {
-    sendAsset: undefined,
-    amount: undefined,
-    amountInCrypto: true,
-    fiatCurrency: undefined,
-    country: undefined,
-    countrySubdivision: undefined,
-    accountDescriptor: undefined,
-} as const;
-
 const quoteDerivedCryptoErrorTypes = ['insufficient-balance', 'network-reserve'] as const;
 
 const isQuoteDerivedCryptoError = (fieldName: string, type: unknown) =>
     fieldName === 'cryptoStringAmount' &&
     quoteDerivedCryptoErrorTypes.some(errorType => errorType === type);
 
-const useShouldFetchSellQuotes = ({ watch, control }: SellFormType): ShouldFetchSellQuotes => {
-    const prevState = useRef<ShouldFetchSellQuotesRef>(defaultState);
-
-    const amountInCrypto = watch('amountInCrypto');
-
-    const { isValid, errors } = useFormState({ control });
-
-    if (!isValid) {
-        const errorEntries = Object.entries(errors);
-        const errorCausedByQuote =
-            !amountInCrypto &&
-            errorEntries.every(([fieldName, { type }]) =>
-                isQuoteDerivedCryptoError(fieldName, type),
-            );
-
-        if (!errorCausedByQuote) {
-            prevState.current = defaultState;
-
-            return {
-                isFetchAllowed: false,
-                shouldFetchQuotes: false,
-            };
-        }
-    }
-
+const useSellQuoteRequestState = ({ control }: SellFormType): SellQuoteRequestState => {
     const [
+        amountInCrypto,
         sendAsset,
         sendAccount,
         cryptoStringAmount,
@@ -85,35 +48,33 @@ const useShouldFetchSellQuotes = ({ watch, control }: SellFormType): ShouldFetch
         fiatCurrency,
         country,
         countrySubdivision,
-    ] = watch([
-        'sendAsset',
-        'sendAccount',
-        'cryptoStringAmount',
-        'fiatStringAmount',
-        'fiatCurrency',
-        'country',
-        'countrySubdivision',
-    ]);
+    ] = useWatch({
+        control,
+        name: [
+            'amountInCrypto',
+            'sendAsset',
+            'sendAccount',
+            'cryptoStringAmount',
+            'fiatStringAmount',
+            'fiatCurrency',
+            'country',
+            'countrySubdivision',
+        ],
+    });
+    const { isValid, errors } = useFormState({ control });
+
+    const errorEntries = Object.entries(errors);
+    const isErrorCausedByQuote =
+        !amountInCrypto &&
+        errorEntries.every(([fieldName, { type }]) => isQuoteDerivedCryptoError(fieldName, type));
+    const isFormValidForQuotes = isValid || isErrorCausedByQuote;
 
     const amount = amountInCrypto ? cryptoStringAmount : fiatStringAmount;
-    const isFetchAllowed = !!(sendAsset && fiatCurrency && amount && parseFloat(amount) > 0);
+    const isFetchAllowed =
+        isFormValidForQuotes && !!(sendAsset && fiatCurrency && amount && parseFloat(amount) > 0);
 
-    if (
-        sendAsset?.cryptoId === prevState.current.sendAsset &&
-        amount === prevState.current.amount &&
-        amountInCrypto === prevState.current.amountInCrypto &&
-        fiatCurrency === prevState.current.fiatCurrency &&
-        country?.value === prevState.current.country &&
-        countrySubdivision?.value === prevState.current.countrySubdivision &&
-        sendAccount?.descriptor === prevState.current.accountDescriptor
-    ) {
-        return {
-            isFetchAllowed,
-            shouldFetchQuotes: false,
-        };
-    }
-
-    prevState.current = {
+    return {
+        isFetchAllowed,
         sendAsset: sendAsset?.cryptoId,
         amount,
         amountInCrypto,
@@ -121,11 +82,6 @@ const useShouldFetchSellQuotes = ({ watch, control }: SellFormType): ShouldFetch
         country: country?.value,
         countrySubdivision: countrySubdivision?.value,
         accountDescriptor: sendAccount?.descriptor,
-    };
-
-    return {
-        isFetchAllowed,
-        shouldFetchQuotes: true,
     };
 };
 
@@ -150,8 +106,7 @@ const useSellQuotesInvalidator = (
 
 const useSellQuotesThunk = (
     getValues: SellFormType['getValues'],
-    isFetchAllowed: boolean,
-    shouldFetchQuotes: boolean,
+    requestState: SellQuoteRequestState,
     quotesPromiseRef: RefObject<AbortablePromise | undefined>,
     debounce: ReturnType<typeof useDebounce>,
 ) => {
@@ -161,6 +116,16 @@ const useSellQuotesThunk = (
     const shouldSendInSats = useSelector((state: WalletSettingsRootState) =>
         selectIsAmountInSats(state, symbol),
     );
+    const {
+        isFetchAllowed,
+        sendAsset,
+        amount,
+        amountInCrypto,
+        fiatCurrency,
+        country,
+        countrySubdivision,
+        accountDescriptor,
+    } = requestState;
 
     const fetchQuotes = useCallback(() => {
         const selectedAsset = getValues('sendAsset');
@@ -177,15 +142,30 @@ const useSellQuotesThunk = (
         quotesPromiseRef.current = dispatch(sellThunks.handleRequestThunk(payload));
     }, [getValues, shouldSendInSats, quotesPromiseRef, dispatch]);
 
-    useEffect(() => {
-        if (!isFetchAllowed || !shouldFetchQuotes) return;
-
+    const requestQuotes = useEffectEvent(() => {
         if (quotesPromiseRef.current?.abort) {
             quotesPromiseRef.current.abort('Request was replaced by another one.');
         }
 
         debounce(fetchQuotes);
-    }, [isFetchAllowed, shouldFetchQuotes, quotesPromiseRef, debounce, fetchQuotes]);
+    });
+
+    useEffect(() => {
+        if (!isFetchAllowed) {
+            return;
+        }
+
+        requestQuotes();
+    }, [
+        isFetchAllowed,
+        sendAsset,
+        amount,
+        amountInCrypto,
+        fiatCurrency,
+        country,
+        countrySubdivision,
+        accountDescriptor,
+    ]);
 
     useTradingRefetchScheduler({
         onRefetch: () => {
@@ -199,8 +179,8 @@ export const useSellQuotes = (form: SellFormType) => {
     const debounce = useDebounce();
     const promiseRef = useRef<AbortablePromise | undefined>(undefined);
 
-    const { isFetchAllowed, shouldFetchQuotes } = useShouldFetchSellQuotes(form);
+    const requestState = useSellQuoteRequestState(form);
 
-    useSellQuotesInvalidator(isFetchAllowed, promiseRef, debounce);
-    useSellQuotesThunk(form.getValues, isFetchAllowed, shouldFetchQuotes, promiseRef, debounce);
+    useSellQuotesInvalidator(requestState.isFetchAllowed, promiseRef, debounce);
+    useSellQuotesThunk(form.getValues, requestState, promiseRef, debounce);
 };

--- a/suite-native/module-trading/src/hooks/sell/useSellSelectQuote.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellSelectQuote.ts
@@ -9,7 +9,7 @@ import {
     sellThunks,
     tradingSellActions,
 } from '@suite-common/trading';
-import { useFormState } from '@suite-native/forms';
+import { useFormState, useWatch } from '@suite-native/forms';
 import {
     type RootStackParamList,
     RootStackRoutes,
@@ -37,9 +37,9 @@ type SellSelectQuoteReturn = {
 export const useSellSelectQuote = (form: SellFormType): SellSelectQuoteReturn => {
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
-    const { watch, control } = form;
+    const { control } = form;
     const { isValid } = useFormState({ control });
-    const candidateQuote = watch('quote');
+    const candidateQuote = useWatch({ control, name: 'quote' });
     const isLoading = useSelector(selectTradingSellIsLoading);
     const sellInfo = useSelector(selectTradingSellInfo);
 

--- a/suite-native/trading-residence/src/components/ConfirmLocationButton.tsx
+++ b/suite-native/trading-residence/src/components/ConfirmLocationButton.tsx
@@ -2,7 +2,7 @@ import { useDispatch } from 'react-redux';
 
 import { isCountrySubdivisionRequired } from '@suite-common/trading';
 import { Button } from '@suite-native/atoms';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 import { residenceActions } from '@suite-native/trading-state';
 
@@ -19,8 +19,8 @@ export type ConfirmLocationButtonProps = {
 
 export const ConfirmLocationButton = ({ afterConfirm, testId }: ConfirmLocationButtonProps) => {
     const countryCode = useFormCountryCode();
-    const { watch } = useFormContext<TradingLocationFormValues>();
-    const countrySubdivision = watch('countrySubdivision');
+    const { control } = useFormContext<TradingLocationFormValues>();
+    const countrySubdivision = useWatch({ control, name: 'countrySubdivision' });
     const { showSheet: showCountrySubdivisionPicker } = useCountrySubdivisionPickerControls();
     const dispatch = useDispatch();
     const analyticsReport = useCountrySelectionAnalyticsReport();

--- a/suite-native/trading-residence/src/components/CountrySheet/CountryOfResidencePicker.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountryOfResidencePicker.tsx
@@ -9,7 +9,7 @@ import {
     selectNativeAnalyticsDep,
 } from '@suite-native/analytics';
 import { Flag, HStack, Text } from '@suite-native/atoms';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { OverviewRow, useBottomSheetControls } from '@suite-native/trading-atoms';
 import { type Analytics } from '@trezor/analytics-uploader';
@@ -45,8 +45,8 @@ export const CountryOfResidencePicker = ({
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const { isSheetVisible, hideSheet, showSheet } = useBottomSheetControls();
 
-    const { watch, setValue } = useFormContext<TradingLocationFormValues>();
-    const selectedValue = watch('country');
+    const { control, setValue } = useFormContext<TradingLocationFormValues>();
+    const selectedValue = useWatch({ control, name: 'country' });
     const selectedFlag = getCountryFlag(selectedValue?.value);
 
     const handleCountrySelect = useCallback(

--- a/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionPicker.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionPicker.tsx
@@ -5,7 +5,7 @@ import {
     isCountrySubdivisionRequired,
 } from '@suite-common/trading';
 import { Text } from '@suite-native/atoms';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { OverviewRow } from '@suite-native/trading-atoms';
 
@@ -24,9 +24,11 @@ export const CountrySubdivisionPicker = ({
 }: CountrySubdivisionPickerProps) => {
     const { translate } = useTranslate();
     const { isSheetVisible, hideSheet, showSheet } = useCountrySubdivisionPickerControls();
-    const { watch, setValue } = useFormContext<TradingLocationFormValues>();
-    const selectedCountry = watch('country');
-    const selectedValue = watch('countrySubdivision');
+    const { control, setValue } = useFormContext<TradingLocationFormValues>();
+    const [selectedCountry, selectedValue] = useWatch({
+        control,
+        name: ['country', 'countrySubdivision'],
+    });
     const isSubdivisionRequired = isCountrySubdivisionRequired(selectedCountry?.value);
 
     const handleSubdivisionSelect = useCallback(

--- a/suite-native/trading-residence/src/components/TradingLocationPickers.tsx
+++ b/suite-native/trading-residence/src/components/TradingLocationPickers.tsx
@@ -1,6 +1,6 @@
 import { isCountrySubdivisionRequired } from '@suite-common/trading';
 import { type CountryChangeContext } from '@suite-native/analytics';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 
 import { CountryOfResidencePicker } from './CountrySheet/CountryOfResidencePicker';
 import { CountrySubdivisionPicker } from './CountrySheet/CountrySubdivisionPicker';
@@ -19,8 +19,8 @@ export const TradingLocationPickers = ({
     hideSubdivisionPicker = false,
     noBottomBorder,
 }: TradingLocationPickersProps) => {
-    const { watch } = useFormContext<TradingLocationFormValues>();
-    const selectedCountry = watch('country');
+    const { control } = useFormContext<TradingLocationFormValues>();
+    const selectedCountry = useWatch({ control, name: 'country' });
     const isSubdivisionRequired = isCountrySubdivisionRequired(selectedCountry?.value);
 
     const residencePickerBottomBorder =

--- a/suite-native/trading-residence/src/hooks/useFormCountryCode.ts
+++ b/suite-native/trading-residence/src/hooks/useFormCountryCode.ts
@@ -1,9 +1,10 @@
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 
 import { type TradingLocationFormValues } from '../types/tradingLocationForm';
 
 export const useFormCountryCode = () => {
-    const { watch } = useFormContext<TradingLocationFormValues>();
+    const { control } = useFormContext<TradingLocationFormValues>();
+    const country = useWatch({ control, name: 'country' });
 
-    return watch('country').value;
+    return country.value;
 };

--- a/suite-native/trading-residence/src/hooks/useIsTradingAvailableForForm.ts
+++ b/suite-native/trading-residence/src/hooks/useIsTradingAvailableForForm.ts
@@ -1,13 +1,16 @@
 import { isCountrySubdivisionEmpty } from '@suite-common/trading';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 import { tradingCountriesWhitelistSet } from '@suite-native/trading-consts';
 
 import { type TradingLocationFormValues } from '../types/tradingLocationForm';
 
 export const useIsTradingAvailableForForm = () => {
-    const { watch } = useFormContext<TradingLocationFormValues>();
-    const countryCode = watch('country')?.value;
-    const countrySubdivision = watch('countrySubdivision');
+    const { control } = useFormContext<TradingLocationFormValues>();
+    const [country, countrySubdivision] = useWatch({
+        control,
+        name: ['country', 'countrySubdivision'],
+    });
+    const countryCode = country?.value;
 
     return (
         tradingCountriesWhitelistSet.has(countryCode) &&

--- a/suite-native/trading-slippage/src/components/SlippageSummary.tsx
+++ b/suite-native/trading-slippage/src/components/SlippageSummary.tsx
@@ -2,18 +2,18 @@ import { useSelector } from 'react-redux';
 
 import { type SlippageFormValues, selectTradingExchangeSelectedQuote } from '@suite-common/trading';
 import { Divider, HStack, Text, VStack } from '@suite-native/atoms';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 import { useFormatCryptoValue } from '@suite-native/trading-atoms';
 import { BigNumber } from '@trezor/utils';
 
 export const SlippageSummary = () => {
-    const { watch, formState } = useFormContext<SlippageFormValues>();
+    const { control, formState } = useFormContext<SlippageFormValues>();
     const formatCryptoValue = useFormatCryptoValue();
     const { receive, receiveStringAmount, swapSlippage } =
         useSelector(selectTradingExchangeSelectedQuote) ?? {};
 
-    const slippageValue = watch('slippage');
+    const slippageValue = useWatch({ control, name: 'slippage' });
 
     if (swapSlippage === undefined) {
         throw new Error('swapSlippage is required in quote for SlippageSummary');

--- a/suite-native/trading-state/src/selectors/__tests__/exchangeSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/exchangeSelectors.test.ts
@@ -139,17 +139,6 @@ describe('exchangeSelectors', () => {
             expect(selectExchangeBuyTradeableAssets(state)).toEqual([]);
         });
 
-        it('should filter out forbidden cryptoId', () => {
-            const result = selectExchangeBuyTradeableAssets(
-                state,
-                'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-            );
-            expect(result).toEqual([
-                expect.objectContaining({ cryptoId: 'ethereum' }),
-                expect.objectContaining({ cryptoId: 'bitcoin' }),
-            ]);
-        });
-
         it('should filter out coins with invalid network symbols', () => {
             // Add a coin with an invalid symbol that doesn't map to a network
             state.wallet.trading.exchange.exchangeInfo!.buyCryptoIds = [

--- a/suite-native/trading-state/src/selectors/exchangeSelectors.ts
+++ b/suite-native/trading-state/src/selectors/exchangeSelectors.ts
@@ -53,9 +53,7 @@ export const selectExchangeSelectedReceiveAccount = createMemoizedSelectorWithAc
 
 export const selectExchangeBuyTradeableAssets = createTradingWithFeatureFlagsMemoizedSelector(
     [
-        selectTradingExchangeBuyCryptoIds as unknown as (
-            state: TradingRootState,
-        ) => ReturnType<typeof selectTradingExchangeBuyCryptoIds>,
+        selectTradingExchangeBuyCryptoIds,
         ({ wallet }) => wallet.trading.info.coins,
         state => selectIsFeatureFlagEnabled(state, FeatureFlag.AreDebugOnlyNetworksEnabled),
         state => selectIsFeatureFlagEnabled(state, FeatureFlag.AreExperimentalOnlyNetworksEnabled),
@@ -68,7 +66,9 @@ export const selectExchangeBuyTradeableAssets = createTradingWithFeatureFlagsMem
         return cryptoIds
             .flatMap(cryptoId => {
                 const coinInfo = coins[cryptoId];
-                if (!coinInfo) return [];
+                if (!coinInfo) {
+                    return [];
+                }
 
                 return [coinInfoToTradeableAsset(cryptoId, coinInfo)];
             })

--- a/suite-native/trading-state/src/selectors/exchangeSelectors.ts
+++ b/suite-native/trading-state/src/selectors/exchangeSelectors.ts
@@ -57,23 +57,15 @@ export const selectExchangeBuyTradeableAssets = createTradingWithFeatureFlagsMem
             state: TradingRootState,
         ) => ReturnType<typeof selectTradingExchangeBuyCryptoIds>,
         ({ wallet }) => wallet.trading.info.coins,
-        (_state: TradingRootState, forbiddenCryptoId?: string) => forbiddenCryptoId,
         state => selectIsFeatureFlagEnabled(state, FeatureFlag.AreDebugOnlyNetworksEnabled),
         state => selectIsFeatureFlagEnabled(state, FeatureFlag.AreExperimentalOnlyNetworksEnabled),
     ],
-    (
-        cryptoIds,
-        coins,
-        forbiddenCryptoId,
-        areDebugOnlyNetworksEnabled,
-        areExperimentalOnlyNetworksEnabled,
-    ) => {
+    (cryptoIds, coins, areDebugOnlyNetworksEnabled, areExperimentalOnlyNetworksEnabled) => {
         if (!coins || !cryptoIds) {
             return [];
         }
 
         return cryptoIds
-            .filter(cryptoId => cryptoId !== forbiddenCryptoId)
             .flatMap(cryptoId => {
                 const coinInfo = coins[cryptoId];
                 if (!coinInfo) return [];

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOption.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOption.tsx
@@ -27,7 +27,7 @@ import {
     CryptoToFiatAmountFormatter,
     EmptyAmountSkeleton,
 } from '@suite-native/formatters';
-import { FormContext } from '@suite-native/forms';
+import { FormContext, useWatch } from '@suite-native/forms';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { type Color } from '@trezor/theme';
@@ -104,7 +104,7 @@ export const FeeOption = ({
     onSelectedFeeLevel,
 }: FeeOptionProps) => {
     const { utils, applyStyle } = useNativeStyles();
-    const { watch, setValue } = useContext(FormContext);
+    const { control, setValue } = useContext(FormContext);
 
     const feeTimeEstimate = useSelector((state: FeesRootState) =>
         selectConvertedNetworkFeeLevelTimeEstimate(state, symbol, feeKey),
@@ -116,7 +116,7 @@ export const FeeOption = ({
 
     const areFeeValuesComplete = isFinalPrecomposedTransaction(feeLevel);
 
-    const selectedLevel = watch('feeLevel');
+    const selectedLevel = useWatch({ control, name: 'feeLevel' });
     const isChecked = selectedLevel === feeKey;
 
     const highlightColor: Color = areFeeValuesComplete
@@ -235,6 +235,8 @@ export const FeeOption = ({
                                 isChecked={isChecked}
                                 value={feeKey}
                                 onPress={handleSelectFeeLevel}
+                                accessibilityRole="radio"
+                                accessibilityState={{ checked: isChecked }}
                                 testID={`@transactionManagement/fees-level-radio-${feeKey}`}
                             />
                         )}

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/__tests__/FeeOptionsList.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/__tests__/FeeOptionsList.test.tsx
@@ -6,6 +6,7 @@ import { type AccountKey } from '@suite-common/wallet-types';
 import { Form } from '@suite-native/forms';
 import { localeReducer } from '@suite-native/intl';
 import {
+    act,
     createLightStore,
     createStaticReducer,
     renderHookWithStoreProvider,
@@ -101,10 +102,12 @@ describe('FeeOptionsList', () => {
         const store = createFeeOptionsStore(preloadedState);
         const form = renderUseFeesForm(store);
 
-        return renderWithStoreProvider(<FeeOptionsList {...finalProps} />, {
+        const view = renderWithStoreProvider(<FeeOptionsList {...finalProps} />, {
             store,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
+
+        return { ...view, form };
     };
 
     beforeEach(() => {
@@ -188,6 +191,32 @@ describe('FeeOptionsList', () => {
 
             await userEvent.press(getByTestId('@transactionManagement/fees-level-radio-high'));
             expect(defaultProps.onSelectedFeeLevel).toHaveBeenCalledWith('high');
+        });
+
+        it('should update the visually selected fee option', async () => {
+            const { getByTestId, form } = renderFeeOptionsList({});
+            act(() => form.setValue('feeLevel', 'normal'));
+
+            expect(getByTestId('@transactionManagement/fees-level-radio-normal')).toHaveProp(
+                'accessibilityState',
+                expect.objectContaining({ checked: true }),
+            );
+            expect(getByTestId('@transactionManagement/fees-level-radio-high')).toHaveProp(
+                'accessibilityState',
+                expect.objectContaining({ checked: false }),
+            );
+
+            await userEvent.press(getByTestId('@transactionManagement/fees-level-radio-high'));
+
+            expect(form.getValues('feeLevel')).toBe('high');
+            expect(getByTestId('@transactionManagement/fees-level-radio-normal')).toHaveProp(
+                'accessibilityState',
+                expect.objectContaining({ checked: false }),
+            );
+            expect(getByTestId('@transactionManagement/fees-level-radio-high')).toHaveProp(
+                'accessibilityState',
+                expect.objectContaining({ checked: true }),
+            );
         });
 
         it('should make options interactive when multiple options are available', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13454,6 +13454,7 @@ __metadata:
     "@types/invity-api": "npm:^1.1.19"
     expo-linear-gradient: "npm:~56.0.4"
     react: "npm:19.2.3"
+    react-hook-form: "npm:^7.77.0"
     react-intl: "npm:^8.1.3"
     react-native: "npm:0.85.3"
     react-native-gesture-handler: "npm:2.31.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13454,7 +13454,6 @@ __metadata:
     "@types/invity-api": "npm:^1.1.19"
     expo-linear-gradient: "npm:~56.0.4"
     react: "npm:19.2.3"
-    react-hook-form: "npm:^7.77.0"
     react-intl: "npm:^8.1.3"
     react-native: "npm:0.85.3"
     react-native-gesture-handler: "npm:2.31.1"


### PR DESCRIPTION
## Description

- Fixes buy, sell, and exchange form behavior after enabling the React Compiler for the native app.
- Updates input controls, quote handling, asset and currency pickers, country selection, account balances, and validation states.
- Updates affected unit tests and trading-related components.

## Notes for QA

- Verify buy, sell, and exchange flows, including amount inputs, quote refreshes, asset/currency selection, account selection, validation errors, and country/subdivision pickers.

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/30176

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/30176-multiple-trade-form-issues-after-enablig-react-compiler-for-native&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/30176-multiple-trade-form-issues-after-enablig-react-compiler-for-native&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/30176-multiple-trade-form-issues-after-enablig-react-compiler-for-native&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/30176-multiple-trade-form-issues-after-enablig-react-compiler-for-native/web/](https://dev.suite.sldev.cz/suite-web/fix/30176-multiple-trade-form-issues-after-enablig-react-compiler-for-native/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-24T12:57:38.103Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-24T12:58:00.928Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->