### PR TITLE
fix(e2e): correct regex in waitForSync to properly validate best offer

### DIFF
--- a/suite/e2e/support/pageObjects/trading/quotesSection.ts
+++ b/suite/e2e/support/pageObjects/trading/quotesSection.ts
@@ -28,7 +28,7 @@ export class TradingQuotesSection {
     async waitForSync() {
         await expect(this.loadingSpinner).toBeHidden({ timeout: 30000 });
         // Even though the offer sync is finished, the best offer might not be displayed correctly yet and show 0 BTC
-        await expect(this.bestOfferAmount).not.toHaveText(/^0( w+)?$/);
+        await expect(this.bestOfferAmount).not.toHaveText(/^0( \w+)?$/);
     }
 
     @step()


### PR DESCRIPTION
## Description
`waitForSync()` used the regex `/^0( w+)?$/` to detect the placeholder `0 SOL`, but the missing backslash meant `( w+)` matched literal `w`s instead of the currency symbol (`\w+`). As a result the guard never matched `"0 SOL"` and returned immediately, so tests read the amount before the real quote loaded — leaving `receiveAmount = "0"` and causing flaky swap tests.

Fixed the pattern to `/^0( \w+)?$/` so the wait correctly holds until a genuine non-zero offer is displayed.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-trade-tests/web/](https://dev.suite.sldev.cz/suite-web/fix-trade-tests/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-trade-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-23T07:58:31.960Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-23T07:58:25.983Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->