### PR TITLE
chore(message-system): remove message about Cardano network sync issues

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2026-07-20T00:00:00+00:00",
-    "sequence": 149,
+    "timestamp": "2026-07-22T00:00:00+00:00",
+    "sequence": 150,
     "actions": [
         {
             "conditions": [
@@ -1113,43 +1113,6 @@
                     }
                 },
                 "context": { "domain": ["accounts.coinjoin", "accounts.btc.coinjoin"] }
-            }
-        },
-        {
-            "conditions": [
-                {
-                    "settings": [
-                        {
-                            "ada": true
-                        }
-                    ],
-                    "environment": {
-                        "desktop": "*",
-                        "mobile": "*",
-                        "web": "*"
-                    }
-                }
-            ],
-            "message": {
-                "id": "17152a45-0802-4c7f-8165-e551e230688d",
-                "priority": 92,
-                "dismissible": true,
-                "variant": "warning",
-                "category": ["banner"],
-                "content": {
-                    "en": "We’re having temporary syncing issues with the Cardano network, which may cause delays or errors. Your Cardano assets are completely safe. Thanks for your patience.",
-                    "es": "Estamos teniendo problemas temporales de sincronización con la red Cardano, lo que puede causar retrasos o errores. Tus activos de Cardano están completamente seguros. Gracias por tu paciencia.",
-                    "cs": "Máme dočasné problémy se synchronizací sítě Cardano, což může způsobit zpoždění nebo chyby. Vaše prostředky v Cardano jsou zcela v bezpečí. Děkujeme za trpělivost.",
-                    "ru": "У нас возникли временные проблемы с синхронизацией сети Cardano, что может вызвать задержки или ошибки. Ваши активы Cardano находятся в полной безопасности. Спасибо за терпение.",
-                    "ja": "Cardano ネットワークで一時的な同期の問題が発生しており、遅延やエラーが発生する可能性があります。お客様の Cardano 資産は完全に安全です。しばらくお待ちください。",
-                    "hu": "Átmeneti szinkronizálási problémáink vannak a(z) Cardano hálózattal, ami késéseket vagy hibákat okozhat. A(z) Cardano eszközei teljes biztonságban vannak. Köszönjük türelmét.",
-                    "it": "Stiamo riscontrando problemi temporanei di sincronizzazione con la rete Cardano, che potrebbero causare ritardi o errori. I tuoi asset Cardano sono completamente al sicuro. Grazie per la pazienza.",
-                    "fr": "Nous rencontrons des problèmes de synchronisation temporaires avec le réseau Cardano, ce qui peut entraîner des retards ou des erreurs. Vos actifs Cardano sont en parfaite sécurité. Merci de votre patience.",
-                    "de": "Wir haben vorübergehende Synchronisierungsprobleme mit dem Cardano-Netzwerk, was zu Verzögerungen oder Fehlern führen kann. Deine Cardano-Assets sind vollkommen sicher. Danke für deine Geduld.",
-                    "tr": "Cardano ağıyla ilgili geçici senkronizasyon sorunları yaşıyoruz, bu da gecikmelere veya hatalara neden olabilir. Cardano varlıklarınız tamamen güvendedir. Sabrınız için teşekkürler.",
-                    "pt": "Estamos enfrentando problemas temporários de sincronização com a rede Cardano, o que pode causar atrasos ou erros. Seus ativos Cardano estão totalmente seguros. Obrigado pela sua paciência.",
-                    "uk": "У нас виникли тимчасові проблеми з синхронізацією мережі Cardano, що може спричинити затримки або помилки. Ваші активи Cardano у цілковитій безпеці. Дякуємо за терпіння."
-                }
             }
         },
         {


### PR DESCRIPTION
## Description

Remove message about Cardano network sync issues.

## Notes for QA

Enable Cardano in the device settings and check that the banner is not displayed.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/message-system-remove-ada-network-sync-issues/web/](https://dev.suite.sldev.cz/suite-web/chore/message-system-remove-ada-network-sync-issues/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/message-system-remove-ada-network-sync-issues&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/message-system-remove-ada-network-sync-issues&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/message-system-remove-ada-network-sync-issues&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-22T11:56:15.257Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| TrezorConnect > Error screen | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-22T11:56:00.723Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->