### PR TITLE
refactor(suite-native): trading-debug: add violet accent

### DIFF
--- a/suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.tsx
@@ -1,6 +1,6 @@
 import { cryptoIdToNetworkAndContractAddress, getApprovalStatus } from '@suite-common/trading';
 import { findToken, isAllowanceUnlimited } from '@suite-common/wallet-utils';
-import { HStack, Text } from '@suite-native/atoms';
+import { HStack, Text, VStack } from '@suite-native/atoms';
 import { useWatch } from '@suite-native/forms';
 import { DebugModeView } from '@suite-native/trading-debug';
 
@@ -26,19 +26,21 @@ export const ExchangeFormQuoteDebugView = () => {
 
     return (
         <DebugModeView>
-            <HStack>
-                <Text variant="body-xs">Approval status</Text>
-                <Text variant="body-xs" color="contentSecondary">
-                    {approvalStatus ?? 'none'}
-                </Text>
-            </HStack>
-            <HStack>
-                <Text variant="body-xs">Pre-approved</Text>
-                <Text variant="body-xs" color="contentSecondary">
-                    {preapproved}
-                </Text>
-            </HStack>
-            <HStack>
+            <HStack justifyContent="space-between">
+                <VStack spacing="sp2" justifyContent="center">
+                    <HStack>
+                        <Text variant="body-xs">Approval status</Text>
+                        <Text variant="body-xs" color="contentSecondary">
+                            {approvalStatus ?? 'none'}
+                        </Text>
+                    </HStack>
+                    <HStack>
+                        <Text variant="body-xs">Pre-approved</Text>
+                        <Text variant="body-xs" color="contentSecondary">
+                            {preapproved}
+                        </Text>
+                    </HStack>
+                </VStack>
                 <ExchangeUsdcPresetButton />
             </HStack>
         </DebugModeView>

--- a/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.test.tsx
@@ -63,7 +63,7 @@ describe('ExchangeUsdcPresetButton', () => {
         });
 
         it('renders the preset button', () => {
-            expect(screen.getByText('Prefill 1 USDC → USDT')).toBeOnTheScreen();
+            expect(screen.getByText('Prefill 1 USDC→USDT')).toBeOnTheScreen();
         });
 
         it('fills form for 1 USDC -> USDT trade', () => {

--- a/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.tsx
@@ -3,9 +3,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import { cryptoIdToSymbol, tradingExchangeActions } from '@suite-common/trading';
 import { type AccountsRootState, selectAccounts } from '@suite-common/wallet-core';
 import { type TokenAddress } from '@suite-common/wallet-types';
-import { Text, TextButton } from '@suite-native/atoms';
+import { Button, Text } from '@suite-native/atoms';
 import { exchangeActions } from '@suite-native/trading-state';
 import { type TradeableAsset } from '@suite-native/trading-types';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { useExchangeFormContext } from '../../hooks/exchange/useExchangeFormContext';
 
@@ -27,7 +28,13 @@ const USDT_ETH: TradeableAsset = {
     contractAddress: '0xdac17f958d2ee523a2206206994597c13d831ec7' as TokenAddress,
 };
 
+const ButtonStyleOverride = prepareNativeStyle(({ spacings }) => ({
+    paddingHorizontal: spacings.sp4,
+    paddingVertical: spacings.sp2,
+}));
+
 export const ExchangeUsdcPresetButton = () => {
+    const { applyStyle } = useNativeStyles();
     const { getValues, setValue } = useExchangeFormContext();
     const dispatch = useDispatch();
     const debugAccount = useSelector((state: AccountsRootState) =>
@@ -64,8 +71,13 @@ export const ExchangeUsdcPresetButton = () => {
     };
 
     return (
-        <TextButton size="small" onPress={handlePress} intent="accentViolet">
-            Prefill 1 USDC → USDT
-        </TextButton>
+        <Button
+            size="medium"
+            onPress={handlePress}
+            intent="accentViolet"
+            style={applyStyle(ButtonStyleOverride)}
+        >
+            Prefill 1 USDC→USDT
+        </Button>
     );
 };

--- a/suite-native/trading-debug/src/components/DebugModeView.tsx
+++ b/suite-native/trading-debug/src/components/DebugModeView.tsx
@@ -5,14 +5,14 @@ import { useTradingDebugModeFlag } from '../hooks/useTradingDebugModeFlag';
 
 export type DebugModeViewProps = BoxProps;
 
-const DebugModeViewStyle = prepareNativeStyle(({ colors, spacings }) => ({
-    marginHorizontal: spacings.sp4,
+const DebugModeViewStyle = prepareNativeStyle(({ colors, spacings, borders }) => ({
     marginVertical: spacings.sp2,
-    paddingHorizontal: spacings.sp4,
+    paddingHorizontal: spacings.sp8,
     paddingVertical: spacings.sp2,
     borderWidth: 1,
-    borderColor: colors.elementBorderField,
-    backgroundColor: colors.elementFillBoldDisabled,
+    borderColor: colors.elementBorderAccentVioletSofter,
+    backgroundColor: colors.elementFillAccentVioletSoft,
+    borderRadius: borders.radii.r12,
 }));
 
 export const DebugModeView = ({ style, ...otherProps }: DebugModeViewProps) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add violet accent to trading debug view as discussed [here](https://satoshilabs.slack.com/archives/G019WLX2P7B/p1783935116985959).
- Improve Exchange debug component layout.
- 
<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-07-23 at 10 20 07" src="https://github.com/user-attachments/assets/4f1e66cd-473f-49ca-842e-6239e47a1b3f" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=debug-violet-accent&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->