### PR TITLE
feat(tests): add test for custom BTC backend configuration without enabling network

### DIFF
--- a/packages/e2e-utils/src/mocks/blockbookProxyMock.ts
+++ b/packages/e2e-utils/src/mocks/blockbookProxyMock.ts
@@ -31,6 +31,10 @@ export class BlockbookProxyMock {
         return `ws://localhost:${this.port}`;
     }
 
+    get connectedClients(): number {
+        return this.server?.clients.size ?? 0;
+    }
+
     setHandler(method: string, handler: BlockbookWsHandler) {
         this.handlers.set(method, handler);
     }

--- a/suite/e2e/support/pageObjects/settings/coinsTab.ts
+++ b/suite/e2e/support/pageObjects/settings/coinsTab.ts
@@ -35,8 +35,8 @@ export class CoinsTab {
     }
 
     @step()
-    async openNetworkAdvanceSettings(symbol: NetworkSymbol) {
-        if (!(await this.isNetworkEnabled(symbol))) {
+    async openNetworkAdvanceSettings(symbol: NetworkSymbol, { autoEnable = true } = {}) {
+        if (autoEnable && !(await this.isNetworkEnabled(symbol))) {
             await this.enableNetwork(symbol);
         }
         await this.networkButton(symbol).hover();

--- a/suite/e2e/tests/settings/coins-custom-backend.test.ts
+++ b/suite/e2e/tests/settings/coins-custom-backend.test.ts
@@ -1,8 +1,10 @@
 import type { BackendType, NetworkSymbol } from '@suite-common/wallet-config';
-import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+import { BlockbookProxyMock, TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 
 import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
+
+const BTC_BACKEND_WS_URL = 'wss://btc1.trezor.io/websocket';
 
 type Coin = {
     coin: NetworkSymbol;
@@ -120,4 +122,65 @@ test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1'] }, () => {
             },
         );
     }
+
+    test(
+        'Set a custom BTC backend before enabling the network',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Verifies that a custom Bitcoin blockbook backend can be configured while the network is still disabled, that no communication reaches the backend until the network is enabled, and that discovery then talks to that backend.',
+                category: TestCategory.Settings,
+                priority: TestPriority.Medium,
+                stream: TestStream.Foundation,
+            }),
+        },
+        async ({ page, settingsPage, walletPage }) => {
+            const backendType: BackendType = 'blockbook';
+            const backendProxy = new BlockbookProxyMock(BTC_BACKEND_WS_URL);
+            await backendProxy.start();
+
+            try {
+                await test.step('BTC starts disabled', async () => {
+                    await settingsPage.coinsTab.expectNetworkDisabled('btc');
+                });
+
+                await test.step('Set a custom backend without enabling the network', async () => {
+                    await settingsPage.coinsTab.openNetworkAdvanceSettings('btc', {
+                        autoEnable: false,
+                    });
+                    await settingsPage.coinsTab.changeBackend(backendType, backendProxy.url);
+                    await settingsPage.coinsTab.expectCustomBackendIndicator('btc');
+                    await settingsPage.coinsTab.expectNetworkDisabled('btc');
+                    expect(
+                        backendProxy.connectedClients,
+                        'Expected no connection to the backend while the network is disabled',
+                    ).toBe(0);
+                });
+
+                await test.step('Enable BTC & run discovery against the custom backend', async () => {
+                    await settingsPage.coinsTab.enableNetwork('btc');
+                    await settingsPage.coinsTab.expectCustomBackendIndicator('btc');
+                    await settingsPage.coinsTab.activateCoinsButton.click();
+                    await Promise.all([
+                        settingsPage.verifyDiscoveryLoaderFinishes(),
+                        page.discoveryShouldFinish(),
+                    ]);
+                    await expect
+                        .poll(() => backendProxy.connectedClients, {
+                            message: 'Expected discovery to connect to the custom backend',
+                        })
+                        .toBeGreaterThan(0);
+                });
+
+                await test.step('Open BTC account & verify it is loaded successfully', async () => {
+                    await walletPage.openAccount({ symbol: 'btc' });
+                    await expect(walletPage.emptyAccount).toContainTranslation(
+                        'TR_ACCOUNT_IS_EMPTY_TITLE',
+                    );
+                });
+            } finally {
+                await backendProxy.stop();
+            }
+        },
+    );
 });


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

added test for custom BTC backend configuration without enabling network
## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/custom-btc-backend-test/web/](https://dev.suite.sldev.cz/suite-web/custom-btc-backend-test/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=custom-btc-backend-test&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=custom-btc-backend-test&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-21T13:45:01.103Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-21T13:44:23.935Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->