### PR TITLE
fix(suite-common): displaying of L2 evm fees

### DIFF
--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -127,8 +127,10 @@ export interface EthereumSpecific {
     gasLimit?: number;
     /** Actual gas consumed by the transaction execution. */
     gasUsed?: number;
-    /** Price (in Wei or base units) per gas unit. */
+    /** Price (in Wei or base units) per gas unit bid by the sender. */
     gasPrice?: string;
+    /** Actual gas price paid per gas unit; on L2 networks this differs from gasPrice and is used for the fee. */
+    effectiveGasPrice?: string;
     maxPriorityFeePerGas?: string;
     maxFeePerGas?: string;
     baseFeePerGas?: string;

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -98,6 +98,7 @@ export interface EthereumSpecific {
     gasLimit: number;
     gasUsed?: number;
     gasPrice?: string;
+    effectiveGasPrice?: string;
     maxPriorityFeePerGas?: string;
     maxFeePerGas?: string;
     baseFeePerGas?: string;

--- a/packages/blockchain-link-utils/src/__fixtures__/blockbook.ts
+++ b/packages/blockchain-link-utils/src/__fixtures__/blockbook.ts
@@ -659,6 +659,7 @@ export const transformTransaction: {
                 gasLimit: 21000,
                 gasUsed: 21000,
                 gasPrice: '3',
+                effectiveGasPrice: '2', // L2: actual price paid, below the gasPrice bid
             },
             ...FEES,
         },
@@ -666,6 +667,10 @@ export const transformTransaction: {
             type: 'sent',
             amount: '90',
             fee: '10', // fee from blockbook, not calculated from ethereumSpecific
+            ethereumSpecific: {
+                gasPrice: '3',
+                effectiveGasPrice: '2', // passes through the transform
+            },
             targets: [
                 {
                     addresses: ['B'],

--- a/packages/blockchain-link/src/transaction.test.ts
+++ b/packages/blockchain-link/src/transaction.test.ts
@@ -1,0 +1,50 @@
+import type { Block, Transaction, TransactionReceipt } from 'viem';
+
+import { mapGetTransactionResponse } from './workers/evm-rpc/mappers/transaction';
+
+const baseTx = {
+    hash: '0xabc',
+    from: '0x1111111111111111111111111111111111111111',
+    to: '0x2222222222222222222222222222222222222222',
+    value: 0n,
+    nonce: 5,
+    gas: 21000n,
+    input: '0x',
+    blockHash: '0xblock',
+    blockNumber: 100n,
+} as unknown as Transaction;
+
+const block = { timestamp: 1720000000n } as unknown as Block;
+
+describe('mapGetTransactionResponse (evm-rpc)', () => {
+    it('uses receipt.effectiveGasPrice for the fee and exposes it', () => {
+        const tx = { ...baseTx, gasPrice: 1000000000n } as Transaction;
+        const receipt = {
+            status: 'success',
+            gasUsed: 21000n,
+            effectiveGasPrice: 150000000n,
+        } as unknown as TransactionReceipt;
+
+        const { payload } = mapGetTransactionResponse({ tx, receipt, block });
+
+        // 150000000 * 21000
+        expect(payload.fee).toBe('3150000000000');
+        expect(payload.ethereumSpecific?.effectiveGasPrice).toBe('150000000');
+        expect(payload.ethereumSpecific?.gasPrice).toBe('1000000000');
+    });
+
+    it('falls back to the gasPrice bid when effectiveGasPrice is not positive', () => {
+        const tx = { ...baseTx, gasPrice: 2000000000n } as Transaction;
+        const receipt = {
+            status: 'success',
+            gasUsed: 21000n,
+            effectiveGasPrice: 0n,
+        } as unknown as TransactionReceipt;
+
+        const { payload } = mapGetTransactionResponse({ tx, receipt, block });
+
+        // 2000000000 * 21000
+        expect(payload.fee).toBe('42000000000000');
+        expect(payload.ethereumSpecific?.effectiveGasPrice).toBeUndefined();
+    });
+});

--- a/packages/blockchain-link/src/workers/evm-rpc/mappers/transaction.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/mappers/transaction.ts
@@ -35,8 +35,11 @@ export const mapGetTransactionResponse = ({
     userAddress,
 }: MapTransactionParams): Responses.GetTransaction => {
     const { value, gasPrice } = tx;
-    const { gasUsed } = receipt;
-    const fee = (gasUsed * (gasPrice ?? 0n)).toString(10);
+    const { gasUsed, effectiveGasPrice } = receipt;
+    // effectiveGasPrice is the price actually charged and differs from the gasPrice bid on L2s;
+    // use it when positive, otherwise fall back to the gasPrice bid (mirrors blockbook).
+    const feeGasPrice = effectiveGasPrice > 0n ? effectiveGasPrice : (gasPrice ?? 0n);
+    const fee = (gasUsed * feeGasPrice).toString(10);
 
     const blockTime = block ? Number(block.timestamp) : 0;
     const blockHash = tx.blockHash || '';
@@ -103,6 +106,8 @@ export const mapGetTransactionResponse = ({
                 gasLimit: Number(tx.gas),
                 gasUsed: Number(receipt.gasUsed),
                 gasPrice: gasPrice?.toString(),
+                effectiveGasPrice:
+                    effectiveGasPrice > 0n ? effectiveGasPrice.toString() : undefined,
                 data: tx.input,
             },
         },

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -6,6 +6,7 @@ import { type Network } from '@suite-common/wallet-config';
 import {
     type PendingEvmNonceStatus,
     fromWei,
+    getEffectiveGasPrice,
     getFeeRate,
     isEip1559,
     isPending,
@@ -242,7 +243,9 @@ export const BasicTxDetails = ({
                         <Item label={<Translation id="TR_GAS_PRICE" />} icon={GasPumpIcon}>
                             {isConfirmed || !isEip1559(tx.ethereumSpecific) ? (
                                 <FeeRate
-                                    feeRate={fromWei(tx.ethereumSpecific?.gasPrice || '0').toGwei()}
+                                    feeRate={fromWei(
+                                        getEffectiveGasPrice(tx.ethereumSpecific),
+                                    ).toGwei()}
                                     networkType="ethereum"
                                     preserveDecimals
                                 />

--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -16,6 +16,7 @@ import {
     convertAmountSubunitsToUnits,
     formatNetworkAmount,
     fromWei,
+    getEffectiveGasPrice,
     getFiatRateKey,
     getNftTokenId,
     isNftTokenTransfer,
@@ -113,7 +114,7 @@ const formatAmounts =
         ethereumSpecific: tx.ethereumSpecific
             ? {
                   ...tx.ethereumSpecific,
-                  gasPrice: fromWei(tx.ethereumSpecific?.gasPrice ?? '0').toGwei(),
+                  gasPrice: fromWei(getEffectiveGasPrice(tx.ethereumSpecific)).toGwei(),
               }
             : undefined,
         cardanoSpecific: tx.cardanoSpecific

--- a/suite-common/graph/src/__fixtures__/eth.ts
+++ b/suite-common/graph/src/__fixtures__/eth.ts
@@ -2065,3 +2065,118 @@ export const ethTokenBalanceHistoryResult: Record<string, AccountHistoryMovement
         },
     ],
 };
+
+// L2 transactions exercising the effectiveGasPrice + l1Fee fee formula.
+export const l2AccountTransactions: WalletAccountTransaction[] = [
+    {
+        // L2 tx: effectiveGasPrice (actual, 0.15 Gwei) is far below gasPrice (bid, 1 Gwei),
+        // plus an L1 data fee. Fee = 150000000 * 21000 + 12345 = 3150000012345.
+        descriptor: asAccountDescriptor('0x1111111111111111111111111111111111111111'),
+        deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
+        symbol: 'op',
+        type: 'sent',
+        txid: '0xaaa1',
+        blockTime: 1720000000,
+        blockHeight: 100,
+        blockHash: '0xblock100',
+        amount: '0',
+        fee: '3150000012345',
+        targets: [],
+        tokens: [],
+        internalTransfers: [],
+        ethereumSpecific: {
+            status: 1,
+            nonce: 1,
+            gasLimit: 21000,
+            gasUsed: 21000,
+            gasPrice: '1000000000',
+            effectiveGasPrice: '150000000',
+            l1Fee: 12345,
+            data: '0x',
+        },
+        details: {
+            vin: [
+                {
+                    n: 0,
+                    addresses: ['0x1111111111111111111111111111111111111111'],
+                    isAddress: true,
+                },
+            ],
+            vout: [
+                {
+                    value: '0',
+                    n: 0,
+                    addresses: ['0x2222222222222222222222222222222222222222'],
+                    isAddress: true,
+                },
+            ],
+            size: 0,
+            totalInput: '0',
+            totalOutput: '0',
+        },
+    },
+    {
+        // Legacy tx: no effectiveGasPrice / l1Fee -> falls back to gasPrice.
+        // Fee = 2000000000 * 21000 = 42000000000000.
+        descriptor: asAccountDescriptor('0x1111111111111111111111111111111111111111'),
+        deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
+        symbol: 'op',
+        type: 'sent',
+        txid: '0xaaa2',
+        blockTime: 1720000100,
+        blockHeight: 101,
+        blockHash: '0xblock101',
+        amount: '0',
+        fee: '42000000000000',
+        targets: [],
+        tokens: [],
+        internalTransfers: [],
+        ethereumSpecific: {
+            status: 1,
+            nonce: 2,
+            gasLimit: 21000,
+            gasUsed: 21000,
+            gasPrice: '2000000000',
+            data: '0x',
+        },
+        details: {
+            vin: [
+                {
+                    n: 0,
+                    addresses: ['0x1111111111111111111111111111111111111111'],
+                    isAddress: true,
+                },
+            ],
+            vout: [
+                {
+                    value: '0',
+                    n: 0,
+                    addresses: ['0x2222222222222222222222222222222222222222'],
+                    isAddress: true,
+                },
+            ],
+            size: 0,
+            totalInput: '0',
+            totalOutput: '0',
+        },
+    },
+];
+
+export const l2AccountBalanceHistoryResult: AccountHistoryMovementItem[] = [
+    {
+        time: 1720000000,
+        txs: 1,
+        received: new BigNumber('0'),
+        // effectiveGasPrice (150000000) * gasUsed (21000) + l1Fee (12345)
+        sent: new BigNumber('3150000012345'),
+        sentToSelf: new BigNumber('0'),
+    },
+    {
+        time: 1720000100,
+        txs: 1,
+        received: new BigNumber('0'),
+        // fallback to gasPrice (2000000000) * gasUsed (21000)
+        sent: new BigNumber('42000000000000'),
+        sentToSelf: new BigNumber('0'),
+    },
+];

--- a/suite-common/graph/src/balanceHistoryUtils.test.ts
+++ b/suite-common/graph/src/balanceHistoryUtils.test.ts
@@ -5,6 +5,8 @@ import {
     ethAccountBalanceHistoryResult,
     ethAccountTransactions,
     ethTokenBalanceHistoryResult,
+    l2AccountBalanceHistoryResult,
+    l2AccountTransactions,
 } from './__fixtures__/eth';
 import { xrpAccountTransactions, xrpBalanceHistoryResult } from './__fixtures__/xrp';
 import { getAccountHistoryMovementFromTransactions } from './balanceHistoryUtils';
@@ -69,6 +71,15 @@ describe('Account balance movement history', () => {
         });
 
         expect(balanceHistory.main).toMatchObject(ethAccountBalanceHistoryResult);
+    });
+
+    it('should use effectiveGasPrice and add l1Fee for L2 fees, falling back to gasPrice', async () => {
+        const balanceHistory = await getAccountHistoryMovementFromTransactions({
+            transactions: l2AccountTransactions,
+            symbol: 'op',
+        });
+
+        expect(balanceHistory.main).toMatchObject(l2AccountBalanceHistoryResult);
     });
 
     it('should getAccoutBalanceHistory for ethereum with timestamp filters', async () => {

--- a/suite-common/graph/src/balanceHistoryUtils.ts
+++ b/suite-common/graph/src/balanceHistoryUtils.ts
@@ -1,4 +1,5 @@
 import type { TokenAddress, WalletAccountTransaction } from '@suite-common/wallet-types';
+import { getEffectiveGasPrice } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { type LocalBalanceHistoryCoin } from './constants';
@@ -224,8 +225,15 @@ const getAccountHistoryMovementItemETH = ({
                     }
 
                     let feesSat = new BigNumber(0);
-                    if (ethTxData.gasUsed !== undefined && ethTxData.gasPrice !== undefined) {
-                        feesSat = new BigNumber(ethTxData.gasPrice).times(ethTxData.gasUsed);
+                    if (ethTxData.gasUsed !== undefined) {
+                        // Use effectiveGasPrice (actual price paid on L2s) when present, else the
+                        // gasPrice bid, and add the L1 data fee. Mirrors blockbook's fee logic.
+                        feesSat = new BigNumber(getEffectiveGasPrice(ethTxData)).times(
+                            ethTxData.gasUsed,
+                        );
+                        if (ethTxData.l1Fee) {
+                            feesSat = feesSat.plus(ethTxData.l1Fee);
+                        }
                     }
                     bh.sent = bh.sent.plus(feesSat);
                 }

--- a/suite-common/wallet-utils/src/ethUtils.test.ts
+++ b/suite-common/wallet-utils/src/ethUtils.test.ts
@@ -5,6 +5,7 @@ import { BigNumber } from '@trezor/utils';
 
 import {
     buildApprovalTransactionData,
+    getEffectiveGasPrice,
     getEvmTransactionPurpose,
     getEvmTransactionTextSignature,
     getNativeWrapTxKind,
@@ -38,6 +39,29 @@ describe('eth utils', () => {
         expect(strip('0x')).toBe('');
         expect(strip('0x2540be3ff')).toBe('02540be3ff');
         expect(strip('2540be3ff')).toBe('02540be3ff');
+    });
+
+    describe('getEffectiveGasPrice', () => {
+        it('returns effectiveGasPrice when present and greater than zero', () => {
+            expect(
+                getEffectiveGasPrice({ effectiveGasPrice: '150000000', gasPrice: '1000000000' }),
+            ).toBe('150000000');
+        });
+
+        it('falls back to gasPrice when effectiveGasPrice is zero', () => {
+            expect(getEffectiveGasPrice({ effectiveGasPrice: '0', gasPrice: '1000000000' })).toBe(
+                '1000000000',
+            );
+        });
+
+        it('falls back to gasPrice when effectiveGasPrice is undefined', () => {
+            expect(getEffectiveGasPrice({ gasPrice: '1000000000' })).toBe('1000000000');
+        });
+
+        it('returns "0" when neither value is defined', () => {
+            expect(getEffectiveGasPrice({})).toBe('0');
+            expect(getEffectiveGasPrice(undefined)).toBe('0');
+        });
     });
 
     describe('getEvmTransactionTextSignature', () => {

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -5,7 +5,7 @@ import {
     type EvmTransactionPurpose,
     type WalletAccountTransaction,
 } from '@suite-common/wallet-types';
-import { type TokenInfo } from '@trezor/blockchain-link-types';
+import { type EthereumSpecific, type TokenInfo } from '@trezor/blockchain-link-types';
 import { exhaustive } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils';
 
@@ -16,6 +16,15 @@ import { isWrappedNativeToken } from './tokenUtils';
 export const isEip1559 = (
     tx: Record<string, any> | null | undefined,
 ): tx is { maxFeePerGas: string } => !!tx && !!tx.maxFeePerGas;
+
+// Returns the per-gas price actually charged: effectiveGasPrice when present and > 0
+// (L2 networks), otherwise the gasPrice bid. Mirrors blockbook's L2 fee logic.
+export const getEffectiveGasPrice = (
+    ethereumSpecific: Pick<EthereumSpecific, 'effectiveGasPrice' | 'gasPrice'> | undefined,
+): string =>
+    ethereumSpecific?.effectiveGasPrice && new BigNumber(ethereumSpecific.effectiveGasPrice).gt(0)
+        ? ethereumSpecific.effectiveGasPrice
+        : (ethereumSpecific?.gasPrice ?? '0');
 
 export const hasEip1559MaxPriorityFee = (
     tx: Record<string, any> | null | undefined,

--- a/suite-native/formatters/src/components/FeeFormatter.tsx
+++ b/suite-native/formatters/src/components/FeeFormatter.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { networks } from '@suite-common/wallet-config';
 import { type WalletAccountTransaction } from '@suite-common/wallet-types';
-import { fromWei, getFeeRate, getFeeUnits } from '@suite-common/wallet-utils';
+import { fromWei, getEffectiveGasPrice, getFeeRate, getFeeUnits } from '@suite-common/wallet-utils';
 import { Text } from '@suite-native/atoms';
 
 type FeeFormatterProps = {
@@ -15,7 +15,7 @@ export const FeeFormatter = ({ transaction }: FeeFormatterProps) => {
     const formattedValue = useMemo(
         () =>
             networkType === 'ethereum'
-                ? fromWei(transaction.ethereumSpecific?.gasPrice ?? '0').toGwei()
+                ? fromWei(getEffectiveGasPrice(transaction.ethereumSpecific)).toGwei()
                 : transaction.feeRate || getFeeRate(transaction),
         [networkType, transaction],
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR mirrors changes https://github.com/trezor/blockbook/pull/1645 to improve displaying of actual fees for L2 transactions.

## Notes for QA

Once backend changes are deployed and available displayed spent gas should equal the one displayed on the blockchain explorer.

## Screenshot

<img width="1120" height="709" alt="Screenshot 2026-07-23 at 17 19 35" src="https://github.com/user-attachments/assets/31dc56ff-b1af-44a1-a890-7c6615aaedc5" />
<img width="833" height="582" alt="Screenshot 2026-07-23 at 17 19 29" src="https://github.com/user-attachments/assets/5892551f-4db1-4594-b4b2-3c41a6fe6bbc" />


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/l2-evm-fees/web/](https://dev.suite.sldev.cz/suite-web/fix/l2-evm-fees/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/l2-evm-fees&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/l2-evm-fees&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/l2-evm-fees&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T13:44:06.392Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T13:44:50.275Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is concentrated in EVM/ETH transaction handling (blockchain-link types, EVM RPC mapper, ethUtils), transaction export logic, transaction detail UI, and balance history utilities. Highest regression risk is in ETH/Base send flows, ETH staking/trading fee displays, and transaction exports, so the targeted tests above should be run first. The graph/balance history and native FeeFormatter changes have no direct E2E coverage and should be validated through unit tests or manual QA.

<details><summary><b>Changed files (13)</b></summary>

- `packages/blockchain-link-types/src/blockbook-api.ts`
- `packages/blockchain-link-types/src/common.ts`
- `packages/blockchain-link-utils/src/__fixtures__/blockbook.ts`
- `packages/blockchain-link/src/transaction.test.ts`
- `packages/blockchain-link/src/workers/evm-rpc/mappers/transaction.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx`
- `packages/suite/src/utils/wallet/exportTransactionsUtils.ts`
- `suite-common/graph/src/__fixtures__/eth.ts`
- `suite-common/graph/src/balanceHistoryUtils.test.ts`
- `suite-common/graph/src/balanceHistoryUtils.ts`
- `suite-common/wallet-utils/src/ethUtils.test.ts`
- `suite-common/wallet-utils/src/ethUtils.ts`
- `suite-native/formatters/src/components/FeeFormatter.tsx`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — Directly exercises exportTransactionsUtils.ts across BTC, LTC, ETH, and ADA exports. This is the only E2E test covering the changed export utility and will catch regressions in exported file content or format.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking flow validates transaction construction, custom/max fee display, pending transaction states, and transaction detail amounts. Changes to ethUtils and EVM transaction mapping directly affect these assertions.
- `suite/e2e/tests/wallet/send-base.test.ts` — Tests full EVM (Base) send flow with custom gas fees and verifies amount/fee rendering on both the Suite prompt and hardware device screen. Directly depends on ethUtils and EVM transaction mapping.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Core ETH send test covering custom fee parameters, amount/fee display, and device confirmation screens. The changed ethUtils, EVM RPC transaction mapper, and Blockbook types are in the direct code path for these assertions.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Specifically validates custom Ethereum fee values (gas limit, max fee per gas, max priority fee per gas) during a swap and checks them on both the UI modal and device emulator. Highly sensitive to ethUtils and EVM fee logic changes.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — Opens the transaction detail modal to verify txid. Changes to BasicTxDetails.tsx could affect how transaction details render in this modal, though the test uses BTC regtest rather than ETH.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — ETH message signing flow uses Ethereum address derivation and message handling. ethUtils changes could impact address or signature formatting, and the flow confirms the device prompt UI.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Additional ETH staking scenario that exercises pending transaction display, fee handling, and dashboard amount updates after a second stake. Shares ETH transaction infrastructure with the initial stake test.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — ETH-to-USDC DEX swap validates gas limit, network fee, minimum received amount, and transaction detail values. Directly exercises EVM transaction composition and fee display paths.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstake and claim flow validates transaction detail amounts, fees, and status transitions. Depends on the same ETH transaction mapping and fee utilities as staking deposits.

</details>

⚠️ **Changes with no test coverage (6)**
- `packages/blockchain-link-types/src/blockbook-api.ts`
- `packages/blockchain-link-types/src/common.ts`
- `packages/blockchain-link-utils/src/__fixtures__/blockbook.ts`
- `suite-common/graph/src/__fixtures__/eth.ts`
- `suite-common/graph/src/balanceHistoryUtils.ts`
- `suite-native/formatters/src/components/FeeFormatter.tsx`

_Updated: 2026-08-03T13:44:16.555Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->