### PR TITLE
feat(suite): add dummy wrap and unwrap steps to yield flows

### DIFF
--- a/packages/suite/src/components/earn/yield/__tests__/yieldFlowUtils.test.ts
+++ b/packages/suite/src/components/earn/yield/__tests__/yieldFlowUtils.test.ts
@@ -1,45 +1,98 @@
+import { getYieldFlowStepSequence } from '@suite-common/wallet-core';
+
 import { getYieldFlowSteps } from '../yieldFlowUtils';
+
+const depositSequence = getYieldFlowStepSequence({ flowType: 'deposit' });
+const depositWithWrapSequence = getYieldFlowStepSequence({
+    flowType: 'deposit',
+    isWrappedNativeVault: true,
+});
+const withdrawSequence = getYieldFlowStepSequence({ flowType: 'withdraw' });
+const withdrawWithUnwrapSequence = getYieldFlowStepSequence({
+    flowType: 'withdraw',
+    isWrappedNativeVault: true,
+});
 
 describe('yieldFlowUtils', () => {
     describe('getYieldFlowSteps', () => {
         it('describes deposit steps on the approve step', () => {
-            expect(getYieldFlowSteps('deposit', 'approve')).toEqual({
+            expect(getYieldFlowSteps(depositSequence, 'approve')).toEqual({
+                wrap: { state: 'done', indicator: { index: 0, total: 2 } },
                 approve: { state: 'active', indicator: { index: 1, total: 2 } },
                 action: { state: 'pending', indicator: { index: 2, total: 2 } },
+                unwrap: { state: 'done', indicator: { index: 0, total: 2 } },
                 complete: { state: 'pending', indicator: { index: 0, total: 2 } },
             });
         });
 
         it('describes deposit steps on the action step', () => {
-            expect(getYieldFlowSteps('deposit', 'action')).toEqual({
+            expect(getYieldFlowSteps(depositSequence, 'action')).toEqual({
+                wrap: { state: 'done', indicator: { index: 0, total: 2 } },
                 approve: { state: 'done', indicator: { index: 1, total: 2 } },
                 action: { state: 'active', indicator: { index: 2, total: 2 } },
+                unwrap: { state: 'done', indicator: { index: 0, total: 2 } },
                 complete: { state: 'pending', indicator: { index: 0, total: 2 } },
             });
         });
 
         it('describes deposit steps on the complete step', () => {
-            expect(getYieldFlowSteps('deposit', 'complete')).toEqual({
+            expect(getYieldFlowSteps(depositSequence, 'complete')).toEqual({
+                wrap: { state: 'done', indicator: { index: 0, total: 2 } },
                 approve: { state: 'done', indicator: { index: 1, total: 2 } },
                 action: { state: 'done', indicator: { index: 2, total: 2 } },
+                unwrap: { state: 'done', indicator: { index: 0, total: 2 } },
                 complete: { state: 'active', indicator: { index: 0, total: 2 } },
+            });
+        });
+
+        it('describes wrap-deposit steps on the wrap step', () => {
+            expect(getYieldFlowSteps(depositWithWrapSequence, 'wrap')).toEqual({
+                wrap: { state: 'active', indicator: { index: 1, total: 3 } },
+                approve: { state: 'pending', indicator: { index: 2, total: 3 } },
+                action: { state: 'pending', indicator: { index: 3, total: 3 } },
+                unwrap: { state: 'done', indicator: { index: 0, total: 3 } },
+                complete: { state: 'pending', indicator: { index: 0, total: 3 } },
+            });
+        });
+
+        it('describes wrap-deposit steps on the approve step', () => {
+            expect(getYieldFlowSteps(depositWithWrapSequence, 'approve')).toEqual({
+                wrap: { state: 'done', indicator: { index: 1, total: 3 } },
+                approve: { state: 'active', indicator: { index: 2, total: 3 } },
+                action: { state: 'pending', indicator: { index: 3, total: 3 } },
+                unwrap: { state: 'done', indicator: { index: 0, total: 3 } },
+                complete: { state: 'pending', indicator: { index: 0, total: 3 } },
+            });
+        });
+
+        it('describes unwrap-withdraw steps on the unwrap step', () => {
+            expect(getYieldFlowSteps(withdrawWithUnwrapSequence, 'unwrap')).toEqual({
+                wrap: { state: 'done', indicator: { index: 0, total: 2 } },
+                approve: { state: 'done', indicator: { index: 0, total: 2 } },
+                action: { state: 'done', indicator: { index: 1, total: 2 } },
+                unwrap: { state: 'active', indicator: { index: 2, total: 2 } },
+                complete: { state: 'pending', indicator: { index: 0, total: 2 } },
             });
         });
 
         it('numbers the complete step when it is displayed as a list item', () => {
             expect(
-                getYieldFlowSteps('deposit', 'approve', ['approve', 'action', 'complete']),
+                getYieldFlowSteps(depositSequence, 'approve', ['approve', 'action', 'complete']),
             ).toEqual({
+                wrap: { state: 'done', indicator: { index: 0, total: 3 } },
                 approve: { state: 'active', indicator: { index: 1, total: 3 } },
                 action: { state: 'pending', indicator: { index: 2, total: 3 } },
+                unwrap: { state: 'done', indicator: { index: 0, total: 3 } },
                 complete: { state: 'pending', indicator: { index: 3, total: 3 } },
             });
         });
 
         it('reports steps outside the flow as passed', () => {
-            expect(getYieldFlowSteps('withdraw', 'action')).toEqual({
+            expect(getYieldFlowSteps(withdrawSequence, 'action')).toEqual({
+                wrap: { state: 'done', indicator: { index: 0, total: 1 } },
                 approve: { state: 'done', indicator: { index: 0, total: 1 } },
                 action: { state: 'active', indicator: { index: 1, total: 1 } },
+                unwrap: { state: 'done', indicator: { index: 0, total: 1 } },
                 complete: { state: 'pending', indicator: { index: 0, total: 1 } },
             });
         });

--- a/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
@@ -11,6 +11,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import { type YieldAccountRewards } from '@suite-common/earn-stablecoin-api';
 import { Context } from '@suite-common/message-system';
 import {
+    YIELD_FLOW_AVAILABLE_STEPS,
     isStablecoinYieldSupported,
     selectStablecoinYieldSession,
     selectStablecoinYieldTxReview,
@@ -176,7 +177,7 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
                     <YieldDisabledBanner type="claim" content={content} variant={variant} />
                 ) : (
                     <YieldFlowStepList
-                        flowType="claim"
+                        sequence={YIELD_FLOW_AVAILABLE_STEPS.claim}
                         currentStep={currentStep}
                         steps={{
                             action: {

--- a/packages/suite/src/components/earn/yield/common/YieldFlowStepList.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowStepList.tsx
@@ -1,22 +1,16 @@
 import { type ReactNode } from 'react';
 
 import { Translation } from '@suite/intl';
-import {
-    YIELD_FLOW_STEP_SEQUENCES,
-    type YieldFlowStepId,
-    type YieldFlowType,
-} from '@suite-common/wallet-core';
+import { type YieldFlowStepId } from '@suite-common/wallet-core';
 import { Column, Row, StepList, Text } from '@trezor/components';
 
 import { type YieldFlowStepView, getYieldFlowSteps } from '../yieldFlowUtils';
 
-/** Steps of a given flow derived from its sequence — a new step in the sequence must be defined. */
-export type YieldFlowStepOf<TFlowType extends YieldFlowType> =
-    (typeof YIELD_FLOW_STEP_SEQUENCES)[TFlowType][number];
-
 export type YieldFlowStepDefinition = {
     /** Label on the title row next to the step number. */
     title?: ReactNode;
+    /** Supplementary text tight under the title; shown only while the step is active. */
+    description?: ReactNode;
     /** Right side of the title row (e.g. a modify action); receives the view for state-dependent actions. */
     rightContent?: (view: YieldFlowStepView) => ReactNode;
     /**
@@ -30,25 +24,25 @@ export type YieldFlowStepDefinition = {
     inactiveContent?: (view: YieldFlowStepView) => ReactNode;
 };
 
-type YieldFlowStepListProps<TFlowType extends YieldFlowType> = {
-    flowType: TFlowType;
+type YieldFlowStepListProps<TSequence extends readonly YieldFlowStepId[]> = {
+    /** Ordered steps of the flow — every step in the sequence must be defined in `steps`. */
+    sequence: TSequence;
     currentStep: YieldFlowStepId;
-    steps: Record<YieldFlowStepOf<TFlowType>, YieldFlowStepDefinition>;
+    steps: Record<TSequence[number], YieldFlowStepDefinition>;
     /** Renders the steps as an ordered StepList; without it only the current step's content shows. */
     hasStepList?: boolean;
 };
 
-export const YieldFlowStepList = <TFlowType extends YieldFlowType>({
-    flowType,
+export const YieldFlowStepList = <TSequence extends readonly YieldFlowStepId[]>({
+    sequence,
     currentStep,
     steps,
     hasStepList = false,
-}: YieldFlowStepListProps<TFlowType>) => {
+}: YieldFlowStepListProps<TSequence>) => {
     // Widened — the prop is keyed by the flow's own steps, but we index it with generic step ids.
     const stepDefinitions: Partial<Record<YieldFlowStepId, YieldFlowStepDefinition>> = steps;
-    const sequence: readonly YieldFlowStepId[] = YIELD_FLOW_STEP_SEQUENCES[flowType];
     const listSteps = sequence.filter(stepId => stepDefinitions[stepId]?.isListItem !== false);
-    const views = getYieldFlowSteps(flowType, currentStep, listSteps);
+    const views = getYieldFlowSteps(sequence, currentStep, listSteps);
 
     const renderStepContent = (stepId: YieldFlowStepId) => {
         const definition = stepDefinitions[stepId];
@@ -93,15 +87,27 @@ export const YieldFlowStepList = <TFlowType extends YieldFlowType>({
                                     <Translation id="TR_STEP_OF_TOTAL" values={view.indicator} />
                                 </Text>
 
-                                <Row
-                                    justifyContent="space-between"
-                                    alignItems="center"
-                                    width="100%"
-                                    gap={16}
-                                >
-                                    {definition?.title}
-                                    {definition?.rightContent?.(view)}
-                                </Row>
+                                <Column gap={4} width="100%">
+                                    <Row
+                                        justifyContent="space-between"
+                                        alignItems="center"
+                                        width="100%"
+                                        gap={16}
+                                    >
+                                        {definition?.title}
+                                        {definition?.rightContent?.(view)}
+                                    </Row>
+
+                                    {view.state === 'active' && definition?.description && (
+                                        <Text
+                                            typographyStyle="body-sm"
+                                            intent="neutral"
+                                            priority="secondary"
+                                        >
+                                            {definition.description}
+                                        </Text>
+                                    )}
+                                </Column>
                             </Column>
                         }
                     >

--- a/packages/suite/src/components/earn/yield/common/YieldUnwrapStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldUnwrapStep.tsx
@@ -1,0 +1,48 @@
+import { Translation } from '@suite/intl';
+import { Button, Column, Row } from '@trezor/components';
+
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+
+import { YieldAmountCard } from './YieldAmountCard';
+
+type YieldUnwrapStepProps = {
+    tokenSymbol: string;
+    tokenDecimals: number;
+    tokenBalance: string;
+    onMaxClick: () => void;
+    onSubmit: () => void;
+    onSkip: () => void;
+};
+
+export const YieldUnwrapStep = ({
+    tokenSymbol,
+    tokenDecimals,
+    tokenBalance,
+    onMaxClick,
+    onSubmit,
+    onSkip,
+}: YieldUnwrapStepProps) => (
+    <Column gap={16}>
+        <YieldAmountCard
+            tokenSymbol={tokenSymbol}
+            decimals={tokenDecimals}
+            heading={{
+                amountLabelTranslationId: 'TR_EARN_YIELD_UNWRAP_AMOUNT',
+            }}
+            summary={{
+                labelTranslationId: 'TR_BALANCE',
+                value: <FormattedCryptoAmount value={tokenBalance} symbol={tokenSymbol} />,
+                onMaxClick,
+            }}
+        />
+
+        <Row gap={8} width="100%">
+            <Button size="large" flex="1" onClick={onSubmit}>
+                <Translation id="TR_EARN_YIELD_UNWRAP_SUBMIT" values={{ tokenSymbol }} />
+            </Button>
+            <Button size="large" intent="neutral" priority="secondary" onClick={onSkip}>
+                <Translation id="TR_SKIP" />
+            </Button>
+        </Row>
+    </Column>
+);

--- a/packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx
@@ -1,0 +1,71 @@
+import { Translation } from '@suite/intl';
+import type { YieldFlowDisplayToken } from '@suite-common/wallet-core';
+import { Button, Card, Column, Row, Text } from '@trezor/components';
+import { TokenIcon } from '@trezor/product-components';
+
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+
+import { YieldAmountCard } from './YieldAmountCard';
+
+type YieldWrapStepProps = {
+    token: YieldFlowDisplayToken;
+    nativeSymbol: string;
+    nativeBalance: string;
+    onMaxClick: () => void;
+    onSubmit: () => void;
+    onSkip: () => void;
+};
+
+export const YieldWrapStep = ({
+    token,
+    nativeSymbol,
+    nativeBalance,
+    onMaxClick,
+    onSubmit,
+    onSkip,
+}: YieldWrapStepProps) => (
+    <Column gap={16}>
+        <YieldAmountCard
+            tokenSymbol={nativeSymbol}
+            decimals={token.decimals}
+            heading={{
+                amountLabelTranslationId: 'TR_EARN_YIELD_WRAP_AMOUNT',
+            }}
+            summary={{
+                labelTranslationId: 'TR_BALANCE',
+                value: <FormattedCryptoAmount value={nativeBalance} symbol={nativeSymbol} />,
+                onMaxClick,
+            }}
+        />
+
+        <Card type="contrast" paddingType="small">
+            <Row justifyContent="space-between" alignItems="center" width="100%">
+                <Text typographyStyle="body-md">
+                    <Translation id="TR_EARN_YIELD_WRAP_RECEIVING" />
+                </Text>
+                <Row alignItems="center" gap={8}>
+                    <TokenIcon
+                        size={20}
+                        symbol={token.networkSymbol}
+                        contractAddress={token.contractAddress ?? null}
+                        placeholder={token.symbol}
+                        showNetworkIcon
+                        isBordered={false}
+                    />
+                    <Text typographyStyle="body-md">
+                        <FormattedCryptoAmount value="0" symbol={token.symbol} />
+                    </Text>
+                </Row>
+            </Row>
+        </Card>
+
+        <Row gap={8} width="100%">
+            <Button size="large" flex="1" onClick={onSubmit}>
+                <Translation id="TR_EARN_YIELD_WRAP_SUBMIT" values={{ nativeSymbol }} />
+            </Button>
+            <Button size="large" intent="neutral" priority="secondary" onClick={onSkip}>
+                <Translation id="TR_SKIP" />
+            </Button>
+        </Row>
+    </Column>
+);

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -2,7 +2,8 @@ import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
-import { splitYieldPendingTransaction } from '@suite-common/wallet-core';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getYieldFlowStepSequence, splitYieldPendingTransaction } from '@suite-common/wallet-core';
 import { getApyBreakdown } from '@suite-common/wallet-utils';
 import { Banner, Button, Column, Text } from '@trezor/components';
 
@@ -16,6 +17,7 @@ import { YieldApproveStep } from '../common/YieldApproveStep';
 import { YieldApprovedAmountCard } from '../common/YieldApprovedAmountCard';
 import { YieldFlowCompleteDeposit } from '../common/YieldFlowCompleteDeposit';
 import { YieldFlowStepList } from '../common/YieldFlowStepList';
+import { YieldWrapStep } from '../common/YieldWrapStep';
 
 export const YieldDepositForm = () => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
@@ -43,6 +45,7 @@ export const YieldDepositForm = () => {
         isSubmittingApprove,
         isSubmittingAction,
         setAmountInput,
+        completeWrapStep,
         submitApprovalAction,
         submitAction,
         revokeAllowance,
@@ -56,6 +59,12 @@ export const YieldDepositForm = () => {
 
     const { approvalPendingTransaction, actionPendingTransaction: depositPendingTransaction } =
         splitYieldPendingTransaction(pendingTransaction, 'deposit');
+
+    const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
+    const sequence = getYieldFlowStepSequence({
+        flowType: 'deposit',
+        isWrappedNativeVault: flow.isWrappedNativeVault,
+    });
 
     const handleOnApprovalSubmit = () => {
         analytics.report({
@@ -176,10 +185,34 @@ export const YieldDepositForm = () => {
                     )}
 
                     <YieldFlowStepList
-                        flowType="deposit"
+                        sequence={sequence}
                         currentStep={flow.currentStep}
                         hasStepList
                         steps={{
+                            wrap: {
+                                title: (
+                                    <Translation
+                                        id="TR_EARN_YIELD_WRAP_TITLE"
+                                        values={{ nativeSymbol, tokenSymbol: token.symbol }}
+                                    />
+                                ),
+                                description: (
+                                    <Translation
+                                        id="TR_EARN_YIELD_WRAP_DESCRIPTION"
+                                        values={{ nativeSymbol }}
+                                    />
+                                ),
+                                content: () => (
+                                    <YieldWrapStep
+                                        token={token}
+                                        nativeSymbol={nativeSymbol}
+                                        nativeBalance={account.formattedBalance}
+                                        onMaxClick={() => setAmountInput(account.formattedBalance)}
+                                        onSubmit={completeWrapStep}
+                                        onSkip={completeWrapStep}
+                                    />
+                                ),
+                            },
                             approve: {
                                 title: <Translation id="TR_EARN_YIELD_SELECT_AMOUNT_AND_APPROVE" />,
                                 rightContent: view =>
@@ -228,14 +261,15 @@ export const YieldDepositForm = () => {
                                         onPendingTxClick={openPendingTransaction}
                                     />
                                 ),
-                                inactiveContent: () => (
-                                    <YieldApprovedAmountCard
-                                        token={token}
-                                        amount={allowanceAmount}
-                                        isLoading={allowanceStatus === 'loading'}
-                                        hasError={allowanceStatus === 'error'}
-                                    />
-                                ),
+                                inactiveContent: view =>
+                                    view.state === 'done' && (
+                                        <YieldApprovedAmountCard
+                                            token={token}
+                                            amount={allowanceAmount}
+                                            isLoading={allowanceStatus === 'loading'}
+                                            hasError={allowanceStatus === 'error'}
+                                        />
+                                    ),
                             },
                             action: {
                                 title: <Translation id="TR_EARN_YIELD_DEPOSIT" />,

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { type UseFormReturn, useForm, useWatch } from 'react-hook-form';
 
 import { selectDesktopAnalyticsDep } from '@suite/analytics';
@@ -28,6 +28,7 @@ import {
     submitYieldRevokeThunk,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
+import { isWrappedNativeToken } from '@suite-common/wallet-utils';
 import { useCurrentRef } from '@trezor/react-utils';
 
 import { setConnectionModal, setConnectionMode } from 'src/actions/device/deviceSlice';
@@ -56,6 +57,7 @@ type UseYieldFlowProps = {
 
 type UseYieldFlowStepsResult = {
     currentStep: YieldFlowStepId;
+    isWrappedNativeVault: boolean;
 };
 
 export type UseYieldFlowResult = {
@@ -90,6 +92,8 @@ export type UseYieldFlowResult = {
     isSubmittingApprove: boolean;
     isSubmittingAction: boolean;
     setAmountInput: (amount: string) => void;
+    completeWrapStep: () => void;
+    completeUnwrapStep: () => void;
     submitApprovalAction: () => void;
     submitAction: () => void;
     revokeAllowance: () => void;
@@ -147,6 +151,12 @@ export const useYieldFlow = ({
     const session = useSelector(state => selectStablecoinYieldSession(state, flowType, flowKey));
     const sessionRef = useCurrentRef(session);
 
+    const isWrappedNativeVault = isWrappedNativeToken(account.symbol, vault.token.address);
+    const hasWrapStep = flowType === 'deposit' && isWrappedNativeVault;
+    const hasUnwrapStep = isYieldWithdrawFlow(flowType) && isWrappedNativeVault;
+    const [isWrapStepCompleted, setIsWrapStepCompleted] = useState(false);
+    const [isUnwrapStepResolved, setIsUnwrapStepResolved] = useState(false);
+
     const isSharesInput = flowType === 'redeem';
     const canToggleWithdrawUnit = isYieldWithdrawFlow(flowType) && !!token && !!receiptToken;
 
@@ -176,6 +186,8 @@ export const useYieldFlow = ({
         dispatch(stablecoinYieldActions.resetSession({ flowType, flowKey }));
 
         methodsRef.current.reset({ amountInput: '' });
+        setIsWrapStepCompleted(false);
+        setIsUnwrapStepResolved(false);
 
         return () => {
             dispatch(stablecoinYieldActions.disposeSession({ flowType, flowKey }));
@@ -280,7 +292,33 @@ export const useYieldFlow = ({
         prevStepRef.current = nextStep;
     }, [session.step, session.action.amount, methodsRef, maxAmount]);
 
-    const flow = useMemo(() => ({ currentStep: session.step }), [session.step]);
+    // TODO(#29864, #29866): dummy wrap/unwrap steps — they only advance the UI; the wrap
+    // and unwrap transactions themselves come with the shared wrap thunks.
+    const completeWrapStep = useCallback(() => {
+        setIsWrapStepCompleted(true);
+    }, []);
+
+    const completeUnwrapStep = useCallback(() => {
+        setIsUnwrapStepResolved(true);
+    }, []);
+
+    const getCurrentStep = (): YieldFlowStepId => {
+        if (hasWrapStep && !isWrapStepCompleted) {
+            return 'wrap';
+        }
+
+        // The unwrap step is chained after the action confirms, before the complete screen.
+        if (hasUnwrapStep && !isUnwrapStepResolved && session.step === 'complete') {
+            return 'unwrap';
+        }
+
+        return session.step;
+    };
+    const currentStep = getCurrentStep();
+    const flow = useMemo(
+        () => ({ currentStep, isWrappedNativeVault }),
+        [currentStep, isWrappedNativeVault],
+    );
 
     const openPendingTransaction = useCallback(
         (txid: string) => {
@@ -581,6 +619,8 @@ export const useYieldFlow = ({
             session.approval.modalState !== null,
         isSubmittingAction: session.action.isSubmitting,
         setAmountInput,
+        completeWrapStep,
+        completeUnwrapStep,
         submitApprovalAction,
         submitAction,
         revokeAllowance,

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -4,7 +4,8 @@ import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
-import { splitYieldPendingTransaction } from '@suite-common/wallet-core';
+import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getYieldFlowStepSequence, splitYieldPendingTransaction } from '@suite-common/wallet-core';
 import { getApyBreakdown } from '@suite-common/wallet-utils';
 import { Banner, Column, Text } from '@trezor/components';
 
@@ -15,11 +16,13 @@ import { YieldActionStep } from '../common/YieldActionStep';
 import { YieldActionStepWarning } from '../common/YieldActionStepWarning';
 import { YieldFlowCompleteWithdraw } from '../common/YieldFlowCompleteWithdraw';
 import { YieldFlowStepList } from '../common/YieldFlowStepList';
+import { YieldUnwrapStep } from '../common/YieldUnwrapStep';
 
 export const YieldWithdrawForm = () => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const {
+        account,
         vault,
         token,
         receiptToken,
@@ -40,6 +43,8 @@ export const YieldWithdrawForm = () => {
         isMaxWithdrawInfoVisible,
         toggleWithdrawFlowType,
         submitAction,
+        setAmountInput,
+        completeUnwrapStep,
         openPendingTransaction,
         flow,
     } = useYieldWithdrawContext();
@@ -49,6 +54,12 @@ export const YieldWithdrawForm = () => {
         flowType,
     );
     const withdrawInputUnit = flowType === 'redeem' ? 'shares' : 'asset';
+
+    const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
+    const sequence = getYieldFlowStepSequence({
+        flowType,
+        isWrappedNativeVault: flow.isWrappedNativeVault,
+    });
 
     const handleOnWithdraw = () => {
         const apyBreakdown = getApyBreakdown(vault.rewardRate?.components);
@@ -159,11 +170,12 @@ export const YieldWithdrawForm = () => {
                 )}
 
                 <YieldFlowStepList
-                    flowType={flowType}
+                    sequence={sequence}
                     currentStep={flow.currentStep}
+                    hasStepList={sequence.includes('unwrap')}
                     steps={{
                         action: {
-                            title: <Translation id="TR_EARN_YIELD_WITHDRAW" />,
+                            title: <Translation id="TR_EARN_YIELD_WITHDRAW_ASSETS" />,
                             content: () => (
                                 <YieldActionStep
                                     flowType={flowType}
@@ -195,6 +207,33 @@ export const YieldWithdrawForm = () => {
                                     onMaxClick={handleMaxClick}
                                     onSubmit={handleOnWithdraw}
                                     onPendingTxClick={openPendingTransaction}
+                                />
+                            ),
+                        },
+                        unwrap: {
+                            title: (
+                                <Translation
+                                    id="TR_EARN_YIELD_UNWRAP_TITLE"
+                                    values={{ tokenSymbol: token.symbol, nativeSymbol }}
+                                />
+                            ),
+                            description: (
+                                <Translation
+                                    id="TR_EARN_YIELD_UNWRAP_DESCRIPTION"
+                                    values={{
+                                        tokenSymbol: token.symbol,
+                                        networkName: getNetwork(account.symbol).name,
+                                    }}
+                                />
+                            ),
+                            content: () => (
+                                <YieldUnwrapStep
+                                    tokenSymbol={token.symbol}
+                                    tokenDecimals={token.decimals}
+                                    tokenBalance={token.balance}
+                                    onMaxClick={() => setAmountInput(token.balance)}
+                                    onSubmit={completeUnwrapStep}
+                                    onSkip={completeUnwrapStep}
                                 />
                             ),
                         },

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
@@ -1,8 +1,4 @@
-import {
-    YIELD_FLOW_STEP_SEQUENCES,
-    type YieldFlowStepId,
-    type YieldFlowType,
-} from '@suite-common/wallet-core';
+import { type YieldFlowStepId } from '@suite-common/wallet-core';
 import type { StepListItemState } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
@@ -45,13 +41,11 @@ export type YieldFlowStepView = {
 
 /** `listSteps` are the steps rendered as list items; they default to the flow's sequence without 'complete'. */
 export const getYieldFlowSteps = (
-    flowType: YieldFlowType,
+    sequence: readonly YieldFlowStepId[],
     currentStep: YieldFlowStepId,
     listSteps?: readonly YieldFlowStepId[],
 ): Record<YieldFlowStepId, YieldFlowStepView> => {
-    // Both annotations widen the per-flow tuples (and the filter's inferred type predicate)
-    // so indexOf below accepts any step id.
-    const sequence: readonly YieldFlowStepId[] = YIELD_FLOW_STEP_SEQUENCES[flowType];
+    // The annotation widens the filter's inferred type predicate so indexOf below accepts any step id.
     const effectiveListSteps: readonly YieldFlowStepId[] =
         listSteps ?? sequence.filter(stepId => stepId !== 'complete');
     const currentStepIndex = sequence.indexOf(currentStep);
@@ -82,8 +76,10 @@ export const getYieldFlowSteps = (
     });
 
     return {
+        wrap: getStepView('wrap'),
         approve: getStepView('approve'),
         action: getStepView('action'),
+        unwrap: getStepView('unwrap'),
         complete: getStepView('complete'),
     };
 };

--- a/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts
@@ -7,6 +7,7 @@ import {
     buildYieldUnsignedTransaction,
     buildYieldWithdrawCalldata,
     getNextYieldFlowStep,
+    getYieldFlowStepSequence,
     splitYieldPendingTransaction,
 } from '../stablecoinYieldUtils';
 
@@ -108,6 +109,43 @@ describe('stablecoinYieldUtils', () => {
 
         it('stays on a step that is not part of the flow', () => {
             expect(getNextYieldFlowStep('withdraw', 'approve')).toBe('approve');
+        });
+    });
+
+    describe('getYieldFlowStepSequence', () => {
+        it('excludes optional steps by default', () => {
+            expect(getYieldFlowStepSequence({ flowType: 'deposit' })).toEqual([
+                'approve',
+                'action',
+                'complete',
+            ]);
+            expect(getYieldFlowStepSequence({ flowType: 'withdraw' })).toEqual([
+                'action',
+                'complete',
+            ]);
+        });
+
+        it('includes the wrap step for a wrapped-native vault deposit', () => {
+            expect(
+                getYieldFlowStepSequence({ flowType: 'deposit', isWrappedNativeVault: true }),
+            ).toEqual(['wrap', 'approve', 'action', 'complete']);
+        });
+
+        it.each(['withdraw', 'redeem'] as const)(
+            'includes the unwrap step in %s for a wrapped-native vault',
+            flowType => {
+                expect(getYieldFlowStepSequence({ flowType, isWrappedNativeVault: true })).toEqual([
+                    'action',
+                    'unwrap',
+                    'complete',
+                ]);
+            },
+        );
+
+        it('keeps flows without optional steps unchanged', () => {
+            expect(
+                getYieldFlowStepSequence({ flowType: 'claim', isWrappedNativeVault: true }),
+            ).toEqual(['action', 'complete']);
         });
     });
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldConstants.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldConstants.ts
@@ -2,9 +2,13 @@ import type { YieldFlowStepId, YieldFlowType } from './stablecoinYieldTypes';
 
 export const STABLECOIN_YIELD_PREFIX = '@suite-common/wallet-core/stablecoin-yield';
 
-export const YIELD_FLOW_STEP_SEQUENCES = {
-    deposit: ['approve', 'action', 'complete'],
-    withdraw: ['action', 'complete'],
-    redeem: ['action', 'complete'],
+/**
+ * All steps a flow can go through, in order. Optional steps ('wrap'/'unwrap' — offered only
+ * for wrapped-native vaults like WETH) are filtered per situation by `getYieldFlowStepSequence`.
+ */
+export const YIELD_FLOW_AVAILABLE_STEPS = {
+    deposit: ['wrap', 'approve', 'action', 'complete'],
+    withdraw: ['action', 'unwrap', 'complete'],
+    redeem: ['action', 'unwrap', 'complete'],
     claim: ['action', 'complete'],
 } as const satisfies Record<YieldFlowType, readonly YieldFlowStepId[]>;

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -9,7 +9,7 @@ import {
 } from '@suite-common/wallet-types';
 import { isSafeObjectKey } from '@trezor/utils';
 
-import { STABLECOIN_YIELD_PREFIX, YIELD_FLOW_STEP_SEQUENCES } from './stablecoinYieldConstants';
+import { STABLECOIN_YIELD_PREFIX } from './stablecoinYieldConstants';
 import {
     type StablecoinYieldClaimUnsignedTransaction,
     type YieldApproveModalState,
@@ -19,7 +19,7 @@ import {
     type YieldPendingTransactionState,
     type YieldPositionFlowType,
 } from './stablecoinYieldTypes';
-import { getNextYieldFlowStep } from './stablecoinYieldUtils';
+import { getNextYieldFlowStep, getYieldFlowStepSequence } from './stablecoinYieldUtils';
 import { transactionsActions } from '../transactions/transactionsActions';
 
 // Message ids must exist in the desktop `suite/intl` messages — the desktop app renders
@@ -164,7 +164,7 @@ const createInitialStablecoinYieldSessionState = (
     flowType: YieldFlowType,
 ): StablecoinYieldSessionState => ({
     ...initialStablecoinYieldSessionState,
-    step: YIELD_FLOW_STEP_SEQUENCES[flowType][0],
+    step: getYieldFlowStepSequence({ flowType })[0],
     approval: { ...initialStablecoinYieldSessionState.approval },
     action: { ...initialStablecoinYieldSessionState.action },
     result: {

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
@@ -4,7 +4,7 @@ import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { Account } from '@suite-common/wallet-types';
 
 export const YIELD_FLOW_TYPES = ['deposit', 'withdraw', 'redeem', 'claim'] as const;
-export const YIELD_FLOW_STEPS = ['approve', 'action', 'complete'] as const;
+export const YIELD_FLOW_STEPS = ['wrap', 'approve', 'action', 'unwrap', 'complete'] as const;
 
 export type YieldFlowType = (typeof YIELD_FLOW_TYPES)[number];
 export type YieldPositionFlowType = Exclude<YieldFlowType, 'claim'>;

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -11,7 +11,7 @@ import {
 } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
-import { YIELD_FLOW_STEP_SEQUENCES } from './stablecoinYieldConstants';
+import { YIELD_FLOW_AVAILABLE_STEPS } from './stablecoinYieldConstants';
 import type {
     YieldFlowDisplayToken,
     YieldFlowResolvedData,
@@ -111,6 +111,35 @@ export const getStablecoinYieldFlowKey = ({
 export const isYieldWithdrawFlow = (flowType: YieldFlowType): flowType is YieldWithdrawFlowType =>
     flowType === 'withdraw' || flowType === 'redeem';
 
+type GetYieldFlowStepSequenceParams<TFlowType extends YieldFlowType> = {
+    flowType: TFlowType;
+    isWrappedNativeVault?: boolean;
+};
+
+type YieldFlowStepOf<TFlowType extends YieldFlowType> =
+    (typeof YIELD_FLOW_AVAILABLE_STEPS)[TFlowType][number];
+
+type YieldFlowStepSequence<TFlowType extends YieldFlowType> = readonly [
+    YieldFlowStepOf<TFlowType>,
+    ...YieldFlowStepOf<TFlowType>[],
+];
+
+export const getYieldFlowStepSequence = <TFlowType extends YieldFlowType>({
+    flowType,
+    isWrappedNativeVault = false,
+}: GetYieldFlowStepSequenceParams<TFlowType>): YieldFlowStepSequence<TFlowType> => {
+    const availableSteps: readonly YieldFlowStepOf<TFlowType>[] =
+        YIELD_FLOW_AVAILABLE_STEPS[flowType];
+
+    const sequence: readonly YieldFlowStepOf<TFlowType>[] = availableSteps.filter(step =>
+        step === 'wrap' || step === 'unwrap' ? isWrappedNativeVault : true,
+    );
+
+    // Every flow keeps its unconditional 'action' and 'complete' steps, so the
+    // filtered sequence is never empty.
+    return sequence as YieldFlowStepSequence<TFlowType>;
+};
+
 /**
  * Returns the step that follows `step` in the flow's step sequence. Stays on `step`
  * when it is the last one or not part of the flow at all.
@@ -119,8 +148,7 @@ export const getNextYieldFlowStep = (
     flowType: YieldFlowType,
     step: YieldFlowStepId,
 ): YieldFlowStepId => {
-    // Widened so indexOf accepts any step id across the per-flow tuples.
-    const sequence: readonly YieldFlowStepId[] = YIELD_FLOW_STEP_SEQUENCES[flowType];
+    const sequence = getYieldFlowStepSequence({ flowType });
     const stepIndex = sequence.indexOf(step);
 
     if (stepIndex === -1) {

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10063,6 +10063,48 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_DASHBOARD_DEPOSIT_NOW',
         defaultMessage: 'Deposit now',
     },
+    TR_EARN_YIELD_WRAP_TITLE: {
+        id: 'TR_EARN_YIELD_WRAP_TITLE',
+        defaultMessage: 'Wrap {nativeSymbol} to {tokenSymbol}',
+    },
+    TR_EARN_YIELD_WRAP_DESCRIPTION: {
+        id: 'TR_EARN_YIELD_WRAP_DESCRIPTION',
+        defaultMessage:
+            "Wrap the {nativeSymbol} you want to deposit — it's 1:1, and you can unwrap anytime.",
+    },
+    TR_EARN_YIELD_WRAP_AMOUNT: {
+        id: 'TR_EARN_YIELD_WRAP_AMOUNT',
+        defaultMessage: 'Amount to wrap',
+    },
+    TR_EARN_YIELD_WRAP_RECEIVING: {
+        id: 'TR_EARN_YIELD_WRAP_RECEIVING',
+        defaultMessage: 'Receiving',
+    },
+    TR_EARN_YIELD_WRAP_SUBMIT: {
+        id: 'TR_EARN_YIELD_WRAP_SUBMIT',
+        defaultMessage: 'Wrap {nativeSymbol}',
+    },
+    TR_EARN_YIELD_UNWRAP_TITLE: {
+        id: 'TR_EARN_YIELD_UNWRAP_TITLE',
+        defaultMessage: 'Unwrap {tokenSymbol} to {nativeSymbol}',
+    },
+    TR_EARN_YIELD_UNWRAP_DESCRIPTION: {
+        id: 'TR_EARN_YIELD_UNWRAP_DESCRIPTION',
+        defaultMessage:
+            'You can also unwrap {tokenSymbol} anytime from the {networkName} account screen.',
+    },
+    TR_EARN_YIELD_UNWRAP_AMOUNT: {
+        id: 'TR_EARN_YIELD_UNWRAP_AMOUNT',
+        defaultMessage: 'Amount to unwrap',
+    },
+    TR_EARN_YIELD_UNWRAP_SUBMIT: {
+        id: 'TR_EARN_YIELD_UNWRAP_SUBMIT',
+        defaultMessage: 'Unwrap {tokenSymbol}',
+    },
+    TR_EARN_YIELD_WITHDRAW_ASSETS: {
+        id: 'TR_EARN_YIELD_WITHDRAW_ASSETS',
+        defaultMessage: 'Withdraw assets',
+    },
     TR_EARN_YIELD_SELECT_AMOUNT_AND_APPROVE: {
         id: 'TR_EARN_YIELD_SELECT_AMOUNT_AND_APPROVE',
         defaultMessage: 'Select amount & approve',


### PR DESCRIPTION
## Description

Dummy UI for the wrap/unwrap steps in yield flows on wrapped-native (WETH) vaults.
The steps only advance the UI - wrap/unwrap transactions come with the shared thunks.

- `YieldWrapStep` as step 1 of deposit (amount card, Receiving row, Wrap/Skip buttons)
- `YieldUnwrapStep` chained after withdraw (amount card, Unwrap/Skip buttons); step list shown only when the flow has more steps than the action itself
- Wrapped-native vault detection via `isWrappedNativeToken` (#30089)

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #29864
Resolve #29866

## Screenshots:

<img width="895" height="726" alt="image" src="https://github.com/user-attachments/assets/0b70de0c-e2ab-4576-85f6-8d5a3a5a7e87" />

<img width="899" height="704" alt="image" src="https://github.com/user-attachments/assets/d62ecb41-dae4-4320-95e4-156c4ca8d90c" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/wrapped-native-yield-steps/web/](https://dev.suite.sldev.cz/suite-web/feat/wrapped-native-yield-steps/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/wrapped-native-yield-steps&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/wrapped-native-yield-steps&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/wrapped-native-yield-steps&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-23T08:57:15.694Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-23T08:56:59.389Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->