### PR TITLE
fix(suite-native): prevent hanging Android E2E jobs

### DIFF
--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -38,6 +38,7 @@ on:
 jobs:
   run_android_e2e_tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/suite-native/app/.detoxrc.js
+++ b/suite-native/app/.detoxrc.js
@@ -7,6 +7,8 @@ module.exports = {
         args: {
             $0: 'jest',
             config: 'e2e/jest.config.js',
+            // Detox project runs can leave native communication handles open after Jest finishes.
+            forceExit: true,
         },
         jest: {
             setupTimeout: 120_000,


### PR DESCRIPTION
## Description

Prevents Android Detox jobs from remaining active after Jest has printed its final test summary.

- Force Jest to exit after reporters and global teardown finish, so lingering native communication handles cannot keep the Detox child process alive.
- Limit each Android E2E matrix job to 60 minutes as a final safeguard.

This follows the stuck shard behavior observed in https://github.com/trezor/trezor-suite/actions/runs/29917802892/job/88917821441.

## Notes for QA

CI-only change. Verify that the suite-native Android E2E workflow completes or fails within 60 minutes and still publishes its normal test reports and artifacts. No application behavior is changed.

## Related Issue

Follow-up to #30189.

## Screenshots:

N/A

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/juriczech/fix-detox-receive-test/web/](https://dev.suite.sldev.cz/suite-web/juriczech/fix-detox-receive-test/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=juriczech/fix-detox-receive-test&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=juriczech/fix-detox-receive-test&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/fix-detox-receive-test&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-22T13:37:29.760Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect.ethereumSignMessage > TrezorConnect.ethereumSignMessage | 🤖 auto |
| TrezorConnect.signTransaction > TrezorConnect.signTransaction | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| TrezorConnect > Error screen | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-22T13:37:10.271Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->