### PR TITLE
feat(evm): wallet-declared privatePending hint for nonce + gas routing (backs blockbook#1639)

### DIFF
--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -789,6 +789,8 @@ export interface WsAccountInfoReq {
     gap?: number;
     /** If true, additionally fetch and return the confirmed (mined-only) nonce for Ethereum-like addresses (extra backend call). */
     confirmedNonce?: boolean;
+    /** Wallet-declared in-flight private (alternative send-tx / relay) txs so blockbook routes the pending-nonce lookup deterministically instead of via its recentSenders heuristic. EVM only. */
+    privatePending?: { nonces: number[]; txids?: string[] };
 }
 export interface WsContractInfoReq {
     /** Contract address to query. */

--- a/packages/blockchain-link-types/src/params.ts
+++ b/packages/blockchain-link-types/src/params.ts
@@ -22,6 +22,17 @@ export interface GetFiatRatesTickersListParams {
     token?: string;
 }
 
+/**
+ * Wallet-declared in-flight PRIVATE (alternative send-tx / relay) transactions. Lets blockbook route
+ * the nonce lookup and gas estimate deterministically from authoritative wallet state instead of
+ * inferring it from its per-instance `recentSenders` heuristic (fragile across restarts and
+ * load-balanced replicas). Blockbook only (EVM). See trezor/blockbook#1639.
+ */
+export interface PrivatePendingHint {
+    nonces: number[]; // account nonces of the in-flight private txs; blockbook raises the reported pending nonce to max(nonces)+1
+    txids?: string[]; // forward-compat only; not yet consumed by blockbook
+}
+
 export interface EstimateFeeParams {
     blocks?: number[];
     specific?: {
@@ -32,6 +43,7 @@ export interface EstimateFeeParams {
         data?: string; // eth tx data, sol tx message
         value?: string; // eth tx amount
         newAccountProgramName?: 'staking' | 'spl-token' | 'spl-token-2022'; // program name of the Solana account that is being created, default: 'spl-token'
+        privatePending?: { nonces: number[] }; // eth: presence-only routing hint (see PrivatePendingHint) - routes the estimate to the relay's pending-private state
     };
 }
 
@@ -60,4 +72,5 @@ export interface AccountInfoParams {
     tokenAccountsPubKeys?: string[]; // solana only, token accounts to fetch txids for
     protocols?: 'erc4626'[]; // protocols to include in the response (e.g. 'erc4626')
     confirmedNonce?: boolean; // blockbook only (EVM), additionally fetch the confirmed (mined-only) nonce
+    privatePending?: PrivatePendingHint; // blockbook only (EVM), authoritatively declares in-flight private txs for deterministic nonce routing
 }

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -55,6 +55,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                 { name: 'marker', type: 'object' },
                 { name: 'protocols', type: 'array' },
                 { name: 'confirmedNonce', type: 'boolean' },
+                { name: 'privatePending', type: 'object' },
                 { name: 'defaultAccountType', type: 'string' },
                 { name: 'derivationType', type: 'number' },
                 { name: 'suppressBackupWarning', type: 'boolean' },
@@ -245,6 +246,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                     tokenAccountsPubKeys: request.tokenAccountsPubKeys,
                     protocols: request.protocols,
                     confirmedNonce: request.confirmedNonce,
+                    privatePending: request.privatePending,
                 });
 
                 if (this.disposed) break;

--- a/packages/suite/src/reducers/wallet/index.ts
+++ b/packages/suite/src/reducers/wallet/index.ts
@@ -10,6 +10,7 @@ import {
     type FiatRatesState,
     type FormDraftState,
     type PhishingState,
+    type PrivatePendingState,
     type SendState,
     type StablecoinYieldState,
     type StakeState,
@@ -27,6 +28,7 @@ import {
     prepareStakeReducer,
     prepareTransactionsReducer,
     prepareWalletSettingsReducer,
+    privatePendingReducer,
     stablecoinYieldReducer,
     tronStakeReducer,
 } from '@suite-common/wallet-core';
@@ -67,6 +69,7 @@ export type WalletState = {
     accountsRefreshTime: AccountsRefreshTimeState;
     selectedAccount: SelectedAccountStatus;
     fees: FeesState;
+    privatePending: PrivatePendingState;
     blockchain: BlockchainNetworks;
     explorer: ExplorerConfig;
     trading: TradingState;
@@ -94,6 +97,7 @@ export const walletReducers: Reducer<
     accountsRefreshTime: accountsRefreshTimeReducer,
     selectedAccount: selectedAccountReducer,
     fees: feesReducer,
+    privatePending: privatePendingReducer,
     blockchain: blockchainReducer,
     explorer: explorerReducer,
     trading: tradingReducer,

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -30,6 +30,8 @@ import {
 import { accountRefreshed } from './accountsRefreshTimeReducer';
 import { selectAccountByKey } from './accountsSelectors';
 import { selectBlockchainHeightBySymbol, selectGapLimit } from '../blockchain/blockchainReducer';
+import { privatePendingActions } from '../privatePending/privatePendingActions';
+import { selectAccountPrivatePendingHint } from '../privatePending/privatePendingReducer';
 import { selectBitcoinAmountUnit } from '../settings/walletSettingsReducer';
 import { transactionsActions } from '../transactions/transactionsActions';
 import { selectTransactions } from '../transactions/transactionsSelectors';
@@ -132,6 +134,19 @@ export const fetchAndUpdateAccountThunk = createThunk(
                 ? selectGapLimit(getState(), account.symbol)
                 : undefined;
 
+        // Declare the wallet's in-flight PRIVATE (relay) txs on the UNCONDITIONAL basic refresh so
+        // blockbook routes the pending nonce deterministically even for txs its node cannot see - and
+        // even after reconnecting to a different (load-balanced) instance, since this call fires on
+        // every connect / periodic sync / block. It rides the basic (not the gated details:'txs')
+        // call because a blockbook-invisible private tx does not make the account "outdated", so the
+        // txs call may be skipped. selectAccountPrivatePendingHint is undefined when nothing is in
+        // flight, so the hint (and the extra confirmedNonce round-trip below) are sent only when
+        // relevant - which is also the over-declaration guard. See trezor/blockbook#1639.
+        const privatePendingHint =
+            account.networkType === 'ethereum'
+                ? selectAccountPrivatePendingHint(getState(), account.key)
+                : undefined;
+
         const basic = await TrezorConnect.getAccountInfo({
             coin: account.symbol,
             identity: tryGetAccountIdentity(account),
@@ -141,9 +156,29 @@ export const fetchAndUpdateAccountThunk = createThunk(
             tokenAccountsPubKeys,
             protocols: account.networkType === 'ethereum' ? ['erc4626'] : undefined,
             gap,
+            // confirmedNonce is the trustworthy mined nonce used to prune settled private nonces
+            // below; request it only when a private tx is in flight, to avoid the extra backend call.
+            confirmedNonce: privatePendingHint ? true : undefined,
+            privatePending: privatePendingHint,
         });
 
         if (!basic.success) return;
+
+        // Prune the declared private nonces against the mined nonce on every basic refresh, BEFORE
+        // the not-outdated early-return below, so a settled or relay-dropped private nonce stops
+        // being declared. confirmedNonce is instance-agnostic, so this self-heals after reconnecting
+        // to a different blockbook instance.
+        if (privatePendingHint) {
+            const confirmedNonce = Number.parseInt(basic.payload.misc?.confirmedNonce ?? '', 10);
+            if (!Number.isNaN(confirmedNonce)) {
+                dispatch(
+                    privatePendingActions.privatePendingPruned({
+                        accountKey: account.key,
+                        confirmedNonce,
+                    }),
+                );
+            }
+        }
 
         const accountOutdated = isAccountOutdated(account, basic.payload);
         const accountTransactions = selectTransactions(getState());

--- a/suite-common/wallet-core/src/allowance/composeAllowanceTransactionThunk.ts
+++ b/suite-common/wallet-core/src/allowance/composeAllowanceTransactionThunk.ts
@@ -7,13 +7,18 @@ import {
     type FeeLevelLabel,
     type PrecomposedLevels,
 } from '@suite-common/wallet-types';
-import { findToken, getAccountIdentity } from '@suite-common/wallet-utils';
+import {
+    buildEvmEstimateSpecific,
+    findToken,
+    getAccountIdentity,
+} from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
 import { BigNumber, typedObjectFromEntries } from '@trezor/utils';
 
 import { ALLOWANCE_MODULE_PREFIX } from './allowanceConstants';
 import { buildAllowanceTransaction } from './buildAllowanceTransaction';
 import { ETHEREUM_ADJUST_GAS_LIMIT } from '../fees/feesUtils';
+import { selectAccountPrivatePendingNonces } from '../privatePending/privatePendingReducer';
 import { type ComposeFeeLevelsError } from '../send/sendFormTypes';
 
 export interface ComposeAllowanceTransactionThunkParams {
@@ -36,7 +41,10 @@ export const composeAllowanceTransactionThunk = createThunk<
     { rejectValue: ComposeFeeLevelsError }
 >(
     `${ALLOWANCE_MODULE_PREFIX}/composeAllowanceTransactionThunk`,
-    async ({ feeInfo, account, contract, selectedFee, customFee, data }, { rejectWithValue }) => {
+    async (
+        { feeInfo, account, contract, selectedFee, customFee, data },
+        { rejectWithValue, getState },
+    ) => {
         const token = findToken(account.tokens, contract);
 
         if (!token) {
@@ -51,12 +59,17 @@ export const composeAllowanceTransactionThunk = createThunk<
             identity: getAccountIdentity(account),
             request: {
                 blocks: [2],
-                specific: {
-                    from: account.descriptor,
-                    to: contract,
-                    value: '0x0',
-                    data,
-                },
+                // Route the estimate to the relay's pending-private state when this account has
+                // in-flight private txs (presence-only; no-op otherwise). See trezor/blockbook#1639.
+                specific: buildEvmEstimateSpecific(
+                    {
+                        from: account.descriptor,
+                        to: contract,
+                        value: '0x0',
+                        data,
+                    },
+                    selectAccountPrivatePendingNonces(getState(), account.key),
+                ),
             },
         });
 

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -37,6 +37,8 @@ export * from './fees/feesReducer';
 export * from './fees/feesThunks';
 export * from './fees/feesUtils';
 export * from './fees/hooks/useRefetchFees';
+export * from './privatePending/privatePendingActions';
+export * from './privatePending/privatePendingReducer';
 export * from './fiat-rates/fiatRatesMiddleware';
 export * from './fiat-rates/fiatRatesReducer';
 export * from './fiat-rates/fiatRatesSelectors';

--- a/suite-common/wallet-core/src/privatePending/privatePendingActions.ts
+++ b/suite-common/wallet-core/src/privatePending/privatePendingActions.ts
@@ -1,0 +1,36 @@
+import { createAction } from '@reduxjs/toolkit';
+
+import { type AccountKey } from '@suite-common/wallet-types';
+
+export const PRIVATE_PENDING_MODULE_PREFIX = '@common/wallet-core/privatePending';
+
+// Record a genuinely-private (MEV-protected / relay-routed) in-flight tx at broadcast time. Upsert by
+// nonce so a speed-up/cancel at the same nonce rewrites the txid rather than orphaning the entry.
+const privatePendingAdded = createAction(
+    `${PRIVATE_PENDING_MODULE_PREFIX}/added`,
+    (payload: { accountKey: AccountKey; nonce: number; txid: string }) => ({
+        payload: { ...payload, submittedAt: Date.now() },
+    }),
+);
+
+// STOP condition: drop entries for one account that are now mined (nonce < confirmedNonce) or older
+// than the TTL backstop. Dispatched on every basic getAccountInfo response so it self-heals across
+// load-balanced blockbook instances (confirmedNonce is instance-agnostic). now is stamped here to
+// keep the reducer pure.
+const privatePendingPruned = createAction(
+    `${PRIVATE_PENDING_MODULE_PREFIX}/pruned`,
+    (payload: { accountKey: AccountKey; confirmedNonce: number }) => ({
+        payload: { ...payload, now: Date.now() },
+    }),
+);
+
+const privatePendingAccountRemoved = createAction(
+    `${PRIVATE_PENDING_MODULE_PREFIX}/accountRemoved`,
+    (payload: { accountKey: AccountKey }) => ({ payload }),
+);
+
+export const privatePendingActions = {
+    privatePendingAdded,
+    privatePendingPruned,
+    privatePendingAccountRemoved,
+};

--- a/suite-common/wallet-core/src/privatePending/privatePendingReducer.ts
+++ b/suite-common/wallet-core/src/privatePending/privatePendingReducer.ts
@@ -1,0 +1,103 @@
+import { createReducer } from '@reduxjs/toolkit';
+
+import { type AccountKey } from '@suite-common/wallet-types';
+
+import { privatePendingActions } from './privatePendingActions';
+
+// A private in-flight tx must never be declared forever: if the relay drops it and it never mines,
+// confirmedNonce never advances past its nonce, so this TTL is the backstop that stops declaring a
+// nonce that will never confirm (bounds the trezor/blockbook#1629 over-declaration window). Kept a
+// little above the send flow's fake-pending-tx TTL (~15 min) so a slow relay inclusion is not
+// dropped prematurely (which would re-open under-declaration).
+export const PRIVATE_PENDING_TTL_MS = 20 * 60 * 1000;
+
+export interface PrivatePendingEntry {
+    nonce: number;
+    txid: string;
+    submittedAt: number;
+}
+
+// Keyed by account.key (a template-literal type, hence the string index). Only genuinely-private
+// (MEV-protected) in-flight txs are recorded here; this slice is the sole source of truth for the
+// privatePending hint - deliberately NOT derived from the tx list, which cannot represent the
+// private/public bit and misses the staking / walletconnect / claim flows that leave no tx-list
+// artifact.
+export type PrivatePendingState = {
+    [accountKey: string]: PrivatePendingEntry[];
+};
+
+export type PrivatePendingRootState = {
+    wallet: { privatePending: PrivatePendingState };
+};
+
+export const privatePendingInitialState: PrivatePendingState = {};
+
+export const privatePendingReducer = createReducer(privatePendingInitialState, builder => {
+    builder
+        .addCase(privatePendingActions.privatePendingAdded, (state, { payload }) => {
+            const { accountKey, nonce, txid, submittedAt } = payload;
+            if (!state[accountKey]) {
+                state[accountKey] = [];
+            }
+            const existing = state[accountKey].find(entry => entry.nonce === nonce);
+            if (existing) {
+                existing.txid = txid;
+                existing.submittedAt = submittedAt;
+            } else {
+                state[accountKey].push({ nonce, txid, submittedAt });
+            }
+        })
+        .addCase(privatePendingActions.privatePendingPruned, (state, { payload }) => {
+            const { accountKey, confirmedNonce, now } = payload;
+            const entries = state[accountKey];
+            if (!entries) return;
+            const kept = entries.filter(
+                entry =>
+                    entry.nonce >= confirmedNonce &&
+                    now - entry.submittedAt < PRIVATE_PENDING_TTL_MS,
+            );
+            if (kept.length > 0) {
+                state[accountKey] = kept;
+            } else {
+                delete state[accountKey];
+            }
+        })
+        .addCase(privatePendingActions.privatePendingAccountRemoved, (state, { payload }) => {
+            delete state[payload.accountKey];
+        });
+});
+
+const selectAccountPrivatePendingEntries = (
+    state: PrivatePendingRootState,
+    accountKey: AccountKey,
+    // Optional chaining tolerates a partial store that omits this slice (e.g. hook unit tests with a
+    // hand-built mock state); the real store always initializes it via combineReducers.
+): PrivatePendingEntry[] | undefined => state.wallet.privatePending?.[accountKey];
+
+// The unpruned private nonces for this account, ascending. The routing/floor source for both hint
+// sites. Deliberately independent of the tx list so the no-fake-tx flows stay covered.
+export const selectAccountPrivatePendingNonces = (
+    state: PrivatePendingRootState,
+    accountKey: AccountKey,
+): number[] => {
+    const entries = selectAccountPrivatePendingEntries(state, accountKey);
+
+    return entries ? entries.map(entry => entry.nonce).sort((a, b) => a - b) : [];
+};
+
+// The getAccountInfo hint object, or undefined when nothing is in flight (a safe no-op, like
+// confirmedNonce's default). Returning undefined for the empty case is also what gates the extra
+// confirmedNonce round-trip and the relay routing off for accounts with no private tx in flight.
+export const selectAccountPrivatePendingHint = (
+    state: PrivatePendingRootState,
+    accountKey: AccountKey,
+): { nonces: number[]; txids: string[] } | undefined => {
+    const entries = selectAccountPrivatePendingEntries(state, accountKey);
+    if (!entries || entries.length === 0) return undefined;
+    const sorted = [...entries].sort((a, b) => a.nonce - b.nonce);
+
+    return {
+        nonces: sorted.map(entry => entry.nonce),
+        txids: sorted.map(entry => entry.txid),
+    };
+};

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -23,6 +23,7 @@ import {
 import {
     asAmountSubunit,
     asAmountUnit,
+    buildEvmEstimateSpecific,
     calculateMax,
     calculateTotal,
     calculateTotalGasCost,
@@ -57,6 +58,7 @@ import {
     type SignTransactionError,
     type SignTransactionThunkArguments,
 } from './sendFormTypes';
+import { selectAccountPrivatePendingNonces } from '../privatePending/privatePendingReducer';
 import { selectAddressDisplayType } from '../settings/walletSettingsReducer';
 import { selectAccountTransactions } from '../transactions/transactionsSelectors';
 
@@ -319,10 +321,15 @@ export const composeEthereumTransactionFeeLevelsThunk = createThunk<
             identity: getAccountIdentity(account),
             request: {
                 blocks: [2],
-                specific: {
-                    from: account.descriptor,
-                    ...ethereumEstimateFeeParams,
-                },
+                // Route the estimate to the relay's pending-private state when this account has
+                // in-flight private txs (presence-only; no-op otherwise). See trezor/blockbook#1639.
+                specific: buildEvmEstimateSpecific(
+                    {
+                        from: account.descriptor,
+                        ...ethereumEstimateFeeParams,
+                    },
+                    selectAccountPrivatePendingNonces(getState(), account.key),
+                ),
             },
         });
 

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -35,6 +35,7 @@ import {
     isEvmApprovalTxByTextSignature,
     isEvmYieldTxByTextSignature,
     isExchangeTradingForm,
+    isMevPrivateSend,
     isRbfCancelTransaction,
     subunitsToUnits,
     tryGetAccountIdentity,
@@ -84,6 +85,7 @@ import {
 import { accountsActions } from '../accounts/accountsActions';
 import { selectAccountByKey } from '../accounts/accountsSelectors';
 import { syncAccountsWithBlockchainThunk } from '../blockchain/blockchainThunks';
+import { privatePendingActions } from '../privatePending/privatePendingActions';
 import {
     selectAreSatsAmountUnit,
     selectBitcoinAmountUnit,
@@ -478,6 +480,24 @@ export const pushSendFormTransactionThunk = createThunk<
                     ethereumNonce: resolvedEthereumNonce,
                 }),
             );
+
+            // Record a genuinely-private (MEV-protected / relay-routed) EVM send so the account's
+            // subsequent getAccountInfo / estimateFee requests declare it to blockbook as
+            // privatePending (trezor/blockbook#1639). Gated by isMevPrivateSend so public sends never
+            // declare; the entry is pruned once the nonce confirms (see privatePendingReducer).
+            if (
+                selectedAccount.networkType === 'ethereum' &&
+                resolvedEthereumNonce !== undefined &&
+                isMevPrivateSend(selectedAccount.symbol, isMevProtectionEnabled)
+            ) {
+                dispatch(
+                    privatePendingActions.privatePendingAdded({
+                        accountKey: selectedAccount.key,
+                        nonce: Number(resolvedEthereumNonce),
+                        txid,
+                    }),
+                );
+            }
         } else {
             dispatch(
                 notificationsActions.addToast({

--- a/suite-common/wallet-utils/src/__tests__/sendFormUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/sendFormUtils.test.ts
@@ -9,6 +9,7 @@ import { BigNumber } from '@trezor/utils';
 
 import * as fixtures from '../__fixtures__/sendFormUtils';
 import {
+    buildEvmEstimateSpecific,
     calculateMax,
     calculateTotal,
     calculateTotalGasCost,
@@ -784,6 +785,37 @@ describe('sendForm utils', () => {
                     amount: '8.00000001',
                 }),
             ).toBe(false);
+        });
+    });
+
+    describe('buildEvmEstimateSpecific', () => {
+        const base = { from: '0xabc', to: '0xdef', value: '0x0', data: '0x' };
+
+        it('returns the base unchanged when there are no private-pending nonces', () => {
+            expect(buildEvmEstimateSpecific(base)).toEqual(base);
+            expect(buildEvmEstimateSpecific(base)).not.toHaveProperty('privatePending');
+        });
+
+        it('returns the base unchanged for an empty nonce array (presence-only guard)', () => {
+            expect(buildEvmEstimateSpecific(base, [])).toEqual(base);
+            expect(buildEvmEstimateSpecific(base, [])).not.toHaveProperty('privatePending');
+        });
+
+        it('attaches privatePending only when at least one nonce is declared', () => {
+            expect(buildEvmEstimateSpecific(base, [5])).toEqual({
+                ...base,
+                privatePending: { nonces: [5] },
+            });
+            expect(buildEvmEstimateSpecific(base, [5, 6])).toEqual({
+                ...base,
+                privatePending: { nonces: [5, 6] },
+            });
+        });
+
+        it('does not mutate the base object', () => {
+            const input = { ...base };
+            buildEvmEstimateSpecific(input, [1]);
+            expect(input).toEqual(base);
         });
     });
 });

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -682,6 +682,14 @@ export const getMevProtectedTxData = (
     return hex;
 };
 
+// Whether a send is genuinely private, i.e. exactly the case where getMevProtectedTxData drops
+// disableAlternativeRPC and the tx is broadcast through the alternative relay (MEV protection on AND
+// a relay-capable network). This is the condition under which the tx must be recorded and declared
+// to blockbook as privatePending. isMevProtectionEnabled is expected to already fold in the
+// message-system feature flag, as the send and walletconnect flows do.
+export const isMevPrivateSend = (symbol: NetworkSymbol, isMevProtectionEnabled: boolean): boolean =>
+    isMevProtectionEnabled && getNetwork(symbol).features.includes('mev-protection');
+
 export const isExchangeTradingForm = (
     form: FormStateTrading | undefined,
 ): form is FormStateTradingExchange => form?.activeSection === 'exchange';

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -137,6 +137,26 @@ const getSerializedErc20Transfer = (token: TokenInfo, to: string, amount: string
     return `0x${ERC20_TRANSFER}${erc20recipient}${erc20amount}`;
 };
 
+type EvmEstimateSpecificBase = {
+    from?: string;
+    to?: string;
+    data?: string;
+    value?: string;
+};
+
+// Attach the wallet-declared privatePending hint to an EVM estimateFee `specific` object, but ONLY
+// when there are in-flight private nonces to declare. The `length > 0` guard is deliberate: blockbook
+// treats the hint as presence-only and routes any request that carries a non-empty `nonces` array to
+// the rate-limited private relay, so declaring on every keystroke would re-open the relay quota drain
+// (trezor/blockbook#1629). With no private nonces the base object is returned unchanged.
+export const buildEvmEstimateSpecific = (
+    base: EvmEstimateSpecificBase,
+    privatePendingNonces?: number[],
+): EvmEstimateSpecificBase & { privatePending?: { nonces: number[] } } =>
+    privatePendingNonces && privatePendingNonces.length > 0
+        ? { ...base, privatePending: { nonces: privatePendingNonces } }
+        : base;
+
 // TrezorConnect.blockchainEstimateFee for ETH
 export const getEthereumEstimateFeeParams = (
     to: string,

--- a/suite-common/walletconnect/src/adapters/ethereum.ts
+++ b/suite-common/walletconnect/src/adapters/ethereum.ts
@@ -9,11 +9,17 @@ import { type Network, getNetwork, networksCollection } from '@suite-common/wall
 import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import {
     ethereumGetCurrentNonceThunk,
+    privatePendingActions,
     selectAccounts,
     selectIsMevProtectionEnabled,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
-import { getAccountIdentity, getMevProtectedTxData, sanitizeHex } from '@suite-common/wallet-utils';
+import {
+    getAccountIdentity,
+    getMevProtectedTxData,
+    isMevPrivateSend,
+    sanitizeHex,
+} from '@suite-common/wallet-utils';
 import TrezorConnect, {
     type CallMethodResponse,
     type EthereumSignTypedData,
@@ -217,6 +223,25 @@ const ethereumRequestThunk = createThunk<
             if (!pushResponse.success) {
                 console.error('eth_sendTransaction push error', pushResponse);
                 throw new Error('eth_sendTransaction push error');
+            }
+
+            // Record a genuinely-private (MEV-protected / relay-routed) WalletConnect send so the
+            // account's subsequent read requests declare it to blockbook as privatePending
+            // (trezor/blockbook#1639); pruned once the nonce confirms. Uses the same combined MEV
+            // condition as the broadcast above.
+            if (
+                isMevPrivateSend(
+                    account.symbol,
+                    isMevProtectionEnabled && isMevProtectionFeatureEnabled,
+                )
+            ) {
+                dispatch(
+                    privatePendingActions.privatePendingAdded({
+                        accountKey: account.key,
+                        nonce: Number(nonce),
+                        txid: pushResponse.payload.txid,
+                    }),
+                );
             }
 
             return pushResponse.payload.txid;


### PR DESCRIPTION
## Summary

Populates the wallet-declared **`privatePending`** hint that blockbook trezor/blockbook#1639 consumes, so Blockbook can route EVM **nonce lookups** (`getAccountInfo`) and **gas estimates** (`estimateFee`) deterministically from authoritative wallet state, instead of inferring "did this instance recently accept a private send" via its per-instance `recentSenders` heuristic — which is fragile across restarts, load-balanced replicas or different websocket connections on different replica.

> **Draft — proposal, backs the design note:** https://gist.github.com/pragmaxim/f71b03a4ed4c0030b6cba7fb0a302e96
> Requires the blockbook side (trezor/blockbook#1639) to be deployed to have any effect; until then every field transmits `undefined` and behavior is unchanged.

## Why this needed real design (the two original blockers)

1. **Suite couldn't cleanly populate the field.** The private-vs-public decision is transient — it lives only at broadcast time in `getMevProtectedTxData` (drop `disableAlternativeRPC` ⇒ relay-routed) and is stored on **neither** the fake pending tx **nor** the real tx. Worse, the reducer whole-object-overwrites the fake pending tx with blockbook's real (unmarked) tx *mid-flight*, so any per-tx marker is wiped exactly when it's still needed. And the staking / WalletConnect / Merkl-claim / stablecoin-yield flows create no fake tx at all.
2. **Plumbing asymmetry.** The nonce hint goes on `getAccountInfo` (validateParams whitelist + the explicit forward object); the estimate hint is hand-built at ~8 independent `specific` call sites with no choke point.

## Design decisions

- **Dedicated durable slice** keyed by `(accountKey, nonce)` (`suite-common/wallet-core/src/privatePending`) is the sole source of truth. Nonce is invariant across the fake→real swap; the slice is independent of the tx list, so it also covers the no-fake-tx flows. A tx-object marker or a `getOwnEvmNonceSets`-derived set both provably fail (marker wiped mid-flight; derivation can't tell private from public → would over-declare public txs to the rate-limited relay and under-declare the no-tx-list flows).
- **Delivery rides the *unconditional basic* `getAccountInfo` call** in `fetchAndUpdateAccountThunk`, **not** the gated `details:'txs'` call. A blockbook-invisible private tx does not make the account "outdated", so the txs call is skipped for exactly the flows that need the hint. Sent only when the account has an in-flight private nonce (also the over-declaration guard).
- **Instance-agnostic STOP:** prune entries with `nonce < confirmedNonce` (mined) or past a TTL backstop, on every basic refresh — so it self-heals after reconnecting to a different (load-balanced) blockbook instance, and a relay-dropped tx that never confirms can't be declared forever (bounds the trezor/blockbook#1629 quota concern).
- **`buildEvmEstimateSpecific()`** attaches the hint to an EVM estimate `specific` only when `nonces.length > 0` — the presence-only routing means a keystroke with nothing in flight never hits the relay.

## Commits

1. **`feat(blockchain-link)`** — plumbing, no behavior change: shared `PrivatePendingHint` type on `AccountInfoParams` + presence-only `{nonces}` on `EstimateFeeParams.specific`; forward through connect `getAccountInfo` (mirroring `confirmedNonce`); doc-mirror on `WsAccountInfoReq`; `buildEvmEstimateSpecific` helper + unit tests.
2. **`feat(wallet-core)`** — durable Redux slice + delivery on the basic call + confirmedNonce/TTL prune. Still a no-op (no producer writes yet).
3. **`feat(wallet-core)`** — first observable behavior: `isMevPrivateSend` predicate; record private sends in the **send** + **WalletConnect** flows (signed nonce already in scope); adopt `buildEvmEstimateSpecific` at the send + allowance estimate sites.

## Scope / deferred

- **Deferred to a follow-up:** the **staking / Merkl-claim / stablecoin-yield** writes. Those flows have no resolved signed nonce in scope (`PrecomposedTransactionFinal` carries none), so recording them faithfully needs signed-nonce capture (RLP-decode the serialized tx, or thread the computed nonce through compose/sign) — declaring them with a guessed nonce would be worse than the fallback. Until then they fall back to blockbook's heuristic, which #1639 keeps as the fallback, so partial coverage never regresses below today.
- **Deferred:** IndexedDB persistence of the slice. Redux alone already covers the reconnect-to-a-different-instance case (Redux isn't reset on WS disconnect); persistence only matters for an app restart mid-private-tx, which matches today's heuristic fallback.

## Related

- blockbook: trezor/blockbook#1639 (consumes the hint) — stacked on trezor/blockbook#1638
- design note: https://gist.github.com/pragmaxim/f71b03a4ed4c0030b6cba7fb0a302e96

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/evm-privatepending-hint/web/](https://dev.suite.sldev.cz/suite-web/feat/evm-privatepending-hint/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/evm-privatepending-hint&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/evm-privatepending-hint&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/evm-privatepending-hint&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-23T09:21:48.175Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-23T09:23:55.528Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->