### PR TITLE
test(suite): add hint for changeNetwork method

### DIFF
--- a/suite/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/suite/e2e/support/pageObjects/settings/settingsPage.ts
@@ -259,6 +259,16 @@ export class SettingsPage {
         await this.page.getByTestId('@settings/testnet-networks-switch').click();
     }
 
+    /**
+     * Enables and disables specified networks, then conditionally activates coins and waits for discovery.
+     * @example
+     * // Enable eth and btc with a custom backend (opens advanced settings and sets it)
+     * await settingsPage.changeNetworks({
+     *     enableNetworks: ['eth', { symbol: 'btc', backend: { type: 'blockbook', url: 'http://localhost:19121' } }],
+     * });
+     * // Enable by symbol
+     * await settingsPage.changeNetworks({ enableNetworks: ['btc', 'eth'] });
+     */
     @step()
     async changeNetworks(options: {
         enableNetworks: NetworkToEnable[];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

minor hint to ease usage of our important method changeNetwork

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=hint-change-net&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=hint-change-net&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| TrezorConnect > Error screen | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-22T13:06:38.175Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-22T13:05:54.017Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->