### PR TITLE
Fix receive persistance

### DIFF
--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -22,6 +22,7 @@ import { discreetModeActions } from '@suite-common/discreet-mode';
 import { firmwareActions } from '@suite-common/firmware';
 import { messageSystemActions } from '@suite-common/message-system';
 import { receiveActions } from '@suite-common/receive';
+import { type ActionFromMatcher, createLegacyActionTypeMatcher } from '@suite-common/redux-utils';
 import {
     setSuiteSyncOwner,
     setSuiteSyncRelayUrl,
@@ -29,6 +30,7 @@ import {
     updateSuiteSyncEnabled,
 } from '@suite-common/suite-sync';
 import { suiteSyncQuotaManagerActions } from '@suite-common/suite-sync-quota-manager';
+import { type TrezorDevice } from '@suite-common/suite-types';
 import { getIsDeviceRemembered } from '@suite-common/suite-utils';
 import { thpActions } from '@suite-common/thp';
 import { TokenManagementAction } from '@suite-common/token-definitions';
@@ -57,8 +59,232 @@ import { STORAGE, SUITE } from 'src/actions/suite/constants';
 import * as storageActions from 'src/actions/suite/storageActions';
 import { GRAPH } from 'src/actions/wallet/constants';
 import { db } from 'src/storage';
-import type { AppState, Dispatch, Action as SuiteAction } from 'src/types/suite';
+import type { AppState, Dispatch, GetState, Action as SuiteAction } from 'src/types/suite';
 import type { WalletAction } from 'src/types/wallet';
+
+type StorageAction = SuiteAction | WalletAction;
+
+const matchLegacyActionType = createLegacyActionTypeMatcher<StorageAction>();
+
+const getDeviceByAccountKey = (accountKey: AccountKey, state: AppState) => {
+    const account = selectAccountByKey(state, accountKey);
+
+    return account ? findAccountDevice(account, selectDevices(state)) : undefined;
+};
+
+type RememberedDeviceSaveParams<TAction> = {
+    action: TAction;
+    device: TrezorDevice;
+};
+
+type RememberedDeviceSaveDeps = {
+    dispatch: Dispatch;
+    getState: GetState;
+};
+
+type RememberedDeviceHandler = {
+    match: ReadonlyArray<(action: StorageAction) => boolean>;
+    getDevice: (action: any, state: AppState) => TrezorDevice | undefined;
+    save: (params: RememberedDeviceSaveParams<any>, deps: RememberedDeviceSaveDeps) => void;
+};
+
+const defineRememberedDeviceHandler = <
+    Matchers extends ReadonlyArray<(action: StorageAction) => boolean>,
+>(handler: {
+    match: readonly [...Matchers];
+    getDevice: (
+        action: ActionFromMatcher<Matchers[number]>,
+        state: AppState,
+    ) => TrezorDevice | undefined;
+    save: (
+        params: RememberedDeviceSaveParams<ActionFromMatcher<Matchers[number]>>,
+        deps: RememberedDeviceSaveDeps,
+    ) => void;
+}): RememberedDeviceHandler => handler;
+
+// Device-scoped data must be persisted only for remembered devices. Do not check
+// getIsDeviceRemembered by hand — register a handler here and the loop in the middleware below
+// applies the check based on the declared getDevice.
+const rememberedDeviceHandlers: RememberedDeviceHandler[] = [
+    defineRememberedDeviceHandler({
+        match: [
+            accountsActions.createAccount.match,
+            accountsActions.changeAccountVisibility.match,
+            accountsActions.updateAccount.match,
+        ],
+        getDevice: (action, state) => findAccountDevice(action.payload, selectDevices(state)),
+        save: ({ action }, { dispatch }) => {
+            const account = action.payload;
+
+            if (!isAccountSuccessful(account)) {
+                return;
+            }
+
+            storageActions.saveAccounts([account]);
+            dispatch(storageActions.saveCoinjoinAccount(account.key));
+        },
+    }),
+    defineRememberedDeviceHandler({
+        // When setDeviceState/addAuthorizedDevice is dispatched for passphrase wallet, it means
+        // that its device was just created, but already discovered accounts may have not been
+        // persisted, so try to do it now.
+        match: [deviceActions.setDeviceState.match, deviceActions.addAuthorizedDevice.match],
+        getDevice: (action, state) => selectDeviceByState(state, action.payload.state),
+        save: ({ action, device }, { getState }) => {
+            if (device.useEmptyPassphrase) {
+                return;
+            }
+
+            const accounts = selectAccountsByDeviceState(getState(), action.payload.state).filter(
+                isAccountSuccessful,
+            );
+
+            storageActions.saveAccounts(accounts);
+        },
+    }),
+    defineRememberedDeviceHandler({
+        // If there is a change in account.metadata (metadataActions.setAccountLoaded), update database.
+        match: [metadataActions.setAccountAdd.match],
+        getDevice: (action, state) => findAccountDevice(action.payload, selectDevices(state)),
+        save: ({ action }) => {
+            if (!isAccountSuccessful(action.payload)) {
+                return;
+            }
+
+            storageActions.saveAccounts([action.payload]);
+        },
+    }),
+    defineRememberedDeviceHandler({
+        match: [receiveActions.showAddress.match, receiveActions.setCurrentFreshAddress.match],
+        getDevice: (action, state) => getDeviceByAccountKey(action.payload.accountKey, state),
+        save: ({ action }, { dispatch }) => {
+            dispatch(storageActions.saveAccountReceive(action.payload.accountKey));
+        },
+    }),
+    defineRememberedDeviceHandler({
+        match: [
+            transactionsActions.addTransaction.match,
+            transactionsActions.removeTransaction.match,
+        ],
+        getDevice: (action, state) =>
+            findAccountDevice(action.payload.account, selectDevices(state)),
+        save: ({ action }, { dispatch }) => {
+            const { account } = action.payload;
+
+            storageActions.removeAccountTransactions(account);
+            dispatch(storageActions.saveAccountTransactions(account));
+        },
+    }),
+    defineRememberedDeviceHandler({
+        match: [transactionsActions.markTransactionAsNotScam.match],
+        getDevice: (action, state) => getDeviceByAccountKey(action.payload.key, state),
+        save: ({ action }, { dispatch, getState }) => {
+            const account = selectAccountByKey(getState(), action.payload.key);
+
+            if (account) {
+                dispatch(storageActions.saveAccountTransactions(account));
+            }
+        },
+    }),
+    defineRememberedDeviceHandler({
+        match: [
+            transactionsActions.removeTransaction.match,
+            updateTxsFiatRatesThunk.fulfilled.match,
+        ],
+        getDevice: (action, state) => {
+            const { account } = action.payload;
+
+            return account ? findAccountDevice(account, selectDevices(state)) : undefined;
+        },
+        save: ({ action }, { dispatch, getState }) => {
+            const { account } = action.payload;
+
+            if (!account) {
+                return;
+            }
+
+            storageActions.removeAccountHistoricRates(account.key);
+
+            const historicRates = selectHistoricFiatRates(getState());
+            if (historicRates) {
+                dispatch(storageActions.saveAccountHistoricRates(account.key, historicRates));
+            }
+        },
+    }),
+    defineRememberedDeviceHandler({
+        match: [deviceActions.updateSelectedDevice.match],
+        getDevice: action => action.payload,
+        save: ({ device }, { getState }) => {
+            const isAutoEjectEnabled = selectIsDeviceAutoEjectEnabled(getState());
+
+            if (device.mode !== 'normal' || isAutoEjectEnabled) {
+                return;
+            }
+
+            (storageActions.saveAccounts([]) ?? Promise.resolve())
+                // This is a bit strange workaround to ensure that device data will be stored after all account-related db transactions are settled,
+                // in order not to persist successful discovery before persisting all its accounts
+                .then(() => storageActions.saveDevice(device));
+        },
+    }),
+    defineRememberedDeviceHandler({
+        match: [suiteSettingsActions.setCoinjoinReceiveWarningHidden.match],
+        getDevice: (_action, state) => selectSelectedDevice(state),
+        save: (_params, { dispatch }) => {
+            dispatch(storageActions.saveSuiteSettings());
+        },
+    }),
+    defineRememberedDeviceHandler({
+        match: [matchLegacyActionType(GRAPH.ACCOUNT_GRAPH_SUCCESS, GRAPH.ACCOUNT_GRAPH_FAIL)],
+        getDevice: (action, state) =>
+            selectDevices(state).find(
+                device => device.state?.staticSessionId === action.payload.account.deviceState,
+            ),
+        save: ({ action }) => {
+            storageActions.saveGraph([action.payload]);
+        },
+    }),
+    defineRememberedDeviceHandler({
+        match: [matchLegacyActionType(METADATA.SET_ERROR_FOR_DEVICE)],
+        getDevice: (action, state) =>
+            selectDeviceByStaticSessionId(state, action.payload.deviceState),
+        save: ({ device }, { dispatch }) => {
+            dispatch(storageActions.saveDeviceMetadataError(device));
+        },
+    }),
+    defineRememberedDeviceHandler({
+        // Au, this hurts, I need to call saveDevice manually. Saved device should be updated
+        // automatically anytime any of its properties change.
+        match: [matchLegacyActionType(METADATA.SET_DEVICE_METADATA)],
+        getDevice: (action, state) =>
+            selectDeviceByStaticSessionId(state, action.payload.deviceState),
+        save: ({ action, device }) => {
+            storageActions.saveDevice({
+                ...device,
+                metadata: action.payload.metadata,
+            });
+        },
+    }),
+    defineRememberedDeviceHandler({
+        match: [
+            matchLegacyActionType(
+                COINJOIN.ACCOUNT_DISCOVERY_RESET,
+                COINJOIN.ACCOUNT_DISCOVERY_PROGRESS,
+                COINJOIN.ACCOUNT_AUTHORIZE_SUCCESS,
+                COINJOIN.ACCOUNT_UNREGISTER,
+                COINJOIN.ACCOUNT_UPDATE_SETUP_OPTION,
+                COINJOIN.ACCOUNT_UPDATE_TARGET_ANONYMITY,
+                COINJOIN.ACCOUNT_UPDATE_MAX_MING_FEE,
+                COINJOIN.ACCOUNT_TOGGLE_SKIP_ROUNDS,
+            ),
+        ],
+        getDevice: (action, state) =>
+            getDeviceByAccountKey(action.payload.accountKey as AccountKey, state),
+        save: ({ action }, { dispatch }) => {
+            dispatch(storageActions.saveCoinjoinAccount(action.payload.accountKey as AccountKey));
+        },
+    }),
+];
 
 const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
     db.onBlocking = () => api.dispatch({ type: STORAGE.ERROR, payload: 'blocking' });
@@ -69,63 +295,22 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
             // pass action
             next(action);
 
-            if (
-                isAnyOf(
-                    accountsActions.createAccount,
-                    accountsActions.changeAccountVisibility,
-                    accountsActions.updateAccount,
-                )(action)
-            ) {
-                const newAccount = action.payload;
-                const state = api.getState();
-                const device = findAccountDevice(newAccount, selectDevices(state));
-
-                // update only transactions for remembered device
-                if (getIsDeviceRemembered(device) && isAccountSuccessful(newAccount)) {
-                    storageActions.saveAccounts([newAccount]);
-                    api.dispatch(storageActions.saveCoinjoinAccount(newAccount.key));
+            // IMPORTANT: The single place enforcing that device-scoped data is persisted only for
+            //            remembered devices (see rememberedDeviceHandlers above).
+            rememberedDeviceHandlers.forEach(({ match, getDevice, save }) => {
+                if (!match.some(matcher => matcher(action))) {
+                    return;
                 }
-            }
 
-            if (isAnyOf(deviceActions.setDeviceState, deviceActions.addAuthorizedDevice)(action)) {
-                const device = selectDeviceByState(api.getState(), action.payload.state);
+                const device = getDevice(action, api.getState());
 
-                // When setDeviceState/addAuthorizedDevice is dispatched for passphrase wallet,
-                // it means that its device was just created, but already discovered accounts
-                // may have not been persisted, so try to do it now
-                if (device && !device.useEmptyPassphrase && getIsDeviceRemembered(device)) {
-                    const accounts = selectAccountsByDeviceState(
-                        api.getState(),
-                        action.payload.state,
-                    ).filter(isAccountSuccessful);
-
-                    storageActions.saveAccounts(accounts);
+                if (device && getIsDeviceRemembered(device)) {
+                    save({ action, device }, { dispatch: api.dispatch, getState: api.getState });
                 }
-            }
+            });
 
             if (accountsActions.removeAccount.match(action)) {
                 action.payload.forEach(storageActions.removeAccountWithDependencies(api.getState));
-            }
-
-            if (
-                isAnyOf(receiveActions.showAddress, receiveActions.setCurrentFreshAddress)(action)
-            ) {
-                const account = selectAccountByKey(api.getState(), action.payload.accountKey);
-                const device = account
-                    ? findAccountDevice(account, selectDevices(api.getState()))
-                    : undefined;
-
-                if (getIsDeviceRemembered(device)) {
-                    api.dispatch(storageActions.saveAccountReceive(action.payload.accountKey));
-                }
-            }
-
-            if (isAnyOf(metadataActions.setAccountAdd)(action)) {
-                const device = findAccountDevice(action.payload, selectDevices(api.getState()));
-                // if device is remembered, and there is a change in account.metadata (metadataActions.setAccountLoaded), update database
-                if (getIsDeviceRemembered(device) && isAccountSuccessful(action.payload)) {
-                    storageActions.saveAccounts([action.payload]);
-                }
             }
 
             if (changeNetworks.match(action)) {
@@ -140,60 +325,12 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 storageActions.removeAccountPhishing(account.key);
             }
 
-            if (
-                isAnyOf(
-                    transactionsActions.addTransaction,
-                    transactionsActions.removeTransaction,
-                )(action)
-            ) {
-                const { account } = action.payload;
-                const device = findAccountDevice(account, selectDevices(api.getState()));
-                // update only transactions for remembered device
-                if (getIsDeviceRemembered(device)) {
-                    storageActions.removeAccountTransactions(account);
-                    api.dispatch(storageActions.saveAccountTransactions(account));
-                }
-            }
-
-            if (transactionsActions.markTransactionAsNotScam.match(action)) {
-                const account = selectAccountByKey(api.getState(), action.payload.key);
-                const device = account
-                    ? findAccountDevice(account, selectDevices(api.getState()))
-                    : undefined;
-                if (account && getIsDeviceRemembered(device)) {
-                    api.dispatch(storageActions.saveAccountTransactions(account));
-                }
-            }
-
             if (phishingActions.setDustPhishing.match(action)) {
                 api.dispatch(
                     storageActions.savePhishingMetadata({
                         dustPhishing: action.payload,
                     }),
                 );
-            }
-
-            if (
-                isAnyOf(
-                    transactionsActions.removeTransaction,
-                    updateTxsFiatRatesThunk.fulfilled,
-                )(action)
-            ) {
-                const { account } = action.payload;
-                // TS doesn't know return type of updateTxsFiatRatesThunk.fulfilled, investigate why
-                if (account) {
-                    const device = findAccountDevice(account, selectDevices(api.getState()));
-                    const historicRates = selectHistoricFiatRates(api.getState());
-                    // update only historic rates for remembered device
-                    if (getIsDeviceRemembered(device)) {
-                        storageActions.removeAccountHistoricRates(account.key);
-                        if (historicRates) {
-                            api.dispatch(
-                                storageActions.saveAccountHistoricRates(account.key, historicRates),
-                            );
-                        }
-                    }
-                }
             }
 
             if (blockchainActions.setBackend.match(action)) {
@@ -287,21 +424,6 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 );
             }
 
-            if (deviceActions.updateSelectedDevice.match(action)) {
-                const isAutoEjectEnabled = selectIsDeviceAutoEjectEnabled(api.getState());
-
-                if (
-                    getIsDeviceRemembered(action.payload) &&
-                    action.payload?.mode === 'normal' &&
-                    !isAutoEjectEnabled
-                ) {
-                    (storageActions.saveAccounts([]) ?? Promise.resolve())
-                        // This is a bit strange workaround to ensure that device data will be stored after all account-related db transactions are settled,
-                        // in order not to persist successful discovery before persisting all its accounts
-                        .then(() => storageActions.saveDevice(action.payload));
-                }
-            }
-
             if (
                 isAnyOf(
                     deviceActions.connectDevice, // Known device is stored
@@ -392,29 +514,6 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case debugActions.setShowDebugMenu.type:
                     api.dispatch(storageActions.saveDebugSettings());
                     break;
-                case suiteSettingsActions.setCoinjoinReceiveWarningHidden.type: {
-                    const device = selectSelectedDevice(api.getState());
-                    const isWalletRemembered = device?.remember;
-
-                    if (!isWalletRemembered) {
-                        break;
-                    }
-
-                    api.dispatch(storageActions.saveSuiteSettings());
-                    break;
-                }
-
-                case GRAPH.ACCOUNT_GRAPH_SUCCESS:
-                case GRAPH.ACCOUNT_GRAPH_FAIL: {
-                    const devices = selectDevices(api.getState());
-                    const device = devices.find(
-                        d => d.state?.staticSessionId === action.payload.account.deviceState,
-                    );
-                    if (getIsDeviceRemembered(device)) {
-                        storageActions.saveGraph([action.payload]);
-                    }
-                    break;
-                }
                 case tradingActions.saveTrade.type: {
                     const { type, ...trade } = action;
                     storageActions.saveTradingTrade(trade.payload);
@@ -426,58 +525,13 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case METADATA.REMOVE_PROVIDER:
                     api.dispatch(storageActions.saveMetadataSettings());
                     break;
-                case METADATA.SET_ERROR_FOR_DEVICE: {
-                    const device = selectDeviceByStaticSessionId(
-                        api.getState(),
-                        action.payload.deviceState,
-                    );
-                    if (getIsDeviceRemembered(device) && device) {
-                        api.dispatch(storageActions.saveDeviceMetadataError(device));
-                    }
-                    break;
-                }
-                // au, this hurts, I need to call saveDevice manually. saved device should be updated automatically
-                // anytime any of its properties change
-                case METADATA.SET_DEVICE_METADATA: {
-                    const device = selectDeviceByStaticSessionId(
-                        api.getState(),
-                        action.payload.deviceState,
-                    );
-                    if (getIsDeviceRemembered(device) && device) {
-                        storageActions.saveDevice({
-                            ...device,
-                            metadata: action.payload.metadata,
-                        });
-                    }
-                    break;
-                }
-
-                case COINJOIN.ACCOUNT_DISCOVERY_RESET:
-                case COINJOIN.ACCOUNT_DISCOVERY_PROGRESS:
-                case COINJOIN.ACCOUNT_AUTHORIZE_SUCCESS:
-                case COINJOIN.ACCOUNT_UNREGISTER:
-                case COINJOIN.ACCOUNT_UPDATE_SETUP_OPTION:
-                case COINJOIN.ACCOUNT_UPDATE_TARGET_ANONYMITY:
-                case COINJOIN.ACCOUNT_UPDATE_MAX_MING_FEE:
-                case COINJOIN.ACCOUNT_TOGGLE_SKIP_ROUNDS: {
-                    const account = selectAccountByKey(
-                        api.getState(),
-                        action.payload.accountKey as AccountKey,
-                    );
-                    const device =
-                        account && findAccountDevice(account, selectDevices(api.getState()));
-                    if (device && getIsDeviceRemembered(device)) {
-                        api.dispatch(
-                            storageActions.saveCoinjoinAccount(
-                                action.payload.accountKey as AccountKey,
-                            ),
-                        );
-                    }
-                    break;
-                }
                 case COINJOIN.SET_DEBUG_SETTINGS:
                     api.dispatch(storageActions.saveCoinjoinDebugSettings());
                     break;
+
+                // Not a rememberedDeviceHandlers entry: unlike those handlers (one action ->
+                // one device), this one action affects multiple accounts on potentially
+                // different devices, so the remembered-device check must be applied per account.
                 case COINJOIN.CLIENT_PRISON_EVENT: {
                     const affectedAccounts = action.payload.map(inmate => inmate.accountKey);
                     const state = api.getState();

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -194,7 +194,7 @@ const rememberedDeviceHandlers: RememberedDeviceHandler[] = [
         getDevice: (action, state) => {
             const { account } = action.payload;
 
-            return account ? findAccountDevice(account, selectDevices(state)) : undefined;
+            return account ? getDeviceByAccountKey(account.key, state) : undefined;
         },
         save: ({ action }, { dispatch, getState }) => {
             const { account } = action.payload;
@@ -535,10 +535,8 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case COINJOIN.CLIENT_PRISON_EVENT: {
                     const affectedAccounts = action.payload.map(inmate => inmate.accountKey);
                     const state = api.getState();
-                    const devices = selectDevices(state);
                     affectedAccounts.forEach(key => {
-                        const account = selectAccountByKey(state, key as AccountKey);
-                        const device = account && findAccountDevice(account, devices);
+                        const device = getDeviceByAccountKey(key as AccountKey, state);
                         if (device && getIsDeviceRemembered(device)) {
                             api.dispatch(storageActions.saveCoinjoinAccount(key as AccountKey));
                         }

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -110,7 +110,14 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
             if (
                 isAnyOf(receiveActions.showAddress, receiveActions.setCurrentFreshAddress)(action)
             ) {
-                api.dispatch(storageActions.saveAccountReceive(action.payload.accountKey));
+                const account = selectAccountByKey(api.getState(), action.payload.accountKey);
+                const device = account
+                    ? findAccountDevice(account, selectDevices(api.getState()))
+                    : undefined;
+
+                if (getIsDeviceRemembered(device)) {
+                    api.dispatch(storageActions.saveAccountReceive(action.payload.accountKey));
+                }
             }
 
             if (isAnyOf(metadataActions.setAccountAdd)(action)) {

--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -5,6 +5,7 @@
 - remove inaccurate historic ERC4626 fiat rates from storage
 - rename receive `revealedAddresses` to `touchedAddresses`
 - remove `isVerified` flag from receive address entries
+- remove receive data belonging to devices that are not remembered
 
 ## 26.6.0
 

--- a/packages/suite/src/storage/migrations/versions/26.8.0.1.ts
+++ b/packages/suite/src/storage/migrations/versions/26.8.0.1.ts
@@ -1,0 +1,24 @@
+import { createMigration } from '@suite/idb-migration-utils';
+
+import { type SuiteDBSchema } from 'src/storage/definitions';
+
+export default createMigration<SuiteDBSchema>('26.8.0.1', async (_db, tx) => {
+    const rememberedDeviceStates = new Set(await tx.objectStore('devices').getAllKeys());
+    const accounts = await tx.objectStore('accounts').getAll();
+    const rememberedAccountKeys = new Set(
+        accounts
+            .filter(account => rememberedDeviceStates.has(account.deviceState))
+            .map(account => account.key),
+    );
+
+    const receiveStore = tx.objectStore('receive');
+    let cursor = await receiveStore.openCursor();
+
+    while (cursor) {
+        if (!rememberedAccountKeys.has(cursor.key)) {
+            await cursor.delete();
+        }
+
+        cursor = await cursor.continue();
+    }
+});

--- a/packages/suite/src/storage/migrations/versions/__tests__/26.8.0.1.test.ts
+++ b/packages/suite/src/storage/migrations/versions/__tests__/26.8.0.1.test.ts
@@ -1,0 +1,98 @@
+import '@suite-common/test-utils/src/globalOverrides';
+import { type IDBPDatabase, deleteDB, openDB } from 'idb';
+
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { type StaticSessionId } from '@trezor/connect';
+
+import { type SuiteDBSchema } from 'src/storage/definitions';
+import { serializeDevice } from 'src/utils/suite/storage';
+
+import migration from '../26.8.0.1';
+
+const DB_NAME = 'suite-idb-test-26.8.0.1';
+const INITIAL_VERSION = 1;
+
+const REMEMBERED_DEVICE_STATE = 'rememberedWallet@device:0' as StaticSessionId;
+const UNREMEMBERED_DEVICE_STATE = 'unrememberedWallet@device:0' as StaticSessionId;
+const ORPHANED_DEVICE_STATE = 'orphanedWallet@device:0' as StaticSessionId;
+
+const runMigration = () =>
+    openDB(DB_NAME, INITIAL_VERSION + 1, {
+        upgrade(db: IDBPDatabase<SuiteDBSchema>, _oldVersion, _newVersion, tx) {
+            migration.migrate(db, tx);
+        },
+    });
+
+describe('migration 26.8.0.1', () => {
+    beforeEach(async () => {
+        await deleteDB(DB_NAME);
+    });
+
+    test('removes receive data not belonging to a remembered device', async () => {
+        const db = await openDB<SuiteDBSchema>(DB_NAME, INITIAL_VERSION, {
+            upgrade(upgradeDb) {
+                upgradeDb.createObjectStore('devices');
+                upgradeDb.createObjectStore('accounts', {
+                    keyPath: ['descriptor', 'symbol', 'deviceState'],
+                });
+                upgradeDb.createObjectStore('receive');
+            },
+        });
+
+        const rememberedDevice = mockSuiteDevice({
+            remember: true,
+            state: { staticSessionId: REMEMBERED_DEVICE_STATE },
+        });
+        if (rememberedDevice.type !== 'acquired') {
+            throw new Error('Expected an acquired device');
+        }
+
+        const rememberedAccount = mockWalletAccount({
+            descriptor: asAccountDescriptor('rememberedAccount'),
+            symbol: 'btc',
+            deviceState: REMEMBERED_DEVICE_STATE,
+        });
+        const unrememberedAccount = mockWalletAccount({
+            descriptor: asAccountDescriptor('unrememberedAccount'),
+            symbol: 'btc',
+            deviceState: UNREMEMBERED_DEVICE_STATE,
+        });
+        const orphanedAccount = mockWalletAccount({
+            descriptor: asAccountDescriptor('orphanedAccount'),
+            symbol: 'btc',
+            deviceState: ORPHANED_DEVICE_STATE,
+        });
+
+        await db.put('devices', serializeDevice(rememberedDevice), REMEMBERED_DEVICE_STATE);
+        await db.put('accounts', rememberedAccount);
+        await db.put('accounts', unrememberedAccount);
+        await db.put(
+            'receive',
+            { touchedAddresses: [{ path: 'remembered-path', address: 'remembered-address' }] },
+            rememberedAccount.key,
+        );
+        await db.put(
+            'receive',
+            { touchedAddresses: [{ path: 'unremembered-path', address: 'unremembered-address' }] },
+            unrememberedAccount.key,
+        );
+        await db.put(
+            'receive',
+            { touchedAddresses: [{ path: 'orphaned-path', address: 'orphaned-address' }] },
+            orphanedAccount.key,
+        );
+        db.close();
+
+        const migratedDb = await runMigration();
+
+        expect(await migratedDb.get('receive', rememberedAccount.key)).toEqual({
+            touchedAddresses: [{ path: 'remembered-path', address: 'remembered-address' }],
+        });
+        expect(await migratedDb.get('receive', unrememberedAccount.key)).toBeUndefined();
+        expect(await migratedDb.get('receive', orphanedAccount.key)).toBeUndefined();
+
+        migratedDb.close();
+    });
+});

--- a/packages/suite/src/storage/migrations/versions/__tests__/26.8.0.1.test.ts
+++ b/packages/suite/src/storage/migrations/versions/__tests__/26.8.0.1.test.ts
@@ -1,4 +1,4 @@
-import '@suite-common/test-utils/src/globalOverrides';
+import '@suite-common/test-utils/globalOverrides';
 import { type IDBPDatabase, deleteDB, openDB } from 'idb';
 
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';

--- a/packages/suite/src/storage/migrations/versions/index.ts
+++ b/packages/suite/src/storage/migrations/versions/index.ts
@@ -28,3 +28,4 @@ export { default as m26_7_0 } from './26.7.0';
 export { default as m26_7_0_1 } from './26.7.0.1';
 export { default as m26_7_0_2 } from './26.7.0.2';
 export { default as m26_8_0 } from './26.8.0';
+export { default as m26_8_0_1 } from './26.8.0.1';

--- a/suite-common/redux-utils/src/index.ts
+++ b/suite-common/redux-utils/src/index.ts
@@ -11,3 +11,4 @@ export * from './hooks/useSelectorDeepComparison';
 export * from './selectorsUtils';
 export * from './extraWithStoreThunkMiddleware';
 export * from './notImplemented';
+export * from './matchLegacyActionType';

--- a/suite-common/redux-utils/src/matchLegacyActionType.ts
+++ b/suite-common/redux-utils/src/matchLegacyActionType.ts
@@ -13,6 +13,7 @@ declare const matchedLegacyActionType: unique symbol;
 export type LegacyActionTypeMatcher<TAction extends Action> = ((
     action: Action,
 ) => action is TAction) & {
+    // The unique-symbol property brands this intersection so no unrelated type guard can satisfy it.
     readonly [matchedLegacyActionType]: TAction;
 };
 

--- a/suite-common/redux-utils/src/matchLegacyActionType.ts
+++ b/suite-common/redux-utils/src/matchLegacyActionType.ts
@@ -1,0 +1,49 @@
+import { type Action } from 'redux';
+
+declare const matchedLegacyActionType: unique symbol;
+
+/**
+ * A type guard for legacy Redux actions identified by string constants.
+ *
+ * Redux Toolkit action creators expose a `.match` type guard, but older action creators usually
+ * expose only their string `type`. The type-only symbol retains the action narrowed by those
+ * strings so it can later be recovered by {@link ActionFromMatcher} without redeclaring the
+ * action's payload type.
+ */
+export type LegacyActionTypeMatcher<TAction extends Action> = ((
+    action: Action,
+) => action is TAction) & {
+    readonly [matchedLegacyActionType]: TAction;
+};
+
+/**
+ * Extracts the action accepted by either a legacy action-type matcher or a regular type guard.
+ */
+export type ActionFromMatcher<TMatcher> =
+    TMatcher extends LegacyActionTypeMatcher<infer TAction>
+        ? TAction
+        : TMatcher extends (action: any) => action is infer TMatchedAction
+          ? TMatchedAction
+          : never;
+
+/**
+ * Creates a matcher factory for one application's complete action union.
+ *
+ * Configuring the union once makes every returned matcher accept only known action-type strings
+ * and narrow the action to the corresponding union members.
+ *
+ * @example
+ * ```ts
+ * const matchLegacyActionType = createLegacyActionTypeMatcher<AppAction>();
+ * const matchesAccountUpdate = matchLegacyActionType(ACCOUNT_UPDATE, ACCOUNT_REMOVE);
+ * ```
+ */
+export const createLegacyActionTypeMatcher = <TAction extends Action>() =>
+    function matchLegacyActionType<const TActionTypes extends readonly TAction['type'][]>(
+        ...actionTypes: TActionTypes
+    ) {
+        return ((action: Action): action is TAction & { type: TActionTypes[number] } =>
+            (actionTypes as readonly string[]).includes(action.type)) as LegacyActionTypeMatcher<
+            TAction & { type: TActionTypes[number] }
+        >;
+    };

--- a/suite-common/redux-utils/src/tests/matchLegacyActionType.type-test.ts
+++ b/suite-common/redux-utils/src/tests/matchLegacyActionType.type-test.ts
@@ -1,0 +1,58 @@
+import { type Action } from 'redux';
+
+import { type ActionFromMatcher, createLegacyActionTypeMatcher } from '../matchLegacyActionType';
+
+type FirstAction = {
+    type: 'first';
+    payload: { first: string };
+};
+
+type SecondAction = {
+    type: 'second';
+    payload: { second: number };
+};
+
+type ThirdAction = {
+    type: 'third';
+    payload: { third: boolean };
+};
+
+type TestAction = FirstAction | SecondAction | ThirdAction;
+
+const matchLegacyActionType = createLegacyActionTypeMatcher<TestAction>();
+const firstOrSecondMatcher = matchLegacyActionType('first', 'second');
+
+declare const action: TestAction;
+
+if (firstOrSecondMatcher(action)) {
+    const matchedAction: FirstAction | SecondAction = action;
+
+    // @ts-expect-error The third action is not matched.
+    const thirdAction: ThirdAction = action;
+
+    void matchedAction;
+    void thirdAction;
+}
+
+type MatchedAction = ActionFromMatcher<typeof firstOrSecondMatcher>;
+
+declare const matchedAction: MatchedAction;
+const firstOrSecondAction: FirstAction | SecondAction = matchedAction;
+
+// @ts-expect-error The extracted action does not include the third action.
+const thirdAction: ThirdAction = matchedAction;
+
+const firstActionMatcher = (candidate: Action): candidate is FirstAction =>
+    candidate.type === 'first';
+type ActionFromTypeGuard = ActionFromMatcher<typeof firstActionMatcher>;
+
+declare const actionFromTypeGuard: ActionFromTypeGuard;
+const firstAction: FirstAction = actionFromTypeGuard;
+
+// @ts-expect-error The action type is not part of TestAction.
+matchLegacyActionType('fourth');
+
+void firstOrSecondAction;
+void thirdAction;
+void firstActionMatcher;
+void firstAction;


### PR DESCRIPTION
## Description

Fix and refactoring of the remembered device data storage. So it is harder for the developers to forget the `getIsDeviceRemembered` check.

Related to https://github.com/trezor/trezor-suite/pull/28218

## QA Notes
- see: https://github.com/trezor/trezor-suite/pull/30150#pullrequestreview-4754624161
- @honzauher hit me on slack for mo details


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-receive-persistance/web/](https://dev.suite.sldev.cz/suite-web/fix-receive-persistance/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-receive-persistance&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-receive-persistance&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-receive-persistance&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-23T08:14:40.098Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-23T08:14:31.553Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->